### PR TITLE
fix(gateway): dial the Gateway reliably by local (.local) computer name

### DIFF
--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -118,7 +118,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         _activeUrl = _config.Url;
         ProbeGatewayCandidate = (url, ct) => ProbeGatewayHealthzAsync(url, ct);
 
-        _http = new HttpClient
+        _http = new HttpClient(GatewayHttp.Handler())
         {
             Timeout = TimeSpan.FromSeconds(10),
         };
@@ -438,7 +438,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
             throw new ArgumentException("Target session id is required", nameof(toSessionId));
 
         FileLog.Write($"[GatewayClient] AskFleetAsync: POST /sessions/{toSessionId}/prompt (wait <= {timeoutMs}ms)");
-        using var http = new HttpClient
+        using var http = new HttpClient(GatewayHttp.Handler())
         {
             BaseAddress = new Uri(_activeUrl.TrimEnd('/') + "/"),
             Timeout = TimeSpan.FromMilliseconds(timeoutMs + 15_000),
@@ -514,7 +514,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
             throw new ArgumentNullException(nameof(req));
 
         FileLog.Write($"[GatewayClient] SpawnOnMachineAsync: POST /machines/{machine}/sessions, repo={req.RepoPath}, agent={req.Agent}");
-        using var http = new HttpClient
+        using var http = new HttpClient(GatewayHttp.Handler())
         {
             BaseAddress = new Uri(_activeUrl.TrimEnd('/') + "/"),
             Timeout = TimeSpan.FromSeconds(120),
@@ -804,7 +804,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     // which makes GatewayEndpointSelector move to the next candidate.
     private static async Task<string?> ProbeGatewayHealthzAsync(string url, CancellationToken ct)
     {
-        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        using var http = new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(5) };
         return await GatewayEndpointSelector.ProbeHealthzAsync(url, http, ct);
     }
 

--- a/src/CcDirector.ControlApi/GatewayConnectivitySelfTest.cs
+++ b/src/CcDirector.ControlApi/GatewayConnectivitySelfTest.cs
@@ -267,7 +267,7 @@ public sealed class GatewayConnectivitySelfTest
     /// <summary>One short HTTP GET: (2xx?, body-snippet-or-error). 5s budget per probe.</summary>
     private static async Task<(bool ok, string detail)> ProbeHttpAsync(string url, CancellationToken ct)
     {
-        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        using var http = new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(5) };
         try
         {
             var resp = await http.GetAsync(url, ct);

--- a/src/CcDirector.ControlApi/GatewayEnrollmentClient.cs
+++ b/src/CcDirector.ControlApi/GatewayEnrollmentClient.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Network;
 using System.Net;
 using System.Net.Http.Json;
 using CcDirector.Core.Utilities;
@@ -51,7 +52,7 @@ public static class GatewayEnrollmentClient
             DeviceType = "workstation",
         };
 
-        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+        using var http = new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(15) };
         http.BaseAddress = new Uri(gatewayUrl.TrimEnd('/') + "/");
         if (!string.IsNullOrEmpty(token))
             http.DefaultRequestHeaders.Authorization =

--- a/src/CcDirector.ControlApi/GatewayStreamClient.cs
+++ b/src/CcDirector.ControlApi/GatewayStreamClient.cs
@@ -1,4 +1,5 @@
 using CcDirector.Core.Configuration;
+using CcDirector.Core.Network;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
@@ -152,6 +153,13 @@ public sealed class GatewayStreamClient : IAsyncDisposable
                 var token = _config.Token;
                 if (!string.IsNullOrEmpty(token))
                     options.AccessTokenProvider = () => Task.FromResult<string?>(token);
+                // Local-name-friendly dialing (see GatewayHttp): a gateway named soren_north.local
+                // resolves to a link-local IPv6 address first, and the default connect hangs on it.
+                // The handler covers negotiate and the fallback transports; the websocket factory
+                // covers the websocket itself, which dials outside that handler by default.
+                options.HttpMessageHandlerFactory = _ => GatewayHttp.Handler();
+                options.WebSocketFactory = async (context, cancellationToken) =>
+                    await GatewayHttp.ConnectWebSocketAsync(context.Uri, token, cancellationToken);
             })
             .WithAutomaticReconnect(new[]
             {

--- a/src/CcDirector.Core.Tests/GatewayHttpTests.cs
+++ b/src/CcDirector.Core.Tests/GatewayHttpTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using CcDirector.Core.Network;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Pins the address ordering that makes a gateway named by a local (Bonjour/mDNS) computer name
+/// dialable: macOS answers a <c>.local</c> lookup with the link-local IPv6 address first, and the
+/// default sequential connect hangs on it. <see cref="GatewayHttp.OrderForDialing"/> must therefore
+/// put IPv4 first, globally routable IPv6 next, and link-local IPv6 last.
+/// </summary>
+public class GatewayHttpTests
+{
+    private static readonly IPAddress Ipv4 = IPAddress.Parse("192.168.1.18");
+    private static readonly IPAddress Ipv4Second = IPAddress.Parse("10.0.0.7");
+    private static readonly IPAddress Ipv6Global = IPAddress.Parse("2001:db8::1");
+    private static readonly IPAddress Ipv6LinkLocal = IPAddress.Parse("fe80::dd8a:282e:87c1:8f4b");
+
+    [Fact]
+    public void OrderForDialing_LinkLocalFirstFromResolver_MovesIpv4First()
+    {
+        // The exact shape macOS getaddrinfo returns for a .local name.
+        var resolved = new[] { Ipv6LinkLocal, Ipv4 };
+
+        var ordered = GatewayHttp.OrderForDialing(resolved);
+
+        Assert.Equal(new[] { Ipv4, Ipv6LinkLocal }, ordered);
+    }
+
+    [Fact]
+    public void OrderForDialing_AllThreeKinds_OrdersIpv4ThenGlobalIpv6ThenLinkLocal()
+    {
+        var resolved = new[] { Ipv6LinkLocal, Ipv6Global, Ipv4 };
+
+        var ordered = GatewayHttp.OrderForDialing(resolved);
+
+        Assert.Equal(new[] { Ipv4, Ipv6Global, Ipv6LinkLocal }, ordered);
+    }
+
+    [Fact]
+    public void OrderForDialing_SameRank_KeepsResolverOrder()
+    {
+        var resolved = new[] { Ipv4Second, Ipv4 };
+
+        var ordered = GatewayHttp.OrderForDialing(resolved);
+
+        Assert.Equal(new[] { Ipv4Second, Ipv4 }, ordered);
+    }
+
+    [Fact]
+    public void OrderForDialing_OnlyLinkLocal_StillReturnsIt()
+    {
+        // A link-local-only answer is a last resort, not a dead end.
+        var ordered = GatewayHttp.OrderForDialing(new[] { Ipv6LinkLocal });
+
+        Assert.Equal(new[] { Ipv6LinkLocal }, ordered);
+    }
+
+    [Fact]
+    public void OrderForDialing_Loopback_IsUnaffected()
+    {
+        var resolved = new[] { IPAddress.IPv6Loopback, IPAddress.Loopback };
+
+        var ordered = GatewayHttp.OrderForDialing(resolved);
+
+        Assert.Equal(new[] { IPAddress.Loopback, IPAddress.IPv6Loopback }, ordered);
+    }
+
+    [Fact]
+    public void OrderForDialing_Empty_ReturnsEmpty()
+    {
+        Assert.Empty(GatewayHttp.OrderForDialing(Array.Empty<IPAddress>()));
+    }
+}

--- a/src/CcDirector.Core/Account/AccountCreditsClient.cs
+++ b/src/CcDirector.Core/Account/AccountCreditsClient.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Network;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json.Nodes;
@@ -41,7 +42,7 @@ public sealed class AccountCreditsClient
     /// <param name="baseUrl">API base URL; defaults to the shared account-egress base resolution.</param>
     public AccountCreditsClient(HttpClient? client = null, string? baseUrl = null)
     {
-        _client = client ?? new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        _client = client ?? new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(10) };
         _baseUrl = ResolveBaseUrl(baseUrl);
     }
 

--- a/src/CcDirector.Core/Account/AccountNicknameClient.cs
+++ b/src/CcDirector.Core/Account/AccountNicknameClient.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Network;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -35,7 +36,7 @@ public sealed class AccountNicknameClient
     /// <param name="baseUrl">API base URL; defaults to the shared account-egress base resolution.</param>
     public AccountNicknameClient(HttpClient? client = null, string? baseUrl = null)
     {
-        _client = client ?? new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        _client = client ?? new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(10) };
         _baseUrl = ResolveBaseUrl(baseUrl);
     }
 

--- a/src/CcDirector.Core/Account/AccountNotifyClient.cs
+++ b/src/CcDirector.Core/Account/AccountNotifyClient.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Network;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -48,7 +49,7 @@ public sealed class AccountNotifyClient
     /// <param name="baseUrl">API base URL; defaults to the shared account-egress base resolution.</param>
     public AccountNotifyClient(HttpClient? client = null, string? baseUrl = null)
     {
-        _client = client ?? new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        _client = client ?? new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(30) };
         _baseUrl = ResolveBaseUrl(baseUrl);
     }
 

--- a/src/CcDirector.Core/Account/AccountTelemetryClient.cs
+++ b/src/CcDirector.Core/Account/AccountTelemetryClient.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Network;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -61,7 +62,7 @@ public sealed class AccountTelemetryClient
     /// </summary>
     public AccountTelemetryClient(HttpClient? client = null, string? baseUrl = null)
     {
-        _client = client ?? new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        _client = client ?? new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(10) };
         _baseUrl = ResolveBaseUrl(baseUrl);
     }
 

--- a/src/CcDirector.Core/Account/DeviceRegistryClient.cs
+++ b/src/CcDirector.Core/Account/DeviceRegistryClient.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Network;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -135,7 +136,7 @@ public sealed class DeviceRegistryClient
     /// </summary>
     public DeviceRegistryClient(HttpClient? client = null, string? baseUrl = null)
     {
-        _client = client ?? new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        _client = client ?? new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(10) };
         _baseUrl = ResolveBaseUrl(baseUrl);
     }
 

--- a/src/CcDirector.Core/Account/GatewayAccountCreditsClient.cs
+++ b/src/CcDirector.Core/Account/GatewayAccountCreditsClient.cs
@@ -2,6 +2,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.Network;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -55,7 +56,7 @@ public sealed class GatewayAccountCreditsClient
     /// <summary><paramref name="http"/> defaults to a short-timeout client; tests inject a stub.</summary>
     public GatewayAccountCreditsClient(HttpClient? http = null)
     {
-        _http = http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        _http = http ?? new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(5) };
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Account/GatewayAccountStatusClient.cs
+++ b/src/CcDirector.Core/Account/GatewayAccountStatusClient.cs
@@ -2,6 +2,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.Network;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -64,7 +65,7 @@ public sealed class GatewayAccountStatusClient
     /// </summary>
     public GatewayAccountStatusClient(HttpClient? http = null)
     {
-        _http = http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        _http = http ?? new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(5) };
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Network/GatewayHttp.cs
+++ b/src/CcDirector.Core/Network/GatewayHttp.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Network;
+
+/// <summary>
+/// Builds the HTTP plumbing every gateway-facing client dials through, so a gateway named by a
+/// local (Bonjour/mDNS) computer name - <c>http://soren_north.local:7878</c> - connects as reliably
+/// as an IP address does.
+///
+/// Why this exists: macOS answers a <c>.local</c> lookup with the target's link-local IPv6 address
+/// FIRST and its IPv4 address second. The default .NET connect tries the addresses one at a time in
+/// resolver order, and a TCP connect to a link-local IPv6 address is typically black-holed (no scope
+/// id, or the gateway machine not listening on IPv6), so it hangs until the whole HttpClient timeout
+/// elapses - the request dies without ever trying the IPv4 address that would have connected
+/// instantly. curl succeeds on the same name only because it races both address families.
+///
+/// The fix is a connect callback that orders candidate addresses by how likely they are to work on a
+/// local network - IPv4 first, globally routable IPv6 next, link-local IPv6 last - and gives each
+/// address a short connect budget so one dead address can never consume the caller's whole timeout.
+/// Hosts that are already IP literals (including loopback) bypass resolution and connect directly,
+/// so nothing changes for them.
+/// </summary>
+public static class GatewayHttp
+{
+    /// <summary>
+    /// Connect budget per candidate address. Short enough that a dead first address still leaves
+    /// room for the next one inside the 5-second timeout the tightest gateway clients use.
+    /// </summary>
+    private static readonly TimeSpan PerAddressConnectTimeout = TimeSpan.FromSeconds(3);
+
+    /// <summary>
+    /// One shared invoker for websocket upgrades. Never disposed on purpose: the upgraded stream
+    /// lives on inside the returned websocket, so tearing the handler down per-connect would rip the
+    /// transport out from under a live connection.
+    /// </summary>
+    private static readonly HttpMessageInvoker WebSocketInvoker = new(Handler(), disposeHandler: true);
+
+    /// <summary>
+    /// A handler whose connect callback applies the local-name-friendly address ordering. The pooled
+    /// connection lifetime is capped so a long-lived client re-resolves the gateway name within a
+    /// couple of minutes of its address changing (a name is the only stable thing on a home network).
+    /// </summary>
+    public static SocketsHttpHandler Handler() => new()
+    {
+        ConnectCallback = ConnectAsync,
+        PooledConnectionLifetime = TimeSpan.FromMinutes(2),
+    };
+
+    /// <summary>
+    /// Opens a client websocket to <paramref name="uri"/> through the same address-ordered dialing,
+    /// for the SignalR stream clients (their default websocket path uses the OS-ordered addresses
+    /// and hangs on <c>.local</c> names exactly like the HTTP one). Sends the bearer token as an
+    /// Authorization header, matching what the default SignalR websocket transport does.
+    /// </summary>
+    public static async Task<WebSocket> ConnectWebSocketAsync(Uri uri, string? bearerToken, CancellationToken cancellationToken)
+    {
+        var webSocket = new ClientWebSocket();
+        if (!string.IsNullOrEmpty(bearerToken))
+            webSocket.Options.SetRequestHeader("Authorization", "Bearer " + bearerToken);
+        await webSocket.ConnectAsync(uri, WebSocketInvoker, cancellationToken).ConfigureAwait(false);
+        return webSocket;
+    }
+
+    /// <summary>
+    /// Orders resolved addresses by dialing preference: IPv4, then globally routable IPv6, then
+    /// link-local IPv6 as the last resort. The sort is stable, so within one rank the resolver's
+    /// own order is kept. Pure, for direct unit testing.
+    /// </summary>
+    public static IReadOnlyList<IPAddress> OrderForDialing(IEnumerable<IPAddress> addresses)
+    {
+        static int Rank(IPAddress address) =>
+            address.AddressFamily == AddressFamily.InterNetwork ? 0
+            : address.IsIPv6LinkLocal ? 2
+            : 1;
+
+        return addresses.OrderBy(Rank).ToArray();
+    }
+
+    private static async ValueTask<Stream> ConnectAsync(SocketsHttpConnectionContext context, CancellationToken cancellationToken)
+    {
+        var host = context.DnsEndPoint.Host;
+        var port = context.DnsEndPoint.Port;
+
+        IReadOnlyList<IPAddress> addresses;
+        if (IPAddress.TryParse(host, out var literal))
+            addresses = new[] { literal };
+        else
+            addresses = OrderForDialing(await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false));
+
+        if (addresses.Count == 0)
+            throw new SocketException((int)SocketError.HostNotFound);
+
+        Exception? lastFailure = null;
+        foreach (var address in addresses)
+        {
+            var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+            try
+            {
+                using var attempt = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                attempt.CancelAfter(PerAddressConnectTimeout);
+                await socket.ConnectAsync(new IPEndPoint(address, port), attempt.Token).ConfigureAwait(false);
+                if (lastFailure is not null)
+                    FileLog.Write($"[GatewayHttp] ConnectAsync: {host}:{port} connected via {address} after an earlier address failed: {lastFailure.Message}");
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch (Exception ex) when (ex is SocketException or OperationCanceledException)
+            {
+                socket.Dispose();
+                // The caller itself gave up (its HttpClient timeout or an app shutdown) - stop dialing.
+                cancellationToken.ThrowIfCancellationRequested();
+                lastFailure = ex;
+            }
+        }
+
+        FileLog.Write($"[GatewayHttp] ConnectAsync FAILED: no address of {host}:{port} accepted a connection ({addresses.Count} tried): {lastFailure!.Message}");
+        throw new HttpRequestException($"No address of {host}:{port} accepted a connection.", lastFailure);
+    }
+}

--- a/src/CcDirector.Core/Transcription/GatewayTranscriptionClient.cs
+++ b/src/CcDirector.Core/Transcription/GatewayTranscriptionClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.HostedAi;
+using CcDirector.Core.Network;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Transcription;
@@ -14,7 +15,7 @@ namespace CcDirector.Core.Transcription;
 /// </summary>
 public sealed class GatewayTranscriptionClient
 {
-    private static readonly HttpClient SharedHttp = new() { Timeout = TimeSpan.FromMinutes(5) };
+    private static readonly HttpClient SharedHttp = new(GatewayHttp.Handler()) { Timeout = TimeSpan.FromMinutes(5) };
 
     private readonly Func<GatewayConfig> _gatewayProvider;
     private readonly HttpClient _http;

--- a/src/CcDirector.Launcher/DirectorSupervisor.cs
+++ b/src/CcDirector.Launcher/DirectorSupervisor.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Network;
 using System.Diagnostics;
 using System.Net.Http;
 using CcDirector.Core.Storage;
@@ -36,7 +37,7 @@ public sealed class DirectorSupervisor
     public DirectorSupervisor(InstallLayout layout)
     {
         _layout = layout ?? throw new ArgumentNullException(nameof(layout));
-        _http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        _http = new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(5) };
     }
 
     /// <summary>

--- a/src/CcDirector.Launcher/GatewayRegistrationClient.cs
+++ b/src/CcDirector.Launcher/GatewayRegistrationClient.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.Network;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -43,7 +44,7 @@ public sealed class GatewayRegistrationClient : IAsyncDisposable
         _port = port;
         _token = token ?? throw new ArgumentNullException(nameof(token));
         _version = version;
-        _http = new HttpClient
+        _http = new HttpClient(GatewayHttp.Handler())
         {
             Timeout = TimeSpan.FromSeconds(10),
         };

--- a/src/CcDirector.Launcher/LauncherStreamClient.cs
+++ b/src/CcDirector.Launcher/LauncherStreamClient.cs
@@ -1,4 +1,5 @@
 using CcDirector.Core.Configuration;
+using CcDirector.Core.Network;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -67,6 +68,13 @@ public sealed class LauncherStreamClient : IAsyncDisposable
                 var token = _config.Token;
                 if (!string.IsNullOrEmpty(token))
                     options.AccessTokenProvider = () => Task.FromResult<string?>(token);
+                // Local-name-friendly dialing (see GatewayHttp): a gateway named soren_north.local
+                // resolves to a link-local IPv6 address first, and the default connect hangs on it.
+                // The handler covers negotiate and the fallback transports; the websocket factory
+                // covers the websocket itself, which dials outside that handler by default.
+                options.HttpMessageHandlerFactory = _ => GatewayHttp.Handler();
+                options.WebSocketFactory = async (context, cancellationToken) =>
+                    await GatewayHttp.ConnectWebSocketAsync(context.Uri, token, cancellationToken);
             })
             .WithAutomaticReconnect(new[]
             {

--- a/src/CcDirector.Launcher/Program.cs
+++ b/src/CcDirector.Launcher/Program.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using Avalonia;
+using CcDirector.Core.Network;
 using CcDirector.Core.Utilities;
 using CcDirector.Setup.Engine;
 
@@ -156,7 +157,7 @@ public static class Program
         var stagedSelf = Environment.ProcessPath ?? "";
         FileLog.Write($"[Program] --apply-update: version={version}, target={target}, port={port}, args={relaunchArgs}, staged={stagedSelf}");
 
-        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        using var http = new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(5) };
 
         var result = new LauncherSelfUpdate().ApplyAsync(
             target, stagedSelf, version,


### PR DESCRIPTION
## The problem

The owner's Mac could not connect to the Gateway, and a fresh install looked broken. The Gateway was healthy the whole time. The Mac had been resolving the bare name `soren_north` through Tailscale MagicDNS; with Tailscale stopped, that name stopped resolving. The owner's ruling: no Tailscale on workstations - machines must reach the Gateway by local network name, meaning `http://soren_north.local:7878`.

That name did not work either, and this pull request fixes why: macOS answers a `.local` (Bonjour) lookup with the target's **link-local IPv6 address first** and the IPv4 address second. The default .NET connect tries addresses one at a time in resolver order, and the connect to the link-local address is black-holed - so every request burned its whole HttpClient timeout without ever reaching the IPv4 address that connects in under a millisecond. curl succeeds on the same name only because it races both address families.

## The fix

New `GatewayHttp` helper in `CcDirector.Core/Network`:

- A `SocketsHttpHandler` connect callback resolves the host and dials addresses in preference order: IPv4 first, globally routable IPv6 next, link-local IPv6 last.
- Each address gets a three-second connect budget, so one dead address can never consume a caller's whole timeout.
- IP-literal hosts (including loopback) bypass resolution entirely - nothing changes for them.
- The pooled connection lifetime is capped at two minutes so a long-lived client notices when the gateway machine's address changes.

Every gateway-facing client now dials through it: `GatewayClient` (all four construction sites), enrollment, the connectivity self-test, the account clients, the transcription client, the launcher's registration and supervision clients, and both SignalR stream clients - negotiate and fallback transports through `HttpMessageHandlerFactory`, and the websocket itself through a `WebSocketFactory` that connects a `ClientWebSocket` over the same handler (MessagePack protocol intact).

## Proof

Verified live on Sorens-Mac-mini against the production Gateway, with an isolated storage root so the production Director was untouched:

- Before the fix (same day, same machine): every call to `http://soren_north.local:7878` timed out at the full five-second HttpClient limit.
- After the fix: account status answered in about thirty milliseconds, the SignalR stream connected and reseeded full snapshots over MessagePack ("tunnel connected (two-way stream up)"), and the Director appeared in the Gateway's directors registry with `source=stream`.
- Six new unit tests pin the address ordering (`GatewayHttpTests`), all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)