### PR TITLE
Show the injected text, and let the user replace it

### DIFF
--- a/docs/architecture/codex-review-injected-text-first-impressions-1.md
+++ b/docs/architecture/codex-review-injected-text-first-impressions-1.md
@@ -1,0 +1,57 @@
+# First Impressions Review: Injected Text
+
+This review looks only for ways the refactor from hard-coded string building to editable templates could silently change, drop, or corrupt the text that reaches agents.
+
+## Findings
+
+1. Placeholder mistakes can degrade into plausible but wrong text.
+
+   The current code derives `shortId`, substitutes the display name, omits the user identity line when there is no signed-in email, and then joins a fixed list of lines. A template renderer can silently leave `[SESSION_ID]`, `[SHORT_SESSION_ID]`, `[USER_EMAIL]`, or similar placeholders in the delivered text if the placeholder names drift between the default template, the user interface, and the renderer. That failure would still produce readable context, so agents may not report it. The first line and the identity line need tests that prove every supported placeholder is replaced and that unknown placeholders are either rejected or surfaced clearly.
+
+2. Optional user identity is easy to render as broken prose.
+
+   `FleetPreamble.Build` currently omits the signed-in user sentence entirely when there is no email. In a template, a user may leave a sentence that depends on user variables while the renderer has no user value. If missing variables become empty strings, agents could receive text such as `The user of this session is ().` or a sentence that binds "me" to nobody. That is worse than omission because it looks intentional. The design needs an explicit conditional block or a rule that blocks saving or using a template that references unavailable identity variables.
+
+3. Newline behavior can change the command block without failing any launch path.
+
+   The current implementation uses `string.Join("\n", lines)` and preserves indentation for the command list and continuation lines. Loading a template from a file introduces line ending conversion, editor trimming, final newline differences, and possible indentation normalization. Any of those can change the displayed command list while still producing valid context. Tests should compare exact text, including blank lines and leading spaces, for the shipped default template on Windows.
+
+4. Escaping and quoting rules can damage command examples.
+
+   The existing text contains quoted names, quoted command arguments, apostrophes, angle brackets, parentheses, and a literal `--everyone` flag. Moving this into a stored template creates several places where escaping can be accidentally interpreted: project file embedding, resource copy, settings storage, serialization, markup preview, and text area round trips. A silent escape bug could turn `cc-devthrottle session rename "name"` into malformed advice or make angle-bracket placeholders look like variables. The default template should be tested after every storage and delivery step, not only after the renderer runs.
+
+5. The short session identifier is computed, not a simple field.
+
+   The current code shortens the session identifier to eight characters only when possible. If the template system exposes both full and short identifiers, the short form must preserve that rule. A naive renderer could use a fixed substring and throw for short identifiers, or it could expose only the full identifier and force the default text to duplicate it. Either outcome can break tests loudly, but a subtler failure is using the full identifier in both places and making session names harder to scan without any error.
+
+6. User custom text can remove operational instructions silently.
+
+   The mission seed says deleting fleet commands is the user's right. That also means the main product can stop giving agents the instructions required to contact peers while still showing "custom text is active" as if all is well. If the user interface only labels the source and does not show which known variables or command sections are missing, an operator may not realize they have removed fleet awareness until agents fail to coordinate. At minimum, the preview should make the exact rendered text visible for a real or sample session.
+
+7. Delivery paths may diverge after the template is introduced.
+
+   The seed names several delivery mechanisms: native hooks, event bus, extension, instruction file, and an endpoint used by non-Claude agents. If each path loads or renders the template independently, small differences in caching, file paths, line endings, and fallback behavior can make agents receive different preambles. The current single `FleetPreamble.Build` method is a strong consistency point. The refactor should keep one render function used by all delivery paths, with tests for the endpoint and at least one file or hook writer proving they receive the same rendered string.
+
+8. Fallback behavior can hide a broken custom template.
+
+   The requirements say custom text wins over the shipped default and that there is no merging. If a custom template file is unreadable, invalid, or references unsupported variables, silently falling back to the shipped default violates the user's choice and makes the settings tab untrustworthy. If the application must fall back to keep agents usable, the settings tab and logs need to show that the live text is no longer the user's custom text. Otherwise, the system should fail clearly before launching with different text than the user selected.
+
+9. Updates to the shipped default can be present but not actually used in preview or launch.
+
+   The owner asked that our updates are always downloaded and always visible, even when custom text is active. That creates two live versions of the same concept. A common silent failure would be showing the current shipped default in the settings tab while launch code still reads an older embedded resource or a cached copy. The shipped default should have a single source of truth, and tests should prove the settings preview and launch rendering read that same source.
+
+10. Template editing can make policy text appear official when it is user-authored.
+
+   The seed requires the user interface to show when the live text is theirs. The same distinction matters in what reaches agents. If a custom template keeps the `[CC Director fleet]` prefix or other official-looking language, agents cannot infer that the instructions are user-authored. That may be acceptable, but it is a silent trust change: agents could treat a local custom policy as a product policy. The product should decide whether rendered custom text includes any source marker or whether the distinction exists only in the settings interface.
+
+11. Agent-specific constraints can corrupt a single shared template.
+
+   The seed says one text currently reaches several agents through different mechanisms. Those mechanisms may have different limits or formatting rules. A template that renders correctly for one agent may be truncated, escaped, wrapped, or stored differently for another. Since the desired model appears to be all agents at once, the tests should include the most restrictive delivery path and verify that the full rendered text arrives intact.
+
+12. Documentation can lag behind the actual injected text.
+
+   The mission exists because users cannot see what is injected. If the shipped default lives in one place and documentation quotes or describes it somewhere else, the documentation can become stale immediately. That would silently recreate the same consent problem in a softer form. Documentation should point users to the settings tab and describe the mechanism, not duplicate the preamble text unless there is an automated check tying them together.
+
+## Suggested Test Shape
+
+The highest value test is a golden test that renders the shipped default template with a full sample session, a named session, a machine, a repository path, and a signed-in user, then compares it byte for byte to the current `FleetPreamble.Build` output. A second test should render without a user and prove the identity sentence is absent, not empty. A third test should exercise the same renderer through the non-Claude endpoint and one file or hook delivery path so the launch routes cannot drift.

--- a/docs/architecture/codex-review-injected-text-increment-1.md
+++ b/docs/architecture/codex-review-injected-text-increment-1.md
@@ -1,0 +1,39 @@
+# Increment 1 Review: Injected Text Refactor
+
+## Findings
+
+1. The renderer still substitutes known tokens inside larger bracketed prose.
+
+   `FleetPreambleRenderer.Substitute` starts at any `[` and scans to the next `]`. If the first bracketed run is not a known token, it appends one character and continues scanning inside that same bracketed text. That means `[[SESSION_ID]]` renders as `[a3dfb85e-49dd-442a-9e36-40fc44838783]`, and `see [[MACHINE]]` renders as `see [MACHINE_A]`.
+
+   This does not differ from the old builder for the shipped default, because the default does not contain that shape. It does matter for the renderer contract. The comments say unknown bracketed prose survives verbatim, and the test suite proves `[[SESSION_UNKNOWN]]` survives, but it does not prove `[[SESSION_ID]]` survives. A user could reasonably write double-bracketed notes, examples, or literal placeholder documentation and silently get a substituted value inside them.
+
+   If the intended rule is "any exact known token anywhere is replaced," the comments and tests should say that. If the intended rule is "only a whole bracketed token is replaced," the scanner needs a boundary rule so a token preceded by another `[` or followed by another `]` is treated as ordinary text.
+
+2. Deleting the migration proof would currently remove the only byte-for-byte default guard.
+
+   `FleetPreambleTemplateMigrationTests` says it is temporary and that `FleetPreambleGoldenTests` carries the lasting guard, but no such test exists in this worktree. The remaining `FleetPreambleTests` assert important substrings and policy lines, not byte identity for the shipped default.
+
+   The legacy-copy test should not live forever as the rule for future wording. That part of the argument to delete is right: once the default text intentionally changes, a frozen old builder becomes the wrong oracle. But deleting it immediately after this commit is only safe if a current-default golden guard replaces it. Otherwise, a later edit can silently change spacing, blank lines, command indentation, or the no-signed-in-user gap without a byte-level failure.
+
+   My recommendation is: keep the migration test in the pure-refactor commit so the commit proves zero behavior change. After that, delete `LegacyFleetPreamble` only in the same change that adds a lasting golden test against an approved text fixture or snapshot for `FleetPreambleTemplate.Default`. That snapshot can be updated intentionally when the shipped default changes. It should not compare against old code forever.
+
+3. Unknown placeholders should not be rejected by the renderer, but they must be surfaced before user text becomes live.
+
+   Leaving unknown bracketed text verbatim is the right renderer behavior because the shipped default begins with `[CC Director fleet]`, and users will write ordinary bracketed prose. A hard reject in `Render` would make harmless text fail at session launch and would turn a simple text template into a fragile language.
+
+   The silent failure remains real for likely mistakes such as `[SESSION-ID]`, `[SESSIONID]`, or `[USER_MAIL]`. If those are left verbatim, the agent receives plausible-looking but wrong instructions. The right split is: the renderer leaves unknown bracketed text alone, and the future settings save or preview path reports suspicious unknown all-capital bracket tokens as warnings. That preserves bracketed prose while catching placeholder typos before they reach agents.
+
+4. User identity placeholders outside the signed-in block can still create broken prose.
+
+   `Render` maps `[USER_NAME]` and `[USER_EMAIL]` to empty strings when no user is signed in. That is safe for the current default because those tokens are inside `[IF_SIGNED_IN]`. It is not safe for future custom templates. A user can write `The user is [USER_NAME] ([USER_EMAIL]).` outside the block and get `The user is  ().` with no validation error.
+
+   This is not a behavior change for increment 1, but the renderer now defines the future template contract. The save or preview validation should warn when user identity tokens appear outside `[IF_SIGNED_IN]`, or the renderer should leave those tokens verbatim outside a signed-in block. Empty strings are the easiest behavior to miss.
+
+## Answers To The Three Questions
+
+1. The single left-to-right pass is correct for preventing substituted values from being substituted again. It preserves old-builder behavior for values such as a session named `[MACHINE]`. The remaining corruption is not re-substitution; it is the scanner matching known tokens inside larger bracketed prose such as `[[SESSION_ID]]`.
+
+2. Delete the legacy migration test only after the pure-refactor commit has used it to prove byte identity, and only if a lasting golden guard replaces it. Do not leave a frozen old builder as the permanent oracle for wording updates, but do not remove the only byte-for-byte protection and rely only on substring tests.
+
+3. Leaving unknown placeholders verbatim wins in the renderer. Rejecting them there breaks ordinary bracketed prose and the shipped `[CC Director fleet]` prefix. The missing piece is warning or validation in the user-facing edit path for suspicious placeholder-shaped typos, especially all-capital bracket tokens and identity tokens outside the signed-in block.

--- a/docs/architecture/codex-review-injected-text-increment-2.md
+++ b/docs/architecture/codex-review-injected-text-increment-2.md
@@ -1,0 +1,55 @@
+# Increment 2 Review: Injected Text Settings And Live Source
+
+## Findings
+
+1. Pi does not follow the "inject nothing and keep launching" behavior.
+
+   The endpoint paths catch `InjectedTextUnavailableException` and return an empty body, so Claude and Codex can start without receiving the declined DevThrottle text. Pi is different. `SessionManager` calls `PiPreambleWriter.WriteForSession` before the backend starts (`src/CcDirector.Core/Sessions/SessionManager.cs:587` to `600`), and `PiPreambleWriter` lets `FleetPreamble.BuildForSession` exceptions propagate (`src/CcDirector.Core/Pi/PiPreambleWriter.cs:41` to `44`).
+
+   Result: if the user chose their own text and `yours.txt` is missing or unreadable, a Pi session likely fails to launch instead of launching with no injected text. That still does not substitute our text, which is the most important consent rule. But it breaks the documented behavior in `docs/public/features/08-injected-text.md:111` to `114`, which says DevThrottle injects nothing and tells the user.
+
+   The caller comment says "the caller decides what a session does with it," but the caller does not decide today. It lets the exception escape.
+
+2. The macOS and Linux Claude hook can print non-hook error bodies to stdout.
+
+   The shell hook prints whatever the hook-output endpoint returns: `curl -s -m 3 "$api/sessions/$sid/fleet-preamble-hook-output" 2>/dev/null || true` (`src/CcDirector.Core/Claude/ClaudeHookInstaller.cs:87`). That is safe for connection failures and for the intended empty body. It is not safe for an HTTP error with a response body, because `curl` without `--fail` still writes that body to stdout.
+
+   One reachable path is hand-editing `yours.txt` into an invalid template after it was saved. `ActiveTemplate` reads it successfully, then `FleetPreambleRenderer.Render` throws `FleetPreambleTemplateException`. `ControlEndpoints` catches only `InjectedTextUnavailableException` around `BuildForSession` (`src/CcDirector.ControlApi/ControlEndpoints.cs:119` to `130`). The endpoint can therefore return a server error body, and the shell hook will print that body as if it were hook output.
+
+   Windows Claude and Codex are safer here because `Invoke-RestMethod` throws on an HTTP error and the script swallows it (`src/CcDirector.Core/Claude/ClaudeHookInstaller.cs:58` to `64`, `src/CcDirector.Core/Codex/CodexHookInstaller.cs:35` to `41`). The shell path should either use `curl -f` or the endpoint should catch all render failures and return an empty text body.
+
+3. Whitespace-only custom text diverges between delivery paths.
+
+   `/sessions/{sid}/fleet-preamble` returns the rendered text as-is (`src/CcDirector.ControlApi/ControlEndpoints.cs:79` to `81`). The hook-output endpoint returns an empty body when the rendered text is whitespace (`src/CcDirector.ControlApi/ControlEndpoints.cs:132` to `133`). Pi writes the rendered text as-is (`src/CcDirector.Core/Pi/PiPreambleWriter.cs:44` to `46`).
+
+   That means a user who saves `"   "` or newlines as their custom text can get different behavior by agent: plain endpoint consumers and Pi receive whitespace, while macOS and Linux Claude receive no hook output. If whitespace means "nothing," every delivery path should normalize that. If whitespace means "my text," the hook-output endpoint should not use `IsNullOrWhiteSpace`.
+
+4. The settings tab does not accurately show the live injected text when the user's file is unreadable.
+
+   On load, if the user selected their own text but `ActiveTemplate` cannot read it, the tab returns `(source, _store.ReadYours() ?? "", ex.Message)` (`src/CcDirector.Avalonia/Controls/InjectedTextView.axaml.cs:81` to `94`). It then applies the normal "YOUR text" banner and sets the editor label to "Your text (this is what your agents get)" (`src/CcDirector.Avalonia/Controls/InjectedTextView.axaml.cs:124` to `134`).
+
+   If the file is missing, the editor is empty because `ReadYours()` returns null, but sessions are not getting that empty editor text as the selected user template. They are getting no preamble through the endpoint paths, and Pi may fail launch. The error explains the read failure, but the label "this is what your agents get" is now false or at least ambiguous.
+
+   The banner should have a third state for "Your text is selected, but unavailable; hook-based agents get no injected text until this is fixed." That would also give the user a clear way to switch back to ours or save a replacement without implying the empty editor is already the live template.
+
+5. The Pi preamble tests are now dependent on real user configuration.
+
+   `PiPreambleWriterTests` pass an output directory, but `PiPreambleWriter` still calls `FleetPreamble.BuildForSession` with the default `InjectedTextStore` (`src/CcDirector.Core/Pi/PiPreambleWriter.cs:44`). The tests assert the DevThrottle default contains identity and command text (`src/CcDirector.Core.Tests/Pi/PiPreambleWriterTests.cs:17` to `23`, `38` to `49`), but that is only true when the real machine config is using ours.
+
+   If the developer running tests has `injected_text.use_yours` set to true, these tests can read that developer's real custom text or fail because the custom file is missing. The store tests know they touch real `config.json` and use a collection guard; the Pi tests do not. This can make the test suite environment-sensitive.
+
+## Answers To The Attack Questions
+
+1. I did not find a path where a user who declined our text is silently given our text. I did find two adjacent problems: Pi can fail before launch instead of injecting nothing, and the tab can label an unavailable custom file as "this is what your agents get."
+
+2. Empty bodies are safe in the PowerShell scripts and the POSIX shell script. Fetch failures are safe when they produce no body. HTTP failures with a body are not safe in the POSIX shell hook because `curl` prints the body to stdout.
+
+3. Making `fleet-preamble-hook-output` async did not obviously break its normal JSON contract. It fixes the signed-in-user omission for macOS and Linux Claude. The remaining contract risk is unhandled render or config exceptions becoming non-hook stdout through the shell script.
+
+4. The tab's normal Save, UseOurs, and WriteMyOwn state transitions look coherent. The stale or wrong state is the unreadable custom file case: the banner says the user's text is live, the editor may show empty text, and the label says the editor content is what agents get.
+
+5. The docs are false for Pi in the missing custom text case if the exception still aborts launch. The docs say DevThrottle injects nothing and tells the user. The code does that for endpoint-based hooks, not for Pi.
+
+## Verification
+
+I ran `dotnet test --filter "InjectedText|FleetPreamble|PiPreamble"`. It passed in this environment: 74 core tests, 2 gateway tests, and 4 Avalonia tests matched and passed. The Pi test risk above can still be real because this machine's current config did not exercise `use_yours=true` with a custom template.

--- a/docs/architecture/codex-review-injected-text-increment-3.md
+++ b/docs/architecture/codex-review-injected-text-increment-3.md
@@ -1,0 +1,33 @@
+# Increment 3 Review: Injected Text Fixes And CC_FLEET_TOOLS
+
+## Findings
+
+1. The third banner state does not cover hand-edited unrenderable custom text.
+
+   The launch paths now treat unreadable and unrenderable custom text the same way: they inject nothing and do not fall back to the DevThrottle text. `ControlEndpoints` catches `FleetPreambleTemplateException`, and `PiPreambleWriter` writes an empty file for it. That part is fixed.
+
+   The Settings tab only enters the red "NO injected text" state when `_store.ActiveTemplate()` throws `InjectedTextUnavailableException` (`src/CcDirector.Avalonia/Controls/InjectedTextView.axaml.cs:84` to `122`). A hand-edited invalid `yours.txt` is different: `ActiveTemplate()` reads the file successfully, so `readError` is null. The tab then calls `ApplySource(Yours)` and shows `Your agents are getting YOUR text, not DevThrottle's.` plus `Your text (this is what your agents get)` (`src/CcDirector.Avalonia/Controls/InjectedTextView.axaml.cs:134` to `146`).
+
+   `Refresh()` does validate the text and disables saving (`src/CcDirector.Avalonia/Controls/InjectedTextView.axaml.cs:216` to `222`), but the banner and editor label are still wrong. New sessions, Claude clear, Claude compact, Codex clear, Codex compact, and Pi launch will get no injected text, not the invalid custom text shown under a "this is what your agents get" label.
+
+   The fix should classify the loaded custom text through the same renderability rule used by launch. If the selected custom text cannot render, use `ApplyUnavailable` with the validation problem, while still leaving the editor editable so saving a repaired version is the way out.
+
+## Answers To The Questions
+
+1. I did not find a product dependency on `CC_FLEET_TOOLS`. The only code write path is `SessionManager` (`src/CcDirector.Core/Sessions/SessionManager.cs:521` to `524`). Repository search found no product read path. There is one setup comment saying the skill installer covers machines beyond the environment hint, which supports treating the variable as agent-facing prose rather than application state.
+
+2. Removing `CC_FLEET_TOOLS` when the live source is Yours is the right consent boundary. If the user deletes command prose from their custom text, keeping a second command-list channel would make the tab incomplete. Existing sessions can still have an old `CC_FLEET_TOOLS` value because process environments are immutable after launch; the docs now disclose that. There is also a narrow launch race: `CC_FLEET_TOOLS` is decided before process start, while Claude and Codex fetch the preamble from the endpoint at SessionStart. If the user changes the setting in that small window, the environment variable and hook preamble can disagree. That is probably acceptable if documented as "setting changes apply to future fetches, but environment variables are fixed at process start"; it is not a fallback-to-ours bug.
+
+3. Collapsing whitespace in `BuildForSession` is the right shared rule for user text, and putting it in the common render path fixed the delivery-path divergence. It does not create a realistic break for the shipped default because existing default tests assert substantive content through `Build`, and a whitespace-only shipped default would be a catastrophic content regression either way. A small guard that `BuildForSession(..., AlwaysOurs)` is non-empty would make that assumption explicit.
+
+4. The Pi fixes are materially better: unreadable, invalid, and whitespace-only custom text no longer aborts launch or diverges from the hook paths. The new Pi tests also correctly pin their store instead of reading the developer's real config.
+
+5. The POSIX hook fix is correct. `curl -sf` prevents HTTP error bodies from becoming hook stdout, and the endpoint catch for `FleetPreambleTemplateException` removes the known 500 path anyway.
+
+## Documentation Check
+
+The docs are mostly aligned with the new behavior, including `CC_FLEET_TOOLS` and mid-session changes. The statement near the top that the tab shows what agents are actually getting is still false for the invalid-on-disk custom template case above, because the launch paths inject nothing while the tab can show the custom text as live.
+
+## Verification
+
+I ran `dotnet test --filter "InjectedText|FleetPreamble|PiPreamble|ClaudeHookInstaller|FleetTools"`. It passed in this environment: 83 core tests, 2 gateway tests, and 4 Avalonia tests matched and passed.

--- a/docs/architecture/codex-review-injected-text-increment-4.md
+++ b/docs/architecture/codex-review-injected-text-increment-4.md
@@ -1,0 +1,35 @@
+# Increment 4 Review: Final Pass
+
+## Finding
+
+1. Switching back to a stale invalid custom file can still make the banner lie.
+
+   The load path fix is correct: `InjectedTextView.LoadAsync` now asks `FleetPreamble.BuildForSession` whether the selected text can actually be delivered (`src/CcDirector.Avalonia/Controls/InjectedTextView.axaml.cs:113` to `128`). That closes the original missing-file and hand-edited-invalid-file mismatch on first load.
+
+   The remaining gap is the `Write my own version` / `Switch back to my version` button path. When ours is live and `yours.txt` exists, the button calls `_store.UseYours()`, reads the file, clears `_unavailable`, applies the normal Yours banner, and then calls `Refresh()` (`src/CcDirector.Avalonia/Controls/InjectedTextView.axaml.cs:375` to `397`). It never asks `FleetPreamble.BuildForSession` whether that saved file can be delivered.
+
+   Reproducible sequence:
+
+   1. The user has a custom file on disk.
+   2. The user is currently running the DevThrottle text.
+   3. The custom file is edited outside the product into an invalid template such as `[IF_SIGNED_IN]\nhello`.
+   4. The user opens Settings, Injected text. The banner correctly says the DevThrottle text is live.
+   5. The user clicks `Switch back to my version`.
+
+   After step 5, config is set to Yours. Launch paths call `BuildForSession`, catch `FleetPreambleTemplateException`, and inject nothing. The tab says `Your agents are getting YOUR text, not DevThrottle's.` and labels the editor `Your text (this is what your agents get)`. `Refresh()` shows the validation error and disables Save, but the source banner is still wrong.
+
+   There is a similar variant with an existing but unreadable `yours.txt`: `_store.UseYours()` can succeed, `_store.ReadYours()` can throw, the catch only shows an error, and the old Ours banner remains even though the live config has already changed to Yours.
+
+   This is the same class of defect as the previous one, just through a button transition instead of initial load. The fix is to make this transition use the same deliverability path as initial load, or simply reload from the store after `_store.UseYours()` rather than manually reassembling the state.
+
+## Answers
+
+1. The sticky `_unavailable` flag is correct for the loaded-unavailable state and for Save / UseOurs. The bug is that `BtnWriteMyOwn_Click` clears it and applies the normal Yours state before proving the selected custom file is deliverable.
+
+2. Yes, there is still a tab versus launch disagreement: switching back to an invalid or unreadable saved custom file while ours is live.
+
+3. I would block this before main. The core injection paths are much better, and I did not find a remaining path that silently substitutes DevThrottle text after the user declined it. But the stated product requirement is that the banner never mislead the user about what agents are getting, and this transition still violates that.
+
+## Verification
+
+I ran `dotnet test --filter "InjectedText|FleetPreamble|PiPreamble|ClaudeHookInstaller|FleetTools"`. It passed in this environment: 84 core tests, 8 Avalonia tests, and 2 gateway tests matched and passed.

--- a/docs/architecture/codex-review-injected-text-increment-5.md
+++ b/docs/architecture/codex-review-injected-text-increment-5.md
@@ -1,0 +1,33 @@
+# Increment 5 Review: Confirmation Pass
+
+## Result
+
+I would not block this on the injected-text work reviewed here.
+
+The blocking defect from increment 4 is fixed in the right place. The button handlers now mutate the store and re-enter `LoadAsync`, and `LoadAsync` is the single path that asks `FleetPreamble.BuildForSession` whether the selected text can actually be delivered. That removes the class of bugs where a button updates the banner by hand without checking the launch path.
+
+## Checks
+
+1. Save that throws is handled correctly.
+
+   `BtnSave_Click` calls `_store.SaveYours(text)` before `LoadAsync`. If `SaveYours` throws `FleetPreambleTemplateException`, the store is not changed, `LoadAsync` is not reached, and the tab keeps the previous source state while showing the validation error. That is correct. A failed save should not change what agents get.
+
+2. WriteMyOwn that throws is handled correctly.
+
+   If switching to a saved custom version fails before the store changes, the old state remains live and the handler shows the error. If the store changes and the custom text is not deliverable, the following `LoadAsync` detects that through `BuildForSession` and shows the red no-injected-text state. The new `SwitchingBackToAStaleInvalidVersion_DoesNotAnnounceItAsLive` test covers the important version of this.
+
+3. The sticky `_unavailable` flag is now scoped correctly.
+
+   `LoadAsync` sets it only through `ApplyUnavailable` and clears it only after the launch path says the selected text is deliverable. The button handlers no longer clear it directly. That is the right ownership boundary.
+
+4. `async void` handlers are acceptable here.
+
+   Avalonia event handlers are a normal place for `async void`, and these handlers wrap their awaited work in try/catch. The main residual risk is rapid repeated clicks causing overlapping `LoadAsync` calls and last-completion-wins rendering. I would not block on that for this change because each load recomputes from the store through the same authoritative path, so the final state should still converge to the current store choice. Disabling buttons during reload would be polish, not a correctness gate.
+
+5. I did not find a remaining tab versus launch disagreement in the reviewed paths.
+
+   Initial load, UseOurs, WriteMyOwn, SwitchBack, and Save now all end by asking the launch render path. The earlier gap around hand-edited invalid files is covered both on first load and through the switch-back button.
+
+## Verification
+
+I ran `dotnet test --filter "InjectedText|FleetPreamble|PiPreamble|ClaudeHookInstaller|FleetTools"`. It passed in this environment: 84 core tests, 9 Avalonia tests, and 2 gateway tests matched and passed.

--- a/docs/architecture/injected-text-mission-seed-2026-07-16.md
+++ b/docs/architecture/injected-text-mission-seed-2026-07-16.md
@@ -1,0 +1,136 @@
+# Mission Seed: Injected Text
+
+Written 2026-07-16 by the Architect of the Gateway SQLite mission (session 8c17dc1c), handing this
+to the Architect of the Injected Text mission. This is the seed, not the brief. **You write the
+brief.** Everything here came from the owner directly; where I am guessing, I say so.
+
+## The WHY - and it is a consent problem, not a feature gap
+
+**DevThrottle silently injects text into every agent session it launches, on every machine. There is
+no way to see it, no way to decline it, and it is not documented anywhere a user would look.**
+
+That was tolerable while the text was "here is your session id and how to reach the fleet" - useful
+plumbing nobody would object to. It stopped being tolerable on 2026-07-15, when I added an
+**editorial policy** to it: a rule forbidding agents from putting their name on the owner's commits
+(#1696, `FleetPreamble.cs`). The rule itself is the owner's and he wants it. But adding it turned an
+infrastructure detail into a **policy channel**, and that is a change in kind, not degree.
+
+The owner's reaction, verbatim: *"do we inject shit into the agent terminals? I'm not sure I'm okay
+with that... if we do, we need to make it very clear in our documentation. And we might want to let
+the user override this."*
+
+**The point of this mission is to make disagreeing with us a supported action rather than a fork.**
+Someone may genuinely want their agent to sign its commits as Claude Code. On their machine, that is
+their call, and today they cannot make it.
+
+**Read this next part carefully, because it sets your success bar:** the owner has explicitly NOT
+decided whether the no-attribution policy should remain injected at all. He said he will decide
+*after* this feature exists. So you are not defending that policy - you are building the thing that
+makes it a choice. If your work makes it easy for him to delete my rule, you have succeeded, not
+failed.
+
+## What the owner asked for
+
+His words, condensed but not reinterpreted:
+
+1. **A new Settings tab called "Injected text."** It shows the user exactly what we inject.
+2. **Let the user customize it.**
+3. **If they customize it, the UI must clearly show it is THEIR text and not ours.** A user running
+   custom text must never be able to believe they are on ours.
+4. **We keep shipping our version from the repo, deployed with the application.** "The application
+   knows what to inject and puts it in the file."
+5. **If they customize, they lose our updates** to that text.
+6. **Our updates are always downloaded and always there - just not used.** So a user on a custom
+   version can always see the current default and adopt it if they want.
+7. **Variables.** The session id and friends appear as editable placeholders - his example was
+   `[SESSION_ID]`-style square brackets. The user must be able to edit the prose around them and
+   still have the session id injected.
+8. **Yours or ours. No merging.** He said "the simpler way" deliberately - do not invent a
+   three-way reconciliation.
+
+## What this means in code, so you do not spend a day rediscovering it
+
+All verified against `origin/main` at `9ff2c640` on 2026-07-16. **Re-verify before you rely on any
+of it** - main moves, and stale citations have cost this repository real time.
+
+- `src/CcDirector.Core/Sessions/FleetPreamble.cs` - the text itself. Today it is **built in C# with
+  string interpolation**. That is the crux of the work: to be user-editable it must become a
+  **template with placeholders, rendered by substitution**. That is not a small refactor and its
+  tests (`FleetPreambleTests`) assert on the built string.
+- `src/CcDirector.Core/Claude/ClaudeHookInstaller.cs` - how it reaches Claude: a `SessionStart` hook
+  returning `additionalContext`, via a settings file passed with `--settings` that **merges** with
+  the user's own hooks rather than replacing them. It is a documented extension point, not
+  keystrokes into a terminal. Say so in the documentation - the distinction matters and users will
+  assume the worse thing.
+- `src/CcDirector.Core/AgentPlugins/AgentPluginMetadata.cs` - `FleetPreambleStrategy`: `None`,
+  `NativeHook` (Claude, Codex, Gemini, Cursor), `EventBus` (OpenCode), `Extension` (Pi),
+  `InstructionFile` (Grok, Copilot). **One text, four delivery mechanisms, seven agents.**
+- `src/CcDirector.Core/Codex/CodexHookInstaller.cs`, `src/CcDirector.Core/Pi/PiPreambleWriter.cs` -
+  the other installers.
+- `GET /sessions/{sid}/fleet-preamble` - the Control API endpoint non-Claude agents use.
+- Tests: `FleetPreambleTests`, `FleetPreambleEndpointTests`, `PiPreambleWriterTests`.
+- **`None` means "this agent cannot inject", NOT "the user declined."** There is no opt-out today. I
+  checked.
+- **It is not in the public documentation.** The only mention is `docs/public/api/01-control-api.md`,
+  an endpoint description. A user has no way to learn this happens.
+
+## Three questions the owner has NOT answered - they are yours to settle or to ask him
+
+1. **Scope across agents.** One text, four mechanisms, seven agents. Does a custom version apply to
+   all agents at once, or per agent? I would start with all-at-once because it matches "yours or
+   ours", but I am guessing.
+2. **The boundary of the tab.** Is "Injected text" only the fleet preamble, or *everything*
+   DevThrottle puts into an agent's context? My opinion: a tab called "Injected text" that quietly
+   omits some injected text is a worse lie than no tab. Find out what else we inject before you
+   scope this.
+3. **The self-harm case.** If a user deletes the fleet commands from their custom text, their agents
+   lose fleet awareness and will not know how to reach each other. That is their right. The tab
+   should probably show them that is what they are doing rather than let them discover it later.
+
+## How this mission runs
+
+- **A Codex reviewer session gates every commit.** Spawn it as a REAL DevThrottle session
+  (`--agent Codex`), not a background process. It reviews code BEFORE you commit it, and it writes
+  its reviews to files under `docs/architecture/` - never to its terminal, because the session
+  terminal buffer captures only spinner redraw and the findings are unrecoverable from it. The
+  owner's words: this "usually has given us better quality code." He is right; on the last mission
+  Codex found defects nobody else did.
+- **One worktree for the whole mission:** `D:\ReposFred\devthrottle-injected-text`, branch
+  `feat/injected-text`, cut from `origin/main` at `9ff2c640`. Never use the shared checkout
+  `D:\ReposFred\devthrottle`.
+- **Commit freely in the worktree.**
+- **DO NOT push and DO NOT merge to origin/main without notifying the owner FIRST.** He wants to be
+  told before anything reaches origin. This is his explicit instruction and it is the one hard gate.
+- **No agent attribution in anything you write** - no `Co-authored-by` naming any assistant, no
+  "Generated with" line, in any commit, pull request, issue or document. This is the owner's
+  standing rule and it now ships in the preamble you are about to make editable. Check your own text
+  before every commit.
+- Plain ASCII everywhere. Plain English, no abbreviations.
+
+## Learn from how the last mission went wrong
+
+I am the Architect who just spent a full day on the SQLite mission and produced a superb design
+document and almost no working code. **Do not repeat it.**
+
+- **Ship increments to main; do not write a thirty-revision brief.** My brief went through fifteen
+  revisions before a line of product code existed. Several revisions caught real defects. The
+  aggregate was still a failure, because the owner wanted stats in a database and got a document.
+- **Check the premise before doing the work.** I spent most of that day designing a careful
+  migration to preserve the owner's old data. Late in the day he said, unprompted, that he did not
+  want it kept - which deleted the hardest half of the design. I never asked. Ask.
+- **The owner is the only source of the owner's intent.** When you are guessing what he wants, say
+  you are guessing, and ask - one plain question at a time, no jargon, no numbered menus.
+- **Verify, do not trust - including your own checks.** Three times in one day a check reported
+  success because it could not see the thing it was looking for: an assertion that could not match
+  the defect, a "watch it fail" that failed for the wrong reason, and a grep whose filter excluded
+  the only lines that could match. **Empty output is not evidence until you have shown the check can
+  produce output.** Red-watch your grep the way you red-watch your test.
+- **Prefer the design where the mistake is impossible over the one where it is merely avoided** -
+  but only where the failure would be **silent** and the cost is the owner's data or trust. Where it
+  fails loudly, a test is proportionate and the elaborate design is waste.
+
+## What "done" looks like
+
+The owner opens Settings, sees a tab called Injected text, reads exactly what we put into his
+agents, and can either accept ours or write his own - with no doubt about which one is live. And
+then he decides, freely, whether my no-attribution rule stays in it.

--- a/docs/public/features/08-injected-text.md
+++ b/docs/public/features/08-injected-text.md
@@ -1,0 +1,160 @@
+# Injected Text
+
+**DevThrottle gives every agent it starts a short piece of text before your first
+message. This page tells you exactly what that text is, why it is there, how it
+reaches the agent, and how to change it or remove it.**
+
+You can read the live text at any time in **Settings, Injected text**. Nothing on
+this page is hidden from that tab, and the tab always wins: it shows what your
+agents are actually getting on this machine right now.
+
+## What we inject, and why
+
+When DevThrottle starts a session, the agent has no idea it is part of a fleet. It
+does not know which session it is, which machine it is on, or that there are other
+sessions it can talk to. Every session already carries that information in its
+environment, but an agent does not read environment variables unless something
+points at them.
+
+So we hand the agent a short preamble at startup that tells it:
+
+- which session it is (its name, its identifier, the machine, the repository),
+- who you are, if you are signed in, so that "email me" means you and is not
+  guessed from the database,
+- the `cc-devthrottle` commands it can use to reach the rest of your fleet,
+- a warning not to broadcast to every session on every machine,
+- our request that agents do not put their own name on your commits.
+
+That last item is a policy rather than plumbing, which is precisely why this tab
+exists. See "Our editorial policy" below.
+
+## How it reaches the agent
+
+**We do not type into your terminal, and we do not modify what you type.** The
+text is handed over through each agent's own documented startup extension point:
+
+| Agent | How the text is delivered |
+|---|---|
+| Claude Code | A `SessionStart` hook returns it as `additionalContext`. The hook file is passed with `--settings`, which MERGES with your own hooks and never replaces them. |
+| Codex | A `SessionStart` hook entry merged into your `~/.codex/hooks.json`. |
+| Pi | A file passed to `--append-system-prompt` at launch. |
+| Gemini, Cursor, OpenCode, Grok, Copilot | Nothing is injected today. |
+
+For Claude and Codex the hook fires at startup, resume, clear, and compact - the
+four moments an agent's memory of the fleet would otherwise be empty - so the text
+is re-supplied after `/clear` and after auto-compaction.
+
+There is one more channel: when you are running our text, every session also gets
+an environment variable called `CC_FLEET_TOOLS` listing the same `cc-devthrottle`
+commands. Nothing in DevThrottle reads it - it is there purely for the agent to
+find - so it is our words reaching your agent, exactly like the preamble, and it
+reaches every agent including the ones with no preamble at all.
+
+**It follows the same choice.** If you run your own text, we do not set it. Otherwise
+you could delete the fleet commands from your version and we would quietly put them
+back through a channel this page never showed you.
+
+## Reading it, and replacing it
+
+**Settings, Injected text** shows the live text. A coloured banner at the top says
+whose text it is, and it is the one thing on the screen you cannot misread: if you
+are running your own version, it says so.
+
+- **Write my own version** starts you from a copy of ours, which you can edit
+  freely.
+- **Use the DevThrottle text** goes back to ours. Your version is kept, not
+  deleted, and you can switch back to it.
+- **Show the current DevThrottle text** shows the version we ship today, side by
+  side, even while yours is live.
+
+It is yours or ours - never a mixture. We do not merge your text with ours.
+
+### When a change takes effect
+
+**Sessions you start after saving get your text.** Sessions already running keep the
+text they were given until they clear or compact, at which point Claude and Codex
+are handed the current version.
+
+One detail, because it is the kind of thing you should hear from us rather than
+notice: the `CC_FLEET_TOOLS` variable described above is set once when a session's
+process starts and cannot be changed afterwards. So a session that was already
+running when you switched to your own text keeps that variable until you restart
+it. It contains only the command list - never any of our policy text - but if you
+want a clean break, restart the session.
+
+### The trade
+
+**If you write your own version, you stop receiving our updates to this text.**
+That is the deal, and it is deliberate: we will not silently edit words you wrote.
+
+Our updates still arrive with every DevThrottle update and are always written to
+disk where you can read them, so you can see what changed and adopt it if you
+want. You just have to choose to.
+
+### Placeholders
+
+Your text may use these, and DevThrottle fills them in for each session:
+
+| Placeholder | Becomes |
+|---|---|
+| `[SESSION_ID]` | The session's full identifier |
+| `[SESSION_SHORT_ID]` | The first eight characters, which the fleet commands take |
+| `[SESSION_NAME]` | The session's name, or `(unnamed)` |
+| `[MACHINE]` | The machine it runs on |
+| `[REPO_PATH]` | The repository or working directory |
+| `[USER_NAME]` | Your name, if you are signed in |
+| `[USER_EMAIL]` | Your email, if you are signed in |
+
+Anything between `[IF_SIGNED_IN]` and `[END_IF]` is used only when someone is
+signed in, and dropped entirely when nobody is. Use it for any sentence that
+mentions `[USER_NAME]` or `[USER_EMAIL]`, so it disappears cleanly rather than
+rendering as an empty gap.
+
+Bracketed words that are not in the table above are ordinary text and are sent
+exactly as written - our own text starts with the literal `[CC Director fleet]`.
+The one consequence: there is no way to write a placeholder that does NOT expand.
+`[[SESSION_ID]]` renders as the identifier in square brackets.
+
+### Removing things is allowed
+
+You can delete any of it, including all of it. Two consequences worth knowing
+before you find out later, both of which the tab warns you about while you edit:
+
+- **Remove the `cc-devthrottle` commands** and your agents are no longer told how
+  to reach each other. They will not message, list, or coordinate with the rest of
+  your fleet.
+- **Remove `[SESSION_ID]`** and an agent will not know which session it is.
+
+Those are your choices to make. DevThrottle will not overrule them.
+
+### If your text goes missing
+
+If you are running your own version and DevThrottle cannot read it, **it injects
+nothing and tells you.** It does not quietly fall back to our text. You turned our
+text off; a file error is not consent to turn it back on.
+
+## Our editorial policy
+
+The shipped text asks agents not to put their name on your work - no
+"Co-authored-by" trailer naming an assistant, no "Generated with" line. Several
+agents are told by their own vendor to add those by default, and that default is
+wrong for a repository that belongs to you.
+
+We think it is a good rule. It is also **our opinion arriving inside your agent**,
+which is a different kind of thing from telling an agent its session identifier,
+and you did not ask for it.
+
+So: it is in the tab, in plain sight, and you can delete it. If you want your
+agent to sign its commits, that is a legitimate choice on your machine, and
+DevThrottle should not be the reason you cannot make it.
+
+## Where it lives on disk
+
+Under your DevThrottle data directory, in `injected-text/`:
+
+- `ours.txt` - the text we ship. Rewritten on launch, so it is always current.
+  This file is a copy for you to read; editing it changes nothing, because the
+  version we ship lives in the application. Edit your own version in the tab.
+- `yours.txt` - your version, if you have written one.
+
+Which one is live is recorded in `config.json` under `injected_text.use_yours`.

--- a/docs/public/index.json
+++ b/docs/public/index.json
@@ -30,7 +30,8 @@
         { "id": "panels", "title": "Built-in Panels", "file": "features/04-panels.md" },
         { "id": "wingman-and-voice", "title": "Wingman and Voice", "file": "features/05-wingman-and-voice.md" },
         { "id": "mobile", "title": "Mobile and In-Car", "file": "features/06-mobile.md" },
-        { "id": "dialogs", "title": "Key Dialogs", "file": "features/07-dialogs.md" }
+        { "id": "dialogs", "title": "Key Dialogs", "file": "features/07-dialogs.md" },
+        { "id": "injected-text", "title": "Injected Text", "file": "features/08-injected-text.md" }
       ]
     },
     {

--- a/src/CcDirector.Avalonia.Tests/CcDirector.Avalonia.Tests.csproj
+++ b/src/CcDirector.Avalonia.Tests/CcDirector.Avalonia.Tests.csproj
@@ -13,6 +13,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="xunit" Version="2.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+    <!-- Renders real controls with no window, so a XAML mistake fails a test rather than waiting to
+         crash in front of the user. XAML is loaded at RUNTIME: a compiling build proves nothing about
+         whether a view opens. -->
+    <PackageReference Include="Avalonia.Headless" Version="11.*" />
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="11.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CcDirector.Avalonia.Tests/InjectedTextViewTests.cs
+++ b/src/CcDirector.Avalonia.Tests/InjectedTextViewTests.cs
@@ -1,0 +1,264 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+using CcDirector.Avalonia.Controls;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+[assembly: AvaloniaTestApplication(typeof(CcDirector.Avalonia.Tests.InjectedTextViewTestApp))]
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>A bare Avalonia application so controls can be built with no window.</summary>
+public class InjectedTextViewTestApp : Application
+{
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<InjectedTextViewTestApp>().UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}
+
+/// <summary>
+/// The Injected text tab, rendered for real with no window.
+///
+/// XAML is parsed at RUNTIME, so a build that succeeds says nothing about whether this view opens: a
+/// mistyped name or a handler that does not exist is a crash the moment the user clicks the tab. These
+/// tests exist so that lands here instead.
+///
+/// The banner assertions are the ones that matter. The owner's requirement is that a user running
+/// their own text must never be able to believe they are on ours, so "whose text is live" being wrong
+/// is not a cosmetic bug - it is the feature failing.
+/// </summary>
+public class InjectedTextViewTests
+{
+    [AvaloniaFact]
+    public async Task TheTabOpens()
+    {
+        var view = await ShownAsync();
+
+        // Reaching here means the XAML parsed, every x:Name resolved, and every Click handler named in
+        // the markup exists on the class.
+        Assert.NotNull(view);
+    }
+
+    [AvaloniaFact]
+    public async Task TheTabNamesTheMechanismAndDoesNotClaimWeTypeIntoTheTerminal()
+    {
+        var view = await ShownAsync();
+
+        var text = AllTextOf(view);
+
+        // Users assume the worse thing. The tab has to say plainly that this is a startup extension
+        // point and not keystrokes, because that is the distinction they cannot check for themselves.
+        Assert.Contains("not typed into your terminal", text);
+    }
+
+    [AvaloniaFact]
+    public async Task TheBannerStatesWhoseTextIsLive_AndTheTwoStatesCannotBeConfused()
+    {
+        var view = await ShownAsync();
+
+        var title = view.GetControl<TextBlock>("SourceTitle");
+        var banner = view.GetControl<Border>("SourceBanner");
+
+        // Whichever way this machine is configured, the banner must commit to one of the two answers
+        // in words, and it must not be blank or ambiguous.
+        Assert.False(string.IsNullOrWhiteSpace(title.Text));
+        Assert.True(
+            title.Text!.Contains("YOUR text", StringComparison.Ordinal) ||
+            title.Text.Contains("the DevThrottle text", StringComparison.Ordinal),
+            $"The banner must say whose text is live, but said: '{title.Text}'");
+
+        // The two states must not look alike: the colour carries the meaning for someone who glances.
+        Assert.NotNull(banner.Background);
+    }
+
+    [AvaloniaFact]
+    public async Task ThePlaceholdersAreListedWhereTheyAreTyped()
+    {
+        var view = await ShownAsync();
+
+        var hint = view.GetControl<TextBlock>("PlaceholderHint").Text ?? "";
+
+        // Documentation nobody opens is not a control. Every placeholder is named on the screen where
+        // the user writes them.
+        Assert.Contains("[SESSION_ID]", hint);
+        Assert.Contains("[USER_EMAIL]", hint);
+        Assert.Contains("[IF_SIGNED_IN]", hint);
+    }
+
+    // OURS is live: the banner says so, and the editor is not editable, because it is not their text.
+    [AvaloniaFact]
+    public async Task WhenOurTextIsLive_TheBannerSaysSo()
+    {
+        var dir = NewDir();
+        try
+        {
+            var view = await ShownAsync(InjectedTextStore.AlwaysOurs(dir));
+
+            Assert.Contains("the DevThrottle text", view.GetControl<TextBlock>("SourceTitle").Text!);
+            Assert.Contains("this is what your agents get", view.GetControl<TextBlock>("EditorLabel").Text!);
+            Assert.Contains("NEVER SIGN IT", view.GetControl<TextBox>("EditorBox").Text!);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // THEIRS is live: the banner must commit to that, and their words - not ours - must be on screen.
+    [AvaloniaFact]
+    public async Task WhenTheirTextIsLive_TheBannerSaysItIsTheirs_AndOurTextIsNotShownAsLive()
+    {
+        var dir = NewDir();
+        try
+        {
+            var store = TheirsStore(dir);
+            store.SaveYours("only my words. you are [SESSION_SHORT_ID].");
+
+            var view = await ShownAsync(store);
+
+            Assert.Contains("YOUR text", view.GetControl<TextBlock>("SourceTitle").Text!);
+            var editor = view.GetControl<TextBox>("EditorBox").Text!;
+            Assert.Equal("only my words. you are [SESSION_SHORT_ID].", editor);
+            // Our policy text must not be sitting in the live editor claiming to be theirs.
+            Assert.DoesNotContain("NEVER SIGN IT", editor);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // THE STATE THAT MATTERS MOST, and the one a config-dependent test could never reach. Their text is
+    // chosen but cannot be DELIVERED, so agents are getting nothing. The tab must say exactly that
+    // rather than labelling the editor "what your agents get".
+    //
+    // Two ways to get here, and they must look identical to the user because they are identical to the
+    // agent: the file is gone, or the file is there but was hand-edited into something unrenderable.
+    // The second is the one that slipped through: the file reads fine, so nothing failed until launch.
+    [AvaloniaTheory]
+    [InlineData(null)]                       // the file is gone
+    [InlineData("[IF_SIGNED_IN]\nhello")]    // hand-edited into a template that cannot render
+    public async Task WhenTheirTextCannotBeDelivered_TheTabSaysAgentsAreGettingNothing(string? onDisk)
+    {
+        var dir = NewDir();
+        try
+        {
+            var store = TheirsStore(dir);
+            if (onDisk is null)
+            {
+                store.SaveYours("my own text");
+                File.Delete(store.YoursPath);
+            }
+            else
+            {
+                // Bypass SaveYours, which validates - this is a file edited behind the product's back.
+                Directory.CreateDirectory(dir);
+                File.WriteAllText(store.YoursPath, onDisk);
+            }
+
+            var view = await ShownAsync(store);
+
+            var title = view.GetControl<TextBlock>("SourceTitle").Text!;
+            var label = view.GetControl<TextBlock>("EditorLabel").Text!;
+
+            Assert.Contains("NO injected text", title);
+            Assert.Contains("NOT live", label);
+            Assert.DoesNotContain("this is what your agents get", label);
+
+            // The error must be shown, and must NOT be our text quietly reappearing.
+            var error = view.GetControl<TextBlock>("ErrorText");
+            Assert.True(error.IsVisible);
+            Assert.DoesNotContain("NEVER SIGN IT", view.GetControl<TextBox>("EditorBox").Text ?? "");
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // The same lie, through a BUTTON instead of a load. Ours is live, a stale custom file is sitting on
+    // disk hand-edited into something unrenderable, and the user clicks "Switch back to my version".
+    // The config flips to theirs and every launch path injects nothing - so the banner must say so
+    // rather than cheerfully announcing their text is live.
+    //
+    // This is why every transition now mutates the store and RELOADS through the one path: the button
+    // used to reassemble the screen by hand and had no idea the file was undeliverable.
+    [AvaloniaFact]
+    public async Task SwitchingBackToAStaleInvalidVersion_DoesNotAnnounceItAsLive()
+    {
+        var dir = NewDir();
+        try
+        {
+            // Ours is live, but a custom file exists and was edited outside the product into a template
+            // that cannot render.
+            var useYours = false;
+            var store = new InjectedTextStore(dir, () => new InjectedTextConfig(useYours), v => useYours = v);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(store.YoursPath, "[IF_SIGNED_IN]\nhello");
+
+            var view = await ShownAsync(store);
+            Assert.Contains("the DevThrottle text", view.GetControl<TextBlock>("SourceTitle").Text!);
+
+            // The user switches back to their version.
+            await ClickAsync(view, "WriteMyOwnButton");
+
+            // The config really did change - so the tab must not claim their text is reaching agents.
+            Assert.True(useYours);
+            var title = view.GetControl<TextBlock>("SourceTitle").Text!;
+            var label = view.GetControl<TextBlock>("EditorLabel").Text!;
+            Assert.Contains("NO injected text", title);
+            Assert.Contains("NOT live", label);
+            Assert.DoesNotContain("this is what your agents get", label);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    /// <summary>Raise a button's Click and let the handler's async work finish.</summary>
+    private static async Task ClickAsync(InjectedTextView view, string name)
+    {
+        var button = view.GetControl<Button>(name);
+        button.RaiseEvent(new global::Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+
+        // The handlers are async void, so there is no task to await. Pump until the reload settles -
+        // bounded, so a hang fails the test rather than wedging the suite.
+        for (var i = 0; i < 50; i++)
+        {
+            await Task.Delay(10);
+            global::Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    private static InjectedTextStore TheirsStore(string dir)
+    {
+        var useYours = true;
+        return new InjectedTextStore(dir, () => new InjectedTextConfig(useYours), v => useYours = v);
+    }
+
+    private static string NewDir()
+        => Path.Combine(Path.GetTempPath(), "injected-text-view-test-" + Guid.NewGuid().ToString("N"));
+
+    private static void Cleanup(string dir)
+    {
+        try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    /// <summary>Build the view, show it, and WAIT for its first load to finish.</summary>
+    private static async Task<InjectedTextView> ShownAsync(InjectedTextStore? store = null)
+    {
+        var view = store is null ? new InjectedTextView() : new InjectedTextView(store);
+        var window = new Window { Content = view };
+        window.Show();
+        await view.Ready;
+        return view;
+    }
+
+    private static string AllTextOf(Visual root)
+    {
+        var parts = new List<string>();
+        Collect(root, parts);
+        return string.Join(" ", parts);
+
+        static void Collect(Visual v, List<string> into)
+        {
+            if (v is TextBlock tb && !string.IsNullOrEmpty(tb.Text))
+                into.Add(tb.Text);
+            foreach (var child in v.GetVisualChildren())
+                Collect(child, into);
+        }
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/InjectedTextView.axaml
+++ b/src/CcDirector.Avalonia/Controls/InjectedTextView.axaml
@@ -1,0 +1,144 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="CcDirector.Avalonia.Controls.InjectedTextView">
+
+    <UserControl.Styles>
+        <Style Selector="TextBlock.sectionTitle">
+            <Setter Property="Foreground" Value="#CCCCCC" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+        <Style Selector="TextBlock.hint">
+            <Setter Property="Foreground" Value="#888888" />
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+        <Style Selector="Border.card">
+            <Setter Property="Background" Value="#1E1E1E" />
+            <Setter Property="BorderBrush" Value="#3C3C3C" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="6" />
+            <Setter Property="Padding" Value="16" />
+        </Style>
+        <Style Selector="Button.dialogButton">
+            <Setter Property="Height" Value="30" />
+            <Setter Property="MinWidth" Value="76" />
+            <Setter Property="Padding" Value="14,0" />
+            <Setter Property="Background" Value="#3C3C3C" />
+            <Setter Property="Foreground" Value="#CCCCCC" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+        <Style Selector="Button.primaryButton">
+            <Setter Property="Height" Value="30" />
+            <Setter Property="MinWidth" Value="140" />
+            <Setter Property="Padding" Value="14,0" />
+            <Setter Property="Background" Value="#007ACC" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+        <!-- The text itself: monospace, because it lands in a terminal-shaped context and the
+             command block's alignment is meaningful. Scrollbars are always shown, never fading
+             overlays. -->
+        <Style Selector="TextBox.textPane">
+            <Setter Property="Background" Value="#1E1E1E" />
+            <Setter Property="Foreground" Value="#CCCCCC" />
+            <Setter Property="CaretBrush" Value="#CCCCCC" />
+            <Setter Property="BorderBrush" Value="#3C3C3C" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Padding" Value="8,6" />
+            <Setter Property="AcceptsReturn" Value="True" />
+            <Setter Property="TextWrapping" Value="NoWrap" />
+            <Setter Property="FontFamily" Value="Cascadia Mono, Consolas, Courier New" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Visible" />
+            <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Visible" />
+        </Style>
+    </UserControl.Styles>
+
+    <Grid RowDefinitions="Auto,Auto,Auto,*,Auto" Margin="0,4,0,0">
+
+        <!-- What this is. Users assume the worst thing (keystrokes typed into their terminal), so the
+             mechanism is stated plainly and up front. -->
+        <StackPanel Grid.Row="0" Spacing="6" Margin="0,0,0,12">
+            <TextBlock Classes="sectionTitle" Text="Injected text" />
+            <TextBlock Classes="hint"
+                       Text="When DevThrottle starts an agent, it gives the agent this text before your first message. It tells the agent which session it is and how to reach the other sessions in your fleet. It is handed over through each agent's own documented startup extension point - it is not typed into your terminal, and it does not touch anything you type." />
+            <TextBlock Classes="hint"
+                       Text="This is the whole of what DevThrottle adds at the start of a session. You can read it below, and you can replace it with your own." />
+        </StackPanel>
+
+        <!-- WHOSE TEXT IS LIVE. This is the one thing a user must never be wrong about, so it is a
+             full-width banner that changes colour, not a checkbox someone can misread. -->
+        <Border Grid.Row="1" x:Name="SourceBanner" CornerRadius="6" Padding="12,10" Margin="0,0,0,12">
+            <StackPanel Spacing="3">
+                <TextBlock x:Name="SourceTitle" FontSize="13" FontWeight="SemiBold" TextWrapping="Wrap" />
+                <TextBlock x:Name="SourceDetail" FontSize="11" TextWrapping="Wrap" Opacity="0.85" />
+            </StackPanel>
+        </Border>
+
+        <!-- Losing our updates is the trade for writing your own; say so where the choice is made. -->
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" Margin="0,0,0,10">
+            <Button x:Name="UseOursButton" Classes="dialogButton"
+                    Content="Use the DevThrottle text"
+                    ToolTip.Tip="Go back to the text DevThrottle ships. Your own version is kept, not deleted."
+                    Click="BtnUseOurs_Click" />
+            <Button x:Name="WriteMyOwnButton" Classes="dialogButton"
+                    Content="Write my own version"
+                    ToolTip.Tip="Start from a copy of the DevThrottle text and edit it. You stop receiving our updates to this text."
+                    Click="BtnWriteMyOwn_Click" />
+            <Button x:Name="ShowOursButton" Classes="dialogButton"
+                    Content="Show the current DevThrottle text"
+                    ToolTip.Tip="Read the version DevThrottle ships today, even while your own is live."
+                    Click="BtnShowOurs_Click" />
+        </StackPanel>
+
+        <Grid Grid.Row="3" ColumnDefinitions="*,Auto,*" RowDefinitions="Auto,*">
+
+            <!-- Left: the live text. Editable only when it is the user's own. -->
+            <TextBlock Grid.Row="0" Grid.Column="0" x:Name="EditorLabel"
+                       Classes="sectionTitle" FontSize="12" Margin="0,0,0,6" />
+            <TextBox Grid.Row="1" Grid.Column="0" x:Name="EditorBox" Classes="textPane"
+                     TextChanged="Editor_TextChanged" />
+
+            <!-- Right: what DevThrottle ships today, so a user on their own text can always read the
+                 current default and adopt it. Hidden until asked for, so the common case is one pane. -->
+            <GridSplitter Grid.Row="1" Grid.Column="1" x:Name="PaneSplitter"
+                          Width="6" Background="Transparent" IsVisible="False" />
+            <TextBlock Grid.Row="0" Grid.Column="2" x:Name="OursLabel"
+                       Classes="sectionTitle" FontSize="12" Margin="0,0,0,6"
+                       Text="The current DevThrottle text" IsVisible="False" />
+            <TextBox Grid.Row="1" Grid.Column="2" x:Name="OursBox" Classes="textPane"
+                     IsReadOnly="True" IsVisible="False" />
+        </Grid>
+
+        <StackPanel Grid.Row="4" Spacing="8" Margin="0,12,0,0">
+
+            <!-- The placeholders, listed where they are typed rather than in documentation nobody
+                 opens. -->
+            <TextBlock Classes="hint" x:Name="PlaceholderHint" />
+
+            <!-- Consequences of what the user has actually written: an unrenderable template, or a
+                 version with the fleet commands removed. Both are their right; neither should be
+                 discovered later. -->
+            <TextBlock x:Name="WarningText" FontSize="11" TextWrapping="Wrap"
+                       Foreground="#D7A650" IsVisible="False" />
+            <TextBlock x:Name="ErrorText" FontSize="11" TextWrapping="Wrap"
+                       Foreground="#E06C56" IsVisible="False" />
+
+            <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">
+                <TextBlock x:Name="SaveStatus" Text="" Foreground="#888888" FontSize="11"
+                           VerticalAlignment="Center" Margin="0,0,8,0" />
+                <Button x:Name="RevertButton" Classes="dialogButton"
+                        Content="Discard changes" IsVisible="False"
+                        Click="BtnRevert_Click" />
+                <Button x:Name="SaveButton" Classes="primaryButton"
+                        Content="Save my version" IsVisible="False"
+                        Click="BtnSave_Click" />
+            </StackPanel>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/CcDirector.Avalonia/Controls/InjectedTextView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/InjectedTextView.axaml.cs
@@ -1,0 +1,480 @@
+using Avalonia.Controls;
+using Avalonia.Media;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia.Controls;
+
+/// <summary>
+/// The Settings tab that shows the user exactly what DevThrottle injects into their agents, and lets
+/// them replace it with their own.
+///
+/// The point of this screen is CONSENT, so its first duty is that a user is never wrong about whose
+/// text is live. That is why the source is a full-width coloured banner rather than a checkbox: a
+/// user running their own text must never be able to believe they are on ours, and the reverse.
+/// </summary>
+public partial class InjectedTextView : UserControl
+{
+    // The colours of the two states. Ours is the calm, expected one; theirs is deliberately warmer,
+    // because "this text is not the one DevThrottle ships" is the fact this screen exists to convey.
+    private static readonly SolidColorBrush OursBannerBackground = new(Color.Parse("#173A2F"));
+    private static readonly SolidColorBrush OursBannerForeground = new(Color.Parse("#7BD1A8"));
+    private static readonly SolidColorBrush YoursBannerBackground = new(Color.Parse("#3A2E17"));
+    private static readonly SolidColorBrush YoursBannerForeground = new(Color.Parse("#E0B761"));
+    // The third state: chosen theirs, but it cannot be read, so agents are getting nothing at all.
+    private static readonly SolidColorBrush UnavailableBannerBackground = new(Color.Parse("#3A1D19"));
+    private static readonly SolidColorBrush UnavailableBannerForeground = new(Color.Parse("#E88E7D"));
+
+    private readonly InjectedTextStore _store;
+
+    /// <summary>The text as it is saved on disk, so "discard changes" and the dirty check are exact.</summary>
+    private string _savedText = "";
+
+    /// <summary>True while the code is setting the editor's text, so the change handler stays quiet.</summary>
+    private bool _loading;
+
+    /// <summary>True when the editor holds a draft of the user's own version, saved or not.</summary>
+    private bool _editingOwn;
+
+    /// <summary>
+    /// Set while their chosen text cannot be delivered, so agents are getting nothing.
+    ///
+    /// It is sticky on purpose. Refresh() re-validates whatever is in the editor and clears the error
+    /// when it is fine - which is right while typing, and wrong here: an unreadable file leaves an EMPTY
+    /// editor, empty is a perfectly valid template, so Refresh would cheerfully wipe the "your agents are
+    /// getting nothing" banner and leave the screen looking healthy while agents got nothing. The state
+    /// is about the file on disk, not about the text in the box, so only saving clears it.
+    /// </summary>
+    private bool _unavailable;
+
+    /// <summary>
+    /// The first load. Exposed so a test can await it instead of guessing when the text has arrived -
+    /// a test that races the load would go green on an empty screen, which is worse than no test.
+    /// </summary>
+    public Task Ready { get; }
+
+    /// <summary>The tab as the application builds it, over this machine's real injected text.</summary>
+    public InjectedTextView() : this(new InjectedTextStore()) { }
+
+    /// <summary>
+    /// Testable constructor over an explicit store.
+    ///
+    /// Without this, a test of the "your agents are getting nothing" banner could only pass by luck:
+    /// it would assert against whatever the developer's own machine happens to be set to, go green
+    /// having never entered the state it names, and stay green if that state broke. A test that cannot
+    /// reach the case it guards is decoration.
+    /// </summary>
+    public InjectedTextView(InjectedTextStore store)
+    {
+        _store = store;
+
+        InitializeComponent();
+
+        // The dialog must respond immediately (project rule 1), so the panel appears at once and the
+        // text arrives when it has been read.
+        EditorBox.Text = "Loading...";
+        EditorBox.IsEnabled = false;
+
+        // The banner must NEVER be blank or wrong, not even for the moment before the text arrives.
+        // "Whose text is live" is the one thing this screen exists to be right about, so it starts by
+        // admitting it does not know yet rather than showing a colour that means something.
+        SourceTitle.Text = "Checking which text your agents are getting...";
+        SourceDetail.Text = "";
+        SourceBanner.Background = new SolidColorBrush(Color.Parse("#2D2D2D"));
+        SourceTitle.Foreground = new SolidColorBrush(Color.Parse("#888888"));
+
+        Ready = InitialLoadAsync();
+    }
+
+    private async Task InitialLoadAsync()
+    {
+        try
+        {
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[InjectedTextView] InitialLoadAsync FAILED: {ex.Message}");
+            ShowError($"The injected text could not be loaded: {ex.Message}");
+        }
+    }
+
+    private async Task LoadAsync()
+    {
+        FileLog.Write("[InjectedTextView] LoadAsync");
+
+        // Writing our current text to disk is part of the promise that our updates are always there
+        // to read, even for a user running their own.
+        var (source, text, problem) = await Task.Run(() =>
+        {
+            _store.EnsureOursWritten();
+            var src = _store.ActiveSource();
+
+            try
+            {
+                // Ask the ACTUAL LAUNCH PATH what a session would be given, rather than re-deciding it
+                // here. This is the only way the tab and the agents cannot drift apart: any reason a
+                // session would get nothing - unreadable file, a template hand-edited into something
+                // that cannot render - surfaces here through the same code, automatically, including
+                // reasons added later that nobody remembers to mirror into this screen.
+                //
+                // The rendered result is thrown away; only whether it THROWS matters. What the user
+                // edits is the template, not the rendering.
+                FleetPreamble.BuildForSession(
+                    Guid.Empty.ToString(), "sample", Environment.MachineName, "sample", null, _store);
+
+                return (src, _store.ActiveTemplate(), (string?)null);
+            }
+            catch (Exception ex) when (ex is InjectedTextUnavailableException or FleetPreambleTemplateException)
+            {
+                // Their text is chosen but cannot be delivered. Show that plainly - we have NOT swapped
+                // ours in, and sessions are launching with no injected text at all until it is fixed.
+                string? theirs = null;
+                try { theirs = _store.ReadYours(); } catch { /* unreadable is the whole problem */ }
+                return (src, theirs ?? "", ex.Message);
+            }
+        });
+
+        _savedText = text;
+        _editingOwn = source == InjectedTextSource.Yours;
+
+        _loading = true;
+        EditorBox.Text = text;
+        _loading = false;
+        EditorBox.IsEnabled = true;
+        EditorBox.IsReadOnly = false;
+
+        PlaceholderHint.Text =
+            "DevThrottle fills these in for each session: " +
+            string.Join(", ", FleetPreamblePlaceholders.All) +
+            ". Write them anywhere in your text and they are replaced when a session starts. " +
+            "The lines between [IF_SIGNED_IN] and [END_IF] are used only when you are signed in.";
+
+        if (problem is not null)
+        {
+            // THE THIRD STATE, and it is not a detail. Their text is selected but cannot be delivered,
+            // so agents are getting NOTHING right now. Painting the ordinary "your text is live" banner
+            // over it would be a lie of exactly the kind this tab exists to stop: the label would say
+            // "this is what your agents get" about text they are not getting.
+            ApplyUnavailable(problem);
+        }
+        else
+        {
+            // LoadAsync is the ONLY thing that decides this state, in either direction. Every button
+            // that changes whose text is live now mutates the store and re-enters here rather than
+            // reassembling the screen by hand - the last defect in this tab was a button that set the
+            // ordinary "your text is live" banner without ever asking whether that text could be
+            // delivered, so a stale invalid file on disk was announced as live while agents got nothing.
+            _unavailable = false;
+            ApplySource(source);
+            Refresh();
+        }
+
+        FileLog.Write($"[InjectedTextView] LoadAsync: source={source}, {text.Length} characters, " +
+                      $"deliverable={problem is null}");
+    }
+
+    /// <summary>Paint the banner and set what the editor is allowed to do for this source.</summary>
+    private void ApplySource(InjectedTextSource source)
+    {
+        if (source == InjectedTextSource.Yours)
+        {
+            SourceBanner.Background = YoursBannerBackground;
+            SourceTitle.Foreground = YoursBannerForeground;
+            SourceDetail.Foreground = YoursBannerForeground;
+            SourceTitle.Text = "Your agents are getting YOUR text, not DevThrottle's.";
+            SourceDetail.Text =
+                "You are running a version you wrote. DevThrottle's updates to this text are still " +
+                "downloaded and can be read at any time, but they are not applied to yours.";
+            EditorLabel.Text = "Your text (this is what your agents get)";
+            EditorBox.IsReadOnly = false;
+            UseOursButton.IsVisible = true;
+            WriteMyOwnButton.IsVisible = false;
+        }
+        else
+        {
+            SourceBanner.Background = OursBannerBackground;
+            SourceTitle.Foreground = OursBannerForeground;
+            SourceDetail.Foreground = OursBannerForeground;
+            SourceTitle.Text = "Your agents are getting the DevThrottle text.";
+            SourceDetail.Text =
+                "This is the version we ship. It updates when DevThrottle updates. " +
+                "You can replace it with your own at any time.";
+            EditorLabel.Text = "The DevThrottle text (this is what your agents get)";
+            EditorBox.IsReadOnly = true;
+            UseOursButton.IsVisible = false;
+            WriteMyOwnButton.IsVisible = true;
+
+            // If they have a version of their own put aside, offer it back by name rather than making
+            // them retype it - and never word it as "write my own", which would suggest starting over
+            // and losing what they wrote.
+            WriteMyOwnButton.Content = _store.HasYours
+                ? "Switch back to my version"
+                : "Write my own version";
+        }
+    }
+
+    /// <summary>
+    /// The state where the user's text is chosen but cannot be read or rendered, so their agents are
+    /// currently getting NOTHING. It is called out in its own colour because it is neither of the two
+    /// normal answers, and because the honest sentence - "your agents have no injected text right now"
+    /// - is not one the user could work out from a banner that just says theirs is live.
+    /// </summary>
+    private void ApplyUnavailable(string problem)
+    {
+        _unavailable = true;
+        SourceBanner.Background = UnavailableBannerBackground;
+        SourceTitle.Foreground = UnavailableBannerForeground;
+        SourceDetail.Foreground = UnavailableBannerForeground;
+        SourceTitle.Text = "Your agents are getting NO injected text.";
+        SourceDetail.Text =
+            "You chose to run your own text, but it cannot be read. DevThrottle has NOT put its own " +
+            "text back in its place, because you turned that off. Save a version below, or switch to " +
+            "the DevThrottle text.";
+
+        EditorLabel.Text = "Your text (NOT live - it could not be read)";
+        EditorBox.IsReadOnly = false;
+        UseOursButton.IsVisible = true;
+        WriteMyOwnButton.IsVisible = false;
+
+        ShowError(problem);
+
+        // Saving is the way out, so the save controls are offered even though nothing has been typed.
+        SaveButton.IsVisible = true;
+        SaveButton.IsEnabled = true;
+        RevertButton.IsVisible = false;
+        SaveStatus.Text = "";
+    }
+
+    /// <summary>Recompute everything that depends on what is currently in the editor.</summary>
+    private void Refresh()
+    {
+        // While their text cannot be delivered, the screen keeps saying so. Saving is the way out, and
+        // BtnSave_Click is what clears this - see the field's note for why re-validating the editor is
+        // the wrong question to ask here.
+        if (_unavailable)
+            return;
+
+        var text = EditorBox.Text ?? "";
+        var dirty = _editingOwn && text != _savedText;
+
+        SaveButton.IsVisible = dirty;
+        RevertButton.IsVisible = dirty;
+        SaveStatus.Text = dirty ? "Not saved - your agents are still getting the previous text." : "";
+
+        ErrorText.IsVisible = false;
+
+        // An unrenderable template cannot be saved. Say so while they type, not at a session launch.
+        var problem = FleetPreambleRenderer.Validate(text);
+        if (problem is not null)
+        {
+            ShowError(problem);
+            SaveButton.IsEnabled = false;
+            return;
+        }
+
+        SaveButton.IsEnabled = true;
+        ShowWarningsFor(text);
+    }
+
+    /// <summary>
+    /// Tell the user what their own text will cost them, WITHOUT refusing it. Removing the fleet
+    /// commands is their right; discovering months later that their agents cannot find each other is
+    /// not a consequence they agreed to.
+    /// </summary>
+    private void ShowWarningsFor(string text)
+    {
+        var warnings = new List<string>();
+
+        if (!text.Contains("cc-devthrottle", StringComparison.Ordinal))
+            warnings.Add(
+                "Your text does not mention the cc-devthrottle command. Your agents will not be told " +
+                "how to reach each other, so they will not message, list, or coordinate with the rest " +
+                "of your fleet unless they work it out another way.");
+
+        if (!text.Contains(FleetPreamblePlaceholders.SessionId, StringComparison.Ordinal) &&
+            !text.Contains(FleetPreamblePlaceholders.SessionShortId, StringComparison.Ordinal))
+            warnings.Add(
+                "Your text does not include [SESSION_ID] or [SESSION_SHORT_ID], so an agent will not " +
+                "know which session it is.");
+
+        // The likeliest silent mistake: a placeholder-shaped word that is not one of ours reaches the
+        // agent verbatim. Catch it here, where the person who typed it is looking.
+        var unknown = FindUnknownPlaceholders(text);
+        if (unknown.Count > 0)
+            warnings.Add(
+                "This looks like a placeholder but is not one DevThrottle knows, so it will be sent to " +
+                "the agent exactly as written: " + string.Join(", ", unknown) + ".");
+
+        WarningText.Text = string.Join("\n\n", warnings);
+        WarningText.IsVisible = warnings.Count > 0;
+    }
+
+    /// <summary>
+    /// Find bracket-shaped words that look like a placeholder typo - all-capitals with underscores,
+    /// which is the shape of ours and not the shape of ordinary prose. Deliberately narrow: our own
+    /// text opens with the literal "[CC Director fleet]", and a user's "[see the docs]" is prose, not
+    /// a mistake. Warn about the near-misses only.
+    /// </summary>
+    private static List<string> FindUnknownPlaceholders(string text)
+    {
+        var found = new List<string>();
+        var known = new HashSet<string>(FleetPreamblePlaceholders.All, StringComparer.Ordinal)
+        {
+            FleetPreamblePlaceholders.IfSignedIn,
+            FleetPreamblePlaceholders.EndIf,
+        };
+
+        var i = 0;
+        while (i < text.Length)
+        {
+            var open = text.IndexOf('[', i);
+            if (open < 0) break;
+            var close = text.IndexOf(']', open);
+            if (close < 0) break;
+
+            var token = text[open..(close + 1)];
+            var inner = token[1..^1];
+
+            var placeholderShaped =
+                inner.Length > 0 &&
+                inner.All(c => char.IsAsciiLetterUpper(c) || c == '_' || c == '-' || char.IsAsciiDigit(c));
+
+            if (placeholderShaped && !known.Contains(token) && !found.Contains(token))
+                found.Add(token);
+
+            i = close + 1;
+        }
+
+        return found;
+    }
+
+    private void ShowError(string message)
+    {
+        ErrorText.Text = message;
+        ErrorText.IsVisible = true;
+        WarningText.IsVisible = false;
+    }
+
+    // -- Event handlers. Try-catch lives here and nowhere below (project rule 4). --
+
+    private void Editor_TextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (_loading) return;
+
+        try
+        {
+            Refresh();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[InjectedTextView] Editor_TextChanged FAILED: {ex.Message}");
+        }
+    }
+
+    private async void BtnWriteMyOwn_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        try
+        {
+            FileLog.Write("[InjectedTextView] BtnWriteMyOwn_Click");
+
+            if (_store.HasYours)
+            {
+                // They already have one put aside: bring it back rather than overwrite it. Note this
+                // file may be stale or hand-edited into something that cannot render - which is exactly
+                // why the reload below decides how it looks, instead of this method assuming.
+                _store.UseYours();
+            }
+            else
+            {
+                // Start from a copy of ours, which is the only sensible blank page: it is what their
+                // agents get today, and editing it is easier than writing from nothing.
+                _store.SaveYours(InjectedTextStore.Ours);
+            }
+
+            await LoadAsync();
+            SaveStatus.Text = "Your version is now live. Edit it and save.";
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[InjectedTextView] BtnWriteMyOwn_Click FAILED: {ex.Message}");
+            ShowError($"Could not switch to your own version: {ex.Message}");
+        }
+    }
+
+    private async void BtnUseOurs_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        try
+        {
+            FileLog.Write("[InjectedTextView] BtnUseOurs_Click");
+
+            _store.UseOurs();
+
+            await LoadAsync();
+            SaveStatus.Text = "Your version is kept - you can switch back to it at any time.";
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[InjectedTextView] BtnUseOurs_Click FAILED: {ex.Message}");
+            ShowError($"Could not switch to the DevThrottle version: {ex.Message}");
+        }
+    }
+
+    private void BtnShowOurs_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        try
+        {
+            var showing = !OursBox.IsVisible;
+            OursBox.IsVisible = showing;
+            OursLabel.IsVisible = showing;
+            PaneSplitter.IsVisible = showing;
+            OursBox.Text = InjectedTextStore.Ours;
+            ShowOursButton.Content = showing
+                ? "Hide the DevThrottle text"
+                : "Show the current DevThrottle text";
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[InjectedTextView] BtnShowOurs_Click FAILED: {ex.Message}");
+        }
+    }
+
+    private void BtnRevert_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        try
+        {
+            _loading = true;
+            EditorBox.Text = _savedText;
+            _loading = false;
+            Refresh();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[InjectedTextView] BtnRevert_Click FAILED: {ex.Message}");
+        }
+    }
+
+    private async void BtnSave_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        try
+        {
+            var text = EditorBox.Text ?? "";
+            FileLog.Write($"[InjectedTextView] BtnSave_Click: {text.Length} characters");
+
+            _store.SaveYours(text);
+
+            await LoadAsync();
+            SaveStatus.Text = "Saved. New sessions get this text.";
+        }
+        catch (FleetPreambleTemplateException ex)
+        {
+            FileLog.Write($"[InjectedTextView] BtnSave_Click rejected: {ex.Message}");
+            ShowError(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[InjectedTextView] BtnSave_Click FAILED: {ex.Message}");
+            ShowError($"Could not save your version: {ex.Message}");
+        }
+    }
+}

--- a/src/CcDirector.Avalonia/SettingsDialog.axaml
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml
@@ -286,6 +286,13 @@
                 </ScrollViewer>
             </TabItem>
 
+            <!-- What DevThrottle puts into an agent before the user's first message, and the controls
+                 to read it, replace it, or go back to ours. Its own view because it owns real state
+                 (two files plus a choice), not just a form field. -->
+            <TabItem Header="Injected text">
+                <controls:InjectedTextView />
+            </TabItem>
+
             <TabItem Header="Advanced">
                 <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Padding="0,0,14,0">
                     <StackPanel Spacing="12" Margin="0,4,0,0">

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -70,8 +70,30 @@ internal static class ControlEndpoints
 
             // A session only ever calls its OWN Director, so this Director's machine name is the
             // session's machine.
-            var text = FleetPreamble.Build(session.Id.ToString(), name, Environment.MachineName, session.RepoPath, user);
-            return Results.Text(text, "text/plain");
+            //
+            // BuildForSession, not Build: this is a live launch, so it must honour the user's choice
+            // of whose text is injected. Build renders the DevThrottle default regardless, which is
+            // only correct for previewing ours.
+            try
+            {
+                var text = FleetPreamble.BuildForSession(
+                    session.Id.ToString(), name, Environment.MachineName, session.RepoPath, user);
+                return Results.Text(text, "text/plain");
+            }
+            catch (Exception ex) when (ex is InjectedTextUnavailableException or FleetPreambleTemplateException)
+            {
+                // The user's text is live but unreadable, or was edited on disk into something that
+                // cannot render. Do NOT substitute ours - they turned ours off. An empty body means the
+                // hook injects nothing, so the session still starts and the agent simply has no
+                // preamble, rather than silently receiving the text (and the policy) they declined.
+                //
+                // This catches the render failure too, not just the read failure: an uncaught one would
+                // become a 500 WITH A BODY, and the macOS/Linux hook pipes this response straight to
+                // stdout - so an error page would arrive in the agent's context dressed as the
+                // preamble. An empty body is the only thing that reliably means "nothing".
+                FileLog.Write($"[ControlEndpoints] fleet-preamble unavailable for {sid}: {ex.Message}");
+                return Results.Text("", "text/plain");
+            }
         });
 
         // The fleet preamble pre-wrapped as ready-to-print SessionStart hook output. The
@@ -79,7 +101,7 @@ internal static class ControlEndpoints
         // POSIX shell), so the Director serializes the whole hookSpecificOutput envelope and the
         // script just prints this response body to stdout. Empty body when there is no preamble,
         // so the hook emits nothing rather than an empty envelope.
-        app.MapGet("/sessions/{sid}/fleet-preamble-hook-output", (string sid) =>
+        app.MapGet("/sessions/{sid}/fleet-preamble-hook-output", async (string sid, CancellationToken ct) =>
         {
             if (!Guid.TryParse(sid, out var guid))
                 return Results.BadRequest(new { error = "invalid session id format" });
@@ -92,8 +114,31 @@ internal static class ControlEndpoints
                 SessionName.FolderName(session.RepoPath),
                 SessionName.Disambiguator(session.Id));
 
-            var text = FleetPreamble.Build(session.Id.ToString(), name, Environment.MachineName, session.RepoPath);
-            if (string.IsNullOrWhiteSpace(text))
+            // Issue #1357: this path silently omitted the signed-in user, so Claude on macOS and Linux
+            // never got the identity line that Windows got - the same text built two ways, one of them
+            // wrong. Resolving the user here (which is why this handler is now async) makes the two
+            // platforms agree.
+            SignedInUser? user = signedInUserResolver is null ? null : await signedInUserResolver(ct);
+
+            string text;
+            try
+            {
+                text = FleetPreamble.BuildForSession(
+                    session.Id.ToString(), name, Environment.MachineName, session.RepoPath, user);
+            }
+            catch (Exception ex) when (ex is InjectedTextUnavailableException or FleetPreambleTemplateException)
+            {
+                // See the sibling endpoint: the user's text is live but unreadable or unrenderable, so
+                // we inject nothing rather than substituting the text they declined - and an empty body
+                // rather than an error body, because this response is piped straight to the hook's
+                // stdout.
+                FileLog.Write($"[ControlEndpoints] fleet-preamble-hook-output unavailable for {sid}: {ex.Message}");
+                return Results.Text("", "text/plain");
+            }
+
+            // BuildForSession already collapses whitespace-only text to empty, so this agrees with the
+            // sibling endpoint and with Pi by construction rather than by coincidence.
+            if (string.IsNullOrEmpty(text))
                 return Results.Text("", "text/plain");
 
             return Results.Json(new

--- a/src/CcDirector.Core.Tests/Pi/PiPreambleWriterTests.cs
+++ b/src/CcDirector.Core.Tests/Pi/PiPreambleWriterTests.cs
@@ -1,41 +1,50 @@
 using CcDirector.Core.Account;
+using CcDirector.Core.Configuration;
 using CcDirector.Core.Pi;
+using CcDirector.Core.Sessions;
 using Xunit;
 
 namespace CcDirector.Core.Tests.Pi;
 
 public class PiPreambleWriterTests
 {
+    // These tests assert the content of the DEVTHROTTLE default, so they pin the store to ours. Once
+    // the writer started honouring the user's choice, a bare call would read the real config.json and
+    // these would pass or fail depending on whether the developer running them happens to be running
+    // their own injected text. A test whose result depends on the tester is not a test.
+    private static InjectedTextStore OursStore(string dir) => InjectedTextStore.AlwaysOurs(dir);
+
+    private static InjectedTextStore TheirsStore(string dir, bool useYours = true)
+        => new(dir, () => new InjectedTextConfig(useYours), _ => { });
+
     // Issue #1357: when a signed-in user is supplied, the Pi preamble file names that user.
     [Fact]
     public void WriteForSession_WithSignedInUser_WritesIdentityLine()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "pi-preamble-test-" + Guid.NewGuid().ToString("N"));
+        var dir = NewDir();
         try
         {
             var sid = "abc12345-1111-2222-3333-444455556666";
             var path = PiPreambleWriter.WriteForSession(
                 sid, "myrepo", "MACHINE_A", @"D:\repo\myrepo", dir,
-                new SignedInUser("soren@example.com", "Starlord"));
+                new SignedInUser("soren@example.com", "Starlord"), OursStore(dir));
 
             var text = File.ReadAllText(path);
             Assert.Contains("The user of this session is Starlord (soren@example.com).", text);
             Assert.Contains("do not guess identity from usage or the database", text);
         }
-        finally
-        {
-            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
-        }
+        finally { Cleanup(dir); }
     }
 
     [Fact]
     public void WriteForSession_WritesPreambleFile_WithIdentityAndCommands()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "pi-preamble-test-" + Guid.NewGuid().ToString("N"));
+        var dir = NewDir();
         try
         {
             var sid = "abc12345-1111-2222-3333-444455556666";
-            var path = PiPreambleWriter.WriteForSession(sid, "myrepo", "MACHINE_A", @"D:\repo\myrepo", dir);
+            var path = PiPreambleWriter.WriteForSession(
+                sid, "myrepo", "MACHINE_A", @"D:\repo\myrepo", dir, user: null, store: OursStore(dir));
 
             Assert.True(File.Exists(path));
             Assert.Equal(Path.Combine(dir, sid + ".txt"), path);
@@ -52,26 +61,104 @@ public class PiPreambleWriterTests
             Assert.DoesNotContain("cc-send", text);
             Assert.DoesNotContain("cc-ask", text);
         }
-        finally
-        {
-            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
-        }
+        finally { Cleanup(dir); }
     }
 
     [Fact]
     public void WriteForSession_UnnamedSession_StillWritesUsableFile()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "pi-preamble-test-" + Guid.NewGuid().ToString("N"));
+        var dir = NewDir();
         try
         {
-            var path = PiPreambleWriter.WriteForSession("603b2066-aaaa-bbbb-cccc-ddddeeeeffff", null, "MACHINE_A", @"D:\repo", dir);
+            var path = PiPreambleWriter.WriteForSession(
+                "603b2066-aaaa-bbbb-cccc-ddddeeeeffff", null, "MACHINE_A", @"D:\repo", dir,
+                user: null, store: OursStore(dir));
+
             var text = File.ReadAllText(path);
             Assert.Contains("(unnamed)", text);
             Assert.Contains("603b2066", text);
         }
-        finally
+        finally { Cleanup(dir); }
+    }
+
+    // The behaviour the documentation promises, and the behaviour Pi did NOT have: when the user's text
+    // is chosen but unreadable, Pi launches with NOTHING injected. It must not abort the launch - the
+    // exception used to escape and take the session start down with it - and it must certainly not fall
+    // back to the DevThrottle text the user turned off.
+    [Fact]
+    public void WriteForSession_TheirTextChosenButMissing_WritesAnEmptyFile_AndNeverOurs()
+    {
+        var dir = NewDir();
+        try
         {
-            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+            var path = PiPreambleWriter.WriteForSession(
+                "abc12345-1111-2222-3333-444455556666", "myrepo", "MACHINE_A", @"D:\repo\myrepo",
+                dir, user: null, store: TheirsStore(dir));
+
+            // The file exists - Pi is launched with --append-system-prompt pointing at it - and is
+            // empty, so nothing is injected.
+            Assert.True(File.Exists(path));
+            var text = File.ReadAllText(path);
+            Assert.Equal("", text);
+
+            // The thing that must never happen: our text, and our policy, reaching someone who declined it.
+            Assert.DoesNotContain("NEVER SIGN IT", text);
+            Assert.DoesNotContain("cc-devthrottle", text);
         }
+        finally { Cleanup(dir); }
+    }
+
+    // Whitespace means nothing, and it must mean nothing HERE too - the same answer the hook endpoints
+    // give. Pi used to write the spaces while the hook path dropped them, so two agents disagreed about
+    // the same saved text.
+    [Fact]
+    public void WriteForSession_TheirTextIsWhitespace_WritesAnEmptyFile()
+    {
+        var dir = NewDir();
+        try
+        {
+            var useYours = false;
+            var store = new InjectedTextStore(
+                dir, () => new InjectedTextConfig(useYours), v => useYours = v);
+            store.SaveYours("   \n  \n");
+
+            var path = PiPreambleWriter.WriteForSession(
+                "abc12345-1111-2222-3333-444455556666", "myrepo", "MACHINE_A", @"D:\repo\myrepo",
+                dir, user: null, store: store);
+
+            Assert.Equal("", File.ReadAllText(path));
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // The user's own text reaches Pi intact when it is readable.
+    [Fact]
+    public void WriteForSession_TheirText_IsWhatPiGets()
+    {
+        var dir = NewDir();
+        try
+        {
+            var useYours = false;
+            var store = new InjectedTextStore(
+                dir, () => new InjectedTextConfig(useYours), v => useYours = v);
+            store.SaveYours("only my words. you are [SESSION_SHORT_ID].");
+
+            var path = PiPreambleWriter.WriteForSession(
+                "abc12345-1111-2222-3333-444455556666", "myrepo", "MACHINE_A", @"D:\repo\myrepo",
+                dir, user: null, store: store);
+
+            var text = File.ReadAllText(path);
+            Assert.Equal("only my words. you are abc12345.", text);
+            Assert.DoesNotContain("NEVER SIGN IT", text);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    private static string NewDir()
+        => Path.Combine(Path.GetTempPath(), "pi-preamble-test-" + Guid.NewGuid().ToString("N"));
+
+    private static void Cleanup(string dir)
+    {
+        try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
     }
 }

--- a/src/CcDirector.Core.Tests/Sessions/FleetPreambleRendererTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/FleetPreambleRendererTests.cs
@@ -1,0 +1,176 @@
+using CcDirector.Core.Account;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Sessions;
+
+/// <summary>
+/// The rendering MECHANICS, tested independently of whatever text we happen to ship. These hold for
+/// the user's own template too, which is the point: once a user can write this text, the renderer is
+/// the only thing standing between their words and seven agents.
+/// </summary>
+public class FleetPreambleRendererTests
+{
+    private const string Id = "a3dfb85e-49dd-442a-9e36-40fc44838783";
+    private static readonly SignedInUser User = new("soren@example.com", "Starlord");
+
+    private static string Render(string template, SignedInUser? user = null, string? name = "devthrottle")
+        => FleetPreambleRenderer.Render(template, Id, name, "MACHINE_A", @"C:\repos\devthrottle", user);
+
+    [Fact]
+    public void Render_SubstitutesEveryPlaceholder()
+    {
+        var text = Render(
+            "[SESSION_ID] [SESSION_SHORT_ID] [SESSION_NAME] [MACHINE] [REPO_PATH]", User);
+
+        Assert.Equal($"{Id} a3dfb85e devthrottle MACHINE_A C:\\repos\\devthrottle", text);
+    }
+
+    // The short id is a PREFIX of the full id, so a naive replace of [SESSION_ID] first would corrupt
+    // [SESSION_SHORT_ID], and vice versa. Pinned because the failure is silent: the agent gets a
+    // plausible-looking id that no fleet command accepts.
+    [Fact]
+    public void Render_ShortIdAndFullId_DoNotCorruptEachOther()
+    {
+        var text = Render("short=[SESSION_SHORT_ID] full=[SESSION_ID]", User);
+
+        Assert.Equal($"short=a3dfb85e full={Id}", text);
+    }
+
+    // THE TRAP THIS RENDERER EXISTS TO AVOID. Our own default text opens with the literal
+    // "[CC Director fleet]", and a user may write any bracketed prose they like. Only exact known
+    // tokens are substituted; everything else is ordinary text.
+    [Theory]
+    [InlineData("[CC Director fleet] hello")]
+    [InlineData("see [the docs] for more")]
+    [InlineData("[SESSION_IDENTIFIER] is not a token")]
+    [InlineData("[session_id] is case-sensitive and is not a token")]
+    [InlineData("[]")]
+    [InlineData("[[SESSION_UNKNOWN]]")]
+    [InlineData("[SESSION_ID")]
+    [InlineData("SESSION_ID]")]
+    public void Render_LeavesUnknownBracketedTextExactlyAsWritten(string template)
+    {
+        Assert.Equal(template, Render(template, User));
+    }
+
+    // The exact boundary of the rule above, pinned because the honest version is narrower than
+    // "unknown brackets survive". A KNOWN token expands wherever it appears - including nested inside
+    // other brackets - so there is no way to write a literal, non-expanding [SESSION_ID]. Accepted:
+    // an escape syntax would be a language the user must learn to edit a paragraph. Pinned so the
+    // limitation is a decision rather than a surprise.
+    //
+    // Note the sibling test above cannot catch this: it uses UNKNOWN tokens, which survive whatever
+    // the scanner does, so it would stay green even if this rule silently changed.
+    [Theory]
+    [InlineData("[[SESSION_SHORT_ID]]", "[a3dfb85e]")]
+    [InlineData("write [SESSION_SHORT_ID] to expand it", "write a3dfb85e to expand it")]
+    [InlineData("[MACHINE][MACHINE]", "MACHINE_AMACHINE_A")]
+    public void Render_KnownToken_ExpandsWhereverItAppears_IncludingInsideOtherBrackets(
+        string template, string expected)
+    {
+        Assert.Equal(expected, Render(template, User));
+    }
+
+    [Fact]
+    public void Render_SignedIn_KeepsTheBlockAndDropsOnlyTheMarkers()
+    {
+        var text = Render("before\n[IF_SIGNED_IN]\nhello [USER_NAME] <[USER_EMAIL]>\n[END_IF]\nafter", User);
+
+        Assert.Equal("before\nhello Starlord <soren@example.com>\nafter", text);
+    }
+
+    // The block must vanish WHOLE - no blank line where it was. A stray blank line is the kind of
+    // thing nobody notices in review and everybody sees in the agent's context.
+    [Fact]
+    public void Render_NotSignedIn_DropsTheBlockLeavingNoBlankLine()
+    {
+        var text = Render("before\n[IF_SIGNED_IN]\nhello [USER_NAME]\n[END_IF]\nafter", user: null);
+
+        Assert.Equal("before\nafter", text);
+    }
+
+    // A user with no email is not identified, whatever else the account carries.
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Render_SignedInUserWithoutAnEmail_IsTreatedAsNotSignedIn(string email)
+    {
+        var text = Render("[IF_SIGNED_IN]\nhello\n[END_IF]\nafter", new SignedInUser(email, "Starlord"));
+
+        Assert.Equal("after", text);
+    }
+
+    [Fact]
+    public void Render_UnnamedSession_UsesThePlaceholderName()
+    {
+        Assert.Equal("(unnamed)", Render("[SESSION_NAME]", User, name: null));
+        Assert.Equal("(unnamed)", Render("[SESSION_NAME]", User, name: ""));
+        Assert.Equal("(unnamed)", Render("[SESSION_NAME]", User, name: "   "));
+    }
+
+    // A value that happens to look like a token is DATA, not a token: substitution runs once over the
+    // template, never over its own output. Otherwise naming a session "[MACHINE]" would rewrite it.
+    [Fact]
+    public void Render_ValuesThatLookLikeTokens_AreNotSubstitutedAgain()
+    {
+        var text = FleetPreambleRenderer.Render(
+            "[SESSION_NAME]", Id, "[MACHINE]", "MACHINE_A", @"C:\repos\devthrottle", User);
+
+        Assert.Equal("[MACHINE]", text);
+    }
+
+    // A user pasting into the Settings tab produces \r\n. A stray carriage return renders as a control
+    // character in a terminal, so it is normalized here rather than shipped to seven agents.
+    [Fact]
+    public void Render_WindowsLineEndings_AreNormalized()
+    {
+        var text = Render("one\r\ntwo\r\n[IF_SIGNED_IN]\r\nhello\r\n[END_IF]\r\nthree", User);
+
+        Assert.Equal("one\ntwo\nhello\nthree", text);
+        Assert.DoesNotContain('\r', text);
+    }
+
+    [Fact]
+    public void Render_TemplateWithNoPlaceholders_IsReturnedUnchanged()
+    {
+        Assert.Equal("just some words", Render("just some words", User));
+    }
+
+    // The user is allowed to throw our text away entirely - including the fleet commands and the
+    // no-attribution rule. That is the whole point of the feature, so an empty template renders empty
+    // rather than failing or resurrecting a default.
+    [Fact]
+    public void Render_EmptyTemplate_RendersEmpty()
+    {
+        Assert.Equal("", Render("", User));
+    }
+
+    [Theory]
+    [InlineData("[IF_SIGNED_IN]\nhello", "never closed")]
+    [InlineData("hello\n[END_IF]", "no matching")]
+    [InlineData("[IF_SIGNED_IN]\n[IF_SIGNED_IN]\nhello\n[END_IF]\n[END_IF]", "cannot be nested")]
+    public void Validate_UnbalancedConditionals_AreRejectedInPlainEnglish(string template, string expected)
+    {
+        var problem = FleetPreambleRenderer.Validate(template);
+
+        Assert.NotNull(problem);
+        Assert.Contains(expected, problem);
+    }
+
+    [Fact]
+    public void Validate_TheShippedDefault_IsWellFormed()
+    {
+        Assert.Null(FleetPreambleRenderer.Validate(FleetPreambleTemplate.Default));
+    }
+
+    // Rendering a malformed template throws rather than guessing which half the author meant. The
+    // Settings tab validates at save, so a user never reaches this by typing.
+    [Fact]
+    public void Render_MalformedTemplate_ThrowsRatherThanGuessing()
+    {
+        var ex = Assert.Throws<FleetPreambleTemplateException>(() => Render("[IF_SIGNED_IN]\nhello", User));
+
+        Assert.Contains("never closed", ex.Message);
+    }
+}

--- a/src/CcDirector.Core.Tests/Sessions/FleetPreambleTemplateMigrationTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/FleetPreambleTemplateMigrationTests.cs
@@ -1,0 +1,65 @@
+using CcDirector.Core.Account;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Sessions;
+
+/// <summary>
+/// MIGRATION PROOF. The preamble used to be assembled with C# string interpolation; it is now a
+/// template rendered by substitution. This asserts the change was a pure refactor: for every shape of
+/// session, the new renderer produces text BYTE-IDENTICAL to the old builder.
+///
+/// LegacyFleetPreamble is the old implementation, copied mechanically from the commit before this one
+/// with only its namespace and class name changed - not retyped, because a transcription slip would
+/// land in both the template and the expectation and this test would pass while both were wrong.
+///
+/// WHY THIS IS STILL HERE, AND WHEN IT GOES. A frozen copy of the old builder must NOT become the
+/// permanent oracle for this text: the moment we intentionally reword the default - which we intend
+/// to do, and which the user may now do for themselves - an old builder is simply the wrong answer.
+/// But it is the only byte-for-byte guard that currently exists; the other tests assert substrings
+/// and policy lines, which would not notice a change to spacing, indentation, or the gap left when
+/// nobody is signed in. So it stays until the SAME change that adds a lasting golden test against an
+/// approved snapshot of FleetPreambleTemplate.Default - a snapshot that can be updated deliberately,
+/// where the diff shows a reviewer exactly what changed in the text reaching every agent. Deleting it
+/// before then would trade a real guard for no guard.
+/// </summary>
+public class FleetPreambleTemplateMigrationTests
+{
+    private const string Id = "a3dfb85e-49dd-442a-9e36-40fc44838783";
+
+    public static TheoryData<string, string?, string, string, SignedInUser?> Sessions() => new()
+    {
+        // Signed in, with a nickname - the everyday case.
+        { Id, "devthrottle", "MACHINE_A", @"C:\repos\devthrottle", new SignedInUser("soren@example.com", "Starlord") },
+        // Signed in, no nickname - the identity line falls back to the email as the display name.
+        { Id, "devthrottle", "MACHINE_A", @"C:\repos\devthrottle", new SignedInUser("soren@example.com", null) },
+        // Nobody signed in - the whole identity line must vanish, leaving no blank line behind.
+        { Id, "devthrottle", "MACHINE_A", @"C:\repos\devthrottle", null },
+        // An unnamed session renders the "(unnamed)" placeholder.
+        { Id, null, "MACHINE_A", @"C:\repos\devthrottle", null },
+        { Id, "", "MACHINE_A", @"C:\repos\devthrottle", null },
+        { Id, "   ", "MACHINE_A", @"C:\repos\devthrottle", null },
+        // A signed-in user with a blank email is NOT signed in as far as the identity line goes.
+        { Id, "devthrottle", "MACHINE_A", @"C:\repos\devthrottle", new SignedInUser("", "Starlord") },
+        { Id, "devthrottle", "MACHINE_A", @"C:\repos\devthrottle", new SignedInUser("   ", "Starlord") },
+        // A session id shorter than the eight characters the short id wants.
+        { "abc", "devthrottle", "MACHINE_A", @"C:\repos\devthrottle", null },
+        { "", "devthrottle", "MACHINE_A", @"C:\repos\devthrottle", null },
+        // Values that are themselves bracket-shaped must not be treated as placeholders.
+        { Id, "[SESSION_ID]", "MACHINE_A", @"C:\repos\devthrottle", null },
+        { Id, "devthrottle", "[MACHINE]", @"C:\repos\[REPO_PATH]", null },
+        // A repo path with spaces and a trailing backslash.
+        { Id, "my repo", "MACHINE_A", @"C:\Program Files\repos\", null },
+    };
+
+    [Theory]
+    [MemberData(nameof(Sessions))]
+    public void Render_MatchesTheOldBuilder_Exactly(
+        string sessionId, string? name, string machine, string repoPath, SignedInUser? user)
+    {
+        var legacy = LegacyFleetPreamble.Build(sessionId, name, machine, repoPath, user);
+        var rendered = FleetPreamble.Build(sessionId, name, machine, repoPath, user);
+
+        Assert.Equal(legacy, rendered);
+    }
+}

--- a/src/CcDirector.Core.Tests/Sessions/InjectedTextStoreTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/InjectedTextStoreTests.cs
@@ -1,0 +1,205 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Sessions;
+
+/// <summary>
+/// The store decides WHOSE text reaches the agent. These tests are about that decision, and about the
+/// one rule that matters most: when the user has declined our text, no failure path may quietly put
+/// it back.
+///
+/// The choice of whose text is live is held in memory here, NOT read from the real config.json. A test
+/// that read the developer's own setting would pass or fail based on how that developer happens to
+/// have their machine configured, which is a coin toss wearing a test's clothes.
+/// </summary>
+public sealed class InjectedTextStoreTests : IDisposable
+{
+    private readonly string _dir;
+    private bool _useYours;
+
+    public InjectedTextStoreTests()
+        => _dir = Path.Combine(Path.GetTempPath(), "cc-injected-text-tests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir))
+            Directory.Delete(_dir, recursive: true);
+    }
+
+    private InjectedTextStore NewStore()
+        => new(_dir, () => new InjectedTextConfig(_useYours), v => _useYours = v);
+
+    // BuildForSession collapses whitespace-only text to nothing, which is correct for a user who cleared
+    // their version - but it means a shipped default that ever rendered to whitespace would silently
+    // inject NOTHING into every agent, everywhere, with no error. That cannot happen today and this test
+    // is why it stays that way: the assumption is load-bearing, so it is asserted rather than trusted.
+    [Fact]
+    public void OurDefault_NeverRendersToNothing()
+    {
+        var dir = Path.Combine(_dir, "always-ours");
+
+        var text = FleetPreamble.BuildForSession(
+            "a3dfb85e-49dd-442a-9e36-40fc44838783", "devthrottle", "MACHINE_A", @"C:\repos\devthrottle",
+            user: null, store: InjectedTextStore.AlwaysOurs(dir));
+
+        Assert.False(string.IsNullOrWhiteSpace(text));
+        Assert.Contains("cc-devthrottle", text);
+    }
+
+    [Fact]
+    public void EnsureOursWritten_PutsTheShippedTextOnDisk()
+    {
+        var store = NewStore();
+
+        store.EnsureOursWritten();
+
+        Assert.True(File.Exists(store.OursPath));
+        Assert.Equal(FleetPreambleTemplate.Default, File.ReadAllText(store.OursPath));
+    }
+
+    // The owner's requirement: our updates are always there, even for someone running their own text,
+    // so they can read the current default and adopt it.
+    [Fact]
+    public void EnsureOursWritten_RefreshesOurText_EvenWhileTheUserIsRunningTheirOwn()
+    {
+        var store = NewStore();
+        store.SaveYours("my own text");
+        File.WriteAllText(store.OursPath, "a stale default from an older version");
+
+        store.EnsureOursWritten();
+
+        Assert.Equal(FleetPreambleTemplate.Default, File.ReadAllText(store.OursPath));
+        Assert.Equal(InjectedTextSource.Yours, store.ActiveSource());
+        Assert.Equal("my own text", store.ActiveTemplate());
+    }
+
+    // ours.txt is a COPY for the user to read, never the source. Hand-editing it must not change what
+    // gets injected, or the Settings tab would show one thing and sessions would launch with another.
+    [Fact]
+    public void OursOnDisk_IsACopy_HandEditsDoNotChangeWhatIsInjected()
+    {
+        var store = NewStore();
+        store.EnsureOursWritten();
+
+        File.WriteAllText(store.OursPath, "somebody edited this file by hand");
+
+        Assert.Equal(FleetPreambleTemplate.Default, store.ActiveTemplate());
+    }
+
+    [Fact]
+    public void AFreshInstall_RunsOurText()
+    {
+        _useYours = false;
+        var store = NewStore();
+
+        Assert.Equal(InjectedTextSource.Ours, store.ActiveSource());
+        Assert.Equal(FleetPreambleTemplate.Default, store.ActiveTemplate());
+        Assert.False(store.HasYours);
+    }
+
+    [Fact]
+    public void SaveYours_MakesTheirTextLive()
+    {
+        var store = NewStore();
+
+        store.SaveYours("just my words, [SESSION_ID]");
+
+        Assert.Equal(InjectedTextSource.Yours, store.ActiveSource());
+        Assert.Equal("just my words, [SESSION_ID]", store.ActiveTemplate());
+    }
+
+    // Yours or ours - never a merge, and never a mix. What is live is exactly one of the two.
+    [Fact]
+    public void SwitchingBackToOurs_KeepsTheirTextOnDisk()
+    {
+        var store = NewStore();
+        store.SaveYours("my own text");
+
+        store.UseOurs();
+
+        Assert.Equal(InjectedTextSource.Ours, store.ActiveSource());
+        Assert.Equal(FleetPreambleTemplate.Default, store.ActiveTemplate());
+        // Their words survive: switching back to ours to compare must never destroy their writing.
+        Assert.True(store.HasYours);
+        Assert.Equal("my own text", store.ReadYours());
+
+        store.UseYours();
+        Assert.Equal("my own text", store.ActiveTemplate());
+    }
+
+    // THE RULE THIS FEATURE EXISTS FOR. The user turned our text off. If their file cannot be read we
+    // must NOT hand the agent ours instead - that would silently inject the policy they declined,
+    // which is the exact thing they opted out of. It fails loudly instead.
+    [Fact]
+    public void TheirTextLiveButUnreadable_FailsLoudly_AndNeverSubstitutesOurs()
+    {
+        var store = NewStore();
+        store.SaveYours("my own text");
+
+        // Their live text disappears from under them - a sync, a cleanup, a disk error.
+        File.Delete(store.YoursPath);
+
+        Assert.Equal(InjectedTextSource.Yours, store.ActiveSource());
+        var ex = Assert.Throws<InjectedTextUnavailableException>(() => store.ActiveTemplate());
+
+        // The message must not carry our text, and must say plainly that we did NOT swap ours in.
+        Assert.DoesNotContain("NEVER SIGN IT", ex.Message);
+        Assert.Contains("you turned that off", ex.Message);
+        Assert.Contains("Injected text", ex.Message);
+    }
+
+    // THE SAME RULE, AT THE OTHER END. This test previously asserted the OPPOSITE - that choosing
+    // theirs with no file on disk quietly left our text live. That was a defect being defended by a
+    // test: it is indistinguishable from the case above where a live custom file is deleted, and in
+    // that case it silently resumes injecting our text, and our policy, into someone who declined it.
+    // Chosen-but-absent is a loud failure, not a quiet reversal.
+    [Fact]
+    public void TheirTextChosenButNeverWritten_FailsLoudly_AndNeverSubstitutesOurs()
+    {
+        _useYours = true;
+        var store = NewStore();
+
+        Assert.False(store.HasYours);
+        Assert.Equal(InjectedTextSource.Yours, store.ActiveSource());
+
+        var ex = Assert.Throws<InjectedTextUnavailableException>(() => store.ActiveTemplate());
+        Assert.DoesNotContain("NEVER SIGN IT", ex.Message);
+    }
+
+    [Fact]
+    public void UseYours_WithNothingWritten_IsRejectedInPlainEnglish()
+    {
+        var store = NewStore();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => store.UseYours());
+
+        Assert.Contains("Write one first", ex.Message);
+    }
+
+    // The failure lands on the person editing, not on seven agents at launch.
+    [Fact]
+    public void SaveYours_RejectsATemplateThatCannotRender()
+    {
+        var store = NewStore();
+
+        var ex = Assert.Throws<FleetPreambleTemplateException>(
+            () => store.SaveYours("[IF_SIGNED_IN]\nhello"));
+
+        Assert.Contains("never closed", ex.Message);
+        Assert.False(store.HasYours);
+    }
+
+    // The user is allowed to throw all of it away, including the fleet commands and our policy text.
+    // That is their right and the whole point; it must not be quietly refused.
+    [Fact]
+    public void TheUserMayInjectNothingAtAll()
+    {
+        var store = NewStore();
+
+        store.SaveYours("");
+
+        Assert.Equal(InjectedTextSource.Yours, store.ActiveSource());
+        Assert.Equal("", store.ActiveTemplate());
+    }
+}

--- a/src/CcDirector.Core.Tests/Sessions/LegacyFleetPreamble.cs
+++ b/src/CcDirector.Core.Tests/Sessions/LegacyFleetPreamble.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using CcDirector.Core.Account;
+
+namespace CcDirector.Core.Tests.Sessions;
+
+/// <summary>
+/// Builds the one-screen "fleet awareness" preamble that a session receives at launch so the
+/// agent knows its own identity and how to reach the rest of the fleet WITHOUT first having to
+/// discover and read a skill. This removes the discovery delay: every session already carries
+/// CC_SESSION_ID and CC_DIRECTOR_API in its environment, but an agent never reads environment
+/// variables unless something surfaces them - this is that something.
+///
+/// Surfaced into Claude sessions through the SessionStart hook's additionalContext (zero turn
+/// cost; see <see cref="Claude.ClaudeHookInstaller"/>) and reusable by other agent integrations
+/// through the GET /sessions/{sid}/fleet-preamble Control API endpoint.
+///
+/// ASCII only (no Unicode) so it renders cleanly in every agent's terminal on Windows.
+/// </summary>
+public static class LegacyFleetPreamble
+{
+    /// <summary>
+    /// Render the preamble for one session. <paramref name="name"/> may be null/empty
+    /// (an unnamed session); the other values are always present on a live session.
+    /// <paramref name="user"/> is the signed-in DevThrottle user (issue #1357); when null (no one
+    /// signed in) the user-identity line is omitted cleanly - no blank line, no "null" artifact.
+    /// </summary>
+    public static string Build(string sessionId, string? name, string machine, string repoPath, SignedInUser? user = null)
+    {
+        var shortId = sessionId.Length >= 8 ? sessionId.Substring(0, 8) : sessionId;
+        var displayName = string.IsNullOrWhiteSpace(name) ? "(unnamed)" : name;
+
+        var lines = new List<string>
+        {
+            $"[CC Director fleet] You are session {shortId} \"{displayName}\" on machine {machine}, repo {repoPath}.",
+            $"Your full session id is {sessionId}.",
+        };
+
+        // Issue #1357: tell the agent WHO the human is, so "me / my account / email me" binds to the
+        // signed-in account instead of being guessed from usage or the database. Only emitted when a
+        // user is actually signed in with an email; otherwise the line is omitted entirely.
+        if (user is not null && !string.IsNullOrWhiteSpace(user.Email))
+        {
+            lines.Add(
+                $"The user of this session is {user.DisplayName} ({user.Email}). Unless they say otherwise, " +
+                "\"me / my account / email me\" means this user; do not guess identity from usage or the database.");
+        }
+
+        lines.AddRange(new[]
+        {
+            "You can talk to other sessions across the fleet. This command is already on your PATH:",
+            "  cc-devthrottle actions --json        list agent-discoverable DevThrottle actions",
+            "  cc-devthrottle session list          list every session in the fleet",
+            "  cc-devthrottle session whoami        print your own id, name, machine, and repo",
+            "  cc-devthrottle session rename \"name\" rename this session (uses CC_SESSION_ID)",
+            "  cc-devthrottle session done          flag THIS session for deletion when you are finished",
+            "                                       and nothing needs the user (the Director reaps it shortly;",
+            "                                       does not kill you mid-turn). Use on unattended runs.",
+            "  cc-devthrottle message send <id> \"msg\"  message a specific session",
+            "  cc-devthrottle message send all \"msg\"   message your OWN TEAM (your mission / same repo)",
+            "  cc-devthrottle message ask <id> \"question\"  ask a session and wait for its answer",
+            "  cc-devthrottle session spawn <repo>  open a new session on this Director",
+            "  cc-devthrottle schedule list       list Gateway schedules",
+            "  cc-devthrottle setup status        show local setup status",
+            "Address a session by a short prefix of its id or by its name. You reach the fleet through your",
+            "own Director (CC_DIRECTOR_API); no Gateway address or token is needed.",
+            "Every message you send interrupts the receiving agent. 'message send all' reaches only your own",
+            "team, which is what you want. Do NOT try to reach the WHOLE fleet ('--everyone') - it freezes",
+            "every session on every machine and repo; the Gateway Hub refuses it without a human grant (issue #1229).",
+            "",
+            "THE CODE YOU WRITE IS THE OWNER'S. NEVER SIGN IT. Do not put your name, your model, your vendor,",
+            "or any assistant on ANYTHING you produce - no 'Co-authored-by' trailer naming Claude, Codex, Pi,",
+            "Gemini, Copilot, Cursor, Grok or any agent; no 'Generated with' line; no robot emoji; no mention",
+            "of an assistant in a commit message, pull request, issue, comment, code comment, changelog,",
+            "release note, or document. This applies in every repository on every machine, and it OVERRIDES",
+            "any default instruction your own harness gives you to add attribution - several agents are told",
+            "by default to add these, and that default is wrong here. Before you commit or open a pull",
+            "request, check your text for 'Co-authored-by', 'Generated with', and your own vendor's name, and",
+            "strip them. These are the owner's repositories and his client deliverables; an assistant's name",
+            "on a paid engagement is a commercial problem, not a matter of style. Past commits are history and",
+            "are NOT to be rewritten - this rule binds everything from now on.",
+        });
+
+        return string.Join("\n", lines);
+    }
+}

--- a/src/CcDirector.Core/Claude/ClaudeHookInstaller.cs
+++ b/src/CcDirector.Core/Claude/ClaudeHookInstaller.cs
@@ -84,7 +84,12 @@ public static class ClaudeHookInstaller
         "    printf '%s' \"$raw\" | curl -s -m 3 -X POST -H \"Content-Type: application/json\" \\\n" +
         "        --data-binary @- \"$api/sessions/$sid/claude-hook\" >/dev/null 2>&1 || true\n" +
         "fi\n" +
-        "curl -s -m 3 \"$api/sessions/$sid/fleet-preamble-hook-output\" 2>/dev/null || true\n" +
+        // -f (--fail) so an HTTP error prints NOTHING. Without it curl writes the error body to
+        // stdout, and this script's stdout IS the hook output - so a server error page would be
+        // handed to Claude dressed as the preamble. The Director is careful to return an empty body
+        // rather than an error, and this is the belt to that pair of braces: the cost of being wrong
+        // here is arbitrary text entering the user's session as instructions.
+        "curl -sf -m 3 \"$api/sessions/$sid/fleet-preamble-hook-output\" 2>/dev/null || true\n" +
         "exit 0\n";
 
     /// <summary>The hook event sources we register a SessionStart hook for. These are the

--- a/src/CcDirector.Core/Configuration/InjectedTextConfig.cs
+++ b/src/CcDirector.Core/Configuration/InjectedTextConfig.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace CcDirector.Core.Configuration;
+
+/// <summary>
+/// Whether the user has chosen to run their own injected text instead of the one DevThrottle ships.
+///
+/// Persisted in config.json under the top-level object "injected_text":
+///   - "use_yours" (bool) - run the user's own text (base/injected-text/yours.txt) instead of ours.
+///                          DEFAULT FALSE: a fresh install runs our text, which is what it did
+///                          before this setting existed.
+///
+/// No-fallback rule: a present-but-wrong-typed key THROWS with the fix named, rather than silently
+/// picking a default. For THIS setting that matters more than most - silently reading a malformed
+/// "use_yours" as false would inject our text, including our policy text, into the sessions of
+/// someone who had explicitly turned it off. That is the exact failure this feature exists to
+/// prevent, so it fails loudly instead.
+/// </summary>
+public sealed record InjectedTextConfig(bool UseYours)
+{
+    /// <summary>The default posture: DevThrottle's text, as it was before the user could choose.</summary>
+    public static readonly InjectedTextConfig Default = new(UseYours: false);
+
+    /// <summary>Read the effective setting from config.json's "injected_text" object.</summary>
+    public static InjectedTextConfig Get()
+    {
+        var node = CcDirectorConfigService.ReadRaw()["injected_text"];
+        if (node is null)
+            return Default;
+
+        if (node is not JsonObject obj)
+            throw new InvalidOperationException(
+                "config.json key 'injected_text' must be an object. " +
+                "Fix the value or remove the key to use the DevThrottle text.");
+
+        return new InjectedTextConfig(UseYours: ReadBool(obj, "use_yours", Default.UseYours));
+    }
+
+    /// <summary>Record the user's choice of whose text is live.</summary>
+    public static void SetUseYours(bool useYours)
+        => CcDirectorConfigService.MergePatch(new JsonObject
+        {
+            ["injected_text"] = new JsonObject { ["use_yours"] = useYours },
+        });
+
+    private static bool ReadBool(JsonObject obj, string key, bool fallback)
+    {
+        var node = obj[key];
+        if (node is null)
+            return fallback;
+        if (node is JsonValue v && v.GetValueKind() == JsonValueKind.True) return true;
+        if (node is JsonValue v2 && v2.GetValueKind() == JsonValueKind.False) return false;
+
+        throw new InvalidOperationException(
+            $"config.json key 'injected_text.{key}' must be true or false. " +
+            "Fix the value or remove the key to use the DevThrottle text.");
+    }
+}

--- a/src/CcDirector.Core/Pi/PiPreambleWriter.cs
+++ b/src/CcDirector.Core/Pi/PiPreambleWriter.cs
@@ -35,12 +35,41 @@ public static class PiPreambleWriter
 
     /// <summary>Testable overload that writes under an explicit directory and names the signed-in user.</summary>
     public static string WriteForSession(string sessionId, string? name, string machine, string repoPath, string directory, SignedInUser? user)
+        => WriteForSession(sessionId, name, machine, repoPath, directory, user, store: null);
+
+    /// <summary>Testable overload that also pins the injected-text store.</summary>
+    public static string WriteForSession(
+        string sessionId, string? name, string machine, string repoPath, string directory,
+        SignedInUser? user, InjectedTextStore? store)
     {
         Directory.CreateDirectory(directory);
-        var text = FleetPreamble.Build(sessionId, name, machine, repoPath, user);
+
+        // BuildForSession, not Build: Pi is a live delivery path, so it injects the user's own text
+        // when they are running one.
+        string text;
+        try
+        {
+            text = FleetPreamble.BuildForSession(sessionId, name, machine, repoPath, user, store);
+        }
+        catch (Exception ex) when (ex is InjectedTextUnavailableException or FleetPreambleTemplateException)
+        {
+            // The user's text is live but unreadable or unrenderable. Write an EMPTY file: Pi is
+            // launched with --append-system-prompt pointing at it, so empty means nothing is injected.
+            //
+            // This mirrors what the hook endpoints do for Claude and Codex, and it is the behaviour the
+            // documentation promises: DevThrottle injects nothing and says so. Letting the exception
+            // escape here would abort the Pi session's launch instead - a different, undocumented, and
+            // much ruder answer to the same situation. Note what is NOT done: substituting our text.
+            // They turned ours off, and a file error is not consent to turn it back on.
+            FileLog.Write(
+                $"[PiPreambleWriter] the user's injected text is unavailable for {sessionId}, so NOTHING " +
+                $"is injected (the DevThrottle text is deliberately not substituted): {ex.Message}");
+            text = "";
+        }
+
         var path = Path.Combine(directory, $"{sessionId}.txt");
         File.WriteAllText(path, text);
-        FileLog.Write($"[PiPreambleWriter] wrote fleet preamble for {sessionId} to {path}");
+        FileLog.Write($"[PiPreambleWriter] wrote fleet preamble for {sessionId} to {path} ({text.Length} characters)");
         return path;
     }
 

--- a/src/CcDirector.Core/Sessions/FleetPreamble.cs
+++ b/src/CcDirector.Core/Sessions/FleetPreamble.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using CcDirector.Core.Account;
 
 namespace CcDirector.Core.Sessions;
@@ -14,72 +13,22 @@ namespace CcDirector.Core.Sessions;
 /// cost; see <see cref="Claude.ClaudeHookInstaller"/>) and reusable by other agent integrations
 /// through the GET /sessions/{sid}/fleet-preamble Control API endpoint.
 ///
+/// THE TEXT ITSELF LIVES IN <see cref="FleetPreambleTemplate"/> and is filled in by
+/// <see cref="FleetPreambleRenderer"/>. It used to be assembled here with C# string interpolation,
+/// which made it impossible for a user to see or change what we put into their agents. Keeping the
+/// text as data is what lets the Settings tab show it and, later, let the user replace it.
+///
 /// ASCII only (no Unicode) so it renders cleanly in every agent's terminal on Windows.
 /// </summary>
 public static class FleetPreamble
 {
     /// <summary>
-    /// Render the preamble for one session. <paramref name="name"/> may be null/empty
-    /// (an unnamed session); the other values are always present on a live session.
-    /// <paramref name="user"/> is the signed-in DevThrottle user (issue #1357); when null (no one
-    /// signed in) the user-identity line is omitted cleanly - no blank line, no "null" artifact.
+    /// Render the DEFAULT preamble - the text DevThrottle ships - for one session.
+    /// <paramref name="name"/> may be null/empty (an unnamed session); the other values are always
+    /// present on a live session. <paramref name="user"/> is the signed-in DevThrottle user (issue
+    /// #1357); when null (no one signed in) the user-identity line is omitted cleanly - no blank
+    /// line, no "null" artifact.
     /// </summary>
     public static string Build(string sessionId, string? name, string machine, string repoPath, SignedInUser? user = null)
-    {
-        var shortId = sessionId.Length >= 8 ? sessionId.Substring(0, 8) : sessionId;
-        var displayName = string.IsNullOrWhiteSpace(name) ? "(unnamed)" : name;
-
-        var lines = new List<string>
-        {
-            $"[CC Director fleet] You are session {shortId} \"{displayName}\" on machine {machine}, repo {repoPath}.",
-            $"Your full session id is {sessionId}.",
-        };
-
-        // Issue #1357: tell the agent WHO the human is, so "me / my account / email me" binds to the
-        // signed-in account instead of being guessed from usage or the database. Only emitted when a
-        // user is actually signed in with an email; otherwise the line is omitted entirely.
-        if (user is not null && !string.IsNullOrWhiteSpace(user.Email))
-        {
-            lines.Add(
-                $"The user of this session is {user.DisplayName} ({user.Email}). Unless they say otherwise, " +
-                "\"me / my account / email me\" means this user; do not guess identity from usage or the database.");
-        }
-
-        lines.AddRange(new[]
-        {
-            "You can talk to other sessions across the fleet. This command is already on your PATH:",
-            "  cc-devthrottle actions --json        list agent-discoverable DevThrottle actions",
-            "  cc-devthrottle session list          list every session in the fleet",
-            "  cc-devthrottle session whoami        print your own id, name, machine, and repo",
-            "  cc-devthrottle session rename \"name\" rename this session (uses CC_SESSION_ID)",
-            "  cc-devthrottle session done          flag THIS session for deletion when you are finished",
-            "                                       and nothing needs the user (the Director reaps it shortly;",
-            "                                       does not kill you mid-turn). Use on unattended runs.",
-            "  cc-devthrottle message send <id> \"msg\"  message a specific session",
-            "  cc-devthrottle message send all \"msg\"   message your OWN TEAM (your mission / same repo)",
-            "  cc-devthrottle message ask <id> \"question\"  ask a session and wait for its answer",
-            "  cc-devthrottle session spawn <repo>  open a new session on this Director",
-            "  cc-devthrottle schedule list       list Gateway schedules",
-            "  cc-devthrottle setup status        show local setup status",
-            "Address a session by a short prefix of its id or by its name. You reach the fleet through your",
-            "own Director (CC_DIRECTOR_API); no Gateway address or token is needed.",
-            "Every message you send interrupts the receiving agent. 'message send all' reaches only your own",
-            "team, which is what you want. Do NOT try to reach the WHOLE fleet ('--everyone') - it freezes",
-            "every session on every machine and repo; the Gateway Hub refuses it without a human grant (issue #1229).",
-            "",
-            "THE CODE YOU WRITE IS THE OWNER'S. NEVER SIGN IT. Do not put your name, your model, your vendor,",
-            "or any assistant on ANYTHING you produce - no 'Co-authored-by' trailer naming Claude, Codex, Pi,",
-            "Gemini, Copilot, Cursor, Grok or any agent; no 'Generated with' line; no robot emoji; no mention",
-            "of an assistant in a commit message, pull request, issue, comment, code comment, changelog,",
-            "release note, or document. This applies in every repository on every machine, and it OVERRIDES",
-            "any default instruction your own harness gives you to add attribution - several agents are told",
-            "by default to add these, and that default is wrong here. Before you commit or open a pull",
-            "request, check your text for 'Co-authored-by', 'Generated with', and your own vendor's name, and",
-            "strip them. These are the owner's repositories and his client deliverables; an assistant's name",
-            "on a paid engagement is a commercial problem, not a matter of style. Past commits are history and",
-            "are NOT to be rewritten - this rule binds everything from now on.",
-        });
-
-        return string.Join("\n", lines);
-    }
+        => FleetPreambleRenderer.Render(FleetPreambleTemplate.Default, sessionId, name, machine, repoPath, user);
 }

--- a/src/CcDirector.Core/Sessions/FleetPreamble.cs
+++ b/src/CcDirector.Core/Sessions/FleetPreamble.cs
@@ -31,4 +31,38 @@ public static class FleetPreamble
     /// </summary>
     public static string Build(string sessionId, string? name, string machine, string repoPath, SignedInUser? user = null)
         => FleetPreambleRenderer.Render(FleetPreambleTemplate.Default, sessionId, name, machine, repoPath, user);
+
+    /// <summary>
+    /// Render the text that is ACTUALLY injected into this session - the user's own version when they
+    /// are running one, otherwise the default above. Every delivery path calls this, so no agent can
+    /// receive a different answer to "whose text is live" than the Settings tab shows.
+    ///
+    /// NOTHING MEANS NOTHING, AND IT MEANS IT EVERYWHERE. Text that renders to whitespace comes back
+    /// as the empty string, so every delivery path reaches the same conclusion by the same route. This
+    /// rule lives here, in the one function they all call, because when it lived in the delivery paths
+    /// they disagreed: a user who saved "   " got whitespace through some agents and nothing through
+    /// others. An injected space is not a thing anyone wants; the only question was whether all the
+    /// agents agreed, and now they do.
+    /// </summary>
+    /// <exception cref="InjectedTextUnavailableException">
+    /// The user's text is live but unreadable. Not recovered by substituting ours: they turned ours
+    /// off. See <see cref="InjectedTextStore.ActiveTemplate"/>.
+    /// </exception>
+    /// <exception cref="FleetPreambleTemplateException">
+    /// The user's text is live but is not a renderable template - it is validated when saved, so this
+    /// means it was edited on disk afterwards. Also not recovered by substituting ours.
+    /// </exception>
+    public static string BuildForSession(
+        string sessionId,
+        string? name,
+        string machine,
+        string repoPath,
+        SignedInUser? user = null,
+        InjectedTextStore? store = null)
+    {
+        var text = FleetPreambleRenderer.Render(
+            (store ?? new InjectedTextStore()).ActiveTemplate(), sessionId, name, machine, repoPath, user);
+
+        return string.IsNullOrWhiteSpace(text) ? "" : text;
+    }
 }

--- a/src/CcDirector.Core/Sessions/FleetPreambleRenderer.cs
+++ b/src/CcDirector.Core/Sessions/FleetPreambleRenderer.cs
@@ -1,0 +1,247 @@
+using System.Collections.Generic;
+using System.Text;
+using CcDirector.Core.Account;
+
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// The placeholder tokens a fleet-preamble template may use. These are the ONLY tokens the renderer
+/// substitutes; every other run of square brackets in the text is left exactly as written.
+/// </summary>
+public static class FleetPreamblePlaceholders
+{
+    /// <summary>The session's full identifier.</summary>
+    public const string SessionId = "[SESSION_ID]";
+
+    /// <summary>The first eight characters of the session id - what the fleet commands take.</summary>
+    public const string SessionShortId = "[SESSION_SHORT_ID]";
+
+    /// <summary>The session's display name, or "(unnamed)".</summary>
+    public const string SessionName = "[SESSION_NAME]";
+
+    /// <summary>The machine the session runs on.</summary>
+    public const string Machine = "[MACHINE]";
+
+    /// <summary>The session's repository / working directory.</summary>
+    public const string RepoPath = "[REPO_PATH]";
+
+    /// <summary>The signed-in user's display name. Only meaningful inside an [IF_SIGNED_IN] block.</summary>
+    public const string UserName = "[USER_NAME]";
+
+    /// <summary>The signed-in user's email. Only meaningful inside an [IF_SIGNED_IN] block.</summary>
+    public const string UserEmail = "[USER_EMAIL]";
+
+    /// <summary>Opens a block kept only when a user is signed in.</summary>
+    public const string IfSignedIn = "[IF_SIGNED_IN]";
+
+    /// <summary>Closes an [IF_SIGNED_IN] block.</summary>
+    public const string EndIf = "[END_IF]";
+
+    /// <summary>Every substitution token, for documentation and for the Settings tab to list.</summary>
+    public static IReadOnlyList<string> All { get; } = new[]
+    {
+        SessionId, SessionShortId, SessionName, Machine, RepoPath, UserName, UserEmail,
+    };
+}
+
+/// <summary>
+/// Renders a fleet-preamble template - ours or the user's - into the exact text one session receives.
+///
+/// The whole design is SUBSTITUTION, not evaluation: there is no expression language, no loops, and
+/// exactly ONE conditional ([IF_SIGNED_IN]), which exists only because the signed-in-user line has to
+/// vanish completely when nobody is signed in and a half-rendered "The user of this session is  ()."
+/// would be worse than no line. Anything more would be a language the user has to learn in order to
+/// edit a paragraph.
+///
+/// SUBSTITUTION IS EXACT-TOKEN ONLY. The default text itself opens with the literal "[CC Director
+/// fleet]", and a user may write anything bracket-shaped in their own prose. So the renderer replaces
+/// only the known tokens above and never pattern-matches brackets. Bracketed text that is not a known
+/// token is ordinary text and survives verbatim.
+///
+/// THE RULE, STATED EXACTLY, because a vaguer version of it was wrong: a known token is replaced
+/// WHEREVER it appears, including when it sits inside other brackets - "[[SESSION_ID]]" renders as
+/// "[" + the id + "]". There is deliberately no escape syntax for writing a literal "[SESSION_ID]"
+/// that does not expand. That is a real if rare limitation, accepted because the alternative is an
+/// escaping language the user must learn in order to edit a paragraph, and because the tokens are
+/// all-capital names nobody writes by accident. It is pinned by test rather than left to be
+/// rediscovered.
+/// </summary>
+public static class FleetPreambleRenderer
+{
+    /// <summary>
+    /// Render <paramref name="template"/> for one session. <paramref name="name"/> may be null/empty
+    /// (an unnamed session). <paramref name="user"/> is the signed-in DevThrottle user; when null, or
+    /// when they have no email, every [IF_SIGNED_IN] block is dropped whole - no blank line, no "null".
+    /// </summary>
+    /// <exception cref="FleetPreambleTemplateException">
+    /// The template's conditional markers are unbalanced. This is thrown rather than papered over: a
+    /// malformed template means the text reaching the agent is not the text the author intended, and
+    /// silently guessing which half they meant is how the wrong instructions reach seven agents.
+    /// Callers that accept user-authored templates validate with <see cref="Validate"/> at the point
+    /// the user saves, so this surfaces at the edit, not at a session launch.
+    /// </exception>
+    public static string Render(
+        string template,
+        string sessionId,
+        string? name,
+        string machine,
+        string repoPath,
+        SignedInUser? user = null)
+    {
+        var signedIn = user is not null && !string.IsNullOrWhiteSpace(user.Email);
+        var kept = ApplyConditionals(template, signedIn);
+
+        var shortId = sessionId.Length >= 8 ? sessionId.Substring(0, 8) : sessionId;
+        var displayName = string.IsNullOrWhiteSpace(name) ? "(unnamed)" : name;
+
+        var values = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [FleetPreamblePlaceholders.SessionId] = sessionId,
+            [FleetPreamblePlaceholders.SessionShortId] = shortId,
+            [FleetPreamblePlaceholders.SessionName] = displayName,
+            [FleetPreamblePlaceholders.Machine] = machine,
+            [FleetPreamblePlaceholders.RepoPath] = repoPath,
+            // Outside an [IF_SIGNED_IN] block these can appear with nobody signed in. They render
+            // empty rather than leaking the token text to the agent.
+            [FleetPreamblePlaceholders.UserName] = signedIn ? user!.DisplayName : "",
+            [FleetPreamblePlaceholders.UserEmail] = signedIn ? user!.Email : "",
+        };
+
+        return Substitute(kept, values);
+    }
+
+    /// <summary>
+    /// Check a template's conditional markers are balanced. Returns null when the template is fine,
+    /// or a plain-English description of the problem to show the user.
+    /// </summary>
+    public static string? Validate(string template)
+    {
+        var depth = 0;
+        var lineNumber = 0;
+
+        foreach (var line in SplitLines(template))
+        {
+            lineNumber++;
+            var trimmed = line.Trim();
+
+            if (trimmed == FleetPreamblePlaceholders.IfSignedIn)
+            {
+                if (depth > 0)
+                    return $"Line {lineNumber} opens another {FleetPreamblePlaceholders.IfSignedIn} " +
+                           $"before the previous one was closed with {FleetPreamblePlaceholders.EndIf}. " +
+                           "These blocks cannot be nested.";
+                depth++;
+            }
+            else if (trimmed == FleetPreamblePlaceholders.EndIf)
+            {
+                if (depth == 0)
+                    return $"Line {lineNumber} has an {FleetPreamblePlaceholders.EndIf} with no " +
+                           $"matching {FleetPreamblePlaceholders.IfSignedIn} above it.";
+                depth--;
+            }
+        }
+
+        return depth > 0
+            ? $"An {FleetPreamblePlaceholders.IfSignedIn} block was never closed with " +
+              $"{FleetPreamblePlaceholders.EndIf}."
+            : null;
+    }
+
+    /// <summary>
+    /// Replace known tokens in ONE left-to-right pass over the template.
+    ///
+    /// A single pass is the whole correctness argument, and it is not a micro-optimisation. Chained
+    /// String.Replace calls run over their own output, so a value substituted early is still visible
+    /// to every later replacement: a session named "[MACHINE]" would come out as the machine name.
+    /// Scanning once means a substituted VALUE is never re-examined, so what the user's data says can
+    /// never be mistaken for what their template says.
+    /// </summary>
+    private static string Substitute(string text, IReadOnlyDictionary<string, string> values)
+    {
+        var output = new StringBuilder(text.Length);
+        var i = 0;
+
+        while (i < text.Length)
+        {
+            if (text[i] == '[')
+            {
+                var end = text.IndexOf(']', i);
+                if (end > i)
+                {
+                    var token = text[i..(end + 1)];
+                    if (values.TryGetValue(token, out var value))
+                    {
+                        output.Append(value);
+                        i = end + 1;
+                        continue;
+                    }
+                }
+            }
+
+            // Not a known token: ordinary text, including any bracket-shaped prose.
+            output.Append(text[i]);
+            i++;
+        }
+
+        return output.ToString();
+    }
+
+    /// <summary>
+    /// Drop the marker lines, and - when nobody is signed in - the lines they wrap. Whole lines are
+    /// removed, so a dropped block leaves no blank line behind.
+    /// </summary>
+    private static string ApplyConditionals(string template, bool signedIn)
+    {
+        var problem = Validate(template);
+        if (problem is not null)
+            throw new FleetPreambleTemplateException(problem);
+
+        var output = new StringBuilder();
+        var inBlock = false;
+        var first = true;
+
+        foreach (var line in SplitLines(template))
+        {
+            var trimmed = line.Trim();
+
+            if (trimmed == FleetPreamblePlaceholders.IfSignedIn)
+            {
+                inBlock = true;
+                continue;
+            }
+
+            if (trimmed == FleetPreamblePlaceholders.EndIf)
+            {
+                inBlock = false;
+                continue;
+            }
+
+            if (inBlock && !signedIn)
+                continue;
+
+            if (!first)
+                output.Append('\n');
+            output.Append(line);
+            first = false;
+        }
+
+        return output.ToString();
+    }
+
+    /// <summary>
+    /// Split on newlines, tolerating Windows line endings. A user pasting text into the Settings tab
+    /// will produce \r\n; the agents want \n, and a stray \r renders as a control character in a
+    /// terminal, so the \r is dropped here rather than shipped to seven agents.
+    /// </summary>
+    private static IEnumerable<string> SplitLines(string text)
+    {
+        foreach (var line in text.Split('\n'))
+            yield return line.EndsWith('\r') ? line[..^1] : line;
+    }
+}
+
+/// <summary>Thrown when a fleet-preamble template cannot be rendered as written.</summary>
+public class FleetPreambleTemplateException : Exception
+{
+    public FleetPreambleTemplateException(string message) : base(message) { }
+}

--- a/src/CcDirector.Core/Sessions/FleetPreambleTemplate.cs
+++ b/src/CcDirector.Core/Sessions/FleetPreambleTemplate.cs
@@ -1,0 +1,67 @@
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// The DEFAULT injected text DevThrottle ships, as a template rather than as built-up C# strings.
+///
+/// This is the text every agent receives at the start of a session. It is OURS: it ships with the
+/// application, it is deployed from the repository, and it is refreshed on every launch. The user
+/// may replace it with their own version, in which case this text is still written to disk and still
+/// shown in Settings so they can read the current default and adopt it - it is simply not the text
+/// that gets injected.
+///
+/// WHY THIS IS A TEMPLATE AND NOT INTERPOLATED C#: the user must be able to edit the prose while
+/// the session id and friends still get filled in. That is only possible if the substitution points
+/// are data in the text rather than code around it.
+///
+/// ASCII only (no Unicode) so it renders cleanly in every agent's terminal on Windows.
+/// </summary>
+public static class FleetPreambleTemplate
+{
+    /// <summary>
+    /// The shipped default. Placeholders are the square-bracket tokens listed in
+    /// <see cref="FleetPreamblePlaceholders"/>; the lines between [IF_SIGNED_IN] and [END_IF] are
+    /// dropped entirely when nobody is signed in.
+    ///
+    /// Note the first line opens with the literal text "[CC Director fleet]", which is bracket-shaped
+    /// but is NOT a placeholder. The renderer only ever substitutes exact known tokens, so bracketed
+    /// prose that is not one of them survives verbatim. See FleetPreambleRenderer for the exact rule
+    /// and its one accepted limitation.
+    /// </summary>
+    public const string Default =
+        "[CC Director fleet] You are session [SESSION_SHORT_ID] \"[SESSION_NAME]\" on machine [MACHINE], repo [REPO_PATH].\n" +
+        "Your full session id is [SESSION_ID].\n" +
+        "[IF_SIGNED_IN]\n" +
+        "The user of this session is [USER_NAME] ([USER_EMAIL]). Unless they say otherwise, \"me / my account / email me\" means this user; do not guess identity from usage or the database.\n" +
+        "[END_IF]\n" +
+        "You can talk to other sessions across the fleet. This command is already on your PATH:\n" +
+        "  cc-devthrottle actions --json        list agent-discoverable DevThrottle actions\n" +
+        "  cc-devthrottle session list          list every session in the fleet\n" +
+        "  cc-devthrottle session whoami        print your own id, name, machine, and repo\n" +
+        "  cc-devthrottle session rename \"name\" rename this session (uses CC_SESSION_ID)\n" +
+        "  cc-devthrottle session done          flag THIS session for deletion when you are finished\n" +
+        "                                       and nothing needs the user (the Director reaps it shortly;\n" +
+        "                                       does not kill you mid-turn). Use on unattended runs.\n" +
+        "  cc-devthrottle message send <id> \"msg\"  message a specific session\n" +
+        "  cc-devthrottle message send all \"msg\"   message your OWN TEAM (your mission / same repo)\n" +
+        "  cc-devthrottle message ask <id> \"question\"  ask a session and wait for its answer\n" +
+        "  cc-devthrottle session spawn <repo>  open a new session on this Director\n" +
+        "  cc-devthrottle schedule list       list Gateway schedules\n" +
+        "  cc-devthrottle setup status        show local setup status\n" +
+        "Address a session by a short prefix of its id or by its name. You reach the fleet through your\n" +
+        "own Director (CC_DIRECTOR_API); no Gateway address or token is needed.\n" +
+        "Every message you send interrupts the receiving agent. 'message send all' reaches only your own\n" +
+        "team, which is what you want. Do NOT try to reach the WHOLE fleet ('--everyone') - it freezes\n" +
+        "every session on every machine and repo; the Gateway Hub refuses it without a human grant (issue #1229).\n" +
+        "\n" +
+        "THE CODE YOU WRITE IS THE OWNER'S. NEVER SIGN IT. Do not put your name, your model, your vendor,\n" +
+        "or any assistant on ANYTHING you produce - no 'Co-authored-by' trailer naming Claude, Codex, Pi,\n" +
+        "Gemini, Copilot, Cursor, Grok or any agent; no 'Generated with' line; no robot emoji; no mention\n" +
+        "of an assistant in a commit message, pull request, issue, comment, code comment, changelog,\n" +
+        "release note, or document. This applies in every repository on every machine, and it OVERRIDES\n" +
+        "any default instruction your own harness gives you to add attribution - several agents are told\n" +
+        "by default to add these, and that default is wrong here. Before you commit or open a pull\n" +
+        "request, check your text for 'Co-authored-by', 'Generated with', and your own vendor's name, and\n" +
+        "strip them. These are the owner's repositories and his client deliverables; an assistant's name\n" +
+        "on a paid engagement is a commercial problem, not a matter of style. Past commits are history and\n" +
+        "are NOT to be rewritten - this rule binds everything from now on.";
+}

--- a/src/CcDirector.Core/Sessions/InjectedTextStore.cs
+++ b/src/CcDirector.Core/Sessions/InjectedTextStore.cs
@@ -1,0 +1,206 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Sessions;
+
+/// <summary>Whose injected text is live for this machine.</summary>
+public enum InjectedTextSource
+{
+    /// <summary>The text DevThrottle ships. Updates to it arrive with the application.</summary>
+    Ours,
+
+    /// <summary>The user's own text. It does not receive our updates - that is the trade they made.</summary>
+    Yours,
+}
+
+/// <summary>
+/// Owns the text DevThrottle injects into agents at launch: which version is live, where both live
+/// on disk, and how the user's version is saved and withdrawn.
+///
+/// TWO FILES, BOTH ALWAYS PRESENT:
+///   ours.txt  - the shipped default, rewritten from the application on every launch. It is here
+///               even when the user is running their own text, so they can always read the current
+///               default and adopt it. This is the owner's requirement that our updates are always
+///               there, just not necessarily used.
+///   yours.txt - the user's version. Exists only once they write one.
+///
+/// YOURS OR OURS, NEVER A MERGE. Deliberately: a three-way reconciliation of prose nobody asked for
+/// is how you end up injecting a sentence neither party wrote.
+///
+/// ours.txt IS A COPY, NOT THE SOURCE. The shipped default's source of truth is
+/// <see cref="FleetPreambleTemplate.Default"/>, in the application. The file exists so the text is
+/// visible on disk and diffable; if it is edited by hand it is overwritten on the next launch. This
+/// is what stops the Settings tab showing one default while sessions launch with another.
+/// </summary>
+public sealed class InjectedTextStore
+{
+    private readonly string _directory;
+    private readonly Func<InjectedTextConfig> _readConfig;
+    private readonly Action<bool> _writeUseYours;
+
+    /// <summary>The store over the real per-user Director data directory and the real config.json.</summary>
+    public InjectedTextStore() : this(CcStorage.InjectedText()) { }
+
+    /// <summary>Testable constructor over an explicit directory, using the real config.json.</summary>
+    public InjectedTextStore(string directory)
+        : this(directory, InjectedTextConfig.Get, InjectedTextConfig.SetUseYours) { }
+
+    /// <summary>
+    /// Testable constructor over an explicit directory AND an explicit choice of whose text is live.
+    ///
+    /// The choice is a dependency rather than a global read because it is not incidental: a test that
+    /// reaches into the real config.json passes or fails depending on how the developer running it has
+    /// their own machine set up, which is not a test, it is a coin toss. It also made unrelated tests -
+    /// the Pi preamble writer's - quietly depend on this setting the moment the writer started honouring
+    /// it.
+    /// </summary>
+    public InjectedTextStore(string directory, Func<InjectedTextConfig> readConfig, Action<bool> writeUseYours)
+    {
+        _directory = directory;
+        _readConfig = readConfig;
+        _writeUseYours = writeUseYours;
+    }
+
+    /// <summary>
+    /// A store whose text is definitely the DevThrottle default, over a throwaway directory. For tests
+    /// that need a preamble rendered and do not care whose it is - they must not become sensitive to
+    /// the developer's own choice.
+    /// </summary>
+    public static InjectedTextStore AlwaysOurs(string directory)
+        => new(directory, () => new InjectedTextConfig(UseYours: false), _ => { });
+
+    /// <summary>Where the shipped default is written for the user to read.</summary>
+    public string OursPath => Path.Combine(_directory, "ours.txt");
+
+    /// <summary>Where the user's own text lives, if they have written one.</summary>
+    public string YoursPath => Path.Combine(_directory, "yours.txt");
+
+    /// <summary>The text DevThrottle ships, straight from the application - never from disk.</summary>
+    public static string Ours => FleetPreambleTemplate.Default;
+
+    /// <summary>True when the user has written their own text, whether or not it is live.</summary>
+    public bool HasYours => File.Exists(YoursPath);
+
+    /// <summary>
+    /// Write the shipped default to disk so it is always readable, even when the user's text is live.
+    /// Called at launch. Best-effort: failing to write this COPY must never stop a session starting,
+    /// because the real default is in the application and rendering does not depend on this file.
+    /// </summary>
+    public void EnsureOursWritten()
+    {
+        try
+        {
+            Directory.CreateDirectory(_directory);
+            var path = OursPath;
+
+            // Only write when it differs, so the file's timestamp means "our text changed" rather
+            // than "the application started".
+            if (File.Exists(path) && File.ReadAllText(path) == Ours)
+                return;
+
+            File.WriteAllText(path, Ours);
+            FileLog.Write($"[InjectedTextStore] wrote the shipped injected text to {path}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[InjectedTextStore] EnsureOursWritten failed for '{_directory}': {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Which version is live. This is the user's CHOICE, and nothing else - deliberately NOT
+    /// "their choice, if their file happens to be readable".
+    ///
+    /// An earlier version of this method returned Ours when the user had chosen theirs but the file
+    /// was missing. That reads like sensible defensiveness and is the exact bug this whole feature
+    /// exists to prevent: someone declines our text, their file later goes missing, and we silently
+    /// resume injecting our text - including our policy - into their agents, with the Settings tab
+    /// still saying theirs is live. A missing file is now a loud failure in
+    /// <see cref="ActiveTemplate"/>, never a quiet reversal of their decision.
+    /// </summary>
+    public InjectedTextSource ActiveSource()
+        => _readConfig().UseYours ? InjectedTextSource.Yours : InjectedTextSource.Ours;
+
+    /// <summary>
+    /// The template that will actually be injected into the next session.
+    /// </summary>
+    /// <exception cref="InjectedTextUnavailableException">
+    /// The user's text is live but cannot be read. This does NOT fall back to ours, and the reason is
+    /// the whole point of the feature: the user declined our text, so injecting it anyway because we
+    /// hit a file error would be the exact thing they opted out of - silently, and with our policy in
+    /// it. The caller fails loudly instead. See the callers for what a session does with that.
+    /// </exception>
+    public string ActiveTemplate()
+    {
+        if (ActiveSource() == InjectedTextSource.Ours)
+            return Ours;
+
+        try
+        {
+            // File.ReadAllText on a missing path throws, which is the behaviour wanted here: chosen
+            // but absent is a failure, not a reason to reach for our text.
+            return File.ReadAllText(YoursPath);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[InjectedTextStore] ActiveTemplate FAILED reading '{YoursPath}': {ex.Message}");
+            throw new InjectedTextUnavailableException(
+                $"Your injected text could not be read from {YoursPath} ({ex.Message}). " +
+                "DevThrottle has not substituted its own text, because you turned that off. " +
+                "Fix or restore the file, or switch back to the DevThrottle version in " +
+                "Settings, Injected text.", ex);
+        }
+    }
+
+    /// <summary>Read the user's text, or null when they have not written one.</summary>
+    public string? ReadYours() => HasYours ? File.ReadAllText(YoursPath) : null;
+
+    /// <summary>
+    /// Save the user's text and make it live. Rejects a template that cannot render, so the failure
+    /// lands on the person editing it rather than on seven agents at launch.
+    /// </summary>
+    /// <exception cref="FleetPreambleTemplateException">The text is not a renderable template.</exception>
+    public void SaveYours(string text)
+    {
+        var problem = FleetPreambleRenderer.Validate(text);
+        if (problem is not null)
+            throw new FleetPreambleTemplateException(problem);
+
+        Directory.CreateDirectory(_directory);
+        File.WriteAllText(YoursPath, text);
+        _writeUseYours(true);
+        FileLog.Write($"[InjectedTextStore] saved the user's injected text to {YoursPath}; it is now live");
+    }
+
+    /// <summary>
+    /// Go back to the DevThrottle version. The user's text is KEPT on disk, not deleted - switching
+    /// back to ours is a reversible choice, and silently destroying the paragraphs they wrote because
+    /// they wanted to compare against the default would be unforgivable.
+    /// </summary>
+    public void UseOurs()
+    {
+        _writeUseYours(false);
+        FileLog.Write("[InjectedTextStore] the DevThrottle injected text is now live; the user's version is kept");
+    }
+
+    /// <summary>Make the user's text live again, if they have one.</summary>
+    public void UseYours()
+    {
+        if (!HasYours)
+            throw new InvalidOperationException(
+                "There is no custom injected text to switch to. Write one first.");
+
+        _writeUseYours(true);
+        FileLog.Write("[InjectedTextStore] the user's injected text is now live");
+    }
+}
+
+/// <summary>
+/// Thrown when the user's injected text is live but unreadable. Deliberately NOT recoverable by
+/// substituting the DevThrottle default - see <see cref="InjectedTextStore.ActiveTemplate"/>.
+/// </summary>
+public class InjectedTextUnavailableException : Exception
+{
+    public InjectedTextUnavailableException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -508,8 +508,21 @@ public sealed class SessionManager : IDisposable
             // Issue #705: make session-to-session messaging discoverable to the agent. This is a
             // one-line reminder, NOT a credential - the tools reach the fleet through CC_DIRECTOR_API
             // above (the Director relays to the Gateway), so the fleet token never enters the session.
-            envVars["CC_FLEET_TOOLS"] =
-                "cc-devthrottle actions --json (list DevThrottle actions); cc-devthrottle session list; cc-devthrottle session whoami; cc-devthrottle session rename \"name\"; cc-devthrottle message send <id|all> \"message\"; cc-devthrottle message ask <id> \"question\"; cc-devthrottle schedule list; cc-devthrottle setup status";
+            //
+            // It is ALSO injected text, and it is OURS: nothing in the product reads this variable, so
+            // its only reader is the agent. That makes it prose we put in front of an agent without
+            // being asked, exactly like the preamble - and it reaches every agent, including the ones
+            // with no preamble at all.
+            //
+            // So it follows the same choice. A user running their own text has declined our words, and
+            // continuing to whisper our command list through the environment would make the Settings
+            // tab a liar: they could delete the fleet commands from their text and we would put them
+            // back through a channel the tab never mentions.
+            if (new InjectedTextStore().ActiveSource() == InjectedTextSource.Ours)
+            {
+                envVars["CC_FLEET_TOOLS"] =
+                    "cc-devthrottle actions --json (list DevThrottle actions); cc-devthrottle session list; cc-devthrottle session whoami; cc-devthrottle session rename \"name\"; cc-devthrottle message send <id|all> \"message\"; cc-devthrottle message ask <id> \"question\"; cc-devthrottle schedule list; cc-devthrottle setup status";
+            }
 
             // Cursor authenticates via CURSOR_API_KEY (issue #517, assumption A5). Inject the
             // configured key into the session environment so cursor-agent picks it up. The key
@@ -545,6 +558,12 @@ public sealed class SessionManager : IDisposable
                 envVars["OPENCODE_DISABLE_UPDATE_CHECK"] = "1";
                 envVars["OPENCODE_DISABLE_AUTO_UPDATE"] = "1";
             }
+
+            // Keep the copy of OUR injected text on disk current, whatever the user is running. It is
+            // what the Settings tab offers them to read and adopt, so a user on their own version can
+            // always see the default they are declining. Best-effort by design: the real default is in
+            // the application, so a failure to write this copy must never stop a session starting.
+            new InjectedTextStore().EnsureOursWritten();
 
             // For Claude, install the session-pointer hooks and pass them via --settings so the
             // Director learns the current Claude session id + transcript path across /clear and

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -187,6 +187,11 @@ public static class CcStorage
     /// <summary>Codex hook scripts the Director installs: base/codex-hooks/.</summary>
     public static string CodexHooks() => Path.Combine(Base(), "codex-hooks");
 
+    /// <summary>The text DevThrottle injects into agents at launch: base/injected-text/. Holds
+    /// ours.txt (the shipped default, rewritten every launch) and yours.txt (the user's version,
+    /// present only if they wrote one).</summary>
+    public static string InjectedText() => Path.Combine(Base(), "injected-text");
+
     /// <summary>Dictation root: base/dictation/. Holds the user dictionary plus the
     /// recordings/ and sessions/ subfolders.</summary>
     public static string Dictation() => Path.Combine(Base(), "dictation");


### PR DESCRIPTION
## Why

DevThrottle silently injects text into every agent session it starts, on every machine, with no way to see it, no way to decline it, and no mention of it anywhere a user would look. That was tolerable while it was plumbing. It stopped being tolerable when an editorial policy went into it. The rule is a good one, but it is our opinion arriving inside someone else's agent, and they did not ask for it.

This makes it a choice.

## What

- A new Settings tab, "Injected text", that shows exactly what DevThrottle gives an agent at the start of a session - the whole of it, and nothing else - and lets the user replace it with their own. Yours or ours, never a merge. A full-width banner makes it impossible to be wrong about which one is live.
- Writing your own means you stop getting our updates to that text, but our version is still written to disk and readable at any time, so the current default can always be adopted.
- The fleet preamble becomes a template rendered by substitution rather than interpolated C#, so placeholders like the session id survive user editing.
- Cross-platform fixes surfaced along the way: the macOS/Linux signed-in-user omission, the POSIX hook using curl -sf, whitespace collapse in the renderer, and the fleet tools environment following the same yours-or-ours choice.

## Verification

- Full solution build: 0 warnings, 0 errors.
- Full Core test suite: 3199 passed, 0 failed, 8 skipped.
- Injected-text and preamble tests across Core, Gateway, and Avalonia: all green.
- Reviewed increment by increment by an independent reviewer; the one blocking defect found was fixed at the authoritative launch path and re-confirmed clean.