### PR TITLE
feat(stats): resolve Azure DevOps remotes to a repo slug, not just GitHub

### DIFF
--- a/src/CcDirector.Core.Tests/Utilities/GitHubUrlsTests.cs
+++ b/src/CcDirector.Core.Tests/Utilities/GitHubUrlsTests.cs
@@ -60,11 +60,34 @@ public class GitHubUrlsTests
     }
 
     [Theory]
+    // Modern HTTPS (with and without the user@ prefix the tooling adds), modern SSH, and legacy
+    // visualstudio.com. All resolve to org/repo, dropping the project segment - so the mindzieWeb repo and
+    // its "mw-filter-everywhere" worktree, which share this origin, fold into one row.
+    [InlineData("https://mindzie@dev.azure.com/mindzie/mindzieStudio1/_git/mindzieWeb")]
+    [InlineData("https://dev.azure.com/mindzie/mindzieStudio1/_git/mindzieWeb")]
+    [InlineData("git@ssh.dev.azure.com:v3/mindzie/mindzieStudio1/mindzieWeb")]
+    [InlineData("https://mindzie.visualstudio.com/mindzieStudio1/_git/mindzieWeb")]
+    public void ParseSlug_AzureDevOpsRemoteShapes_ReturnsOrgRepo(string originUrl)
+    {
+        Assert.Equal("mindzie/mindzieWeb", GitHubUrls.ParseSlug(originUrl));
+    }
+
+    [Theory]
     [InlineData("https://gitlab.com/owner/repo.git")]
     [InlineData("git@bitbucket.org:owner/repo.git")]
-    public void ParseSlug_NonGitHubRemote_Throws(string originUrl)
+    public void ParseSlug_UnrecognizedRemote_Throws(string originUrl)
     {
         Assert.Throws<InvalidOperationException>(() => GitHubUrls.ParseSlug(originUrl));
+    }
+
+    [Fact]
+    public void ParseNewIssueUrl_AzureDevOpsRemote_StillThrows()
+    {
+        // "New issue" is a GitHub concept; ParseSlug understanding Azure DevOps must NOT make the issue-URL
+        // helper accept it and build a bogus github.com URL.
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            GitHubUrls.ParseNewIssueUrl("https://dev.azure.com/mindzie/mindzieStudio1/_git/mindzieWeb"));
+        Assert.Contains("not a GitHub remote", ex.Message);
     }
 
     // ---------- ResolveSlugCached (best-effort, never throws) ----------
@@ -76,6 +99,20 @@ public class GitHubUrlsTests
         try
         {
             Assert.Equal("someowner/somerepo", GitHubUrls.ResolveSlugCached(repoDir));
+        }
+        finally
+        {
+            Directory.Delete(repoDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveSlugCached_RepoWithAzureDevOpsOrigin_ReturnsOrgRepo()
+    {
+        var repoDir = CreateTempGitRepo("https://mindzie@dev.azure.com/mindzie/mindzieStudio1/_git/mindzieWeb");
+        try
+        {
+            Assert.Equal("mindzie/mindzieWeb", GitHubUrls.ResolveSlugCached(repoDir));
         }
         finally
         {

--- a/src/CcDirector.Core/Utilities/GitHubUrls.cs
+++ b/src/CcDirector.Core/Utilities/GitHubUrls.cs
@@ -1,10 +1,12 @@
 namespace CcDirector.Core.Utilities;
 
 /// <summary>
-/// Builds GitHub web URLs for a local repository by resolving its origin remote.
-/// Used by the desktop "New GitHub Issue" session menu item, the screenshot Issue
-/// button, and the Director's GET /sessions/{sid}/github-urls endpoint (which the
-/// Cockpit's session menu calls, since the repo lives on the Director's machine).
+/// Resolves a local repository's origin remote to a host slug and to GitHub web URLs. The GitHub
+/// "new issue" helpers (used by the desktop "New GitHub Issue" menu item, the screenshot Issue button, and
+/// the Director's GET /sessions/{sid}/github-urls endpoint) are GitHub-only. The slug helpers
+/// (<see cref="ResolveSlugCached"/> / <see cref="ParseSlug"/>, used by the DevThrottle Stats repo grouping)
+/// understand BOTH github.com and Azure DevOps (dev.azure.com and the legacy visualstudio.com), so a repo on
+/// either host folds its worktrees and per-machine clones into one Repos row.
 /// </summary>
 public static class GitHubUrls
 {
@@ -36,10 +38,11 @@ public static class GitHubUrls
     }
 
     /// <summary>
-    /// The GitHub "owner/repo" slug for a local checkout, or "" when the checkout has no github.com origin
-    /// (no origin remote, not a git repo, or a non-GitHub remote). Best-effort and NEVER throws: an empty
-    /// result is a legitimate answer - not every checkout is on GitHub - and the caller (the DevThrottle
-    /// Stats repo grouping) falls back to the local path for those. Cached by path; see <see cref="SlugCache"/>.
+    /// The "owner/repo" (GitHub) or "org/repo" (Azure DevOps) slug for a local checkout, or "" when the
+    /// checkout's origin is on neither host (no origin remote, not a git repo, or an unrecognized remote).
+    /// Best-effort and NEVER throws: an empty result is a legitimate answer - not every checkout is on a host
+    /// we recognize - and the caller (the DevThrottle Stats repo grouping) falls back to the folder name for
+    /// those. Cached by path; see <see cref="SlugCache"/>.
     ///
     /// This is the key that makes every worktree and every per-machine clone of one repository roll up into
     /// a single row on the Repos page: they all share one origin remote, so they all resolve to one slug.
@@ -61,41 +64,92 @@ public static class GitHubUrls
         }
         catch (Exception ex)
         {
-            // A checkout with no origin, or one whose origin is not on github.com, is an expected state, not
-            // a failure to hide: it simply has no slug and groups by its path instead. Recorded, then "".
-            FileLog.Write($"[GitHubUrls] ResolveSlugCached: {repoPath} has no GitHub slug: {ex.Message}");
+            // A checkout with no origin, or one on a host we do not recognize, is an expected state, not a
+            // failure to hide: it simply has no slug and groups by its folder name instead. Recorded, then "".
+            FileLog.Write($"[GitHubUrls] ResolveSlugCached: {repoPath} has no recognized remote slug: {ex.Message}");
             return "";
         }
     }
 
     /// <summary>
-    /// Converts an origin remote URL to the GitHub "new issue" URL. Pure string
-    /// logic so it is unit-testable without git. Accepts the three remote shapes:
+    /// Converts an origin remote URL to the GitHub "new issue" URL. Pure string logic so it is unit-testable
+    /// without git. Accepts the three GitHub remote shapes:
     ///   git@github.com:owner/repo.git
     ///   ssh://git@github.com/owner/repo.git
     ///   https://github.com/owner/repo(.git)
-    /// Throws when the remote is not on github.com.
+    /// Throws when the remote is not on github.com - "new issue" is a GitHub concept, so this stays
+    /// GitHub-only even though <see cref="ParseSlug"/> also understands Azure DevOps.
     /// </summary>
     internal static string ParseNewIssueUrl(string originUrl)
-        => $"https://github.com/{ParseSlug(originUrl)}/issues/new";
+    {
+        if (string.IsNullOrWhiteSpace(originUrl))
+            throw new ArgumentException("Origin remote URL is required", nameof(originUrl));
+        var gh = TryMatchGitHub(originUrl.Trim());
+        if (gh is null)
+            throw new InvalidOperationException($"Origin is not a GitHub remote: {originUrl}");
+        return $"https://github.com/{gh.Value.owner}/{gh.Value.repo}/issues/new";
+    }
 
     /// <summary>
-    /// Extracts the "owner/repo" slug from an origin remote URL. Pure string logic so it is unit-testable
-    /// without git; accepts the same three remote shapes as <see cref="ParseNewIssueUrl"/>. Throws when the
-    /// remote is empty or not on github.com.
+    /// Extracts the "owner/repo" (GitHub) or "org/repo" (Azure DevOps) slug from an origin remote URL. Pure
+    /// string logic so it is unit-testable without git. The slug is host-neutral on purpose: every worktree
+    /// and every per-machine clone of one repository shares one origin, so they all resolve to the identical
+    /// slug and fold into a single Repos row. Throws when the remote is empty or on neither host.
+    ///
+    /// Azure DevOps identifies a repo as org/project/repo; the slug keeps org/repo (dropping the project) to
+    /// match GitHub's two-part shape and how the owner refers to it. The bounded cost: two repos of the same
+    /// name in different projects of one org would share a slug - accepted, and vanishingly rare here.
     /// </summary>
     internal static string ParseSlug(string originUrl)
     {
         if (string.IsNullOrWhiteSpace(originUrl))
             throw new ArgumentException("Origin remote URL is required", nameof(originUrl));
 
-        var match = System.Text.RegularExpressions.Regex.Match(
-            originUrl.Trim(), @"github\.com[:/](?<owner>[^/\s]+)/(?<repo>[^/\s]+?)(\.git)?$",
-            System.Text.RegularExpressions.RegexOptions.None, RemoteUrlRegexTimeout);
-        if (!match.Success)
-            throw new InvalidOperationException($"Origin is not a GitHub remote: {originUrl}");
+        var url = originUrl.Trim();
+        var gh = TryMatchGitHub(url);
+        if (gh is not null)
+            return $"{gh.Value.owner}/{gh.Value.repo}";
 
-        return $"{match.Groups["owner"].Value}/{match.Groups["repo"].Value}";
+        var az = TryMatchAzureDevOps(url);
+        if (az is not null)
+            return $"{az.Value.org}/{az.Value.repo}";
+
+        throw new InvalidOperationException($"Origin is not a recognized GitHub or Azure DevOps remote: {originUrl}");
+    }
+
+    // GitHub remote -> (owner, repo), or null when the URL is not a github.com remote. Accepts the SSH
+    // (git@github.com:owner/repo), ssh:// and https:// shapes; the ".git" suffix is optional.
+    private static (string owner, string repo)? TryMatchGitHub(string url)
+    {
+        var m = System.Text.RegularExpressions.Regex.Match(
+            url, @"github\.com[:/](?<owner>[^/\s]+)/(?<repo>[^/\s]+?)(\.git)?$",
+            System.Text.RegularExpressions.RegexOptions.None, RemoteUrlRegexTimeout);
+        return m.Success ? (m.Groups["owner"].Value, m.Groups["repo"].Value) : null;
+    }
+
+    // Azure DevOps remote -> (org, repo), or null. Covers the three shapes the tooling emits:
+    //   https://[user@]dev.azure.com/{org}/{project}/_git/{repo}   (modern HTTPS)
+    //   git@ssh.dev.azure.com:v3/{org}/{project}/{repo}            (modern SSH)
+    //   https://{org}.visualstudio.com/[collection/]{project}/_git/{repo}  (legacy)
+    // The project segment is matched but discarded; the slug is org/repo. The ".git" suffix is optional.
+    private static (string org, string repo)? TryMatchAzureDevOps(string url)
+    {
+        var https = System.Text.RegularExpressions.Regex.Match(
+            url, @"dev\.azure\.com/(?<org>[^/\s]+)/[^/\s]+/_git/(?<repo>[^/\s]+?)(\.git)?$",
+            System.Text.RegularExpressions.RegexOptions.None, RemoteUrlRegexTimeout);
+        if (https.Success) return (https.Groups["org"].Value, https.Groups["repo"].Value);
+
+        var ssh = System.Text.RegularExpressions.Regex.Match(
+            url, @"ssh\.dev\.azure\.com:v3/(?<org>[^/\s]+)/[^/\s]+/(?<repo>[^/\s]+?)(\.git)?$",
+            System.Text.RegularExpressions.RegexOptions.None, RemoteUrlRegexTimeout);
+        if (ssh.Success) return (ssh.Groups["org"].Value, ssh.Groups["repo"].Value);
+
+        var legacy = System.Text.RegularExpressions.Regex.Match(
+            url, @"(?<org>[^/@\s.]+)\.visualstudio\.com/(?:[^\s]+/)?_git/(?<repo>[^/\s]+?)(\.git)?$",
+            System.Text.RegularExpressions.RegexOptions.None, RemoteUrlRegexTimeout);
+        if (legacy.Success) return (legacy.Groups["org"].Value, legacy.Groups["repo"].Value);
+
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
## Why
Repo grouping resolved a slug only from `github.com`. A repo on **Azure DevOps** (mindzieWeb, origin `dev.azure.com/mindzie/mindzieStudio1/_git/mindzieWeb`) got no slug and fell back to its folder name — splitting it from its worktrees. That's why `mw-filter-everywhere` (a worktree of mindzieWeb) showed as its own row.

## What
`ParseSlug` now also parses Azure DevOps remotes — modern HTTPS, modern SSH (`ssh.dev.azure.com:v3/...`), and legacy `visualstudio.com` — into an `org/repo` slug (project dropped, to match GitHub's two-part shape). Worktrees and per-machine clones of an Azure DevOps repo fold into one row, like GitHub. `ParseNewIssueUrl` stays GitHub-only.

## Effect
Director-side (the slug is resolved where the repo lives), so it takes effect once Directors are on the new build — same as the GitHub slug.

## Tests
GitHubUrls suite green (31), incl. mindzieWeb's exact remote in all three shapes → `mindzie/mindzieWeb`.