### PR TITLE
Fold token spend into SQLite, sliced by hour and model

### DIFF
--- a/docs/architecture/review-token-column-2026-07-16.md
+++ b/docs/architecture/review-token-column-2026-07-16.md
@@ -1,0 +1,31 @@
+# Review: Token Column
+
+## Verdict
+
+No blocking findings. I would land this change.
+
+## Findings
+
+None.
+
+## Review Notes
+
+The version 3 migration is atomic with the version stamp. `Migrate` opens one transaction, runs each needed migration step, writes the final `PRAGMA user_version`, and commits only after the steps complete. `MigrateToVersion3` creates `token_delta`, its hour index, and `token_highwater` inside that caller transaction. I do not see a normal on-disk path that can half-apply those tables while still ending at schema version 3.
+
+The token fold uses the same high-water rule as the existing counter lanes. It runs before the input bucket guard, so a poll that has token growth but no new submitted-turn bucket still folds the token increase. For each persisted scalar, growth folds only the increment, a dropped snapshot folds the current value as fresh spend, and a repeated identical snapshot queues neither a token row nor a high-water write.
+
+The prune path preserves token spend. `PruneLocked` now runs when there are input rows or token rows, so token-only growth can trigger old detail cleanup. The token archive insert carries `model_id` in both the `SELECT` and `GROUP BY`, so pruning does not collapse known models into the null bucket or merge different models together. All-time token totals include archive rows, while hourly token totals exclude the archive marker.
+
+The schema stores only summable spend. `token_delta` has input, output, cache-read, and cache-creation token columns plus the nullable model id. There is no context occupancy column, and the aggregate methods sum only those four spend columns.
+
+I did not find a nondeterministic write introduced by this diff. Writes are driven by deterministic high-water comparisons under the aggregator lock, and the in-memory mirrors advance only after the database transaction commits.
+
+## Verification
+
+Ran:
+
+```text
+dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter "FullyQualifiedName~GatewayStatsDatabaseTests|FullyQualifiedName~GatewayInputStatsAggregatorTests" --no-restore
+```
+
+Result: passed, 60 tests.

--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -725,4 +725,175 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         Assert.True(DateTime.TryParse(agg.ModelsSinceUtc, System.Globalization.CultureInfo.InvariantCulture,
             System.Globalization.DateTimeStyles.RoundtripKind, out _));
     }
+
+    // ---- The token dimension (issue #1637): what the work actually cost. ----
+
+    // A session carrying both a model and a cumulative token snapshot. Tokens are (input, output, cacheRead,
+    // cacheCreation); a bucket is added so the session looks like a real one that took a turn.
+    private static SessionDto SessionWithTokens(string id, string? model,
+        (long In, long Out, long CacheRead, long CacheCreation) tokens,
+        params (string modality, string surface, long turns, long chars)[] buckets)
+    {
+        var dto = Session(id, buckets.Length == 0 ? new[] { ("typed", "desktop", 1L, 10L) } : buckets);
+        dto.CurrentModel = model;
+        dto.TokenTotals = new TokenTotalsDto
+        {
+            InputTokens = tokens.In,
+            OutputTokens = tokens.Out,
+            CacheReadTokens = tokens.CacheRead,
+            CacheCreationTokens = tokens.CacheCreation,
+            ContextTokens = tokens.In + tokens.CacheRead + tokens.CacheCreation,
+        };
+        return dto;
+    }
+
+    [Fact]
+    public void TokenSpend_FoldsTheIncrementOnly_NotTheRunningTotal()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        // Cumulative snapshots, like the wire delivers: 100 in / 50 out, then 130 / 70. Only the GROWTH
+        // folds - the same high-water discipline as turns and characters - so the store holds 130/70, not
+        // 100+130.
+        agg.Observe(SessionWithTokens("s-1", "claude-opus-4-8", (100, 50, 900, 40)));
+        agg.Observe(SessionWithTokens("s-1", "claude-opus-4-8", (130, 70, 1200, 55)));
+
+        var spend = agg.TokenSpend();
+        Assert.Equal(130, spend.InputTokens);
+        Assert.Equal(70, spend.OutputTokens);
+        Assert.Equal(1200, spend.CacheReadTokens);
+        Assert.Equal(55, spend.CacheCreationTokens);
+        Assert.Equal(130 + 70 + 1200 + 55, spend.TotalTokens);
+    }
+
+    [Fact]
+    public void TokenSpend_RepeatedIdenticalSnapshot_DoesNotDoubleCount()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        var s = SessionWithTokens("s-1", "claude-opus-4-8", (100, 50, 900, 40));
+        agg.Observe(s);
+        agg.Observe(s); // a periodic re-push of the same totals - must add nothing
+        agg.Observe(s);
+
+        Assert.Equal(100, agg.TokenSpend().InputTokens);
+        Assert.Equal(50, agg.TokenSpend().OutputTokens);
+    }
+
+    [Fact]
+    public void TokenSpend_DroppedSnapshot_CountsAsFreshSpend()
+    {
+        // A Director restarts the session with a fresh conversation: the reported totals DROP. The new
+        // conversation's spend is fresh from zero, added on top of what was already banked - never a negative.
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(SessionWithTokens("s-1", "claude-opus-4-8", (1000, 500, 9000, 400)));
+        agg.Observe(SessionWithTokens("s-1", "claude-opus-4-8", (120, 60, 1100, 45)));
+
+        var spend = agg.TokenSpend();
+        Assert.Equal(1120, spend.InputTokens);
+        Assert.Equal(560, spend.OutputTokens);
+    }
+
+    [Fact]
+    public void TokenSpend_AttributesToTheModelThatWasRunning_NullWhenUnrecorded()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(SessionWithTokens("s-1", "claude-opus-4-8", (100, 50, 900, 40)));
+        agg.Observe(SessionWithTokens("s-2", null, (200, 80, 1500, 60)));
+
+        var byModel = agg.TokenSpendByModel();
+        Assert.Equal(100, byModel.First(m => m.Model == "claude-opus-4-8").InputTokens);
+        // The null-model bucket is a REAL bucket - spend folded before the model was recorded - and must be
+        // present, never an empty-string model and never filtered out.
+        Assert.Equal(200, byModel.First(m => m.Model is null).InputTokens);
+        Assert.DoesNotContain(byModel, m => m.Model == "");
+    }
+
+    [Fact]
+    public void TokenSpendByModel_SumsToTheAllTimeTotal_IncludingTheNullBucket()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(SessionWithTokens("s-1", "claude-opus-4-8", (100, 50, 900, 40)));
+        agg.Observe(SessionWithTokens("s-2", null, (200, 80, 1500, 60)));
+
+        var total = agg.TokenSpend().TotalTokens;
+        var byModelSum = agg.TokenSpendByModel().Sum(m => m.TotalTokens);
+        Assert.Equal(total, byModelSum);
+    }
+
+    [Fact]
+    public void TokenSpend_SurvivesAGatewayRestart_WithoutDoubleCountingALiveSession()
+    {
+        using (var first = new GatewayInputStatsAggregator(_path))
+            first.Observe(SessionWithTokens("s-1", "claude-opus-4-8", (100, 50, 900, 40)));
+
+        // The restart rebuilds the token high-water FROM the database. Without it, the same still-live
+        // session re-pushing its snapshot would look like fresh spend and double the numbers.
+        using var reopened = new GatewayInputStatsAggregator(_path);
+        Assert.Equal(100, reopened.TokenSpend().InputTokens);
+
+        reopened.Observe(SessionWithTokens("s-1", "claude-opus-4-8", (100, 50, 900, 40)));
+        Assert.Equal(100, reopened.TokenSpend().InputTokens);
+
+        reopened.Observe(SessionWithTokens("s-1", "claude-opus-4-8", (130, 70, 1200, 55)));
+        Assert.Equal(130, reopened.TokenSpend().InputTokens);
+    }
+
+    [Fact]
+    public void TokenSpend_SessionWithoutTokenTotals_FoldsNothing()
+    {
+        // A driver that reports no token spend (no TokenUsage capability) leaves TokenTotals null. Its turns
+        // still count; its token spend is simply absent, not zero-stamped.
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(Session("s-1", ("typed", "desktop", 3, 30)));
+
+        Assert.Equal(0, agg.TokenSpend().TotalTokens);
+        Assert.Empty(agg.TokenSpendByModel());
+    }
+
+    [Fact]
+    public void TokenSpendByHour_LogsSpendPerHour_AndSumsToTheTotal()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        var h9 = new DateTime(2026, 7, 16, 9, 0, 0, DateTimeKind.Utc);
+        var h10 = new DateTime(2026, 7, 16, 10, 0, 0, DateTimeKind.Utc);
+
+        agg.Observe(SessionWithTokens("s-1", "claude-opus-4-8", (100, 50, 900, 40)), h9);
+        agg.Observe(SessionWithTokens("s-1", "claude-opus-4-8", (130, 70, 1200, 55)), h10); // +30/+20/... in h10
+
+        var hours = agg.TokenSpendByHour();
+        Assert.Equal(2, hours.Count);
+        Assert.Equal(100, hours.First(h => h.Hour == "2026-07-16T09").InputTokens);
+        Assert.Equal(30, hours.First(h => h.Hour == "2026-07-16T10").InputTokens);
+        Assert.Equal(agg.TokenSpend().TotalTokens, hours.Sum(h => h.TotalTokens));
+    }
+
+    [Fact]
+    public void TokenSpend_PruningOldRows_KeepsEveryModelsSpend()
+    {
+        // The ninety-day fold for tokens: token_delta archives by model_id, so a model's spend must survive
+        // pruning unchanged. Asserts the prune FIRED (the old hour leaves the hourly series) before asserting
+        // what it preserved, so an archive that never ran cannot pass this green.
+        var agg = new GatewayInputStatsAggregator(_path);
+        var old = new DateTime(2026, 1, 1, 9, 0, 0, DateTimeKind.Utc);
+        var now = old.AddDays(200);
+
+        agg.Observe(SessionWithTokens("old-1", "claude-opus-4-8", (500, 200, 4000, 150)), old);
+        agg.Observe(SessionWithTokens("old-2", null, (300, 90, 2000, 80)), old);
+        // A second poll of old-1 so the archive has two rows of one model to MERGE, not just copy.
+        agg.Observe(SessionWithTokens("old-1", "claude-opus-4-8", (900, 400, 7000, 250)), old);
+
+        var beforeInput = agg.TokenSpend().InputTokens;
+
+        agg.Observe(SessionWithTokens("new-1", "claude-sonnet-5", (10, 5, 90, 4)), now); // triggers prune
+
+        Assert.DoesNotContain(agg.TokenSpendByHour(), h => h.Hour == "2026-01-01T09");
+
+        var byModel = agg.TokenSpendByModel();
+        Assert.Equal(900, byModel.First(m => m.Model == "claude-opus-4-8").InputTokens);
+        Assert.Equal(300, byModel.First(m => m.Model is null).InputTokens);
+        Assert.Equal(10, byModel.First(m => m.Model == "claude-sonnet-5").InputTokens);
+        // The all-time total did not shrink because detail was pruned.
+        Assert.Equal(beforeInput + 10, agg.TokenSpend().InputTokens);
+    }
 }

--- a/src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs
@@ -72,6 +72,9 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         Assert.True(TableExists(db, "repo_identity"));
         Assert.True(TableExists(db, "agent_identity"));
         Assert.True(TableExists(db, "model_identity"));
+        // Token spend (issue #1637) - the delta lane and its per-session high-water.
+        Assert.True(TableExists(db, "token_delta"));
+        Assert.True(TableExists(db, "token_highwater"));
         // The agent-to-agent lane (issue #1636) - its OWN tables, so these turns cannot be summed
         // into the human voice-versus-typed totals by accident.
         Assert.True(TableExists(db, "agent_driven_delta"));
@@ -326,26 +329,71 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
     }
 
     [Fact]
-    public void Migrate_Version1File_UpgradesToVersion2AndKeepsEveryRow()
+    public void Migrate_Version1File_UpgradesToCurrentVersionAndKeepsEveryRow()
     {
         WriteVersion1Database(("2026-07-16T09", 40, 400), ("2026-07-16T10", 27, 270));
 
         using var db = new GatewayStatsDatabase(_path);
 
-        Assert.Equal(2, UserVersion(db));
+        // A version-1 file on disk migrates through EVERY step to the current version - the whole chain, not
+        // one hop. The owner's real database is version 1, so this is the path his numbers actually take.
+        Assert.Equal(GatewayStatsDatabase.SchemaVersion, UserVersion(db));
 
-        // The version stamp ALONE proves nothing, and this assertion is here because the first draft of
+        // The version stamp ALONE proves nothing, and these assertions are here because the first draft of
         // this test proved nothing: Migrate writes PRAGMA user_version unconditionally, after the steps, so
-        // a version 2 stamp appears whether or not the version 2 step ran. With MigrateToVersion2 disabled
-        // this test still passed, green and useless, exactly the "dead test that looks like coverage" this
-        // mission keeps finding. Reading back the column the step ADDS is what makes the name true.
-        Assert.Contains("model_id", ColumnsOf(db, "stat_delta"));
+        // the current-version stamp appears whether or not the steps ran. With a step disabled this test
+        // still passed, green and useless, exactly the "dead test that looks like coverage" this mission
+        // keeps finding. Reading back what each step ADDS is what makes the name true.
+        Assert.Contains("model_id", ColumnsOf(db, "stat_delta")); // version 2
+        Assert.True(TableExists(db, "token_delta"));              // version 3
+        Assert.True(TableExists(db, "token_highwater"));          // version 3
 
         // The numbers are the promise. A migration that loses turns is the failure this whole mission
         // exists to prevent, so it is asserted on the totals and not merely on the row count.
         Assert.Equal(2, ScalarLong(db, "SELECT COUNT(*) FROM stat_delta"));
         Assert.Equal(67, ScalarLong(db, "SELECT SUM(turns) FROM stat_delta"));
         Assert.Equal(670, ScalarLong(db, "SELECT SUM(chars) FROM stat_delta"));
+    }
+
+    [Fact]
+    public void Migrate_Version1File_AddsTheTokenDimensionEmpty()
+    {
+        // The token tables are created by the version 3 step and start EMPTY - there was no token history to
+        // carry across (nothing recorded tokens before this), so every number begins at the cutover, exactly
+        // like the model dimension. Not a bug that they are empty; the honest starting state.
+        WriteVersion1Database(("2026-07-16T09", 40, 400));
+
+        using var db = new GatewayStatsDatabase(_path);
+
+        Assert.True(TableExists(db, "token_delta"));
+        Assert.True(TableExists(db, "token_highwater"));
+        Assert.Equal(0, ScalarLong(db, "SELECT COUNT(*) FROM token_delta"));
+        Assert.Equal(0, ScalarLong(db, "SELECT COUNT(*) FROM token_highwater"));
+    }
+
+    [Fact]
+    public void TokenDelta_CarriesSpendScalarsAndModel_ButNeverContextOccupancy()
+    {
+        // The schema itself enforces spend-not-occupancy: the four columns are the cumulative, additive token
+        // counts plus the nullable model, and NOTHING else. A context-occupancy column here would be a gauge
+        // that lies the moment a SUM is taken over it, so its absence is the design. An exhaustive whitelist,
+        // not a forbidden-name list, so any new column fails here until stated deliberately.
+        using var db = new GatewayStatsDatabase(_path);
+
+        var columns = ColumnsOf(db, "token_delta");
+        var expected = new[]
+        {
+            "id", "hour_utc", "model_id",
+            "input_tokens", "output_tokens", "cache_read_tokens", "cache_creation_tokens",
+        };
+        Assert.Equal(expected.OrderBy(c => c, StringComparer.Ordinal),
+                     columns.OrderBy(c => c, StringComparer.Ordinal));
+
+        // No modality, no surface: tokens are the model's work, not the human's input channel.
+        Assert.DoesNotContain("modality", columns);
+        Assert.DoesNotContain("surface", columns);
+        // The one gauge on the wire must not have leaked into the summable table.
+        Assert.DoesNotContain("context_tokens", columns);
     }
 
     private static List<string> ColumnsOf(GatewayStatsDatabase db, string table)

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -54,6 +54,11 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     private readonly Dictionary<string, Counters> _agentDrivenHighWater = new(StringComparer.Ordinal);
     private readonly HashSet<string> _wingmanSessions = new(StringComparer.Ordinal);
 
+    // The last cumulative token spend seen per session (issue #1637), so only the INCREASE folds - the same
+    // high-water discipline as _highWater, one dimension over. A dropped count is a restart and folds fresh
+    // from zero.
+    private readonly Dictionary<string, TokenCounters> _tokenHighWater = new(StringComparer.Ordinal);
+
     // Sessions whose already-counted turns have been attributed to their agent (issue #1633). MUST persist:
     // session_highwater survives a restart, so without this the back-fill would run a second time against a
     // non-empty high-water and double every agent's numbers.
@@ -85,6 +90,16 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     {
         public long Turns { get; set; }
         public long Characters { get; set; }
+    }
+
+    /// <summary>The four CUMULATIVE, additive token spend counts a session carries. Context occupancy is not
+    /// here: it is a gauge, not spend, and never enters this arithmetic.</summary>
+    private sealed class TokenCounters
+    {
+        public long Input { get; set; }
+        public long Output { get; set; }
+        public long CacheRead { get; set; }
+        public long CacheCreation { get; set; }
     }
 
     /// <summary>
@@ -189,6 +204,11 @@ public sealed class GatewayInputStatsAggregator : IDisposable
             });
             Read("SELECT session_id, turns, chars FROM agent_driven_highwater",
                 r => _agentDrivenHighWater[r.GetString(0)] = new Counters { Turns = r.GetInt64(1), Characters = r.GetInt64(2) });
+            Read("SELECT session_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens FROM token_highwater",
+                r => _tokenHighWater[r.GetString(0)] = new TokenCounters
+                {
+                    Input = r.GetInt64(1), Output = r.GetInt64(2), CacheRead = r.GetInt64(3), CacheCreation = r.GetInt64(4),
+                });
             Read("SELECT session_id FROM wingman_session", r => _wingmanSessions.Add(r.GetString(0)));
             Read("SELECT session_id FROM agents_seeded", r => _agentsSeeded.Add(r.GetString(0)));
             Read("SELECT repo_id, repo_display FROM repo_identity", r =>
@@ -276,9 +296,15 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         public readonly List<(string Display, string SessionId, IdentityKind Kind)> NewIdentitySessions = new();
         public string? StampAgentsSince;
 
+        // Token spend (issue #1637). Model is nullable for the same reason it is on Rows: the spend
+        // attributes to the model the session was recorded running, which is null until its records name one.
+        public readonly List<(string Hour, string? Model, long Input, long Output, long CacheRead, long CacheCreation)> TokenRows = new();
+        public readonly List<(string SessionId, long Input, long Output, long CacheRead, long CacheCreation)> TokenHighWater = new();
+
         public bool IsEmpty => Rows.Count == 0 && AgentRows.Count == 0 && AgentDrivenRows.Count == 0
             && HighWater.Count == 0 && AgentDrivenHighWater.Count == 0 && NewWingmanSessions.Count == 0
             && NewSeeded.Count == 0 && NewIdentities.Count == 0 && NewIdentitySessions.Count == 0
+            && TokenRows.Count == 0 && TokenHighWater.Count == 0
             && StampAgentsSince is null;
     }
 
@@ -317,6 +343,12 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         // buckets guard, because a session driven only by other agents has no human buckets at all - and
         // those are exactly the sessions this tally is about.
         FoldAgentDrivenLocked(s, batch);
+
+        // Issue #1637: token spend, on its own lane. Folded BEFORE the buckets guard too, and for a reason
+        // that is not obvious: tokens grow at turn-END while the input buckets grow at turn SUBMISSION, so a
+        // poll can see this session's spend rise with no NEW bucket delta this interval (the turn was counted
+        // last poll). Gating the token fold on a bucket delta would drop exactly those increases.
+        FoldTokensLocked(s, batch);
 
         if (s.InputStats?.Buckets is null || s.InputStats.Buckets.Count == 0) return;
 
@@ -448,6 +480,49 @@ public sealed class GatewayInputStatsAggregator : IDisposable
             batch.NewIdentitySessions.Add((agentKey, s.SessionId, IdentityKind.Agent));
     }
 
+    // Fold this session's cumulative token spend (issue #1637) via the same high-water increment the human
+    // buckets use: store only the GROWTH since the last poll, and treat a DROP - a Director that restarted
+    // the session with a fresh conversation - as fresh spend from zero, never a negative. Attributed to the
+    // hour and to the model the session was recorded running, on token_delta's own lane. NO modality or
+    // surface: tokens are the model's work, not the human's input channel (see MigrateToVersion3).
+    private void FoldTokensLocked(SessionDto s, FoldBatch batch)
+    {
+        var t = s.TokenTotals;
+        if (t is null) return;
+
+        _tokenHighWater.TryGetValue(s.SessionId, out var prev);
+        var prevIn = prev?.Input ?? 0;
+        var prevOut = prev?.Output ?? 0;
+        var prevCacheR = prev?.CacheRead ?? 0;
+        var prevCacheC = prev?.CacheCreation ?? 0;
+
+        // Per-scalar reset test, exactly as the turns/characters fold: a value below the last seen is a fresh
+        // conversation counting from zero, so the whole current value is new spend. All four are running sums
+        // over the same transcript, so on a real restart they drop together; testing each independently is
+        // simply the same safe rule applied per column.
+        var dIn = t.InputTokens >= prevIn ? t.InputTokens - prevIn : t.InputTokens;
+        var dOut = t.OutputTokens >= prevOut ? t.OutputTokens - prevOut : t.OutputTokens;
+        var dCacheR = t.CacheReadTokens >= prevCacheR ? t.CacheReadTokens - prevCacheR : t.CacheReadTokens;
+        var dCacheC = t.CacheCreationTokens >= prevCacheC ? t.CacheCreationTokens - prevCacheC : t.CacheCreationTokens;
+
+        // Advance the high-water whenever the reported totals moved, even if nothing is folded this poll -
+        // but only queue the upsert when they actually changed, so an idle re-poll of a steady session writes
+        // nothing (the same idle-poll silence the other high-waters protect).
+        if (prev is null || prev.Input != t.InputTokens || prev.Output != t.OutputTokens
+            || prev.CacheRead != t.CacheReadTokens || prev.CacheCreation != t.CacheCreationTokens)
+            batch.TokenHighWater.Add((s.SessionId, t.InputTokens, t.OutputTokens, t.CacheReadTokens, t.CacheCreationTokens));
+
+        if (dIn <= 0 && dOut <= 0 && dCacheR <= 0 && dCacheC <= 0) return;
+
+        // Attribute to the model the session was RECORDED running, null until its records name one - the same
+        // records-only nullability as stat_delta.model_id. Only a named model earns an identity row.
+        var modelKey = string.IsNullOrWhiteSpace(s.CurrentModel) ? null : s.CurrentModel;
+        if (modelKey is not null)
+            NeedIdentity(modelKey, IdentityKind.Model, batch);
+
+        batch.TokenRows.Add((batch.HourKey, modelKey, dIn, dOut, dCacheR, dCacheC));
+    }
+
     private void NeedIdentity(string display, IdentityKind kind, FoldBatch batch)
     {
         if (IdsFor(kind).ContainsKey(display)) return;
@@ -531,6 +606,18 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                       ON CONFLICT(session_id) DO UPDATE SET turns=$t, chars=$c", tx,
                 ("$s", h.SessionId), ("$t", h.Turns), ("$c", h.Chars));
 
+        foreach (var r in batch.TokenRows)
+            Execute(@"INSERT INTO token_delta(hour_utc, model_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
+                      VALUES ($h, $d, $i, $o, $cr, $cc)", tx,
+                ("$h", r.Hour), ("$d", ResolveModel(r.Model)),
+                ("$i", r.Input), ("$o", r.Output), ("$cr", r.CacheRead), ("$cc", r.CacheCreation));
+
+        foreach (var h in batch.TokenHighWater)
+            Execute(@"INSERT INTO token_highwater(session_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
+                      VALUES ($s, $i, $o, $cr, $cc)
+                      ON CONFLICT(session_id) DO UPDATE SET input_tokens=$i, output_tokens=$o, cache_read_tokens=$cr, cache_creation_tokens=$cc", tx,
+                ("$s", h.SessionId), ("$i", h.Input), ("$o", h.Output), ("$cr", h.CacheRead), ("$cc", h.CacheCreation));
+
         foreach (var sid in batch.NewWingmanSessions)
             Execute("INSERT OR IGNORE INTO wingman_session(session_id) VALUES ($s)", tx, ("$s", sid));
 
@@ -550,7 +637,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                 ("$i", Resolve(display, kind)), ("$s", sessionId));
         }
 
-        if (batch.Rows.Count > 0) PruneLocked(batch.NowUtc, tx);
+        if (batch.Rows.Count > 0 || batch.TokenRows.Count > 0) PruneLocked(batch.NowUtc, tx);
 
         tx.Commit();
 
@@ -569,6 +656,11 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         }
         foreach (var h in batch.AgentDrivenHighWater)
             _agentDrivenHighWater[h.SessionId] = new Counters { Turns = h.Turns, Characters = h.Chars };
+        foreach (var h in batch.TokenHighWater)
+            _tokenHighWater[h.SessionId] = new TokenCounters
+            {
+                Input = h.Input, Output = h.Output, CacheRead = h.CacheRead, CacheCreation = h.CacheCreation,
+            };
         foreach (var sid in batch.NewWingmanSessions) _wingmanSessions.Add(sid);
         foreach (var sid in batch.NewSeeded) _agentsSeeded.Add(sid);
         foreach (var (display, sessionId, kind) in batch.NewIdentitySessions)
@@ -584,9 +676,13 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         if (string.IsNullOrEmpty(sessionId)) return;
         lock (_lock)
         {
-            if (!_highWater.ContainsKey(sessionId)) return;
-            Execute("DELETE FROM session_highwater WHERE session_id=$s", null, ("$s", sessionId));
-            _highWater.Remove(sessionId);
+            // The token high-water is cleaned up on its own, not under the session_highwater guard: a session
+            // has both, and dropping only one would leave the other's map growing without bound. Each is
+            // removed only if present, so forgetting a session that never spent a token is still a no-op.
+            if (_highWater.Remove(sessionId))
+                Execute("DELETE FROM session_highwater WHERE session_id=$s", null, ("$s", sessionId));
+            if (_tokenHighWater.Remove(sessionId))
+                Execute("DELETE FROM token_highwater WHERE session_id=$s", null, ("$s", sessionId));
         }
     }
 
@@ -616,6 +712,19 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                    GROUP BY modality, surface, is_voice, repo_id, model_id, wingman", tx,
             ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
         Execute("DELETE FROM stat_delta WHERE hour_utc <> $marker AND hour_utc < $cutoff", tx,
+            ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
+
+        // token_delta prunes on the SAME rule and the same care: its one dimension, model_id, is carried in
+        // both the SELECT and the GROUP BY, or the ninety-day fold turns every archived model's spend into
+        // "model unknown". Its all-time totals INCLUDE archive rows (that is the point of archiving), so the
+        // spend must not shrink when detail is pruned.
+        Execute(@"INSERT INTO token_delta(hour_utc, model_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
+                  SELECT $marker, model_id, SUM(input_tokens), SUM(output_tokens), SUM(cache_read_tokens), SUM(cache_creation_tokens)
+                    FROM token_delta
+                   WHERE hour_utc <> $marker AND hour_utc < $cutoff
+                   GROUP BY model_id", tx,
+            ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
+        Execute("DELETE FROM token_delta WHERE hour_utc <> $marker AND hour_utc < $cutoff", tx,
             ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
     }
 
@@ -881,6 +990,96 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         }
     }
 
+    /// <summary>
+    /// All-time token spend (issue #1637): the running sums of input, output, cache-read and cache-creation
+    /// tokens across the whole record. INCLUDES archive rows - the same reason the model tally does: an
+    /// all-time figure that dropped them would shrink as history is pruned. No context occupancy here; it is
+    /// not spend and was never stored.
+    /// </summary>
+    public TokenSpendDto TokenSpend()
+    {
+        lock (_lock)
+        {
+            var dto = new TokenSpendDto();
+            Read(@"SELECT COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
+                          COALESCE(SUM(cache_read_tokens),0), COALESCE(SUM(cache_creation_tokens),0)
+                     FROM token_delta", r =>
+            {
+                dto.InputTokens = r.GetInt64(0);
+                dto.OutputTokens = r.GetInt64(1);
+                dto.CacheReadTokens = r.GetInt64(2);
+                dto.CacheCreationTokens = r.GetInt64(3);
+            });
+            return dto;
+        }
+    }
+
+    /// <summary>
+    /// Token spend per UTC hour (issue #1637), for the working-day "what did I spend" series. EXCLUDES the
+    /// archive marker, exactly as the hourly turn series does: an archive row is not a real hour and would
+    /// grow a phantom bucket. Ordered by hour.
+    /// </summary>
+    public IReadOnlyList<TokenHourDto> TokenSpendByHour()
+    {
+        lock (_lock)
+        {
+            var list = new List<TokenHourDto>();
+            Read(@"SELECT hour_utc,
+                          COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
+                          COALESCE(SUM(cache_read_tokens),0), COALESCE(SUM(cache_creation_tokens),0)
+                     FROM token_delta
+                    WHERE hour_utc <> $marker
+                    GROUP BY hour_utc", r => list.Add(new TokenHourDto
+            {
+                Hour = r.GetString(0),
+                InputTokens = r.GetInt64(1),
+                OutputTokens = r.GetInt64(2),
+                CacheReadTokens = r.GetInt64(3),
+                CacheCreationTokens = r.GetInt64(4),
+            }), ("$marker", GatewayStatsDatabase.ArchiveMarker));
+            list.Sort((a, b) => string.CompareOrdinal(a.Hour, b.Hour));
+            return list;
+        }
+    }
+
+    /// <summary>
+    /// Token spend per model (issue #1637), ranked most-spent first, for "which model cost what". INCLUDES
+    /// archive rows. The null-model bucket is a REAL bucket - spend folded before the session's model was
+    /// recorded - and is reported, not filtered, so the per-model spend sums to the all-time total.
+    /// </summary>
+    public IReadOnlyList<ModelSpendDto> TokenSpendByModel()
+    {
+        lock (_lock)
+        {
+            var list = new List<ModelSpendDto>();
+            Read(@"SELECT model_id,
+                          COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
+                          COALESCE(SUM(cache_read_tokens),0), COALESCE(SUM(cache_creation_tokens),0)
+                     FROM token_delta GROUP BY model_id", r =>
+            {
+                // A null model_id is the "not recorded" bucket and stays null to the page; the display
+                // spelling comes from the identity mirror, never a SQL join over the string.
+                string? display = r.IsDBNull(0)
+                    ? null
+                    : (_modelDisplay.TryGetValue(r.GetInt64(0), out var d) ? d : "");
+                list.Add(new ModelSpendDto
+                {
+                    Model = display,
+                    InputTokens = r.GetInt64(1),
+                    OutputTokens = r.GetInt64(2),
+                    CacheReadTokens = r.GetInt64(3),
+                    CacheCreationTokens = r.GetInt64(4),
+                });
+            });
+            list.Sort((a, b) =>
+            {
+                var byTotal = b.TotalTokens.CompareTo(a.TotalTokens);
+                return byTotal != 0 ? byTotal : string.CompareOrdinal(a.Model ?? "", b.Model ?? "");
+            });
+            return list;
+        }
+    }
+
     // An explicit map, not a PascalCase splitter: "OpenCode" is the product's own spelling and must not
     // become "Open Code". An unrecognised token is shown verbatim - it is a real value we simply do not have
     // a nicer name for, so showing it is honest where hiding it behind "Other" would not be.
@@ -1009,6 +1208,49 @@ public sealed class ModelStatBucketDto
     public long VoiceTurns { get; set; }
     public long TypedTurns { get; set; }
     public long Characters { get; set; }
+}
+
+/// <summary>All-time token spend (issue #1637): the four cumulative, additive counts. No context occupancy -
+/// that is a gauge, not spend, and is never summed.</summary>
+public sealed class TokenSpendDto
+{
+    public long InputTokens { get; set; }
+    public long OutputTokens { get; set; }
+    public long CacheReadTokens { get; set; }
+    public long CacheCreationTokens { get; set; }
+
+    /// <summary>Every token the work cost, cached or not - the single "how much did I spend" figure.</summary>
+    public long TotalTokens => InputTokens + OutputTokens + CacheReadTokens + CacheCreationTokens;
+}
+
+/// <summary>Token spend in one UTC hour (issue #1637), for the working-day series.</summary>
+public sealed class TokenHourDto
+{
+    /// <summary>The hour key, "yyyy-MM-ddTHH".</summary>
+    public string Hour { get; set; } = "";
+
+    public long InputTokens { get; set; }
+    public long OutputTokens { get; set; }
+    public long CacheReadTokens { get; set; }
+    public long CacheCreationTokens { get; set; }
+
+    public long TotalTokens => InputTokens + OutputTokens + CacheReadTokens + CacheCreationTokens;
+}
+
+/// <summary>One model's all-time token spend (issue #1637), for "which model cost what". The null-model
+/// bucket is a real answer - spend folded before the session's model was recorded - not an omission.</summary>
+public sealed class ModelSpendDto
+{
+    /// <summary>The model the owning Director recorded, or null for spend folded when no model had been
+    /// recorded. Never an empty string: absence is null.</summary>
+    public string? Model { get; set; }
+
+    public long InputTokens { get; set; }
+    public long OutputTokens { get; set; }
+    public long CacheReadTokens { get; set; }
+    public long CacheCreationTokens { get; set; }
+
+    public long TotalTokens => InputTokens + OutputTokens + CacheReadTokens + CacheCreationTokens;
 }
 
 /// <summary>One agent CLI's all-time input tally for the private Agents page.</summary>

--- a/src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs
@@ -35,7 +35,7 @@ public sealed class GatewayStatsDatabase : IDisposable
 {
     /// <summary>The schema version this build understands. Bump it and add a migration step; never reshape
     /// an existing table in place without one.</summary>
-    public const int SchemaVersion = 2;
+    public const int SchemaVersion = 3;
 
     /// <summary>The meta key holding when the model dimension started recording - an ISO-8601 UTC stamp
     /// written once, by the migration that added the dimension. See <see cref="MigrateToVersion2"/> for why
@@ -128,6 +128,9 @@ public sealed class GatewayStatsDatabase : IDisposable
 
         if (current < 2)
             MigrateToVersion2(tx);
+
+        if (current < 3)
+            MigrateToVersion3(tx);
 
         Execute($"PRAGMA user_version={SchemaVersion}", tx);
         tx.Commit();
@@ -401,6 +404,61 @@ public sealed class GatewayStatsDatabase : IDisposable
         Execute("INSERT OR IGNORE INTO meta(name, value) VALUES ($n, $v)", tx,
             ("$n", ModelsSinceKey),
             ("$v", DateTime.UtcNow.ToString("o", System.Globalization.CultureInfo.InvariantCulture)));
+    }
+
+    // Version 3: the token dimension - how many tokens the work actually cost.
+    //
+    // SPEND, NOT OCCUPANCY, ENFORCED BY THE SCHEMA. Four columns and every one is a cumulative, additive
+    // count: input, output, cache-read and cache-creation tokens. Context-window occupancy is deliberately
+    // absent - it is a gauge (how full the window is at a point in time), it goes up AND down, and summing
+    // it is meaningless. The wire carries it (SessionDto.TokenTotals.ContextTokens) for the live gauge, but
+    // it MUST NOT enter a delta table where a SUM would be taken, so it is not here. A future hand tempted
+    // to "just add context too" would be adding a number that lies the moment it is aggregated.
+    //
+    // No modality and no surface, unlike stat_delta. Tokens are the model's WORK, not the human's input
+    // channel: a turn costs the same tokens whether the human typed it or spoke it, and the token total
+    // arrives per session as one cumulative figure that cannot be split across voice/typed buckets. Adding
+    // those columns would advertise a division the data cannot make - the agent_id-on-stat_delta mistake in
+    // a new shape.
+    //
+    // model_id is carried and NULLABLE, exactly as on stat_delta and for the same reason: the spend
+    // attributes to the model the session was RECORDED running at fold time, and that is null until the
+    // agent's records name one. Unlike stat_delta, a token row's null model has ONLY ONE meaning - "not
+    // recorded yet" - because every token row is written after this migration, so none can predate the model
+    // dimension (version 2, already applied by the time this runs). No since-stamp is needed to read it.
+    private void MigrateToVersion3(SqliteTransaction tx)
+    {
+        // One row per observed token increase, attributed to the hour and the session's current model. High-
+        // watered per session (see token_highwater) so only the GROWTH since the last poll is folded, never
+        // the running total - the same increment discipline as stat_delta's turns and characters.
+        Execute(@"
+            CREATE TABLE IF NOT EXISTS token_delta (
+                id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+                hour_utc              TEXT    NOT NULL,
+                model_id              INTEGER,
+                input_tokens          INTEGER NOT NULL,
+                output_tokens         INTEGER NOT NULL,
+                cache_read_tokens     INTEGER NOT NULL,
+                cache_creation_tokens INTEGER NOT NULL
+            )", tx);
+        Execute("CREATE INDEX IF NOT EXISTS ix_token_delta_hour ON token_delta(hour_utc)", tx);
+
+        // The last cumulative token counts seen for each live session, so only the INCREASE folds. Mirrors
+        // session_highwater exactly: a reported count that DROPPED (a Director restarted the session with a
+        // fresh conversation) is fresh spend from zero, not a negative. Cleared for one session by Forget.
+        //
+        // All four counts are running sums over the whole transcript (SessionUsageDto sums them across every
+        // assistant line), so they only grow within one conversation - which is what makes the high-water
+        // increment correct. Context occupancy is NOT here: it is not cumulative and high-watering it would
+        // be meaningless.
+        Execute(@"
+            CREATE TABLE IF NOT EXISTS token_highwater (
+                session_id            TEXT    PRIMARY KEY,
+                input_tokens          INTEGER NOT NULL,
+                output_tokens         INTEGER NOT NULL,
+                cache_read_tokens     INTEGER NOT NULL,
+                cache_creation_tokens INTEGER NOT NULL
+            )", tx);
     }
 
     private int QueryUserVersion()

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -74,6 +74,14 @@ public static class StatsPageEndpoint
                 // "the agent had not recorded one yet" bucket, not a missing value to hide.
                 models = aggregator.ModelTotals(),
                 modelsSinceUtc = aggregator.ModelsSinceUtc,
+                // DevThrottle Stats (issue #1637): TOKEN SPEND - what the work actually cost. Three views of
+                // one number: the all-time total, the per-hour series for "what did I spend today / this
+                // week / this month", and the per-model split for "which model cost what". Cumulative,
+                // additive tokens only (input / output / cache) - never context-window occupancy, which is a
+                // gauge and cannot be summed. Claude-only until other agents' drivers report cumulative spend.
+                tokenSpend = aggregator.TokenSpend(),
+                tokenSpendByHour = aggregator.TokenSpendByHour(),
+                tokenSpendByModel = aggregator.TokenSpendByModel(),
                 // DevThrottle Stats (issue #1636): turns the fleet drove into ITSELF - one agent prompting
                 // another. Reported alongside the human tally but never inside it: "how do you drive" and
                 // "how much does the fleet drive itself" are different questions, and the ratio between


### PR DESCRIPTION
The wire delivers each session's cumulative token spend; this folds it into storage so the governance view can answer **"what did I spend today, this week, this month, and on which model."** Schema version 3 - the second real migration, and the owner's version-1 database now climbs the whole chain to 3 and keeps every row.

## Its own lane, not a column on stat_delta

Tokens are the model's **work**, not the human's input channel: a turn costs the same tokens whether typed or spoken, and a session's spend arrives as one cumulative figure that cannot be split across voice/typed buckets. Forcing it into `stat_delta`'s `(modality, surface)` key would advertise a division the data cannot make - the `agent_id` mistake in a new shape.

So `token_delta` carries hour, the model, and the four spend scalars; `token_highwater` holds the per-session running totals so only the **growth** folds, treating a drop as a restart counting fresh from zero - exactly as turns and characters do.

## Spend, not occupancy - enforced by the schema

Four columns, every one a cumulative additive count: input, output, cache-read, cache-creation. Context-window occupancy is **deliberately absent** - it is a gauge that goes up and down and lies the moment a `SUM` is taken over it. The wire still carries it for the live display; it just never enters a table where it would be summed.

`model_id` is nullable for the same records-only reason it is on `stat_delta`, and its null has only one meaning here: every token row is written after this migration, so none can predate the model dimension - a null is always "the session's model was not recorded yet."

## Why it folds before the buckets guard

Tokens grow at turn-**end** while the input buckets grow at turn **submission**, so a poll can see spend rise with no new bucket delta this interval. Gating tokens on a bucket delta would drop exactly those increases. The prune trigger was widened to fire on token growth too, so token-only activity still ages out old detail.

`/stats/data` serves three views of the one number: the all-time total, the per-hour series, and the per-model split. The null-model bucket is reported, not filtered, so per-model spend sums to the total.

## Proof

- All seven test projects green (Gateway 2510), rebased onto the v1.4.0 release (no file overlap).
- **Watched failing**: the version 3 step disabled, the increment folded as a running total, and `model_id` dropped from the token archive.
- One unrelated test failed once on the first post-rebase run and did **not** reproduce across a clean re-run plus five repeats of the token tests - consistent with the pre-existing intermittent failure noted in the mission handover, not this change. The token tests are deterministic.
- Independently reviewed before merge (`docs/architecture/review-token-column-2026-07-16.md`), which separately checked the diff for a non-deterministic write and found none.