### PR TITLE
Group the session rail by computer:port and widen the new-session dialog

### DIFF
--- a/apps/cockpit/src/sessions/NewSessionDialog.tsx
+++ b/apps/cockpit/src/sessions/NewSessionDialog.tsx
@@ -9,6 +9,8 @@ import {
   type DirectorInfo,
   type RepoInfo,
 } from "@devthrottle/client-core/api/client";
+import { directorPort } from "@devthrottle/client-core/fleet/directorEndpoint";
+import { durationLabel, useNow } from "@devthrottle/client-core/sessions/waiting";
 
 // The desktop Cockpit "New session" dialog (issue #1023, QA sweep epic #967). The React Cockpit had
 // no way to start a session; this is the dedicated picker dialog the roster rail's "+ New session"
@@ -74,6 +76,19 @@ function directorLabel(d: DirectorInfo): string {
   return d.directorId || "director";
 }
 
+// The Director to default-select: the NEWEST-started one (the freshest cc-director launch), which is
+// also how the newest slot wins when a machine runs several. startedAt is ISO 8601 UTC, so a lexical
+// max is chronological; a Director with no startedAt sorts oldest. Falls back to the first entry when
+// nothing carries a startedAt.
+function newestDirector(list: DirectorInfo[]): DirectorInfo | null {
+  if (list.length === 0) return null;
+  let best = list[0];
+  for (const d of list) {
+    if ((d.startedAt || "").localeCompare(best.startedAt || "") > 0) best = d;
+  }
+  return best;
+}
+
 function repoLabel(r: RepoInfo): string {
   if (r.name.trim()) return r.name.trim();
   const parts = r.path.replace(/[\\/]+$/, "").split(/[\\/]/).filter(Boolean);
@@ -117,19 +132,25 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
 
   const selectedAgent = agents?.find((a) => a.type === selectedAgentType) ?? null;
 
+  // A slow tick (30s) so each machine's "up <uptime>" subtitle stays roughly current while the dialog
+  // is open, without a per-second re-render this picker does not need.
+  const now = useNow(30000);
+
   // Guards against a stale repo/agent response landing after the user switched machines.
   const reposReqRef = useRef(0);
   const agentsReqRef = useRef(0);
 
-  // Step 1: load the machines once, default-selecting the most-recently-seen (directors[0]) so the
-  // repos and agents load immediately (desktop New Session parity).
+  // Step 1: load the machines once, default-selecting the NEWEST-started Director so the repos and
+  // agents load immediately (desktop New Session parity) and, when a machine runs several cc-director
+  // slots, the freshest one is picked.
   useEffect(() => {
     const controller = new AbortController();
     getDirectors(controller.signal)
       .then((list) => {
         setDirectors(list);
         setDirectorsError(null);
-        if (list.length > 0) setSelectedId(list[0].directorId);
+        const pick = newestDirector(list);
+        if (pick) setSelectedId(pick.directorId);
       })
       .catch((err) => {
         if (controller.signal.aborted) return;
@@ -273,23 +294,39 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
               <div className="newsess-status">No machines found on this Gateway.</div>
             )}
             {directors !== null && directors.length > 0 && (
-              <ul className="newsess-list">
-                {directors.map((d) => (
-                  <li key={d.directorId}>
-                    <button
-                      type="button"
-                      className={`newsess-pick${d.directorId === selectedId ? " sel" : ""}`}
-                      onClick={() => setSelectedId(d.directorId)}
-                    >
-                      <span className="newsess-pick-name">{directorLabel(d)}</span>
-                      {d.directorId === selectedId && (
-                        <span className="newsess-pick-check" aria-hidden="true">
-                          selected
+              <ul className="newsess-machines">
+                {directors.map((d) => {
+                  const port = directorPort(d.controlEndpoint);
+                  const uptime = durationLabel(d.startedAt, now);
+                  const version = d.version.trim();
+                  // The subtitle tells two same-named Directors apart: how long each has been up, and its
+                  // version. Either part is omitted when absent, never faked.
+                  const subtitle = [uptime ? `up ${uptime}` : "", version ? `v${version}` : ""]
+                    .filter((part) => part.length > 0)
+                    .join("   ");
+                  return (
+                    <li key={d.directorId}>
+                      <button
+                        type="button"
+                        className={`newsess-machine${d.directorId === selectedId ? " sel" : ""}`}
+                        onClick={() => setSelectedId(d.directorId)}
+                      >
+                        <span className="newsess-machine-top">
+                          <span className="newsess-machine-name">{directorLabel(d)}</span>
+                          {port && <span className="newsess-machine-port">:{port}</span>}
                         </span>
-                      )}
-                    </button>
-                  </li>
-                ))}
+                        <span className="newsess-machine-sub">
+                          <span className="newsess-machine-meta">{subtitle}</span>
+                          {d.directorId === selectedId && (
+                            <span className="newsess-machine-check" aria-hidden="true">
+                              selected
+                            </span>
+                          )}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
               </ul>
             )}
           </div>

--- a/apps/cockpit/src/sessions/SessionRoster.tsx
+++ b/apps/cockpit/src/sessions/SessionRoster.tsx
@@ -5,10 +5,11 @@ import {
   contextLine,
   dotColor,
   effectiveColor,
+  groupByDirector,
   inBucket,
-  inDesktopOrder,
   snoozeExpired,
 } from "@devthrottle/client-core/sessions/ordering";
+import { machinePortLabel } from "@devthrottle/client-core/fleet/directorEndpoint";
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
 import {
   reachabilityFor,
@@ -27,8 +28,10 @@ import { SessionMenu } from "./SessionMenu";
 //
 // Ordering rule (the session-rail ordering decision): manual "My order" is the DEFAULT - the stable
 // desktop order (the owning Director's drag-to-reorder SortOrder), so rows hold their slot and never
-// reshuffle on a color change. "Attention first" is an OPT-IN view that groups needs-you at the top
-// and on-hold at the bottom; it is never applied automatically.
+// reshuffle on a color change. In "My order" the sessions are grouped by their owning cc-director under
+// a "computer:port" header (the port tells apart several Directors on one machine), and each session's
+// facts get their own line so nothing truncates. "Attention first" is an OPT-IN view that groups
+// needs-you at the top and on-hold at the bottom, across every machine; it is never applied automatically.
 
 export type RosterView = "my-order" | "attention";
 
@@ -36,6 +39,9 @@ export interface SessionRosterProps {
   sessions: SessionDto[] | null;
   /** Per-Director reachability for the Online / Wobbly / Offline rendering (issue #1215). */
   directors: DirectorReachability[];
+  /** directorId -> Control API port, for the "computer:port" group headers. Empty until GET /directors
+   *  lands, or for a Director whose endpoint carries no port - the header then shows the bare machine. */
+  portByDirector: Map<string, string>;
   selectedId: string | undefined;
   view: RosterView;
   onView: (view: RosterView) => void;
@@ -44,7 +50,7 @@ export interface SessionRosterProps {
   onNewSession: () => void;
 }
 
-export function SessionRoster({ sessions, directors, selectedId, view, onView, error, onNewSession }: SessionRosterProps) {
+export function SessionRoster({ sessions, directors, portByDirector, selectedId, view, onView, error, onNewSession }: SessionRosterProps) {
   const total = sessions?.length ?? 0;
 
   return (
@@ -92,29 +98,56 @@ export function SessionRoster({ sessions, directors, selectedId, view, onView, e
       )}
 
       {sessions !== null && total > 0 && view === "my-order" && (
-        <ul className="roster-list">
-          {inDesktopOrder(sessions).map((s) => (
-            <RosterRow key={s.sessionId} session={s} directors={directors} selectedId={selectedId} />
+        <>
+          {groupByDirector(sessions, portByDirector).map((group) => (
+            <div className="roster-group" key={group.directorId || "(no-director)"}>
+              <div className="roster-group-head">
+                <span className="roster-group-name">
+                  {machinePortLabel(group.machineName, group.port) || "(unknown director)"}
+                </span>
+              </div>
+              <ul className="roster-list">
+                {group.sessions.map((s) => (
+                  <RosterRow
+                    key={s.sessionId}
+                    session={s}
+                    directors={directors}
+                    portByDirector={portByDirector}
+                    showMachine={false}
+                    selectedId={selectedId}
+                  />
+                ))}
+              </ul>
+            </div>
           ))}
-        </ul>
+        </>
       )}
 
       {sessions !== null && total > 0 && view === "attention" && (
-        <AttentionGroups sessions={sessions} directors={directors} selectedId={selectedId} />
+        <AttentionGroups
+          sessions={sessions}
+          directors={directors}
+          portByDirector={portByDirector}
+          selectedId={selectedId}
+        />
       )}
     </div>
   );
 }
 
 // Opt-in attention view: needs-you first, then active, then on-hold. Each bucket keeps its members in
-// desktop order (inBucket), so a session holds its slot within its bucket and does not reshuffle.
+// desktop order (inBucket), so a session holds its slot within its bucket and does not reshuffle. These
+// buckets mix machines, so - unlike the grouped "My order" view - each card still shows its own
+// "computer:port" line so you can see which cc-director a needs-you session lives on.
 function AttentionGroups({
   sessions,
   directors,
+  portByDirector,
   selectedId,
 }: {
   sessions: SessionDto[];
   directors: DirectorReachability[];
+  portByDirector: Map<string, string>;
   selectedId: string | undefined;
 }) {
   const needs = inBucket(sessions, "needsYou");
@@ -125,21 +158,21 @@ function AttentionGroups({
       {needs.length > 0 && (
         <Bucket title="Needs you" tone="needs" count={needs.length}>
           {needs.map((s) => (
-            <RosterRow key={`needs-${s.sessionId}`} session={s} directors={directors} selectedId={selectedId} />
+            <RosterRow key={`needs-${s.sessionId}`} session={s} directors={directors} portByDirector={portByDirector} showMachine selectedId={selectedId} />
           ))}
         </Bucket>
       )}
       {active.length > 0 && (
         <Bucket title="Active" count={active.length}>
           {active.map((s) => (
-            <RosterRow key={`active-${s.sessionId}`} session={s} directors={directors} selectedId={selectedId} />
+            <RosterRow key={`active-${s.sessionId}`} session={s} directors={directors} portByDirector={portByDirector} showMachine selectedId={selectedId} />
           ))}
         </Bucket>
       )}
       {held.length > 0 && (
         <Bucket title="Snoozed" tone="hold" count={held.length}>
           {held.map((s) => (
-            <RosterRow key={`hold-${s.sessionId}`} session={s} directors={directors} selectedId={selectedId} />
+            <RosterRow key={`hold-${s.sessionId}`} session={s} directors={directors} portByDirector={portByDirector} showMachine selectedId={selectedId} />
           ))}
         </Bucket>
       )}
@@ -171,10 +204,16 @@ function Bucket({
 function RosterRow({
   session,
   directors,
+  portByDirector,
+  showMachine,
   selectedId,
 }: {
   session: SessionDto;
   directors: DirectorReachability[];
+  portByDirector: Map<string, string>;
+  /** Show the "computer:port" line on the card. False in "My order" (the group header carries it); true
+   *  in the cross-machine Attention view, where each card needs to say which cc-director it lives on. */
+  showMachine: boolean;
   selectedId: string | undefined;
 }) {
   const sid = session.sessionId ?? "";
@@ -184,13 +223,24 @@ function RosterRow({
   const name = session.name && session.name.trim().length > 0 ? session.name : session.repoPath || "(unnamed session)";
   const num = session.number;
   const hasNum = num !== null && num !== undefined && String(num).trim().length > 0;
-  const machine = (session.machineName ?? "").trim();
+  const directorId = (session.directorId ?? "").trim();
+  const machineLine = showMachine
+    ? machinePortLabel((session.machineName ?? "").trim(), portByDirector.get(directorId) ?? "")
+    : "";
   // The owning Director's reachability (issue #1215): a Wobbly/Offline Director dims its sessions in
   // place and shows a "last seen" age; an Online (or unknown) Director renders normally.
   const reach = reachabilityFor(directors, session.directorId);
   const wobbly = reach?.state === REACHABILITY_WOBBLY;
   const offline = reach?.state === REACHABILITY_OFFLINE;
   const lastSeen = wobbly || offline ? reachabilityLastSeen(reach?.lastSeenAgeSeconds) : "";
+  // The tag row (voice / snoozed / snooze-ended / last-seen / waiting) renders only when it has
+  // something to say, so a plain working session stays a compact two lines (name + state).
+  const hasTags =
+    !!session.onHold ||
+    snoozeExpired(session) ||
+    !!session.voiceMode ||
+    lastSeen.length > 0 ||
+    (attention && !!session.needsYouSince);
   return (
     <li className="roster-li">
       <Link
@@ -201,19 +251,30 @@ function RosterRow({
       >
         <span className="roster-dot" style={{ backgroundColor: dotColor(color) }} aria-hidden="true" />
         <span className="roster-body">
+          {/* Line 1: the session number badge + the full name (wraps freely, no clamp). */}
           <span className="roster-name">
             {hasNum && <span className="num-badge">{num}</span>}
             <span className="roster-name-text">{name}</span>
           </span>
-          <span className="roster-meta">
-            <span className="roster-state">{contextLine(session)}</span>
-            {session.onHold && <span className="roster-tag">snoozed</span>}
-            {snoozeExpired(session) && <span className="roster-tag snooze-ended">Snooze ended</span>}
-            {session.voiceMode && <span className="roster-tag voice">voice</span>}
-            {machine && <span className="roster-machine" title={session.directorId ?? undefined}>{machine}</span>}
-            {lastSeen && <span className="roster-lastseen">{lastSeen}</span>}
-            {attention && session.needsYouSince && <WaitingTime since={String(session.needsYouSince)} />}
-          </span>
+          {/* Line 2: the Gateway-stamped status, on its own line so it is never squeezed to "Wor...". */}
+          <span className="roster-state">{contextLine(session)}</span>
+          {/* Line 3 (Attention view only): which cc-director this session lives on. */}
+          {machineLine && (
+            <span className="roster-machine" title={session.directorId ?? undefined}>
+              {machineLine}
+            </span>
+          )}
+          {/* Line 4 (only when there is something to show): the tags and the live waiting timer. */}
+          {hasTags && (
+            <span className="roster-tags">
+              {session.voiceMode && <span className="roster-tag voice">voice</span>}
+              {session.onHold && <span className="roster-tag">snoozed</span>}
+              {snoozeExpired(session) && <span className="roster-tag snooze-ended">Snooze ended</span>}
+              {lastSeen && <span className="roster-lastseen">{lastSeen}</span>}
+              {attention && session.needsYouSince && <WaitingTime since={String(session.needsYouSince)} />}
+            </span>
+          )}
+          {/* The attention narration line, when present. */}
           {attention && session.railLine && session.railLine.trim().length > 0 && (
             <span className="roster-railline">{session.railLine}</span>
           )}

--- a/apps/cockpit/src/sessions/SessionsView.tsx
+++ b/apps/cockpit/src/sessions/SessionsView.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Outlet, useMatch, useNavigate } from "react-router-dom";
-import { type SessionDto } from "@devthrottle/client-core/api/client";
+import { getDirectors, type SessionDto } from "@devthrottle/client-core/api/client";
 import { type DirectorReachability } from "@devthrottle/client-core/fleet/fleetClient";
+import { directorPort } from "@devthrottle/client-core/fleet/directorEndpoint";
 import { useSharedRoster } from "@devthrottle/client-core/fleet/rosterStore";
 import { inBucket } from "@devthrottle/client-core/sessions/ordering";
 import { reconcileBadge } from "@devthrottle/client-core/push/register";
@@ -42,6 +43,31 @@ export function SessionsView() {
   const [view, setView] = useState<RosterView>(initialView);
   const [showNew, setShowNew] = useState(false);
   const navigate = useNavigate();
+
+  // The roster's per-Director reachability (from GET /sessions?envelope=true) carries the machine name
+  // but NOT the Control API port, and the port is what tells apart several cc-directors on one machine.
+  // So we read GET /directors here (which carries controlEndpoint) and hand the roster a directorId ->
+  // port map for its "computer:port" group headers. Refetched whenever the set of live Directors
+  // changes (a new slot/machine appears), not on every roster tick.
+  const [portByDirector, setPortByDirector] = useState<Map<string, string>>(new Map());
+  const directorKey = useMemo(
+    () => directors.map((d) => d.directorId).sort().join("|"),
+    [directors],
+  );
+  useEffect(() => {
+    const controller = new AbortController();
+    getDirectors(controller.signal)
+      .then((list) => {
+        const map = new Map<string, string>();
+        for (const d of list) map.set(d.directorId, directorPort(d.controlEndpoint));
+        setPortByDirector(map);
+      })
+      .catch(() => {
+        // A failed /directors read just means the headers fall back to the bare machine name; the
+        // roster itself still renders from the reachability it already has.
+      });
+    return () => controller.abort();
+  }, [directorKey]);
 
   // The selected session id comes from the child route (/session/:sessionId). This layout route is an
   // ancestor of that route, so it reads the id with useMatch rather than useParams (which only exposes
@@ -86,6 +112,7 @@ export function SessionsView() {
       <SessionRoster
         sessions={sessions}
         directors={directors}
+        portByDirector={portByDirector}
         selectedId={selectedId}
         view={view}
         onView={onView}

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -265,7 +265,9 @@ body {
   height: calc(100% + 48px);
   min-height: 0;
   display: grid;
-  grid-template-columns: 264px 1fr;
+  /* Wider rail (was 264px): the roster now stacks each session's facts onto their own line, so it needs
+     the room to show a full name, status, and computer:port without truncating to "Wor..." / "SORE...". */
+  grid-template-columns: 340px 1fr;
 }
 
 /* ---- the roster rail (left) ---- */
@@ -359,7 +361,9 @@ body {
 }
 
 .newsess-modal {
-  width: 480px;
+  /* Wider (was 480px) so it reads like the desktop New Session dialog: the machine picker lays out
+     2-up and the repo paths get room to breathe. */
+  width: 680px;
   max-width: 92vw;
   max-height: 88vh;
   background: var(--surface);
@@ -418,6 +422,87 @@ body {
   gap: 3px;
   max-height: 200px;
   overflow-y: auto;
+}
+
+/* The machine picker: a 2-up grid of cards (each cc-director), so several Directors do not stack into a
+   tall thin column and same-named machines sit side by side to compare. */
+.newsess-machines {
+  list-style: none;
+  margin: 0 0 4px;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.newsess-machine {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: left;
+  padding: 9px 11px;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.newsess-machine:hover {
+  border-color: var(--accent);
+}
+
+.newsess-machine.sel {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+/* Top line: machine name + its Control API port (the disambiguator). */
+.newsess-machine-top {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.newsess-machine-name {
+  font-size: 13px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.newsess-machine-port {
+  flex: 0 0 auto;
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+/* Subtitle: uptime + version on the left, the "selected" marker on the right. */
+.newsess-machine-sub {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.newsess-machine-meta {
+  font-size: 11.5px;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.newsess-machine-check {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--accent);
 }
 
 .newsess-pick {
@@ -687,17 +772,11 @@ body {
   line-height: 1.35;
 }
 
-/* Reserve EXACTLY two lines for the title so every card is the same height regardless of title length;
-   a longer title wraps onto the second line and then clips with an ellipsis (issue #1211). */
+/* The name wraps freely to as many lines as it needs - the whole point of the roomier rail is that a
+   long session name reads in full instead of clipping. (The old 2-line -webkit-line-clamp is gone.) */
 .roster-name-text {
   flex: 1 1 auto;
   min-width: 0;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  overflow: hidden;
-  min-height: calc(2 * 1.35em);
   word-break: break-word;
 }
 
@@ -716,25 +795,24 @@ body {
   padding: 0 5px;
 }
 
-/* One line, clipped - so the meta never wraps to a second row and cards keep a uniform height. */
-.roster-meta {
+/* The tag row (voice / snoozed / snooze-ended / last-seen / waiting): small chips on their own line so
+   they never fight the status for space. It may wrap if several are present rather than clip. */
+.roster-tags {
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   align-items: center;
   gap: 6px;
   font-size: 11.5px;
   color: var(--text-dim);
-  overflow: hidden;
 }
 
-/* The state fills the meta line and, being the primary signal, keeps priority: it truncates only after
-   the machine name yields (the machine has the higher shrink priority below). */
+/* The Gateway-stamped status on its own line, shown in FULL - it wraps rather than truncating, so it
+   never reads as "Wor..." again. */
 .roster-state {
-  flex: 1 1 auto;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  font-size: 11.5px;
+  color: var(--text-dim);
+  word-break: break-word;
 }
 
 .roster-tag {
@@ -757,16 +835,46 @@ body {
   color: #d99120;
 }
 
-/* The machine name yields FIRST when the meta line is tight (it truncates before the state does). */
+/* The "computer:port" line on a card (Attention view only - in My order the group header carries it).
+   Its own line, shown in full so a long machine name never clips. */
 .roster-machine {
-  flex: 0 1 auto;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   color: var(--text-dim);
   font-family: "Cascadia Mono", Consolas, Menlo, monospace;
   font-size: 10.5px;
+  word-break: break-word;
+}
+
+/* ---- the "computer:port" group (My order view) ---- */
+/* Each cc-director's sessions sit under one header. A little top margin sets the groups apart; the
+   first group hugs the toggle above it. */
+.roster-group + .roster-group {
+  margin-top: 10px;
+}
+
+.roster-group-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 4px 4px;
+}
+
+/* The header text: COMPUTER:PORT, mono so the port reads as an address, with a rule trailing off to the
+   right to bracket the group. */
+.roster-group-name {
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.roster-group-head::after {
+  content: "";
+  flex: 1 1 auto;
+  height: 1px;
+  background: var(--border);
 }
 
 .roster-waiting {

--- a/packages/client-core/src/fleet/directorEndpoint.test.ts
+++ b/packages/client-core/src/fleet/directorEndpoint.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { directorPort, machinePortLabel } from "./directorEndpoint";
+
+describe("directorPort", () => {
+  it("reads the port from a loopback Control API endpoint", () => {
+    expect(directorPort("http://127.0.0.1:7880")).toBe("7880");
+  });
+
+  it("reads the port when the endpoint has a trailing slash", () => {
+    expect(directorPort("http://127.0.0.1:7885/")).toBe("7885");
+  });
+
+  it("reads the port from an https tailnet endpoint", () => {
+    expect(directorPort("https://host.tailnet.ts.net:7880")).toBe("7880");
+  });
+
+  it("returns empty for an endpoint carrying no explicit port", () => {
+    expect(directorPort("https://host.tailnet.ts.net")).toBe("");
+  });
+
+  it("returns empty for an empty or nullish endpoint", () => {
+    expect(directorPort("")).toBe("");
+    expect(directorPort(null)).toBe("");
+    expect(directorPort(undefined)).toBe("");
+  });
+
+  it("does not mistake the scheme colon for a port", () => {
+    expect(directorPort("http://localhost")).toBe("");
+  });
+});
+
+describe("machinePortLabel", () => {
+  it("joins machine and port with a colon", () => {
+    expect(machinePortLabel("SOREN_NORTH", "7880")).toBe("SOREN_NORTH:7880");
+  });
+
+  it("shows the bare machine name when the port is unknown", () => {
+    expect(machinePortLabel("SOREN_NORTH", "")).toBe("SOREN_NORTH");
+  });
+
+  it("shows just the port when the machine name is missing", () => {
+    expect(machinePortLabel("", "7880")).toBe(":7880");
+  });
+});

--- a/packages/client-core/src/fleet/directorEndpoint.ts
+++ b/packages/client-core/src/fleet/directorEndpoint.ts
@@ -1,0 +1,26 @@
+// A cc-director is identified to the user by its machine name AND its Control API port - the port is
+// what tells apart several Directors (slots) running on the SAME machine (e.g. two "SOREN_NORTH"
+// entries). Both the roster's computer:port group headers and the New-session machine picker read the
+// port out of the Director's controlEndpoint with this one helper, so they agree on how a port is
+// derived from an endpoint like "http://127.0.0.1:7880" or "https://host.tailnet.ts.net:7880/".
+
+// The port segment of a Director controlEndpoint, or "" when the endpoint carries none (an unusual
+// default-port endpoint) or is empty. A pure string parse - no URL constructor, so it never throws on
+// a partial/odd endpoint; it matches a trailing ":<digits>" that ends the authority (end of string or
+// before the path slash), which is exactly the Control API endpoint shape the Gateway advertises.
+export function directorPort(controlEndpoint: string | null | undefined): string {
+  const raw = (controlEndpoint ?? "").trim();
+  if (raw.length === 0) return "";
+  const match = raw.match(/:(\d{2,5})(?=\/|$)/);
+  return match ? match[1] : "";
+}
+
+// The human "computer:port" label for a Director - the roster group header and any compact Director
+// reference. Falls back to the bare machine name only when the port is genuinely unknown (the endpoint
+// carried none), never inventing one.
+export function machinePortLabel(machineName: string, port: string): string {
+  const name = (machineName ?? "").trim();
+  const p = (port ?? "").trim();
+  if (name.length === 0) return p.length > 0 ? `:${p}` : "";
+  return p.length > 0 ? `${name}:${p}` : name;
+}

--- a/packages/client-core/src/sessions/ordering.test.ts
+++ b/packages/client-core/src/sessions/ordering.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { SessionDto } from "../api/client";
-import { classify, contextLine, dotColor, effectiveColor, inBucket, inWaitingOrder, isWorking, stateLabel } from "./ordering";
+import { classify, contextLine, dotColor, effectiveColor, groupByDirector, inBucket, inWaitingOrder, isWorking, stateLabel } from "./ordering";
 
 function session(fields: Partial<SessionDto> & { sessionId?: string } = {}): SessionDto {
   return {
@@ -167,5 +167,52 @@ describe("needs-you waiting-line order", () => {
     ];
 
     expect(inWaitingOrder(sessions).map((s) => s.sessionId)).toEqual(["has-stamp", "no-stamp"]);
+  });
+});
+
+describe("groupByDirector", () => {
+  it("groups sessions by their owning Director and labels each with its port", () => {
+    const sessions = [
+      session({ sessionId: "a", directorId: "d1", machineName: "SOREN_NORTH", sortOrder: 1 }),
+      session({ sessionId: "b", directorId: "d2", machineName: "Sorens-Mac-mini", sortOrder: 0 }),
+      session({ sessionId: "c", directorId: "d1", machineName: "SOREN_NORTH", sortOrder: 0 }),
+    ];
+    const ports = new Map([
+      ["d1", "7880"],
+      ["d2", "7880"],
+    ]);
+
+    const groups = groupByDirector(sessions, ports);
+
+    expect(groups.map((g) => `${g.machineName}:${g.port}`)).toEqual([
+      "SOREN_NORTH:7880",
+      "Sorens-Mac-mini:7880",
+    ]);
+    // Within the first Director, sessions come back in desktop (sortOrder) order.
+    expect(groups[0].sessions.map((s) => s.sessionId)).toEqual(["c", "a"]);
+  });
+
+  it("keeps two Directors on the same machine as separate groups, ordered by port", () => {
+    const sessions = [
+      session({ sessionId: "a", directorId: "hi", machineName: "SOREN_NORTH" }),
+      session({ sessionId: "b", directorId: "lo", machineName: "SOREN_NORTH" }),
+    ];
+    const ports = new Map([
+      ["hi", "7885"],
+      ["lo", "7880"],
+    ]);
+
+    const groups = groupByDirector(sessions, ports);
+
+    expect(groups.map((g) => g.port)).toEqual(["7880", "7885"]);
+  });
+
+  it("degrades to the bare machine name when the port is unknown", () => {
+    const sessions = [session({ sessionId: "a", directorId: "d1", machineName: "SOREN_NORTH" })];
+
+    const groups = groupByDirector(sessions, new Map());
+
+    expect(groups[0].port).toBe("");
+    expect(groups[0].machineName).toBe("SOREN_NORTH");
   });
 });

--- a/packages/client-core/src/sessions/ordering.ts
+++ b/packages/client-core/src/sessions/ordering.ts
@@ -26,6 +26,58 @@ export function inDesktopOrder(sessions: SessionDto[]): SessionDto[] {
   });
 }
 
+// One cc-director's group in the roster's "My order" view: the sessions of a single Director, under a
+// "computer:port" header. sortOrder is the OWNING Director's per-Director drag order, so it only orders
+// sessions WITHIN a Director - which is exactly why the roster groups by Director and sorts each group
+// by inDesktopOrder, rather than trying to interleave sortOrders that mean different things on different
+// machines.
+export interface DirectorGroup {
+  /** The owning Director's id - the group key, unique per running cc-director. */
+  directorId: string;
+  /** The machine the Director runs on (from the sessions' machineName), for the header. */
+  machineName: string;
+  /** The Director's Control API port, or "" when unknown - the header's disambiguator. */
+  port: string;
+  /** This Director's sessions, in desktop (drag) order. */
+  sessions: SessionDto[];
+}
+
+// Group sessions into their owning cc-director, ordered for the roster's "My order" view: each group's
+// sessions are in desktop order, and the groups themselves are ordered by machine name then port so the
+// list is stable (sortOrder cannot order ACROSS Directors, since it is per-Director). `portByDirector`
+// maps a directorId to its Control API port (from GET /directors); a missing entry yields an empty port
+// and the header degrades to the bare machine name.
+export function groupByDirector(
+  sessions: SessionDto[],
+  portByDirector: Map<string, string>,
+): DirectorGroup[] {
+  const byDirector = new Map<string, DirectorGroup>();
+  for (const s of sessions) {
+    const directorId = (s.directorId ?? "").trim();
+    // A session with no directorId cannot be attributed to a cc-director; bucket it under a stable empty
+    // key so it still shows (rather than vanishing) instead of guessing an owner.
+    const group = byDirector.get(directorId);
+    if (group) {
+      group.sessions.push(s);
+    } else {
+      byDirector.set(directorId, {
+        directorId,
+        machineName: (s.machineName ?? "").trim(),
+        port: portByDirector.get(directorId) ?? "",
+        sessions: [s],
+      });
+    }
+  }
+  const groups = [...byDirector.values()];
+  for (const g of groups) g.sessions = inDesktopOrder(g.sessions);
+  groups.sort((a, b) => {
+    const byMachine = a.machineName.localeCompare(b.machineName);
+    if (byMachine !== 0) return byMachine;
+    return a.port.localeCompare(b.port, undefined, { numeric: true });
+  });
+  return groups;
+}
+
 // The ONE rule for reading a Gateway-stamped presentation field: it is there, or we fail loudly. A
 // client that cannot get a stamped answer must never guess one - a guessed colour is indistinguishable
 // from a real one on screen, so it does not degrade gracefully, it lies quietly.


### PR DESCRIPTION
## Why

Two readability problems reported on the desktop Cockpit:

1. The session rail packed each session's status, machine name, and timer onto one overflow-hidden line inside a 264px column, so the text truncated to "Wor..." / "SORE...", and there was no way to see which computer or cc-director a session belonged to.
2. The new-session dialog was a narrow 480px column that showed only machine names, so two directors on the same machine (same name) were indistinguishable.

## What changed

**Session rail**
- "My order" is now grouped by the owning cc-director under a `computer:port` header. The port is what tells apart several directors (slots) on one machine.
- Rail widened 264px -> 340px.
- Each session's facts get their own line (name / status / tags + waiting), so nothing truncates. The machine name moved off every card into the group header.
- "Attention first" keeps its cross-machine triage buckets, with the same roomier cards and a `computer:port` line per card.

**New-session dialog**
- Widened 480px -> 680px.
- Machines laid out two-up, each showing name : port plus `up <uptime>  v<version>`.
- Default-selects the newest-started director.

**Plumbing**
- The rail reads `GET /directors` to map each director to its Control API port. No Gateway change.
- New pure helpers `directorPort` / `machinePortLabel` and `groupByDirector`, each unit-tested.

## Verification
- Typecheck clean on all three workspaces.
- Cockpit production build passes.
- 538/538 client-core tests pass (12 new).