### PR TITLE
Rewrite the install docs around the headless CLI installer

### DIFF
--- a/docs/install/install-prompt.md
+++ b/docs/install/install-prompt.md
@@ -1,70 +1,94 @@
 # DevThrottle - install prompt (Windows + macOS)
 
-The **prompt you hand to Claude Code** to download and install the latest DevThrottle. One prompt,
-OS-aware: the agent detects the platform and installs the right asset to a **per-user, user-writable**
-location so the built-in **auto-update can replace it in place with no admin/sudo**. Never
-`Program Files` (Windows) or `/Applications` (macOS). Philosophy: [../PHILOSOPHY.md](../PHILOSOPHY.md).
+The **prompt you hand to Claude Code** to install the latest DevThrottle headlessly. One prompt,
+OS-aware: the agent detects the platform and uses the **command-line installer** (never the graphical
+wizard) to lay everything down **per-user, with no admin/sudo**, so the built-in **auto-update can
+replace it in place**. Never `Program Files` (Windows) or `/Applications` (macOS).
+Philosophy: [../PHILOSOPHY.md](../PHILOSOPHY.md).
+
+The command-line installer is the **same install engine** the graphical wizard uses, so a human and
+an agent end up with an identical setup. It installs the Director app, every `cc-*` CLI tool (on your
+`PATH`), and the launcher.
 
 Copy everything in the block below into a Claude Code session on the target machine.
 
 ---
 
 ```text
-Install the latest release of DevThrottle on THIS machine. You are doing the install yourself -
-no installer wizard, no admin/sudo. Detect the OS and follow the matching section. STOP with a
-clear message if any step fails; do not silently work around it or build from source.
+Install the latest release of DevThrottle on THIS machine, headlessly. Use the command-line
+installer, NOT the graphical wizard, and never require admin/sudo. Detect the OS and follow the
+matching section. STOP with a clear message if any step fails; do not silently work around it or
+build from source.
 
-REPO: github.com/example-org/devthrottle
-Find the latest release - prefer `gh release view --repo example-org/devthrottle --json tagName,assets`,
-else the public API https://api.github.com/repos/example-org/devthrottle/releases/latest. It must
+REPO: github.com/thefrederiksen/devthrottle  (public)
+Find the latest release - prefer `gh release view --repo thefrederiksen/devthrottle --json tagName,assets`,
+else the public API https://api.github.com/repos/thefrederiksen/devthrottle/releases/latest. It must
 include `release-manifest.json` plus this OS's asset below. ALWAYS verify the downloaded asset's
-SHA-256 against the manifest's entry for that asset before installing; mismatch = STOP.
+SHA-256 against the manifest's entry for that asset before running it; mismatch = STOP. Assets are at
+https://github.com/thefrederiksen/devthrottle/releases/latest/download/<asset-name>.
 
 == WINDOWS ==
-ASSET:  cc-director-win-x64.exe        (self-contained; no .NET needed)
-TARGET: %LOCALAPPDATA%\cc-director\app\cc-director.exe   (user-writable -> auto-update needs no admin)
-1. Download cc-director-win-x64.exe + release-manifest.json to %TEMP%\ccd-install.
-2. Verify: Get-FileHash -Algorithm SHA256 == manifest sha256 for cc-director-win-x64.exe, else STOP.
-3. Create %LOCALAPPDATA%\cc-director\app. If cc-director.exe is there AND running, ask the user to
-   close it (do not kill it).
-4. Copy the verified exe to %LOCALAPPDATA%\cc-director\app\cc-director.exe.
-5. Start Menu shortcut: %APPDATA%\Microsoft\Windows\Start Menu\Programs\DevThrottle.lnk -> the exe
-   (working dir = its folder). OPTIONAL autostart on login: also drop a shortcut in
-   %APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup.
+ASSETS: devthrottle-setup-cli-win-x64.exe  +  release-manifest.json  (the CLI installer is
+        self-contained, so it runs before .NET is present)
+1. Download both to %TEMP%\ccd-install.
+2. Verify: Get-FileHash -Algorithm SHA256 of devthrottle-setup-cli-win-x64.exe == the manifest's
+   sha256 for that asset, else STOP.
+3. Install (per-user workstation, no admin). `prereqs` confirms a coding agent is present; `install`
+   lays down the Director app, the cc-* tools (added to PATH), and the launcher under
+   %LOCALAPPDATA%\cc-director. Add --json to either for machine-readable output:
+      devthrottle-setup-cli-win-x64.exe prereqs
+      devthrottle-setup-cli-win-x64.exe install
+4. The Director is a .NET 10 app (framework-dependent). If `dotnet --list-runtimes` does not list
+   Microsoft.AspNetCore.App 10, install the runtime (still no admin):
+      winget install Microsoft.DotNet.AspNetCore.10
 
 == macOS (Apple Silicon) ==
-ASSET:  cc-director-mac-arm64.zip      (contains "CC Director.app"; self-contained)
-TARGET: ~/Applications/CC Director.app  (user-writable, NOT /Applications -> auto-update needs no sudo)
-1. Download cc-director-mac-arm64.zip + release-manifest.json to /tmp/ccd-install.
-2. Verify: `shasum -a 256` of the zip == manifest sha256 for cc-director-mac-arm64.zip, else STOP.
-3. Unzip it. `mkdir -p ~/Applications`. If "~/Applications/CC Director.app" is running, ask the user
-   to quit it (do not kill it).
-4. Replace: `rm -rf "~/Applications/CC Director.app"` then move the unzipped "CC Director.app" into
-   ~/Applications.
-5. Clear Gatekeeper quarantine: `xattr -dr com.apple.quarantine "~/Applications/CC Director.app"`.
-   It's now in Launchpad/Spotlight. OPTIONAL: add to the Dock; OPTIONAL autostart via Login Items.
+macOS has no fully-headless path today: the app is ad-hoc-signed, not Apple-notarized, so a browser
+download is Gatekeeper-blocked. Run the official curl bootstrap - a curl download is never
+quarantined. It downloads the setup app, verifies its SHA-256 against the manifest, installs it to
+~/Applications, and opens it:
+      curl -fsSL https://raw.githubusercontent.com/thefrederiksen/devthrottle/main/scripts/install-mac.sh | bash
+Then complete the short setup app. macOS is workstation-only (no Gateway).
 
 == BOTH ==
-6. Launch it once and confirm the running version matches the release tag (check the newest log under
-   %LOCALAPPDATA%\cc-director\logs\director\ on Windows, or the app's log dir on macOS).
-7. Report: release tag installed, install path, the SHA you verified, and the shortcut/Dock entry.
-   Note the runtime prerequisites if not set up: a Claude subscription (for Claude Code) and an
-   OpenAI API key (audio/transcription/TTS) in the cc-director config dir
+5. Launch DevThrottle once and SIGN IN. It opens devthrottle.com in the browser; the user enters a
+   password there (or creates a free account) and the app captures the session automatically. That
+   browser sign-in is the ONLY step a human has to do - everything else the agent runs unattended.
+6. Confirm the running version matches the release tag (Windows: the newest log under
+   %LOCALAPPDATA%\cc-director\logs\director\; macOS: the app's log dir). Report: the release tag
+   installed, the install path, and the SHA-256 you verified.
+   Note the runtime prerequisites if not set up: a Claude subscription (for Claude Code) and, for
+   hosted audio/transcription/TTS, an OpenAI API key in the cc-director config dir
    (%LOCALAPPDATA%\cc-director\config\credentials.env on Windows; the equivalent config dir on macOS).
 
-DO NOT: use Program Files or /Applications, require admin/sudo, build from source, or skip SHA verification.
+DO NOT: download or run the graphical installer on Windows (use the CLI installer), require
+admin/sudo, build from source, place files in Program Files or /Applications, or skip SHA verification.
 ```
 
 ---
 
 ## Why this shape
 
-- **Per-user, user-writable target** (`%LOCALAPPDATA%\cc-director\app` / `~/Applications`) - the auto-updater overwrites the running app's own path, so a user-writable location means updates need **no admin/sudo**. `Program Files` / `/Applications` would force elevation on every update or fail.
-- **Self-contained assets** - no .NET install step on either OS.
-- **SHA-256 against `release-manifest.json`** - the same trust check the auto-updater uses, so install and update share one verification.
-- **One OS-aware prompt** - hand the same prompt to any machine (this Windows box, the Mac-mini, Windows-2); the agent picks the right branch.
+- **Command-line installer, not the wizard** - the CLI front-end (`devthrottle-setup-cli`) drives the
+  same install engine as the graphical wizard, so there is nothing to click through. An AI agent can
+  run the whole install unattended; the one human step is the browser sign-in.
+- **Per-user, user-writable target** (`%LOCALAPPDATA%\cc-director` / `~/Applications`) - the
+  auto-updater overwrites the running app's own path, so a user-writable location means updates need
+  **no admin/sudo**. `Program Files` / `/Applications` would force elevation on every update or fail.
+- **SHA-256 against `release-manifest.json`** - the same trust check the auto-updater uses, so install
+  and update share one verification.
+- **The Director needs the .NET 10 runtime** (it ships framework-dependent). The CLI installer does
+  not install the runtime, so the prompt ensures it on Windows. The macOS app is self-contained.
+- **One OS-aware prompt** - hand the same prompt to any machine; the agent picks the right branch.
 
 ## Try it / next steps
 
-1. Run the prompt in Claude Code on the target machine. Current latest is **v0.3.3** (has both `cc-director-win-x64.exe` and `cc-director-mac-arm64.zip` + manifest).
-2. Cut a newer release; launch the installed build and confirm **auto-update** pulls it (the build must be a CI release build, i.e. `UpdaterEnabled=true`).
+1. Run the prompt in Claude Code on the target machine. The current latest release (with
+   `devthrottle-setup-cli-win-x64.exe`, `cc-director-mac-arm64.zip` and `release-manifest.json`) is on
+   the [releases page](https://github.com/thefrederiksen/devthrottle/releases/latest).
+2. Cut a newer release; launch the installed build and confirm **auto-update** pulls it (the build
+   must be a CI release build, i.e. `UpdaterEnabled=true`).
+
+The public website carries the same guidance for an agent that reads it:
+[devthrottle.com/docs/install#install-agent](https://devthrottle.com/docs/install#install-agent) and
+`devthrottle.com/llms.txt`.

--- a/docs/public/getting-started/02-installation.md
+++ b/docs/public/getting-started/02-installation.md
@@ -98,10 +98,10 @@ This downloads all tools from GitHub releases, places them in `%LOCALAPPDATA%\cc
 On macOS, use the **DevThrottle Setup** app instead. Install and open it with one command in Terminal:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/example-org/devthrottle/main/scripts/install-mac.sh | bash
+curl -fsSL https://raw.githubusercontent.com/thefrederiksen/devthrottle/main/scripts/install-mac.sh | bash
 ```
 
-The command downloads the wizard from the [latest release](https://github.com/example-org/devthrottle/releases/latest), verifies its SHA-256 hash against the release manifest, places **DevThrottle Setup** in `~/Applications`, and opens it.
+The command downloads the wizard from the [latest release](https://github.com/thefrederiksen/devthrottle/releases/latest), verifies its SHA-256 hash against the release manifest, places **DevThrottle Setup** in `~/Applications`, and opens it.
 
 It uses `curl` on purpose. The wizard is ad-hoc-signed, not notarized by Apple, so a **browser** download of it is blocked by Gatekeeper — "Apple could not verify 'DevThrottle Setup' is free of malware" — and on macOS 15 (Sequoia) and later that dialog offers no way to open the app (the old right-click -> Open bypass was removed). Downloads made with `curl` are never quarantined, so the wizard opens normally.
 
@@ -119,25 +119,35 @@ cc-excel --version
 cc-hardware
 ```
 
-## Install the Desktop Engine
+## Install the Desktop App
 
-Clone the repository and build:
+You do **not** build the desktop app from source to install it - the released build is what
+auto-updates in place. On **Windows**, install it one of two ways:
 
-```bash
-git clone https://github.com/example-org/devthrottle.git
-cd cc-director
-dotnet build src/CcDirector.Wpf/CcDirector.Wpf.csproj
-```
+- **Headless (recommended for an AI coding agent):** download the command-line installer
+  `devthrottle-setup-cli-win-x64.exe` from the [latest release](https://github.com/thefrederiksen/devthrottle/releases/latest),
+  verify its SHA-256 against `release-manifest.json`, then run it:
 
-Run the application:
+  ```powershell
+  devthrottle-setup-cli-win-x64.exe install
+  ```
 
-```bash
-dotnet run --project src/CcDirector.Wpf/CcDirector.Wpf.csproj
-```
+  This installs the Director app, the `cc-*` tools (added to your `PATH`), and the launcher -
+  per-user, no admin. The Director is a .NET 10 app, so also ensure the runtime is present:
+  `winget install Microsoft.DotNet.AspNetCore.10`. Full agent walkthrough:
+  [Installing with an AI coding agent](https://devthrottle.com/docs/install#install-agent).
+
+- **Graphical wizard:** download **DevThrottle Setup** from your [account page](https://devthrottle.com/signup)
+  and run it - it walks you through the same install.
+
+On **macOS**, use the **DevThrottle Setup** app via the Terminal command shown above under
+[macOS](#macos) (Workstation-only; no Gateway on macOS).
 
 ## Configure Claude Code Skills
 
-DevThrottle includes Claude Code skills that extend what Claude can do. After cloning, the skills in `.claude/skills/` are automatically available when you run Claude Code from the repository directory.
+DevThrottle includes Claude Code skills that extend what Claude can do. The installer places them in
+`~/.claude/skills/`, so they are available whenever you run Claude Code. (When working in a clone of
+the repository, the skills in `.claude/skills/` are also available from the repository directory.)
 
 Key skills:
 - `/commit` -- create commits following project standards


### PR DESCRIPTION
Recommendation C from the install-flow review. Both install docs were stale and would misguide an agent or a person.

## `docs/install/install-prompt.md`
The prompt handed to Claude Code did a raw download-and-hand-place of `cc-director-win-x64.exe`. Problems:
- `example-org/devthrottle` placeholder (real repo is `thefrederiksen/devthrottle`).
- Claimed the Director is self-contained / needs no .NET - it is framework-dependent (38MB) and needs the .NET 10 runtime.
- Installed neither the `cc-*` tools nor the launcher - just dropped the Director exe.

Rewritten around `devthrottle-setup-cli-win-x64.exe` (the same install engine the wizard uses): verify SHA-256, `prereqs` + `install` (per-user, no admin), ensure .NET 10, then sign in once in the browser. macOS keeps the proven `install-mac.sh` curl bootstrap.

## `docs/public/getting-started/02-installation.md`
- "Install the Desktop Engine" told people to `git clone` and `dotnet build src/CcDirector.Wpf/...` - that project no longer exists (the app is Avalonia). Replaced with the real install (headless setup CLI or the graphical wizard); no build-from-source.
- Fixed the `example-org` placeholder in the macOS curl and release link.
- Adjusted the "Configure Claude Code Skills" note (installer places skills in `~/.claude/skills/`; clone is no longer the assumed path).

Matches the website guidance already shipped in `devthrottle_internal` (`/docs/install#install-agent`, `llms.txt`). Docs-only; no code touched.

Note: `example-org` still appears in other non-install docs (architecture/plans/archive) - left out of scope here; can be swept separately if wanted.
