### PR TITLE
feat(core): single-tenant tenancy seam (TenantId + ITenantContext)

### DIFF
--- a/src/CcDirector.Core.Tests/Tenancy/TenantSeamTests.cs
+++ b/src/CcDirector.Core.Tests/Tenancy/TenantSeamTests.cs
@@ -1,0 +1,68 @@
+using System;
+using CcDirector.Core.Tenancy;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Tenancy;
+
+/// <summary>
+/// The tenancy seam primitives. These pin the two invariants the isolation design rests on - a tenant
+/// id is validated (never a bare/empty string), and the single-tenant core resolves everything to the
+/// one well-known local tenant so behavior is unchanged.
+/// </summary>
+public sealed class TenantSeamTests
+{
+    [Fact]
+    public void Local_IsValidAndFlaggedLocal()
+    {
+        Assert.True(TenantId.Local.IsValid);
+        Assert.True(TenantId.Local.IsLocal);
+        Assert.Equal("local", TenantId.Local.Value);
+    }
+
+    [Fact]
+    public void Construct_TrimsAndKeepsValue()
+    {
+        var id = new TenantId("  acme  ");
+
+        Assert.True(id.IsValid);
+        Assert.False(id.IsLocal);
+        Assert.Equal("acme", id.Value);
+        Assert.Equal("acme", id.ToString());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Construct_RejectsNullEmptyOrWhitespace(string? bad)
+    {
+        Assert.Throws<ArgumentException>(() => new TenantId(bad!));
+    }
+
+    [Fact]
+    public void Default_IsNotValid()
+    {
+        // A default(TenantId) bypasses the constructor; it must never be treated as a real tenant.
+        TenantId uninitialized = default;
+
+        Assert.False(uninitialized.IsValid);
+        Assert.False(uninitialized.IsLocal);
+        Assert.Equal("<invalid-tenant>", uninitialized.ToString());
+    }
+
+    [Fact]
+    public void Equality_IsByValue()
+    {
+        Assert.Equal(new TenantId("acme"), new TenantId("acme"));
+        Assert.NotEqual(new TenantId("acme"), new TenantId("globex"));
+    }
+
+    [Fact]
+    public void SingleTenantContext_AlwaysResolvesToLocal()
+    {
+        ITenantContext context = new SingleTenantContext();
+
+        Assert.Equal(TenantId.Local, context.Current);
+        Assert.True(context.Current.IsLocal);
+    }
+}

--- a/src/CcDirector.Core/Tenancy/ITenantContext.cs
+++ b/src/CcDirector.Core/Tenancy/ITenantContext.cs
@@ -1,0 +1,17 @@
+namespace CcDirector.Core.Tenancy;
+
+/// <summary>
+/// The tenancy seam: the one place that answers "which tenant is this request or connection for?" It is
+/// resolved ONCE at ingress from the authenticated principal and then carried - never re-derived per
+/// frame or per call, and never read from a client-supplied value.
+///
+/// The core ships exactly one implementation, <see cref="SingleTenantContext"/>, which always returns
+/// <see cref="TenantId.Local"/>; that is the single-tenant (N=1) case and behaves as it does today. A
+/// resolver that maps an authenticated principal to a real tenant can plug in behind this same
+/// interface, so no consumer of <see cref="ITenantContext"/> has to change.
+/// </summary>
+public interface ITenantContext
+{
+    /// <summary>The tenant the current unit of work belongs to. Always a valid, resolved tenant.</summary>
+    TenantId Current { get; }
+}

--- a/src/CcDirector.Core/Tenancy/SingleTenantContext.cs
+++ b/src/CcDirector.Core/Tenancy/SingleTenantContext.cs
@@ -1,0 +1,12 @@
+namespace CcDirector.Core.Tenancy;
+
+/// <summary>
+/// The single-tenant implementation of <see cref="ITenantContext"/>. Every unit of work resolves to
+/// <see cref="TenantId.Local"/>, so this is the N=1 case and nothing about behavior changes. A resolver
+/// can replace this behind the same seam later; this type stays exactly what the single-tenant core runs.
+/// </summary>
+public sealed class SingleTenantContext : ITenantContext
+{
+    /// <inheritdoc />
+    public TenantId Current => TenantId.Local;
+}

--- a/src/CcDirector.Core/Tenancy/TenantId.cs
+++ b/src/CcDirector.Core/Tenancy/TenantId.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace CcDirector.Core.Tenancy;
+
+/// <summary>
+/// The isolation boundary a request, connection, session, or stored record belongs to. A
+/// <see cref="TenantId"/> is a validated wrapper around a non-empty string, never a bare string passed
+/// around, so a tenant identity cannot be silently confused with an ordinary id.
+///
+/// The core is single-tenant: everything resolves to <see cref="Local"/> and nothing about behavior
+/// changes. Making the core tenancy-aware lets a resolver scope work per connection later without
+/// touching any consumer; such a resolver always derives the tenant from the authenticated principal at
+/// ingress and never reads a tenant id from client input.
+///
+/// NOTE on <c>default(TenantId)</c>: like any struct, a default value bypasses the constructor and
+/// has a null <see cref="Value"/>. A default TenantId is NOT valid and must never be treated as a
+/// tenant. Consumers obtain a TenantId from <see cref="ITenantContext"/> (always valid) or construct
+/// one explicitly (validated); they do not fabricate one from <c>default</c>. Use
+/// <see cref="IsValid"/> when a value's provenance is uncertain.
+/// </summary>
+public readonly record struct TenantId
+{
+    /// <summary>The well-known single-tenant identity. Self-host and the open core resolve to this.</summary>
+    public static readonly TenantId Local = new("local");
+
+    /// <summary>The underlying identifier. Null only for an invalid <c>default(TenantId)</c>.</summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Construct a validated tenant id. Fails loud on a null, empty, or whitespace value rather than
+    /// carrying an unusable identity forward (no fallback - an unresolved tenant is denied, not defaulted).
+    /// </summary>
+    public TenantId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("A TenantId cannot be null, empty, or whitespace.", nameof(value));
+        }
+
+        Value = value.Trim();
+    }
+
+    /// <summary>True when this value came through the validating constructor and carries an identifier.</summary>
+    public bool IsValid => !string.IsNullOrEmpty(Value);
+
+    /// <summary>True when this is the well-known single-tenant identity (the self-host / N=1 case).</summary>
+    public bool IsLocal => IsValid && string.Equals(Value, Local.Value, StringComparison.Ordinal);
+
+    /// <inheritdoc />
+    public override string ToString() => IsValid ? Value : "<invalid-tenant>";
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1182,6 +1182,9 @@ public sealed class GatewayHost : IAsyncDisposable
         builder.Services.AddSingleton(SnoozeLandings);
         builder.Services.AddSingleton(FleetRoles);
         builder.Services.AddSingleton(FleetDisplayState);
+        // Register the tenancy seam. The core ships the single-tenant default (everything resolves to
+        // TenantId.Local), so behavior is unchanged; a resolver can replace this behind the same interface.
+        builder.Services.AddSingleton<CcDirector.Core.Tenancy.ITenantContext, CcDirector.Core.Tenancy.SingleTenantContext>();
         builder.Services.AddSingleton(SessionConcurrency);
         builder.Services.AddSingleton(Registry);
         // launcher-persistent-join: the LauncherHub (constructed per-invocation by SignalR) and


### PR DESCRIPTION
## What

Introduce a tenancy seam in the core, single-tenant by default:

- `TenantId` - a validated value type (never a bare string), with a well-known `Local` identity. A null/empty/whitespace value fails loud; `default(TenantId)` is explicitly invalid.
- `ITenantContext` - the one place that answers "which tenant is this unit of work for?", resolved once at ingress.
- `SingleTenantContext` - the single-tenant implementation: every unit of work resolves to `TenantId.Local`.
- Registered in the Gateway host.

## Why

Make the core tenancy-aware so a resolver can scope work per connection later, behind the same interface, without touching any consumer.

## Behavior change

**None.** The core stays single-tenant (N=1): everything resolves to `Local`, and nothing observable changes for a self-hosted Gateway. This is purely the seam + primitives.

## Proof

- `CcDirector.Gateway` builds clean (0 warnings, 0 errors) with the seam registered.
- New unit tests green (8/8): validation, trimming, invalid-default, value equality, and single-tenant resolution to `Local`.
- The Linux `Dockerfile` image builds with the change in it, so the container path is unaffected.
