### PR TITLE
release: v1.5.0 - Gateway-owned session state, headless Gateway on Linux and macOS, command-line install

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
   </PropertyGroup>
 </Project>

--- a/docs/public/release-notes/v1.5.0.md
+++ b/docs/public/release-notes/v1.5.0.md
@@ -1,0 +1,19 @@
+## v1.5.0 - July 16, 2026
+
+The Gateway becomes the single source of truth for what each session is doing, the Gateway itself now runs on Linux and macOS, and you can install and sign in from the command line with no wizard.
+
+### Highlights
+- One honest picture of every session: the Gateway now decides each session's state and pushes it out, so the desktop rail, the Cockpit, and the mobile roster all show the same thing - including how long a session has been on hold and when it is winding down - instead of each surface guessing on its own.
+- Run the Gateway on Linux and macOS: the Gateway is no longer Windows-only, so you can host it on a plain Linux or macOS machine and drive your fleet from there.
+- Install and sign in with no wizard: a new command-line installer lets an agent set up DevThrottle, sign in, and enroll a machine entirely from the terminal, and macOS gets a curl-based install that Gatekeeper cannot block.
+- See what you have spent: new governance screens show your usage by day, week, and month, and each session's token spend is stored and sliced by hour and model.
+
+### Also in this release
+- The text injected into every new session is now a Gateway-owned setting you can view and replace, so a change reaches the whole fleet from one place.
+- When an agent puts itself on hold, the hold now goes through the Gateway and actually takes effect, instead of only looking held on its own machine.
+- Your Throttle stats group your work by repository, now recognizing Azure DevOps remotes as well as GitHub and falling back to a clean folder name when there is no remote.
+- Remote session spawn now works on Directors that reach the Gateway through a tunnel only.
+- The move-session skill ships, so you can hand a live session to another machine through the Gateway.
+- The Cockpit groups the session rail by machine, widens the new-session dialog, and replaces the unfinished Learning screen with a direct link to the documentation.
+- The Speak box opens immediately and never opens a second copy, and a slow voice moment now reads as "on its way" rather than a false "Voice service down".
+- The sign-in status box repaints the instant the panel settles, so it never shows a stale state.


### PR DESCRIPTION
Bumps the product version to v1.5.0 and adds the public release notes.

This is the version-bump pull request for the v1.5.0 release (28 commits since v1.4.0). It changes exactly two files:

- Directory.Build.props: version 1.4.0 -> 1.5.0
- docs/public/release-notes/v1.5.0.md: the canonical release notes

Headline changes in this release:
- Gateway-owned session state pushed to the desktop rail, Cockpit, and mobile roster (hold time and winding-down included)
- The Gateway now runs headless on Linux and macOS
- Command-line install, sign-in, and enroll with no wizard; curl-based macOS install
- Governance screens for spend by day, week, and month, with per-session token spend in SQLite

Once this merges green, the v1.5.0 tag is cut on main at the merge commit and the Release workflow builds and attaches cc-director.exe.