### PR TITLE
Sync fleet-comms into the Avalonia installer's skill list

### DIFF
--- a/tools/cc-director-setup-avalonia/Services/ToolInstaller.cs
+++ b/tools/cc-director-setup-avalonia/Services/ToolInstaller.cs
@@ -23,6 +23,10 @@ public class ToolInstaller
     [
         // dev-throttle: the product's main skill (renamed from cc-director).
         "dev-throttle",
+        // fleet-comms (issue #723): teaches an agent the cc-devthrottle session/message verbs
+        // so every machine's agents know the capability, not just the CC_FLEET_TOOLS env hint.
+        // Kept in sync with SkillInstaller.SkillNames in tools/cc-director-setup.
+        "fleet-comms",
         // move-session: relocate a live session to another slot/Director via the Gateway handover,
         // with an approval gate and a verify-before-mark lifecycle.
         "move-session",


### PR DESCRIPTION
## What

Adds `fleet-comms` to the Avalonia installer's `ToolInstaller.SkillNames` so both installer paths ship the same skills: `dev-throttle`, `fleet-comms`, `move-session`.

## Why

The two installer lists had drifted. `SkillInstaller.SkillNames` (in `tools/cc-director-setup`) shipped `dev-throttle` + `fleet-comms`, but the Avalonia `ToolInstaller.SkillNames` shipped only `dev-throttle`. An install through the Avalonia setup UI therefore never delivered `fleet-comms`. Noticed while shipping move-session (#1720), which added move-session to both lists but left this pre-existing gap.

## Change

- `ToolInstaller.SkillNames`: add `fleet-comms` (with a note to keep it in sync with `SkillInstaller.SkillNames`).