### PR TITLE
Render the Gateway's folded session state on the desktop rail, not a local re-fold

### DIFF
--- a/src/CcDirector.Avalonia.Tests/FifoQueueFoldTests.cs
+++ b/src/CcDirector.Avalonia.Tests/FifoQueueFoldTests.cs
@@ -7,99 +7,83 @@ using Xunit;
 namespace CcDirector.Avalonia.Tests;
 
 /// <summary>
-/// Gap 2: the FIFO takeover's queue must be built by the SHARED FOLD, not by the window re-deciding
-/// state for itself.
+/// The FIFO takeover's queue is built from the GATEWAY'S folded triage stamp - the SAME stamp the rail's
+/// "N need you" count renders - so the queue and the count beside it cannot disagree about one session.
 ///
-/// NOTHING defended this window before. It filtered on the Director's raw cooked colour
-/// (<c>StatusColor == "red" &amp;&amp; !OnHold &amp;&amp; not exited/failed</c>) while the rail beside it,
-/// the phone and the Cockpit all folded <c>ControlEndpoints.Map</c> through <see cref="SessionOrdering"/> -
-/// so the queue could hand the owner a session the rail was not calling red. That is the mission's whole
-/// defect class (two readings of one session, nothing reconciling them) living one window over.
+/// The desktop no longer folds for itself. Both this window and the rail read
+/// <c>SessionDto.TriageBucket</c>, stamped down from the Gateway (<c>Session.GatewayTriageBucket</c>), so a
+/// session is queued here exactly when the Gateway calls it needs-you - never when a local re-fold, blind to
+/// the Gateway-only inputs (dictation, voice, the snooze clock), would have. A session with no stamp is not
+/// queued: the "no Gateway, no fold" floor.
 ///
 /// These drive REAL <see cref="Session"/> objects through the REAL production queue builder
-/// (FifoWindow.BuildQueue), so they exercise the shipped fold rather than a re-implementation of it.
-/// Every one has been watched FAILING with the reported symptom against the old raw-colour predicate.
+/// (FifoWindow.BuildQueue), stamping each with the display state the Gateway would push down.
 /// </summary>
 public sealed class FifoQueueFoldTests
 {
-    /// <summary>A session parked at a turn end with the wingman's raw colour written red - the ordinary
-    /// "waiting on you" shape, and the one the old predicate matched on.</summary>
-    private static Session RedAtTurnEnd()
+    private static Session AtTurnEnd()
     {
         var session = new Session(
             Guid.NewGuid(), @"C:\test\repo", @"C:\test\repo", null,
             new InertBackend(), SessionBackendType.ConPty);
-
-        // ActivityState defaults to WaitingForInput - a real turn end. IsBrandNew must be cleared or the
-        // fold answers "green" (ready) and these would pass for entirely the wrong reason.
         session.IsBrandNew = false;
-        session.SetStatusColor("red", "needs you");
+        return session;
+    }
+
+    /// <summary>Stamp the display state the Gateway would push down for a needs-you session.</summary>
+    private static Session NeedsYou(string repo = @"C:\test\repo")
+    {
+        var session = new Session(Guid.NewGuid(), repo, repo, null, new InertBackend(), SessionBackendType.ConPty);
+        session.IsBrandNew = false;
+        session.ApplyGatewayDisplayState("red", "Needs you", "needsYou", DateTime.UtcNow, null, false);
         return session;
     }
 
     // ===== The control. If this breaks, the fix has broken the feature rather than the defect =====
 
     [Fact]
-    public void AnOrdinaryRedSession_IsQueued()
+    public void AGatewayNeedsYouSession_IsQueued()
     {
-        var session = RedAtTurnEnd();
+        var session = NeedsYou();
 
         var queue = FifoWindow.BuildQueue(new[] { session });
 
         Assert.Equal(new[] { session.Id }, queue.Select(s => s.Id));
     }
 
-    // ===== THE GAP 2 DEFECT: the fold suppresses a controlled worker's red; the queue ignored it =====
+    // ===== A controlled worker: the Gateway folds it Active ("Sub-agent"), never needs-you =====
 
     /// <summary>
-    /// A live-controlled Worker must NOT be handed to the owner as "needs you".
-    ///
-    /// The Gateway resolves this session's role from the whole fleet and stamps it Worker; the fold reads
-    /// that and suppresses its red to "supporting" ("Sub-agent" on the rail), because its manager is
-    /// dealing with it - the owner is not needed. The rail therefore does not call it red and does not
-    /// count it. The old queue predicate never asked: it saw a raw "red" that is not on hold and not
-    /// exited, and queued it. So the FIFO handed over a session the rail beside it was calling
-    /// "Sub-agent".
-    ///
-    /// The raw colour is STILL red here, and that assertion is the point: the defect was never that the
-    /// colour is wrong, it is that the queue read the raw colour instead of the fold's verdict.
-    ///
-    /// Watched failing on revert: with the raw-colour predicate restored this session IS queued, so the
-    /// queue reads [worker] where it must read [].
+    /// A live-controlled Worker must NOT be handed to the owner as "needs you". The Gateway resolves the role
+    /// from the whole fleet, suppresses the worker's red to "supporting"/"Sub-agent" and buckets it Active -
+    /// and stamps that down. The queue reads the stamp, so it never queues a session the rail is calling
+    /// "Sub-agent". (Before, this window re-folded and could diverge from the Gateway on the four
+    /// Gateway-only inputs.)
     /// </summary>
     [Fact]
-    public void ALiveControlledWorker_IsNotQueued_BecauseTheFoldSuppressesItsRed()
+    public void AGatewayActiveWorker_IsNotQueued()
     {
-        var worker = RedAtTurnEnd();
-        worker.ControllerSessionId = Guid.NewGuid();          // controlled - possibly from another machine
-        worker.SetGatewayResolvedRole(SessionRoles.Worker);   // ...and the Gateway says so
+        var worker = AtTurnEnd();
+        worker.ApplyGatewayDisplayState("supporting", "Sub-agent", "active", null, null, false);
 
-        // The raw fact the old predicate read is unchanged - it genuinely IS at a turn end, which is
-        // exactly why reading the raw colour queued it.
-        Assert.Equal("red", worker.StatusColor);
-        Assert.False(worker.OnHold);
-        // ...and the shared fold says otherwise, in the words the rail beside this window is using.
+        // The rail beside this window renders the same stamped label.
         Assert.Equal("Sub-agent", new SessionViewModel(worker).ActivityLabel);
 
-        var queue = FifoWindow.BuildQueue(new[] { worker });
-
-        Assert.Empty(queue);
+        Assert.Empty(FifoWindow.BuildQueue(new[] { worker }));
     }
 
     /// <summary>
-    /// The queue and the rail's "N need you" count must agree about the SAME roster, because they now ask
-    /// the same function. This is the invariant gap 2 is really about - not "the queue is wrong" but "two
-    /// surfaces disagree about one session".
+    /// The queue and the rail's "N need you" count contain EXACTLY the same sessions, because they read the
+    /// same stamp. This is the invariant: two surfaces never disagree about one session.
     /// </summary>
     [Fact]
     public void TheQueue_ContainsExactlyWhatTheRailCounts()
     {
-        var ordinary = RedAtTurnEnd();
-        var worker = RedAtTurnEnd();
-        worker.ControllerSessionId = Guid.NewGuid();
-        worker.SetGatewayResolvedRole(SessionRoles.Worker);
-        var snoozed = RedAtTurnEnd();
-        snoozed.ApplyGatewayHold(HoldState.Held);
+        var ordinary = NeedsYou();
+        var worker = AtTurnEnd();
+        worker.ApplyGatewayDisplayState("supporting", "Sub-agent", "active", null, null, false);
+        var snoozed = AtTurnEnd();
+        snoozed.ApplyGatewayDisplayState("grey", "Snoozed", "onHold", null, DateTime.UtcNow.AddHours(4), false);
         var roster = new[] { ordinary, worker, snoozed };
 
         var queue = FifoWindow.BuildQueue(roster);
@@ -109,49 +93,50 @@ public sealed class FifoQueueFoldTests
         Assert.Equal(new[] { ordinary.Id }, queue.Select(s => s.Id));
     }
 
-    // ===== The conditions the old predicate hand-rolled. The fold must subsume all three =====
+    // ===== The Gateway's other buckets are not queued =====
 
-    /// <summary>The fold classifies a held session OnHold, so the removed <c>!s.OnHold</c> clause is not
-    /// missed. Green both before and after - a control on the fold, not a proof of the fix.</summary>
     [Fact]
-    public void ASnoozedRedSession_IsNotQueued()
+    public void AGatewaySnoozedSession_IsNotQueued()
     {
-        var session = RedAtTurnEnd();
-        session.ApplyGatewayHold(HoldState.Held);
+        var session = AtTurnEnd();
+        session.ApplyGatewayDisplayState("grey", "Snoozed", "onHold", null, DateTime.UtcNow.AddHours(4), false);
 
         Assert.Empty(FifoWindow.BuildQueue(new[] { session }));
     }
 
-    /// <summary>A working session is BLUE - nothing outranks working - so it is never queued, however red
-    /// the Director's stale cooked colour still reads. The old predicate had no working check at all: it
-    /// would queue this session on the strength of a raw colour the fold has already overruled.</summary>
     [Fact]
-    public void AWorkingSession_IsNotQueued_HoweverStaleTheRawColour()
+    public void AGatewayWorkingSession_IsNotQueued()
     {
-        var session = RedAtTurnEnd();
-        session.ApplyTerminalActivityState(ActivityState.Working);
+        var session = AtTurnEnd();
+        session.ApplyGatewayDisplayState("blue", "Working", "active", null, null, false);
 
-        Assert.Equal("red", session.StatusColor);   // the stale raw fact the old predicate would have read
         Assert.Empty(FifoWindow.BuildQueue(new[] { session }));
     }
 
-    // ===== The queue's ORDER is unchanged - this closed a membership disagreement, not an ordering one ====
+    /// <summary>The "no Gateway, no fold" floor: a session no Gateway has stamped is not queued, rather than
+    /// being queued from a local guess. Its TriageBucket is null, so it never matches "needsYou".</summary>
+    [Fact]
+    public void AnUnstampedSession_IsNotQueued()
+    {
+        var session = AtTurnEnd();   // no ApplyGatewayDisplayState
+
+        Assert.Empty(FifoWindow.BuildQueue(new[] { session }));
+    }
+
+    // ===== The queue's ORDER is unchanged (repo path, then id) =====
 
     [Fact]
     public void TheQueue_IsOrderedByRepoPathThenId()
     {
-        var b = new Session(Guid.NewGuid(), @"C:\b\repo", @"C:\b\repo", null, new InertBackend(), SessionBackendType.ConPty);
-        b.IsBrandNew = false; b.SetStatusColor("red", "needs you");
-        var a = new Session(Guid.NewGuid(), @"C:\a\repo", @"C:\a\repo", null, new InertBackend(), SessionBackendType.ConPty);
-        a.IsBrandNew = false; a.SetStatusColor("red", "needs you");
+        var b = NeedsYou(@"C:\b\repo");
+        var a = NeedsYou(@"C:\a\repo");
 
         var queue = FifoWindow.BuildQueue(new[] { b, a });
 
         Assert.Equal(new[] { a.Id, b.Id }, queue.Select(s => s.Id));
     }
 
-    /// <summary>An inert backend: the Session needs one, these tests never run a process. Mirrors the one
-    /// in SessionRailStateTests - same interface, same inert answers.</summary>
+    /// <summary>An inert backend: the Session needs one, these tests never run a process.</summary>
     private sealed class InertBackend : ISessionBackend
     {
         public int ProcessId => 1234;

--- a/src/CcDirector.Avalonia.Tests/SessionRailStateTests.cs
+++ b/src/CcDirector.Avalonia.Tests/SessionRailStateTests.cs
@@ -9,132 +9,229 @@ using Xunit;
 namespace CcDirector.Avalonia.Tests;
 
 /// <summary>
-/// Regression tests for the session rail's reading of state (mission "Session State Truth", phase 4).
+/// Regression tests for the session rail's reading of state, after the desktop stopped folding for itself.
 ///
-/// NOTHING defended any of these before - the rail's "N need you" count, its grey brushes, and its
-/// palette were all untested, which is how a snoozed session came to sit grey and labelled "Snoozed"
-/// underneath a header reading "1 need you". Three readings of one session, and nothing reconciled
-/// them.
+/// THE LAW (owner, 2026): every surface renders the GATEWAY'S folded answer and computes nothing. The rail
+/// binds a REAL <see cref="SessionViewModel"/>, and its dot (StatusColorBrush), its row text (ActivityLabel),
+/// its "N need you" verdict (NeedsYou), its waiting timer, its snooze countdown and its snooze-ended badge
+/// all read the display state the Gateway STAMPS DOWN onto the Session (Session.Gateway*, applied by
+/// <see cref="Session.ApplyGatewayDisplayState"/> and read back through ControlEndpoints.Map). The rail no
+/// longer runs SessionOrdering over local facts - which is exactly why a snoozed session read red "Needs
+/// you" here while the phone and the Cockpit read "Snoozed".
 ///
-/// These build a REAL <see cref="Session"/> and a REAL <see cref="SessionViewModel"/> and read the
-/// same properties the XAML binds, so they exercise the production fold
-/// (SessionViewModel.FoldInput -> ControlEndpoints.Map -> SessionOrdering) rather than a
-/// re-implementation of it. Every one of them has been watched to FAIL with the reported symptom
-/// before the fix was restored.
+/// So these stamp the display state the Gateway would push, then assert the rail renders it verbatim. A
+/// session with NO stamp shows a neutral placeholder - the "no Gateway, no fold" floor - not a local guess.
 ///
 /// Design: docs/new_architecture/session-state.html
 /// </summary>
 public sealed class SessionRailStateTests
 {
-    /// <summary>
-    /// A session parked at a turn end with the wingman's raw colour already written red - i.e. the
-    /// ordinary "Claude is waiting on you" session, and the exact shape the old count mis-read once
-    /// it was snoozed.
-    /// </summary>
-    private static Session RedAtTurnEnd()
+    /// <summary>A bare session with no Gateway stamp yet - the pre-first-push / no-tunnel shape.</summary>
+    private static Session Bare()
     {
         var session = new Session(
             Guid.NewGuid(), @"C:\test\repo", @"C:\test\repo", null,
             new InertBackend(), SessionBackendType.ConPty);
-
-        // ActivityState defaults to WaitingForInput - a real turn end, no private setter needed.
-        // IsBrandNew must be cleared or the fold answers "green" (ready) and the test would pass for
-        // entirely the wrong reason: a brand-new session is not red at all.
         session.IsBrandNew = false;
-        session.SetStatusColor("red", "needs you");
         return session;
     }
 
-    // ===== Defect 2, leg 1: the COUNT reads the fold, not the raw cooked colour =====
+    // ===== The "no Gateway, no fold" floor: an unstamped session shows a neutral placeholder =====
 
     [Fact]
-    public void NeedsYou_SessionAtTurnEnd_IsCounted()
+    public void NoGatewayStamp_RailShowsNeutralPlaceholder_NotCountedNotLabelled()
     {
-        // The control. If this ever goes false the fix has broken the feature rather than the defect.
-        var vm = new SessionViewModel(RedAtTurnEnd());
+        var vm = new SessionViewModel(Bare());
 
+        Assert.Equal(Color.Parse(StatusPalette.Grey), ((ISolidColorBrush)vm.StatusColorBrush).Color);
+        Assert.Equal("", vm.ActivityLabel);
+        Assert.False(vm.NeedsYou);
+        Assert.False(vm.HasWaitingDuration);
+        Assert.False(vm.HasHoldTime);
+        Assert.False(vm.IsSnoozeEnded);
+    }
+
+    // ===== The dot, the label and the count read the Gateway's stamp verbatim =====
+
+    [Fact]
+    public void NeedsYou_ReadsTheGatewayTriageStamp()
+    {
+        var session = Bare();
+        var vm = new SessionViewModel(session);
+
+        session.ApplyGatewayDisplayState("red", "Needs you", "needsYou", DateTime.UtcNow, null, false);
         Assert.True(vm.NeedsYou);
+
+        // The Gateway folds a snooze onHold - the count must drop even though the raw session is at a turn end.
+        session.ApplyGatewayDisplayState("grey", "Snoozed", "onHold", null, DateTime.UtcNow.AddHours(4), false);
+        Assert.False(vm.NeedsYou);
+
+        session.ApplyGatewayDisplayState("blue", "Working", "active", null, null, false);
+        Assert.False(vm.NeedsYou);
     }
 
     [Fact]
-    public void NeedsYou_SnoozedSessionAtTurnEnd_IsNotCounted()
+    public void ActivityLabel_And_Dot_ReadTheGatewayStamp()
     {
-        var session = RedAtTurnEnd();
-        // The real Snooze path the user's button calls, not a poke at internals. A settled session
-        // holds immediately (a working one would defer) - assert that, so this can never silently
-        // become a test of a session that was never actually held.
-        session.ApplyGatewayHold(HoldState.Held);
+        var session = Bare();
         var vm = new SessionViewModel(session);
 
-        // The raw fact the old predicate read is STILL "red" - a snoozed session genuinely IS at a
-        // turn end, which is exactly why counting the raw colour counted it. This assertion is the
-        // whole point: the defect is not that the colour is wrong, it is that the count read it.
-        Assert.Equal("red", session.StatusColor);
+        session.ApplyGatewayDisplayState("grey", "Snoozed", "onHold", null, DateTime.UtcNow.AddHours(4), false);
 
-        // ...and the fold says otherwise, so the header must not nag.
-        Assert.False(vm.NeedsYou);
-
-        // The row it is counted against says "Snoozed" and renders grey. All three readings agree.
         Assert.Equal("Snoozed", vm.ActivityLabel);
         Assert.Equal(Color.Parse(StatusPalette.Grey), ((ISolidColorBrush)vm.StatusColorBrush).Color);
     }
 
-    // ===== Defect 2, leg 2: the count is NOTIFIED when the verdict moves, not only when a colour is written =====
-
     [Fact]
-    public void NeedsYou_RaisesChangeNotification_WhenHoldChanges()
+    public void StatusColorBrush_ReadsTheGatewayEffectiveColor()
     {
-        // The header subscribes to this property. It used to hang off Session.OnStatusColorChanged
-        // alone - but snoozing writes no colour, so the count went stale until the 15-second git
-        // timer happened to fire, leaving "1 need you" above a grey "Snoozed" row for up to fifteen
-        // seconds.
-        var session = RedAtTurnEnd();
-        var vm = new SessionViewModel(session);
-        var raised = new List<string?>();
-        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
-
-        session.ApplyGatewayHold(HoldState.Held);
-        Dispatcher.UIThread.RunJobs();   // the view-model marshals its repaints; pump them
-
-        Assert.Contains(nameof(SessionViewModel.NeedsYou), raised);
-        Assert.False(vm.NeedsYou);       // and the new value is the folded one
-    }
-
-    // ===== Defect 17: ONE grey. The rail must not re-split it by re-reading a raw flag =====
-
-    [Fact]
-    public void StatusColorBrush_SnoozedSession_IsTheOneGrey_NotTheOldLightGrey()
-    {
-        var session = RedAtTurnEnd();
-        session.ApplyGatewayHold(HoldState.Held);
+        var session = Bare();
         var vm = new SessionViewModel(session);
 
-        var actual = ((ISolidColorBrush)vm.StatusColorBrush).Color;
+        session.ApplyGatewayDisplayState("red", "Needs you", "needsYou", DateTime.UtcNow, null, false);
+        Assert.Equal(Color.Parse(StatusPalette.Red), ((ISolidColorBrush)vm.StatusColorBrush).Color);
 
-        Assert.Equal(Color.Parse(StatusPalette.Grey), actual);
-        // The strays that died. #9CA3AF was the on-hold light grey the rail invented by re-reading
-        // Session.OnHold; #6A6A6A was its exited/unknown grey. Neither is in any palette now, and the
-        // phone never had either - which is why the devices disagreed.
-        Assert.NotEqual(Color.Parse("#9CA3AF"), actual);
-        Assert.NotEqual(Color.Parse("#6A6A6A"), actual);
+        session.ApplyGatewayDisplayState("blue", "Working", "active", null, null, false);
+        Assert.Equal(Color.Parse(StatusPalette.Blue), ((ISolidColorBrush)vm.StatusColorBrush).Color);
     }
 
-    // ===== Gap 1: the role BADGE reads the Gateway's stamp, never a local guess =====
+    /// <summary>An effective-color the desktop's palette does not know is a bug, not a state, and must hit
+    /// the unmistakable magenta sentinel - never render as a real colour (grey would read as "parked").</summary>
+    [Fact]
+    public void StatusColorBrush_UnknownStampValue_FallsToMagentaSentinel()
+    {
+        var session = Bare();
+        var vm = new SessionViewModel(session);
 
-    /// <summary>
-    /// Before any Gateway has spoken, the badge has NO answer - not the answer "Standalone".
-    ///
-    /// This asserts the VALUE, not just the absence of a glyph, and that is deliberate. The old field
-    /// defaulted to Standalone, which also renders no glyph, so an "is the badge hidden?" assertion
-    /// passes just as happily against the defect and would prove nothing. The distinction that matters
-    /// is between "the Gateway has not classified this session yet" and "the Gateway classified this
-    /// session as Standalone": identical on screen, opposite in meaning, and the old default asserted
-    /// the second while knowing only the first.
-    /// </summary>
+        session.ApplyGatewayDisplayState("chartreuse", "???", "active", null, null, false);
+
+        Assert.Equal(Color.Parse(StatusPalette.Broken), ((ISolidColorBrush)vm.StatusColorBrush).Color);
+    }
+
+    // ===== The waiting timer reads the Gateway's needs-you clock, so it matches every surface =====
+
+    [Fact]
+    public void WaitingDuration_ReadsTheGatewayNeedsYouSince()
+    {
+        var session = Bare();
+        var vm = new SessionViewModel(session);
+
+        session.ApplyGatewayDisplayState("red", "Needs you", "needsYou", DateTime.UtcNow.AddMinutes(-11), null, false);
+
+        Assert.True(vm.HasWaitingDuration);
+        Assert.Equal("waiting 11m", vm.WaitingDurationLabel);
+    }
+
+    [Fact]
+    public void WaitingDuration_IsHidden_WhenNotRed()
+    {
+        var session = Bare();
+        var vm = new SessionViewModel(session);
+
+        // Snoozed carries a NeedsYouSince of null, and the colour is grey - the timer must not nag.
+        session.ApplyGatewayDisplayState("grey", "Snoozed", "onHold", null, DateTime.UtcNow.AddHours(4), false);
+
+        Assert.False(vm.HasWaitingDuration);
+        Assert.Equal("", vm.WaitingDurationLabel);
+    }
+
+    // ===== NEW: the hold time, from the Gateway's snooze clock =====
+
+    [Fact]
+    public void Snoozed_ShowsHoldTime_FromTheGatewaySnoozeClock()
+    {
+        var session = Bare();
+        var vm = new SessionViewModel(session);
+
+        // Wakes in 3h 48m.
+        session.ApplyGatewayDisplayState("grey", "Snoozed", "onHold", null,
+            DateTime.UtcNow.AddHours(3).AddMinutes(48), false);
+
+        Assert.True(vm.HasHoldTime);
+        Assert.Equal("Snoozed", vm.ActivityLabel);
+        Assert.StartsWith("wakes in 3h", vm.HoldTimeLabel);
+    }
+
+    [Fact]
+    public void HoldTime_IsHidden_WhenThereIsNoSnoozeClock()
+    {
+        var session = Bare();
+        var vm = new SessionViewModel(session);
+
+        session.ApplyGatewayDisplayState("red", "Needs you", "needsYou", DateTime.UtcNow, null, false);
+
+        Assert.False(vm.HasHoldTime);
+        Assert.Equal("", vm.HoldTimeLabel);
+    }
+
+    // ===== NEW: the snooze-ended badge, from the Gateway's expiry overlay =====
+
+    [Fact]
+    public void SnoozeEnded_ShowsTheBadge_FromTheGatewayMarker()
+    {
+        var session = Bare();
+        var vm = new SessionViewModel(session);
+
+        // An expired snooze folds back to red "Needs you" AND carries the just-returned marker.
+        session.ApplyGatewayDisplayState("red", "Needs you", "needsYou", DateTime.UtcNow, null, snoozeExpired: true);
+
+        Assert.True(vm.IsSnoozeEnded);
+        Assert.True(vm.NeedsYou);
+    }
+
+    // ===== A stamp arriving must move the WHOLE row together, not half of it =====
+
+    [Fact]
+    public void ADisplayStamp_MovesEveryRenderedFieldTogether()
+    {
+        var session = Bare();
+        var vm = new SessionViewModel(session);
+
+        var changed = new List<string>();
+        vm.PropertyChanged += (_, e) => { if (e.PropertyName is not null) changed.Add(e.PropertyName); };
+
+        session.ApplyGatewayDisplayState("grey", "Snoozed", "onHold", null, DateTime.UtcNow.AddHours(4), false);
+        Dispatcher.UIThread.RunJobs();
+
+        // Named individually and deliberately: asserting "something changed" would pass with the row text
+        // stale, which IS the failure this whole change removes.
+        Assert.Contains(nameof(SessionViewModel.StatusColorBrush), changed);
+        Assert.Contains(nameof(SessionViewModel.ActivityLabel), changed);
+        Assert.Contains(nameof(SessionViewModel.NeedsYou), changed);
+        Assert.Contains(nameof(SessionViewModel.HasWaitingDuration), changed);
+        Assert.Contains(nameof(SessionViewModel.WaitingDurationLabel), changed);
+        Assert.Contains(nameof(SessionViewModel.HasHoldTime), changed);
+        Assert.Contains(nameof(SessionViewModel.HoldTimeLabel), changed);
+        Assert.Contains(nameof(SessionViewModel.IsSnoozeEnded), changed);
+
+        // And the row agrees with itself afterwards.
+        Assert.False(vm.NeedsYou);
+        Assert.Equal("Snoozed", vm.ActivityLabel);
+        Assert.True(vm.HasHoldTime);
+    }
+
+    [Fact]
+    public void ClearingTheStamp_ReturnsTheRailToTheNeutralPlaceholder()
+    {
+        var session = Bare();
+        var vm = new SessionViewModel(session);
+        session.ApplyGatewayDisplayState("red", "Needs you", "needsYou", DateTime.UtcNow, null, false);
+        Assert.True(vm.NeedsYou);   // precondition, so this cannot pass vacuously
+
+        // The Gateway clears its stamp (a Director that lost its tunnel) by pushing a null colour.
+        session.ApplyGatewayDisplayState(null, null, null, null, null, false);
+
+        Assert.Equal(Color.Parse(StatusPalette.Grey), ((ISolidColorBrush)vm.StatusColorBrush).Color);
+        Assert.Equal("", vm.ActivityLabel);
+        Assert.False(vm.NeedsYou);
+    }
+
+    // ===== The role BADGE is a separate Gateway-owned fact (GatewayResolvedRole), unchanged by this work ===
+
     [Fact]
     public void ResolvedRole_BeforeAnyGatewayStamp_IsUnknown_NotAssertedStandalone()
     {
-        var vm = new SessionViewModel(RedAtTurnEnd());
+        var vm = new SessionViewModel(Bare());
 
         Assert.Null(vm.ResolvedRole);
         Assert.False(vm.HasRoleGlyph);
@@ -142,28 +239,11 @@ public sealed class SessionRailStateTests
         Assert.Equal("", vm.RoleTooltip);
     }
 
-    /// <summary>
-    /// THE GAP 1 DEFECT ITSELF: the badge must follow the GATEWAY's stamp, on a session this Director
-    /// cannot classify for itself.
-    ///
-    /// The session below is controlled by a controller that is NOT in this Director's roster - the
-    /// ordinary cross-machine case, and the one the down-channel exists to serve. The deleted
-    /// SessionManager.ResolveLocalRole scored exactly this session "Standalone" with total confidence,
-    /// because it could only see the local roster and the controller was not in it. So the colour folded
-    /// the Gateway's "Worker" and suppressed the red, while the glyph beside it showed the Director's
-    /// local guess. One row, two authorities, and they disagreed.
-    ///
-    /// Watched failing on revert: with the stamped property restored, RoleGlyphText is "" here, because
-    /// nothing in the view model reads GatewayResolvedRole at all - the badge only ever moved when
-    /// MainWindow stamped it from the local fleet.
-    /// </summary>
     [Fact]
-    public void ResolvedRole_FollowsTheGatewayStamp_EvenWhenTheLocalRosterCannotKnowIt()
+    public void ResolvedRole_FollowsTheGatewayStamp()
     {
-        var session = RedAtTurnEnd();
-        // No controller by this id exists on this Director - it is a session on another machine. The
-        // local resolver's answer for this shape was Standalone; the Gateway's is Worker.
-        session.ControllerSessionId = Guid.NewGuid();
+        var session = Bare();
+        session.ControllerSessionId = Guid.NewGuid();   // a controller on another machine
         var vm = new SessionViewModel(session);
 
         session.SetGatewayResolvedRole(SessionRoles.Worker);
@@ -175,46 +255,14 @@ public sealed class SessionRailStateTests
         Assert.Equal("Worker", vm.RoleTooltip);
     }
 
-    /// <summary>
-    /// The badge and the dot must never contradict each other, because they now read the SAME fact.
-    ///
-    /// This is the invariant gap 1 was really about: not "the badge is wrong" but "the row disagrees with
-    /// itself". The Gateway names this session a Worker; the fold suppresses its red to supporting AND
-    /// the glyph says "W", in the same repaint. Before, the first happened without the second.
-    /// </summary>
-    [Fact]
-    public void AStampedWorker_MovesTheBadgeAndTheDotTogether_SoTheRowAgreesWithItself()
-    {
-        var session = RedAtTurnEnd();
-        session.ControllerSessionId = Guid.NewGuid();
-        var vm = new SessionViewModel(session);
-
-        // Before the stamp: an ordinary red session that wants you, and no badge to explain it.
-        Assert.True(vm.NeedsYou);
-        Assert.False(vm.HasRoleGlyph);
-
-        session.SetGatewayResolvedRole(SessionRoles.Worker);
-        Dispatcher.UIThread.RunJobs();
-
-        // After: the dot stops nagging and the glyph says why, together.
-        Assert.False(vm.NeedsYou);
-        Assert.Equal("W", vm.RoleGlyphText);
-    }
-
-    /// <summary>
-    /// Clearing the stamp returns the badge to "no answer" rather than stranding the last role on screen.
-    /// The Gateway clears a role by sending null (SetGatewayResolvedRole normalizes blank to null), and a
-    /// badge that kept saying "W" after the Gateway withdrew the claim is a stale lie of exactly the kind
-    /// this mission exists to end.
-    /// </summary>
     [Fact]
     public void ResolvedRole_WhenTheGatewayClearsTheStamp_ReturnsToUnknown()
     {
-        var session = RedAtTurnEnd();
+        var session = Bare();
         var vm = new SessionViewModel(session);
         session.SetGatewayResolvedRole(SessionRoles.Worker);
         Dispatcher.UIThread.RunJobs();
-        Assert.Equal("W", vm.RoleGlyphText);   // the precondition, so this cannot pass vacuously
+        Assert.Equal("W", vm.RoleGlyphText);   // precondition
 
         session.SetGatewayResolvedRole(null);
         Dispatcher.UIThread.RunJobs();
@@ -222,123 +270,6 @@ public sealed class SessionRailStateTests
         Assert.Null(vm.ResolvedRole);
         Assert.False(vm.HasRoleGlyph);
         Assert.Equal("", vm.RoleGlyphText);
-    }
-
-    // ===== Defect 5: the role stamp must move the WHOLE row, not just the dot =====
-
-    /// <summary>
-    /// The row a controlled worker actually renders once the Gateway names its role. This is the
-    /// PROJECTION, not the model event: GatewayResolvedRoleSignalTests prove Session raises the change,
-    /// and raising it means nothing if the view model does not re-read what the fold feeds.
-    ///
-    /// The first fix here raised only the brush, the reason and the count - so the dot went "supporting"
-    /// while the row text still read "Needs you" beside a running waiting timer. One row disagreeing with
-    /// itself is worse than the stale row it replaced: it looks deliberate. Caught by review, not by the
-    /// suite, because nothing asserted the row AS A WHOLE.
-    /// </summary>
-    [Fact]
-    public void AStampedWorker_MovesEveryFoldFedFieldTogether_NotJustTheDot()
-    {
-        var session = RedAtTurnEnd();
-        // The waiting timer only shows once an explain has been cached - that is what stamps the "waiting
-        // since" instant. Without it HasWaitingDuration is false for a reason unrelated to the role, and
-        // this test would prove nothing about the fix.
-        session.SetCachedExplain("waiting on you", model: "test");
-        var vm = new SessionViewModel(session);
-
-        // Before: an ordinary red session that wants you, timer running.
-        Assert.True(vm.NeedsYou);
-        Assert.True(vm.HasWaitingDuration);
-
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => { if (e.PropertyName is not null) changed.Add(e.PropertyName); };
-
-        session.SetGatewayResolvedRole("Worker");
-        Dispatcher.UIThread.RunJobs();
-
-        // Every field the fold feeds must be re-read. Name them individually: a missing one is exactly
-        // the defect, and asserting "some property changed" would pass while the label stayed wrong.
-        Assert.Contains(nameof(SessionViewModel.StatusColorBrush), changed);
-        Assert.Contains(nameof(SessionViewModel.ActivityLabel), changed);
-        Assert.Contains(nameof(SessionViewModel.HasWaitingDuration), changed);
-        Assert.Contains(nameof(SessionViewModel.WaitingDurationLabel), changed);
-        Assert.Contains(nameof(SessionViewModel.NeedsYou), changed);
-        Assert.Contains(nameof(SessionViewModel.StatusReason), changed);
-
-        // And the row must actually AGREE with itself afterwards - the point of raising them at all.
-        Assert.False(vm.NeedsYou);
-        Assert.False(vm.HasWaitingDuration);
-        Assert.DoesNotContain("Needs you", vm.ActivityLabel, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// EVERY fold input must move the whole row, not just the one its author happened to think of.
-    ///
-    /// Each handler in SessionViewModel used to keep its own list of properties to raise, and they all
-    /// disagreed - hold raised seven, activity three, the cached explain two, the role stamp three. Each
-    /// list was a private chance to miss one, and missing one renders a HALF-updated row: the dot moves,
-    /// the text beside it does not. Three fold inputs (background task, dictation, auto-explain) had no
-    /// subscription at all, so they moved no part of the row.
-    ///
-    /// This drives each fold input through a REAL Session and REAL SessionViewModel and demands the same
-    /// invariant of all of them, so a future handler that re-grows its own list fails here rather than in
-    /// someone's rail. Found by review of pull request 1598 after two of these were fixed one at a time.
-    /// </summary>
-    [Theory]
-    [InlineData("role")]
-    [InlineData("activity")]
-    [InlineData("hold")]
-    [InlineData("dictation")]
-    [InlineData("background")]
-    [InlineData("explaining")]
-    [InlineData("wingman-gate")]
-    public void EveryFoldInput_RaisesTheWholeProjection(string foldInput)
-    {
-        var session = RedAtTurnEnd();
-        session.SetCachedExplain("waiting on you", model: "test");
-        // The gate case needs something for the gate to gate: parked on its own background task, which the
-        // fold answers purple ONLY while the Wingman is on. Turning it off must move the whole row to red.
-        if (foldInput == "wingman-gate")
-        {
-            session.WingmanEnabled = true;
-            session.SetBackgroundRunning(true, "running in background");
-        }
-        var vm = new SessionViewModel(session);
-
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => { if (e.PropertyName is not null) changed.Add(e.PropertyName); };
-
-        switch (foldInput)
-        {
-            case "role": session.SetGatewayResolvedRole("Worker"); break;
-            case "activity": session.ApplyTerminalActivityState(ActivityState.Working); break;
-            case "hold": session.ApplyGatewayHold(HoldState.Held); break;
-            case "dictation": session.IsTranscribing = true; break;
-            case "background": session.SetBackgroundRunning(true, "running in background"); break;
-            case "explaining": session.IsExplaining = true; break;
-            case "wingman-gate": session.WingmanEnabled = false; break;
-            default: throw new ArgumentOutOfRangeException(nameof(foldInput), foldInput, "unknown fold input");
-        }
-        Dispatcher.UIThread.RunJobs();
-
-        // Named individually and deliberately: asserting "something changed" would pass with the row text
-        // stale, which IS the defect. These are exactly the properties whose getters fold.
-        Assert.Contains(nameof(SessionViewModel.StatusColorBrush), changed);
-        Assert.Contains(nameof(SessionViewModel.StatusReason), changed);
-        Assert.Contains(nameof(SessionViewModel.ActivityLabel), changed);
-        Assert.Contains(nameof(SessionViewModel.NeedsYou), changed);
-        Assert.Contains(nameof(SessionViewModel.HasWaitingDuration), changed);
-        Assert.Contains(nameof(SessionViewModel.WaitingDurationLabel), changed);
-
-        // The role badge (gap 1). It reads Session.GatewayResolvedRole - the same Gateway-owned fact the
-        // colour folds - so it belongs to the row's projection and must move with it. Demanded of EVERY
-        // fold input, not just "role", for the reason this theory exists at all: the moment the badge is
-        // raised from one handler's private list, it is one edit away from being the field that gets
-        // missed, and a glyph contradicting the dot beside it is gap 1 returning.
-        Assert.Contains(nameof(SessionViewModel.ResolvedRole), changed);
-        Assert.Contains(nameof(SessionViewModel.HasRoleGlyph), changed);
-        Assert.Contains(nameof(SessionViewModel.RoleGlyphText), changed);
-        Assert.Contains(nameof(SessionViewModel.RoleTooltip), changed);
     }
 
     /// <summary>An inert backend: the Session needs one, these tests never run a process.</summary>

--- a/src/CcDirector.Avalonia/FifoWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/FifoWindow.axaml.cs
@@ -127,37 +127,25 @@ public partial class FifoWindow : Window
     private List<Session> BuildQueue() => BuildQueue(_sm.ListSessions());
 
     /// <summary>
-    /// The sessions this takeover will walk, in order: the ones the SHARED FOLD says are waiting on you.
+    /// The sessions this takeover will walk, in order: the ones the GATEWAY'S FOLD says are waiting on you.
     ///
-    /// GAP 2, CLOSED. This used to filter on the Director's raw cooked colour -
-    /// <c>s.StatusColor == "red" &amp;&amp; !s.OnHold &amp;&amp; not exited/failed</c> - which made it a
-    /// second place the desktop decided state for itself, outside the fold the rail, the phone and the
-    /// Cockpit all run. It predated the fold and was not migrated with the rail. What that cost: a
-    /// controlled worker whose red the fold suppresses to "supporting" was still queued here as needs-you,
-    /// and every other overlay the fold applies - dictation, background task, briefing, a crashed session -
-    /// was ignored. So this window could hand you a session the rail was not calling red: the same
-    /// disagreement the mission exists to end, one window over.
+    /// This reads the GATEWAY'S folded triage bucket (<c>SessionDto.TriageBucket == "needsYou"</c>, stamped
+    /// down onto the Session and read back through <c>ControlEndpoints.Map</c>) - the SAME stamp the rail's
+    /// "N need you" count now renders, so this queue and the count beside it cannot drift. It used to re-run
+    /// <c>SessionOrdering.Classify</c> over local facts, which was correct for the inputs the Director could
+    /// see but blind to the Gateway-only ones (a phone dictation, the Gateway's transcription, a voice
+    /// summary, the snooze clock) - the same divergence the rail carried. The desktop no longer folds; it
+    /// renders the Gateway's answer.
     ///
-    /// It now asks <see cref="SessionOrdering.Classify"/> for the triage verdict - the SAME function the
-    /// rail's "N need you" count and the phone's web-push badge read, folding the SAME
-    /// <c>ControlEndpoints.Map</c> input. Not <c>EffectiveColor == "red"</c>, which would have been the
-    /// nearer-looking swap: Classify IS the "is this waiting on you?" question, it already answers Active
-    /// for a working session and OnHold for a parked one, and asking the shared question means this queue
-    /// cannot drift from the count beside it.
-    ///
-    /// The three hand-rolled conditions are gone rather than kept alongside as a safety net, and that is
-    /// deliberate: the fold subsumes all three (a held session classifies OnHold; an exited one folds grey
-    /// and a crashed one folds error, so neither is NeedsYou), and a second predicate ANDed onto a shared
-    /// one is just a private fold that disagrees more quietly.
-    ///
-    /// Static and taking the roster as a parameter so the queue's shape can be tested without standing up
-    /// a Window - see FifoQueueFoldTests. The ORDER is unchanged (repo path, then id): this closes a
-    /// disagreement about membership, and re-ordering the owner's queue is not in scope.
+    /// A session with no stamp yet (a Director with no tunnel, or one that just connected) is NOT queued -
+    /// the "no Gateway, no fold" floor, exactly as the rail shows it a neutral placeholder rather than
+    /// guessing. Static and taking the roster as a parameter so the queue's shape can be tested without
+    /// standing up a Window - see FifoQueueFoldTests. The ORDER is unchanged (repo path, then id).
     /// </summary>
     internal static List<Session> BuildQueue(IEnumerable<Session> sessions) =>
         sessions
-            .Where(s => SessionOrdering.Classify(ControlEndpoints.Map(s, directorId: ""))
-                        == SessionOrdering.TriageBucket.NeedsYou)
+            .Where(s => string.Equals(
+                ControlEndpoints.Map(s, directorId: "").TriageBucket, "needsYou", StringComparison.Ordinal))
             .OrderBy(s => s.RepoPath, StringComparer.OrdinalIgnoreCase)
             .ThenBy(s => s.Id)
             .ToList();

--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -617,6 +617,25 @@
                                                        FontSize="9"
                                                        FontWeight="SemiBold" />
                                         </Border>
+                                        <!-- Snooze-ended badge: this session came back ON ITS OWN because its
+                                             snooze timer fired (SessionDto.SnoozeExpired, folded by the
+                                             Gateway and stamped down). The dot is already red "Needs you" -
+                                             the fold puts an expired snooze straight back into needs-you - so
+                                             this badge only annotates WHY it returned: a "go see why it went
+                                             quiet" item, not a fresh turn-end. Neutral gray like the other
+                                             badges, never a status colour; it never competes with the dot. -->
+                                        <Border Background="{DynamicResource ButtonBackground}"
+                                                CornerRadius="6"
+                                                Padding="6,1"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                IsVisible="{Binding IsSnoozeEnded}"
+                                                ToolTip.Tip="Snooze ended - this session came back on its own and is still waiting on you">
+                                            <TextBlock Text="SNOOZE ENDED"
+                                                       Foreground="#9CA3AF"
+                                                       FontSize="9"
+                                                       FontWeight="SemiBold" />
+                                        </Border>
                                         <!-- Agent badge: shows which CLI this session is running -->
                                         <Border Background="{Binding AgentBadgeBrush}"
                                                 CornerRadius="6"
@@ -645,6 +664,16 @@
                                             <TextBlock Text="{Binding WaitingDurationLabel}"
                                                        IsVisible="{Binding HasWaitingDuration}"
                                                        Foreground="#E0883C"
+                                                       FontSize="11"
+                                                       Margin="6,0,0,0"
+                                                       VerticalAlignment="Center" />
+                                            <!-- How long until an armed snooze wakes this session ("wakes in
+                                                 3h 48m"), shown beside the "Snoozed" label. The Gateway owns
+                                                 the clock (SessionDto.SnoozeUntil, stamped down); the rail
+                                                 only renders the countdown. Muted, never a status colour. -->
+                                            <TextBlock Text="{Binding HoldTimeLabel}"
+                                                       IsVisible="{Binding HasHoldTime}"
+                                                       Foreground="#888888"
                                                        FontSize="11"
                                                        Margin="6,0,0,0"
                                                        VerticalAlignment="Center" />

--- a/src/CcDirector.Avalonia/SessionViewModel.cs
+++ b/src/CcDirector.Avalonia/SessionViewModel.cs
@@ -63,6 +63,12 @@ public class SessionViewModel : INotifyPropertyChanged
         session.OnNumberChanged += OnNumberChangedVm;
         session.OnPendingDeletionChanged += OnPendingDeletionChangedVm;
         session.OnGatewayResolvedRoleChanged += OnGatewayResolvedRoleChangedVm;
+        // THE FOLD ITSELF, arriving over the wire. The Gateway stamps this session's folded display state
+        // (colour, label, triage, needs-you-since, the snooze clock, the snooze-ended marker) down onto the
+        // Session, and the rail renders it VERBATIM instead of re-folding from local facts it cannot see.
+        // Like the role stamp, a fold answer arriving is none of the activity/hold/dictation events the rail
+        // already hears, so without this the row keeps its last answer until an unrelated event repaints it.
+        session.OnGatewayDisplayStateChanged += OnGatewayDisplayStateChangedVm;
         // THE THREE TRANSIENT OVERLAYS THE RAIL NEVER HEARD ABOUT. Map feeds IsBackgroundRunning,
         // IsTranscribing and IsAutoExplaining into the fold, which renders them purple, orange and yellow -
         // and nothing subscribed, so a desktop dictation or a background-task verdict reached the Gateway
@@ -123,6 +129,9 @@ public class SessionViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(NeedsYou));
         OnPropertyChanged(nameof(HasWaitingDuration));
         OnPropertyChanged(nameof(WaitingDurationLabel));
+        OnPropertyChanged(nameof(HasHoldTime));
+        OnPropertyChanged(nameof(HoldTimeLabel));
+        OnPropertyChanged(nameof(IsSnoozeEnded));
         OnPropertyChanged(nameof(ResolvedRole));
         OnPropertyChanged(nameof(HasRoleGlyph));
         OnPropertyChanged(nameof(RoleGlyphText));
@@ -163,36 +172,25 @@ public class SessionViewModel : INotifyPropertyChanged
     private SessionDto FoldInput => ControlEndpoints.Map(Session, directorId: "");
 
     /// <summary>
-    /// The ONE presentation fold, shared with the Gateway and therefore with the Cockpit and the phone
-    /// (<see cref="SessionOrdering"/> lives in CcDirector.Gateway.Contracts, which this app references).
+    /// The presentation colour the rail renders - the GATEWAY'S folded answer, stamped down onto this
+    /// Session and read back through <see cref="FoldInput"/> (<c>SessionDto.EffectiveColor</c>, sourced from
+    /// <c>Session.GatewayEffectiveColor</c>). The rail RENDERS it and computes nothing.
     ///
-    /// The desktop used to hand-roll three separate folds of its own - the strip read the hold flag, while
-    /// the label and the "waiting" clock read the activity state and the wingman colour and had never heard
-    /// of hold. That is why a snoozed session showed a grey strip next to a red "Your Turn" and a nagging
-    /// hours-long clock, while the phone correctly showed "Snoozed": four readings of the same session, and
-    /// nothing reconciled them. Calling the same function the other screens call makes agreement structural
-    /// instead of something we re-verify every release.
+    /// This used to be <c>SessionOrdering.EffectiveColor(FoldInput)</c> - the rail re-running the shared fold
+    /// over its own LOCAL facts. That was the disease, not the cure: the fold reads inputs only the Gateway
+    /// has (a phone dictation, the Gateway's transcription, a voice summary being prepared, and the snooze
+    /// clock and its expiry), so the desktop's copy diverged for every session that had stopped - a snoozed
+    /// session read red "Needs you" here while the phone and the Cockpit read "Snoozed". Pushing four more
+    /// inputs down would have narrowed the gap; the fix is that the desktop does not fold at all. The Gateway
+    /// is the single fold; this seam carries its answer down to the one screen that cannot poll for itself.
     ///
-    /// SessionRole IS here now, and this comment used to say it was not. It said: "Known gap (Phase 2b):
-    /// ... it is absent here until the Gateway pushes it down. Until then a live Worker's red is suppressed
-    /// on the Cockpit and the phone but still surfaces on this rail." That was defect 5, and it is FIXED -
-    /// the Gateway resolves the role from the whole fleet (only it can: the Director cannot know whether a
-    /// controlled session's controller is alive on another machine) and pushes it down over the
-    /// set-resolved-role verb; ControlEndpoints.Map reads it back off Session.GatewayResolvedRole, so this
-    /// fold input carries it and the rail reaches the same answer as the phone.
-    ///
-    /// The comment is corrected rather than deleted because a stale "known gap" is worse than no comment at
-    /// all: it invites the next agent to re-implement a fix that already shipped. That is not hypothetical -
-    /// the specification called defect 4 open for four paragraphs after it had merged, and the error ledger
-    /// records what it cost. Proved end to end, with nothing hand-set, by DesktopRoleStampWireProofTests.
-    ///
-    /// WHAT IS STILL TRUE, and is the real remaining gap (measured in phase 5): the role was ONE of FIVE
-    /// Gateway-only fold inputs. Map still does not carry DictationStatus, Transcribing or VoiceGenerating,
-    /// and nothing pushes them down - so for a session that is NOT working, this rail can still differ from
-    /// the phone (a phone dictation is orange there and red here). Blue outranks all of them, so it can
-    /// never affect a working session. See docs/new_architecture/session-state.html.
+    /// NO STAMP YET -&gt; "unknown" (a neutral grey), NOT magenta. Until a Gateway has stamped a fold (a fresh
+    /// session before its first push, or a Director with no tunnel - the "no Gateway, no fold" floor) the
+    /// value is null, and the rail shows a neutral placeholder rather than guessing a colour. A genuinely
+    /// unrecognised stamp value still falls through to the magenta sentinel in <see cref="StatusColorBrush"/>,
+    /// which is the real fail-loud. (docs/new_architecture/session-state.html.)
     /// </summary>
-    private string EffectiveColor => SessionOrdering.EffectiveColor(FoldInput);
+    private string EffectiveColor => FoldInput.EffectiveColor ?? "unknown";
 
     /// <summary>
     /// The sidebar colour strip's brush: the shared fold's colour, mapped through the ONE palette.
@@ -274,6 +272,21 @@ public class SessionViewModel : INotifyPropertyChanged
         });
     }
 
+    /// <summary>
+    /// The Gateway stamped this session's folded display state down (colour, label, triage, needs-you-since,
+    /// snooze clock, snooze-ended). That IS what the rail renders now - the dot, the row text, the "N need
+    /// you" verdict, the waiting timer, the snooze countdown and the snooze-ended badge all read it - so a
+    /// stamp arriving must repaint the whole projection. RaiseFoldProjection covers the fold outputs; the
+    /// countdown/timer labels ride along because HoldTimeLabel/WaitingDurationLabel are in it.
+    /// </summary>
+    private void OnGatewayDisplayStateChangedVm()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            RaiseFoldProjection();
+        });
+    }
+
     /// <summary>True when the user has parked this session on hold. Drives the menu toggle
     /// label and the light-gray strip color.</summary>
     public bool IsOnHold => Session.OnHold;
@@ -319,33 +332,67 @@ public class SessionViewModel : INotifyPropertyChanged
         });
     }
 
-    /// <summary>How long this session has been waiting on you, shown in the list only when red,
-    /// so you can see at a glance WHICH needs-you session is the most stale and triage it first.
-    /// Proxied from the last briefing time (generated at turn-end, when the session goes red).
-    /// Reads the shared fold, NOT the raw wingman colour: a snoozed session is not red and must not nag
-    /// with an hours-long clock - that mismatch is exactly what this change removes.</summary>
+    /// <summary>How long this session has been waiting on you, shown in the list only when red, so you can
+    /// see at a glance WHICH needs-you session is the most stale and triage it first. Reads the GATEWAY-owned
+    /// clock (<c>SessionDto.NeedsYouSince</c>, stamped down from <c>Session.GatewayNeedsYouSince</c>) so the
+    /// "waiting 11m" here matches every other surface exactly. It used to proxy the local last-briefing time,
+    /// which drifted from the Gateway's. Gated on the folded colour being red, so a snoozed session (grey)
+    /// never nags with a clock.</summary>
     public bool HasWaitingDuration =>
         string.Equals(EffectiveColor, "red", StringComparison.OrdinalIgnoreCase)
-        && Session.CachedExplainAt is not null;
+        && FoldInput.NeedsYouSince is not null;
 
     public string WaitingDurationLabel
     {
         get
         {
-            if (!HasWaitingDuration) return "";
-            var d = DateTime.UtcNow - Session.CachedExplainAt!.Value;
+            if (FoldInput.NeedsYouSince is not { } since || !HasWaitingDuration) return "";
+            var d = DateTime.UtcNow - since.ToUniversalTime();
             if (d.TotalMinutes < 1) return "waiting <1m";
             if (d.TotalMinutes < 60) return $"waiting {(int)d.TotalMinutes}m";
             return $"waiting {(int)d.TotalHours}h";
         }
     }
 
-    /// <summary>Re-raise time-derived list labels; called periodically so the waiting duration
-    /// ticks up without an event.</summary>
+    /// <summary>True when this session is snoozed with a running clock, so the rail can show WHEN it comes
+    /// back. Reads the GATEWAY-owned snooze deadline (<c>SessionDto.SnoozeUntil</c>, stamped down from
+    /// <c>Session.GatewaySnoozeUntil</c>) - the Director never owns the snooze clock. Null for a deferred
+    /// snooze that has not landed (no deadline yet) and for anything not snoozed.</summary>
+    public bool HasHoldTime => FoldInput.SnoozeUntil is not null;
+
+    /// <summary>"wakes in 3h 48m" - how long until an armed snooze returns the session to needs-you. Shown
+    /// beside the "Snoozed" label so a snoozed row says not just that it is parked but until when. Reads the
+    /// Gateway's deadline; the Director renders the countdown but owns no clock. Empty when there is no
+    /// running snooze.</summary>
+    public string HoldTimeLabel
+    {
+        get
+        {
+            if (FoldInput.SnoozeUntil is not { } until) return "";
+            var remaining = until.ToUniversalTime() - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero) return "waking up";
+            if (remaining.TotalMinutes < 1) return "wakes in <1m";
+            if (remaining.TotalMinutes < 60) return $"wakes in {(int)remaining.TotalMinutes}m";
+            var hours = (int)remaining.TotalHours;
+            var mins = remaining.Minutes;
+            return mins > 0 ? $"wakes in {hours}h {mins}m" : $"wakes in {hours}h";
+        }
+    }
+
+    /// <summary>True when this session JUST came back on its own because its snooze timer fired - the
+    /// Gateway's <c>SessionDto.SnoozeExpired</c> marker (stamped down from <c>Session.GatewaySnoozeExpired</c>).
+    /// Drives the rail's distinct "SNOOZE ENDED" badge so the owner knows this is a "go see why it went
+    /// quiet" item, not a fresh turn-end.</summary>
+    public bool IsSnoozeEnded => FoldInput.SnoozeExpired;
+
+    /// <summary>Re-raise time-derived list labels; called periodically so the waiting duration and the
+    /// snooze countdown tick without an event.</summary>
     public void RefreshTimeLabels()
     {
         OnPropertyChanged(nameof(WaitingDurationLabel));
         OnPropertyChanged(nameof(HasWaitingDuration));
+        OnPropertyChanged(nameof(HoldTimeLabel));
+        OnPropertyChanged(nameof(HasHoldTime));
     }
 
     public string DisplayName => Session.CustomName
@@ -408,11 +455,13 @@ public class SessionViewModel : INotifyPropertyChanged
     }
 
     /// <summary>
-    /// The session's state in words. The shared fold's label - the SAME string the Cockpit and the phone
-    /// render - so a session cannot read "Your Turn" here and "Snoozed" there. This used to read the raw
-    /// activity state and therefore had no idea the session was held.
+    /// The session's state in words - the GATEWAY'S folded label (<c>SessionDto.StateLabel</c>, stamped down
+    /// from <c>Session.GatewayStateLabel</c>), the SAME string the Cockpit and the phone render, so a session
+    /// cannot read "Needs you" here and "Snoozed" there. Rendered VERBATIM; the rail does not label anything
+    /// itself. This used to be <c>SessionOrdering.StateLabel(FoldInput)</c> - the rail re-folding locally -
+    /// which is exactly why it disagreed. Empty until a Gateway stamps one (the no-Gateway floor).
     /// </summary>
-    public string ActivityLabel => SessionOrdering.StateLabel(FoldInput);
+    public string ActivityLabel => FoldInput.StateLabel ?? "";
 
     /// <summary>
     /// True when this session is waiting on YOU - the shared fold's triage verdict, not a colour.
@@ -425,12 +474,13 @@ public class SessionViewModel : INotifyPropertyChanged
     /// snoozed session sat grey and labelled "Snoozed" underneath a header reading "1 need you".
     /// Three readings of one session, and nothing reconciled them.
     ///
-    /// Defect 5 IS closed here, and this comment used to say "NOT closed here" - that a live Worker's red
-    /// "still counts on this rail". It does not: the Gateway pushes the resolved role down and
-    /// ControlEndpoints.Map carries it onto this fold input, so a live Worker classifies Active here exactly
-    /// as it does on the phone, and its need routes to its manager rather than to this header.
+    /// This reads the GATEWAY'S folded triage bucket (<c>SessionDto.TriageBucket</c>, stamped down from
+    /// <c>Session.GatewayTriageBucket</c>), the SAME verdict the phone's web-push badge counts by, rendered
+    /// VERBATIM. It used to be <c>SessionOrdering.Classify(FoldInput)</c> - the rail re-classifying locally,
+    /// so a session the Gateway had bucketed onHold (dictation, voice, a snooze) still counted here. Absent
+    /// stamp counts as not-needing-you (the no-Gateway floor never nags).
     /// </summary>
-    public bool NeedsYou => SessionOrdering.Classify(FoldInput) == SessionOrdering.TriageBucket.NeedsYou;
+    public bool NeedsYou => string.Equals(FoldInput.TriageBucket, "needsYou", StringComparison.Ordinal);
 
     // Agent badge for the session list. Colored pill shown next to the session name
     // so it's visually obvious which agent CLI this session is running.

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1394,6 +1394,21 @@ internal static class ControlEndpoints
             // where PushedSessionStore DISCARDS it at ingest so this echo can never be mistaken for an
             // authority. (docs/new_architecture/session-state.html, defect 5.)
             SessionRole = s.GatewayResolvedRole,
+            // The Gateway's folded DISPLAY STATE, stamped back down onto this Director (Session.Gateway*,
+            // written only by the set-display-state verb) and echoed here for the loopback reader that
+            // cannot ask upstream: the desktop rail. The rail renders these VERBATIM instead of re-folding
+            // from local facts it cannot see (dictation, transcription, voice generation, the snooze clock) -
+            // which is exactly why a snoozed session read red "Needs you" on the desktop while the phone and
+            // the Cockpit read "Snoozed". Null until a Gateway stamps them (the standalone-desktop floor);
+            // the rail shows a neutral waiting-for-gateway placeholder rather than guessing. Like SessionRole
+            // these ride back UP on the next delta, where the Gateway OVERWRITES them from its own fold, so
+            // the echo can never be mistaken for an authority. (docs/new_architecture/session-state.html.)
+            EffectiveColor = s.GatewayEffectiveColor,
+            StateLabel = s.GatewayStateLabel,
+            TriageBucket = s.GatewayTriageBucket,
+            NeedsYouSince = s.GatewayNeedsYouSince,
+            SnoozeUntil = s.GatewaySnoozeUntil,
+            SnoozeExpired = s.GatewaySnoozeExpired,
             // Chunk 3: the auto-vs-explicit name marker (a future auto-rename gates on it).
             IsAutoNamed = s.IsAutoNamed,
             IsBackgroundRunning = s.IsBackgroundRunning,

--- a/src/CcDirector.ControlApi/FleetDisplayStateExecutor.cs
+++ b/src/CcDirector.ControlApi/FleetDisplayStateExecutor.cs
@@ -1,0 +1,72 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// The DISPLAY-STATE area of the Director's tunnel command surface - one verb, <c>set-display-state</c>,
+/// through which the Gateway tells this Director the FOLDED display state (effective color, label, triage
+/// bucket, needs-you-since, the snooze clock, the snooze-ended marker) of one of its sessions.
+///
+/// Like <see cref="FleetRoleExecutor"/> this verb is the Gateway telling the Director a FACT, not asking it
+/// to DO something. The desktop rail is the one screen that folds from the in-process Session and cannot ask
+/// the Gateway for itself, so it re-derived a colour and a label from local facts it could not see -
+/// dictation, transcription, voice generation, the snooze clock - and disagreed with every other surface (a
+/// snoozed session read red "Needs you" on the rail while the phone and the Cockpit read "Snoozed"). The
+/// Gateway is the single fold; this seam carries its answer down to the rail. The Director stores the fold
+/// verbatim on <c>Session.Gateway*</c> and reads it back out through <c>ControlEndpoints.Map</c>; it never
+/// computes or second-guesses the fold.
+///
+/// Its own area because a verb belongs to exactly one area and an area is the unit that avoids the merge
+/// chokepoint - adding this verb touched no other area's file.
+/// (docs/new_architecture/session-state.html.)
+/// </summary>
+internal sealed class FleetDisplayStateExecutor : ISessionCommandArea
+{
+    public IReadOnlyCollection<string> Verbs { get; } = new[]
+    {
+        "set-display-state",
+    };
+
+    public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(command.Verb switch
+        {
+            "set-display-state" => SetDisplayState(context, command),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the fleet display-state area"),
+        });
+    }
+
+    /// <summary>
+    /// The <c>set-display-state</c> verb: store the Gateway's folded display state for one session.
+    ///
+    /// A blank <see cref="SetDisplayStateRequest.EffectiveColor"/> CLEARS the stamp (back to "no answer")
+    /// rather than being rejected - that is how a Director with no Gateway falls back to its neutral
+    /// waiting placeholder, and it must be expressible. Nothing here is validated against the fold's
+    /// vocabulary: the Gateway is the authority on what the fold says, and a Director second-guessing it
+    /// would be the Director deciding a colour, which the law forbids.
+    /// </summary>
+    internal static DirectorCommandResult SetDisplayState(SessionCommandContext context, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var request = SessionCommandExecutor.Deserialize<SetDisplayStateRequest>(command.PayloadJson);
+        if (request is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "display-state payload is required");
+
+        var session = context.SessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        session.ApplyGatewayDisplayState(
+            request.EffectiveColor,
+            request.StateLabel,
+            request.TriageBucket,
+            request.NeedsYouSince,
+            request.SnoozeUntil,
+            request.SnoozeExpired);
+        FileLog.Write($"[FleetDisplayStateExecutor] set-display-state: session={guid}, color={request.EffectiveColor ?? "(cleared)"}, label={request.StateLabel ?? "(none)"}");
+        return DirectorCommandResult.Success();
+    }
+}

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -86,6 +86,9 @@ internal static class SessionCommandExecutor
         new DirectorConfigExecutor(),
         // Defect 5: the Gateway stamping a session's resolved role down onto this Director.
         new FleetRoleExecutor(),
+        // The Gateway stamping a session's FOLDED display state down onto this Director, so the desktop
+        // rail renders the Gateway's answer instead of re-folding from local facts it cannot see.
+        new FleetDisplayStateExecutor(),
     };
 
     /// <summary>

--- a/src/CcDirector.Core.Tests/GatewayDisplayStateSignalTests.cs
+++ b/src/CcDirector.Core.Tests/GatewayDisplayStateSignalTests.cs
@@ -1,0 +1,135 @@
+using CcDirector.Core.Backends;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// The Gateway folds each session's display state (colour, label, triage, needs-you-since, snooze clock,
+/// snooze-ended) and stamps it down onto the owning Director, which caches it and renders it verbatim. A
+/// cached fact with no signal is invisible - the same failure defect 5 shipped with the role - so these pin
+/// the SIGNAL: the fact announces itself once, on real changes only, and the cache is authoritative.
+///
+/// Design: docs/new_architecture/session-state.html.
+/// </summary>
+public sealed class GatewayDisplayStateSignalTests
+{
+    private static Session NewSession()
+    {
+        var s = new Session(
+            Guid.NewGuid(),
+            repoPath: @"C:\test\repo",
+            workingDirectory: @"C:\test\repo",
+            claudeArgs: null,
+            backend: new NullBackend(),
+            claudeSessionId: "claude-test",
+            activityState: ActivityState.Working,
+            createdAt: DateTimeOffset.UtcNow,
+            customName: null,
+            customColor: null);
+        s.MarkRunning();
+        return s;
+    }
+
+    [Fact]
+    public void StampingADisplayState_RaisesTheChange_AndCachesEveryField()
+    {
+        var s = NewSession();
+        var heard = 0;
+        s.OnGatewayDisplayStateChanged += () => heard++;
+
+        var since = DateTime.UtcNow.AddMinutes(-11);
+        var until = DateTime.UtcNow.AddHours(4);
+        s.ApplyGatewayDisplayState("grey", "Snoozed", "onHold", since, until, snoozeExpired: false);
+
+        Assert.Equal(1, heard);
+        Assert.Equal("grey", s.GatewayEffectiveColor);
+        Assert.Equal("Snoozed", s.GatewayStateLabel);
+        Assert.Equal("onHold", s.GatewayTriageBucket);
+        Assert.Equal(since, s.GatewayNeedsYouSince);
+        Assert.Equal(until, s.GatewaySnoozeUntil);
+        Assert.False(s.GatewaySnoozeExpired);
+    }
+
+    [Fact]
+    public void ReStampingTheSameState_IsSilent_SoTheSweepDoesNotChurnTheRail()
+    {
+        var s = NewSession();
+        s.ApplyGatewayDisplayState("red", "Needs you", "needsYou", null, null, false);
+        var heard = 0;
+        s.OnGatewayDisplayStateChanged += () => heard++;
+
+        // The Gateway re-folds the whole fleet on every push and on its periodic sweep, re-stamping unchanged
+        // answers. If that fired, every sweep would repaint every row.
+        s.ApplyGatewayDisplayState("red", "Needs you", "needsYou", null, null, false);
+        s.ApplyGatewayDisplayState("red", "Needs you", "needsYou", null, null, false);
+
+        Assert.Equal(0, heard);
+    }
+
+    [Fact]
+    public void AnyFieldChanging_RaisesTheChange()
+    {
+        var s = NewSession();
+        s.ApplyGatewayDisplayState("grey", "Snoozed", "onHold", null, DateTime.UtcNow.AddHours(4), false);
+        var heard = 0;
+        s.OnGatewayDisplayStateChanged += () => heard++;
+
+        // Only the snooze-ended marker flips; everything else is identical. The row must still be told.
+        s.ApplyGatewayDisplayState("grey", "Snoozed", "onHold", null, DateTime.UtcNow.AddHours(4), snoozeExpired: true);
+
+        Assert.Equal(1, heard);
+        Assert.True(s.GatewaySnoozeExpired);
+    }
+
+    [Fact]
+    public void ANullColour_ClearsTheStamp_BackToNoAnswer()
+    {
+        var s = NewSession();
+        s.ApplyGatewayDisplayState("red", "Needs you", "needsYou", DateTime.UtcNow, null, false);
+        var heard = 0;
+        s.OnGatewayDisplayStateChanged += () => heard++;
+
+        s.ApplyGatewayDisplayState(null, null, null, null, null, false);
+
+        Assert.Equal(1, heard);
+        Assert.Null(s.GatewayEffectiveColor);
+        Assert.Null(s.GatewayStateLabel);
+        Assert.Null(s.GatewayTriageBucket);
+    }
+
+    [Fact]
+    public void AHandlerThatThrows_DoesNotBreakTheStamp_TheCacheIsStillWritten()
+    {
+        var s = NewSession();
+        s.OnGatewayDisplayStateChanged += () => throw new InvalidOperationException("a view blew up");
+
+        s.ApplyGatewayDisplayState("blue", "Working", "active", null, null, false);
+
+        Assert.Equal("blue", s.GatewayEffectiveColor);
+    }
+
+    /// <summary>A backend that does nothing: these tests are about the display signal, not the process.</summary>
+    private sealed class NullBackend : ISessionBackend
+    {
+        public int ProcessId => 4321;
+        public string Status => "Null";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+        public CircularTerminalBuffer? Buffer => null;
+
+#pragma warning disable CS0067 // Required by the interface, unused here.
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -229,6 +229,87 @@ public sealed class Session : IDisposable
     /// </summary>
     public event Action<string?>? OnGatewayResolvedRoleChanged;
 
+    // ===== Gateway-pushed DISPLAY STATE (the fold answer), cached so the desktop rail renders exactly what
+    // the Gateway decided instead of re-folding from local facts it cannot see (dictation, transcription,
+    // voice generation, the snooze clock). THE GATEWAY DECIDES; THE DIRECTOR CARRIES. Written only by the
+    // set-display-state verb, read back out through ControlEndpoints.Map onto the SessionDto. Deliberately
+    // NOT persisted - a restarted Director has no business remembering a fold it never owned, and the
+    // Gateway re-stamps within one push of reconnecting (same rule as GatewayResolvedRole).
+    // (docs/new_architecture/session-state.html - "the desktop must ask".) =====
+
+    /// <summary>The Gateway's folded effective color (<see cref="SessionOrdering.EffectiveColor"/>), or null
+    /// until a Gateway has stamped one. The rail renders this verbatim - it does not compute a colour.</summary>
+    public string? GatewayEffectiveColor { get; private set; }
+
+    /// <summary>The Gateway's folded human-readable state label ("Working" / "Needs you" / "Snoozed" / ...),
+    /// or null until stamped. The rail renders this verbatim.</summary>
+    public string? GatewayStateLabel { get; private set; }
+
+    /// <summary>The Gateway's folded triage bucket ("needsYou" / "active" / "onHold"), or null until stamped.
+    /// The rail's "needs you" count and ordering read this, never a local classification.</summary>
+    public string? GatewayTriageBucket { get; private set; }
+
+    /// <summary>The Gateway-owned instant this session entered red (<see cref="SessionDto.NeedsYouSince"/>),
+    /// so the rail's "waiting 11m" matches every other surface. Null when not red.</summary>
+    public DateTime? GatewayNeedsYouSince { get; private set; }
+
+    /// <summary>The Gateway-owned armed-snooze deadline (<see cref="SessionDto.SnoozeUntil"/>), so the rail
+    /// can show "Snoozed - wakes in 3h 48m". Null when there is no running snooze clock.</summary>
+    public DateTime? GatewaySnoozeUntil { get; private set; }
+
+    /// <summary>The Gateway's "this session JUST came back from an expired snooze" marker
+    /// (<see cref="SessionDto.SnoozeExpired"/>), rendered as a distinct "Snooze ended" badge.</summary>
+    public bool GatewaySnoozeExpired { get; private set; }
+
+    /// <summary>
+    /// Raised when any pushed display-state field changes, so the desktop rail re-reads the fold. Same shape
+    /// and same reason as <see cref="OnGatewayResolvedRoleChanged"/>: a new fact with no signal is invisible -
+    /// the rail is only told to re-read on activity/status/hold/dictation/number/role changes, and a fold
+    /// answer arriving over the wire is none of those.
+    /// </summary>
+    public event Action? OnGatewayDisplayStateChanged;
+
+    /// <summary>
+    /// Store the display state the Gateway folded for this session. This ONLY caches values it was told - it
+    /// does not compute, validate, or adjust the fold; the Gateway is the authority. Fires
+    /// <see cref="OnGatewayDisplayStateChanged"/> only on a real change, so the Gateway re-stamping the same
+    /// answer every sweep does not churn the rail. A null <paramref name="effectiveColor"/> clears the stamp
+    /// back to "no answer" (the desktop then shows its neutral waiting-for-gateway placeholder).
+    /// </summary>
+    public void ApplyGatewayDisplayState(
+        string? effectiveColor,
+        string? stateLabel,
+        string? triageBucket,
+        DateTime? needsYouSince,
+        DateTime? snoozeUntil,
+        bool snoozeExpired)
+    {
+        var color = string.IsNullOrWhiteSpace(effectiveColor) ? null : effectiveColor.Trim();
+        var label = string.IsNullOrWhiteSpace(stateLabel) ? null : stateLabel.Trim();
+        var bucket = string.IsNullOrWhiteSpace(triageBucket) ? null : triageBucket.Trim();
+
+        var changed =
+            !string.Equals(GatewayEffectiveColor, color, StringComparison.Ordinal)
+            || !string.Equals(GatewayStateLabel, label, StringComparison.Ordinal)
+            || !string.Equals(GatewayTriageBucket, bucket, StringComparison.Ordinal)
+            || GatewayNeedsYouSince != needsYouSince
+            || GatewaySnoozeUntil != snoozeUntil
+            || GatewaySnoozeExpired != snoozeExpired;
+
+        if (!changed) return;
+
+        GatewayEffectiveColor = color;
+        GatewayStateLabel = label;
+        GatewayTriageBucket = bucket;
+        GatewayNeedsYouSince = needsYouSince;
+        GatewaySnoozeUntil = snoozeUntil;
+        GatewaySnoozeExpired = snoozeExpired;
+
+        FileLog.Write($"[Session] ApplyGatewayDisplayState: session={Id}, color={color ?? "(cleared)"}, label={label ?? "(none)"}, bucket={bucket ?? "(none)"}, snoozeUntil={snoozeUntil?.ToString("O") ?? "(none)"}, snoozeExpired={snoozeExpired}");
+        try { OnGatewayDisplayStateChanged?.Invoke(); }
+        catch (Exception ex) { FileLog.Write($"[Session] {Id} OnGatewayDisplayStateChanged handler threw: {ex.Message}"); }
+    }
+
     /// <summary>Set (or clear, on a null/blank value) this session's sticky explicit role. The value is
     /// validated against the role set by the caller; this only stores it.</summary>
     public void SetExplicitRole(string? role)

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -169,6 +169,18 @@ public sealed class SessionDto
     public DateTime? NeedsYouSince { get; set; }
 
     /// <summary>
+    /// The absolute UTC time an ARMED snooze returns this session to "needs you" - the snooze clock's
+    /// deadline, so a client can show "wakes in 3h 48m". Gateway-owned: the snooze registry
+    /// (<c>SnoozeRegistry.SnoozeEntry.SnoozeUntilUtc</c>) is the sole source of the timer, stamped by the
+    /// Gateway during the /sessions aggregation and pushed DOWN to the owning Director's display mirror so
+    /// the desktop rail can render the hold time without owning the clock. Null when the session carries no
+    /// armed snooze: no hold at all, OR a DEFERRED hold that has not landed yet (there is no deadline until
+    /// the work ends - defect 20). Always null in Director-local responses that predate the display-state
+    /// push. Pairs with <see cref="HoldState"/> = "Held": the state says it is parked, this says until when.
+    /// </summary>
+    public DateTime? SnoozeUntil { get; set; }
+
+    /// <summary>
     /// When the OWNER last drove a turn on this session - a person typing or speaking - or null if they
     /// never have. Reported by the owning Director; null from a Director too old to send it.
     ///

--- a/src/CcDirector.Gateway.Contracts/SetDisplayStateRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/SetDisplayStateRequest.cs
@@ -1,0 +1,40 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// The payload of the <c>set-display-state</c> command - the Gateway telling a Director the FOLDED display
+/// state of one of its sessions, so the desktop rail renders exactly what the phone and the Cockpit render
+/// instead of re-folding from local facts it cannot see (dictation, transcription, voice generation, the
+/// snooze clock).
+///
+/// Like <see cref="SetResolvedRoleRequest"/> this is a FACT being delivered, not a request for the Director
+/// to decide anything. The Director stores it verbatim on <c>Session</c> (via
+/// <c>ApplyGatewayDisplayState</c>) and reports it back out through <c>ControlEndpoints.Map</c>; it never
+/// computes, adjusts, or second-guesses the fold. The Gateway is the single fold, and the one screen that
+/// cannot poll the Gateway for itself - the local rail - has to be told. See
+/// docs/new_architecture/session-state.html.
+/// </summary>
+public sealed class SetDisplayStateRequest
+{
+    /// <summary>The folded effective color (<see cref="SessionOrdering.EffectiveColor"/>). Blank/whitespace
+    /// clears the stamp back to "no answer", and the desktop shows its neutral waiting-for-gateway
+    /// placeholder rather than guessing a colour.</summary>
+    public string? EffectiveColor { get; set; }
+
+    /// <summary>The folded human-readable label (<see cref="SessionOrdering.StateLabel"/>).</summary>
+    public string? StateLabel { get; set; }
+
+    /// <summary>The folded triage bucket: "needsYou" | "active" | "onHold".</summary>
+    public string? TriageBucket { get; set; }
+
+    /// <summary>The Gateway-owned instant the session entered red (<see cref="SessionDto.NeedsYouSince"/>),
+    /// so the rail's "waiting Xm" matches every surface. Null when not red.</summary>
+    public DateTime? NeedsYouSince { get; set; }
+
+    /// <summary>The Gateway-owned armed-snooze deadline (<see cref="SessionDto.SnoozeUntil"/>), so the rail
+    /// can show "Snoozed - wakes in Xh". Null when there is no running snooze clock.</summary>
+    public DateTime? SnoozeUntil { get; set; }
+
+    /// <summary>The Gateway's "just came back from an expired snooze" marker
+    /// (<see cref="SessionDto.SnoozeExpired"/>), rendered as a distinct "Snooze ended" badge.</summary>
+    public bool SnoozeExpired { get; set; }
+}

--- a/src/CcDirector.Gateway.Tests/FleetDisplayStateObserverTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetDisplayStateObserverTests.cs
@@ -1,0 +1,155 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Fleet;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The display-state push seam: the Gateway stamps each session's folded answer down to its owning Director,
+/// and the two legs that make that STAY correct - the change gate (stamping a fold down does not make the
+/// observer chase its own echo), and a dropped send being retried rather than recorded as delivered.
+///
+/// The fold itself is proved elsewhere (SessionOrderingTests); here the fold is a deterministic stub so the
+/// tests target the observer's gate and payload, exactly as FleetRoleObserverTests target the role
+/// observer's. Design: docs/new_architecture/session-state.html.
+/// </summary>
+public sealed class FleetDisplayStateObserverTests
+{
+    private static SessionDto Session(string id, string state = "WaitingForInput") => new()
+    {
+        SessionId = id,
+        ActivityState = state,
+    };
+
+    /// <summary>A stub fold: colour/label/triage derived from the raw activity, so a test can change the
+    /// answer by changing the session's ActivityState - the same shape the real fold produces.</summary>
+    private static void StubFold(List<SessionDto> sessions)
+    {
+        foreach (var s in sessions)
+        {
+            var working = string.Equals(s.ActivityState, "Working", StringComparison.OrdinalIgnoreCase);
+            s.EffectiveColor = working ? "blue" : "red";
+            s.StateLabel = working ? "Working" : "Needs you";
+            s.TriageBucket = working ? "active" : "needsYou";
+        }
+    }
+
+    private sealed class RecordingSender
+    {
+        public readonly List<(string DirectorId, string SessionId, SetDisplayStateRequest Payload)> Sent = new();
+        public Func<DirectorCommandResult?> Reply = () => DirectorCommandResult.Success();
+
+        public Task<DirectorCommandResult?> SendAsync(string directorId, DirectorCommand command, CancellationToken ct)
+        {
+            var payload = System.Text.Json.JsonSerializer.Deserialize<SetDisplayStateRequest>(
+                command.PayloadJson, new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+            lock (Sent) Sent.Add((directorId, command.SessionId, payload!));
+            return Task.FromResult(Reply());
+        }
+    }
+
+    /// <summary>
+    /// THE LOOP. Stamping a fold down makes the Director report it back up on its next delta
+    /// (ControlEndpoints.Map echoes the cached values), which lands back in Observe. Without the change gate
+    /// that is fold -> delta -> observe -> fold, forever. Sweeping an unchanged fleet must send exactly ONCE.
+    /// </summary>
+    [Fact]
+    public void RepeatedSweeps_WithAnUnchangedFleet_SendTheFoldOnlyOnce()
+    {
+        var sender = new RecordingSender();
+        var fleet = new List<(string, SessionDto)> { ("dir-A", Session("s1")) };
+        var observer = new FleetDisplayStateObserver(() => fleet, StubFold, sender.SendAsync);
+
+        for (var i = 0; i < 5; i++)
+            observer.Sweep();
+
+        var sent = Assert.Single(sender.Sent);
+        Assert.Equal("dir-A", sent.DirectorId);
+        Assert.Equal("s1", sent.SessionId);
+        Assert.Equal("red", sent.Payload.EffectiveColor);
+        Assert.Equal("Needs you", sent.Payload.StateLabel);
+        Assert.Equal("needsYou", sent.Payload.TriageBucket);
+    }
+
+    /// <summary>The gate must not be a mute button: when the fold genuinely CHANGES, the new answer goes down
+    /// again. A gate that suppressed real changes would trade the echo for a stale desktop - the same defect.</summary>
+    [Fact]
+    public void WhenTheFoldChanges_TheNewFoldIsSentDown()
+    {
+        var sender = new RecordingSender();
+        var s1 = Session("s1");
+        var fleet = new List<(string, SessionDto)> { ("dir-A", s1) };
+        var observer = new FleetDisplayStateObserver(() => fleet, StubFold, sender.SendAsync);
+
+        observer.Sweep();
+        Assert.Equal("red", sender.Sent.Single().Payload.EffectiveColor);
+
+        // The session starts working -> the fold flips to blue -> the desktop must be told.
+        s1.ActivityState = "Working";
+        observer.Sweep();
+
+        Assert.Equal(2, sender.Sent.Count);
+        Assert.Equal("blue", sender.Sent[^1].Payload.EffectiveColor);
+        Assert.Equal("active", sender.Sent[^1].Payload.TriageBucket);
+    }
+
+    /// <summary>A Director with no tunnel gets no stamp, and the observer must NOT record that as delivered -
+    /// the fold has to be re-sent the moment it reconnects. Recording a failed send as done would leave that
+    /// desktop permanently wrong, and silently.</summary>
+    [Fact]
+    public void WhenTheDirectorHasNoStream_TheStampIsRetriedOnTheNextSweep()
+    {
+        var sender = new RecordingSender { Reply = () => null };   // null = no active stream
+        var fleet = new List<(string, SessionDto)> { ("dir-A", Session("s1")) };
+        var observer = new FleetDisplayStateObserver(() => fleet, StubFold, sender.SendAsync);
+
+        observer.Sweep();
+        observer.Sweep();
+
+        Assert.Equal(2, sender.Sent.Count);
+    }
+
+    /// <summary>
+    /// THE ROLLOUT STORM. The normal deploy order ships the Gateway BEFORE the Directors, so for a while an
+    /// old Director rejects this brand-new verb with BadRequest. That rejection must be recorded like a
+    /// delivery - one send per fold change - not retried every single sweep, or every session that Director
+    /// owns generates a rejected command every few seconds until it upgrades.
+    /// </summary>
+    [Fact]
+    public void WhenADirectorRejectsTheVerb_ItIsNotReSentEverySweep()
+    {
+        var sender = new RecordingSender
+        {
+            Reply = () => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "unknown verb 'set-display-state'"),
+        };
+        var fleet = new List<(string, SessionDto)> { ("dir-old", Session("s1")) };
+        var observer = new FleetDisplayStateObserver(() => fleet, StubFold, sender.SendAsync);
+
+        for (var i = 0; i < 5; i++)
+            observer.Sweep();
+
+        // Recorded on the first rejection, so the unchanged fold is not re-sent to the old Director.
+        Assert.Single(sender.Sent);
+    }
+
+    /// <summary>A session that leaves the fleet must drop out of the change gate, so if it ever returns its
+    /// fold is stamped fresh rather than suppressed by a stale gate entry.</summary>
+    [Fact]
+    public void ASessionThatLeavesTheFleet_IsStampedAgainIfItReturns()
+    {
+        var sender = new RecordingSender();
+        var fleet = new List<(string, SessionDto)> { ("dir-A", Session("s1")) };
+        var observer = new FleetDisplayStateObserver(() => fleet, StubFold, sender.SendAsync);
+
+        observer.Sweep();
+        Assert.Single(sender.Sent);
+
+        fleet.Clear();
+        observer.Sweep();                       // s1 is gone - the gate entry must be pruned
+
+        fleet.Add(("dir-A", Session("s1")));
+        observer.Sweep();                       // ...so its return is a fresh stamp, not a suppressed echo
+
+        Assert.Equal(2, sender.Sent.Count);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/SessionDtoRawFactsTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionDtoRawFactsTests.cs
@@ -39,6 +39,48 @@ public sealed class SessionDtoRawFactsTests
     }
 
     [Fact]
+    public void Map_EchoesTheGatewayStampedDisplayStateBackOntoTheDto()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            // The Gateway folded this session and stamped its answer down onto the Director. Map must echo
+            // every field back onto the DTO the desktop rail reads, or the rail has no fold to render.
+            var since = new DateTime(2026, 7, 16, 12, 0, 0, DateTimeKind.Utc);
+            var until = since.AddHours(4);
+            session.ApplyGatewayDisplayState("grey", "Snoozed", "onHold", since, until, snoozeExpired: true);
+
+            var dto = ControlEndpoints.Map(session, "dir-A");
+
+            Assert.Equal("grey", dto.EffectiveColor);
+            Assert.Equal("Snoozed", dto.StateLabel);
+            Assert.Equal("onHold", dto.TriageBucket);
+            Assert.Equal(since, dto.NeedsYouSince);
+            Assert.Equal(until, dto.SnoozeUntil);
+            Assert.True(dto.SnoozeExpired);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public void Map_WithNoGatewayStamp_LeavesTheDisplayStateNull()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            // No Gateway has stamped a fold - the "no Gateway, no fold" floor. Map must not invent one.
+            var dto = ControlEndpoints.Map(session, "dir-A");
+
+            Assert.Null(dto.EffectiveColor);
+            Assert.Null(dto.StateLabel);
+            Assert.Null(dto.TriageBucket);
+            Assert.Null(dto.SnoozeUntil);
+            Assert.False(dto.SnoozeExpired);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
     public void Map_ControlledSubAgent_EmitsIsControlledAndControllerId()
     {
         var (sm, session) = NewSession();

--- a/src/CcDirector.Gateway.Tests/SnoozeRegistryTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeRegistryTests.cs
@@ -44,6 +44,37 @@ public sealed class SnoozeRegistryTests : IDisposable
     }
 
     [Fact]
+    public void SnoozeUntilFor_returns_the_armed_deadline()
+    {
+        var reg = new SnoozeRegistry(Path_);
+        var now = new DateTime(2026, 7, 16, 12, 0, 0, DateTimeKind.Utc);
+        var until = now.AddHours(4);
+        reg.Snooze("s1", until, "dir-1");
+
+        Assert.Equal(until, reg.SnoozeUntilFor("s1"));
+        // Returns the real deadline even once it is in the past - "is it over?" is IsExpired's ruling.
+        reg.Snooze("s2", now.AddMinutes(-1), "dir-1");
+        Assert.Equal(now.AddMinutes(-1), reg.SnoozeUntilFor("s2"));
+    }
+
+    [Fact]
+    public void SnoozeUntilFor_is_null_for_a_deferred_snooze()
+    {
+        var reg = new SnoozeRegistry(Path_);
+        // A deferral has no clock yet - it starts when the work ends - so there is no deadline to show.
+        reg.SnoozeDeferred("s1", 720, "dir-1");
+
+        Assert.Null(reg.SnoozeUntilFor("s1"));
+    }
+
+    [Fact]
+    public void SnoozeUntilFor_is_null_for_a_session_with_no_entry()
+    {
+        var reg = new SnoozeRegistry(Path_);
+        Assert.Null(reg.SnoozeUntilFor("nobody"));
+    }
+
+    [Fact]
     public void Snooze_again_overwrites_the_prior_time_no_escalation()
     {
         var reg = new SnoozeRegistry(Path_);

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -2656,6 +2656,11 @@ internal static class GatewayEndpoints
                 var isRed = string.Equals(effectiveColor, "red", StringComparison.OrdinalIgnoreCase);
                 s.NeedsYouSince = needsYouStampFor(s.SessionId, isRed);
             }
+            // The armed-snooze deadline, so a client can show "Snoozed - wakes in Xh". Read straight from the
+            // registry (the sole timer owner) alongside HoldState above; null when there is no running clock
+            // (no snooze, or a deferred one that has not landed). Folded HERE so the roster, the observer that
+            // pushes this down to the desktop, and the single-session read all emit the same deadline.
+            s.SnoozeUntil = snoozeRegistry?.SnoozeUntilFor(s.SessionId);
         }
     }
 

--- a/src/CcDirector.Gateway/Fleet/FleetDisplayStateObserver.cs
+++ b/src/CcDirector.Gateway/Fleet/FleetDisplayStateObserver.cs
@@ -1,0 +1,202 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Fleet;
+
+/// <summary>
+/// Pushes each session's FOLDED display state DOWN to the Director that owns it, so the desktop rail renders
+/// exactly what the phone and the Cockpit render instead of re-folding from local facts it cannot see. This
+/// is the PUSH seam for the fold, modelled exactly on <see cref="FleetRoleObserver"/> - which pushed ONE
+/// fold input (the role) down and closed one of five measured desktop-versus-phone disagreements. This
+/// pushes the fold ANSWER, closing the other four (a phone dictation, the Gateway's transcription, a voice
+/// summary being prepared, and the snooze clock) and the disease behind them: the desktop folding at all.
+///
+/// THE FOLD RUNS ONCE, HERE AND EVERYWHERE. The delegate is <c>GatewayEndpoints.StampFleetRolesAndFold</c> -
+/// the SAME method the roster, /exes/list and the single-session read fold through - so the answer pushed to
+/// the desktop is byte-identical to the answer served to every browser. A second fold would be a second
+/// authority, and a drifting second authority IS the disagreement this exists to end.
+///
+/// WHY THE WHOLE FLEET. The fold reads roles resolved across the whole fleet (a controller's liveness), so a
+/// push for session X can change session Y's answer on another Director. Every trigger re-folds the fleet
+/// and fans the CHANGED answers out, exactly as the role observer does.
+///
+/// WHY THE CHANGE GATE IS LOAD-BEARING. Sending a fold down makes the Director report it back up on its next
+/// delta (ControlEndpoints.Map echoes the cached values), which lands here again. Ungated that is an
+/// infinite echo. The send is gated on the fold SIGNATURE having actually changed from what we last sent, so
+/// the echo resolves to the same signature, sends nothing, and the loop terminates on its first turn.
+/// <see cref="_lastSent"/> is that gate and it is the only thing between this class and a spin.
+///
+/// NO GATEWAY, NO FOLD. A Director with no tunnel never receives a stamp, so its rail leaves the fold null
+/// and shows a neutral waiting-for-gateway placeholder. That is the honest answer and the status quo: the
+/// Gateway owns the fold, and a client inventing a local one IS the defect.
+/// </summary>
+public sealed class FleetDisplayStateObserver
+{
+    private readonly Func<IReadOnlyList<(string DirectorId, SessionDto Session)>> _snapshot;
+    private readonly Func<string, DirectorCommand, CancellationToken, Task<DirectorCommandResult?>> _sendCommand;
+    // The shared fold. Given a list, it stamps EffectiveColor / StateLabel / TriageBucket / NeedsYouSince /
+    // SnoozeUntil / SnoozeExpired / HoldState onto each entry - the identical pass the roster runs. Injected
+    // rather than referenced so this observer does not reach across into the Api layer's endpoint type.
+    private readonly Action<List<SessionDto>> _stampFold;
+
+    /// <summary>
+    /// The change gate: session id -> the fold signature we last successfully sent down. Written only AFTER
+    /// a send is accepted, so a dropped send is retried on the next trigger rather than recorded as
+    /// delivered. Bounded by pruning sessions that have left the fleet.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, string> _lastSent = new(StringComparer.Ordinal);
+
+    /// <param name="snapshot">The fresh pushed sessions across every stream-connected Director, each paired
+    /// with its owning directorId (PushedSessionStore.SnapshotFresh) - the same fleet read the role observer
+    /// and the auto-dismiss sweeper use. The fold needs the WHOLE fleet, not one Director's slice.</param>
+    /// <param name="stampFold">The shared fold (GatewayEndpoints.StampFleetRolesAndFold over the fleet as
+    /// both universe and stamp set, with the roster's NeedsYouClock and the snooze registry) - the ONE
+    /// implementation, so the pushed answer equals the served answer.</param>
+    /// <param name="sendCommand">The down-channel command sender (GatewayHost.SendCommandAsync). A null
+    /// RESULT means that Director has no stream, which is the documented "no Gateway, no fold" floor.</param>
+    public FleetDisplayStateObserver(
+        Func<IReadOnlyList<(string DirectorId, SessionDto Session)>> snapshot,
+        Action<List<SessionDto>> stampFold,
+        Func<string, DirectorCommand, CancellationToken, Task<DirectorCommandResult?>> sendCommand)
+    {
+        _snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
+        _stampFold = stampFold ?? throw new ArgumentNullException(nameof(stampFold));
+        _sendCommand = sendCommand ?? throw new ArgumentNullException(nameof(sendCommand));
+    }
+
+    /// <summary>Observe one pushed session. Any push can change any session's fold, so this re-folds the
+    /// whole fleet - see the class remarks.</summary>
+    public void Observe(SessionDto? session)
+    {
+        if (session is null || string.IsNullOrEmpty(session.SessionId)) return;
+        Sweep();
+    }
+
+    /// <summary>Observe a whole pushed snapshot - the reconnect path, where a fold change can hide.</summary>
+    public void ObserveSnapshot(IReadOnlyList<SessionDto>? sessions)
+    {
+        if (sessions is null || sessions.Count == 0) return;
+        Sweep();
+    }
+
+    /// <summary>Observe a session LEAVING the fleet. A departure changes other sessions' folds (a
+    /// controller's tombstone un-suppresses its workers' red) exactly as an arrival does.</summary>
+    public void ObserveRemoval(string? sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return;
+        Sweep();
+    }
+
+    /// <summary>
+    /// Re-fold every session from the whole fleet and push down the ones whose fold CHANGED.
+    ///
+    /// Fire-and-forget by design: this runs on the hub's push path and on the periodic sweep, and a Director
+    /// slow to answer a stamp must not stall the delta that triggered it. A dropped send costs one stale
+    /// fold until the next trigger, the same bound every other pushed fact carries.
+    ///
+    /// Public so a periodic timer (the backstop for Gateway-only overlay changes - voice generation,
+    /// transcription, a snooze expiring - which arrive on no Director push) can drive it too.
+    /// </summary>
+    public void Sweep()
+    {
+        var fleet = _snapshot() ?? Array.Empty<(string, SessionDto)>();
+
+        // Fold over the WHOLE fleet. SnapshotFresh hands back deep copies, so stamping these cannot touch the
+        // cache - the roster read does its own stamping pass on its own copies. The tuple entries reference
+        // these same objects, so iterating the fleet below sees the stamped values. An empty fleet still runs
+        // the prune below (a Director whose last session left must not keep a stale gate entry that would
+        // suppress the stamp when that session returns).
+        var toFold = fleet.Select(f => f.Session).ToList();
+        if (toFold.Count > 0)
+            _stampFold(toFold);
+
+        var live = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (directorId, s) in fleet)
+        {
+            if (string.IsNullOrEmpty(s.SessionId) || string.IsNullOrEmpty(directorId)) continue;
+            live.Add(s.SessionId);
+
+            var signature = Signature(s);
+            // THE GATE. Unchanged fold -> no send -> the echo of our own stamp dies here rather than
+            // becoming the next push. Removing this makes the observer spin.
+            if (_lastSent.TryGetValue(s.SessionId, out var sent) && string.Equals(sent, signature, StringComparison.Ordinal))
+                continue;
+
+            _ = SendDisplayStateAsync(directorId, s, signature);
+        }
+
+        // Keep the gate bounded: a session that has left the fleet keeps no entry.
+        foreach (var key in _lastSent.Keys)
+            if (!live.Contains(key))
+                _lastSent.TryRemove(key, out _);
+    }
+
+    /// <summary>The fold answer as one comparable string. Any field the desktop renders changing must re-push,
+    /// so every rendered field is in the signature.</summary>
+    private static string Signature(SessionDto s) =>
+        string.Join(
+            '|',
+            s.EffectiveColor ?? "",
+            s.StateLabel ?? "",
+            s.TriageBucket ?? "",
+            s.NeedsYouSince?.ToUniversalTime().ToString("O") ?? "",
+            s.SnoozeUntil?.ToUniversalTime().ToString("O") ?? "",
+            s.SnoozeExpired ? "1" : "0");
+
+    private async Task SendDisplayStateAsync(string directorId, SessionDto s, string signature)
+    {
+        try
+        {
+            var command = new DirectorCommand
+            {
+                CommandId = Guid.NewGuid().ToString("N"),
+                Verb = "set-display-state",
+                SessionId = s.SessionId,
+                PayloadJson = System.Text.Json.JsonSerializer.Serialize(
+                    new SetDisplayStateRequest
+                    {
+                        EffectiveColor = s.EffectiveColor,
+                        StateLabel = s.StateLabel,
+                        TriageBucket = s.TriageBucket,
+                        NeedsYouSince = s.NeedsYouSince,
+                        SnoozeUntil = s.SnoozeUntil,
+                        SnoozeExpired = s.SnoozeExpired,
+                    },
+                    new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web)),
+            };
+
+            var result = await _sendCommand(directorId, command, CancellationToken.None);
+            if (result is null)
+            {
+                // No tunnel. Not an error - that Director's rail simply has no stamped fold, the documented
+                // "no Gateway, no fold" floor. Record NOTHING, so the stamp is retried the moment the
+                // Director reconnects and pushes.
+                FileLog.Write($"[FleetDisplayStateObserver] sid={s.SessionId}: no stream for director={directorId}; fold not delivered");
+                return;
+            }
+
+            // A DEFINITIVE response - success OR rejection - counts as delivered for the gate, so record it
+            // either way. A rejection is almost always an OLD Director that does not know this verb yet
+            // during a Gateway-ahead-of-Directors rollout (the normal deploy order: the Gateway ships first).
+            // Re-sending every sweep would be a rejection STORM for every session that Director owns. Recorded
+            // here, it gets ONE send per fold change instead. When that Director upgrades it RECONNECTS, which
+            // drops its sessions from the fleet and prunes this gate (see Sweep), so the new code then
+            // receives a fresh stamp. Only "no stream" (null) is retried, because that alone is transient
+            // with no response to record.
+            _lastSent[s.SessionId] = signature;
+            if (result.Status != DirectorCommandStatus.Ok)
+            {
+                FileLog.Write($"[FleetDisplayStateObserver] sid={s.SessionId}: director={directorId} rejected fold (recorded, not re-stormed): {result.Status} {result.Error}");
+                return;
+            }
+            FileLog.Write($"[FleetDisplayStateObserver] sid={s.SessionId}: fold '{s.EffectiveColor}'/'{s.StateLabel}' stamped down to director={directorId}");
+        }
+        catch (Exception ex)
+        {
+            // A boundary: fire-and-forget off the hub's push path, so a faulting send must not take down the
+            // push that triggered it, and must not be recorded as delivered.
+            FileLog.Write($"[FleetDisplayStateObserver] sid={s.SessionId}: fold stamp FAILED for director={directorId}: {ex.Message}");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -93,6 +93,16 @@ public sealed class GatewayHost : IAsyncDisposable
     internal Fleet.FleetRoleObserver FleetRoles { get; }
 
     /// <summary>
+    /// The observer that stamps each session's FOLDED display state (effective color, label, triage bucket,
+    /// needs-you-since, the snooze clock, the snooze-ended marker) back DOWN to the Director that owns it, so
+    /// the desktop rail renders the Gateway's answer instead of re-folding from local facts it cannot see.
+    /// Shared with the DirectorHub through the container, like <see cref="FleetRoles"/>; also driven by a
+    /// periodic sweep (<see cref="_displayStateSweepTimer"/>) as the backstop for Gateway-only overlay
+    /// changes that arrive on no Director push.
+    /// </summary>
+    internal Fleet.FleetDisplayStateObserver FleetDisplayState { get; }
+
+    /// <summary>
     /// The durable fleet CONCURRENCY record (how many sessions run at once, and how many are actively
     /// working at once) that the private Gateway dashboard and the agent API read. Fed from the same
     /// assembled /sessions roster as <see cref="InputStats"/>, so it is fleet-wide with no per-Director
@@ -329,6 +339,14 @@ public sealed class GatewayHost : IAsyncDisposable
     private Running.AutoDismissSweeper? _autoDismissSweeper;
     private static readonly TimeSpan AutoDismissSweepInterval = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan AutoDismissStaleAfter = TimeSpan.FromSeconds(30);
+    // The fold push backstop: the DirectorHub seam re-folds immediately on every Director push, which covers
+    // every Director-driven change (activity, hold, desktop dictation). This periodic sweep catches the
+    // GATEWAY-ONLY overlay changes that arrive on no push - voice generation, the Gateway's own
+    // transcription, a phone dictation, a snooze expiring - so the desktop rail is never more than one
+    // interval behind them. The observer's change gate keeps it quiet when nothing changed. Disposed in
+    // StopAsync.
+    private System.Threading.Timer? _displayStateSweepTimer;
+    private static readonly TimeSpan DisplayStateSweepInterval = TimeSpan.FromSeconds(5);
     private readonly Running.WorkListRunnerManager _runnerManager = new();
     // Issue #218: Gateway-owned clock for when each session entered the red / NEEDS-YOU state.
     private readonly NeedsYouClock _needsYouClock = new();
@@ -587,6 +605,19 @@ public sealed class GatewayHost : IAsyncDisposable
         // echoing back up and re-triggering itself forever.
         FleetRoles = new Fleet.FleetRoleObserver(
             () => PushedSessions.SnapshotFresh(AutoDismissStaleAfter),
+            SendCommandAsync);
+        // The fold push seam: stamps each session's folded display state down to its owning Director, so the
+        // desktop rail stops re-folding from local facts it cannot see. Folds through the SAME method the
+        // roster serves from (StampFleetRolesAndFold with THIS host's NeedsYouClock and snooze registry), so
+        // the answer pushed to the desktop is byte-identical to the answer every browser gets - one fold, one
+        // authority. Like FleetRoles it holds the change gate that stops the stamp echoing back up forever.
+        FleetDisplayState = new Fleet.FleetDisplayStateObserver(
+            () => PushedSessions.SnapshotFresh(AutoDismissStaleAfter),
+            sessions => Api.GatewayEndpoints.StampFleetRolesAndFold(
+                sessions,
+                sessions,
+                needsYouStampFor: (sid, isRed) => _needsYouClock.Stamp(sid, isRed),
+                snoozeRegistry: _snoozeRegistry),
             SendCommandAsync);
         // Mission Screen mission (Phase 1b, issue #1405): the mission-WHY store, at a Gateway-side file
         // (CcStorage.Root(), the same location the snooze and cron stores use). Loaded here so a Gateway
@@ -1150,6 +1181,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // the Director pushes up "the hold landed".
         builder.Services.AddSingleton(SnoozeLandings);
         builder.Services.AddSingleton(FleetRoles);
+        builder.Services.AddSingleton(FleetDisplayState);
         builder.Services.AddSingleton(SessionConcurrency);
         builder.Services.AddSingleton(Registry);
         // launcher-persistent-join: the LauncherHub (constructed per-invocation by SignalR) and
@@ -1757,6 +1789,14 @@ public sealed class GatewayHost : IAsyncDisposable
         _autoDismissTimer = new System.Threading.Timer(_ => SweepAutoDismiss(), null, AutoDismissSweepInterval, AutoDismissSweepInterval);
         FileLog.Write($"[GatewayHost] auto-dismiss sweep started: every {AutoDismissSweepInterval.TotalSeconds:0}s");
 
+        // The fold push backstop: re-fold the fleet and stamp changed answers down, catching the Gateway-only
+        // overlays (voice, transcription, dictation, snooze expiry) that arrive on no Director push. Never
+        // throws into the timer.
+        _displayStateSweepTimer = new System.Threading.Timer(
+            _ => { try { FleetDisplayState.Sweep(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] display-state sweep error: {ex.Message}"); } },
+            null, DisplayStateSweepInterval, DisplayStateSweepInterval);
+        FileLog.Write($"[GatewayHost] display-state sweep started: every {DisplayStateSweepInterval.TotalSeconds:0}s");
+
         // Issue #629: start the durable telemetry retry-queue flusher. It drains any events restored
         // from disk on construction (so a backend outage that spanned the previous run's lifetime now
         // delivers) and every event the relay enqueues going forward, in FIFO order, retrying with
@@ -1962,6 +2002,8 @@ public sealed class GatewayHost : IAsyncDisposable
         _cronTimer = null;
         try { _autoDismissTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] auto-dismiss timer dispose error: {ex.Message}"); }
         _autoDismissTimer = null;
+        try { _displayStateSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] display-state sweep timer dispose error: {ex.Message}"); }
+        _displayStateSweepTimer = null;
 
 
         // Issue #640: stop the background token refresh timer.

--- a/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
+++ b/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
@@ -339,6 +339,21 @@ public sealed class SnoozeRegistry
     }
 
     /// <summary>
+    /// The absolute UTC deadline an ARMED snooze returns at (<see cref="SessionDto.SnoozeUntil"/>), or null
+    /// when there is no clock to show: no entry, or a DEFERRED entry whose clock has not started (the work
+    /// it waits on has not ended - defect 20). Deliberately returns the deadline even once it is in the past
+    /// - an elapsed armed entry still has a real <c>SnoozeUntilUtc</c>; whether that reads as "over" is
+    /// <see cref="HoldStateFor"/>'s and <see cref="IsExpired"/>'s ruling, not this getter's. Pure, so it is
+    /// safe on the fold's read path alongside <see cref="HoldStateFor"/>.
+    /// </summary>
+    public DateTime? SnoozeUntilFor(string sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) return null;
+        lock (_gate)
+            return _entries.TryGetValue(sessionId, out var e) ? e.SnoozeUntilUtc : null;
+    }
+
+    /// <summary>
     /// The owner came back: if they drove a turn on this session after the hold was asked for, drop it.
     /// Returns true only when an entry was actually removed.
     ///

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -33,10 +33,11 @@ public sealed class DirectorHub : Hub
     private readonly GatewayStreamRegistry _streamRegistry;
     private readonly Snooze.SnoozeLandingObserver? _snoozeLandings;
     private readonly Fleet.FleetRoleObserver? _fleetRoles;
+    private readonly Fleet.FleetDisplayStateObserver? _fleetDisplayState;
 
     public DirectorHub(PushedSessionStore store, DirectorRegistry registry, GatewayInputStatsAggregator inputStats,
         GatewayStreamRegistry streamRegistry, Snooze.SnoozeLandingObserver? snoozeLandings = null,
-        Fleet.FleetRoleObserver? fleetRoles = null)
+        Fleet.FleetRoleObserver? fleetRoles = null, Fleet.FleetDisplayStateObserver? fleetDisplayState = null)
     {
         _store = store;
         _registry = registry;
@@ -44,6 +45,7 @@ public sealed class DirectorHub : Hub
         _streamRegistry = streamRegistry;
         _snoozeLandings = snoozeLandings;
         _fleetRoles = fleetRoles;
+        _fleetDisplayState = fleetDisplayState;
     }
 
     /// <summary>
@@ -105,6 +107,10 @@ public sealed class DirectorHub : Hub
         // re-enter the liveness set, so their controllers' and workers' roles move with them). Re-resolve
         // and stamp down whatever changed, or the desktop keeps folding a role from before the reconnect.
         _fleetRoles?.ObserveSnapshot(set);
+        // The fold seam: a reconnecting Director's whole roster can change any session's folded display state
+        // (its own, and others' across the fleet). Re-fold and stamp down whatever changed, so the desktop
+        // rail renders the Gateway's answer rather than one from before the reconnect.
+        _fleetDisplayState?.ObserveSnapshot(set);
     }
 
     /// <summary>A single-session delta: upserts one session for the bound Director.</summary>
@@ -129,6 +135,10 @@ public sealed class DirectorHub : Hub
         // way the resolution is fleet-wide, and the changed roles are stamped back down so every desktop
         // folds the same answer the phone does.
         _fleetRoles?.Observe(session);
+        // THE FOLD SEAM. This delta changed this session's raw facts (activity, hold, dictation) and may
+        // change another session's fold across the fleet. Re-fold and stamp the changed answers down, so the
+        // desktop rail shows the Gateway's colour/label/triage within milliseconds of the change.
+        _fleetDisplayState?.Observe(session);
     }
 
     /// <summary>A remove/tombstone: drops one session from the bound Director's set.</summary>
@@ -147,6 +157,8 @@ public sealed class DirectorHub : Hub
         // its workers being Workers. Must run AFTER ApplyRemove so the sweep resolves the fleet that now
         // exists rather than the one that just left.
         _fleetRoles?.ObserveRemoval(sessionId);
+        // A departure re-folds the survivors too (a controller leaving un-suppresses its workers' red).
+        _fleetDisplayState?.ObserveRemoval(sessionId);
     }
 
     public override Task OnConnectedAsync()


### PR DESCRIPTION
## What and why

The desktop rail computed its own colour, label and triage from local Director facts, so it could not see the Gateway-only fold inputs: a phone dictation, the Gateway's own transcription, a voice summary being prepared, and the snooze clock and its expiry. A snoozed session therefore read red "Needs you" on the desktop while the phone and the Cockpit read "Snoozed" - the reported disagreement. The Gateway is the single fold; the fix is that the desktop stops folding and renders the Gateway's stamped answer.

## How

A push seam that stamps each session's folded display state down to the owning Director, modelled on the existing role and snooze push seams.

- **Gateway -> Director.** A new `FleetDisplayStateObserver` folds the whole fleet through the same `StampFleetRolesAndFold` the roster serves from (one authority, no divergence) and pushes effective colour, state label, triage bucket, needs-you-since, the snooze clock and the snooze-ended marker down over a new `set-display-state` command. It fires on every Director push and on a periodic backstop sweep for the Gateway-only overlays, change-gated so it never echoes. A rejection from an older Director is recorded rather than retried every sweep, so deploying the Gateway ahead of the Directors does not storm.
- **Director.** Caches the pushed state on the session (with a change signal) and reads it back through `ControlEndpoints.Map`. New wire field `SnoozeUntil` carries the snooze deadline.
- **Rail.** `SessionViewModel` renders the stamped colour, label and triage verbatim, adds the hold time ("wakes in 3h 48m") and the snooze-ended badge, and shows a neutral placeholder when no Gateway has stamped a fold yet. The voice takeover queue reads the same stamp so it cannot disagree with the rail.

## Tests

New coverage across the push seam (echo gate, rollout-rejection gate), the snooze clock, the Director signal, the mapper round trip, and the rail rendering. The rail and voice-queue suites that encoded the old local fold are rewritten to the new model. All seven test projects pass (Gateway 2527, Core 3233, Avalonia 220, plus Engine/HostedAgent/Launcher/Terminal).

## Notes

- Cockpit and mobile already render the Gateway's effective colour; their label/triage cleanups are a separate follow-up.
- A Director on old code renders unchanged (its rail keeps the local fold) until rebuilt; the Gateway's push to it is rejected harmlessly.