### PR TITLE
fix(hold): route an agent's self-hold through the Gateway so it actually holds

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -795,6 +795,16 @@ internal static class ControlEndpoints
         // POST /fleet/hold - park a session, or release it (the old POST /sessions/{sid}/hold). A hold asked
         // for mid-turn is DEFERRED and applies when the turn settles (see HoldState) - the response's pending
         // flag says so, which is why it is surfaced rather than swallowed.
+        //
+        // THE GATEWAY OWNS HOLD. When one is configured, EVERY hold - a session holding ITSELF (always a
+        // local session), a manager holding a worker, local or remote - is routed to the Gateway, because
+        // only the Gateway's SnoozeRegistry records the hold, defers it while the turn runs, lands it when
+        // the work settles, and expires it on the clock. A hold that stops at this Director only tints the
+        // local rail mirror, which the Gateway's roster fold then overwrites back to "not held" - so it
+        // evaporates within a poll. That was the agent-self-hold defect: `cc-devthrottle session hold` on a
+        // LOCAL session short-circuited to a mirror-only write and never reached the registry, so it never
+        // landed and never held. Only when there is NO Gateway does the local mirror become the sole owner
+        // worth writing, and only then do we dispatch the hold verb here.
         app.MapPost("/fleet/hold", async (FleetHoldRequest req, CancellationToken ct) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.ToSessionId))
@@ -802,7 +812,25 @@ internal static class ControlEndpoints
             if (!Guid.TryParse(req.ToSessionId, out var toGuid))
                 return Results.BadRequest(new { error = "invalid toSessionId format" });
 
-            if (sessionManager.GetSession(toGuid) is not null)
+            var gw = gatewayClientProvider?.Invoke();
+            var route = ChooseHoldRoute(gw is { IsEnabled: true }, sessionManager.GetSession(toGuid) is not null);
+
+            if (route == HoldRoute.Gateway)
+            {
+                try
+                {
+                    var held = await gw!.HoldFleetAsync(req.ToSessionId, req.OnHold, req.SnoozeMinutes, ct);
+                    return Results.Json(held);
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[ControlEndpoints] /fleet/hold relay to {toGuid} FAILED: {ex.Message}");
+                    return Results.Json(new { error = $"Cannot hold the target via the Gateway: {ex.Message}" },
+                        statusCode: StatusCodes.Status502BadGateway);
+                }
+            }
+
+            if (route == HoldRoute.LocalMirror)
             {
                 var command = new DirectorCommand
                 {
@@ -814,21 +842,8 @@ internal static class ControlEndpoints
                 return CommandResultToHttp(result);
             }
 
-            var gw = gatewayClientProvider?.Invoke();
-            if (gw is not { IsEnabled: true })
-                return Results.Json(new { error = "Session not found on this Director and no Gateway is configured." },
-                    statusCode: StatusCodes.Status404NotFound);
-            try
-            {
-                var held = await gw.HoldFleetAsync(req.ToSessionId, req.OnHold, req.SnoozeMinutes, ct);
-                return Results.Json(held);
-            }
-            catch (Exception ex)
-            {
-                FileLog.Write($"[ControlEndpoints] /fleet/hold relay to {toGuid} FAILED: {ex.Message}");
-                return Results.Json(new { error = $"Cannot hold the target via the Gateway: {ex.Message}" },
-                    statusCode: StatusCodes.Status502BadGateway);
-            }
+            return Results.Json(new { error = "Session not found on this Director and no Gateway is configured." },
+                statusCode: StatusCodes.Status404NotFound);
         });
 
         // GET /fleet/buffer?sessionId=... - read what a session's terminal is showing (the old GET
@@ -1113,6 +1128,32 @@ internal static class ControlEndpoints
         var tailnetEndpoint = resolution.IsResolved ? resolution.Endpoint : "";
         return (machineName, user, tailnetEndpoint);
     }
+
+    /// <summary>
+    /// Where a hold on <c>POST /fleet/hold</c> is decided. Extracted from the endpoint so the one rule
+    /// that broke agent self-hold is unit-testable without an HTTP round trip.
+    /// </summary>
+    internal enum HoldRoute
+    {
+        /// <summary>Record it in the Gateway's SnoozeRegistry - the only place a hold is enforced.</summary>
+        Gateway,
+        /// <summary>No Gateway: write the local rail mirror, the only owner standalone has.</summary>
+        LocalMirror,
+        /// <summary>Unknown session and no Gateway to ask - 404.</summary>
+        NotFound,
+    }
+
+    /// <summary>
+    /// The hold routing rule. The Gateway owns hold, so whenever one is configured EVERY hold goes to it -
+    /// including a session holding ITSELF, which is always local. Short-circuiting a local session to the
+    /// mirror-only local path (the pre-fix behaviour) never reached the SnoozeRegistry, so the hold never
+    /// landed and evaporated on the next roster fold. The local mirror is written only when there is no
+    /// Gateway to own the hold.
+    /// </summary>
+    internal static HoldRoute ChooseHoldRoute(bool gatewayEnabled, bool sessionIsLocal)
+        => gatewayEnabled ? HoldRoute.Gateway
+         : sessionIsLocal ? HoldRoute.LocalMirror
+         : HoldRoute.NotFound;
 
     /// <summary>Folder name of a repo path, for display fallback. Empty path -> "Unknown Project".</summary>
     // Gateway Cleanup Phase 0 (Worker R2): widened to internal so CatalogReadExecutor's claude-sessions core

--- a/src/CcDirector.Gateway.Tests/FleetHoldRouteTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetHoldRouteTests.cs
@@ -1,0 +1,50 @@
+using CcDirector.ControlApi;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Locks the routing rule for <c>POST /fleet/hold</c> - the exact decision whose old value made
+/// <c>cc-devthrottle session hold</c> (an agent holding ITSELF) silently fail.
+///
+/// The Gateway owns hold: only its SnoozeRegistry defers a hold while the turn runs, lands it when the
+/// work settles, and expires it on the clock. Before the fix, a LOCAL session (which a self-hold always
+/// is) was short-circuited to a mirror-only write on the Director and never reached the registry, so the
+/// hold never landed and evaporated on the next roster fold. These assertions fail against that old rule
+/// (local + gateway -> LocalMirror) and pass against the fix (local + gateway -> Gateway).
+/// </summary>
+public sealed class FleetHoldRouteTests
+{
+    [Fact]
+    public void LocalSession_WithGateway_RoutesToGateway_notTheMirror()
+    {
+        // The headline case: a session holds itself while a Gateway is connected. It MUST reach the
+        // Gateway's registry, not stop at the Director's local rail mirror.
+        var route = ControlEndpoints.ChooseHoldRoute(gatewayEnabled: true, sessionIsLocal: true);
+        Assert.Equal(ControlEndpoints.HoldRoute.Gateway, route);
+    }
+
+    [Fact]
+    public void RemoteSession_WithGateway_RoutesToGateway()
+    {
+        // A manager holding a worker on another Director already worked; it stays routed to the Gateway.
+        var route = ControlEndpoints.ChooseHoldRoute(gatewayEnabled: true, sessionIsLocal: false);
+        Assert.Equal(ControlEndpoints.HoldRoute.Gateway, route);
+    }
+
+    [Fact]
+    public void LocalSession_NoGateway_WritesLocalMirror()
+    {
+        // Standalone (no Gateway): the local mirror is the only owner there is, so the hold is written here.
+        var route = ControlEndpoints.ChooseHoldRoute(gatewayEnabled: false, sessionIsLocal: true);
+        Assert.Equal(ControlEndpoints.HoldRoute.LocalMirror, route);
+    }
+
+    [Fact]
+    public void UnknownSession_NoGateway_IsNotFound()
+    {
+        // No local session and no Gateway to ask -> nothing can own the hold -> 404.
+        var route = ControlEndpoints.ChooseHoldRoute(gatewayEnabled: false, sessionIsLocal: false);
+        Assert.Equal(ControlEndpoints.HoldRoute.NotFound, route);
+    }
+}


### PR DESCRIPTION
## Problem

A session holding itself with `cc-devthrottle session hold` never actually holds. The command reports "queued... it parks when it finishes", the roster briefly shows "Held", then the hold silently evaporates within a poll.

A session holding itself is always a **local** session on its own Director. `POST /fleet/hold` short-circuited local sessions to a mirror-only write (`SessionCommandExecutor.Hold` -> `ApplyGatewayHold`) that never reached the Gateway's `SnoozeRegistry`. So the hold was never recorded, deferred, landed, or expired - it only tinted the local rail, which the Gateway roster fold (`GatewayEndpoints` session fold) then overwrote back to "not held". The desktop Snooze button worked only because it takes a different route straight to the Gateway (`GatewayClient.RecordHoldAsync`).

## Fix

The Gateway owns hold, so route **every** hold through it whenever one is configured - local session or remote. Only in standalone mode, with no Gateway to own the hold, does the local mirror remain the sole owner worth writing. The routing decision is extracted into `ChooseHoldRoute(gatewayEnabled, sessionIsLocal)` so the rule that broke is locked by unit tests.

## Evidence

**Broken build** - clean test session, nobody messaging it: ran `session hold --minutes 4`, went idle, stayed `onHold=False` the full 3.5 minutes it should have been held. A/B on the same session: CLI hold -> not held; Gateway-direct hold -> held and stayed. The hold machinery is healthy; the CLI path never reached it.

**Fixed build** (verified live on a real Director + Gateway): a self-hold walked the full state machine - `DeferredHold` while working -> `Held` when the turn finished -> held for the requested 3 minutes -> auto-released on the timer.

## Tests

- New `FleetHoldRouteTests` (4 cases) locks the routing rule: a local session with a Gateway must route to the Gateway, not the mirror.
- Full `CcDirector.Gateway.Tests` suite green (routing + Snooze end-to-end + landing + expiry).

## Coverage gap this closes

`SnoozeEndToEndTests` drove the Gateway endpoint directly and never exercised the Director's `/fleet/hold` local-session path where the bug lived, so it passed while the real agent path was broken.