### PR TITLE
feat(stats): fall back to folder name (not full path) when no GitHub slug

### DIFF
--- a/apps/cockpit/src/throttle/ReposTab.tsx
+++ b/apps/cockpit/src/throttle/ReposTab.tsx
@@ -226,9 +226,10 @@ export function ReposTab({ data }: { data: ThrottleData }) {
           <li>
             Repos are grouped by their GitHub repository, so every worktree and every machine you check a
             repo out on rolls up into one row (the working directories that fed it are listed under the
-            name). A checkout with no GitHub remote falls back to its folder path. Time is deliberately not
-            shown: an idle hour looks the same as a heads-down hour, so it would lie. Turns and characters
-            track what you actually pushed through.
+            name). A checkout whose Director has not reported a GitHub remote is grouped by its folder name
+            instead, so the same repo across machines still merges. Time is deliberately not shown: an idle
+            hour looks the same as a heads-down hour, so it would lie. Turns and characters track what you
+            actually pushed through.
           </li>
           <li>
             Tokens are not shown - the tally counts turns and characters, never tokens, and this tab never

--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -281,7 +281,7 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         Assert.Equal(2, dt.TypedTurns);
         Assert.Equal(640, dt.Characters);
         Assert.Equal(2, dt.Sessions);                         // two distinct sessions drove it
-        Assert.Equal(@"D:\ReposFred\devthrottle", dt.Repo);   // full path preserved
+        Assert.Equal("devthrottle", dt.Repo);                 // no slug -> grouped by folder name
     }
 
     [Fact]
@@ -332,17 +332,41 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
     }
 
     [Fact]
-    public void RepoTotals_NoGitHubSlug_FallsBackToPath()
+    public void RepoTotals_NoGitHubSlug_FallsBackToFolderName()
     {
         var agg = new GatewayInputStatsAggregator(_path);
-        // A checkout with no github.com origin reports an empty slug; it must still appear, keyed by its path.
+        // A checkout with no github.com origin reports an empty slug; it appears keyed by its FOLDER NAME
+        // (not its full path), so a display shows the repo, not the machine-specific directory.
         agg.Observe(SessionInRepo("s1", @"D:\repos\local-only", ("typed", "desktop", 4, 80)));
 
         var repo = Repo(agg, "local-only");
         Assert.NotNull(repo);
-        Assert.Equal(@"D:\repos\local-only", repo!.Repo);        // fell back to the path as the key
+        Assert.Equal("local-only", repo!.Repo);                 // grouped by folder name
         Assert.Equal(4, repo.Turns);
-        Assert.Equal(new[] { @"D:\repos\local-only" }, repo.Checkouts);
+        Assert.Equal(new[] { @"D:\repos\local-only" }, repo.Checkouts);  // the full path is still retained
+    }
+
+    [Fact]
+    public void RepoTotals_NoSlug_SameFolderNameAcrossMachines_CollapsesToOneRow()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        // The owner's case: the SAME repository worked in from three machines - a Windows box, a Mac, and a
+        // second Windows box - with no slug (older Directors). All three share the folder name "devthrottle",
+        // so they must fold into ONE row, with the three machine paths retained as its checkouts.
+        agg.Observe(SessionInRepo("s1", @"D:\ReposFred\devthrottle", ("typed", "desktop", 6, 600)));
+        agg.Observe(SessionInRepo("s2", "/Users/soren/ReposFred/devthrottle", ("voice", "phone", 2, 40)));
+        agg.Observe(SessionInRepo("s3", @"C:\ReposFred\devthrottle", ("typed", "desktop", 1, 10)));
+
+        var repos = agg.RepoTotals();
+        Assert.Single(repos);                                   // three machines, one repository row
+        var dt = repos[0];
+        Assert.Equal("devthrottle", dt.Repo);
+        Assert.Equal(9, dt.Turns);                              // 6 + 2 + 1 folded together
+        Assert.Equal(3, dt.Sessions);
+        Assert.Equal(3, dt.Checkouts.Count);                    // the three machine paths, retained
+        Assert.Contains(@"D:\ReposFred\devthrottle", dt.Checkouts);
+        Assert.Contains("/Users/soren/ReposFred/devthrottle", dt.Checkouts);
+        Assert.Contains(@"C:\ReposFred\devthrottle", dt.Checkouts);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -387,18 +387,29 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                     AttributeToAgentLocked(s, key.Modality, prior.Turns, prior.Characters, batch);
         }
 
-        // The repository grouping key is the GitHub "owner/repo" slug the owning Director resolved for this
-        // checkout, so every worktree and every per-machine clone of one repository folds into a single row.
-        // A checkout with no github.com origin (RepoSlug empty) falls back to its path, which still groups
-        // that repo sensibly and never drops its turns.
+        // The repository grouping key is a two-tier identity:
         //
-        // The checkout key is the raw working-directory path, retained as its own dimension so the store
-        // still records exactly which checkout each turn ran in - the path is not lost when the slug collapses
-        // the worktrees together. Path separators are deliberately NOT normalized on either key: a slug never
-        // carries a separator to disagree on, and for a path the old behaviour (OrdinalIgnoreCase folds case
-        // but not '/' against '\') is preserved, so a fallback path row reads exactly as it did before.
+        //   1. The GitHub "owner/repo" slug the owning Director resolved for this checkout, when it sent one.
+        //      This is the ideal key: it folds every worktree AND every per-machine clone of one repository
+        //      into a single row, and it never collides two genuinely different repos that share a folder name.
+        //
+        //   2. Otherwise the checkout's FOLDER NAME (the last path segment), not its full path. A Director on
+        //      an older build sends no slug, so the Gateway - which has no filesystem to resolve the origin,
+        //      and may be on a different machine than the checkout entirely - only has the path. Grouping by
+        //      the folder name still collapses the SAME repository worked in from several machines
+        //      ("D:\ReposFred\devthrottle", "/Users/soren/ReposFred/devthrottle" and "C:\ReposFred\devthrottle"
+        //      are one "devthrottle" row), which is the owner's rule: the same repo is the same repo, whichever
+        //      machine drove it. The trade-off is deliberate and bounded to the no-slug case: it does NOT fold
+        //      a differently-named worktree (only the slug can, since it reads the shared origin), and two
+        //      unrelated repositories that happen to share a folder name would merge. Once the Directors are on
+        //      a slug-emitting build, tier 1 takes over and both limitations go away.
+        //
+        // The checkout key stays the raw working-directory path, retained as its own dimension so the store
+        // still records exactly which checkout each turn ran in - the individual paths are listed under the
+        // merged row, not lost. Separators are not normalized: RepoLeaf treats both '/' and '\' as segment
+        // separators, so a Windows and a POSIX checkout of one repo yield the identical folder-name key.
         var checkoutKey = s.RepoPath ?? "";
-        var repoKey = !string.IsNullOrWhiteSpace(s.RepoSlug) ? s.RepoSlug! : checkoutKey;
+        var repoKey = !string.IsNullOrWhiteSpace(s.RepoSlug) ? s.RepoSlug! : RepoLeaf(checkoutKey);
 
         // The model this session's agent was last RECORDED using (issue #1637). Unlike the repository and
         // the agent, an unknown model is stored as SQL NULL rather than folded into an empty-string
@@ -1234,13 +1245,14 @@ public sealed class WingmanUsageDto
 public sealed class RepoStatBucketDto
 {
     /// <summary>The grouping key: the GitHub "owner/repo" slug the sessions' checkouts belong to
-    /// (e.g. "thefrederiksen/devthrottle"), so every worktree and every per-machine clone of one repository
-    /// is one row. Falls back to the local working-directory path for a checkout that has no github.com
-    /// origin.</summary>
+    /// (e.g. "thefrederiksen/devthrottle") when a Director resolved one, so every worktree and every
+    /// per-machine clone of one repository is one row. Falls back to the checkout's FOLDER NAME (not its full
+    /// path) for a checkout with no slug, so the same repository worked in from several machines still folds
+    /// into one row.</summary>
     public string Repo { get; set; } = "";
 
     /// <summary>The display leaf of <see cref="Repo"/> (its last segment): the repository name for a slug,
-    /// e.g. "devthrottle", or the folder name for a fallback path.</summary>
+    /// e.g. "devthrottle". For the folder-name fallback this equals <see cref="Repo"/>.</summary>
     public string RepoName { get; set; } = "";
 
     public long Turns { get; set; }


### PR DESCRIPTION
## Why
Grouping the Repos view by GitHub slug is correct, but the slug is resolved on the **Director**, and older-build Directors send none — so the Gateway only has the checkout path. Falling back to the full path split the *same* repo worked in from several machines into a row each (`D:\ReposFred\devthrottle`, `/Users/soren/ReposFred/devthrottle`, `C:\ReposFred\devthrottle`).

## What
Fall back to the checkout's **folder name** instead of the full path, so the same repo across machines folds into one row using data the Gateway already has — no Director update needed. The GitHub slug still takes precedence when present (it additionally merges differently-named worktrees, which a folder name can't). Machine paths are retained as the row's checkouts.

**Trade-off** (bounded to the no-slug case): two unrelated repos sharing a folder name would merge; the slug removes that once Directors emit it.

## Tests
Stats suite green (68), incl. a new `RepoTotals_NoSlug_SameFolderNameAcrossMachines_CollapsesToOneRow`.