### PR TITLE
feat(stats): group Your Throttle repos by GitHub repository

### DIFF
--- a/apps/cockpit/src/throttle/ReposTab.tsx
+++ b/apps/cockpit/src/throttle/ReposTab.tsx
@@ -102,6 +102,11 @@ function RepoRow({
           {repo.repo && repo.repo !== repo.repoName && <span className="repo-path">{repo.repo}</span>}
         </div>
         <div className="repo-meta">{meta}</div>
+        {repo.checkouts.length > 1 && (
+          <div className="repo-checkouts" title={repo.checkouts.join("\n")}>
+            {repo.checkouts.length} checkouts: {repo.checkouts.join(" - ")}
+          </div>
+        )}
         <div className="repo-bar-track" title={`${formatValue(value, metric)} ${METRIC_WORD[metric]}`}>
           {showSplit ? (
             <>
@@ -219,9 +224,11 @@ export function ReposTab({ data }: { data: ThrottleData }) {
             spoke, the grey part is the share you typed.
           </li>
           <li>
-            Repos are grouped by the session&apos;s working directory. Time is deliberately not shown: an
-            idle hour looks the same as a heads-down hour, so it would lie. Turns and characters track what
-            you actually pushed through.
+            Repos are grouped by their GitHub repository, so every worktree and every machine you check a
+            repo out on rolls up into one row (the working directories that fed it are listed under the
+            name). A checkout with no GitHub remote falls back to its folder path. Time is deliberately not
+            shown: an idle hour looks the same as a heads-down hour, so it would lie. Turns and characters
+            track what you actually pushed through.
           </li>
           <li>
             Tokens are not shown - the tally counts turns and characters, never tokens, and this tab never

--- a/apps/cockpit/src/throttle/throttle.css
+++ b/apps/cockpit/src/throttle/throttle.css
@@ -602,6 +602,17 @@
   margin-bottom: 7px;
   font-variant-numeric: tabular-nums;
 }
+.repo-checkouts {
+  font-size: 11px;
+  color: var(--text-dim);
+  opacity: 0.75;
+  margin-top: -3px;
+  margin-bottom: 7px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
 .repo-bar-track {
   height: 10px;
   background: var(--surface-2);

--- a/apps/mobile/src/pages/Repos.tsx
+++ b/apps/mobile/src/pages/Repos.tsx
@@ -190,7 +190,7 @@ export function Repos() {
         <ul>
           <li>
             A turn is one submitted message; the amber part of each bar is the share driven by voice.
-            Repos are grouped by the session's working directory.
+            Repos are grouped by their GitHub repository, so every worktree and machine rolls up into one row.
           </li>
           <li>
             Time is not shown (an idle hour looks like a busy one), and tokens are not shown - the tally

--- a/packages/client-core/src/stats/statsClient.test.ts
+++ b/packages/client-core/src/stats/statsClient.test.ts
@@ -36,7 +36,7 @@ function data(buckets: ThrottleData["buckets"]): ThrottleData {
 }
 
 function repo(repoName: string, turns: number, voiceTurns: number, characters: number, sessions: number): RepoStat {
-  return { repo: `D:/${repoName}`, repoName, turns, voiceTurns, typedTurns: turns - voiceTurns, characters, sessions };
+  return { repo: `owner/${repoName}`, repoName, turns, voiceTurns, typedTurns: turns - voiceTurns, characters, sessions, checkouts: [`D:/${repoName}`] };
 }
 
 function agent(agentToken: string, agentName: string, turns: number, voiceTurns: number, characters: number, sessions: number,

--- a/packages/client-core/src/stats/statsClient.ts
+++ b/packages/client-core/src/stats/statsClient.ts
@@ -71,9 +71,12 @@ export interface InputHour {
  * codebase, in submitted turns (total + voice/typed split), character volume, and distinct sessions.
  * Mirrors the Gateway RepoStatBucketDto. Counts only - never any message text. */
 export interface RepoStat {
-  /** Full repository / working-directory path the sessions ran in (the grouping key). */
+  /** Grouping key: the GitHub "owner/repo" slug the sessions' checkouts belong to
+   * (e.g. "thefrederiksen/devthrottle"), so worktrees and per-machine clones are one row. Falls back to the
+   * local working-directory path for a checkout with no github.com origin. */
   repo: string;
-  /** Display leaf of the path (its last segment), e.g. "devthrottle". */
+  /** Display leaf of the key: the repository name for a slug (e.g. "devthrottle"), or the folder name for a
+   * fallback path. */
   repoName: string;
   /** Total submitted turns into this repo (voice + typed). */
   turns: number;
@@ -85,6 +88,9 @@ export interface RepoStat {
   characters: number;
   /** Distinct sessions that drove counted input into this repo. */
   sessions: number;
+  /** Local checkout paths (worktrees, per-machine clones) whose turns rolled up into this repo, sorted.
+   * Retained so the page can show which working directories the work came from. */
+  checkouts: string[];
 }
 
 /** One agent CLI's all-time input tally for the private Agents page: how much development you drive
@@ -279,6 +285,7 @@ function normalizeRepo(raw: unknown): RepoStat {
     typedTurns: num(r.typedTurns),
     characters: num(r.characters),
     sessions: num(r.sessions),
+    checkouts: Array.isArray(r.checkouts) ? r.checkouts.map((c) => String(c)) : [],
   };
 }
 

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1376,6 +1376,11 @@ internal static class ControlEndpoints
             RemoteThreadUrl = s.RemoteThreadUrl ?? "",
             RemoteRunUrl = s.RemoteRunUrl ?? "",
             RemoteRunStatus = s.RemoteRunStatus ?? "",
+            // DevThrottle Stats: the GitHub "owner/repo" of this local checkout, resolved here on the
+            // Director because the git repo lives on this machine. Cached per path so this roster mapper
+            // never forks git twice for the same checkout; "" when the checkout has no github.com origin,
+            // in which case the Gateway groups it by RepoPath instead.
+            RepoSlug = GitHubUrls.ResolveSlugCached(s.RepoPath),
             // Issue #335: identity fields populated by the Director (not patched by the Gateway).
             MachineName = machineName,
             User = user,

--- a/src/CcDirector.Core.Tests/Utilities/GitHubUrlsTests.cs
+++ b/src/CcDirector.Core.Tests/Utilities/GitHubUrlsTests.cs
@@ -47,6 +47,73 @@ public class GitHubUrlsTests
         Assert.Throws<ArgumentException>(() => GitHubUrls.ParseNewIssueUrl(originUrl));
     }
 
+    // ---------- ParseSlug (pure owner/repo extraction) ----------
+
+    [Theory]
+    [InlineData("https://github.com/example-org/devthrottle.git")]
+    [InlineData("https://github.com/example-org/devthrottle")]
+    [InlineData("git@github.com:example-org/devthrottle.git")]
+    [InlineData("ssh://git@github.com/example-org/devthrottle.git")]
+    public void ParseSlug_KnownRemoteShapes_ReturnsOwnerRepo(string originUrl)
+    {
+        Assert.Equal("example-org/devthrottle", GitHubUrls.ParseSlug(originUrl));
+    }
+
+    [Theory]
+    [InlineData("https://gitlab.com/owner/repo.git")]
+    [InlineData("git@bitbucket.org:owner/repo.git")]
+    public void ParseSlug_NonGitHubRemote_Throws(string originUrl)
+    {
+        Assert.Throws<InvalidOperationException>(() => GitHubUrls.ParseSlug(originUrl));
+    }
+
+    // ---------- ResolveSlugCached (best-effort, never throws) ----------
+
+    [Fact]
+    public void ResolveSlugCached_RepoWithGitHubOrigin_ReturnsSlug()
+    {
+        var repoDir = CreateTempGitRepo("https://github.com/someowner/somerepo.git");
+        try
+        {
+            Assert.Equal("someowner/somerepo", GitHubUrls.ResolveSlugCached(repoDir));
+        }
+        finally
+        {
+            Directory.Delete(repoDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveSlugCached_RepoWithoutOrigin_ReturnsEmpty_NeverThrows()
+    {
+        var repoDir = CreateTempGitRepo(originUrl: null);
+        try
+        {
+            Assert.Equal("", GitHubUrls.ResolveSlugCached(repoDir));
+        }
+        finally
+        {
+            Directory.Delete(repoDir, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveSlugCached_NullOrBlankPath_ReturnsEmpty(string? repoPath)
+    {
+        Assert.Equal("", GitHubUrls.ResolveSlugCached(repoPath));
+    }
+
+    [Fact]
+    public void ResolveSlugCached_MissingDirectory_ReturnsEmpty_NeverThrows()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"cc-director-missing-{Guid.NewGuid():N}");
+
+        Assert.Equal("", GitHubUrls.ResolveSlugCached(missing));
+    }
+
     // ---------- BuildNewIssueUrl (against real temp git repos) ----------
 
     [Fact]

--- a/src/CcDirector.Core/Utilities/GitHubUrls.cs
+++ b/src/CcDirector.Core/Utilities/GitHubUrls.cs
@@ -10,6 +10,14 @@ public static class GitHubUrls
 {
     private static readonly TimeSpan RemoteUrlRegexTimeout = TimeSpan.FromMilliseconds(50);
 
+    // repoPath -> resolved "owner/repo" slug, or "" when the checkout has no github.com origin. A local
+    // clone's origin does not change over a process lifetime, and resolving it spawns a git subprocess, so
+    // this is cached: ResolveSlugCached runs on the Director's roster path (every session, every poll) and
+    // must not fork git each time. Misses ("" - no origin, not a git repo, non-github remote) are cached
+    // too, so a checkout without a GitHub origin is probed once, not on every poll.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> SlugCache =
+        new(StringComparer.Ordinal);
+
     /// <summary>
     /// Resolves the repo's origin remote via git and converts it to the GitHub
     /// "new issue" URL. Throws with a clear message when the directory is not a
@@ -28,6 +36,39 @@ public static class GitHubUrls
     }
 
     /// <summary>
+    /// The GitHub "owner/repo" slug for a local checkout, or "" when the checkout has no github.com origin
+    /// (no origin remote, not a git repo, or a non-GitHub remote). Best-effort and NEVER throws: an empty
+    /// result is a legitimate answer - not every checkout is on GitHub - and the caller (the DevThrottle
+    /// Stats repo grouping) falls back to the local path for those. Cached by path; see <see cref="SlugCache"/>.
+    ///
+    /// This is the key that makes every worktree and every per-machine clone of one repository roll up into
+    /// a single row on the Repos page: they all share one origin remote, so they all resolve to one slug.
+    /// </summary>
+    public static string ResolveSlugCached(string? repoPath)
+    {
+        if (string.IsNullOrWhiteSpace(repoPath)) return "";
+        return SlugCache.GetOrAdd(repoPath, ResolveSlugUncached);
+    }
+
+    private static string ResolveSlugUncached(string repoPath)
+    {
+        try
+        {
+            if (!Directory.Exists(repoPath)) return "";
+            var slug = ParseSlug(GetOriginRemoteUrl(repoPath));
+            FileLog.Write($"[GitHubUrls] ResolveSlugCached: {repoPath} -> {slug}");
+            return slug;
+        }
+        catch (Exception ex)
+        {
+            // A checkout with no origin, or one whose origin is not on github.com, is an expected state, not
+            // a failure to hide: it simply has no slug and groups by its path instead. Recorded, then "".
+            FileLog.Write($"[GitHubUrls] ResolveSlugCached: {repoPath} has no GitHub slug: {ex.Message}");
+            return "";
+        }
+    }
+
+    /// <summary>
     /// Converts an origin remote URL to the GitHub "new issue" URL. Pure string
     /// logic so it is unit-testable without git. Accepts the three remote shapes:
     ///   git@github.com:owner/repo.git
@@ -36,6 +77,14 @@ public static class GitHubUrls
     /// Throws when the remote is not on github.com.
     /// </summary>
     internal static string ParseNewIssueUrl(string originUrl)
+        => $"https://github.com/{ParseSlug(originUrl)}/issues/new";
+
+    /// <summary>
+    /// Extracts the "owner/repo" slug from an origin remote URL. Pure string logic so it is unit-testable
+    /// without git; accepts the same three remote shapes as <see cref="ParseNewIssueUrl"/>. Throws when the
+    /// remote is empty or not on github.com.
+    /// </summary>
+    internal static string ParseSlug(string originUrl)
     {
         if (string.IsNullOrWhiteSpace(originUrl))
             throw new ArgumentException("Origin remote URL is required", nameof(originUrl));
@@ -46,7 +95,7 @@ public static class GitHubUrls
         if (!match.Success)
             throw new InvalidOperationException($"Origin is not a GitHub remote: {originUrl}");
 
-        return $"https://github.com/{match.Groups["owner"].Value}/{match.Groups["repo"].Value}/issues/new";
+        return $"{match.Groups["owner"].Value}/{match.Groups["repo"].Value}";
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -599,6 +599,21 @@ public sealed class SessionDto
     public string RemoteRunStatus { get; set; } = "";
 
     /// <summary>
+    /// DevThrottle Stats: the "owner/repo" GitHub slug of this session's LOCAL checkout, resolved by the
+    /// owning Director from the checkout's origin remote (the git repo lives on the Director's machine, so
+    /// only it can resolve this). Empty when the checkout has no github.com origin. This is the grouping key
+    /// the Repos page uses so every worktree and every per-machine clone of one repository rolls up into a
+    /// single row - <see cref="RepoPath"/> alone splits them, because each checkout is a different path.
+    ///
+    /// DISTINCT from <see cref="RemoteRepo"/>: that is populated only for GitHub Actions CLOUD sessions and
+    /// names the repo the cloud run executes against; this is populated for ordinary LOCAL sessions and names
+    /// the GitHub repo their working directory is a checkout of. A session has one or the other, not both.
+    /// Passes through the Gateway aggregation unchanged; the aggregator folds it as the repository identity
+    /// and retains <see cref="RepoPath"/> alongside as the checkout identity.
+    /// </summary>
+    public string RepoSlug { get; set; } = "";
+
+    /// <summary>
     /// DevThrottle Stats: this session's input tally (submitted turns + character volume by modality and
     /// surface), taken at the Director's SendInput/SendTextAsync choke point so desktop-local input is
     /// counted too. Rides the existing snapshot/delta path up to the Gateway, which aggregates every

--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -51,6 +51,15 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         return dto;
     }
 
+    // A session whose Director resolved a GitHub slug for its checkout - the grouping key the Repos page uses.
+    private static SessionDto SessionInSlug(string id, string slug, string repoPath, params (string modality, string surface, long turns, long chars)[] buckets)
+    {
+        var dto = Session(id, buckets);
+        dto.RepoSlug = slug;
+        dto.RepoPath = repoPath;
+        return dto;
+    }
+
     private static RepoStatBucketDto? Repo(GatewayInputStatsAggregator agg, string repoName) =>
         agg.RepoTotals().FirstOrDefault(r => r.RepoName == repoName);
 
@@ -295,6 +304,61 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         Assert.Equal(5, app2!.Turns);
         Assert.Equal(200, app2.Characters);
         Assert.Equal(1, app2.Sessions);
+    }
+
+    [Fact]
+    public void RepoTotals_GroupsByGitHubSlug_CollapsingWorktreesAndClones_RetainingCheckouts()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        // The same GitHub repo, driven from three different checkouts: the main clone, a worktree, and a
+        // second machine's clone (a forward-slash path). All must roll up into ONE row keyed by the slug.
+        agg.Observe(SessionInSlug("s1", "thefrederiksen/devthrottle", @"D:\ReposFred\devthrottle", ("voice", "phone", 6, 600)));
+        agg.Observe(SessionInSlug("s2", "thefrederiksen/devthrottle", @"D:\ReposFred\devthrottle-gateway-sqlite", ("typed", "desktop", 2, 40)));
+        agg.Observe(SessionInSlug("s3", "thefrederiksen/devthrottle", "/Users/soren/ReposFred/devthrottle", ("typed", "cockpit", 1, 10)));
+
+        var repos = agg.RepoTotals();
+        Assert.Single(repos);                                    // three checkouts, one repository row
+        var dt = repos[0];
+        Assert.Equal("thefrederiksen/devthrottle", dt.Repo);     // grouped by the slug
+        Assert.Equal("devthrottle", dt.RepoName);                // leaf of the slug is the repo name
+        Assert.Equal(9, dt.Turns);                               // 6 + 2 + 1 folded together
+        Assert.Equal(3, dt.Sessions);                            // three distinct sessions
+
+        // The checkout paths are retained, not lost when the worktrees collapsed together.
+        Assert.Equal(3, dt.Checkouts.Count);
+        Assert.Contains(@"D:\ReposFred\devthrottle", dt.Checkouts);
+        Assert.Contains(@"D:\ReposFred\devthrottle-gateway-sqlite", dt.Checkouts);
+        Assert.Contains("/Users/soren/ReposFred/devthrottle", dt.Checkouts);
+    }
+
+    [Fact]
+    public void RepoTotals_NoGitHubSlug_FallsBackToPath()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        // A checkout with no github.com origin reports an empty slug; it must still appear, keyed by its path.
+        agg.Observe(SessionInRepo("s1", @"D:\repos\local-only", ("typed", "desktop", 4, 80)));
+
+        var repo = Repo(agg, "local-only");
+        Assert.NotNull(repo);
+        Assert.Equal(@"D:\repos\local-only", repo!.Repo);        // fell back to the path as the key
+        Assert.Equal(4, repo.Turns);
+        Assert.Equal(new[] { @"D:\repos\local-only" }, repo.Checkouts);
+    }
+
+    [Fact]
+    public void RepoTotals_SlugGrouping_SurvivesGatewayRestart()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(SessionInSlug("s1", "owner/app", @"D:\a\app", ("voice", "phone", 3, 120)));
+        agg.Observe(SessionInSlug("s2", "owner/app", @"D:\b\app", ("typed", "desktop", 2, 40)));
+
+        // The identity mirror (repo + checkout) must reload from disk and still group by slug.
+        var reloaded = new GatewayInputStatsAggregator(_path);
+        var repos = reloaded.RepoTotals();
+        Assert.Single(repos);
+        Assert.Equal("owner/app", repos[0].Repo);
+        Assert.Equal(5, repos[0].Turns);
+        Assert.Equal(2, repos[0].Checkouts.Count);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs
@@ -72,6 +72,8 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         Assert.True(TableExists(db, "repo_identity"));
         Assert.True(TableExists(db, "agent_identity"));
         Assert.True(TableExists(db, "model_identity"));
+        // The checkout dimension (schema v4): the local working directory retained beside the repository slug.
+        Assert.True(TableExists(db, "checkout_identity"));
         // Token spend (issue #1637) - the delta lane and its per-session high-water.
         Assert.True(TableExists(db, "token_delta"));
         Assert.True(TableExists(db, "token_highwater"));
@@ -181,7 +183,7 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         var expected = new[]
         {
             "id", "hour_utc", "session_id", "modality", "surface",
-            "is_voice", "repo_id", "model_id", "wingman", "turns", "chars",
+            "is_voice", "repo_id", "checkout_id", "model_id", "wingman", "turns", "chars",
         };
         Assert.Equal(expected.OrderBy(c => c, StringComparer.Ordinal),
                      columns.Keys.OrderBy(c => c, StringComparer.Ordinal));
@@ -193,6 +195,9 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         // OrdinalIgnoreCase map must be the only thing that ever decides two model names are one model.
         Assert.Equal("INTEGER", columns["repo_id"]);
         Assert.Equal("INTEGER", columns["model_id"]);
+        // checkout_id is a surrogate id too, for the same reason: the local path is free text and only the
+        // in-memory OrdinalIgnoreCase map may decide two paths are one checkout.
+        Assert.Equal("INTEGER", columns["checkout_id"]);
 
         // Ruling B: agent_id is NOT on stat_delta. The agent tally is not derivable from these rows -
         // the first-fold back-fill attributes turns that are already in the totals, so a row here would
@@ -259,17 +264,15 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         Assert.Contains("will not fall back", ex.Message);
     }
 
-    // ---- Schema version 2: the model dimension. THE FIRST REAL MIGRATION. ----
+    // ---- A hand-built PRE-SLUG store, used to exercise the schema v4 reset. ----
     //
-    // These tests are why the mission exists. Version 1 shipped the migration MACHINERY against a single
-    // version, where nothing exercised it - a green suite proved only that the machinery compiled. The
-    // claim being made now is the one the owner is actually owed: his database, holding real turns, gains
-    // a dimension and does not lose a number.
-    //
-    // A hand-built version 1 file, not a downgraded current one. It is the shape the PREVIOUS BUILD wrote,
-    // reproduced from its migration: stat_delta without model_id, no model_identity, user_version=1. That
-    // is what is on the owner's disk right now, and a test that starts from the current schema and pretends
-    // would prove nothing about it.
+    // This writes the exact shape a PREVIOUS BUILD wrote: stat_delta without model_id or checkout_id, no
+    // model_identity, repo_id keyed by a local PATH, user_version=1. Until v4 the contract was that such a
+    // file migrated forward and kept every row; at v4 the repository dimension changed meaning (path became
+    // GitHub slug) and a path-keyed row can no longer be re-keyed, so the owner ruled it is not carried
+    // across - the file is retired aside unread and the store starts empty. These rows are therefore what a
+    // real pre-slug store looks like on disk, so the retire tests can prove it is retired (not migrated) and
+    // that the retired copy stays intact.
     private void WriteVersion1Database(params (string Hour, long Turns, long Chars)[] rows)
     {
         using var connection = new SqliteConnection($"Data Source={_path}");
@@ -329,46 +332,68 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
     }
 
     [Fact]
-    public void Migrate_Version1File_UpgradesToCurrentVersionAndKeepsEveryRow()
+    public void Open_PreSlugStore_IsRetiredAsideUnread_AndStartsEmpty()
     {
+        // The repository dimension changed meaning at schema v4: repo_id was the session's local path and is
+        // now its GitHub slug. A stored path-keyed row cannot be re-keyed to a slug (the Gateway has no
+        // filesystem to resolve the path), so - as with the legacy JSON store, and by the same owner ruling -
+        // a pre-slug store (any version 1..3) is not migrated forward. It is renamed aside UNREAD and this
+        // store starts empty. This is the reset the owner approved ("we're not really live yet").
         WriteVersion1Database(("2026-07-16T09", 40, 400), ("2026-07-16T10", 27, 270));
 
         using var db = new GatewayStatsDatabase(_path);
 
-        // A version-1 file on disk migrates through EVERY step to the current version - the whole chain, not
-        // one hop. The owner's real database is version 1, so this is the path his numbers actually take.
+        // The fresh store is at the current version and carries NONE of the pre-slug rows.
         Assert.Equal(GatewayStatsDatabase.SchemaVersion, UserVersion(db));
+        Assert.Equal(0, ScalarLong(db, "SELECT COUNT(*) FROM stat_delta"));
+        Assert.Equal(0, ScalarLong(db, "SELECT COUNT(*) FROM repo_identity"));
+        // The new dimension is present on the fresh store.
+        Assert.True(TableExists(db, "checkout_identity"));
+        Assert.Contains("checkout_id", ColumnsOf(db, "stat_delta"));
 
-        // The version stamp ALONE proves nothing, and these assertions are here because the first draft of
-        // this test proved nothing: Migrate writes PRAGMA user_version unconditionally, after the steps, so
-        // the current-version stamp appears whether or not the steps ran. With a step disabled this test
-        // still passed, green and useless, exactly the "dead test that looks like coverage" this mission
-        // keeps finding. Reading back what each step ADDS is what makes the name true.
-        Assert.Contains("model_id", ColumnsOf(db, "stat_delta")); // version 2
-        Assert.True(TableExists(db, "token_delta"));              // version 3
-        Assert.True(TableExists(db, "token_highwater"));          // version 3
-
-        // The numbers are the promise. A migration that loses turns is the failure this whole mission
-        // exists to prevent, so it is asserted on the totals and not merely on the row count.
-        Assert.Equal(2, ScalarLong(db, "SELECT COUNT(*) FROM stat_delta"));
-        Assert.Equal(67, ScalarLong(db, "SELECT SUM(turns) FROM stat_delta"));
-        Assert.Equal(670, ScalarLong(db, "SELECT SUM(chars) FROM stat_delta"));
+        // Renamed, never deleted - the old numbers are recoverable, which was the owner's line on the JSON
+        // store too. Exactly one retired copy sits beside the fresh database.
+        var retired = Directory.GetFiles(_dir, "gateway-stats.db.pre-slug-*");
+        Assert.Single(retired);
     }
 
     [Fact]
-    public void Migrate_Version1File_AddsTheTokenDimensionEmpty()
+    public void Open_PreSlugStore_LeavesTheRetiredCopyIntactAndReadable()
     {
-        // The token tables are created by the version 3 step and start EMPTY - there was no token history to
-        // carry across (nothing recorded tokens before this), so every number begins at the cutover, exactly
-        // like the model dimension. Not a bug that they are empty; the honest starting state.
-        WriteVersion1Database(("2026-07-16T09", 40, 400));
+        // "Renamed aside UNREAD" must mean the bytes are untouched: the retired file still holds the old rows,
+        // so the reset is recoverable rather than a destructive wipe.
+        WriteVersion1Database(("2026-07-16T09", 40, 400), ("2026-07-16T10", 27, 270));
 
-        using var db = new GatewayStatsDatabase(_path);
+        using (var db = new GatewayStatsDatabase(_path)) { /* triggers the retire */ }
+        SqliteConnection.ClearAllPools();
 
-        Assert.True(TableExists(db, "token_delta"));
-        Assert.True(TableExists(db, "token_highwater"));
-        Assert.Equal(0, ScalarLong(db, "SELECT COUNT(*) FROM token_delta"));
-        Assert.Equal(0, ScalarLong(db, "SELECT COUNT(*) FROM token_highwater"));
+        var retired = Directory.GetFiles(_dir, "gateway-stats.db.pre-slug-*").Single();
+        using var old = new SqliteConnection($"Data Source={retired}");
+        old.Open();
+        using var cmd = old.CreateCommand();
+        cmd.CommandText = "SELECT SUM(turns) FROM stat_delta";
+        Assert.Equal(67L, Convert.ToInt64(cmd.ExecuteScalar()));
+    }
+
+    [Fact]
+    public void Open_CurrentVersionStore_IsNotRetired()
+    {
+        // The retire is one-time and version-gated: a store already at the current version is current, so a
+        // reopen must leave it exactly in place and mint no retired copy. This is what makes the retire
+        // self-idempotent - the fresh v4 store this build writes is never retired on the next startup.
+        using (var first = new GatewayStatsDatabase(_path))
+        {
+            using var cmd = first.Connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO meta(name, value) VALUES ('probe', 'kept')";
+            cmd.ExecuteNonQuery();
+        }
+        SqliteConnection.ClearAllPools();
+
+        using var second = new GatewayStatsDatabase(_path);
+        Assert.Empty(Directory.GetFiles(_dir, "gateway-stats.db.pre-slug-*"));
+        using var read = second.Connection.CreateCommand();
+        read.CommandText = "SELECT value FROM meta WHERE name='probe'";
+        Assert.Equal("kept", read.ExecuteScalar() as string);
     }
 
     [Fact]
@@ -407,24 +432,13 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
     }
 
     [Fact]
-    public void Migrate_Version1File_AddsTheModelDimensionAndReadsNullOnPreExistingRows()
+    public void Open_FreshStore_StampsWhenTheModelDimensionBegan()
     {
-        WriteVersion1Database(("2026-07-16T09", 40, 400));
-
-        using var db = new GatewayStatsDatabase(_path);
-
-        Assert.True(TableExists(db, "model_identity"));
-        // Every row folded before the dimension existed reads NULL, which is the true thing to say about
-        // them: they were recorded when no model was being observed at all. Not zero, not a placeholder id.
-        Assert.Equal(1, ScalarLong(db, "SELECT COUNT(*) FROM stat_delta WHERE model_id IS NULL"));
-        Assert.Equal(0, ScalarLong(db, "SELECT COUNT(*) FROM stat_delta WHERE model_id IS NOT NULL"));
-    }
-
-    [Fact]
-    public void Migrate_Version1File_StampsWhenTheModelDimensionBegan()
-    {
+        // The model dimension's since-stamp is written by the version 2 migration, which runs as part of
+        // building even a FRESH store (0 -> current), so a brand-new database carries it. A null model_id is
+        // unreadable without it: a row that predates the dimension and one whose session had recorded no model
+        // yet both store NULL, and only this stamp separates them.
         var before = DateTime.UtcNow.AddSeconds(-1);
-        WriteVersion1Database(("2026-07-16T09", 40, 400));
 
         using var db = new GatewayStatsDatabase(_path);
 
@@ -433,35 +447,9 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         cmd.Parameters.AddWithValue("$n", GatewayStatsDatabase.ModelsSinceKey);
         var stamped = cmd.ExecuteScalar() as string;
 
-        // Without this stamp a null model_id is unreadable: a row that predates the dimension and a row
-        // whose session had recorded no model yet both store NULL, and only the stamp separates them.
         Assert.False(string.IsNullOrEmpty(stamped));
         Assert.True(DateTime.TryParse(stamped, System.Globalization.CultureInfo.InvariantCulture,
             System.Globalization.DateTimeStyles.RoundtripKind, out var since));
-        Assert.True(since >= before, $"models_since_utc '{stamped}' predates the migration.");
-    }
-
-    [Fact]
-    public void Migrate_AlreadyMigratedFile_DoesNotMoveTheModelSinceStamp()
-    {
-        // The stamp records when the dimension BEGAN. Re-stamping it on a later open would push it past
-        // rows that already carry real models and silently reclassify them as predating the dimension -
-        // a re-run that quietly rewrites history is precisely the failure mode the version guard exists for.
-        WriteVersion1Database(("2026-07-16T09", 40, 400));
-
-        string? first;
-        using (var db = new GatewayStatsDatabase(_path))
-        {
-            using var cmd = db.Connection.CreateCommand();
-            cmd.CommandText = $"SELECT value FROM meta WHERE name='{GatewayStatsDatabase.ModelsSinceKey}'";
-            first = cmd.ExecuteScalar() as string;
-        }
-        SqliteConnection.ClearAllPools();
-
-        using var reopened = new GatewayStatsDatabase(_path);
-        using var read = reopened.Connection.CreateCommand();
-        read.CommandText = $"SELECT value FROM meta WHERE name='{GatewayStatsDatabase.ModelsSinceKey}'";
-
-        Assert.Equal(first, read.ExecuteScalar() as string);
+        Assert.True(since >= before, $"models_since_utc '{stamped}' predates the store's creation.");
     }
 }

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -71,9 +71,15 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     private readonly Dictionary<string, long> _repoIds = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, long> _agentIds = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, long> _modelIds = new(StringComparer.OrdinalIgnoreCase);
+    // The checkout (local working directory) dimension retained beside the repository (issue: group the
+    // Repos page by GitHub repository). repo_id is now the GitHub slug, so worktrees and per-machine clones
+    // of one repository share a repo_id; checkout_id keeps the path each turn actually ran in so it is not
+    // lost. Same first-seen-wins OrdinalIgnoreCase identity as the others.
+    private readonly Dictionary<string, long> _checkoutIds = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<long, string> _repoDisplay = new();
     private readonly Dictionary<long, string> _agentDisplay = new();
     private readonly Dictionary<long, string> _modelDisplay = new();
+    private readonly Dictionary<long, string> _checkoutDisplay = new();
 
     private readonly HashSet<(long Id, string SessionId)> _repoSessions = new();
     private readonly HashSet<(long Id, string SessionId)> _agentSessions = new();
@@ -111,14 +117,20 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     /// <see cref="Model"/> is a first-class kind here but has NO distinct-session set: nothing asks how many
     /// sessions ran a model, so <see cref="SessionsFor"/> refuses it rather than carrying a set nothing
     /// populates. It is also the only kind that can be ABSENT - see <see cref="FoldLocked"/>.
+    ///
+    /// <see cref="Checkout"/> is the local working-directory path retained beside the repository slug. Like
+    /// <see cref="Model"/> it keeps no distinct-session set (the session count the Repos page shows is per
+    /// repository, not per checkout), so <see cref="SessionsFor"/> refuses it too. Unlike Model it is never
+    /// absent - a session always has a working directory.
     /// </summary>
-    private enum IdentityKind { Repo, Agent, Model }
+    private enum IdentityKind { Repo, Agent, Model, Checkout }
 
     private Dictionary<string, long> IdsFor(IdentityKind kind) => kind switch
     {
         IdentityKind.Repo => _repoIds,
         IdentityKind.Agent => _agentIds,
         IdentityKind.Model => _modelIds,
+        IdentityKind.Checkout => _checkoutIds,
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown identity kind."),
     };
 
@@ -127,11 +139,12 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         IdentityKind.Repo => _repoDisplay,
         IdentityKind.Agent => _agentDisplay,
         IdentityKind.Model => _modelDisplay,
+        IdentityKind.Checkout => _checkoutDisplay,
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown identity kind."),
     };
 
-    // The distinct-session sets exist for repositories and agents only. A model has none, deliberately, so
-    // asking for one is a programming error and says so rather than inventing an empty answer.
+    // The distinct-session sets exist for repositories and agents only. A model and a checkout have none,
+    // deliberately, so asking for one is a programming error and says so rather than inventing an empty answer.
     private HashSet<(long Id, string SessionId)> SessionsFor(IdentityKind kind) => kind switch
     {
         IdentityKind.Repo => _repoSessions,
@@ -145,6 +158,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         IdentityKind.Repo => ("repo_identity", "repo_display"),
         IdentityKind.Agent => ("agent_identity", "agent_display"),
         IdentityKind.Model => ("model_identity", "model_display"),
+        IdentityKind.Checkout => ("checkout_identity", "checkout_display"),
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown identity kind."),
     };
 
@@ -226,6 +240,11 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                 var id = r.GetInt64(0); var d = r.GetString(1);
                 _modelIds[d] = id; _modelDisplay[id] = d;
             });
+            Read("SELECT checkout_id, checkout_display FROM checkout_identity", r =>
+            {
+                var id = r.GetInt64(0); var d = r.GetString(1);
+                _checkoutIds[d] = id; _checkoutDisplay[id] = d;
+            });
             Read("SELECT repo_id, session_id FROM repo_session", r => _repoSessions.Add((r.GetInt64(0), r.GetString(1))));
             Read("SELECT agent_id, session_id FROM agent_session", r => _agentSessions.Add((r.GetInt64(0), r.GetString(1))));
             _agentsSinceUtc = ReadScalarString("SELECT value FROM meta WHERE name=$n", ("$n", AgentsSinceKey)) ?? "";
@@ -238,7 +257,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
             FileLog.Write($"[GatewayInputStatsAggregator] LoadMirror: {_highWater.Count} live session(s), " +
                           $"{_wingmanSessions.Count} wingman session(s), {_repoIds.Count} repo(s), {_agentIds.Count} agent(s), " +
-                          $"{_modelIds.Count} model(s), {_agentsSeeded.Count} seeded, agentsSince='{_agentsSinceUtc}', " +
+                          $"{_modelIds.Count} model(s), {_checkoutIds.Count} checkout(s), {_agentsSeeded.Count} seeded, agentsSince='{_agentsSinceUtc}', " +
                           $"modelsSince='{_modelsSinceUtc}' from {_db.Path}");
         }
     }
@@ -285,7 +304,9 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
         // Model is the only nullable member of a row: null means the owning Director had recorded no model
         // for that session when the turn folded, which is the honest state and never a lookup failure.
-        public readonly List<(string Hour, string SessionId, string Modality, string Surface, bool IsVoice, string Repo, string? Model, bool Wingman, long Turns, long Chars)> Rows = new();
+        // Repo is the GitHub slug (the grouping key); Checkout is the local working directory the turn ran in,
+        // retained beside it so the path is not lost when worktrees and clones collapse into one repo row.
+        public readonly List<(string Hour, string SessionId, string Modality, string Surface, bool IsVoice, string Repo, string Checkout, string? Model, bool Wingman, long Turns, long Chars)> Rows = new();
         public readonly List<(string Agent, bool IsVoice, long Turns, long Chars)> AgentRows = new();
         public readonly List<(string Agent, long Turns, long Chars)> AgentDrivenRows = new();
         public readonly List<(string SessionId, string Modality, string Surface, long Turns, long Chars)> HighWater = new();
@@ -366,13 +387,18 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                     AttributeToAgentLocked(s, key.Modality, prior.Turns, prior.Characters, batch);
         }
 
-        // Path separators are deliberately NOT normalized. OrdinalIgnoreCase folds case but not '/' against
-        // '\', so "D:/ReposFred/devthrottle" and "D:\ReposFred\devthrottle" are genuinely different keys and
-        // the Repos page already shows them separately - measured on the owner's real store, three
-        // repositories are stored under both spellings and normalizing would collapse 20 rows to 17. It
-        // looks like a bug; fixing it would CHANGE THE OWNER'S NUMBERS. Whether the page should merge them
-        // is his question, not this mission's.
-        var repoKey = s.RepoPath ?? "";
+        // The repository grouping key is the GitHub "owner/repo" slug the owning Director resolved for this
+        // checkout, so every worktree and every per-machine clone of one repository folds into a single row.
+        // A checkout with no github.com origin (RepoSlug empty) falls back to its path, which still groups
+        // that repo sensibly and never drops its turns.
+        //
+        // The checkout key is the raw working-directory path, retained as its own dimension so the store
+        // still records exactly which checkout each turn ran in - the path is not lost when the slug collapses
+        // the worktrees together. Path separators are deliberately NOT normalized on either key: a slug never
+        // carries a separator to disagree on, and for a path the old behaviour (OrdinalIgnoreCase folds case
+        // but not '/' against '\') is preserved, so a fallback path row reads exactly as it did before.
+        var checkoutKey = s.RepoPath ?? "";
+        var repoKey = !string.IsNullOrWhiteSpace(s.RepoSlug) ? s.RepoSlug! : checkoutKey;
 
         // The model this session's agent was last RECORDED using (issue #1637). Unlike the repository and
         // the agent, an unknown model is stored as SQL NULL rather than folded into an empty-string
@@ -405,10 +431,15 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                 // the flag keeps it out of the query layer.
                 var isVoice = string.Equals(key.Item1, "voice", StringComparison.OrdinalIgnoreCase);
 
-                batch.Rows.Add((batch.HourKey, s.SessionId, key.Item1, key.Item2, isVoice, repoKey, modelKey, wingman, deltaTurns, deltaChars));
+                batch.Rows.Add((batch.HourKey, s.SessionId, key.Item1, key.Item2, isVoice, repoKey, checkoutKey, modelKey, wingman, deltaTurns, deltaChars));
                 NeedIdentity(repoKey, IdentityKind.Repo, batch);
                 if (!KnownIdentitySession(repoKey, s.SessionId, IdentityKind.Repo, batch))
                     batch.NewIdentitySessions.Add((repoKey, s.SessionId, IdentityKind.Repo));
+
+                // The checkout the turn ran in earns an identity, retained beside the repository. No
+                // distinct-session set (the Repos page counts sessions per repository, not per checkout), so
+                // it is never queued into NewIdentitySessions - SessionsFor(Checkout) would refuse it.
+                NeedIdentity(checkoutKey, IdentityKind.Checkout, batch);
 
                 // Only a model the Director actually named earns an identity. An absent model writes a null
                 // model_id and creates nothing, so model_identity never grows a row for "not said".
@@ -560,6 +591,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
             [IdentityKind.Repo] = new(StringComparer.OrdinalIgnoreCase),
             [IdentityKind.Agent] = new(StringComparer.OrdinalIgnoreCase),
             [IdentityKind.Model] = new(StringComparer.OrdinalIgnoreCase),
+            [IdentityKind.Checkout] = new(StringComparer.OrdinalIgnoreCase),
         };
         foreach (var (display, kind) in batch.NewIdentities)
         {
@@ -580,10 +612,11 @@ public sealed class GatewayInputStatsAggregator : IDisposable
             display is null ? DBNull.Value : Resolve(display, IdentityKind.Model);
 
         foreach (var r in batch.Rows)
-            Execute(@"INSERT INTO stat_delta(hour_utc, session_id, modality, surface, is_voice, repo_id, model_id, wingman, turns, chars)
-                      VALUES ($h, $s, $m, $u, $v, $r, $d, $w, $t, $c)", tx,
+            Execute(@"INSERT INTO stat_delta(hour_utc, session_id, modality, surface, is_voice, repo_id, checkout_id, model_id, wingman, turns, chars)
+                      VALUES ($h, $s, $m, $u, $v, $r, $k, $d, $w, $t, $c)", tx,
                 ("$h", r.Hour), ("$s", r.SessionId), ("$m", r.Modality), ("$u", r.Surface),
                 ("$v", r.IsVoice ? 1 : 0), ("$r", Resolve(r.Repo, IdentityKind.Repo)),
+                ("$k", Resolve(r.Checkout, IdentityKind.Checkout)),
                 ("$d", ResolveModel(r.Model)), ("$w", r.Wingman ? 1 : 0),
                 ("$t", r.Turns), ("$c", r.Chars));
 
@@ -697,19 +730,21 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     private void PruneLocked(DateTime nowUtc, SqliteTransaction tx)
     {
         var cutoff = HourKey(nowUtc.AddDays(-RetentionDays));
-        // model_id is carried through the archive fold, and it MUST be in BOTH lists. Left out of the SELECT
-        // the archive row would read NULL and every pruned turn would silently become "model unknown"; left
-        // out of the GROUP BY it would collapse different models into one row and take an arbitrary model
+        // model_id and checkout_id are carried through the archive fold, and each MUST be in BOTH lists. Left
+        // out of the SELECT the archive row would read NULL and every pruned turn would silently lose that
+        // dimension (model_id would become "model unknown"; checkout_id would forget which checkout it ran
+        // in); left out of the GROUP BY it would collapse different values into one row and take an arbitrary
         // id with it. Adding a dimension to this table means adding it here, in both places, or pruning
         // quietly destroys it ninety days later - long after the change that caused it.
         //
         // SQLite groups NULLs together, so every unknown-model row of a bucket archives into ONE row that is
-        // still honestly NULL. That is the wanted behaviour: absence aggregates as absence.
-        Execute(@"INSERT INTO stat_delta(hour_utc, session_id, modality, surface, is_voice, repo_id, model_id, wingman, turns, chars)
-                  SELECT $marker, $marker, modality, surface, is_voice, repo_id, model_id, wingman, SUM(turns), SUM(chars)
+        // still honestly NULL. That is the wanted behaviour: absence aggregates as absence. (checkout_id is
+        // never NULL on a row this build wrote, but it rides the same fold for the same reason.)
+        Execute(@"INSERT INTO stat_delta(hour_utc, session_id, modality, surface, is_voice, repo_id, checkout_id, model_id, wingman, turns, chars)
+                  SELECT $marker, $marker, modality, surface, is_voice, repo_id, checkout_id, model_id, wingman, SUM(turns), SUM(chars)
                     FROM stat_delta
                    WHERE hour_utc <> $marker AND hour_utc < $cutoff
-                   GROUP BY modality, surface, is_voice, repo_id, model_id, wingman", tx,
+                   GROUP BY modality, surface, is_voice, repo_id, checkout_id, model_id, wingman", tx,
             ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
         Execute("DELETE FROM stat_delta WHERE hour_utc <> $marker AND hour_utc < $cutoff", tx,
             ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
@@ -824,6 +859,24 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         lock (_lock)
         {
             var sessions = SessionCounts("repo_session", "repo_id");
+
+            // The local checkouts (worktrees, per-machine clones) that rolled up into each repository, kept so
+            // the page can still show which working directories a repo's turns came from - the path is not
+            // lost when the slug collapses them. Display spellings come from the identity mirror, never from a
+            // SQL join; sorted here so the retained list is stable rather than in row-insert order.
+            var checkoutsByRepo = new Dictionary<long, List<string>>();
+            Read("SELECT DISTINCT repo_id, checkout_id FROM stat_delta WHERE checkout_id IS NOT NULL", r =>
+            {
+                var repoId = r.GetInt64(0);
+                var checkoutId = r.GetInt64(1);
+                if (!_checkoutDisplay.TryGetValue(checkoutId, out var path)) return;
+                if (!checkoutsByRepo.TryGetValue(repoId, out var paths))
+                    checkoutsByRepo[repoId] = paths = new List<string>();
+                paths.Add(path);
+            });
+            foreach (var paths in checkoutsByRepo.Values)
+                paths.Sort(StringComparer.OrdinalIgnoreCase);
+
             var list = new List<RepoStatBucketDto>();
             Read(@"SELECT repo_id,
                           COALESCE(SUM(CASE WHEN is_voice = 1 THEN turns ELSE 0 END), 0),
@@ -846,6 +899,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                     TypedTurns = typed,
                     Characters = r.GetInt64(3),
                     Sessions = sessions.TryGetValue(id, out var n) ? n : 0,
+                    Checkouts = checkoutsByRepo.TryGetValue(id, out var cks) ? cks : new List<string>(),
                 });
             });
             // Ranked in C#, matching the original ordering exactly.
@@ -1091,6 +1145,10 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         _ => agent,
     };
 
+    // The last segment of the grouping key, used as the row's short name. For a GitHub slug
+    // ("thefrederiksen/devthrottle") this is the repository name ("devthrottle"); for a fallback path
+    // ("D:\ReposFred\devthrottle") it is the folder name. The same split serves both because '/' and '\' are
+    // both segment separators here.
     private static string RepoLeaf(string path)
     {
         if (string.IsNullOrWhiteSpace(path)) return "(unknown)";
@@ -1175,10 +1233,14 @@ public sealed class WingmanUsageDto
 /// <summary>One repository's all-time input tally for the private Repos page.</summary>
 public sealed class RepoStatBucketDto
 {
-    /// <summary>The full repository / working-directory path the sessions ran in (the grouping key).</summary>
+    /// <summary>The grouping key: the GitHub "owner/repo" slug the sessions' checkouts belong to
+    /// (e.g. "thefrederiksen/devthrottle"), so every worktree and every per-machine clone of one repository
+    /// is one row. Falls back to the local working-directory path for a checkout that has no github.com
+    /// origin.</summary>
     public string Repo { get; set; } = "";
 
-    /// <summary>The display leaf of <see cref="Repo"/> (its last path segment), e.g. "devthrottle".</summary>
+    /// <summary>The display leaf of <see cref="Repo"/> (its last segment): the repository name for a slug,
+    /// e.g. "devthrottle", or the folder name for a fallback path.</summary>
     public string RepoName { get; set; } = "";
 
     public long Turns { get; set; }
@@ -1188,6 +1250,11 @@ public sealed class RepoStatBucketDto
 
     /// <summary>Distinct sessions that drove counted input into this repo.</summary>
     public int Sessions { get; set; }
+
+    /// <summary>The local checkout paths (worktrees, per-machine clones) whose turns rolled up into this
+    /// repository, sorted. Retained so the page can still show which working directories a repo's work came
+    /// from; empty only for a legacy row written before the checkout dimension existed.</summary>
+    public List<string> Checkouts { get; set; } = new();
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs
@@ -35,7 +35,7 @@ public sealed class GatewayStatsDatabase : IDisposable
 {
     /// <summary>The schema version this build understands. Bump it and add a migration step; never reshape
     /// an existing table in place without one.</summary>
-    public const int SchemaVersion = 3;
+    public const int SchemaVersion = 4;
 
     /// <summary>The meta key holding when the model dimension started recording - an ISO-8601 UTC stamp
     /// written once, by the migration that added the dimension. See <see cref="MigrateToVersion2"/> for why
@@ -75,6 +75,8 @@ public sealed class GatewayStatsDatabase : IDisposable
             var dir = System.IO.Path.GetDirectoryName(_path);
             if (!string.IsNullOrEmpty(dir))
                 Directory.CreateDirectory(dir);
+
+            RetirePreSlugStore();
 
             _connection = new SqliteConnection($"Data Source={_path}");
             _connection.Open();
@@ -131,6 +133,9 @@ public sealed class GatewayStatsDatabase : IDisposable
 
         if (current < 3)
             MigrateToVersion3(tx);
+
+        if (current < 4)
+            MigrateToVersion4(tx);
 
         Execute($"PRAGMA user_version={SchemaVersion}", tx);
         tx.Commit();
@@ -459,6 +464,101 @@ public sealed class GatewayStatsDatabase : IDisposable
                 cache_read_tokens     INTEGER NOT NULL,
                 cache_creation_tokens INTEGER NOT NULL
             )", tx);
+    }
+
+    // Version 4: the checkout dimension - the LOCAL working directory each turn was driven in - landing
+    // together with a meaning change to the repository dimension it sits beside.
+    //
+    // repo_id USED to be keyed by the session's local working-directory path; from this version it is keyed
+    // by the session's GitHub "owner/repo" slug (SessionDto.RepoSlug), so one repository's worktrees and its
+    // per-machine clones collapse into a single row on the Repos page instead of one row each. The path is
+    // NOT thrown away in the process - it becomes its own dimension here, so the store still records exactly
+    // which checkout every turn ran in (the owner's ask: keep the checkout AND the repo name). Grouping and
+    // ranking are by repo_id (the slug); checkout_id is retained detail, read back as the set of checkouts
+    // that rolled into a repo.
+    //
+    // Because the meaning of an EXISTING repo_id row changed and the Gateway cannot re-key a stored path to a
+    // slug (it has no filesystem to resolve it, and the path may be another machine's), a pre-version-4 store
+    // is not migrated forward at all: it is retired aside UNREAD before this database is opened
+    // (RetirePreSlugStore), and this store starts empty. So this step only ever runs as part of building a
+    // FRESH database (0 -> 4); it is written as a proper migration all the same, so the schema machinery
+    // stays honest and a fresh build lands the column and table exactly once.
+    //
+    // checkout_id is added by ALTER TABLE and is therefore nullable at the column level (SQLite reads NULL
+    // for any row written before the column existed). No live fold ever writes a NULL: every stat_delta row
+    // is written by this build, which always carries a checkout (RepoPath is always set), and every pre-v4
+    // row was retired aside. The nullable column is the honest shape for an ALTER, not a state the fold
+    // produces - the same as model_id in version 2.
+    private void MigrateToVersion4(SqliteTransaction tx)
+    {
+        Execute("ALTER TABLE stat_delta ADD COLUMN checkout_id INTEGER", tx);
+
+        // Surrogate id to first-seen display spelling, exactly as repo_identity, agent_identity and
+        // model_identity: the in-memory OrdinalIgnoreCase map decides identity and SQLite is never asked to
+        // compare a path string. The full reasoning - most of all why no folded string is stored, because
+        // there is no normalizer equivalent to the comparer - is written out on repo_identity in
+        // MigrateToVersion1 and is not repeated here.
+        Execute(@"
+            CREATE TABLE IF NOT EXISTS checkout_identity (
+                checkout_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+                checkout_display TEXT    NOT NULL
+            )", tx);
+    }
+
+    // Retire a pre-version-4 statistics store aside UNREAD, exactly as the legacy JSON store was retired
+    // (GatewayInputStatsAggregator.RetireLegacyJsonStore). Runs once, before the database is opened.
+    //
+    // Why the old numbers are not carried across: version 4 changed what repo_id MEANS - the session's local
+    // working-directory path became its GitHub "owner/repo" slug. An existing row is keyed by a path, and the
+    // Gateway cannot re-key it to a slug: it has no filesystem to resolve the path against, and the path may
+    // belong to another machine entirely. There is no faithful forward migration, so - as with the JSON store
+    // and by the same owner ruling - the file is renamed aside (never deleted) and this store starts empty.
+    //
+    // The schema version is read straight from the SQLite header (a 4-byte big-endian integer at offset 60)
+    // rather than by opening the file: no connection, no file lock, nothing to release before the rename.
+    // Self-idempotent - the fresh database this build then creates is stamped version 4, so the next startup
+    // reads 4 from the header and retires nothing.
+    private void RetirePreSlugStore()
+    {
+        if (!File.Exists(_path)) return;
+
+        int version;
+        try
+        {
+            Span<byte> header = stackalloc byte[64];
+            int read;
+            using (var fs = new FileStream(_path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                read = fs.Read(header);
+            // Too small to be a real database, or not a SQLite file at all: leave it in place and let the
+            // normal open path either build the schema (empty file) or fail loudly (a genuinely bad file).
+            if (read < 64) return;
+            if (System.Text.Encoding.ASCII.GetString(header.Slice(0, 16)) != "SQLite format 3\0") return;
+            version = (header[60] << 24) | (header[61] << 16) | (header[62] << 8) | header[63];
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayStatsDatabase] RetirePreSlugStore: could not read header of {_path}: " +
+                          $"{ex.Message}; leaving it in place for the normal open path");
+            return;
+        }
+
+        // A valid store already at version 4 (or, defensively, beyond it) is current; version 0 is not a real
+        // stamped store. Only a genuine version 1..3 file is the pre-slug store this retires.
+        if (version <= 0 || version >= SchemaVersion) return;
+
+        var aside = _path + ".pre-slug-" +
+            DateTime.UtcNow.ToString("yyyyMMdd-HHmmss", System.Globalization.CultureInfo.InvariantCulture);
+        MoveAsideIfExists(_path, aside);
+        MoveAsideIfExists(_path + "-wal", aside + "-wal");
+        MoveAsideIfExists(_path + "-shm", aside + "-shm");
+        FileLog.Write($"[GatewayStatsDatabase] RetirePreSlugStore: the repository dimension changed from local " +
+                      $"path to GitHub slug at schema v{SchemaVersion}; renamed the pre-slug store (v{version}) " +
+                      $"to {aside} UNREAD; starting empty");
+    }
+
+    private static void MoveAsideIfExists(string from, string to)
+    {
+        if (File.Exists(from)) File.Move(from, to);
     }
 
     private int QueryUserVersion()


### PR DESCRIPTION
## What

The Your Throttle "By repository" list grouped by the session's local working directory, so every worktree and every per-machine clone of one repository became its own row. This under-counts a repo's real work and clutters the list with things that are not interesting for "how much do we work in each repo".

Now grouped by the **GitHub owner/repo slug**, so every worktree and clone of one repository rolls up into a single row. The local checkout paths are retained and shown under the repo name.

## How

- `GitHubUrls.ResolveSlugCached(path)` resolves `owner/repo` from a checkout's origin remote (cached per path; best-effort, never throws).
- `SessionDto.RepoSlug` carries it up from the Director (the git repo only exists on the Director's machine).
- The Gateway aggregator folds `RepoSlug` as the repository identity, falling back to the local path when a checkout has no github.com origin.
- New retained `checkout` dimension (schema v4) keeps the working directory each turn ran in, so nothing is lost.
- The pre-slug stats store cannot be re-keyed (the Gateway has no filesystem to resolve a stored path to a slug), so it is retired aside unread and re-accumulates by repository.

## Tests

- Core.Tests: 3211 passed (incl. new `GitHubUrls` slug tests)
- Gateway.Tests: 2512 passed (incl. slug-collapse, checkout retention, fallback, pre-slug reset)
- client-core: 526 passed; frontend typecheck clean