### PR TITLE
Governance screens: what you have spent, by day, week, and month

### DIFF
--- a/src/CcDirector.Gateway.Tests/StatsPageEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/StatsPageEndpointTests.cs
@@ -87,6 +87,16 @@ public sealed class StatsPageEndpointTests : IDisposable
             Assert.Contains("data-period=\"month\"", html);
             Assert.Contains("Spend by model", html);
             Assert.Contains("modelSpendTable", html);
+
+            // SOURCE TRIPWIRE, not behavioral coverage - and named as such because this repo has no
+            // JavaScript execution harness, so a C# HTTP test cannot run the page's rendering. The model
+            // name is records-derived free text; a Codex review found it was concatenated into innerHTML,
+            // which would parse markup from a model string as HTML in the Gateway's own origin. The fix
+            // routes every cell through a textContent builder (trow). The BEHAVIOURAL proof that a hostile
+            // model name renders as inert text is the Playwright before/after check run at review time; this
+            // assertion only trips the obvious verbatim revert - it does not claim to prove escaping.
+            Assert.Contains("function trow(", html);          // the safe textContent row builder exists
+            Assert.DoesNotContain("\"<td>\" + name", html);   // the exact vulnerable concatenation is gone
             // Self-contained: no external resource references.
             Assert.DoesNotContain("http://", html);
             Assert.DoesNotContain("https://", html);

--- a/src/CcDirector.Gateway.Tests/StatsPageEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/StatsPageEndpointTests.cs
@@ -78,6 +78,15 @@ public sealed class StatsPageEndpointTests : IDisposable
             var html = await resp.Content.ReadAsStringAsync();
             Assert.Contains("Your Throttle", html); // private per-person view name (owner decision)
             Assert.Contains("/stats/data", html); // the page fetches its own data endpoint
+            // The governance views (issue #1637): the spend headline, the day/week/month activity rollup with
+            // its toggle, and the per-model spend table. A guard so a future edit cannot quietly drop the
+            // "what did I spend" surface the mission exists to deliver.
+            Assert.Contains("What you have spent", html);
+            Assert.Contains("tokenTotal", html);
+            Assert.Contains("periodToggle", html);
+            Assert.Contains("data-period=\"month\"", html);
+            Assert.Contains("Spend by model", html);
+            Assert.Contains("modelSpendTable", html);
             // Self-contained: no external resource references.
             Assert.DoesNotContain("http://", html);
             Assert.DoesNotContain("https://", html);

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -303,6 +303,22 @@ public static class StatsPageEndpoint
   // How many recent periods to show, by grain. Enough to see a trend without an endless table.
   var PERIOD_LIMIT = { day: 14, week: 8, month: 6 };
 
+  // Build a <tr> from cells using textContent, never innerHTML. cells = [{ t: text, num: bool }]. This is the
+  // ONLY way an untrusted value reaches these tables: the model name is records-derived free text taken from
+  // the agent's own transcript, so composing it into an HTML string would let a model string containing
+  // markup parse as HTML in the Gateway's own origin. textContent makes that impossible by construction -
+  // the same discipline the page's row() helper already uses for the bar rows above.
+  function trow(cells) {
+    var tr = document.createElement("tr");
+    cells.forEach(function (c) {
+      var td = document.createElement("td");
+      if (c.num) td.className = "num";
+      td.textContent = c.t;
+      tr.appendChild(td);
+    });
+    return tr;
+  }
+
   function sumBy(buckets, field, keyName, keyVal) {
     var t = 0;
     for (var i = 0; i < buckets.length; i++) {
@@ -440,10 +456,7 @@ public static class StatsPageEndpoint
       return;
     }
     keys.forEach(function (k) {
-      var tr = document.createElement("tr");
-      tr.innerHTML = "<td>" + label(k) + "</td><td class='num'>" + fmt(acc[k].turns) +
-        "</td><td class='num'>" + fmt(acc[k].tokens) + "</td>";
-      tb.appendChild(tr);
+      tb.appendChild(trow([{ t: label(k) }, { t: fmt(acc[k].turns), num: true }, { t: fmt(acc[k].tokens), num: true }]));
     });
   }
 
@@ -457,12 +470,11 @@ public static class StatsPageEndpoint
     }
     rows.forEach(function (r) {
       // A null model is the honest "not recorded yet" bucket - the first turn of every session folds before
-      // its model is known - shown as such, never hidden and never an empty name.
+      // its model is known - shown as such, never hidden and never an empty name. The name is UNTRUSTED
+      // free text and reaches the DOM only through trow's textContent, so markup in it renders as literal
+      // characters, never as HTML.
       var name = r.model ? r.model : "Not recorded";
-      var tr = document.createElement("tr");
-      tr.innerHTML = "<td>" + name + "</td><td class='num'>" + fmt(r.totalTokens) +
-        "</td><td class='num'>" + pct(r.totalTokens, grand) + "%</td>";
-      tb.appendChild(tr);
+      tb.appendChild(trow([{ t: name }, { t: fmt(r.totalTokens), num: true }, { t: pct(r.totalTokens, grand) + "%", num: true }]));
     });
   }
 

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -157,6 +157,13 @@ public static class StatsPageEndpoint
   .empty { color: var(--muted); font-size: 14px; padding: 8px 0; }
   .foot { color: var(--muted); font-size: 12px; margin-top: 18px; }
   .err { color: #c0392b; }
+  .toggle { display: inline-flex; border: 1px solid var(--line); border-radius: 8px;
+    overflow: hidden; margin-bottom: 14px; }
+  .toggle button { border: 0; background: var(--card); color: var(--muted); font: inherit;
+    font-size: 13px; padding: 6px 14px; cursor: pointer; border-right: 1px solid var(--line); }
+  .toggle button:last-child { border-right: 0; }
+  .toggle button.on { background: var(--voice); color: #fff; }
+  .lede { color: var(--muted); font-size: 12.5px; margin: -4px 0 12px; }
 </style>
 </head>
 <body>
@@ -197,6 +204,45 @@ public static class StatsPageEndpoint
     </table>
   </div>
 
+  <div class="section" id="spendSection">
+    <h2>What you have spent</h2>
+    <div class="cards">
+      <div class="card headline">
+        <div class="big" id="tokenTotal">-</div>
+        <div class="lbl">tokens spent</div>
+        <div class="of" id="tokenBreakdown"></div>
+      </div>
+      <div class="card headline">
+        <div class="big" id="turnTotal">-</div>
+        <div class="lbl">turns submitted, all time</div>
+        <div class="of" id="turnChars"></div>
+      </div>
+    </div>
+    <p class="lede" id="spendNote"></p>
+  </div>
+
+  <div class="section">
+    <h2>Your activity</h2>
+    <div class="toggle" id="periodToggle">
+      <button type="button" data-period="day" class="on">By day</button>
+      <button type="button" data-period="week">By week</button>
+      <button type="button" data-period="month">By month</button>
+    </div>
+    <p class="lede" id="activityLede">Turns and token spend, grouped by your local calendar. Most recent first.</p>
+    <table>
+      <thead><tr><th id="periodHead">Day</th><th class="num">Turns</th><th class="num">Tokens</th></tr></thead>
+      <tbody id="activityTable"></tbody>
+    </table>
+  </div>
+
+  <div class="section">
+    <h2>Spend by model</h2>
+    <table>
+      <thead><tr><th>Model</th><th class="num">Tokens</th><th class="num">Share</th></tr></thead>
+      <tbody id="modelSpendTable"></tbody>
+    </table>
+  </div>
+
   <div class="notes section">
     <h2>What is counted, and what is not-captured</h2>
     <ul id="notCaptured"></ul>
@@ -211,6 +257,51 @@ public static class StatsPageEndpoint
 
   function pct(part, whole) { return whole > 0 ? Math.round((part / whole) * 100) : 0; }
   function fmt(n) { return (n || 0).toLocaleString(); }
+
+  // Compact form for the big token numbers, which run to millions: 1234567 -> "1.2M". The exact figure is
+  // always available in the by-model and by-period tables below, so the headline trades precision for a
+  // number the eye can read at a glance.
+  function fmtCompact(n) {
+    n = n || 0;
+    if (n >= 1e9) return (n / 1e9).toFixed(1).replace(/\.0$/, "") + "B";
+    if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
+    if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "K";
+    return String(n);
+  }
+
+  // The local calendar date ("YYYY-MM-DD") of a UTC hour key, in the Gateway's configured display zone. The
+  // stored hour keys are UTC ("yyyy-MM-ddTHH"); grouping by the OWNER'S local day/week/month is what makes
+  // "what did I do today" mean his today, not UTC's. en-CA formats as YYYY-MM-DD, which sorts correctly as a
+  // string. A bad/blank zone falls back to the browser's own, never throws.
+  function localYmd(hourUtc, tz) {
+    var d = new Date(hourUtc + ":00:00Z");
+    try {
+      var f = new Intl.DateTimeFormat("en-CA", { timeZone: tz || undefined, year: "numeric", month: "2-digit", day: "2-digit" });
+      var p = {}; f.formatToParts(d).forEach(function (x) { p[x.type] = x.value; });
+      return p.year + "-" + p.month + "-" + p.day;
+    } catch (e) {
+      return d.getFullYear() + "-" + String(d.getMonth() + 1).padStart(2, "0") + "-" + String(d.getDate()).padStart(2, "0");
+    }
+  }
+
+  // Monday-of-the-week for a local YYYY-MM-DD, as YYYY-MM-DD. Computed from the calendar date alone (parsed
+  // as a plain local date), so it never depends on the hour or the zone offset - the date was already
+  // resolved to the owner's zone by localYmd.
+  function weekStart(ymd) {
+    var parts = ymd.split("-");
+    var d = new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]));
+    var dow = (d.getDay() + 6) % 7; // Monday = 0
+    d.setDate(d.getDate() - dow);
+    return d.getFullYear() + "-" + String(d.getMonth() + 1).padStart(2, "0") + "-" + String(d.getDate()).padStart(2, "0");
+  }
+
+  var MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  function labelDay(ymd) { var p = ymd.split("-"); return MONTHS[Number(p[1]) - 1] + " " + Number(p[2]) + ", " + p[0]; }
+  function labelWeek(ymd) { var p = ymd.split("-"); return "Week of " + MONTHS[Number(p[1]) - 1] + " " + Number(p[2]); }
+  function labelMonth(ym) { var p = ym.split("-"); return MONTHS[Number(p[1]) - 1] + " " + p[0]; }
+
+  // How many recent periods to show, by grain. Enough to see a trend without an endless table.
+  var PERIOD_LIMIT = { day: 14, week: 8, month: 6 };
 
   function sumBy(buckets, field, keyName, keyVal) {
     var t = 0;
@@ -283,6 +374,10 @@ public static class StatsPageEndpoint
       });
     }
 
+    renderSpend(data, turns);
+    renderActivity(data);
+    renderModelSpend(data);
+
     var nc = document.getElementById("notCaptured"); nc.innerHTML = "";
     (data.notCaptured || []).forEach(function (m) {
       var li = document.createElement("li"); li.textContent = m; nc.appendChild(li);
@@ -292,12 +387,104 @@ public static class StatsPageEndpoint
     document.getElementById("foot").textContent = "Updated " + when + " - refreshes every few seconds. Counts only; no message text ever leaves your machine for this page.";
   }
 
+  function renderSpend(data, turns) {
+    var spend = data.tokenSpend || {};
+    var totalTokens = spend.totalTokens || 0;
+    document.getElementById("tokenTotal").textContent = totalTokens > 0 ? fmtCompact(totalTokens) : "--";
+    document.getElementById("tokenBreakdown").textContent = totalTokens > 0
+      ? (fmt(spend.inputTokens) + " in / " + fmt(spend.outputTokens) + " out / "
+         + fmt((spend.cacheReadTokens || 0) + (spend.cacheCreationTokens || 0)) + " cache")
+      : "";
+
+    var chars = total(data.buckets || [], "characters");
+    document.getElementById("turnTotal").textContent = turns > 0 ? fmt(turns) : "--";
+    document.getElementById("turnChars").textContent = turns > 0 ? fmt(chars) + " characters" : "";
+
+    // Say plainly that spend is Claude-only today, so a small number is read as "only Claude reports it yet",
+    // never as "I barely spent anything". Honesty caveat, same spirit as the not-captured notes.
+    document.getElementById("spendNote").textContent = totalTokens > 0
+      ? "Token spend is recorded for agents that report it from their own records - Claude today. Other agents show no spend until their drivers report it."
+      : "No token spend recorded yet. It appears once an agent that reports its usage - Claude today - finishes a turn.";
+  }
+
+  // Roll the per-hour turn and token series into the owner's local day / week / month buckets, newest first.
+  function renderActivity(data) {
+    var tz = data.timeZone;
+    var hoursTurns = data.hourlyTurns || [];
+    var hoursTokens = data.tokenSpendByHour || [];
+    var period = PERIOD;
+
+    var keyOf = period === "month"
+      ? function (ymd) { return ymd.slice(0, 7); }
+      : period === "week"
+        ? function (ymd) { return weekStart(ymd); }
+        : function (ymd) { return ymd; };
+
+    var acc = {}; // key -> { turns, tokens }
+    function bump(hourUtc, field, value) {
+      if (!value) return;
+      var key = keyOf(localYmd(hourUtc, tz));
+      if (!acc[key]) acc[key] = { turns: 0, tokens: 0 };
+      acc[key][field] += value;
+    }
+    hoursTurns.forEach(function (h) { bump(h.hour, "turns", h.turns || 0); });
+    hoursTokens.forEach(function (h) { bump(h.hour, "tokens", h.totalTokens || 0); });
+
+    var label = period === "month" ? labelMonth : period === "week" ? labelWeek : labelDay;
+    document.getElementById("periodHead").textContent = period.charAt(0).toUpperCase() + period.slice(1);
+
+    var keys = Object.keys(acc).sort().reverse().slice(0, PERIOD_LIMIT[period]);
+    var tb = document.getElementById("activityTable"); tb.innerHTML = "";
+    if (keys.length === 0) {
+      tb.innerHTML = '<tr><td colspan="3" class="empty">Nothing recorded in the retained window yet.</td></tr>';
+      return;
+    }
+    keys.forEach(function (k) {
+      var tr = document.createElement("tr");
+      tr.innerHTML = "<td>" + label(k) + "</td><td class='num'>" + fmt(acc[k].turns) +
+        "</td><td class='num'>" + fmt(acc[k].tokens) + "</td>";
+      tb.appendChild(tr);
+    });
+  }
+
+  function renderModelSpend(data) {
+    var rows = data.tokenSpendByModel || [];
+    var grand = 0; rows.forEach(function (r) { grand += (r.totalTokens || 0); });
+    var tb = document.getElementById("modelSpendTable"); tb.innerHTML = "";
+    if (rows.length === 0) {
+      tb.innerHTML = '<tr><td colspan="3" class="empty">No token spend recorded yet.</td></tr>';
+      return;
+    }
+    rows.forEach(function (r) {
+      // A null model is the honest "not recorded yet" bucket - the first turn of every session folds before
+      // its model is known - shown as such, never hidden and never an empty name.
+      var name = r.model ? r.model : "Not recorded";
+      var tr = document.createElement("tr");
+      tr.innerHTML = "<td>" + name + "</td><td class='num'>" + fmt(r.totalTokens) +
+        "</td><td class='num'>" + pct(r.totalTokens, grand) + "%</td>";
+      tb.appendChild(tr);
+    });
+  }
+
   function load() {
     fetch("/stats/data", { credentials: "same-origin" })
       .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
-      .then(render)
+      .then(function (data) { LAST = data; render(data); })
       .catch(function (e) { document.getElementById("foot").innerHTML = '<span class="err">Could not load stats: ' + e.message + "</span>"; });
   }
+
+  // The chosen day/week/month grain, kept across the 4-second refreshes and re-applied to the latest data
+  // without a refetch, so a periodic reload never snaps the toggle back to Day mid-read.
+  var LAST = null;
+  var PERIOD = "day";
+  document.getElementById("periodToggle").addEventListener("click", function (e) {
+    var btn = e.target.closest("button"); if (!btn) return;
+    PERIOD = btn.getAttribute("data-period");
+    Array.prototype.forEach.call(this.querySelectorAll("button"), function (b) {
+      b.classList.toggle("on", b === btn);
+    });
+    if (LAST) renderActivity(LAST);
+  });
 
   load();
   setInterval(load, 4000);


### PR DESCRIPTION
The final piece of the SQLite mission: the surface that reads the spend data now stored. Three sections added to the embedded **Your Throttle** page - the deliberate home for these stats, not a Cockpit route - because the `/stats` feed already serves everything they need.

## What it adds

- **What you have spent** - the headline token figure (compact, e.g. `1.6M`) with the input / output / cache breakdown, plus all-time turns and characters. It says plainly that spend is Claude-only today, so a small number reads as "only Claude reports it yet", never "I barely spent anything".
- **Your activity, by day / week / month** - a toggle over a table of recent periods, each with its turns and token spend. This is the literal ask: "whatever I've done in a day or a week or a month". The per-hour series is rolled into the owner's **local** calendar, so a late-night UTC hour lands on the right local day; the toggle re-applies to the latest data across the 4-second refreshes without snapping back.
- **Spend by model** - which model cost what, with the null-model bucket shown honestly as "Not recorded" rather than hidden, so the per-model rows still sum to the total.

Self-contained, ASCII-only, light/dark aware, matching the existing page.

## A security fix, found in review

The first review round **blocked** on a real defect I introduced: the model name is records-derived free text, and I had composed it into `innerHTML` - a markup-bearing model string would have parsed as HTML in the Gateway's own origin. Every cell in both new tables now goes through a `trow()` builder that sets `textContent`, so an untrusted value can only ever render as literal characters. Proven headless before/after: `<img src=x onerror=...>` fired and injected an element through the old path, and renders as inert text through the fix.

## Proof

- All seven test projects green (Gateway 2510), rebased onto today's installer fix (no overlap).
- Rendering verified headless with Playwright (all three toggles, zero console errors); the timezone rollup proven in isolation including the daylight-saving case where a UTC hour rolls to the previous local day; the injection fix proven with a before/after hostile-input render.
- Independently reviewed - `docs/architecture/review-governance-screens-2026-07-16.md` - which blocked on the injection, then cleared it after the fix.
- **Honest test-gap note:** there is no committed behavioral escaping test, because this repo has no JavaScript execution harness for a C# test to run the page. The committed guard is an honestly-named source tripwire, not behavioral coverage; a proper Playwright/JS test project is a sensible follow-up.