### PR TITLE
fix(voice): a timeout is "on its way", not "Voice service down"

### DIFF
--- a/apps/cockpit/src/sessions/VoiceTab.tsx
+++ b/apps/cockpit/src/sessions/VoiceTab.tsx
@@ -50,14 +50,25 @@ export function VoiceTab({ sessionId }: { sessionId: string | undefined }) {
             drift apart again; the fallback line is only for when the Gateway has said nothing. */}
         {v.audioUnavailable && (
           <>
+            {/* A timeout (Retrying) is not an outage: the audio is on its way and the Gateway is trying
+                again. Calm yellow "on its way", never the red "Voice service down" - that red panel is
+                right for an answered outage (ServiceDown) and a lie for a single slow call. */}
             <div className="voice-statusbar">
-              <span className="voice-state voice-state-red">
-                {v.unavailableIsServiceDown ? "Voice service down" : "Voice unavailable"}
+              <span className={"voice-state " + (v.unavailableIsRetrying ? "voice-state-yellow" : "voice-state-red")}>
+                {v.unavailableIsRetrying
+                  ? "Voice on its way"
+                  : v.unavailableIsServiceDown
+                    ? "Voice service down"
+                    : "Voice unavailable"}
               </span>
             </div>
             <div className="voice-narr">
               <div className="voice-narr-title">
-                {v.unavailableIsServiceDown ? "This is not your fault." : "No narration is ready to play."}
+                {v.unavailableIsRetrying
+                  ? "Taking a moment - still trying."
+                  : v.unavailableIsServiceDown
+                    ? "This is not your fault."
+                    : "No narration is ready to play."}
               </div>
               <div className="voice-narr-body">
                 {v.unavailableReason?.text
@@ -69,9 +80,9 @@ export function VoiceTab({ sessionId }: { sessionId: string | undefined }) {
                       : "There is no spoken summary for this session's latest turn yet. Click Generate narration to make one now."}
               </div>
             </div>
-            {/* No button while the service is down: it hits the same dead service and fails the same
-                way, and the Gateway is already backing off and retrying on its own. */}
-            {!v.unavailableIsServiceDown && (
+            {/* No button while the service is down OR a timeout is retrying: it races the same slow or
+                failing call, and the Gateway is already backing off and retrying on its own. */}
+            {!v.unavailableIsServiceDown && !v.unavailableIsRetrying && (
               <button
                 type="button"
                 className="voice-switch"

--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -60,6 +60,7 @@ export function VoiceMode() {
     audioUnavailable,
     unavailableReason,
     unavailableIsServiceDown,
+    unavailableIsRetrying,
     agentWorking,
     pollDone,
     narrative,
@@ -176,9 +177,16 @@ export function VoiceMode() {
             said nothing. */}
         {audioUnavailable && (
           <>
+            {/* A timeout (Retrying) is NOT an outage: the audio just is not ready yet and the Gateway
+                is trying again. Show a calm yellow "on its way", never the red "Voice service down" -
+                that red panel is right for an answered outage (ServiceDown) and a lie for a slow call. */}
             <div className="voice-statusbar">
-              <span className="voice-state voice-state-red">
-                {unavailableIsServiceDown ? "Voice service down" : "Voice unavailable"}
+              <span className={"voice-state " + (unavailableIsRetrying ? "voice-state-yellow" : "voice-state-red")}>
+                {unavailableIsRetrying
+                  ? "Voice on its way"
+                  : unavailableIsServiceDown
+                    ? "Voice service down"
+                    : "Voice unavailable"}
               </span>
             </div>
             <div className="voice-narr">
@@ -187,7 +195,11 @@ export function VoiceMode() {
                   (what is going on?). A headline has one job - say what happened - and the sentence
                   underneath, which comes from the Gateway, says what is being done about it. */}
               <div className="voice-narr-title">
-                {unavailableIsServiceDown ? "The speech service did not answer." : "No narration is ready to play."}
+                {unavailableIsRetrying
+                  ? "Taking a moment - still trying."
+                  : unavailableIsServiceDown
+                    ? "The speech service did not answer."
+                    : "No narration is ready to play."}
               </div>
               <div className="voice-narr-body">
                 {unavailableReason?.text
@@ -199,10 +211,10 @@ export function VoiceMode() {
                       : "There is no spoken summary for this session's latest turn yet. Tap Generate narration to make one now."}
               </div>
             </div>
-            {/* No button during a service outage: the Gateway is already backing off and retrying, and
-                pressing Generate would hit the same dead service and fail the same way. A button that
-                cannot work is worse than no button - it invites you to keep trying and blame yourself. */}
-            {!unavailableIsServiceDown && (
+            {/* No button during a service outage OR a timeout-retry: the Gateway is already backing off
+                and retrying, and pressing Generate would race the same slow/failing call. A button that
+                cannot help is worse than no button - it invites you to keep trying and blame yourself. */}
+            {!unavailableIsServiceDown && !unavailableIsRetrying && (
               <button
                 type="button"
                 className="voice-switch"

--- a/packages/client-core/src/voice/useVoiceMode.ts
+++ b/packages/client-core/src/voice/useVoiceMode.ts
@@ -88,6 +88,9 @@ export interface VoiceModeView {
   unavailableReason: { state?: string; text?: string; ctaLabel?: string; ctaAction?: string; ctaUrl?: string | null } | null;
   /** The hosted service is down: not the user's fault, nothing for them to press, already retrying. */
   unavailableIsServiceDown: boolean;
+  /** The speech call did not answer in time (a timeout, not an outage): the audio is on its way and
+   *  the Gateway is already trying again. A calm "on its way" state, never the red "down" panel. */
+  unavailableIsRetrying: boolean;
   gatewayPreparing: boolean;
   phoneDownloadPending: boolean;
   agentWorking: boolean;
@@ -638,6 +641,10 @@ export function useVoiceMode(
   // A service outage is not the user's fault and there is nothing for them to press: the Gateway is
   // already backing off and retrying. Offering a "Generate narration now" button here would be a lie.
   const unavailableIsServiceDown = unavailableReason?.state === "ServiceDown";
+  // A timeout is NOT an outage: the service did not answer in time, the audio is still coming, and the
+  // sweep is already trying again. Distinct from ServiceDown so the screen can say "on its way" instead
+  // of the red "Voice service down" panel - the wording that was a lie on a one-off slow call.
+  const unavailableIsRetrying = unavailableReason?.state === "Retrying";
 
   return {
     voiceOn,
@@ -646,6 +653,7 @@ export function useVoiceMode(
     audioUnavailable,
     unavailableReason,
     unavailableIsServiceDown,
+    unavailableIsRetrying,
     gatewayPreparing,
     phoneDownloadPending,
     agentWorking,

--- a/src/CcDirector.Core.Tests/HostedAi/HostedAiMessagesTests.cs
+++ b/src/CcDirector.Core.Tests/HostedAi/HostedAiMessagesTests.cs
@@ -44,6 +44,22 @@ public sealed class HostedAiMessagesTests
     }
 
     [Fact]
+    public void Retrying_SaysItIsComing_NoCtaNoOutageClaim()
+    {
+        // A timeout is the absence of an answer, so the copy must not claim the service is down or
+        // "not responding" - the wording that was a lie on one slow call. It says what is true: the
+        // audio is on its way and we are trying again. No call to action - the surface retries itself.
+        var m = HostedAiMessages.For(HostedAiState.Retrying);
+        Assert.NotEmpty(m.Text);
+        Assert.Equal("", m.CtaLabel);
+        Assert.Equal(HostedAiCtaAction.None, m.CtaAction);
+        Assert.Null(m.CtaUrl);
+        Assert.DoesNotContain("not responding", m.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("down", m.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.True(HostedAiCopyRules.IsClean(m.Text));
+    }
+
+    [Fact]
     public void NeedsKey_OpenSettings_NoUrl()
     {
         var m = HostedAiMessages.For(HostedAiState.NeedsKey);

--- a/src/CcDirector.Core/HostedAi/HostedAiMessages.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiMessages.cs
@@ -50,6 +50,16 @@ public static class HostedAiMessages
             HostedAiCtaAction.None,
             null),
 
+        // The service did not answer in time - a timeout, not an outage. Say what is TRUE (the audio is
+        // still coming and we are trying again), not "the service is down", which we have no evidence
+        // for and which sends the user hunting for a bug that is not theirs. No call to action: the
+        // surface retries by itself. Names no provider, per the copy rules above.
+        HostedAiState.Retrying => new HostedAiMessage(
+            "Voice is taking a moment - retrying automatically. It should come through shortly.",
+            "",
+            HostedAiCtaAction.None,
+            null),
+
         _ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown hosted-AI state"),
     };
 }

--- a/src/CcDirector.Core/HostedAi/HostedAiState.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiState.cs
@@ -27,8 +27,14 @@ public enum HostedAiState
     NeedsKey = 3,
 
     /// <summary>
-    /// The hosted service itself is failing - it answered with an error, or did not answer at all.
-    /// Nothing is wrong with the account, the setup, or this machine: the far end is down.
+    /// The hosted service ANSWERED with a failure - a 5xx, or a 429 asking us to slow down. The service
+    /// itself is genuinely struggling: nothing is wrong with the account, the setup, or this machine.
+    ///
+    /// This is reserved for an ANSWER. A call that simply did not answer in time (a timeout or transport
+    /// failure) is <see cref="Retrying"/>, NOT this - because a non-answer is the absence of evidence,
+    /// and stamping "the service is down" on it is a claim we cannot support. That distinction is the
+    /// whole point of splitting the two: the phone renders a red "Voice service down" panel on this
+    /// state, which is right for a real answered outage and wrong for one slow call.
     ///
     /// This state exists because we USED to throw this reason away. WingmanVoiceService mapped 402 and
     /// NeedsKey and returned a bare null for everything else ("other provider error: logged, no shared
@@ -41,4 +47,21 @@ public enum HostedAiState
     /// RETRY BY ITSELF rather than offering a button that fails the same way.
     /// </summary>
     ServiceDown = 4,
+
+    /// <summary>
+    /// The speech call did not answer in time - a timeout, or a transport failure - so we have NO
+    /// evidence about the service. The audio is simply not ready yet, and a retry is already underway.
+    ///
+    /// This is deliberately NOT <see cref="ServiceDown"/>. A timeout is the ABSENCE of an answer, which
+    /// tells us nothing about whether the service is healthy; on 2026-07-15/16 the service answered
+    /// hand-made calls in ~2 seconds while the sweep's calls were timing out on a cold start. Reporting
+    /// "the voice service is not responding" / "Voice service down" on that is a lie the user cannot
+    /// act on - it sends them hunting for an outage that is not there. The honest thing to say is that
+    /// the audio is on its way and we are trying again, which is exactly what is happening.
+    ///
+    /// Like <see cref="ServiceDown"/> it is not the user's fault and offers no call to action - the
+    /// surface retries by itself. Unlike it, the surface shows a calm "on its way" state, not a red
+    /// outage panel.
+    /// </summary>
+    Retrying = 5,
 }

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
@@ -568,11 +568,12 @@ public sealed class WingmanVoiceServiceTests
         var handler = new TtsTimeoutHandler(timeouts: 1);
         var svc = ServiceWithHandler(handler);
 
-        // The stalled call fails - one attempt, bounded, and it says so honestly.
+        // The stalled call fails - one attempt, bounded, and it says so honestly. A timeout is the
+        // absence of an answer, so it is Retrying ("audio on its way, trying again"), NOT ServiceDown.
         await svc.StoreSpokenAsync("sid-retry", "spoken", "reply");
         Assert.Equal(1, handler.Calls);                                        // exactly one attempt: no in-call retry
         Assert.False(svc.HasVoice("sid-retry"));                               // nothing to play
-        Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-retry"));
+        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-retry"));
         Assert.False(svc.SpeechCooldownArmed, "and it did not drag the rest of the fleet down with it");
 
         // The session tries again - the provider is fine now, and it just works.
@@ -598,8 +599,9 @@ public sealed class WingmanVoiceServiceTests
     // ---- The 2026-07-15 outage: the service failed for ~45 minutes and the phone blamed the user's own
     // machine ("the Gateway has not made one, or this session's computer is offline"). Both false. The
     // reason was KNOWN here and discarded three lines from where it was known, because no state meant
-    // "the service is down". These pin the whole path: the failure must become ServiceDown, ServiceDown
-    // must carry copy the phone can render, and it must survive to the DTO the phone actually reads.
+    // "the service is down". These pin the whole path: an ANSWERED failure becomes ServiceDown, that
+    // state carries copy the phone can render, and it survives to the DTO the phone actually reads. A
+    // call that never answered (a timeout) is Retrying, not ServiceDown - the split proven below.
 
     [Theory]
     [InlineData(500)]   // provider blew up
@@ -618,15 +620,20 @@ public sealed class WingmanVoiceServiceTests
     }
 
     [Fact]
-    public async Task StoreSpokenAsync_TtsTimesOutEveryAttempt_RecordsServiceDown()
+    public async Task StoreSpokenAsync_TtsTimesOutEveryAttempt_RecordsRetrying_NotServiceDown()
     {
         // The TimeoutException that TtsSynthesis exists to bound was the ONE failure that stamped
-        // nothing at all - swallowed by a bare catch. It is the most likely failure in a real outage.
+        // nothing at all - swallowed by a bare catch. It must stamp SOMETHING (so the phone is not left
+        // guessing), but that something is Retrying, NOT ServiceDown: a call that never answered is the
+        // absence of evidence about the service. Stamping ServiceDown here made the phone say "Voice
+        // service down" on a single slow call - a claim we cannot support - which is the wording bug
+        // this test now guards against.
         var handler = new TtsTimeoutHandler(timeouts: int.MaxValue);
         var svc = ServiceWithHandler(handler);
         await svc.StoreSpokenAsync("sid-timeout", "spoken", "reply");
 
-        Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-timeout"));
+        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-timeout"));
+        Assert.NotEqual(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-timeout"));
     }
 
     // ONE SLOW NARRATION MUST NOT SILENCE THE FLEET.
@@ -644,14 +651,14 @@ public sealed class WingmanVoiceServiceTests
     public async Task StoreSpokenAsync_OneTimeout_DoesNotArmTheSharedCooldown()
     {
         // One timeout is not evidence about the SERVICE - it can be one long narration or one stalled
-        // worker. The session still reports ServiceDown (nothing to play, and it must say so), but the
-        // shared gate must stay open so every other session still gets its turn at speech.
+        // worker. The session still reports its own state (Retrying - nothing to play yet, trying
+        // again), but the shared gate must stay open so every other session still gets its turn.
         var handler = new TtsTimeoutHandler(timeouts: TtsSynthesis.Attempts);
         var svc = ServiceWithHandler(handler);
 
         await svc.StoreSpokenAsync("sid-slow", "spoken", "reply");
 
-        Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-slow"));
+        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-slow"));
         Assert.False(svc.SpeechCooldownArmed, "one timeout must not silence every other session's voice");
     }
 
@@ -684,8 +691,9 @@ public sealed class WingmanVoiceServiceTests
 
         Assert.False(svc.SpeechCooldownArmed,
             "no number of timeouts may silence the fleet - the service never answered, so they say nothing about it");
-        // Each session still tells the truth about ITSELF: there is nothing to play.
-        Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-e"));
+        // Each session still tells the truth about ITSELF: nothing to play yet, retrying - Retrying,
+        // never ServiceDown, because none of these calls got an answer from the service.
+        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-e"));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -666,8 +666,7 @@ public sealed class WingmanVoiceService
             // about. A timeout is the absence of evidence: the service said nothing, so we know nothing
             // about the service. Ten narrations timing out on a slow provider are ten sessions having a
             // slow turn, and the honest response is for each of them to try again on its own - the voice
-            // sweep already does exactly that for any session without audio, and the fleet-wide semaphore
-            // already caps the load at two concurrent calls whatever we decide here.
+            // sweep already does exactly that for any session without audio.
             //
             // Only an ANSWER is evidence about the service, and the two answers that are get handled
             // above, where they belong: a 429 with its Retry-After, and a failure status. Those arm the
@@ -677,10 +676,16 @@ public sealed class WingmanVoiceService
             // stops paying for translations whose audio cannot be made" - and paid for it by silencing
             // every session on every machine, on evidence that turned out to be our own doing. Cheap
             // narrations are not the failure mode; a mute fleet is.
-            FileLog.Write($"[WingmanVoiceService] tts FAILED for this narration: {ex.Message} - " +
-                          "not evidence about the service (it did not answer), so the fleet keeps its " +
-                          "turn at speech and this session retries on its own");
-            return new TtsResult(null, null, HostedAiState.ServiceDown);
+            //
+            // And because a timeout is the absence of evidence, it is reported as Retrying, NOT
+            // ServiceDown. ServiceDown makes the phone say "Voice service down" - a claim about the
+            // service that a non-answer cannot support. Retrying tells the honest truth: the audio is
+            // not ready yet and this session is trying again. An ANSWERED failure (the 429/5xx branches
+            // above) keeps ServiceDown, because there the service really did tell us it is failing.
+            FileLog.Write($"[WingmanVoiceService] tts did not answer for this narration: {ex.Message} - " +
+                          "absence of evidence about the service, so this is Retrying (not down); the " +
+                          "fleet keeps its turn at speech and this session retries on its own");
+            return new TtsResult(null, null, HostedAiState.Retrying);
         }
         // NOTE: no `finally { http.Dispose(); }`. `http` is now either the caller's injected client or
         // the shared static, and disposing EITHER would be wrong - the static must outlive every call


### PR DESCRIPTION
## What

Splits the hosted-AI unavailable state so a text-to-speech **timeout** is no longer reported as `ServiceDown`.

## Why

A TTS call that never answered in time was stamped `ServiceDown`, so the phone's Voice screen showed a red **"Voice service down"** panel and **"The voice service is not responding"** - on what was usually one slow call against an otherwise healthy service (measured 2026-07-15/16: the service answered hand-made calls in ~2s while the sweep's calls timed out on a cold start). A timeout is the *absence* of an answer; it tells us nothing about whether the service is up, so claiming it is down is a lie the user cannot act on.

## The split

- `ServiceDown` now means the service **answered** with a failure (a 5xx, or a 429 asking us to slow down) - a genuine outage, still the red panel and shared cooldown.
- New `Retrying` means the call **did not answer** (timeout or transport failure). Honest copy - *"Voice is taking a moment - retrying automatically. It should come through shortly."* - and the phone + Cockpit render a calm yellow **"Voice on its way"** with no Generate button (it is already retrying).

## Surfaces touched

- `HostedAiState` (+ `Retrying`), `HostedAiMessages` copy.
- `WingmanVoiceService` timeout/transport catch returns `Retrying`; answered-failure branches keep `ServiceDown`.
- `useVoiceMode` derives `unavailableIsRetrying`; `VoiceMode.tsx` (mobile) and `VoiceTab.tsx` (Cockpit) render the calm state.

## Tests

- Core `HostedAiMessagesTests`: new `Retrying` copy test (non-empty, no CTA, no "down"/"not responding", clean).
- Gateway `WingmanVoiceServiceTests`: timeout tests updated to assert `Retrying`; answered-failure control keeps `ServiceDown`.
- Targeted .NET suites green (59 Core HostedAi, 68 Gateway voice/hostedai); all JS workspaces typecheck; 526 client-core tests green.