### PR TITLE
Headless signin and enroll for the setup CLI

### DIFF
--- a/tools/cc-director-setup-cli/CcDirector.Setup.Cli.csproj
+++ b/tools/cc-director-setup-cli/CcDirector.Setup.Cli.csproj
@@ -13,6 +13,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\cc-director-setup-engine\CcDirector.Setup.Engine.csproj" />
+    <!-- signin/enroll drive account sign-in + gateway enrollment: GatewayConfig + OperationResult live in
+         Core, and the /m/enroll response type lives in Gateway.Contracts. Both also flow transitively
+         through the engine; referenced directly here because this project now uses them by name. -->
+    <ProjectReference Include="..\..\src\CcDirector.Core\CcDirector.Core.csproj" />
+    <ProjectReference Include="..\..\src\CcDirector.Gateway.Contracts\CcDirector.Gateway.Contracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tools/cc-director-setup-cli/Commands.cs
+++ b/tools/cc-director-setup-cli/Commands.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Configuration;
 using CcDirector.Setup.Engine;
 
 namespace CcDirector.Setup.Cli;
@@ -129,6 +130,137 @@ internal static class Commands
         var (plan, _, _) = await ComputePlanAsync(args, layout);
         PrintPlan(plan, json);
         return Ok;
+    }
+
+    /// <summary>
+    /// Sign this machine's DevThrottle account in from the command line (the headless sibling of the
+    /// wizard's sign-in step). Opens the browser to devthrottle.com, where the user signs in - or creates a
+    /// free account - and the captured credential is stored where the Gateway reads it, so the Gateway does
+    /// not re-prompt on first launch. The account credential lives on the Gateway (Windows-only, per-user), so
+    /// this command is Windows-only; on macOS a machine is a Workstation and uses <c>enroll</c> instead. The
+    /// access token is never printed or logged (security rule DT-05).
+    /// </summary>
+    public static async Task<int> SignInAsync(CliArgs args, bool json)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            const string reason =
+                "'signin' stores the account on the Gateway, which is Windows-only. On macOS, install a Workstation and run 'enroll' to join your gateway.";
+            if (json) Program.WriteJson(new { command = "signin", signedIn = false, outcome = "Failed", message = reason });
+            else Console.Error.WriteLine(reason);
+            return Error;
+        }
+
+        if (!json)
+        {
+            Console.WriteLine("Opening your browser to sign in to DevThrottle...");
+            Console.WriteLine("Sign in - or create a free account - in the browser. Waiting for you to finish (up to 5 minutes)...");
+        }
+
+        var result = await new AccountSignInRunner().RunAsync();
+        if (json)
+            Program.WriteJson(new { command = "signin", signedIn = result.Succeeded, outcome = result.Outcome.ToString(), message = result.Message });
+        else
+            Console.WriteLine(result.Succeeded ? $"OK: {result.Message}" : $"Sign-in did not complete: {result.Message}");
+        return result.Succeeded ? Ok : Error;
+    }
+
+    /// <summary>
+    /// Join this machine (a Workstation) to its gateway from the command line (the headless sibling of the
+    /// wizard's gateway-connect step). Opens the browser to sign in - or create a free account - then registers
+    /// this machine on the account and enrolls it at the gateway for a local, revocable device key, which is
+    /// persisted so the Director and cc-* tools connect on first run. With <c>--gateway &lt;url&gt;</c> it uses
+    /// that address (proven reachable first); without it, it discovers the account's gateways and joins the one
+    /// it finds. Idempotent: a machine already connected reports so and succeeds. Device keys are never printed
+    /// or logged (security rule DT-05).
+    /// </summary>
+    public static async Task<int> EnrollAsync(CliArgs args, bool json)
+    {
+        // Idempotent: an already-connected machine (an update/repair run) has nothing to do.
+        var existing = GatewayConfig.Load();
+        if (existing.IsEnabled)
+        {
+            var msg = $"This machine is already connected to its gateway ({existing.Url}).";
+            if (json) Program.WriteJson(new { command = "enroll", enrolled = true, alreadyConnected = true, gatewayUrl = existing.Url, message = msg });
+            else Console.WriteLine(msg);
+            return Ok;
+        }
+
+        // No running Director yet, so mint a stable device id for this machine (wizard parity): used both as
+        // the account-registration install id and the enroll device id.
+        var deviceId = Guid.NewGuid().ToString();
+        var machineName = Environment.MachineName;
+        var runner = new GatewayAccountEnrollRunner();
+        var gatewayUrl = args.Option("gateway");
+
+        if (!json)
+        {
+            Console.WriteLine("Opening your browser to sign in to DevThrottle...");
+            Console.WriteLine("Sign in - or create a free account - in the browser. Waiting for you to finish (up to 5 minutes)...");
+        }
+
+        // A given gateway URL is proven reachable BEFORE we sign in against it (wizard parity: never register
+        // against an address we could not reach), then sign in + register + enroll.
+        if (!string.IsNullOrWhiteSpace(gatewayUrl))
+        {
+            var test = await runner.TestGatewayAddressAsync(gatewayUrl, 0);
+            if (!test.Success || test.Value is null)
+                return FailEnroll(test.ErrorMessage ?? "Could not reach a gateway at that address.", json);
+
+            var verified = await runner.VerifyAndSaveAsync(test.Value, deviceId, machineName);
+            return ReportEnroll(verified.Success, verified.ErrorMessage, json);
+        }
+
+        // No URL given: sign in and discover the account's gateways.
+        var discovered = await runner.SignInAndDiscoverGatewaysAsync();
+        if (!discovered.Success || discovered.Value is null)
+            return FailEnroll(discovered.ErrorMessage ?? "Could not discover a gateway on your account.", json);
+
+        var gateways = discovered.Value;
+        if (gateways.Count > 1)
+        {
+            // A headless command cannot show an interactive chooser; list the account's gateways and ask the
+            // user to re-run naming one, rather than silently picking.
+            if (json)
+                Program.WriteJson(new
+                {
+                    command = "enroll",
+                    enrolled = false,
+                    message = "Your account has more than one gateway. Re-run 'enroll --gateway <url>' with one of these.",
+                    gateways = gateways.Select(g => new { name = g.Name, url = g.EndpointUrl }),
+                });
+            else
+            {
+                Console.WriteLine("Your account has more than one gateway. Re-run with --gateway <url> naming one of these:");
+                foreach (var g in gateways) Console.WriteLine($"  {g.Name,-24} {g.EndpointUrl}");
+            }
+            return Error;
+        }
+
+        var only = gateways[0];
+        if (!json) Console.WriteLine($"Joining gateway: {only.Name} ({only.EndpointUrl})");
+        var enrolled = await runner.EnrollWithDiscoveredGatewayAsync(only.EndpointUrl, deviceId, machineName);
+        return ReportEnroll(enrolled.Success, enrolled.ErrorMessage, json);
+    }
+
+    /// <summary>Render a successful/failed enroll outcome. The issued device key is never printed (DT-05).</summary>
+    private static int ReportEnroll(bool success, string? errorMessage, bool json)
+    {
+        if (success)
+        {
+            if (json) Program.WriteJson(new { command = "enroll", enrolled = true, message = "Connected to the gateway." });
+            else Console.WriteLine("OK: connected to the gateway.");
+            return Ok;
+        }
+        return FailEnroll(errorMessage ?? "The gateway did not complete the enrollment.", json);
+    }
+
+    /// <summary>Render an enroll failure with a user-safe reason.</summary>
+    private static int FailEnroll(string reason, bool json)
+    {
+        if (json) Program.WriteJson(new { command = "enroll", enrolled = false, message = reason });
+        else Console.Error.WriteLine(reason);
+        return Error;
     }
 
     public static async Task<int> UpdateAsync(CliArgs args, InstallLayout layout, bool json, bool installMode)

--- a/tools/cc-director-setup-cli/Program.cs
+++ b/tools/cc-director-setup-cli/Program.cs
@@ -47,6 +47,8 @@ public static class Program
                 "plan" => await Commands.PlanAsync(args, layout, json),
                 "update" => await Commands.UpdateAsync(args, layout, json, installMode: false),
                 "install" => await Commands.UpdateAsync(args, layout, json, installMode: true),
+                "signin" => await Commands.SignInAsync(args, json),
+                "enroll" => await Commands.EnrollAsync(args, json),
                 "uninstall" => Commands.Uninstall(args, layout, json),
                 "rollback" => Commands.Rollback(args, layout, json),
                 "version" or "--version" => VersionCommand(json),
@@ -132,12 +134,15 @@ public static class Program
               plan                       Show what an update/install would change
               update                     Download, verify, and apply updates
               install --role <r>         Install/update all components for a role
+              signin                     Sign in (or create a free account); store it for the Gateway (Windows)
+              enroll [--gateway <url>]   Join this workstation to its gateway (sign in, then enroll)
               uninstall --role <r>       Remove install-owned files (preserves your data)
               rollback <component>       Restore the previous build and pin away from current
               version                    Print this CLI's product version
 
             Options:
               --role workstation|gateway     Install type (default workstation)
+              --gateway <url>                Gateway to enroll against (enroll; else auto-discover)
               --manifest <path|latest>       Release source (default latest)
               --release-dir <dir>            Use a local directory as the release (offline)
               --component <id|all>           Limit update to one component (default all)

--- a/tools/cc-director-setup-engine.Tests/AccountSignInRunnerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/AccountSignInRunnerTests.cs
@@ -1,0 +1,135 @@
+using System.Net.Http;
+using CcDirector.Core.Account;
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// Tests for the headless account sign-in runner (the engine sibling of the wizard's SignInRunner, driven
+/// by the setup CLI's 'signin' command). They run against a REAL <see cref="LoopbackLoginListener"/> on a
+/// free loopback port (no backend), with the "browser" stood in by a direct HTTP call to the loopback
+/// callback - the same hand-back the dev stand-in and the real backend perform. This proves the success,
+/// cancel, timeout, and failure outcomes end to end, that the captured token pair is handed to the persist
+/// seam ONLY on success, and that a persist failure is reported as a failure (no fallback).
+/// </summary>
+public sealed class AccountSignInRunnerTests
+{
+    private static string HandBackUrl(LoopbackLoginListener listener, string access, string refresh) =>
+        $"{listener.CallbackUrl}?access_token={access}&refresh_token={refresh}";
+
+    [Fact]
+    public async Task RunAsync_BrowserHandsBackCredential_ReturnsSignedIn()
+    {
+        var listener = new LoopbackLoginListener();
+        using var http = new HttpClient();
+
+        var runner = new AccountSignInRunner(
+            listenerFactory: () => listener,
+            openBrowser: url => { _ = Task.Run(() => http.GetAsync(HandBackUrl(listener, "dev-access", "dev-refresh"))); },
+            persistCredential: _ => { /* outcome-only test */ },
+            timeout: TimeSpan.FromSeconds(10));
+
+        var result = await runner.RunAsync();
+
+        Assert.Equal(AccountSignInOutcome.SignedIn, result.Outcome);
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task RunAsync_Success_PersistsTheExactCapturedTokenPair()
+    {
+        var listener = new LoopbackLoginListener();
+        using var http = new HttpClient();
+        DevThrottleTokens? persisted = null;
+
+        var runner = new AccountSignInRunner(
+            listenerFactory: () => listener,
+            openBrowser: url => { _ = Task.Run(() => http.GetAsync(HandBackUrl(listener, "captured-access", "captured-refresh"))); },
+            persistCredential: tokens => persisted = tokens,
+            timeout: TimeSpan.FromSeconds(10));
+
+        var result = await runner.RunAsync();
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(persisted);
+        Assert.Equal("captured-access", persisted!.AccessToken);
+        Assert.Equal("captured-refresh", persisted.RefreshToken);
+    }
+
+    [Fact]
+    public async Task RunAsync_UserCancels_ReturnsCancelled_AndDoesNotPersist()
+    {
+        var listener = new LoopbackLoginListener();
+        using var cts = new CancellationTokenSource();
+        var persistCalled = false;
+
+        var runner = new AccountSignInRunner(
+            listenerFactory: () => listener,
+            openBrowser: _ => cts.CancelAfter(TimeSpan.FromMilliseconds(100)),   // never hands back; the wait ends only by cancellation
+            persistCredential: _ => persistCalled = true,
+            timeout: TimeSpan.FromSeconds(30));
+
+        var result = await runner.RunAsync(cts.Token);
+
+        Assert.Equal(AccountSignInOutcome.Cancelled, result.Outcome);
+        Assert.False(result.Succeeded);
+        Assert.False(persistCalled);
+    }
+
+    [Fact]
+    public async Task RunAsync_NoHandBackWithinTimeout_ReturnsTimedOut_AndDoesNotPersist()
+    {
+        var listener = new LoopbackLoginListener();
+        var persistCalled = false;
+
+        var runner = new AccountSignInRunner(
+            listenerFactory: () => listener,
+            openBrowser: _ => { /* the browser never hands anything back */ },
+            persistCredential: _ => persistCalled = true,
+            timeout: TimeSpan.FromMilliseconds(150));
+
+        var result = await runner.RunAsync();
+
+        Assert.Equal(AccountSignInOutcome.TimedOut, result.Outcome);
+        Assert.False(result.Succeeded);
+        Assert.False(persistCalled);
+    }
+
+    [Fact]
+    public async Task RunAsync_BrowserCannotOpen_ReturnsFailed_AndDoesNotPersist()
+    {
+        var listener = new LoopbackLoginListener();
+        var persistCalled = false;
+
+        var runner = new AccountSignInRunner(
+            listenerFactory: () => listener,
+            openBrowser: _ => throw new InvalidOperationException("no browser"),
+            persistCredential: _ => persistCalled = true,
+            timeout: TimeSpan.FromSeconds(10));
+
+        var result = await runner.RunAsync();
+
+        Assert.Equal(AccountSignInOutcome.Failed, result.Outcome);
+        Assert.False(result.Succeeded);
+        Assert.False(persistCalled);
+    }
+
+    [Fact]
+    public async Task RunAsync_PersistFails_ReturnsFailed()
+    {
+        var listener = new LoopbackLoginListener();
+        using var http = new HttpClient();
+
+        var runner = new AccountSignInRunner(
+            listenerFactory: () => listener,
+            openBrowser: url => { _ = Task.Run(() => http.GetAsync(HandBackUrl(listener, "a", "b"))); },
+            persistCredential: _ => throw new InvalidOperationException("store unavailable"),
+            timeout: TimeSpan.FromSeconds(10));
+
+        var result = await runner.RunAsync();
+
+        Assert.Equal(AccountSignInOutcome.Failed, result.Outcome);
+        Assert.False(result.Succeeded);
+    }
+}

--- a/tools/cc-director-setup-engine/AccountSignInRunner.cs
+++ b/tools/cc-director-setup-engine/AccountSignInRunner.cs
@@ -1,0 +1,206 @@
+using System.Diagnostics;
+using CcDirector.Core.Account;
+using CcDirector.Core.Storage;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>What a headless account sign-in attempt ended as.</summary>
+public enum AccountSignInOutcome
+{
+    /// <summary>The browser handed a credential back over the loopback callback and it was stored.</summary>
+    SignedIn,
+
+    /// <summary>The caller cancelled before the credential arrived.</summary>
+    Cancelled,
+
+    /// <summary>No credential arrived within the timeout (an abandoned sign-in).</summary>
+    TimedOut,
+
+    /// <summary>The browser could not be opened, the hand-back was malformed, or the credential could not be stored.</summary>
+    Failed,
+}
+
+/// <summary>
+/// The outcome of a headless account sign-in. Carries only whether a credential was captured and stored
+/// and, on a non-success, a short user-safe reason. It deliberately does NOT carry the token: keeping the
+/// token off this result is what guarantees it can never reach the CLI output or a log (security rule DT-05).
+/// </summary>
+/// <param name="Outcome">What happened: signed in, cancelled, timed out, or failed.</param>
+/// <param name="Message">A user-safe message describing the outcome; never the token.</param>
+public sealed record AccountSignInResult(AccountSignInOutcome Outcome, string Message)
+{
+    public bool Succeeded => Outcome == AccountSignInOutcome.SignedIn;
+}
+
+/// <summary>
+/// Signs a machine's DevThrottle account in from the command line, with no wizard window, and stores the
+/// captured credential where the Gateway reads it - so a headless install (an agent, a script) can complete
+/// the account sign-in the graphical wizard's sign-in step performs. It is the engine-side sibling of the
+/// Windows wizard's <c>SignInRunner</c>, living in the engine so the headless CLI can drive the SAME flow:
+/// a human and an agent sign in identically.
+///
+/// It reuses the exact loopback contract the app and the wizard use: it stands up a
+/// <see cref="LoopbackLoginListener"/> on <c>127.0.0.1</c>, builds the sign-in URL with that loopback
+/// callback as the <c>redirect_uri</c> via <see cref="FirstRunLoginCoordinator.BuildSignInUrl"/>, opens the
+/// system browser there, and waits for the browser to hand the account token pair back. The user signs in -
+/// or creates a free account - on devthrottle.com; that browser step is the only human action.
+///
+/// On a successful hand-back the captured token pair is persisted into the same operating-system credential
+/// store the GATEWAY reads (Gateway Centralization, issues #636 / #642 / #651 / #906): a
+/// <see cref="WindowsProtectedTokenStore"/> rooted at <see cref="CcStorage.GatewayDevThrottleCredentialBlob"/>
+/// encrypts it at rest, so the Gateway's first-launch sign-in check sees "already signed in" and does not
+/// re-prompt. Persistence happens ONLY on success; on cancel, timeout, or failure nothing is written. The
+/// captured access token is NEVER written to a log and NEVER returned (security rule DT-05).
+///
+/// The default persist writes the Gateway store, which is Windows-only (Data Protection is per-user, and the
+/// Gateway role is Windows-only); the caller guards the OS. The browser, listener, persist, and timeout are
+/// all injectable so the flow is unit-testable with no browser, no backend, and no disk.
+/// </summary>
+public sealed class AccountSignInRunner
+{
+    /// <summary>The default time to wait for the browser hand-back before treating the attempt as
+    /// abandoned. Mirrors the app and wizard gate: long enough for a real sign-in, short enough to recover.</summary>
+    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
+
+    private readonly Func<LoopbackLoginListener> _listenerFactory;
+    private readonly Action<string> _openBrowser;
+    private readonly Action<DevThrottleTokens> _persistCredential;
+    private readonly TimeSpan _timeout;
+
+    /// <summary>
+    /// Creates the runner. The collaborators are injected so the flow is testable without a real browser, a
+    /// real loopback callback, or the real credential store (no fallback construction - each has an explicit
+    /// default).
+    /// </summary>
+    /// <param name="listenerFactory">Creates the loopback listener that receives the hand-back. Defaults to a
+    /// real <see cref="LoopbackLoginListener"/>.</param>
+    /// <param name="openBrowser">Opens the system browser at the sign-in URL. Defaults to a shell-executed
+    /// <see cref="Process.Start(ProcessStartInfo)"/>.</param>
+    /// <param name="persistCredential">Persists the captured token pair into the Gateway's credential store.
+    /// Defaults to a real <see cref="WindowsProtectedTokenStore"/> writing the encrypted blob the Gateway
+    /// reads. Tests inject a recording seam so persistence is provable without Windows Data Protection.</param>
+    /// <param name="timeout">How long to wait for the hand-back before timing out. Defaults to
+    /// <see cref="DefaultTimeout"/>.</param>
+    public AccountSignInRunner(
+        Func<LoopbackLoginListener>? listenerFactory = null,
+        Action<string>? openBrowser = null,
+        Action<DevThrottleTokens>? persistCredential = null,
+        TimeSpan? timeout = null)
+    {
+        _listenerFactory = listenerFactory ?? (() => new LoopbackLoginListener());
+        _openBrowser = openBrowser ?? OpenSystemBrowser;
+        _persistCredential = persistCredential ?? PersistToGatewayCredentialStore;
+        _timeout = timeout ?? DefaultTimeout;
+    }
+
+    /// <summary>
+    /// Runs one sign-in attempt: opens the system browser at the sign-in address and waits for the browser to
+    /// hand a credential back on the loopback callback, then stores it. Returns an
+    /// <see cref="AccountSignInResult"/> the caller renders. It never throws for an expected outcome - it
+    /// returns a user-safe result (cancel, timeout, or failure) instead.
+    /// </summary>
+    /// <param name="ct">Cancelled by the caller. A cancellation produces <see cref="AccountSignInOutcome.Cancelled"/>.</param>
+    public async Task<AccountSignInResult> RunAsync(CancellationToken ct = default)
+    {
+        EngineLog.Write("[AccountSignInRunner] RunAsync: starting headless account sign-in hand-off");
+
+        using var listener = _listenerFactory();
+        var signInUrl = FirstRunLoginCoordinator.BuildSignInUrl(listener.CallbackUrl);
+        EngineLog.Write($"[AccountSignInRunner] RunAsync: sign-in url={signInUrl}");
+
+        try
+        {
+            _openBrowser(signInUrl);
+        }
+        catch (Exception ex)
+        {
+            EngineLog.Write($"[AccountSignInRunner] RunAsync: could not open the system browser: {ex.Message}");
+            return new AccountSignInResult(AccountSignInOutcome.Failed,
+                "Could not open your web browser to sign in. Please check that you have a default browser set, then try again.");
+        }
+
+        // The wait ends on whichever happens first: the caller's cancellation (ct), the timeout, or the
+        // browser hand-back. The timeout is its own source so we can tell "abandoned" from "cancelled".
+        using var timeoutSource = new CancellationTokenSource(_timeout);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutSource.Token);
+
+        DevThrottleTokens capturedTokens;
+        try
+        {
+            // The token pair captured here is handed to the Gateway credential store below. The value is
+            // never logged and never returned (security rule DT-05).
+            capturedTokens = await listener.WaitForCredentialAsync(linked.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            if (timeoutSource.IsCancellationRequested && !ct.IsCancellationRequested)
+            {
+                EngineLog.Write("[AccountSignInRunner] RunAsync: timed out waiting for the browser hand-back");
+                return new AccountSignInResult(AccountSignInOutcome.TimedOut,
+                    "Sign-in timed out. The browser sign-in was not completed in time - please try again.");
+            }
+
+            EngineLog.Write("[AccountSignInRunner] RunAsync: sign-in cancelled before a credential arrived");
+            return new AccountSignInResult(AccountSignInOutcome.Cancelled,
+                "Sign-in was cancelled. Run 'signin' again to retry.");
+        }
+        catch (Exception ex)
+        {
+            EngineLog.Write($"[AccountSignInRunner] RunAsync: hand-back capture failed: {ex.Message}");
+            return new AccountSignInResult(AccountSignInOutcome.Failed,
+                "Sign-in did not complete. Please return to your browser and finish signing in, then try again.");
+        }
+
+        if (capturedTokens is null || string.IsNullOrWhiteSpace(capturedTokens.AccessToken))
+        {
+            EngineLog.Write("[AccountSignInRunner] RunAsync: hand-back returned no usable credential");
+            return new AccountSignInResult(AccountSignInOutcome.Failed,
+                "Sign-in did not return a usable credential. Please try again.");
+        }
+
+        EngineLog.Write("[AccountSignInRunner] RunAsync: credential captured from the browser hand-back");
+
+        // Persist ONLY on a successful capture - the cancel/timeout/failure paths above all returned first,
+        // so no credential is ever written for an incomplete sign-in. A persistence failure is surfaced as a
+        // failure (no fallback): if the credential cannot be stored, the machine is not "signed in", so we
+        // must not report success.
+        try
+        {
+            _persistCredential(capturedTokens);
+        }
+        catch (Exception ex)
+        {
+            EngineLog.Write($"[AccountSignInRunner] RunAsync: persisting the captured credential failed: {ex.Message}");
+            return new AccountSignInResult(AccountSignInOutcome.Failed,
+                "Signed in, but the sign-in could not be saved for the app. Please try again.");
+        }
+
+        EngineLog.Write("[AccountSignInRunner] RunAsync: captured credential persisted to the Gateway credential store");
+        return new AccountSignInResult(AccountSignInOutcome.SignedIn, "Signed in to DevThrottle.");
+    }
+
+    /// <summary>Opens the user's default browser at the given URL via the shell.</summary>
+    private static void OpenSystemBrowser(string url) =>
+        Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+
+    /// <summary>
+    /// Persists the captured token pair into the GATEWAY's operating-system credential store (issue #906) -
+    /// the same store the Windows wizard's SignInRunner writes, so the Gateway's first-launch sign-in check
+    /// sees "already signed in" and does not re-prompt. Writing to the Director store would be thrown away
+    /// (the Director deletes any credential of its own on startup - the Gateway is the account authority).
+    /// The credential store creates its directory on write. The token value is never logged.
+    /// </summary>
+    private static void PersistToGatewayCredentialStore(DevThrottleTokens tokens)
+    {
+        // The Gateway credential store is Windows-only (Data Protection is per-user, and the Gateway role is
+        // Windows-only). The CLI 'signin' command already refuses on non-Windows; this guard fails loud rather
+        // than silently skipping the persist (no fallback), and satisfies the platform analyzer.
+        if (!OperatingSystem.IsWindows())
+            throw new PlatformNotSupportedException("The Gateway credential store is Windows-only.");
+
+        EngineLog.Write("[AccountSignInRunner] PersistToGatewayCredentialStore: storing captured credential for the Gateway");
+        var store = new WindowsProtectedTokenStore(CcStorage.GatewayDevThrottleCredentialBlob());
+        var service = DevThrottleAccountFactory.Build(store, CcStorage.GatewayDevThrottleAuthEventsLog());
+        service.StoreTokens(tokens);
+    }
+}


### PR DESCRIPTION
Recommendation B from the install-flow effort. The command-line installer could install everything headlessly but could not complete account sign-in or gateway enrollment - those lived only in the two graphical wizards. So an agent installing DevThrottle had to stop and hand off to a window. This closes that gap: the whole install is now scriptable, the only human step being the password in the browser.

## New commands on `cc-director-setup-cli`

- **`signin`** - opens the browser to devthrottle.com to sign in (or create a free account) and stores the captured credential where the Gateway reads it, so the Gateway does not re-prompt on first launch. Windows-only (the account credential lives on the Gateway, which is Windows-only); macOS uses `enroll`.
- **`enroll [--gateway <url>]`** - for a Workstation joining a fleet: signs in, then registers this machine on the account and enrolls it at the gateway for a local, revocable device key (persisted so the Director and cc-* tools connect on first run). With `--gateway` it proves the address reachable first, then enrolls; without it, it discovers the account's gateways and joins the one it finds (lists them if more than one). Idempotent when already connected.

## How

`enroll` drives the existing, tested `GatewayAccountEnrollRunner` unchanged. `signin` is a new engine class, `AccountSignInRunner` - the engine sibling of the Windows wizard's `SignInRunner`, so a human and an agent sign in through identical code. The captured access token and device keys are never printed or logged (security rule DT-05).

## Tests / verification

- New `AccountSignInRunnerTests` (6): success, sign-up persist of the exact token pair, cancel, timeout, browser-open failure, store failure - end to end against a real loopback listener with a stand-in browser.
- Full engine suite 303/303 and CLI suite 17/17 green; no regressions.
- `help` lists both commands; `enroll --help` short-circuits without opening a browser.

## Not covered here (needs the clean machine)

The real browser sign-in against the live backend is exercised on the clean-machine install test - the unit tests prove the flow against a loopback listener + stand-in browser, which is as far as it goes without the live sign-in page.

Follow-up: the install docs (`install-prompt.md`, devthrottle.com) can now reference `signin`/`enroll` instead of "launch the app and sign in" - a quick docs pass once this is validated on the clean machine.
