### PR TITLE
Show hold time and winding-down on the Cockpit and mobile rosters, from the Gateway fold

### DIFF
--- a/apps/cockpit/src/sessions/SessionRoster.tsx
+++ b/apps/cockpit/src/sessions/SessionRoster.tsx
@@ -3,10 +3,13 @@ import type { SessionDto } from "@devthrottle/client-core/api/client";
 import {
   classify,
   contextLine,
+  deletionReason,
   dotColor,
   effectiveColor,
   groupByDirector,
   inBucket,
+  pendingDeletion,
+  snoozeCountdown,
   snoozeExpired,
 } from "@devthrottle/client-core/sessions/ordering";
 import { machinePortLabel } from "@devthrottle/client-core/fleet/directorEndpoint";
@@ -233,11 +236,18 @@ function RosterRow({
   const wobbly = reach?.state === REACHABILITY_WOBBLY;
   const offline = reach?.state === REACHABILITY_OFFLINE;
   const lastSeen = wobbly || offline ? reachabilityLastSeen(reach?.lastSeenAgeSeconds) : "";
-  // The tag row (voice / snoozed / snooze-ended / last-seen / waiting) renders only when it has
-  // something to say, so a plain working session stays a compact two lines (name + state).
+  // The hold time ("wakes in 3h 48m") and the winding-down flag are the Gateway's fold, read the same way
+  // the desktop rail reads them - never the raw onHold sensor, which can drift from the fold (a Held
+  // session that starts working is blue, and must not still read "snoozed"). The snooze LABEL already
+  // rides on contextLine (the stamped stateLabel); this tag adds the countdown beside it.
+  const holdCountdown = snoozeCountdown(session);
+  const windingDown = pendingDeletion(session);
+  // The tag row (voice / hold-time / snooze-ended / winding-down / last-seen / waiting) renders only when
+  // it has something to say, so a plain working session stays a compact two lines (name + state).
   const hasTags =
-    !!session.onHold ||
+    holdCountdown !== null ||
     snoozeExpired(session) ||
+    windingDown ||
     !!session.voiceMode ||
     lastSeen.length > 0 ||
     (attention && !!session.needsYouSince);
@@ -268,7 +278,12 @@ function RosterRow({
           {hasTags && (
             <span className="roster-tags">
               {session.voiceMode && <span className="roster-tag voice">voice</span>}
-              {session.onHold && <span className="roster-tag">snoozed</span>}
+              {windingDown && (
+                <span className="roster-tag winding-down" title={deletionReason(session) ?? "Marked for deletion"}>
+                  winding down
+                </span>
+              )}
+              {holdCountdown !== null && <HoldCountdown session={session} />}
               {snoozeExpired(session) && <span className="roster-tag snooze-ended">Snooze ended</span>}
               {lastSeen && <span className="roster-lastseen">{lastSeen}</span>}
               {attention && session.needsYouSince && <WaitingTime since={String(session.needsYouSince)} />}
@@ -295,4 +310,14 @@ function WaitingTime({ since }: { since: string }) {
   const label = waitingLabel(since, now);
   if (label.length === 0) return null;
   return <span className="roster-waiting">{label}</span>;
+}
+
+// The live "wakes in <dur>" hold time for a snoozed row, ticking each second from the Gateway-owned
+// snooze clock (no roster refetch). Only mounted for snoozed rows that carry a clock, so the per-second
+// re-render never touches other rows - the same pattern as WaitingTime.
+function HoldCountdown({ session }: { session: SessionDto }) {
+  const now = useNow(1000);
+  const label = snoozeCountdown(session, now);
+  if (label === null) return null;
+  return <span className="roster-tag hold-time">{label}</span>;
 }

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -835,6 +835,21 @@ body {
   color: #d99120;
 }
 
+/* The Gateway-owned hold time on a snoozed row ("wakes in 3h 48m") - muted, and NOT uppercased so the
+   duration reads naturally beside the stamped "Snoozed" label. */
+.roster-tag.hold-time {
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text-dim);
+}
+
+/* A session flagged for deletion wears a neutral "winding down" badge (a BADGE, never a colour): the dot
+   still tells the truth about the work while this rides beside it. Mirrors the desktop rail's badge. */
+.roster-tag.winding-down {
+  color: #9ca3af;
+  border-color: rgba(156, 163, 175, 0.45);
+}
+
 /* The "computer:port" line on a card (Attention view only - in My order the group header carries it).
    Its own line, shown in full so a long machine name never clips. */
 .roster-machine {

--- a/apps/mobile/src/components/SessionAppBar.tsx
+++ b/apps/mobile/src/components/SessionAppBar.tsx
@@ -188,7 +188,14 @@ export function SessionAppBar({ title, manage, showSnooze = false, showSwitchToV
       </div>
 
       {manage.error !== null && <div className="banner banner-error" role="alert">{manage.error}</div>}
-      {manage.held && <span className="manage-held-pill">Snoozed</span>}
+      {/* The snoozed pill reads the Gateway's FOLD (manage.snoozed), not the raw onHold flag: a Held session
+          that has started working is blue "Working" and must not still read "Snoozed". Shows the hold time
+          beside it when the Gateway's snooze clock is running, matching the roster and the desktop rail. */}
+      {manage.snoozed && (
+        <span className="manage-held-pill">
+          {manage.holdCountdown ? `Snoozed - ${manage.holdCountdown}` : "Snoozed"}
+        </span>
+      )}
 
       {confirming && (
         <div className="confirm-overlay" role="dialog" aria-modal="true" aria-label="Remove session">

--- a/apps/mobile/src/components/useSessionManage.ts
+++ b/apps/mobile/src/components/useSessionManage.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { holdSession, killSession, listSessions } from "@devthrottle/client-core/api/client";
+import { classify, snoozeCountdown } from "@devthrottle/client-core/sessions/ordering";
 
 // The session management verbs (Snooze/Unsnooze + Remove) for ONE session, hoisted out of the old
 // SessionManageBar so two places can drive them from one copy of the state: the app bar's overflow
@@ -16,6 +17,12 @@ const POLL_INTERVAL_MS = 4000;
 export interface SessionManage {
   onHold: boolean | null;
   held: boolean;
+  // The FOLD's verdict for DISPLAY (classify === "onHold"), distinct from the raw `held` the toggle uses.
+  // A Held session that has started working is blue "Working" and must NOT read "snoozed" - working wins in
+  // the fold, so a display pill reads this, never the raw onHold flag.
+  snoozed: boolean;
+  // "wakes in 3h 48m" from the Gateway-owned snooze clock, or null when there is no running clock.
+  holdCountdown: string | null;
   busy: boolean;
   error: string | null;
   setError: (message: string | null) => void;
@@ -26,6 +33,8 @@ export interface SessionManage {
 export function useSessionManage(sessionId: string | undefined): SessionManage {
   const navigate = useNavigate();
   const [onHold, setOnHold] = useState<boolean | null>(null);
+  const [snoozed, setSnoozed] = useState(false);
+  const [holdCountdown, setHoldCountdown] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // While a toggle is in flight the optimistic state must not be clobbered by a slower poll.
@@ -40,7 +49,18 @@ export function useSessionManage(sessionId: string | undefined): SessionManage {
         const all = await listSessions(controller.signal);
         if (cancelled || pendingRef.current) return;
         const match = all.find((s) => s.sessionId === sessionId);
-        if (match) setOnHold(Boolean(match.onHold));
+        if (match) {
+          // The toggle needs the raw hold (what it will flip); the DISPLAY reads the fold (working wins).
+          setOnHold(Boolean(match.onHold));
+          setHoldCountdown(snoozeCountdown(match));
+          // classify fails loud against a Gateway that did not stamp triageBucket; in this polling loop a
+          // mixed-version blip must not throw the refresh, so keep the last verdict on that rare miss.
+          try {
+            setSnoozed(classify(match) === "onHold");
+          } catch {
+            /* keep the last-known snoozed verdict */
+          }
+        }
       } catch {
         /* keep the last-known held state; the actions surface their own errors */
       }
@@ -89,6 +109,8 @@ export function useSessionManage(sessionId: string | undefined): SessionManage {
   return {
     onHold,
     held: onHold === true,
+    snoozed,
+    holdCountdown,
     busy,
     error,
     setError,

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { type SessionDto } from "@devthrottle/client-core/api/client";
 import { getSessionsEnvelope } from "@devthrottle/client-core/fleet/fleetClient";
 import { emptyRetentionCache, mergeRosterRetention, type RosterSessionMark } from "@devthrottle/client-core/fleet/rosterRetention";
-import { classify, contextLine, dotColor, effectiveColor, inBucket, inDesktopOrder, inWaitingOrder, isWorking, repoLeaf, snoozeExpired } from "@devthrottle/client-core/sessions/ordering";
+import { classify, contextLine, deletionReason, dotColor, effectiveColor, inBucket, inDesktopOrder, inWaitingOrder, isWorking, pendingDeletion, repoLeaf, snoozeCountdown, snoozeExpired } from "@devthrottle/client-core/sessions/ordering";
 import { applyFilter, filterIsActive, filterSummary, machineName, pruneFilter } from "@devthrottle/client-core/sessions/filter";
 import { useDictationStatusFor } from "@devthrottle/client-core/dictation/status";
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
@@ -340,6 +340,10 @@ function SessionRow({ session, mark }: { session: SessionDto; mark?: RosterSessi
   // regenerated typed client. Null on sessions/Directors without a number - then no prefix shows.
   const num = session.number;
   const hasNum = num !== null && num !== undefined && String(num).trim().length > 0;
+  // The Gateway-owned hold time ("wakes in 3h 48m") and the winding-down flag, read the same way the
+  // desktop rail and the Cockpit read them - never the raw onHold sensor (which can drift from the fold).
+  const holdCountdown = snoozeCountdown(session);
+  const windingDown = pendingDeletion(session);
   // Issue #948: a voice-mode session opens straight on its Voice tab (the surface it is meant to be
   // used from), not on the default Chat tab; every other session still opens on Chat.
   const sid = encodeURIComponent(session.sessionId ?? "");
@@ -363,11 +367,21 @@ function SessionRow({ session, mark }: { session: SessionDto; mark?: RosterSessi
           <span className="row-meta">
             <span className="row-context">{contextLine(session)}</span>
             {attention && session.needsYouSince && <WaitingTime since={String(session.needsYouSince)} />}
+            {/* The hold time on a snoozed row ("wakes in 3h 48m"), from the Gateway-owned snooze clock,
+                ticking each second - only mounted when there is a clock, so other rows keep no timer. */}
+            {holdCountdown !== null && <HoldCountdown session={session} />}
           </span>
           {/* Snooze Length mission: a distinct "Snooze ended" badge when this session just returned from
               an expired snooze on its own (the dead-man's switch fired) - so the reader knows this is a
               "go see why it went quiet" item, not a fresh turn-end. */}
           {snoozeExpired(session) && <span className="row-snooze-ended">Snooze ended</span>}
+          {/* A session flagged for deletion wears a neutral "winding down" badge (a BADGE, never a colour):
+              the dot keeps telling the truth about the work while this rides beside it. */}
+          {windingDown && (
+            <span className="row-winding-down" title={deletionReason(session) ?? "Marked for deletion"}>
+              winding down
+            </span>
+          )}
           {/* The facts you navigate and filter by - the machine the session runs on and its repo - are
               a bottom row of small chips, so a fleet spread across several machines is legible at a
               glance without crowding the status line. The machine chip is accent-tinted; the repo chip
@@ -508,4 +522,14 @@ function WaitingTime({ since }: { since: string }) {
   const label = waitingLabel(since, now);
   if (label.length === 0) return null;
   return <span className="row-waiting">{label}</span>;
+}
+
+// The live "wakes in <dur>" hold time for a snoozed card, ticking each second from the Gateway-owned
+// snooze clock (no roster refetch). Only mounted for snoozed cards that carry a clock, so the per-second
+// re-render never touches other rows - the same pattern as WaitingTime.
+function HoldCountdown({ session }: { session: SessionDto }) {
+  const now = useNow(1000);
+  const label = snoozeCountdown(session, now);
+  if (label === null) return null;
+  return <span className="row-hold-time">{label}</span>;
 }

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -275,6 +275,34 @@ a.banner-btn {
   color: #d99120;
 }
 
+/* The Gateway-owned hold time on a snoozed row ("wakes in 3h 48m"), right-aligned on the status line like
+   the waiting timer but muted - it annotates the "Snoozed" label rather than nagging. */
+.row-hold-time {
+  margin-left: auto;
+  flex: 0 0 auto;
+  font-size: 12px;
+  color: var(--text-dim, #9aa4b2);
+  white-space: nowrap;
+}
+
+/* A session flagged for deletion wears a neutral "winding down" badge (a BADGE, never a colour): the dot
+   keeps telling the truth about the work while this rides beside it. Same shape as the snooze-ended badge,
+   neutral gray so it never competes with the status dot. */
+.row-winding-down {
+  display: inline-block;
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 1px 7px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  background: rgba(156, 163, 175, 0.14);
+  border: 1px solid rgba(156, 163, 175, 0.45);
+  color: #9ca3af;
+}
+
 /* Issue #838: the dot is top-aligned at the start of the FIRST name line (align-items:
    flex-start) so a name that wraps to several lines keeps the dot beside its first line. */
 .row-link {

--- a/packages/client-core/src/sessions/ordering.test.ts
+++ b/packages/client-core/src/sessions/ordering.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { SessionDto } from "../api/client";
-import { classify, contextLine, dotColor, effectiveColor, groupByDirector, inBucket, inWaitingOrder, isWorking, stateLabel } from "./ordering";
+import { classify, contextLine, deletionReason, dotColor, effectiveColor, groupByDirector, inBucket, inWaitingOrder, isWorking, pendingDeletion, snoozeCountdown, stateLabel } from "./ordering";
 
 function session(fields: Partial<SessionDto> & { sessionId?: string } = {}): SessionDto {
   return {
@@ -214,5 +214,36 @@ describe("groupByDirector", () => {
 
     expect(groups[0].port).toBe("");
     expect(groups[0].machineName).toBe("SOREN_NORTH");
+  });
+});
+
+describe("hold time (snoozeCountdown) - the Gateway-owned snooze clock", () => {
+  const now = Date.parse("2026-07-16T12:00:00Z");
+
+  it("formats the remaining time to match the desktop rail's wording", () => {
+    const at = (iso: string) => snoozeCountdown(session({ snoozeUntil: iso } as Partial<SessionDto>), now);
+    expect(at("2026-07-16T15:48:00Z")).toBe("wakes in 3h 48m"); // 3h 48m
+    expect(at("2026-07-16T15:00:00Z")).toBe("wakes in 3h");      // exact hours -> no minutes
+    expect(at("2026-07-16T12:42:00Z")).toBe("wakes in 42m");     // under an hour
+    expect(at("2026-07-16T12:00:30Z")).toBe("wakes in <1m");     // under a minute
+    expect(at("2026-07-16T11:59:00Z")).toBe("waking up");        // already past due
+  });
+
+  it("returns null when there is no running snooze clock", () => {
+    // Not snoozed, or a deferred snooze that has not landed (no deadline yet).
+    expect(snoozeCountdown(session(), now)).toBeNull();
+    expect(snoozeCountdown(session({ snoozeUntil: null } as Partial<SessionDto>), now)).toBeNull();
+    expect(snoozeCountdown(session({ snoozeUntil: "not-a-date" } as Partial<SessionDto>), now)).toBeNull();
+  });
+});
+
+describe("winding-down (pendingDeletion) - a badge, never a colour", () => {
+  it("reads the Gateway flag and reason, defaulting to false / null", () => {
+    expect(pendingDeletion(session())).toBe(false);
+    expect(deletionReason(session())).toBeNull();
+
+    const flagged = session({ pendingDeletion: true, deletionReason: "jobs-auto: nothing to report" } as Partial<SessionDto>);
+    expect(pendingDeletion(flagged)).toBe(true);
+    expect(deletionReason(flagged)).toBe("jobs-auto: nothing to report");
   });
 });

--- a/packages/client-core/src/sessions/ordering.ts
+++ b/packages/client-core/src/sessions/ordering.ts
@@ -12,6 +12,15 @@ type GatewayStampedSession = SessionDto & {
   // (its Gateway-owned timer elapsed and the fold put it back into "needs you" on its own). The Gateway
   // stamps it; clients render a distinct "Snooze ended" badge. Optional (absent/false for most sessions).
   snoozeExpired?: boolean | null;
+  // The armed-snooze deadline (Gateway-owned snooze clock), so a client can render the hold time
+  // ("wakes in 3h 48m"). Null when there is no running clock: not snoozed, or a deferred snooze that has
+  // not landed yet. The generated schema does not carry it, so it is augmented here like the fields above.
+  snoozeUntil?: string | null;
+  // The session is flagged for deletion and awaiting the reaper - drives the "winding down" badge. A BADGE,
+  // NEVER A COLOUR: the fold does not read it, so the dot keeps telling the truth about the work while this
+  // rides beside it (mirrors the desktop rail's IsPendingDeletion). Optional; false for most sessions.
+  pendingDeletion?: boolean | null;
+  deletionReason?: string | null;
 };
 
 // The stable "desktop order": honor the owning Director's SortOrder (the user-controlled,
@@ -112,6 +121,41 @@ export function stateLabel(s: SessionDto): string {
 // Non-throwing (optional field): a session without the marker is simply not returned-from-snooze.
 export function snoozeExpired(s: SessionDto): boolean {
   return Boolean((s as GatewayStampedSession).snoozeExpired);
+}
+
+// "wakes in 3h 48m" - how long until an armed snooze returns this session to needs-you, read from the
+// Gateway-owned snooze clock (snoozeUntil). Returns null when there is no running clock: not snoozed, or a
+// deferred snooze that has not landed (no deadline yet). The Director never owns the clock; the client only
+// renders the countdown. The wording matches the desktop rail's HoldTimeLabel exactly, so the hold time
+// reads identically on the rail, the Cockpit and the phone. `nowMs` is injectable for deterministic tests.
+export function snoozeCountdown(s: SessionDto, nowMs: number = Date.now()): string | null {
+  const raw = (s as GatewayStampedSession).snoozeUntil?.trim();
+  if (!raw) return null;
+  const until = Date.parse(raw);
+  if (Number.isNaN(until)) return null;
+  const remainingMs = until - nowMs;
+  if (remainingMs <= 0) return "waking up";
+  const totalMin = Math.floor(remainingMs / 60000);
+  if (totalMin < 1) return "wakes in <1m";
+  if (totalMin < 60) return `wakes in ${totalMin}m`;
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return m > 0 ? `wakes in ${h}h ${m}m` : `wakes in ${h}h`;
+}
+
+// True when this session is flagged for deletion and awaiting the reaper - drives the "winding down"
+// badge. A BADGE, NEVER A COLOUR (owner's ruling): pending deletion says nothing about what the agent is
+// DOING - a flagged session may still be working - so the dot keeps telling the truth and this rides
+// beside it. Non-throwing (optional field); mirrors the desktop rail's IsPendingDeletion.
+export function pendingDeletion(s: SessionDto): boolean {
+  return Boolean((s as GatewayStampedSession).pendingDeletion);
+}
+
+// The human reason captured when a session was flagged for deletion (e.g. "jobs-auto: nothing to report"),
+// or null when none was given - surfaced as the winding-down badge's tooltip.
+export function deletionReason(s: SessionDto): string | null {
+  const r = (s as GatewayStampedSession).deletionReason?.trim();
+  return r ? r : null;
 }
 
 // True while the agent is actively running a turn - the "working" state. Blue is the authoritative


### PR DESCRIPTION
## What and why

Follow-up to #1746. The desktop rail now renders the Gateway's folded state including the snooze hold time ("wakes in 3h 48m") and the winding-down (pending-deletion) badge. This brings the Cockpit and mobile rosters to the same parity, so all three surfaces render identically from one shared fold.

Both rosters already rendered effective colour, state label and triage from the Gateway; they were missing the hold time and winding-down badge, and two label reads still came off the raw `onHold` flag (which can drift from the fold - a Held session that has started working is blue "Working" and must not read "Snoozed").

## How

- **`client-core/ordering.ts`**: `snoozeCountdown()` (same wording as the rail's hold-time label), `pendingDeletion()`, `deletionReason()`; `snoozeUntil` augmented onto the session type.
- **Cockpit roster**: raw-`onHold` "snoozed" tag -> fold-driven ticking hold-time tag; new neutral winding-down badge.
- **Mobile roster**: same ticking hold-time + winding-down badge.
- **Mobile app bar**: the "Snoozed" pill reads the fold (`classify === "onHold"`) instead of raw `onHold`, and shows the countdown. The Snooze/Unsnooze button still reads the raw flag - that is the action, not a status render.

## Notes

- Client-only: the Gateway already carries the wire fields (#1746), so no Gateway change and no restart.
- Verified: client-core typecheck + 541 tests; Cockpit typecheck + 145 tests + build; mobile typecheck + build; eslint on all changed files. New ordering tests cover the countdown formatting and the pending-deletion readers.
- Secondary Cockpit views (fleet map, missions board, schedule picker) already render the shared colour + label; the new badges were left off those overview surfaces.