### PR TITLE
chore(stats): call it the "repo name", not "slug", throughout

### DIFF
--- a/packages/client-core/src/stats/statsClient.ts
+++ b/packages/client-core/src/stats/statsClient.ts
@@ -71,12 +71,12 @@ export interface InputHour {
  * codebase, in submitted turns (total + voice/typed split), character volume, and distinct sessions.
  * Mirrors the Gateway RepoStatBucketDto. Counts only - never any message text. */
 export interface RepoStat {
-  /** Grouping key: the GitHub "owner/repo" slug the sessions' checkouts belong to
+  /** Grouping key: the "owner/repo" repo name the sessions' checkouts belong to
    * (e.g. "thefrederiksen/devthrottle"), so worktrees and per-machine clones are one row. Falls back to the
-   * local working-directory path for a checkout with no github.com origin. */
+   * checkout's folder name for a checkout whose Director reported no repo name. */
   repo: string;
-  /** Display leaf of the key: the repository name for a slug (e.g. "devthrottle"), or the folder name for a
-   * fallback path. */
+  /** Display leaf of the key: the short repository name from an "owner/repo" key (e.g. "devthrottle"), or the
+   * folder name for a fallback. */
   repoName: string;
   /** Total submitted turns into this repo (voice + typed). */
   turns: number;

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1417,11 +1417,11 @@ internal static class ControlEndpoints
             RemoteThreadUrl = s.RemoteThreadUrl ?? "",
             RemoteRunUrl = s.RemoteRunUrl ?? "",
             RemoteRunStatus = s.RemoteRunStatus ?? "",
-            // DevThrottle Stats: the GitHub "owner/repo" of this local checkout, resolved here on the
-            // Director because the git repo lives on this machine. Cached per path so this roster mapper
-            // never forks git twice for the same checkout; "" when the checkout has no github.com origin,
-            // in which case the Gateway groups it by RepoPath instead.
-            RepoSlug = GitHubUrls.ResolveSlugCached(s.RepoPath),
+            // DevThrottle Stats: the "owner/repo" repo name of this local checkout (GitHub or Azure DevOps),
+            // resolved here on the Director because the git repo lives on this machine. Cached per path so
+            // this roster mapper never forks git twice for the same checkout; "" when the checkout is on no
+            // host we recognize, in which case the Gateway groups it by its folder name instead.
+            RepoName = GitHubUrls.ResolveRepoNameCached(s.RepoPath),
             // Issue #335: identity fields populated by the Director (not patched by the Gateway).
             MachineName = machineName,
             User = user,

--- a/src/CcDirector.Core.Tests/Utilities/GitHubUrlsTests.cs
+++ b/src/CcDirector.Core.Tests/Utilities/GitHubUrlsTests.cs
@@ -47,16 +47,16 @@ public class GitHubUrlsTests
         Assert.Throws<ArgumentException>(() => GitHubUrls.ParseNewIssueUrl(originUrl));
     }
 
-    // ---------- ParseSlug (pure owner/repo extraction) ----------
+    // ---------- ParseRepoName (pure owner/repo extraction) ----------
 
     [Theory]
     [InlineData("https://github.com/example-org/devthrottle.git")]
     [InlineData("https://github.com/example-org/devthrottle")]
     [InlineData("git@github.com:example-org/devthrottle.git")]
     [InlineData("ssh://git@github.com/example-org/devthrottle.git")]
-    public void ParseSlug_KnownRemoteShapes_ReturnsOwnerRepo(string originUrl)
+    public void ParseRepoName_KnownRemoteShapes_ReturnsOwnerRepo(string originUrl)
     {
-        Assert.Equal("example-org/devthrottle", GitHubUrls.ParseSlug(originUrl));
+        Assert.Equal("example-org/devthrottle", GitHubUrls.ParseRepoName(originUrl));
     }
 
     [Theory]
@@ -67,38 +67,38 @@ public class GitHubUrlsTests
     [InlineData("https://dev.azure.com/mindzie/mindzieStudio1/_git/mindzieWeb")]
     [InlineData("git@ssh.dev.azure.com:v3/mindzie/mindzieStudio1/mindzieWeb")]
     [InlineData("https://mindzie.visualstudio.com/mindzieStudio1/_git/mindzieWeb")]
-    public void ParseSlug_AzureDevOpsRemoteShapes_ReturnsOrgRepo(string originUrl)
+    public void ParseRepoName_AzureDevOpsRemoteShapes_ReturnsOrgRepo(string originUrl)
     {
-        Assert.Equal("mindzie/mindzieWeb", GitHubUrls.ParseSlug(originUrl));
+        Assert.Equal("mindzie/mindzieWeb", GitHubUrls.ParseRepoName(originUrl));
     }
 
     [Theory]
     [InlineData("https://gitlab.com/owner/repo.git")]
     [InlineData("git@bitbucket.org:owner/repo.git")]
-    public void ParseSlug_UnrecognizedRemote_Throws(string originUrl)
+    public void ParseRepoName_UnrecognizedRemote_Throws(string originUrl)
     {
-        Assert.Throws<InvalidOperationException>(() => GitHubUrls.ParseSlug(originUrl));
+        Assert.Throws<InvalidOperationException>(() => GitHubUrls.ParseRepoName(originUrl));
     }
 
     [Fact]
     public void ParseNewIssueUrl_AzureDevOpsRemote_StillThrows()
     {
-        // "New issue" is a GitHub concept; ParseSlug understanding Azure DevOps must NOT make the issue-URL
+        // "New issue" is a GitHub concept; ParseRepoName understanding Azure DevOps must NOT make the issue-URL
         // helper accept it and build a bogus github.com URL.
         var ex = Assert.Throws<InvalidOperationException>(() =>
             GitHubUrls.ParseNewIssueUrl("https://dev.azure.com/mindzie/mindzieStudio1/_git/mindzieWeb"));
         Assert.Contains("not a GitHub remote", ex.Message);
     }
 
-    // ---------- ResolveSlugCached (best-effort, never throws) ----------
+    // ---------- ResolveRepoNameCached (best-effort, never throws) ----------
 
     [Fact]
-    public void ResolveSlugCached_RepoWithGitHubOrigin_ReturnsSlug()
+    public void ResolveRepoNameCached_RepoWithGitHubOrigin_ReturnsRepoName()
     {
         var repoDir = CreateTempGitRepo("https://github.com/someowner/somerepo.git");
         try
         {
-            Assert.Equal("someowner/somerepo", GitHubUrls.ResolveSlugCached(repoDir));
+            Assert.Equal("someowner/somerepo", GitHubUrls.ResolveRepoNameCached(repoDir));
         }
         finally
         {
@@ -107,12 +107,12 @@ public class GitHubUrlsTests
     }
 
     [Fact]
-    public void ResolveSlugCached_RepoWithAzureDevOpsOrigin_ReturnsOrgRepo()
+    public void ResolveRepoNameCached_RepoWithAzureDevOpsOrigin_ReturnsOrgRepo()
     {
         var repoDir = CreateTempGitRepo("https://mindzie@dev.azure.com/mindzie/mindzieStudio1/_git/mindzieWeb");
         try
         {
-            Assert.Equal("mindzie/mindzieWeb", GitHubUrls.ResolveSlugCached(repoDir));
+            Assert.Equal("mindzie/mindzieWeb", GitHubUrls.ResolveRepoNameCached(repoDir));
         }
         finally
         {
@@ -121,12 +121,12 @@ public class GitHubUrlsTests
     }
 
     [Fact]
-    public void ResolveSlugCached_RepoWithoutOrigin_ReturnsEmpty_NeverThrows()
+    public void ResolveRepoNameCached_RepoWithoutOrigin_ReturnsEmpty_NeverThrows()
     {
         var repoDir = CreateTempGitRepo(originUrl: null);
         try
         {
-            Assert.Equal("", GitHubUrls.ResolveSlugCached(repoDir));
+            Assert.Equal("", GitHubUrls.ResolveRepoNameCached(repoDir));
         }
         finally
         {
@@ -138,17 +138,17 @@ public class GitHubUrlsTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    public void ResolveSlugCached_NullOrBlankPath_ReturnsEmpty(string? repoPath)
+    public void ResolveRepoNameCached_NullOrBlankPath_ReturnsEmpty(string? repoPath)
     {
-        Assert.Equal("", GitHubUrls.ResolveSlugCached(repoPath));
+        Assert.Equal("", GitHubUrls.ResolveRepoNameCached(repoPath));
     }
 
     [Fact]
-    public void ResolveSlugCached_MissingDirectory_ReturnsEmpty_NeverThrows()
+    public void ResolveRepoNameCached_MissingDirectory_ReturnsEmpty_NeverThrows()
     {
         var missing = Path.Combine(Path.GetTempPath(), $"cc-director-missing-{Guid.NewGuid():N}");
 
-        Assert.Equal("", GitHubUrls.ResolveSlugCached(missing));
+        Assert.Equal("", GitHubUrls.ResolveRepoNameCached(missing));
     }
 
     // ---------- BuildNewIssueUrl (against real temp git repos) ----------

--- a/src/CcDirector.Core/Utilities/GitHubUrls.cs
+++ b/src/CcDirector.Core/Utilities/GitHubUrls.cs
@@ -1,23 +1,23 @@
 namespace CcDirector.Core.Utilities;
 
 /// <summary>
-/// Resolves a local repository's origin remote to a host slug and to GitHub web URLs. The GitHub
+/// Resolves a local repository's origin remote to its repo name and to GitHub web URLs. The GitHub
 /// "new issue" helpers (used by the desktop "New GitHub Issue" menu item, the screenshot Issue button, and
-/// the Director's GET /sessions/{sid}/github-urls endpoint) are GitHub-only. The slug helpers
-/// (<see cref="ResolveSlugCached"/> / <see cref="ParseSlug"/>, used by the DevThrottle Stats repo grouping)
-/// understand BOTH github.com and Azure DevOps (dev.azure.com and the legacy visualstudio.com), so a repo on
-/// either host folds its worktrees and per-machine clones into one Repos row.
+/// the Director's GET /sessions/{sid}/github-urls endpoint) are GitHub-only. The repo-name helpers
+/// (<see cref="ResolveRepoNameCached"/> / <see cref="ParseRepoName"/>, used by the DevThrottle Stats repo
+/// grouping) understand BOTH github.com and Azure DevOps (dev.azure.com and the legacy visualstudio.com), so
+/// a repo on either host folds its worktrees and per-machine clones into one Repos row.
 /// </summary>
 public static class GitHubUrls
 {
     private static readonly TimeSpan RemoteUrlRegexTimeout = TimeSpan.FromMilliseconds(50);
 
-    // repoPath -> resolved "owner/repo" slug, or "" when the checkout has no github.com origin. A local
-    // clone's origin does not change over a process lifetime, and resolving it spawns a git subprocess, so
-    // this is cached: ResolveSlugCached runs on the Director's roster path (every session, every poll) and
-    // must not fork git each time. Misses ("" - no origin, not a git repo, non-github remote) are cached
-    // too, so a checkout without a GitHub origin is probed once, not on every poll.
-    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> SlugCache =
+    // repoPath -> resolved "owner/repo" repo name, or "" when the checkout is on no host we recognize. A
+    // local clone's origin does not change over a process lifetime, and resolving it spawns a git subprocess,
+    // so this is cached: ResolveRepoNameCached runs on the Director's roster path (every session, every poll)
+    // and must not fork git each time. Misses ("" - no origin, not a git repo, unrecognized remote) are
+    // cached too, so a checkout with no recognized remote is probed once, not on every poll.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> RepoNameCache =
         new(StringComparer.Ordinal);
 
     /// <summary>
@@ -38,35 +38,35 @@ public static class GitHubUrls
     }
 
     /// <summary>
-    /// The "owner/repo" (GitHub) or "org/repo" (Azure DevOps) slug for a local checkout, or "" when the
+    /// The "owner/repo" (GitHub) or "org/repo" (Azure DevOps) repo name for a local checkout, or "" when the
     /// checkout's origin is on neither host (no origin remote, not a git repo, or an unrecognized remote).
     /// Best-effort and NEVER throws: an empty result is a legitimate answer - not every checkout is on a host
     /// we recognize - and the caller (the DevThrottle Stats repo grouping) falls back to the folder name for
-    /// those. Cached by path; see <see cref="SlugCache"/>.
+    /// those. Cached by path; see <see cref="RepoNameCache"/>.
     ///
     /// This is the key that makes every worktree and every per-machine clone of one repository roll up into
-    /// a single row on the Repos page: they all share one origin remote, so they all resolve to one slug.
+    /// a single row on the Repos page: they all share one origin remote, so they all resolve to one repo name.
     /// </summary>
-    public static string ResolveSlugCached(string? repoPath)
+    public static string ResolveRepoNameCached(string? repoPath)
     {
         if (string.IsNullOrWhiteSpace(repoPath)) return "";
-        return SlugCache.GetOrAdd(repoPath, ResolveSlugUncached);
+        return RepoNameCache.GetOrAdd(repoPath, ResolveRepoNameUncached);
     }
 
-    private static string ResolveSlugUncached(string repoPath)
+    private static string ResolveRepoNameUncached(string repoPath)
     {
         try
         {
             if (!Directory.Exists(repoPath)) return "";
-            var slug = ParseSlug(GetOriginRemoteUrl(repoPath));
-            FileLog.Write($"[GitHubUrls] ResolveSlugCached: {repoPath} -> {slug}");
-            return slug;
+            var repoName = ParseRepoName(GetOriginRemoteUrl(repoPath));
+            FileLog.Write($"[GitHubUrls] ResolveRepoNameCached: {repoPath} -> {repoName}");
+            return repoName;
         }
         catch (Exception ex)
         {
             // A checkout with no origin, or one on a host we do not recognize, is an expected state, not a
-            // failure to hide: it simply has no slug and groups by its folder name instead. Recorded, then "".
-            FileLog.Write($"[GitHubUrls] ResolveSlugCached: {repoPath} has no recognized remote slug: {ex.Message}");
+            // failure to hide: it simply has no repo name and groups by its folder name instead. Recorded, "".
+            FileLog.Write($"[GitHubUrls] ResolveRepoNameCached: {repoPath} has no recognized remote repo name: {ex.Message}");
             return "";
         }
     }
@@ -78,7 +78,7 @@ public static class GitHubUrls
     ///   ssh://git@github.com/owner/repo.git
     ///   https://github.com/owner/repo(.git)
     /// Throws when the remote is not on github.com - "new issue" is a GitHub concept, so this stays
-    /// GitHub-only even though <see cref="ParseSlug"/> also understands Azure DevOps.
+    /// GitHub-only even though <see cref="ParseRepoName"/> also understands Azure DevOps.
     /// </summary>
     internal static string ParseNewIssueUrl(string originUrl)
     {
@@ -91,16 +91,16 @@ public static class GitHubUrls
     }
 
     /// <summary>
-    /// Extracts the "owner/repo" (GitHub) or "org/repo" (Azure DevOps) slug from an origin remote URL. Pure
-    /// string logic so it is unit-testable without git. The slug is host-neutral on purpose: every worktree
-    /// and every per-machine clone of one repository shares one origin, so they all resolve to the identical
-    /// slug and fold into a single Repos row. Throws when the remote is empty or on neither host.
+    /// Extracts the "owner/repo" (GitHub) or "org/repo" (Azure DevOps) repo name from an origin remote URL.
+    /// Pure string logic so it is unit-testable without git. The repo name is host-neutral on purpose: every
+    /// worktree and every per-machine clone of one repository shares one origin, so they all resolve to the
+    /// identical repo name and fold into a single Repos row. Throws when the remote is empty or on neither host.
     ///
-    /// Azure DevOps identifies a repo as org/project/repo; the slug keeps org/repo (dropping the project) to
-    /// match GitHub's two-part shape and how the owner refers to it. The bounded cost: two repos of the same
-    /// name in different projects of one org would share a slug - accepted, and vanishingly rare here.
+    /// Azure DevOps identifies a repo as org/project/repo; the repo name keeps org/repo (dropping the project)
+    /// to match GitHub's two-part shape and how the owner refers to it. The bounded cost: two repos of the
+    /// same name in different projects of one org would share a repo name - accepted, and vanishingly rare here.
     /// </summary>
-    internal static string ParseSlug(string originUrl)
+    internal static string ParseRepoName(string originUrl)
     {
         if (string.IsNullOrWhiteSpace(originUrl))
             throw new ArgumentException("Origin remote URL is required", nameof(originUrl));
@@ -131,7 +131,7 @@ public static class GitHubUrls
     //   https://[user@]dev.azure.com/{org}/{project}/_git/{repo}   (modern HTTPS)
     //   git@ssh.dev.azure.com:v3/{org}/{project}/{repo}            (modern SSH)
     //   https://{org}.visualstudio.com/[collection/]{project}/_git/{repo}  (legacy)
-    // The project segment is matched but discarded; the slug is org/repo. The ".git" suffix is optional.
+    // The project segment is matched but discarded; the repo name is org/repo. The ".git" suffix is optional.
     private static (string org, string repo)? TryMatchAzureDevOps(string url)
     {
         var https = System.Text.RegularExpressions.Regex.Match(

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -599,19 +599,20 @@ public sealed class SessionDto
     public string RemoteRunStatus { get; set; } = "";
 
     /// <summary>
-    /// DevThrottle Stats: the "owner/repo" GitHub slug of this session's LOCAL checkout, resolved by the
-    /// owning Director from the checkout's origin remote (the git repo lives on the Director's machine, so
-    /// only it can resolve this). Empty when the checkout has no github.com origin. This is the grouping key
-    /// the Repos page uses so every worktree and every per-machine clone of one repository rolls up into a
-    /// single row - <see cref="RepoPath"/> alone splits them, because each checkout is a different path.
+    /// DevThrottle Stats: the "owner/repo" repo name of this session's LOCAL checkout (GitHub or Azure
+    /// DevOps), resolved by the owning Director from the checkout's origin remote (the git repo lives on the
+    /// Director's machine, so only it can resolve this). Empty when the checkout is on no host we recognize.
+    /// This is the grouping key the Repos page uses so every worktree and every per-machine clone of one
+    /// repository rolls up into a single row - <see cref="RepoPath"/> alone splits them, because each checkout
+    /// is a different path.
     ///
     /// DISTINCT from <see cref="RemoteRepo"/>: that is populated only for GitHub Actions CLOUD sessions and
     /// names the repo the cloud run executes against; this is populated for ordinary LOCAL sessions and names
-    /// the GitHub repo their working directory is a checkout of. A session has one or the other, not both.
+    /// the repo their working directory is a checkout of. A session has one or the other, not both.
     /// Passes through the Gateway aggregation unchanged; the aggregator folds it as the repository identity
     /// and retains <see cref="RepoPath"/> alongside as the checkout identity.
     /// </summary>
-    public string RepoSlug { get; set; } = "";
+    public string RepoName { get; set; } = "";
 
     /// <summary>
     /// DevThrottle Stats: this session's input tally (submitted turns + character volume by modality and

--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -51,11 +51,11 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         return dto;
     }
 
-    // A session whose Director resolved a GitHub slug for its checkout - the grouping key the Repos page uses.
-    private static SessionDto SessionInSlug(string id, string slug, string repoPath, params (string modality, string surface, long turns, long chars)[] buckets)
+    // A session whose Director resolved a repo name for its checkout - the grouping key the Repos page uses.
+    private static SessionDto SessionWithRepoName(string id, string repoName, string repoPath, params (string modality, string surface, long turns, long chars)[] buckets)
     {
         var dto = Session(id, buckets);
-        dto.RepoSlug = slug;
+        dto.RepoName = repoName;
         dto.RepoPath = repoPath;
         return dto;
     }
@@ -281,7 +281,7 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         Assert.Equal(2, dt.TypedTurns);
         Assert.Equal(640, dt.Characters);
         Assert.Equal(2, dt.Sessions);                         // two distinct sessions drove it
-        Assert.Equal("devthrottle", dt.Repo);                 // no slug -> grouped by folder name
+        Assert.Equal("devthrottle", dt.Repo);                 // no repo name -> grouped by folder name
     }
 
     [Fact]
@@ -307,20 +307,20 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
     }
 
     [Fact]
-    public void RepoTotals_GroupsByGitHubSlug_CollapsingWorktreesAndClones_RetainingCheckouts()
+    public void RepoTotals_GroupsByRepoName_CollapsingWorktreesAndClones_RetainingCheckouts()
     {
         var agg = new GatewayInputStatsAggregator(_path);
         // The same GitHub repo, driven from three different checkouts: the main clone, a worktree, and a
-        // second machine's clone (a forward-slash path). All must roll up into ONE row keyed by the slug.
-        agg.Observe(SessionInSlug("s1", "thefrederiksen/devthrottle", @"D:\ReposFred\devthrottle", ("voice", "phone", 6, 600)));
-        agg.Observe(SessionInSlug("s2", "thefrederiksen/devthrottle", @"D:\ReposFred\devthrottle-gateway-sqlite", ("typed", "desktop", 2, 40)));
-        agg.Observe(SessionInSlug("s3", "thefrederiksen/devthrottle", "/Users/soren/ReposFred/devthrottle", ("typed", "cockpit", 1, 10)));
+        // second machine's clone (a forward-slash path). All must roll up into ONE row keyed by the repo name.
+        agg.Observe(SessionWithRepoName("s1", "thefrederiksen/devthrottle", @"D:\ReposFred\devthrottle", ("voice", "phone", 6, 600)));
+        agg.Observe(SessionWithRepoName("s2", "thefrederiksen/devthrottle", @"D:\ReposFred\devthrottle-gateway-sqlite", ("typed", "desktop", 2, 40)));
+        agg.Observe(SessionWithRepoName("s3", "thefrederiksen/devthrottle", "/Users/soren/ReposFred/devthrottle", ("typed", "cockpit", 1, 10)));
 
         var repos = agg.RepoTotals();
         Assert.Single(repos);                                    // three checkouts, one repository row
         var dt = repos[0];
-        Assert.Equal("thefrederiksen/devthrottle", dt.Repo);     // grouped by the slug
-        Assert.Equal("devthrottle", dt.RepoName);                // leaf of the slug is the repo name
+        Assert.Equal("thefrederiksen/devthrottle", dt.Repo);     // grouped by the repo name
+        Assert.Equal("devthrottle", dt.RepoName);                // leaf of the repo name is the short name
         Assert.Equal(9, dt.Turns);                               // 6 + 2 + 1 folded together
         Assert.Equal(3, dt.Sessions);                            // three distinct sessions
 
@@ -332,10 +332,10 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
     }
 
     [Fact]
-    public void RepoTotals_NoGitHubSlug_FallsBackToFolderName()
+    public void RepoTotals_NoRepoName_FallsBackToFolderName()
     {
         var agg = new GatewayInputStatsAggregator(_path);
-        // A checkout with no github.com origin reports an empty slug; it appears keyed by its FOLDER NAME
+        // A checkout with no recognized remote reports an empty repo name; it appears keyed by its FOLDER NAME
         // (not its full path), so a display shows the repo, not the machine-specific directory.
         agg.Observe(SessionInRepo("s1", @"D:\repos\local-only", ("typed", "desktop", 4, 80)));
 
@@ -347,11 +347,11 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
     }
 
     [Fact]
-    public void RepoTotals_NoSlug_SameFolderNameAcrossMachines_CollapsesToOneRow()
+    public void RepoTotals_NoRepoName_SameFolderNameAcrossMachines_CollapsesToOneRow()
     {
         var agg = new GatewayInputStatsAggregator(_path);
         // The owner's case: the SAME repository worked in from three machines - a Windows box, a Mac, and a
-        // second Windows box - with no slug (older Directors). All three share the folder name "devthrottle",
+        // second Windows box - with no repo name (older Directors). All three share the folder name "devthrottle",
         // so they must fold into ONE row, with the three machine paths retained as its checkouts.
         agg.Observe(SessionInRepo("s1", @"D:\ReposFred\devthrottle", ("typed", "desktop", 6, 600)));
         agg.Observe(SessionInRepo("s2", "/Users/soren/ReposFred/devthrottle", ("voice", "phone", 2, 40)));
@@ -370,13 +370,13 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
     }
 
     [Fact]
-    public void RepoTotals_SlugGrouping_SurvivesGatewayRestart()
+    public void RepoTotals_RepoNameGrouping_SurvivesGatewayRestart()
     {
         var agg = new GatewayInputStatsAggregator(_path);
-        agg.Observe(SessionInSlug("s1", "owner/app", @"D:\a\app", ("voice", "phone", 3, 120)));
-        agg.Observe(SessionInSlug("s2", "owner/app", @"D:\b\app", ("typed", "desktop", 2, 40)));
+        agg.Observe(SessionWithRepoName("s1", "owner/app", @"D:\a\app", ("voice", "phone", 3, 120)));
+        agg.Observe(SessionWithRepoName("s2", "owner/app", @"D:\b\app", ("typed", "desktop", 2, 40)));
 
-        // The identity mirror (repo + checkout) must reload from disk and still group by slug.
+        // The identity mirror (repo + checkout) must reload from disk and still group by repo name.
         var reloaded = new GatewayInputStatsAggregator(_path);
         var repos = reloaded.RepoTotals();
         Assert.Single(repos);

--- a/src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs
@@ -72,7 +72,7 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         Assert.True(TableExists(db, "repo_identity"));
         Assert.True(TableExists(db, "agent_identity"));
         Assert.True(TableExists(db, "model_identity"));
-        // The checkout dimension (schema v4): the local working directory retained beside the repository slug.
+        // The checkout dimension (schema v4): the local working directory retained beside the repo name.
         Assert.True(TableExists(db, "checkout_identity"));
         // Token spend (issue #1637) - the delta lane and its per-session high-water.
         Assert.True(TableExists(db, "token_delta"));
@@ -264,15 +264,15 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         Assert.Contains("will not fall back", ex.Message);
     }
 
-    // ---- A hand-built PRE-SLUG store, used to exercise the schema v4 reset. ----
+    // ---- A hand-built INCOMPATIBLE (pre-repo-name) store, used to exercise the schema v4 reset. ----
     //
     // This writes the exact shape a PREVIOUS BUILD wrote: stat_delta without model_id or checkout_id, no
     // model_identity, repo_id keyed by a local PATH, user_version=1. Until v4 the contract was that such a
     // file migrated forward and kept every row; at v4 the repository dimension changed meaning (path became
-    // GitHub slug) and a path-keyed row can no longer be re-keyed, so the owner ruled it is not carried
+    // repo name) and a path-keyed row can no longer be re-keyed, so the owner ruled it is not carried
     // across - the file is retired aside unread and the store starts empty. These rows are therefore what a
-    // real pre-slug store looks like on disk, so the retire tests can prove it is retired (not migrated) and
-    // that the retired copy stays intact.
+    // real incompatible store looks like on disk, so the retire tests can prove it is retired (not migrated)
+    // and that the retired copy stays intact.
     private void WriteVersion1Database(params (string Hour, long Turns, long Chars)[] rows)
     {
         using var connection = new SqliteConnection($"Data Source={_path}");
@@ -332,18 +332,18 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
     }
 
     [Fact]
-    public void Open_PreSlugStore_IsRetiredAsideUnread_AndStartsEmpty()
+    public void Open_IncompatibleStore_IsRetiredAsideUnread_AndStartsEmpty()
     {
         // The repository dimension changed meaning at schema v4: repo_id was the session's local path and is
-        // now its GitHub slug. A stored path-keyed row cannot be re-keyed to a slug (the Gateway has no
+        // now its repo name. A stored path-keyed row cannot be re-keyed to a repo name (the Gateway has no
         // filesystem to resolve the path), so - as with the legacy JSON store, and by the same owner ruling -
-        // a pre-slug store (any version 1..3) is not migrated forward. It is renamed aside UNREAD and this
+        // an incompatible store (any version 1..3) is not migrated forward. It is renamed aside UNREAD and this
         // store starts empty. This is the reset the owner approved ("we're not really live yet").
         WriteVersion1Database(("2026-07-16T09", 40, 400), ("2026-07-16T10", 27, 270));
 
         using var db = new GatewayStatsDatabase(_path);
 
-        // The fresh store is at the current version and carries NONE of the pre-slug rows.
+        // The fresh store is at the current version and carries NONE of the old rows.
         Assert.Equal(GatewayStatsDatabase.SchemaVersion, UserVersion(db));
         Assert.Equal(0, ScalarLong(db, "SELECT COUNT(*) FROM stat_delta"));
         Assert.Equal(0, ScalarLong(db, "SELECT COUNT(*) FROM repo_identity"));
@@ -353,12 +353,12 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
 
         // Renamed, never deleted - the old numbers are recoverable, which was the owner's line on the JSON
         // store too. Exactly one retired copy sits beside the fresh database.
-        var retired = Directory.GetFiles(_dir, "gateway-stats.db.pre-slug-*");
+        var retired = Directory.GetFiles(_dir, "gateway-stats.db.superseded-*");
         Assert.Single(retired);
     }
 
     [Fact]
-    public void Open_PreSlugStore_LeavesTheRetiredCopyIntactAndReadable()
+    public void Open_IncompatibleStore_LeavesTheRetiredCopyIntactAndReadable()
     {
         // "Renamed aside UNREAD" must mean the bytes are untouched: the retired file still holds the old rows,
         // so the reset is recoverable rather than a destructive wipe.
@@ -367,7 +367,7 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         using (var db = new GatewayStatsDatabase(_path)) { /* triggers the retire */ }
         SqliteConnection.ClearAllPools();
 
-        var retired = Directory.GetFiles(_dir, "gateway-stats.db.pre-slug-*").Single();
+        var retired = Directory.GetFiles(_dir, "gateway-stats.db.superseded-*").Single();
         using var old = new SqliteConnection($"Data Source={retired}");
         old.Open();
         using var cmd = old.CreateCommand();
@@ -390,7 +390,7 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         SqliteConnection.ClearAllPools();
 
         using var second = new GatewayStatsDatabase(_path);
-        Assert.Empty(Directory.GetFiles(_dir, "gateway-stats.db.pre-slug-*"));
+        Assert.Empty(Directory.GetFiles(_dir, "gateway-stats.db.superseded-*"));
         using var read = second.Connection.CreateCommand();
         read.CommandText = "SELECT value FROM meta WHERE name='probe'";
         Assert.Equal("kept", read.ExecuteScalar() as string);

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -72,7 +72,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     private readonly Dictionary<string, long> _agentIds = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, long> _modelIds = new(StringComparer.OrdinalIgnoreCase);
     // The checkout (local working directory) dimension retained beside the repository (issue: group the
-    // Repos page by GitHub repository). repo_id is now the GitHub slug, so worktrees and per-machine clones
+    // Repos page by repository). repo_id is now the repo name, so worktrees and per-machine clones
     // of one repository share a repo_id; checkout_id keeps the path each turn actually ran in so it is not
     // lost. Same first-seen-wins OrdinalIgnoreCase identity as the others.
     private readonly Dictionary<string, long> _checkoutIds = new(StringComparer.OrdinalIgnoreCase);
@@ -118,7 +118,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     /// sessions ran a model, so <see cref="SessionsFor"/> refuses it rather than carrying a set nothing
     /// populates. It is also the only kind that can be ABSENT - see <see cref="FoldLocked"/>.
     ///
-    /// <see cref="Checkout"/> is the local working-directory path retained beside the repository slug. Like
+    /// <see cref="Checkout"/> is the local working-directory path retained beside the repo name. Like
     /// <see cref="Model"/> it keeps no distinct-session set (the session count the Repos page shows is per
     /// repository, not per checkout), so <see cref="SessionsFor"/> refuses it too. Unlike Model it is never
     /// absent - a session always has a working directory.
@@ -304,7 +304,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
         // Model is the only nullable member of a row: null means the owning Director had recorded no model
         // for that session when the turn folded, which is the honest state and never a lookup failure.
-        // Repo is the GitHub slug (the grouping key); Checkout is the local working directory the turn ran in,
+        // Repo is the repo name (the grouping key); Checkout is the local working directory the turn ran in,
         // retained beside it so the path is not lost when worktrees and clones collapse into one repo row.
         public readonly List<(string Hour, string SessionId, string Modality, string Surface, bool IsVoice, string Repo, string Checkout, string? Model, bool Wingman, long Turns, long Chars)> Rows = new();
         public readonly List<(string Agent, bool IsVoice, long Turns, long Chars)> AgentRows = new();
@@ -389,27 +389,28 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
         // The repository grouping key is a two-tier identity:
         //
-        //   1. The GitHub "owner/repo" slug the owning Director resolved for this checkout, when it sent one.
-        //      This is the ideal key: it folds every worktree AND every per-machine clone of one repository
-        //      into a single row, and it never collides two genuinely different repos that share a folder name.
+        //   1. The "owner/repo" repo name (GitHub or Azure DevOps) the owning Director resolved for this
+        //      checkout, when it sent one. This is the ideal key: it folds every worktree AND every per-machine
+        //      clone of one repository into a single row, and it never collides two genuinely different repos
+        //      that share a folder name.
         //
         //   2. Otherwise the checkout's FOLDER NAME (the last path segment), not its full path. A Director on
-        //      an older build sends no slug, so the Gateway - which has no filesystem to resolve the origin,
-        //      and may be on a different machine than the checkout entirely - only has the path. Grouping by
-        //      the folder name still collapses the SAME repository worked in from several machines
+        //      an older build sends no repo name, so the Gateway - which has no filesystem to resolve the
+        //      origin, and may be on a different machine than the checkout entirely - only has the path.
+        //      Grouping by the folder name still collapses the SAME repository worked in from several machines
         //      ("D:\ReposFred\devthrottle", "/Users/soren/ReposFred/devthrottle" and "C:\ReposFred\devthrottle"
         //      are one "devthrottle" row), which is the owner's rule: the same repo is the same repo, whichever
-        //      machine drove it. The trade-off is deliberate and bounded to the no-slug case: it does NOT fold
-        //      a differently-named worktree (only the slug can, since it reads the shared origin), and two
-        //      unrelated repositories that happen to share a folder name would merge. Once the Directors are on
-        //      a slug-emitting build, tier 1 takes over and both limitations go away.
+        //      machine drove it. The trade-off is deliberate and bounded to the no-repo-name case: it does NOT
+        //      fold a differently-named worktree (only the repo name can, since it reads the shared origin), and
+        //      two unrelated repositories that happen to share a folder name would merge. Once the Directors are
+        //      on a repo-name-emitting build, tier 1 takes over and both limitations go away.
         //
         // The checkout key stays the raw working-directory path, retained as its own dimension so the store
         // still records exactly which checkout each turn ran in - the individual paths are listed under the
         // merged row, not lost. Separators are not normalized: RepoLeaf treats both '/' and '\' as segment
         // separators, so a Windows and a POSIX checkout of one repo yield the identical folder-name key.
         var checkoutKey = s.RepoPath ?? "";
-        var repoKey = !string.IsNullOrWhiteSpace(s.RepoSlug) ? s.RepoSlug! : RepoLeaf(checkoutKey);
+        var repoKey = !string.IsNullOrWhiteSpace(s.RepoName) ? s.RepoName! : RepoLeaf(checkoutKey);
 
         // The model this session's agent was last RECORDED using (issue #1637). Unlike the repository and
         // the agent, an unknown model is stored as SQL NULL rather than folded into an empty-string
@@ -873,7 +874,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
             // The local checkouts (worktrees, per-machine clones) that rolled up into each repository, kept so
             // the page can still show which working directories a repo's turns came from - the path is not
-            // lost when the slug collapses them. Display spellings come from the identity mirror, never from a
+            // lost when the repo name collapses them. Display spellings come from the identity mirror, never from a
             // SQL join; sorted here so the retained list is stable rather than in row-insert order.
             var checkoutsByRepo = new Dictionary<long, List<string>>();
             Read("SELECT DISTINCT repo_id, checkout_id FROM stat_delta WHERE checkout_id IS NOT NULL", r =>
@@ -1156,8 +1157,8 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         _ => agent,
     };
 
-    // The last segment of the grouping key, used as the row's short name. For a GitHub slug
-    // ("thefrederiksen/devthrottle") this is the repository name ("devthrottle"); for a fallback path
+    // The last segment of the grouping key, used as the row's short name. For a repo name
+    // ("thefrederiksen/devthrottle") this is the short repository name ("devthrottle"); for a fallback path
     // ("D:\ReposFred\devthrottle") it is the folder name. The same split serves both because '/' and '\' are
     // both segment separators here.
     private static string RepoLeaf(string path)
@@ -1244,15 +1245,15 @@ public sealed class WingmanUsageDto
 /// <summary>One repository's all-time input tally for the private Repos page.</summary>
 public sealed class RepoStatBucketDto
 {
-    /// <summary>The grouping key: the GitHub "owner/repo" slug the sessions' checkouts belong to
+    /// <summary>The grouping key: the "owner/repo" repo name the sessions' checkouts belong to
     /// (e.g. "thefrederiksen/devthrottle") when a Director resolved one, so every worktree and every
     /// per-machine clone of one repository is one row. Falls back to the checkout's FOLDER NAME (not its full
-    /// path) for a checkout with no slug, so the same repository worked in from several machines still folds
-    /// into one row.</summary>
+    /// path) for a checkout with no repo name, so the same repository worked in from several machines still
+    /// folds into one row.</summary>
     public string Repo { get; set; } = "";
 
-    /// <summary>The display leaf of <see cref="Repo"/> (its last segment): the repository name for a slug,
-    /// e.g. "devthrottle". For the folder-name fallback this equals <see cref="Repo"/>.</summary>
+    /// <summary>The display leaf of <see cref="Repo"/> (its last segment): the short repository name from an
+    /// "owner/repo" key, e.g. "devthrottle". For the folder-name fallback this equals <see cref="Repo"/>.</summary>
     public string RepoName { get; set; } = "";
 
     public long Turns { get; set; }

--- a/src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs
@@ -76,7 +76,7 @@ public sealed class GatewayStatsDatabase : IDisposable
             if (!string.IsNullOrEmpty(dir))
                 Directory.CreateDirectory(dir);
 
-            RetirePreSlugStore();
+            RetireIncompatibleStore();
 
             _connection = new SqliteConnection($"Data Source={_path}");
             _connection.Open();
@@ -470,18 +470,18 @@ public sealed class GatewayStatsDatabase : IDisposable
     // together with a meaning change to the repository dimension it sits beside.
     //
     // repo_id USED to be keyed by the session's local working-directory path; from this version it is keyed
-    // by the session's GitHub "owner/repo" slug (SessionDto.RepoSlug), so one repository's worktrees and its
+    // by the session's "owner/repo" repo name (SessionDto.RepoName), so one repository's worktrees and its
     // per-machine clones collapse into a single row on the Repos page instead of one row each. The path is
     // NOT thrown away in the process - it becomes its own dimension here, so the store still records exactly
     // which checkout every turn ran in (the owner's ask: keep the checkout AND the repo name). Grouping and
-    // ranking are by repo_id (the slug); checkout_id is retained detail, read back as the set of checkouts
-    // that rolled into a repo.
+    // ranking are by repo_id (the repo name); checkout_id is retained detail, read back as the set of
+    // checkouts that rolled into a repo.
     //
     // Because the meaning of an EXISTING repo_id row changed and the Gateway cannot re-key a stored path to a
-    // slug (it has no filesystem to resolve it, and the path may be another machine's), a pre-version-4 store
-    // is not migrated forward at all: it is retired aside UNREAD before this database is opened
-    // (RetirePreSlugStore), and this store starts empty. So this step only ever runs as part of building a
-    // FRESH database (0 -> 4); it is written as a proper migration all the same, so the schema machinery
+    // repo name (it has no filesystem to resolve it, and the path may be another machine's), a pre-version-4
+    // store is not migrated forward at all: it is retired aside UNREAD before this database is opened
+    // (RetireIncompatibleStore), and this store starts empty. So this step only ever runs as part of building
+    // a FRESH database (0 -> 4); it is written as a proper migration all the same, so the schema machinery
     // stays honest and a fresh build lands the column and table exactly once.
     //
     // checkout_id is added by ALTER TABLE and is therefore nullable at the column level (SQLite reads NULL
@@ -505,20 +505,20 @@ public sealed class GatewayStatsDatabase : IDisposable
             )", tx);
     }
 
-    // Retire a pre-version-4 statistics store aside UNREAD, exactly as the legacy JSON store was retired
-    // (GatewayInputStatsAggregator.RetireLegacyJsonStore). Runs once, before the database is opened.
+    // Retire an incompatible pre-version-4 statistics store aside UNREAD, exactly as the legacy JSON store was
+    // retired (GatewayInputStatsAggregator.RetireLegacyJsonStore). Runs once, before the database is opened.
     //
     // Why the old numbers are not carried across: version 4 changed what repo_id MEANS - the session's local
-    // working-directory path became its GitHub "owner/repo" slug. An existing row is keyed by a path, and the
-    // Gateway cannot re-key it to a slug: it has no filesystem to resolve the path against, and the path may
-    // belong to another machine entirely. There is no faithful forward migration, so - as with the JSON store
-    // and by the same owner ruling - the file is renamed aside (never deleted) and this store starts empty.
+    // working-directory path became its "owner/repo" repo name. An existing row is keyed by a path, and the
+    // Gateway cannot re-key it to a repo name: it has no filesystem to resolve the path against, and the path
+    // may belong to another machine entirely. There is no faithful forward migration, so - as with the JSON
+    // store and by the same owner ruling - the file is renamed aside (never deleted) and this store starts empty.
     //
     // The schema version is read straight from the SQLite header (a 4-byte big-endian integer at offset 60)
     // rather than by opening the file: no connection, no file lock, nothing to release before the rename.
     // Self-idempotent - the fresh database this build then creates is stamped version 4, so the next startup
     // reads 4 from the header and retires nothing.
-    private void RetirePreSlugStore()
+    private void RetireIncompatibleStore()
     {
         if (!File.Exists(_path)) return;
 
@@ -537,23 +537,23 @@ public sealed class GatewayStatsDatabase : IDisposable
         }
         catch (Exception ex)
         {
-            FileLog.Write($"[GatewayStatsDatabase] RetirePreSlugStore: could not read header of {_path}: " +
+            FileLog.Write($"[GatewayStatsDatabase] RetireIncompatibleStore: could not read header of {_path}: " +
                           $"{ex.Message}; leaving it in place for the normal open path");
             return;
         }
 
         // A valid store already at version 4 (or, defensively, beyond it) is current; version 0 is not a real
-        // stamped store. Only a genuine version 1..3 file is the pre-slug store this retires.
+        // stamped store. Only a genuine version 1..3 file is the incompatible store this retires.
         if (version <= 0 || version >= SchemaVersion) return;
 
-        var aside = _path + ".pre-slug-" +
+        var aside = _path + ".superseded-" +
             DateTime.UtcNow.ToString("yyyyMMdd-HHmmss", System.Globalization.CultureInfo.InvariantCulture);
         MoveAsideIfExists(_path, aside);
         MoveAsideIfExists(_path + "-wal", aside + "-wal");
         MoveAsideIfExists(_path + "-shm", aside + "-shm");
-        FileLog.Write($"[GatewayStatsDatabase] RetirePreSlugStore: the repository dimension changed from local " +
-                      $"path to GitHub slug at schema v{SchemaVersion}; renamed the pre-slug store (v{version}) " +
-                      $"to {aside} UNREAD; starting empty");
+        FileLog.Write($"[GatewayStatsDatabase] RetireIncompatibleStore: the repository dimension changed from " +
+                      $"local path to repo name at schema v{SchemaVersion}; renamed the superseded store " +
+                      $"(v{version}) to {aside} UNREAD; starting empty");
     }
 
     private static void MoveAsideIfExists(string from, string to)


### PR DESCRIPTION
## Why
"Slug" is jargon for the repository's name (owner/repo). Rename the repo-grouping term to "repo name" so it's plain everywhere, and can never leak into the app as "slug". No behavior change.

## Renames
- `SessionDto.RepoSlug` -> `RepoName`
- `GitHubUrls.ResolveSlugCached` -> `ResolveRepoNameCached`, `ParseSlug` -> `ParseRepoName`, `SlugCache` -> `RepoNameCache`
- `GatewayStatsDatabase.RetirePreSlugStore` -> `RetireIncompatibleStore` (retired-store suffix `.pre-slug-` -> `.superseded-`)
- All related comments/test names -> "repo name"

Unrelated `slug` uses (URL-safe session-name slugs, the GitHub Actions cloud-session repo) are left untouched — different concepts.

## Tests
Full solution builds 0/0; Gateway stats (68) and GitHubUrls (31) green.