### PR TITLE
fix(account): repaint the sign-in status box the instant the panel settles (#1715)

### DIFF
--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
@@ -107,6 +107,15 @@ public partial class GatewayConnectionPanel : UserControl
     public event EventHandler? ConnectionVerified;
 
     /// <summary>
+    /// Raised when the panel settles the account sign-in state: signed in (Done) or signed out (the sign-in
+    /// step). The sidebar status box listens for this so line 2 repaints the instant the panel learns the
+    /// new state, instead of waiting for its 30-second heartbeat poll (the near-a-minute lag after signing
+    /// in). Purely a nudge to refresh - the box still reads /account/status itself; no state travels on the
+    /// event.
+    /// </summary>
+    public event EventHandler? AccountStateSettled;
+
+    /// <summary>
     /// Build a panel opened on the resolver's current step (spec section 6), for the three hosts that
     /// embed it (Settings Gateway tab, onboarding Gateway step, and the status-box window). Uses the cheap
     /// synchronous signal - the live handshake state - to choose the opening step: a proven handshake
@@ -914,6 +923,7 @@ public partial class GatewayConnectionPanel : UserControl
         SignInButton.IsEnabled = true;
         ShowOnly(SignInPanel);
         FileLog.Write("[GatewayConnectionPanel] showing Step 2 (sign in)");
+        AccountStateSettled?.Invoke(this, EventArgs.Empty);
     }
 
     // Epic #1069 A3 fallback: is a handshake failure an authorization failure (401)? The monitor's failure
@@ -1087,6 +1097,7 @@ public partial class GatewayConnectionPanel : UserControl
         DoneGatewayUrl.Text = config.Url;
         ShowOnly(DonePanel);
         FileLog.Write("[GatewayConnectionPanel] showing Done (both checks green)");
+        AccountStateSettled?.Invoke(this, EventArgs.Empty);
     }
 
     private void DoneAdvancedToggle_IsCheckedChanged(object? sender, RoutedEventArgs e)

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -704,6 +704,10 @@ public partial class MainWindow : Window
     {
         try
         {
+            var panel = Controls.GatewayConnectionPanel.CreateForCurrentState();
+            // Push an immediate status-box refresh the instant the panel settles the sign-in state, so
+            // line 2 flips within a couple of seconds instead of waiting for its 30-second heartbeat poll.
+            panel.AccountStateSettled += (_, _) => _ = RefreshAccountStatusAsync();
             var window = new Window
             {
                 Title = "Gateway Connection",
@@ -711,8 +715,11 @@ public partial class MainWindow : Window
                 Height = 660,
                 WindowStartupLocation = WindowStartupLocation.CenterOwner,
                 Background = global::Avalonia.Media.Brush.Parse("#252526"),
-                Content = Controls.GatewayConnectionPanel.CreateForCurrentState(),
+                Content = panel,
             };
+            // Catch-all: refresh once when the panel window closes, covering any path that signs in and
+            // dismisses the window before the settled event lands.
+            window.Closed += (_, _) => _ = RefreshAccountStatusAsync();
             window.Show(this);
             FileLog.Write("[MainWindow] Gateway Connection panel opened (on the resolver's current step)");
         }


### PR DESCRIPTION
Closes #1715.

## Problem
The sidebar status box (bottom-left, line 2 - the sign-in indicator) took up to about a minute to flip to signed-in after signing in. Line 2 is fed only by a 30-second heartbeat poll of `GET /account/status`, so a fresh sign-in only showed on the next tick (and near a minute if a read was mid-flight).

## Fix
Push an immediate refresh instead of waiting for the poll:
- `GatewayConnectionPanel` raises a new `AccountStateSettled` event when it resolves the account state (signed in at `ShowDone`, signed out at `ShowSignIn`) - which happens within about two seconds of signing in.
- `MainWindow` refreshes the status box on that event, and once more when the panel window closes as a catch-all.

The 30-second poll stays as a backstop. Purely additive - it changes how soon the repaint is triggered, not how the box is painted.

## Verification
- Builds clean (0 warnings, 0 errors).
- Tested live on a slot build: opening the panel logged `ApplyAccountStatus` 6 ms after the panel settled (`showing Done`), off the poll's 30-second cadence - the box repainted on the event, not the timer.
