### PR TITLE
Fix remote session spawn on tunnel-only Directors

### DIFF
--- a/src/CcDirector.Gateway.Tests/CronWorkListTriggerTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronWorkListTriggerTests.cs
@@ -43,7 +43,7 @@ public sealed class CronWorkListTriggerTests : IDisposable
     public async Task Trigger_NoSuchList_ReturnsNoSuchList()
     {
         var store = NewListStore();
-        var t = Trigger(store, new FakeResolver("http://d", "machineA"), new WorkListRunnerManager(), new FakeLauncher());
+        var t = Trigger(store, new FakeResolver("machineA"), new WorkListRunnerManager(), new FakeLauncher());
         Assert.Equal(CronWorkListOutcome.NoSuchList, await t.TriggerAsync(WorkListJob(), CancellationToken.None));
     }
 
@@ -52,7 +52,7 @@ public sealed class CronWorkListTriggerTests : IDisposable
     {
         var store = NewListStore();
         store.Create("Tonight"); // exists but no items
-        var t = Trigger(store, new FakeResolver("http://d", "machineA"), new WorkListRunnerManager(), new FakeLauncher());
+        var t = Trigger(store, new FakeResolver("machineA"), new WorkListRunnerManager(), new FakeLauncher());
         Assert.Equal(CronWorkListOutcome.EmptyList, await t.TriggerAsync(WorkListJob(), CancellationToken.None));
     }
 
@@ -65,7 +65,7 @@ public sealed class CronWorkListTriggerTests : IDisposable
         Assert.Equal(WorkListStore.ClaimResult.Granted, store.Claim("Tonight", "someone-else"));
 
         var launcher = new FakeLauncher();
-        var t = Trigger(store, new FakeResolver("http://d", "machineA"), new WorkListRunnerManager(), launcher);
+        var t = Trigger(store, new FakeResolver("machineA"), new WorkListRunnerManager(), launcher);
 
         Assert.Equal(CronWorkListOutcome.AlreadyClaimed, await t.TriggerAsync(WorkListJob(), CancellationToken.None));
         Assert.Equal(0, launcher.LaunchCount);                 // never launched -> no duplicate claim
@@ -78,7 +78,7 @@ public sealed class CronWorkListTriggerTests : IDisposable
         var store = NewListStore();
         store.Create("Tonight");
         store.AppendItem("Tonight", new WorkListItemRef { Source = "github", Id = "312" });
-        var t = Trigger(store, new FakeResolver(null, null), new WorkListRunnerManager(), new FakeLauncher());
+        var t = Trigger(store, new FakeResolver(null), new WorkListRunnerManager(), new FakeLauncher());
         Assert.Equal(CronWorkListOutcome.NoSuchDirector, await t.TriggerAsync(WorkListJob(), CancellationToken.None));
     }
 
@@ -91,7 +91,7 @@ public sealed class CronWorkListTriggerTests : IDisposable
         var manager = new WorkListRunnerManager();
         Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, manager.TryAdmit("workstation-A", "OtherList"));
 
-        var t = Trigger(store, new FakeResolver("http://d", "machineA"), manager, new FakeLauncher());
+        var t = Trigger(store, new FakeResolver("machineA"), manager, new FakeLauncher());
         Assert.Equal(CronWorkListOutcome.MachineBusy, await t.TriggerAsync(WorkListJob(), CancellationToken.None));
     }
 
@@ -103,7 +103,7 @@ public sealed class CronWorkListTriggerTests : IDisposable
         store.AppendItem("Tonight", new WorkListItemRef { Source = "github", Id = "312" });
         var manager = new WorkListRunnerManager();
         var launcher = new FakeLauncher();
-        var t = Trigger(store, new FakeResolver("http://d", "machineA"), manager, launcher);
+        var t = Trigger(store, new FakeResolver("machineA"), manager, launcher);
 
         var outcome = await t.TriggerAsync(WorkListJob(), CancellationToken.None);
         Assert.Equal(CronWorkListOutcome.Started, outcome);
@@ -156,13 +156,12 @@ public sealed class CronWorkListTriggerTests : IDisposable
 
     private sealed class FakeResolver : IDirectorTargetResolver
     {
-        private readonly string? _endpoint;
         private readonly string? _directorId;
-        public FakeResolver(string? endpoint, string? directorId) { _endpoint = endpoint; _directorId = directorId; }
+        public FakeResolver(string? directorId) { _directorId = directorId; }
         public Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct) =>
-            Task.FromResult(string.IsNullOrEmpty(_endpoint)
-                ? new DirectorTargetResult(null, null, "no director on machine")
-                : new DirectorTargetResult(_endpoint, _directorId, null));
+            Task.FromResult(string.IsNullOrEmpty(_directorId)
+                ? new DirectorTargetResult(null, "no director on machine")
+                : new DirectorTargetResult(_directorId, null));
     }
 
     private sealed class FakeLauncher : ICronWorkListDrainLauncher

--- a/src/CcDirector.Gateway.Tests/MachineSessionSpawnerTests.cs
+++ b/src/CcDirector.Gateway.Tests/MachineSessionSpawnerTests.cs
@@ -9,9 +9,10 @@ namespace CcDirector.Gateway.Tests;
 /// the cron firing engine and the interactive POST /machines/{machine}/sessions relay ("start a session
 /// on another computer"). A stub resolver stands in for the live registry/launcher and a fake create
 /// delegate stands in for the Director's session-create call, so the resolve-then-create DECISION is
-/// verified without a live Director. Covers the good path (resolver returns an endpoint -> create ->
-/// success) and the fail-loud path (resolver returns an offline Error -> failure, and the create is
-/// NEVER attempted, i.e. no local fallback).
+/// verified without a live Director. Covers the good path (resolver returns a DirectorId -> create ->
+/// success), the fail-loud path (resolver returns an offline Error -> failure, and the create is NEVER
+/// attempted, i.e. no local fallback), and - through the REAL resolver - the tunnel-only case of a
+/// Director with a blank control endpoint (issue #1727).
 /// </summary>
 public sealed class MachineSessionSpawnerTests
 {
@@ -32,17 +33,22 @@ public sealed class MachineSessionSpawnerTests
         }
     }
 
-    [Fact]
-    public async Task Spawn_ResolverReturnsEndpoint_CreatesSession_ReturnsIt()
+    /// <summary>A launcher that must never be called: the Director is already registered on the machine.</summary>
+    private sealed class ThrowingLauncher : IDirectorLauncher
     {
-        var resolver = new StubResolver(new DirectorTargetResult("http://127.0.0.1:7900", "d-new", null));
+        public Task<bool> StartAsync(string machine, CancellationToken ct) =>
+            throw new InvalidOperationException("launcher must not be called: the Director is already registered");
+    }
+
+    [Fact]
+    public async Task Spawn_ResolverReturnsDirectorId_CreatesSession_ReturnsIt()
+    {
+        var resolver = new StubResolver(new DirectorTargetResult("d-new", null));
         string? seenDirectorId = null;
-        string? seenEndpoint = null;
         NewSessionRequest? seenReq = null;
-        var spawner = new MachineSessionSpawner(resolver, (directorId, endpoint, req, ct) =>
+        var spawner = new MachineSessionSpawner(resolver, (directorId, req, ct) =>
         {
             seenDirectorId = directorId;
-            seenEndpoint = endpoint;
             seenReq = req;
             return Task.FromResult<(bool, SessionDto?, string?)>((true, new SessionDto { SessionId = "sid-123" }, null));
         });
@@ -55,10 +61,8 @@ public sealed class MachineSessionSpawnerTests
         Assert.Equal("sid-123", dto!.SessionId);
         Assert.Null(error);
         Assert.Equal("d-new", directorId);
-        // The create was made against the resolved Director id (the tunnel leg) and endpoint (the fallback leg)
-        // with the same request.
+        // The create was made against the resolved Director id (the tunnel leg) with the same request.
         Assert.Equal("d-new", seenDirectorId);
-        Assert.Equal("http://127.0.0.1:7900", seenEndpoint);
         Assert.Same(request, seenReq);
         Assert.Equal("MACHINE_A", resolver.LastMachine);
     }
@@ -67,9 +71,9 @@ public sealed class MachineSessionSpawnerTests
     public async Task Spawn_ResolverReturnsOfflineError_FailsLoud_DoesNotCreateLocally()
     {
         var resolver = new StubResolver(
-            new DirectorTargetResult(null, null, "no Director on 'MACHINE_B' and the launcher could not start one"));
+            new DirectorTargetResult(null, "no Director on 'MACHINE_B' and the launcher could not start one"));
         var createCalled = false;
-        var spawner = new MachineSessionSpawner(resolver, (directorId, endpoint, req, ct) =>
+        var spawner = new MachineSessionSpawner(resolver, (directorId, req, ct) =>
         {
             createCalled = true;
             return Task.FromResult<(bool, SessionDto?, string?)>((true, new SessionDto { SessionId = "must-not-happen" }, null));
@@ -89,8 +93,8 @@ public sealed class MachineSessionSpawnerTests
     [Fact]
     public async Task Spawn_CreateFails_ReportsTheCreateError_KeepsResolvedDirectorId()
     {
-        var resolver = new StubResolver(new DirectorTargetResult("http://127.0.0.1:7901", "d-live", null));
-        var spawner = new MachineSessionSpawner(resolver, (directorId, endpoint, req, ct) =>
+        var resolver = new StubResolver(new DirectorTargetResult("d-live", null));
+        var spawner = new MachineSessionSpawner(resolver, (directorId, req, ct) =>
             Task.FromResult<(bool, SessionDto?, string?)>((false, null, "director returned 500: boom")));
 
         var (ok, dto, error, directorId) = await spawner.SpawnOnMachineAsync(
@@ -100,5 +104,42 @@ public sealed class MachineSessionSpawnerTests
         Assert.Null(dto);
         Assert.Equal("director returned 500: boom", error);
         Assert.Equal("d-live", directorId);   // still carries the resolved Director for the run record
+    }
+
+    // Issue #1727 regression: a genuinely remote, tunnel-only Director registers with a BLANK
+    // ControlEndpoint. Resolving it through the REAL RegistryDirectorTargetResolver (not a stub that
+    // injects a fake endpoint the production resolver never emits) and spawning must SUCCEED - delivery
+    // is by DirectorId over the tunnel. The old guard rejected on the blank endpoint with a 502-style
+    // "could not resolve a director" error; this test fails against that code and passes with the fix.
+    [Fact]
+    public async Task Spawn_RealResolver_DirectorWithBlankControlEndpoint_CreatesSession()
+    {
+        var director = new DirectorDto
+        {
+            DirectorId = "d-remote",
+            MachineName = "Sorens-Mac-mini",
+            ControlEndpoint = "",       // tunnel-only mode: always blank
+            Source = "stream",
+        };
+        var resolver = new RegistryDirectorTargetResolver(
+            listDirectors: () => new[] { director },
+            launcher: new ThrowingLauncher());
+
+        string? seenDirectorId = null;
+        var spawner = new MachineSessionSpawner(resolver, (directorId, req, ct) =>
+        {
+            seenDirectorId = directorId;
+            return Task.FromResult<(bool, SessionDto?, string?)>((true, new SessionDto { SessionId = "sid-remote" }, null));
+        });
+
+        var (ok, dto, error, directorId) = await spawner.SpawnOnMachineAsync(
+            "Sorens-Mac-mini", new NewSessionRequest { RepoPath = "/repo" }, CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.NotNull(dto);
+        Assert.Equal("sid-remote", dto!.SessionId);
+        Assert.Null(error);
+        Assert.Equal("d-remote", directorId);
+        Assert.Equal("d-remote", seenDirectorId);   // create invoked with the resolved DirectorId
     }
 }

--- a/src/CcDirector.Gateway.Tests/RegistryDirectorTargetResolverTests.cs
+++ b/src/CcDirector.Gateway.Tests/RegistryDirectorTargetResolverTests.cs
@@ -10,6 +10,10 @@ namespace CcDirector.Gateway.Tests;
 /// running (no launch), none is running so the launcher starts one and it registers (launch + poll),
 /// and the launcher cannot start one (clean error). A fake launcher and a mutable Director list stand
 /// in for the live registry, with tiny wall-clock waits so the poll terminates instantly.
+///
+/// The resolver's result is a DirectorId (or an error) - not an endpoint. In tunnel-only mode a
+/// registered Director is reached over its tunnel by id, so resolving must succeed even when the
+/// Director's control endpoint is blank, which every tunnel-only Director's is (issue #1727).
 /// </summary>
 public sealed class RegistryDirectorTargetResolverTests
 {
@@ -38,12 +42,14 @@ public sealed class RegistryDirectorTargetResolverTests
     }
 
     [Fact]
-    public async Task Resolve_DirectorAlreadyRunning_ReturnsItsEndpoint_DoesNotLaunch()
+    public async Task Resolve_DirectorAlreadyRunning_WithBlankControlEndpoint_ReturnsItsId_DoesNotLaunch()
     {
+        // Tunnel-only shape: the registered Director's control endpoint is blank. Resolving must still
+        // succeed and return its id - the id is the whole result (issue #1727).
         var directors = new List<DirectorDto>
         {
-            Director("d-7882", "MACHINE_A", "http://127.0.0.1:7882/"),
-            Director("d-7879", "MACHINE_B", "http://127.0.0.1:7879"),
+            Director("d-7882", "MACHINE_A", ""),
+            Director("d-7879", "MACHINE_B", ""),
         };
         var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch when one is running"));
         var resolver = new RegistryDirectorTargetResolver(() => directors, launcher, FastTimeout, FastPoll);
@@ -51,7 +57,6 @@ public sealed class RegistryDirectorTargetResolverTests
         var result = await resolver.ResolveAsync("MACHINE_A", CancellationToken.None);
 
         Assert.Null(result.Error);
-        Assert.Equal("http://127.0.0.1:7882", result.Endpoint);   // trailing slash trimmed
         Assert.Equal("d-7882", result.DirectorId);
         Assert.Equal(0, launcher.StartCount);                      // a running Director means no launch
     }
@@ -59,11 +64,11 @@ public sealed class RegistryDirectorTargetResolverTests
     [Fact]
     public async Task Resolve_NoDirector_LauncherStartsOne_RegistersAfterLaunch_Resolves()
     {
-        var directors = new List<DirectorDto> { Director("d-7879", "MACHINE_B", "http://127.0.0.1:7879") };
+        var directors = new List<DirectorDto> { Director("d-7879", "MACHINE_B", "") };
         // The launcher "starts" a Director on MACHINE_A: it registers in the list and the next poll finds it.
         var launcher = new FakeLauncher(machine =>
         {
-            directors.Add(Director("d-new", machine, "http://127.0.0.1:7900"));
+            directors.Add(Director("d-new", machine, ""));
             return true;
         });
         var resolver = new RegistryDirectorTargetResolver(() => directors, launcher, FastTimeout, FastPoll);
@@ -71,7 +76,6 @@ public sealed class RegistryDirectorTargetResolverTests
         var result = await resolver.ResolveAsync("MACHINE_A", CancellationToken.None);
 
         Assert.Null(result.Error);
-        Assert.Equal("http://127.0.0.1:7900", result.Endpoint);
         Assert.Equal("d-new", result.DirectorId);
         Assert.Equal(1, launcher.StartCount);
         Assert.Equal("MACHINE_A", launcher.LastMachine);
@@ -86,7 +90,6 @@ public sealed class RegistryDirectorTargetResolverTests
 
         var result = await resolver.ResolveAsync("MACHINE_A", CancellationToken.None);
 
-        Assert.Null(result.Endpoint);
         Assert.Null(result.DirectorId);
         Assert.NotNull(result.Error);
         Assert.Equal(1, launcher.StartCount);
@@ -102,7 +105,7 @@ public sealed class RegistryDirectorTargetResolverTests
 
         var result = await resolver.ResolveAsync("MACHINE_A", CancellationToken.None);
 
-        Assert.Null(result.Endpoint);
+        Assert.Null(result.DirectorId);
         Assert.NotNull(result.Error);
         Assert.Contains("registered", result.Error!);
     }
@@ -115,7 +118,7 @@ public sealed class RegistryDirectorTargetResolverTests
 
         var result = await resolver.ResolveAsync("   ", CancellationToken.None);
 
-        Assert.Null(result.Endpoint);
+        Assert.Null(result.DirectorId);
         Assert.NotNull(result.Error);
         Assert.Equal(0, launcher.StartCount);
     }

--- a/src/CcDirector.Gateway.Tests/TunnelSpawnerDriverProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelSpawnerDriverProofTests.cs
@@ -13,18 +13,14 @@ namespace CcDirector.Gateway.Tests;
 /// now create sessions and read their buffers DOWN the tunnel, via the director-level
 /// <see cref="SessionVerbClient.CreateSessionAsync"/> and the session-level buffer verb.
 ///
-/// Proof by CONSTRUCTION: each caller is bound to a Director whose control endpoint would refuse a
-/// TCP connection (a dead loopback port), so a call that SUCCEEDS could only have gone down the tunnel -
-/// the HTTP fallback would have thrown. The recording hook stands in for the Director stream and asserts
-/// the exact verb + payload marshaling. This is the same trick the other Phase 2 proofs use
-/// (TunnelDirectorReadProofTests / SessionVerbClientTests).
+/// Proof by CONSTRUCTION: these callers have NO HTTP dial path at all - they are bound to a Director by
+/// id and deliver through the stream hub, so a call that SUCCEEDS could only have gone down the tunnel.
+/// The recording hook stands in for the Director stream and asserts the exact verb + payload marshaling.
+/// This is the same trick the other Phase 2 proofs use (TunnelDirectorReadProofTests / SessionVerbClientTests).
 /// </summary>
 public sealed class TunnelSpawnerDriverProofTests
 {
     private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
-
-    // A control endpoint on a dead loopback port: an HTTP dial here throws, so a success proves the tunnel ran.
-    private const string UnreachableEndpoint = "http://127.0.0.1:59923/";
 
     private sealed class RecordingHub
     {
@@ -54,13 +50,13 @@ public sealed class TunnelSpawnerDriverProofTests
         {
             Next = DirectorCommandResult.Success(JsonSerializer.Serialize(new SessionDto { SessionId = "sid-42" }, Web)),
         };
-        var resolver = new StubResolver(new DirectorTargetResult(UnreachableEndpoint, "dir-7", null));
+        var resolver = new StubResolver(new DirectorTargetResult("dir-7", null));
         var spawner = new MachineSessionSpawner(resolver, hub.Send);
 
         var (ok, dto, error, directorId) = await spawner.SpawnOnMachineAsync(
             "MACHINE_A", new NewSessionRequest { RepoPath = @"C:\repo", Agent = "ClaudeCode" }, CancellationToken.None);
 
-        Assert.True(ok);            // success against a dead endpoint => it went down the tunnel
+        Assert.True(ok);            // the spawner has no HTTP path; the create verb went down the tunnel hub
         Assert.Equal("sid-42", dto?.SessionId);
         Assert.Null(error);
         Assert.Equal("dir-7", directorId);

--- a/src/CcDirector.Gateway/Running/DirectorCronWorkListRunner.cs
+++ b/src/CcDirector.Gateway/Running/DirectorCronWorkListRunner.cs
@@ -59,15 +59,17 @@ public sealed class DirectorCronWorkListRunner : ICronWorkListRunner
         // Resolve the target MACHINE to a Director (launching one if none is running, #503).
         var machine = job.Target.Machine;
         var target = await _resolver.ResolveAsync(machine, ct);
-        if (string.IsNullOrEmpty(target.Endpoint))
+        // Tunnel-only: a resolved DirectorId is the target; a blank control endpoint is still reachable
+        // over the tunnel. Fail only on the resolver's error or a missing DirectorId, NOT on an endpoint
+        // (the same stale REST-era guard issue #1727 removed from the machine-session spawn path).
+        if (!string.IsNullOrEmpty(target.Error) || string.IsNullOrEmpty(target.DirectorId))
         {
             FileLog.Write($"[DirectorCronWorkListRunner] job={job.Id}: no director on machine={machine}: {target.Error}");
             return CronWorkListOutcome.NoSuchDirector;
         }
-        var endpoint = target.Endpoint;
-        var directorId = target.DirectorId ?? "";
+        var directorId = target.DirectorId;
 
-        var machineKey = string.IsNullOrWhiteSpace(machine) ? endpoint : machine;
+        var machineKey = string.IsNullOrWhiteSpace(machine) ? directorId : machine;
         if (_manager.TryAdmit(machineKey, listName) == WorkListRunnerManager.AdmitResult.RefusedMachineBusy)
         {
             FileLog.Write($"[DirectorCronWorkListRunner] job={job.Id}: machine={machineKey} busy (active={_manager.ActiveList(machineKey)})");
@@ -86,7 +88,10 @@ public sealed class DirectorCronWorkListRunner : ICronWorkListRunner
             // unobserved, and the machine slot is always released.
             try
             {
-                await _launcher.LaunchAsync(directorId, endpoint, repoPath, listName, consumer, ct);
+                // The launcher's endpoint parameter is a separate pre-existing vestige, ignored post-cut
+                // (tunnel-only): delivery is by directorId. Pass empty; retiring that parameter chain is a
+                // follow-up beyond issue #1727's scope.
+                await _launcher.LaunchAsync(directorId, string.Empty, repoPath, listName, consumer, ct);
                 FileLog.Write($"[DirectorCronWorkListRunner] job={job.Id}: drain complete list={listName}");
             }
             catch (Exception ex)

--- a/src/CcDirector.Gateway/Running/ICronWorkListRunner.cs
+++ b/src/CcDirector.Gateway/Running/ICronWorkListRunner.cs
@@ -17,7 +17,9 @@ public enum CronWorkListOutcome
     /// <summary>The list already has an active draining consumer (#273) - not re-claimed.</summary>
     AlreadyClaimed,
 
-    /// <summary>The job's target Director is not registered / has no control endpoint.</summary>
+    /// <summary>The job's target machine has no registered Director and none could be launched. In
+    /// tunnel-only mode a registered Director is reached over its tunnel by id, so a blank control
+    /// endpoint is valid and never causes this outcome (issue #1727).</summary>
     NoSuchDirector,
 
     /// <summary>The target machine is already draining another list (#274 single-machine guard).</summary>

--- a/src/CcDirector.Gateway/Running/IDirectorTargetResolver.cs
+++ b/src/CcDirector.Gateway/Running/IDirectorTargetResolver.cs
@@ -5,10 +5,13 @@ using CcDirector.Gateway.Discovery;
 namespace CcDirector.Gateway.Running;
 
 /// <summary>The outcome of resolving a cron job's target machine to a runnable Director (#503).</summary>
-/// <param name="Endpoint">The chosen Director's control endpoint (no trailing slash), or null if none.</param>
-/// <param name="DirectorId">The chosen Director's id (for the run record), or null.</param>
+/// <param name="DirectorId">The chosen Director's id, or null when none could be resolved/launched. In
+/// tunnel-only mode a resolved DirectorId is the WHOLE result: the Director is reached over its tunnel
+/// by id, not by dialing a control endpoint. There used to be an Endpoint field here carrying the
+/// Director's ControlEndpoint; it was always blank in tunnel-only mode and a stale guard rejected the
+/// spawn on it, so it has been retired (issue #1727).</param>
 /// <param name="Error">A human-readable reason when no Director could be resolved/launched, else null.</param>
-public sealed record DirectorTargetResult(string? Endpoint, string? DirectorId, string? Error);
+public sealed record DirectorTargetResult(string? DirectorId, string? Error);
 
 /// <summary>
 /// Resolves a cron job's target MACHINE to a runnable Director (epic #479, #503): picks the first
@@ -50,16 +53,16 @@ public sealed class RegistryDirectorTargetResolver : IDirectorTargetResolver
     public async Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(machine))
-            return new DirectorTargetResult(null, null, "no target machine");
+            return new DirectorTargetResult(null, "no target machine");
 
         var d = PickReachable(machine);
         if (d is not null)
-            return new DirectorTargetResult(d.ControlEndpoint.TrimEnd('/'), d.DirectorId, null);
+            return new DirectorTargetResult(d.DirectorId, null);
 
         // No Director running on the machine: ask its launcher to start one, then wait for it to register.
         FileLog.Write($"[RegistryDirectorTargetResolver] no Director on machine={machine}; asking launcher to start one");
         if (!await _launcher.StartAsync(machine, ct))
-            return new DirectorTargetResult(null, null, $"no Director on '{machine}' and the launcher could not start one");
+            return new DirectorTargetResult(null, $"no Director on '{machine}' and the launcher could not start one");
 
         var deadline = DateTime.UtcNow + _launchTimeout;
         while (DateTime.UtcNow < deadline)
@@ -69,10 +72,10 @@ public sealed class RegistryDirectorTargetResolver : IDirectorTargetResolver
             if (d is not null)
             {
                 FileLog.Write($"[RegistryDirectorTargetResolver] launched Director registered on machine={machine}: {d.DirectorId}");
-                return new DirectorTargetResult(d.ControlEndpoint.TrimEnd('/'), d.DirectorId, null);
+                return new DirectorTargetResult(d.DirectorId, null);
             }
         }
-        return new DirectorTargetResult(null, null, $"launched a Director on '{machine}' but none registered within {_launchTimeout.TotalSeconds:0}s");
+        return new DirectorTargetResult(null, $"launched a Director on '{machine}' but none registered within {_launchTimeout.TotalSeconds:0}s");
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Running/MachineSessionSpawner.cs
+++ b/src/CcDirector.Gateway/Running/MachineSessionSpawner.cs
@@ -22,13 +22,12 @@ public sealed class MachineSessionSpawner
     /// <summary>
     /// The create-session call. Production routes through <see cref="SessionVerbClient.CreateSessionAsync"/>,
     /// which is TUNNEL-ONLY: a Director that is not connected yields an error, never an HTTP dial. Tests
-    /// inject a fake so the resolve-then-create decision is verified without a live Director.
-    ///
-    /// The <c>endpoint</c> parameter is vestigial - the production constructor accepts it and DISCARDS it,
-    /// because the tunnel addresses the Director by id. It survives only in this delegate's shape.
+    /// inject a fake so the resolve-then-create decision is verified without a live Director. Delivery is by
+    /// DirectorId over the tunnel; there is no endpoint (the old vestigial endpoint parameter, always blank
+    /// in tunnel-only mode, was retired with issue #1727).
     /// </summary>
     public delegate Task<(bool ok, SessionDto? body, string? error)> CreateSessionDelegate(
-        string directorId, string endpoint, NewSessionRequest req, CancellationToken ct);
+        string directorId, NewSessionRequest req, CancellationToken ct);
 
     private readonly IDirectorTargetResolver _resolver;
     private readonly CreateSessionDelegate _create;
@@ -37,7 +36,7 @@ public sealed class MachineSessionSpawner
     /// <param name="sendCommand">The send-a-command-down-the-stream hook.</param>
     internal MachineSessionSpawner(IDirectorTargetResolver resolver,
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand)
-        : this(resolver, (directorId, endpoint, req, ct) =>
+        : this(resolver, (directorId, req, ct) =>
             SessionVerbClient.ForDirector(directorId, sendCommand).CreateSessionAsync(req, ct))
     {
     }
@@ -63,15 +62,20 @@ public sealed class MachineSessionSpawner
             throw new ArgumentNullException(nameof(req));
 
         var target = await _resolver.ResolveAsync(machine, ct);
-        if (string.IsNullOrEmpty(target.Endpoint))
+        // Tunnel-only: a resolved DirectorId IS the target - delivery is by id over the tunnel, so a
+        // Director with a blank control endpoint is perfectly reachable. Fail only when the resolver
+        // reported an error (machine off / unreachable / launch failed) or resolved no Director at all;
+        // do NOT reject on an endpoint (that stale REST-era guard is what issue #1727 removed).
+        if (!string.IsNullOrEmpty(target.Error) || string.IsNullOrEmpty(target.DirectorId))
         {
-            FileLog.Write($"[MachineSessionSpawner] SpawnOnMachineAsync FAILED: machine={machine}, {target.Error}");
-            return (false, null, target.Error ?? "could not resolve a director on the target machine", target.DirectorId);
+            var reason = target.Error ?? "the target machine has no registered director";
+            FileLog.Write($"[MachineSessionSpawner] SpawnOnMachineAsync FAILED: machine={machine}, {reason}");
+            return (false, null, reason, target.DirectorId);
         }
 
-        FileLog.Write($"[MachineSessionSpawner] SpawnOnMachineAsync: machine={machine}, director={target.DirectorId}, endpoint={target.Endpoint}, repo={req.RepoPath}");
+        FileLog.Write($"[MachineSessionSpawner] SpawnOnMachineAsync: machine={machine}, director={target.DirectorId}, repo={req.RepoPath}");
 
-        var (ok, body, error) = await _create(target.DirectorId ?? "", target.Endpoint, req, ct);
+        var (ok, body, error) = await _create(target.DirectorId, req, ct);
         if (!ok || body is null || string.IsNullOrEmpty(body.SessionId))
         {
             FileLog.Write($"[MachineSessionSpawner] SpawnOnMachineAsync FAILED: machine={machine}, error={error}");


### PR DESCRIPTION
## Summary

Starting a session on a genuinely remote machine through the Gateway always failed with a 502, even when the target Director was registered and heartbeating over its tunnel. A leftover REST-era guard rejected the spawn on a control endpoint that tunnel-only mode always leaves blank, before the tunnel delivery that would have worked was ever attempted.

Fixes #1727.

## Changes

- Retire the vestigial `Endpoint` field on `DirectorTargetResult` and stop the resolver carrying the always-blank `ControlEndpoint` into it.
- Gate `MachineSessionSpawner` on the resolver's error and `DirectorId`, not on the endpoint. Delivery is by `DirectorId` over the tunnel.
- Fix the identical endpoint gate in `DirectorCronWorkListRunner` (the cron work-list drain path resolves through the same resolver, so it had the same latent 502).
- Drop the now-orphaned vestigial endpoint parameter from the spawner's create delegate.

## Test

The old tests defended the defect by feeding the resolver a fake non-blank endpoint that tunnel-only production never emits. Added a production-shaped regression test that resolves a real stream Director with a blank control endpoint through the real `RegistryDirectorTargetResolver` and asserts the spawn succeeds; it fails against the old guard and passes with the fix. Updated the resolver and cron tests to assert on `DirectorId` rather than the retired endpoint. Full Gateway test suite: 2513 passed, 0 failed.

## Follow-up (out of scope here)

`ICronWorkListDrainLauncher` still carries a separate vestigial endpoint parameter that both the default and the host-injected factory discard; it is passed empty now and retiring that parameter chain is a follow-up.
