### PR TITLE
Reference the new signin/enroll CLI commands in the install docs

### DIFF
--- a/docs/install/install-prompt.md
+++ b/docs/install/install-prompt.md
@@ -51,9 +51,15 @@ quarantined. It downloads the setup app, verifies its SHA-256 against the manife
 Then complete the short setup app. macOS is workstation-only (no Gateway).
 
 == BOTH ==
-5. Launch DevThrottle once and SIGN IN. It opens devthrottle.com in the browser; the user enters a
-   password there (or creates a free account) and the app captures the session automatically. That
-   browser sign-in is the ONLY step a human has to do - everything else the agent runs unattended.
+5. SIGN IN - the ONLY step that needs a human. On WINDOWS, do it from the command line:
+      devthrottle-setup-cli-win-x64.exe signin
+   It opens devthrottle.com in the browser; the user signs in (or creates a free account) and it
+   captures the session automatically. If this machine is instead joining a DevThrottle gateway you
+   already run on another machine, use `enroll` (it signs in AND connects this machine to that
+   gateway - add --gateway <url> to name it, or omit to auto-discover it from your account):
+      devthrottle-setup-cli-win-x64.exe enroll
+   On macOS the setup app you opened in the previous step handles sign-in. Everything else the agent
+   runs unattended.
 6. Confirm the running version matches the release tag (Windows: the newest log under
    %LOCALAPPDATA%\cc-director\logs\director\; macOS: the app's log dir). Report: the release tag
    installed, the install path, and the SHA-256 you verified.
@@ -71,7 +77,8 @@ admin/sudo, build from source, place files in Program Files or /Applications, or
 
 - **Command-line installer, not the wizard** - the CLI front-end (`devthrottle-setup-cli`) drives the
   same install engine as the graphical wizard, so there is nothing to click through. An AI agent can
-  run the whole install unattended; the one human step is the browser sign-in.
+  run the whole install unattended - install, then `signin` (or `enroll`); the one human step is the
+  browser sign-in those commands open.
 - **Per-user, user-writable target** (`%LOCALAPPDATA%\cc-director` / `~/Applications`) - the
   auto-updater overwrites the running app's own path, so a user-writable location means updates need
   **no admin/sudo**. `Program Files` / `/Applications` would force elevation on every update or fail.

--- a/docs/public/getting-started/02-installation.md
+++ b/docs/public/getting-started/02-installation.md
@@ -134,7 +134,10 @@ auto-updates in place. On **Windows**, install it one of two ways:
 
   This installs the Director app, the `cc-*` tools (added to your `PATH`), and the launcher -
   per-user, no admin. The Director is a .NET 10 app, so also ensure the runtime is present:
-  `winget install Microsoft.DotNet.AspNetCore.10`. Full agent walkthrough:
+  `winget install Microsoft.DotNet.AspNetCore.10`. Then sign in from the command line - the only
+  step that needs you - with `devthrottle-setup-cli-win-x64.exe signin` (or, to join a gateway you
+  already run on another machine, `devthrottle-setup-cli-win-x64.exe enroll`); it opens the browser
+  to sign in or create a free account. Full agent walkthrough:
   [Installing with an AI coding agent](https://devthrottle.com/docs/install#install-agent).
 
 - **Graphical wizard:** download **DevThrottle Setup** from your [account page](https://devthrottle.com/signup)


### PR DESCRIPTION
Follow-up to #1735 (headless signin/enroll). The install docs told the reader to "launch the app and sign in"; now that the CLI does sign-in and gateway enrollment headlessly, they show the commands instead.

- `docs/install/install-prompt.md` - the sign-in step now runs `devthrottle-setup-cli-win-x64.exe signin` (sign in or create a free account), with `enroll` for a machine joining a gateway you already run. macOS keeps the setup-app flow.
- `docs/public/getting-started/02-installation.md` - the agent install section adds the same signin/enroll step.

Docs-only. The website carries the matching change separately (devthrottle_internal).