### PR TITLE
Run the Gateway headless on Linux and macOS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Keep the Docker build context lean and deterministic. None of these are needed to publish the
+# headless Gateway; excluding them speeds the build and avoids copying host-only build output.
+.git
+.temp
+**/bin
+**/obj
+**/node_modules
+local_builds
+**/*.user
+**/TestResults
+artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# Headless Linux container image for the DevThrottle Gateway.
+#
+# This ships the cross-platform Gateway host (src/CcDirector.Gateway), NOT the Windows tray skin
+# (src/CcDirector.GatewayApp, which is net10.0-windows). The Gateway library is already net10.0 and
+# framework-dependent; the tray is the only Windows-pinned project, and the container has no tray.
+#
+# The entry point is the headless host (src/CcDirector.Gateway/Program.cs -> GatewayWorker), the same
+# no-user-interface process the dev console loop uses: it constructs GatewayService with the managed
+# self-update loop and autostart both off, which is exactly what a container wants (the container
+# runtime keeps the process alive; there is no start-on-login and no self-update swap).
+#
+# The cockpit and mobile React apps are deliberately NOT built into this image (the npm build targets
+# are skipped with the three Run*=false properties below). Those static assets are not needed to prove
+# the warm brain spawns a Unix-pseudo-terminal agent, and the React build is already cross-platform, so
+# skipping it hides no port risk. A full-asset image is a later concern.
+
+# ---- build stage -------------------------------------------------------------------------------
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Copy the whole repository; `dotnet publish` on the Gateway csproj restores only the projects it
+# transitively references, so the unrelated trees are ignored by the build (and pruned by .dockerignore).
+COPY . .
+
+# Framework-dependent publish for linux-x64. The three Run*=false properties skip the npm-driven
+# mobile build, cockpit build, and workspace typecheck, so the build stage needs no Node.js at all.
+RUN dotnet publish src/CcDirector.Gateway/CcDirector.Gateway.csproj \
+    -c Release -r linux-x64 --no-self-contained \
+    -p:RunMobileBuild=false -p:RunCockpitBuild=false -p:RunWorkspaceTypecheck=false \
+    -o /app/publish --nologo
+
+# ---- runtime stage -----------------------------------------------------------------------------
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+
+# The warm brain spawns a coding-agent command-line tool through a Unix pseudo-terminal. Install
+# Node.js and the agent CLI so `POST /gateway/brain/restart` can actually spawn the agent process on
+# Linux. Authentication for that agent is supplied at run time (an environment variable or a mounted
+# credential) and is recorded in the QA document - never a silent fallback.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g @anthropic-ai/claude-code \
+    && apt-get purge -y gnupg \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /app/publish ./
+
+# Run as a non-root user. This is standard container hardening, and it is also required for the warm
+# brain: the coding-agent command-line tool refuses to run with the skip-permissions flag under
+# root/sudo, so the agent can only spawn as a normal user. HOME is set explicitly so the Gateway's
+# local storage and the agent's own config land under the user's home directory.
+RUN useradd --create-home --shell /bin/bash gateway
+ENV HOME=/home/gateway
+# Pin the Gateway's local storage to a writable path under the user's home. CcStorage honors
+# CC_DIRECTOR_ROOT as its base directory; without it the base resolves relative to the read-only
+# /app working directory and the non-root user cannot create it.
+ENV CC_DIRECTOR_ROOT=/home/gateway/cc-director
+USER gateway
+
+# The Gateway binds to loopback (127.0.0.1:7878) by design - it is reached over the tunnel, not a public
+# port. Exercise it from inside the container (docker exec ... curl 127.0.0.1:7878/...); this EXPOSE is
+# documentation of the internal port, not a public bind.
+EXPOSE 7878
+
+ENTRYPOINT ["dotnet", "CcDirector.Gateway.dll", "--port", "7878"]

--- a/src/CcDirector.Core.Tests/Account/MacKeychainProtectedTokenStoreTests.cs
+++ b/src/CcDirector.Core.Tests/Account/MacKeychainProtectedTokenStoreTests.cs
@@ -1,0 +1,96 @@
+using System.Runtime.Versioning;
+using CcDirector.Core.Account;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Account;
+
+/// <summary>
+/// Tests the macOS login Keychain credential store, the counterpart of the Windows Data Protection
+/// store. macOS-only - it shells out to the <c>security</c> tool against a real Keychain - so these
+/// facts no-op on other platforms (guarded by the OnMac check) and the class is annotated
+/// [SupportedOSPlatform("macos")] so the platform-compatibility analyzer is satisfied. Each test uses
+/// unique service and account labels so it never touches the real machine-wide Gateway item, and
+/// clears them at the end.
+/// </summary>
+[SupportedOSPlatform("macos")]
+public sealed class MacKeychainProtectedTokenStoreTests
+{
+    private static bool OnMac => OperatingSystem.IsMacOS();
+
+    private static (string service, string account) UniqueLabels() =>
+        ("com.devthrottle.test." + Guid.NewGuid().ToString("N"), "tokens");
+
+    [Fact]
+    public void SaveThenLoad_RoundTripsTheTokenPair()
+    {
+        if (!OnMac) return;
+
+        var (service, account) = UniqueLabels();
+        var store = new MacKeychainProtectedTokenStore(service, account);
+        try
+        {
+            store.Save(new DevThrottleTokens("access-abc", "refresh-xyz"));
+
+            Assert.True(store.HasTokens);
+            var loaded = store.Load();
+            Assert.NotNull(loaded);
+            Assert.Equal("access-abc", loaded!.AccessToken);
+            Assert.Equal("refresh-xyz", loaded.RefreshToken);
+        }
+        finally
+        {
+            store.Clear();
+        }
+    }
+
+    [Fact]
+    public void Save_ReplacesAnExistingEntry()
+    {
+        if (!OnMac) return;
+
+        var (service, account) = UniqueLabels();
+        var store = new MacKeychainProtectedTokenStore(service, account);
+        try
+        {
+            store.Save(new DevThrottleTokens("first-access", "first-refresh"));
+            store.Save(new DevThrottleTokens("second-access", "second-refresh"));
+
+            var loaded = store.Load();
+            Assert.NotNull(loaded);
+            Assert.Equal("second-access", loaded!.AccessToken);
+            Assert.Equal("second-refresh", loaded.RefreshToken);
+        }
+        finally
+        {
+            store.Clear();
+        }
+    }
+
+    [Fact]
+    public void Clear_RemovesTheStoredEntry()
+    {
+        if (!OnMac) return;
+
+        var (service, account) = UniqueLabels();
+        var store = new MacKeychainProtectedTokenStore(service, account);
+        store.Save(new DevThrottleTokens("access", "refresh"));
+        Assert.True(store.HasTokens);
+
+        store.Clear();
+
+        Assert.False(store.HasTokens);
+        Assert.Null(store.Load());
+    }
+
+    [Fact]
+    public void Load_ReturnsNull_WhenNothingStored()
+    {
+        if (!OnMac) return;
+
+        var (service, account) = UniqueLabels();
+        var store = new MacKeychainProtectedTokenStore(service, account);
+
+        Assert.Null(store.Load());
+        Assert.False(store.HasTokens);
+    }
+}

--- a/src/CcDirector.Core.Tests/Backends/PlatformSessionBackendTests.cs
+++ b/src/CcDirector.Core.Tests/Backends/PlatformSessionBackendTests.cs
@@ -1,0 +1,34 @@
+using CcDirector.Core.Backends;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Backends;
+
+/// <summary>
+/// The one place the pseudo-console backend is chosen for the current operating system. The Windows
+/// path must stay byte-for-byte what it was - a ConPty - and macOS and Linux must get the Unix
+/// pseudo-terminal instead of a Windows-only ConPty that would throw on first use. This test runs on
+/// every platform and asserts the branch for whichever one it runs on, so the Windows build proves
+/// ConPty and the macOS and Linux runs prove UnixPty.
+/// </summary>
+public sealed class PlatformSessionBackendTests
+{
+    [Fact]
+    public void CreateDefault_SelectsConPtyOnWindows_UnixPtyElsewhere()
+    {
+        using var backend = PlatformSessionBackend.CreateDefault();
+
+        if (OperatingSystem.IsWindows())
+            Assert.IsType<ConPtyBackend>(backend);
+        else
+            Assert.IsType<UnixPtyBackend>(backend);
+    }
+
+    [Fact]
+    public void CreateDefault_HonorsAnExplicitBufferSize()
+    {
+        // The buffer size must flow through the selection unchanged - the desktop Director passes its
+        // configured size, and collapsing the old two-arm switch into this factory must not drop it.
+        using var backend = PlatformSessionBackend.CreateDefault(64 * 1024);
+        Assert.NotNull(backend);
+    }
+}

--- a/src/CcDirector.Core.Tests/Configuration/BrainToolConfigEnsureHostableTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/BrainToolConfigEnsureHostableTests.cs
@@ -1,0 +1,33 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Configuration;
+
+/// <summary>
+/// The warm brain can only be hosted by a driver that satisfies the hosted-agent contract (a
+/// preassigned session id and transcript reads); today that is Claude Code alone. EnsureHostable is
+/// the up-front gate the Gateway host uses at construction, so a brain tool nobody can host fails
+/// loudly and early rather than silently deferring to a spawn-time failure.
+/// </summary>
+public sealed class BrainToolConfigEnsureHostableTests
+{
+    [Fact]
+    public void EnsureHostable_ClaudeCode_ReturnsIt()
+    {
+        Assert.Equal(AgentKind.ClaudeCode, BrainToolConfig.EnsureHostable(AgentKind.ClaudeCode));
+    }
+
+    [Theory]
+    [InlineData(AgentKind.Pi)]
+    [InlineData(AgentKind.Cursor)]
+    [InlineData(AgentKind.Codex)]
+    [InlineData(AgentKind.Copilot)]
+    [InlineData(AgentKind.Gemini)]
+    public void EnsureHostable_NonHostableTool_Throws(AgentKind tool)
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => BrainToolConfig.EnsureHostable(tool));
+        Assert.Contains("cannot be hosted", ex.Message);
+        Assert.Contains(tool.ToString(), ex.Message);
+    }
+}

--- a/src/CcDirector.Core.Tests/Drivers/ClaudeDriverResolveExecutableTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/ClaudeDriverResolveExecutableTests.cs
@@ -1,0 +1,46 @@
+using CcDirector.Core.Drivers;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Drivers;
+
+/// <summary>
+/// The Claude Code binary is claude.exe on Windows and plain "claude" on macOS and Linux. The Gateway
+/// resolves its agent through <see cref="ClaudeDriver.ResolveExecutable"/>, so this name must follow the
+/// platform - a hardcoded claude.exe left the warm brain unable to spawn its agent off Windows. This
+/// test drops a file named for the current platform on a temporary PATH and asserts the driver finds it.
+/// </summary>
+public sealed class ClaudeDriverResolveExecutableTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string? _savedPath;
+
+    public ClaudeDriverResolveExecutableTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "cc-claude-resolve-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _savedPath = Environment.GetEnvironmentVariable("PATH");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("PATH", _savedPath);
+        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void ResolveExecutable_FindsThePlatformBinaryOnPath()
+    {
+        // The Claude Code binary is claude.exe on Windows (resolved via PATHEXT) and plain "claude" on
+        // macOS and Linux (exact extensionless name) - the same rules Codex and Copilot resolve by.
+        var exeName = OperatingSystem.IsWindows() ? "claude.exe" : "claude";
+        var expected = Path.GetFullPath(Path.Combine(_tempDir, exeName));
+        File.WriteAllText(expected, "#!/bin/sh\n");
+        Environment.SetEnvironmentVariable("PATH", _tempDir);
+
+        var resolved = new ClaudeDriver().ResolveExecutable(configuredPath: null);
+
+        // Windows PATHEXT resolution returns the extension in PATHEXT's case (.EXE), so compare
+        // case-insensitively there; POSIX file names are case-sensitive, so compare exactly.
+        Assert.Equal(expected, resolved, ignoreCase: OperatingSystem.IsWindows());
+    }
+}

--- a/src/CcDirector.Core/Account/MacKeychainProtectedTokenStore.cs
+++ b/src/CcDirector.Core/Account/MacKeychainProtectedTokenStore.cs
@@ -1,0 +1,131 @@
+using System.Diagnostics;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// macOS implementation of the operating system credential store, backed by the login Keychain
+/// through the <c>security</c> command-line tool. The token pair is serialized to JSON and stored as
+/// a single generic-password item; the Keychain encrypts it at rest with the user's login key, so the
+/// raw token string never sits in plain text on disk and only the same macOS user can read it back.
+/// This is the macOS counterpart the <see cref="IProtectedTokenStore"/> summary named, standing beside
+/// the Windows Data Protection store; the two present the identical Save / Load / Clear contract.
+///
+/// Threat model note: the value is passed to <c>security add-generic-password -w</c> as a process
+/// argument. On macOS the argument vector of a process is visible only to the same user and to root -
+/// the same principals who can already read this user's Keychain - so this matches the Windows store's
+/// current-user protection scope rather than widening it.
+/// </summary>
+[SupportedOSPlatform("macos")]
+public sealed class MacKeychainProtectedTokenStore : IProtectedTokenStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>The default Keychain service label under which the token pair item is stored.</summary>
+    public const string DefaultService = "com.devthrottle.gateway.credential";
+
+    /// <summary>The default Keychain account label for the token pair item.</summary>
+    public const string DefaultAccount = "devthrottle-tokens";
+
+    private readonly string _service;
+    private readonly string _account;
+
+    /// <summary>
+    /// Creates the store. The default service and account labels address the one machine-wide Gateway
+    /// credential; tests pass unique labels so a round-trip never touches the real login item.
+    /// </summary>
+    public MacKeychainProtectedTokenStore(string? service = null, string? account = null)
+    {
+        _service = string.IsNullOrWhiteSpace(service) ? DefaultService : service;
+        _account = string.IsNullOrWhiteSpace(account) ? DefaultAccount : account;
+        FileLog.Write($"[MacKeychainProtectedTokenStore] ctor: service={_service}, account={_account}");
+    }
+
+    public bool HasTokens => Load() is not null;
+
+    public void Save(DevThrottleTokens tokens)
+    {
+        FileLog.Write("[MacKeychainProtectedTokenStore] Save: writing token pair to the login Keychain");
+
+        if (tokens is null)
+            throw new ArgumentNullException(nameof(tokens));
+        if (string.IsNullOrEmpty(tokens.AccessToken))
+            throw new ArgumentException("Access token is required", nameof(tokens));
+
+        var json = JsonSerializer.Serialize(tokens, JsonOptions);
+
+        // Replace semantics to match the Windows store's overwrite: remove any existing item first, then
+        // add the new one. delete on a missing item is not an error here (there is simply nothing to
+        // replace), which is why its exit code is not treated as a failure.
+        RunSecurity("delete-generic-password", "-s", _service, "-a", _account);
+
+        var (exit, _, stderr) = RunSecurity(
+            "add-generic-password", "-s", _service, "-a", _account, "-U", "-w", json);
+        if (exit != 0)
+            throw new InvalidOperationException(
+                $"security add-generic-password failed (exit {exit}): {stderr.Trim()}");
+
+        FileLog.Write("[MacKeychainProtectedTokenStore] Save: token pair stored in the Keychain");
+    }
+
+    public DevThrottleTokens? Load()
+    {
+        var (exit, stdout, _) = RunSecurity(
+            "find-generic-password", "-s", _service, "-a", _account, "-w");
+
+        // Exit 44 (errSecItemNotFound territory) or any non-zero means nothing is stored - the same
+        // "nothing to load" outcome the Windows store returns when the blob file is absent.
+        if (exit != 0)
+        {
+            FileLog.Write("[MacKeychainProtectedTokenStore] Load: no stored token pair");
+            return null;
+        }
+
+        var json = stdout.TrimEnd('\n', '\r');
+        try
+        {
+            var tokens = JsonSerializer.Deserialize<DevThrottleTokens>(json, JsonOptions);
+            FileLog.Write($"[MacKeychainProtectedTokenStore] Load: read token pair (hasTokens={tokens is not null})");
+            return tokens;
+        }
+        catch (JsonException)
+        {
+            // A stored value that will not parse is treated as "nothing usable", matching the Windows
+            // store's behavior when a blob cannot be decrypted. This is an explicit null, not a fallback.
+            FileLog.Write("[MacKeychainProtectedTokenStore] Load: stored value did not parse; treating as none");
+            return null;
+        }
+    }
+
+    public void Clear()
+    {
+        FileLog.Write("[MacKeychainProtectedTokenStore] Clear: removing token pair from the Keychain");
+        RunSecurity("delete-generic-password", "-s", _service, "-a", _account);
+    }
+
+    private static (int Exit, string StdOut, string StdErr) RunSecurity(params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "/usr/bin/security",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var a in args)
+            psi.ArgumentList.Add(a);
+
+        using var p = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start /usr/bin/security");
+        var stdout = p.StandardOutput.ReadToEnd();
+        var stderr = p.StandardError.ReadToEnd();
+        p.WaitForExit();
+        return (p.ExitCode, stdout, stderr);
+    }
+}

--- a/src/CcDirector.Core/Backends/PlatformSessionBackend.cs
+++ b/src/CcDirector.Core/Backends/PlatformSessionBackend.cs
@@ -1,0 +1,25 @@
+using System.Runtime.InteropServices;
+
+namespace CcDirector.Core.Backends;
+
+/// <summary>
+/// Selects the pseudo-console session backend for the current operating system: the Windows
+/// ConPty on Windows, the Unix pseudo-terminal on macOS and Linux. This is the ONE place that
+/// choice is made, so the shared library never hardcodes a Windows-only terminal on a host that
+/// has no ConPty (the warm brain and the wingman ask both used to default straight to
+/// <see cref="ConPtyBackend"/>, which throws on a non-Windows host).
+/// </summary>
+public static class PlatformSessionBackend
+{
+    /// <summary>The default backend buffer size, matching each backend's own default.</summary>
+    public const int DefaultBufferSizeBytes = 2 * 1024 * 1024;
+
+    /// <summary>
+    /// Create the pseudo-console backend for the current platform: <see cref="ConPtyBackend"/>
+    /// on Windows, <see cref="UnixPtyBackend"/> on macOS and Linux.
+    /// </summary>
+    public static ISessionBackend CreateDefault(int bufferSizeBytes = DefaultBufferSizeBytes) =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? new ConPtyBackend(bufferSizeBytes)
+            : new UnixPtyBackend(bufferSizeBytes);
+}

--- a/src/CcDirector.Core/Configuration/BrainToolConfig.cs
+++ b/src/CcDirector.Core/Configuration/BrainToolConfig.cs
@@ -51,6 +51,24 @@ public static class BrainToolConfig
     }
 
     /// <summary>
+    /// Returns <paramref name="tool"/> when it can be hosted as the warm brain, or throws a clear,
+    /// actionable error when it cannot. This is the up-front gate the Gateway host uses at construction
+    /// so a non-hostable configured brain tool fails loudly at startup, not silently later at the
+    /// brain's first spawn. No-fallback rule: a tool nobody can host is a configuration error to fix,
+    /// never a silent downgrade to the default.
+    /// </summary>
+    public static AgentKind EnsureHostable(AgentKind tool)
+    {
+        if (IsHostable(tool))
+            return tool;
+
+        throw new InvalidOperationException(
+            $"Brain tool '{tool}' cannot be hosted as the Gateway warm brain. " +
+            $"Hostable tools: {string.Join(", ", BrainHostableTools)}. " +
+            $"Set 'brain_tool' in config.json to a hostable tool (default \"{Default}\") or remove the key.");
+    }
+
+    /// <summary>
     /// Resolve the brain tool: config.json "brain_tool" when set, else <see cref="Default"/>.
     ///
     /// As of issue #510 the wingman agent is chosen from the machine's registered agents (any

--- a/src/CcDirector.Core/Drivers/ClaudeDriver.cs
+++ b/src/CcDirector.Core/Drivers/ClaudeDriver.cs
@@ -110,23 +110,20 @@ public sealed class ClaudeDriver : IAgentDriver
 
     public string ResolveExecutable(string? configuredPath)
     {
-        if (!string.IsNullOrWhiteSpace(configuredPath))
-        {
-            if (!File.Exists(configuredPath))
-                throw new FileNotFoundException(
-                    $"[ClaudeDriver] claude executable not found at the configured path: {configuredPath}");
-            return configuredPath;
-        }
+        // Resolve through the shared, platform-aware ExecutableResolver (the same helper Codex and
+        // Copilot use): on macOS and Linux it matches the extensionless "claude"; on Windows it applies
+        // PATHEXT to find claude.exe. This is what lets the warm brain spawn its agent off Windows - a
+        // hand-rolled claude.exe-only search could not. An explicit configured path is resolved directly.
+        var configured = string.IsNullOrWhiteSpace(configuredPath) ? "claude" : configuredPath.Trim();
+        var resolved = ExecutableResolver.Resolve(configured);
+        if (resolved is not null)
+            return resolved;
 
-        var pathVar = Environment.GetEnvironmentVariable("PATH") ?? "";
-        foreach (var dir in pathVar.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            var candidate = Path.Combine(dir.Trim(), "claude.exe");
-            if (File.Exists(candidate))
-                return candidate;
-        }
+        // Keep FileNotFoundException: HostedAgent.StartAsync catches exactly this type to report a
+        // clean "agent not installed" startup error.
         throw new FileNotFoundException(
-            "[ClaudeDriver] claude.exe not found on PATH. Install Claude Code or configure an explicit path.");
+            $"[ClaudeDriver] Could not resolve the Claude Code CLI from '{configured}'. " +
+            "Install Claude Code or configure an explicit path.");
     }
 
     public AgentLaunchSpec BuildLaunchSpec(string? baseArgs, string? resumeSessionId)

--- a/src/CcDirector.Core/Drivers/SessionAskRunner.cs
+++ b/src/CcDirector.Core/Drivers/SessionAskRunner.cs
@@ -73,7 +73,7 @@ public sealed class SessionAskRunner
         double replyStableSeconds = 1.5)
     {
         _driverFactory = driverFactory ?? AgentDrivers.For;
-        _backendFactory = backendFactory ?? (() => new ConPtyBackend());
+        _backendFactory = backendFactory ?? (() => PlatformSessionBackend.CreateDefault());
         _log = log ?? FileLog.Write;
         _quietSeconds = quietSeconds;
         _startTimeoutSeconds = startTimeoutSeconds;

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -455,11 +455,9 @@ public sealed class SessionManager : IDisposable
 
         ISessionBackend backend = backendType switch
         {
-            // ConPty on Windows, UnixPty on macOS/Linux
-            SessionBackendType.ConPty when RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                => new ConPtyBackend(_options.DefaultBufferSizeBytes),
+            // ConPty on Windows, UnixPty on macOS/Linux - one selection, in PlatformSessionBackend.
             SessionBackendType.ConPty
-                => new UnixPtyBackend(_options.DefaultBufferSizeBytes),
+                => PlatformSessionBackend.CreateDefault(_options.DefaultBufferSizeBytes),
             SessionBackendType.Pipe => new PipeBackend(_options.DefaultBufferSizeBytes),
             SessionBackendType.Studio => new StudioBackend(),
             SessionBackendType.Embedded when RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/src/CcDirector.Core/UnixPty/UnixNativeMethods.cs
+++ b/src/CcDirector.Core/UnixPty/UnixNativeMethods.cs
@@ -147,8 +147,16 @@ internal static class UnixNativeMethods
 
     public const int O_RDWR = 0x0002;
 
-    /// <summary>POSIX_SPAWN_SETSID: child becomes a new session leader (macOS 10.15+).</summary>
-    public const short POSIX_SPAWN_SETSID = 0x0400;
+    // POSIX_SPAWN_SETSID (child becomes a new session leader) has a DIFFERENT numeric value on each
+    // platform: 0x0400 on macOS (Darwin) and 0x0080 on Linux glibc. Passing the wrong platform's value
+    // to posix_spawnattr_setflags fails with EINVAL (rc=22), which is exactly what a macOS-only 0x0400
+    // did on Linux. Select the right one at run time.
+    public const short POSIX_SPAWN_SETSID_MACOS = 0x0400;
+    public const short POSIX_SPAWN_SETSID_LINUX = 0x0080;
+
+    /// <summary>POSIX_SPAWN_SETSID for the current platform (macOS 0x0400, Linux glibc 0x0080).</summary>
+    public static short POSIX_SPAWN_SETSID =>
+        OperatingSystem.IsMacOS() ? POSIX_SPAWN_SETSID_MACOS : POSIX_SPAWN_SETSID_LINUX;
 
     [DllImport(LibC, SetLastError = true)]
     public static extern int posix_spawnp(

--- a/src/CcDirector.Gateway.Tests/GatewayHostBrainToolGuardTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayHostBrainToolGuardTests.cs
@@ -1,0 +1,52 @@
+using System.Net.Sockets;
+using CcDirector.Core.Agents;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// A warm brain configured to a non-hostable agent tool must be rejected when the Gateway host is
+/// CONSTRUCTED - loudly and early - not silently deferred to the brain's first spawn where it would
+/// fail deep in StartAsync. The host validates the brain tool at the top of its constructor, before it
+/// opens any resource, so a bad brain tool throws from the constructor itself.
+/// </summary>
+public sealed class GatewayHostBrainToolGuardTests
+{
+    private string InstancesDir() => Path.Combine(Path.GetTempPath(), "cc-braintool-" + Guid.NewGuid().ToString("N"));
+
+    [Theory]
+    [InlineData(AgentKind.Pi)]
+    [InlineData(AgentKind.Cursor)]
+    [InlineData(AgentKind.Codex)]
+    [InlineData(AgentKind.Copilot)]
+    public void Construction_WithNonHostableBrainTool_ThrowsAtConstruction(AgentKind tool)
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => new GatewayHost(
+            port: FreePort(), token: "test-token", authEnabled: true,
+            instancesDirectory: InstancesDir(), brainTool: tool));
+        Assert.Contains("cannot be hosted", ex.Message);
+    }
+
+    [Fact]
+    public async Task Construction_WithClaudeCodeBrainTool_Succeeds()
+    {
+        var dir = InstancesDir();
+        await using var gateway = new GatewayHost(
+            port: FreePort(), token: "test-token", authEnabled: true,
+            instancesDirectory: dir, brainTool: AgentKind.ClaudeCode);
+
+        Assert.Equal(AgentKind.ClaudeCode, gateway.BrainTool);
+
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { }
+    }
+
+    private static int FreePort()
+    {
+        using var l = new TcpListener(System.Net.IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((System.Net.IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WindowsOnlyEndpointsGatingTests.cs
+++ b/src/CcDirector.Gateway.Tests/WindowsOnlyEndpointsGatingTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Two Gateway endpoints only make sense on a Windows dev or desktop machine and are gated off every
+/// other platform (the port to a headless Linux and macOS Gateway):
+///   - the whole /exes surface builds developer slot exes by shelling out to
+///     powershell.exe scripts/local-build-avalonia.ps1, which exists only on a Windows dev box;
+///   - POST /directors launches the Windows desktop cc-director.exe via ShellExecute.
+/// Off Windows these routes are simply not mapped. These facts assert the absence off Windows; they
+/// no-op on Windows, where the routes are present exactly as before (invoking them there has real
+/// side effects - launching processes - so this test never calls them on Windows). The macOS and
+/// Linux runs are where the absence is actually proven.
+/// </summary>
+public sealed class WindowsOnlyEndpointsGatingTests : IAsyncLifetime
+{
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-gate-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: FreePort(), token: "test-token", authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+        await _gateway.StartAsync();
+
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token");
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { }
+    }
+
+    [Fact]
+    public async Task ExesSurface_IsAbsentOffWindows()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        // /exes/list has no non-Windows mapping at all, so an unmapped path answers 404.
+        var resp = await _http.GetAsync("/exes/list");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task LaunchDirectorPost_IsAbsentOffWindows()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        // GET /directors still exists (the roster), so the gated-away POST answers 405 Method Not
+        // Allowed; a host that dropped the path entirely would answer 404. Either proves the launch
+        // action is unreachable off Windows - what it must never be is a 2xx that started a process.
+        var resp = await _http.PostAsync("/directors", content: null);
+        Assert.True(
+            resp.StatusCode is HttpStatusCode.MethodNotAllowed or HttpStatusCode.NotFound,
+            $"expected 405 or 404 for POST /directors off Windows, got {(int)resp.StatusCode}");
+    }
+
+    private static int FreePort()
+    {
+        using var l = new TcpListener(System.Net.IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/Account/GatewayAccountFactory.cs
+++ b/src/CcDirector.Gateway/Account/GatewayAccountFactory.cs
@@ -57,6 +57,23 @@ public static class GatewayAccountFactory
     }
 
     /// <summary>
+    /// Creates the Gateway-hosted credential service on macOS, using the login Keychain as the
+    /// credential store (through the <c>security</c> command-line tool). Same contract and same
+    /// environment seams as <see cref="CreateForWindows"/> - only the store binding differs, which is
+    /// the whole point of the shared <see cref="IProtectedTokenStore"/> interface.
+    /// </summary>
+    [SupportedOSPlatform("macos")]
+    public static DevThrottleAccountService CreateForMac()
+    {
+        FileLog.Write("[GatewayAccountFactory] CreateForMac: building the Gateway-hosted credential service");
+
+        var store = new MacKeychainProtectedTokenStore();
+        var service = Build(store, CcStorage.GatewayDevThrottleAuthEventsLog());
+        SeedTestCredentialIfRequested(service);
+        return service;
+    }
+
+    /// <summary>
     /// Creates the Gateway-hosted credential service over an explicit credential store and an explicit
     /// authentication-event log path. Used by tests (which supply an in-memory or temp-directory store)
     /// and by non-Windows hosts that supply their own <see cref="IProtectedTokenStore"/>. Does NOT seed

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -222,7 +222,11 @@ internal static class GatewayEndpoints
         // Local-machine exe/slot management (the "Exes" page). Defect 6: it gets the snooze registry so its
         // fleet pass applies the SAME expired-snooze override the roster applies - without it the page says
         // "Snoozed" while the roster says "Needs you".
-        ExesEndpoints.Map(app, registry, pushedSessions, streamStaleResolved, snoozeRegistry);
+        // Windows-only: the whole surface builds developer slot exes by shelling out to
+        // powershell.exe scripts/local-build-avalonia.ps1 against a local_builds directory, which
+        // exists only on a Windows dev box. Off Windows the routes are simply not mapped.
+        if (OperatingSystem.IsWindows())
+            ExesEndpoints.Map(app, registry, pushedSessions, streamStaleResolved, snoozeRegistry);
 
         // ===== HTML pages =====
         // The Gateway serves NO UI pages anymore (docs/plans/one-url-cockpit.md): "/" and every
@@ -2458,6 +2462,9 @@ internal static class GatewayEndpoints
             }
         });
 
+        // Windows-only: this launches the Windows desktop cc-director.exe via ShellExecute, which
+        // only exists on a Windows install. Off Windows the route is not mapped.
+        if (OperatingSystem.IsWindows())
         app.MapPost("/directors", async (LaunchDirectorRequest? body) =>
         {
             body ??= new LaunchDirectorRequest();

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -474,8 +474,15 @@ public sealed class GatewayHost : IAsyncDisposable
     /// Shared instances that write to the real user's directories). Production omits it and the host builds
     /// the service over its own key vault, exactly as before.
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null)
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null, Core.Agents.AgentKind? brainTool = null)
     {
+        // Resolve and VALIDATE the warm-brain tool up front, before any resource is opened: a brain tool
+        // that cannot be hosted is a configuration error that must fail loudly at construction, not
+        // silently later at the brain's first spawn. BrainToolConfig.Get reads config.json; a test passes
+        // brainTool directly. Only ClaudeCode is hostable today (the hosted-agent path needs a preassigned
+        // session id and transcript reads), so a non-hostable value throws here with the fix.
+        BrainTool = Core.Configuration.BrainToolConfig.EnsureHostable(brainTool ?? Core.Configuration.BrainToolConfig.Get());
+
         Port = port;
         Token = token ?? GatewayAuth.LoadOrCreate();
         Registry = new DirectorRegistry(instancesDirectory);
@@ -514,9 +521,8 @@ public sealed class GatewayHost : IAsyncDisposable
         // so it runs the configured tool + model deliberately instead of a hardcoded claude.exe
         // and the account-default model. Both default to claude + opus when unset, so existing
         // fleets are unchanged. A config change applies on the next Gateway restart.
-        BrainTool = BrainToolConfig.Get();
+        // BrainTool is resolved and validated hostable at the very top of this constructor.
         BrainModel = BrainModelConfig.Get();
-        var brainDriver = AgentDrivers.For(BrainTool);
         FileLog.Write($"[GatewayHost] brain tool: {BrainTool}, model: {BrainModel}");
         Brain = new BrainSupervisor(
             new HostedAgentOptions
@@ -525,11 +531,12 @@ public sealed class GatewayHost : IAsyncDisposable
                 AgentArgs = $"{ClaudeDriver.DefaultArgs} --model {BrainModel}",
                 Log = FileLog.Write,
             },
-            // Host the chosen agent through its own driver. As of issue #510 the wingman agent is
-            // chosen from the machine's registered agents (any AgentKind), since the driver-level
-            // hostability work landed in issue #509; BrainToolConfig.Get validates the configured
-            // name is a recognised AgentKind (default ClaudeCode).
-            agentFactory: o => new CcDirector.HostedAgent.HostedAgent(o, brainDriver));
+            // Construct the hosted brain through HostedAgent.For - the single guard for which agent kinds
+            // can be hosted headless (only ClaudeCode today). BrainTool is already validated hostable at
+            // the top of this constructor, so this never throws here; routing through For instead of
+            // newing a HostedAgent with an arbitrary registry driver keeps that guard the one and only
+            // path to a hosted brain, so a non-hostable tool can never slip through to fail at Start.
+            agentFactory: o => CcDirector.HostedAgent.HostedAgent.For(BrainTool, o));
         _turnBriefStore = new GatewayTurnBriefStore(turnBriefDirectory);
         // Production omits keyVaultPath for the shared default; tests pass an isolated path so
         // they never touch the real %LOCALAPPDATA% key store.

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -596,17 +596,21 @@ public sealed class GatewayHost : IAsyncDisposable
         _cronRuns = new CronRunHistoryStore(cronRunsPath ?? Path.Combine(CcStorage.Root(), "cronruns.json"));
         // The Gateway-hosted DevThrottle credential service (issue #636, Gateway Centralization Phase 2
         // foundation). Tests inject their own service over an isolated store; production builds the
-        // Windows Data Protection-backed service rooted under the Gateway config directory. The
-        // operating-system credential store is Windows-only for now (the issue's assumption), so on a
-        // non-Windows host Account stays null until the macOS Keychain store is added - the platform
-        // guard also satisfies the platform-compatibility analyzer. Resolved BEFORE the telemetry queue
-        // so the queue can attach the Gateway's own account token when forwarding (issue #639).
+        // service over the operating system credential store rooted under the Gateway config directory:
+        // Windows Data Protection on Windows, the login Keychain on macOS. Linux has no local credential
+        // store here (a headless container has no Keychain and no secret service), so on Linux Account
+        // stays null - an explicit, logged null, not a silent fallback; a local install keeps its data
+        // local and the hosted Supabase story owns Linux durable credentials later. The platform guards
+        // also satisfy the platform-compatibility analyzer. Resolved BEFORE the telemetry queue so the
+        // queue can attach the Gateway's own account token when forwarding (issue #639).
         if (account is not null)
             Account = account;
         else if (OperatingSystem.IsWindows())
             Account = CcDirector.Gateway.Account.GatewayAccountFactory.CreateForWindows();
+        else if (OperatingSystem.IsMacOS())
+            Account = CcDirector.Gateway.Account.GatewayAccountFactory.CreateForMac();
         else
-            FileLog.Write("[GatewayHost] DevThrottle credential service not built: operating-system credential store is Windows-only for now");
+            FileLog.Write("[GatewayHost] DevThrottle credential service not built: no local operating-system credential store on this platform (Linux); Account stays null");
 
         // Durable telemetry retry queue (issue #629): one JSON file under the Gateway config directory
         // (the DeviceRegistry / gateway-token precedent), loaded here so events a previous run left

--- a/src/CcDirector.HostedAgent.Tests/ClaudeDriverTests.cs
+++ b/src/CcDirector.HostedAgent.Tests/ClaudeDriverTests.cs
@@ -197,7 +197,11 @@ public class ClaudeDriverTests
     {
         var ex = Assert.Throws<FileNotFoundException>(
             () => new ClaudeDriver().ResolveExecutable(@"Q:\nope\claude.exe"));
-        Assert.Contains("not found", ex.Message);
+        // ClaudeDriver now resolves through the shared ExecutableResolver, so a missing configured path
+        // fails with the unified "could not resolve" message that names the path - still a
+        // FileNotFoundException, which HostedAgent.StartAsync catches.
+        Assert.Contains("Could not resolve", ex.Message);
+        Assert.Contains(@"Q:\nope\claude.exe", ex.Message);
     }
 
     [Fact]

--- a/src/CcDirector.HostedAgent.Tests/HostedAgentHeadlessDriverGuardTests.cs
+++ b/src/CcDirector.HostedAgent.Tests/HostedAgentHeadlessDriverGuardTests.cs
@@ -1,0 +1,35 @@
+using CcDirector.Core.Agents;
+using Xunit;
+
+namespace CcDirector.HostedAgent.Tests;
+
+/// <summary>
+/// The warm brain and every headless-hosted agent run through <see cref="HostedAgent"/>, which only
+/// accepts the Claude Code kind - <see cref="HostedAgent.For"/> throws for every other kind. That is
+/// what keeps the throw-only drivers (Cursor, Pi, and the generic driver), whose ResolveExecutable is
+/// deliberately not implemented for headless hosting, off the warm-brain path entirely: they can never
+/// be constructed there, so their unimplemented resolvers are unreachable. Only ClaudeDriver, routed
+/// through the shared platform-aware ExecutableResolver, resolves an agent on this path.
+/// </summary>
+public sealed class HostedAgentHeadlessDriverGuardTests
+{
+    private static HostedAgentOptions Options() => new() { WorkingDirectory = Path.GetTempPath() };
+
+    [Theory]
+    [InlineData(AgentKind.Cursor)]
+    [InlineData(AgentKind.Pi)]
+    [InlineData(AgentKind.Codex)]
+    [InlineData(AgentKind.Copilot)]
+    [InlineData(AgentKind.Gemini)]
+    public void For_NonClaudeKind_Throws_SoNoThrowDriverIsReachableHeadless(AgentKind kind)
+    {
+        Assert.Throws<NotSupportedException>(() => HostedAgent.For(kind, Options()));
+    }
+
+    [Fact]
+    public void For_ClaudeCode_IsTheOnlyHostedKind()
+    {
+        using var agent = HostedAgent.For(AgentKind.ClaudeCode, Options());
+        Assert.NotNull(agent);
+    }
+}

--- a/src/CcDirector.HostedAgent/HostedAgent.cs
+++ b/src/CcDirector.HostedAgent/HostedAgent.cs
@@ -52,7 +52,8 @@ public sealed class HostedAgent : IAgentBrain
 
     /// <summary>
     /// Create a hosted agent. The optional parameters are seams: driver defaults to
-    /// <see cref="ClaudeDriver"/>, backend to a real ConPty; tests substitute fakes.
+    /// <see cref="ClaudeDriver"/>, backend to the platform pseudo-console (ConPty on Windows,
+    /// UnixPty on macOS and Linux); tests substitute fakes.
     /// </summary>
     public HostedAgent(
         HostedAgentOptions options,
@@ -61,7 +62,7 @@ public sealed class HostedAgent : IAgentBrain
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _driver = driver ?? new ClaudeDriver();
-        _backendFactory = backendFactory ?? (() => new ConPtyBackend());
+        _backendFactory = backendFactory ?? (() => PlatformSessionBackend.CreateDefault());
         _log = options.Log ?? BrainLog.Write;
     }
 

--- a/tools/cc-director-setup-engine.Tests/GatewayUpdaterOffWindowsTests.cs
+++ b/tools/cc-director-setup-engine.Tests/GatewayUpdaterOffWindowsTests.cs
@@ -1,0 +1,42 @@
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// The Gateway self-update swap is a Windows-only operation (a File.Replace dance plus a detached
+/// helper exe). The managed update loop already only calls it when Managed and on Windows; this fact
+/// pins the belt-and-suspenders guard inside the updater itself, so no future caller can ever trigger
+/// a swap on macOS or Linux. It runs only off Windows (on Windows the method proceeds to the real
+/// staging path, which reaches the network); the macOS and Linux runs are where it executes.
+/// </summary>
+public sealed class GatewayUpdaterOffWindowsTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly InstallLayout _layout;
+
+    public GatewayUpdaterOffWindowsTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cc-gwoffwin-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _layout = new InstallLayout(Path.Combine(_dir, "local"));
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task CheckStageAndLaunch_IsNoOpOffWindows()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        // Off Windows the guard returns null before it reads the release or source arguments or touches
+        // the network, so passing nulls here is safe and deliberate - the point is that it never gets
+        // that far.
+        var updater = new GatewayUpdater(_layout);
+        var result = await updater.CheckStageAndLaunchAsync(release: null!, source: null!);
+        Assert.Null(result);
+    }
+}

--- a/tools/cc-director-setup-engine/GatewayUpdater.cs
+++ b/tools/cc-director-setup-engine/GatewayUpdater.cs
@@ -220,10 +220,25 @@ public sealed class GatewayUpdater
         return p;
     }
 
-    /// <summary>Convenience: if an update is available, stage it and launch the detached helper. Returns the staged version, or null.</summary>
-    [SupportedOSPlatform("windows")]
+    /// <summary>
+    /// Convenience: if an update is available, stage it and launch the detached helper. Returns the
+    /// staged version, or null. A no-op that returns null off Windows - the swap it drives is a
+    /// Windows-only operation, so the method is safe to call on any platform (it simply does nothing
+    /// off Windows) rather than being marked Windows-only and throwing at the call site.
+    /// </summary>
     public async Task<string?> CheckStageAndLaunchAsync(ResolvedRelease release, ReleaseSource source, CancellationToken ct = default)
     {
+        // Belt and suspenders: the Gateway self-update swap is a Windows-only operation (File.Replace
+        // dance, detached helper exe). The update loop already only calls this when Managed and on
+        // Windows; this guard makes the method itself a no-op off Windows so no future caller can
+        // ever trigger a swap on macOS or Linux. The analyzer reads this negated-guard-then-return as
+        // proof the Windows-only LaunchDetachedUpdater call below is reached only on Windows.
+        if (!OperatingSystem.IsWindows())
+        {
+            EngineLog.Write("[GatewayUpdater] CheckStageAndLaunchAsync is a no-op off Windows");
+            return null;
+        }
+
         var staged = await StageAsync(release, source, ct);
         if (staged is null) return null;
         LaunchDetachedUpdater(staged.Value.StagedPath, staged.Value.Version);


### PR DESCRIPTION
## Summary

Make the shared Gateway library run off Windows so it can build and run as a headless Linux container and on the Mac mini, without changing the Windows tray skin's behaviour. This is the first pull request of the Hosted Gateway work; the database interface and local-provider refactor are a separate, later change.

## Port items

- Terminal backend selection unified in one `PlatformSessionBackend` factory (ConPty on Windows, UnixPty on macOS and Linux). `HostedAgent` (the warm brain), the wingman ask runner, and `SessionManager` all route through it instead of hardcoding ConPty.
- A macOS login Keychain credential store (`MacKeychainProtectedTokenStore`) beside the Windows Data Protection one, behind the existing `IProtectedTokenStore`. The Gateway wires it on macOS; on Linux the account stays an explicit, logged null.
- Gate the two Windows-only endpoints - the `/exes` developer-slot builder that shells out to PowerShell, and the `POST /directors` launch of the Windows desktop app - off non-Windows by not mapping the routes there.
- Pin the Gateway self-updater as a no-op off Windows.
- Resolve the agent executable through the shared, platform-aware `ExecutableResolver` so the warm brain finds `claude` on macOS and Linux, not only `claude.exe`.
- Select the correct `POSIX_SPAWN_SETSID` value per platform (macOS vs Linux glibc), which stopped the agent from spawning on Linux with EINVAL.
- Reject a non-hostable warm-brain tool at Gateway construction (validated up front through `HostedAgent.For`), rather than failing later at the brain's first spawn.

## Dockerfile

A new `Dockerfile` and `.dockerignore` publish the headless Gateway for `linux-x64`, run it as a non-root user, and install the agent tool so the warm brain can spawn.

## Evidence (a run, not just a build)

- Windows regression: full solution test suite green (the seven projects), and the tray skin builds unchanged.
- Linux container run: the Gateway serves `/healthz`, the Windows-only routes are absent (404), and the warm brain spawns a Unix-pseudo-terminal agent and reaches prompt-ready with a pid and session id.
- The macOS run is post-merge verification.

Full details are in the internal QA document for the mission.
