### PR TITLE
feat(gateway): partition the pushed-session store by tenant

### DIFF
--- a/src/CcDirector.Gateway.Tests/DirectorHubTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorHubTests.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
 using CcDirector.Gateway.Stats;
@@ -61,7 +62,7 @@ public sealed class DirectorHubTests : IDisposable
 
         Assert.False(ctx.Aborted);
         Assert.True(_registry.IsStateReporting("dir-A"));
-        Assert.True(_store.IsStreamConnected("dir-A"));
+        Assert.True(_store.IsStreamConnected(TenantId.Local, "dir-A"));
     }
 
     [Fact]
@@ -72,7 +73,7 @@ public sealed class DirectorHubTests : IDisposable
 
         hub.PushSnapshot(0, new[] { Session("s1"), Session("s2") });
 
-        var fresh = _store.TryGetFresh("dir-A", _staleAfter);
+        var fresh = _store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(fresh);
         Assert.Equal(2, fresh.Count);
     }
@@ -85,7 +86,7 @@ public sealed class DirectorHubTests : IDisposable
         hub.Hello(Hello("   "));
 
         Assert.True(ctx.Aborted);
-        Assert.False(_store.IsStreamConnected("dir-A"));
+        Assert.False(_store.IsStreamConnected(TenantId.Local, "dir-A"));
     }
 
     [Fact]
@@ -105,7 +106,7 @@ public sealed class DirectorHubTests : IDisposable
 
         hub.PushDelta(2, Session("s1", "WaitingForInput"));
 
-        var fresh = _store.TryGetFresh("dir-A", _staleAfter);
+        var fresh = _store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(fresh);
         Assert.Single(fresh);
         Assert.Equal("WaitingForInput", fresh[0].ActivityState);
@@ -120,7 +121,7 @@ public sealed class DirectorHubTests : IDisposable
 
         hub.RemoveSession(2, "s1");
 
-        var fresh = _store.TryGetFresh("dir-A", _staleAfter);
+        var fresh = _store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(fresh);
         Assert.Single(fresh);
         Assert.Equal("s2", fresh[0].SessionId);
@@ -135,8 +136,8 @@ public sealed class DirectorHubTests : IDisposable
 
         await hub.OnDisconnectedAsync(null);
 
-        Assert.False(_store.IsStreamConnected("dir-A"));
-        Assert.Null(_store.TryGetFresh("dir-A", _staleAfter));
+        Assert.False(_store.IsStreamConnected(TenantId.Local, "dir-A"));
+        Assert.Null(_store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter));
     }
 
     [Fact]
@@ -150,8 +151,8 @@ public sealed class DirectorHubTests : IDisposable
         hubA.PushSnapshot(0, new[] { Session("a1"), Session("a2") });
         hubB.PushSnapshot(0, new[] { Session("b1") });
 
-        var a = _store.TryGetFresh("dir-A", _staleAfter);
-        var b = _store.TryGetFresh("dir-B", _staleAfter);
+        var a = _store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
+        var b = _store.TryGetFresh(TenantId.Local, "dir-B", _staleAfter);
         Assert.NotNull(a);
         Assert.NotNull(b);
         Assert.Equal(2, a.Count);
@@ -171,7 +172,7 @@ public sealed class DirectorHubTests : IDisposable
         hub2.Hello(Hello("dir-A"));
         hub2.PushSnapshot(0, new[] { Session("fresh") });
 
-        var fresh = _store.TryGetFresh("dir-A", _staleAfter);
+        var fresh = _store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(fresh);
         Assert.Single(fresh);
         Assert.Equal("fresh", fresh[0].SessionId);

--- a/src/CcDirector.Gateway.Tests/DoorbellColourFactPushTests.cs
+++ b/src/CcDirector.Gateway.Tests/DoorbellColourFactPushTests.cs
@@ -2,6 +2,7 @@ using System.Net.Sockets;
 using CcDirector.ControlApi;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Sessions;
+using CcDirector.Core.Tenancy;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
@@ -116,7 +117,7 @@ public sealed class DoorbellColourFactPushTests : IAsyncLifetime
         var deadline = DateTime.UtcNow + within;
         while (DateTime.UtcNow < deadline)
         {
-            var pushed = _gateway.PushedSessions.SnapshotFresh(TimeSpan.FromSeconds(30));
+            var pushed = _gateway.PushedSessions.SnapshotFresh(TenantId.Local, TimeSpan.FromSeconds(30));
             var mine = pushed.FirstOrDefault(t => t.Session.SessionId == sessionId).Session;
             if (mine is not null && predicate(mine)) return true;
             await Task.Delay(100);

--- a/src/CcDirector.Gateway.Tests/FleetRoleObserverTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetRoleObserverTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Fleet;
 using CcDirector.Gateway.Streaming;
@@ -40,14 +41,14 @@ public sealed class FleetRoleObserverTests
     public void ApplyDelta_DiscardsAnyRoleTheDirectorEchoedBack()
     {
         var store = new PushedSessionStore(() => _now);
-        store.RegisterConnection("dir-A", "conn-1");
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
 
         var echoed = Session("s1");
         echoed.SessionRole = SessionRoles.Worker; // what a Director sends back up after we stamped it
 
-        Assert.True(store.ApplyDelta("dir-A", "conn-1", 1, echoed));
+        Assert.True(store.ApplyDelta(TenantId.Local, "dir-A", "conn-1", 1, echoed));
 
-        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        var fresh = store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(fresh);
         Assert.Null(Assert.Single(fresh!).SessionRole);
     }
@@ -58,16 +59,16 @@ public sealed class FleetRoleObserverTests
     public void ApplySnapshot_DiscardsAnyRoleTheDirectorEchoedBack()
     {
         var store = new PushedSessionStore(() => _now);
-        store.RegisterConnection("dir-A", "conn-1");
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
 
         var a = Session("s1");
         a.SessionRole = SessionRoles.Worker;
         var b = Session("s2");
         b.SessionRole = SessionRoles.Manager;
 
-        Assert.True(store.ApplySnapshot("dir-A", "conn-1", 1, new[] { a, b }));
+        Assert.True(store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 1, new[] { a, b }));
 
-        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        var fresh = store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(fresh);
         Assert.All(fresh!, s => Assert.Null(s.SessionRole));
     }

--- a/src/CcDirector.Gateway.Tests/Issue1593FailedAttemptRebaselineTests.cs
+++ b/src/CcDirector.Gateway.Tests/Issue1593FailedAttemptRebaselineTests.cs
@@ -7,6 +7,7 @@ using CcDirector.Core;
 using CcDirector.Core.Audio;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Transcription;
 using CcDirector.Gateway.Voice;
@@ -280,9 +281,9 @@ public sealed class Issue1593FailedAttemptRebaselineTests : IAsyncLifetime
     /// </summary>
     private void ReportBuffer(long bufferBytes)
     {
-        var connectionId = _gateway.PushedSessions.GetActiveConnectionId(DirectorId)!;
+        var connectionId = _gateway.PushedSessions.GetActiveConnectionId(TenantId.Local, DirectorId)!;
         var applied = _gateway.PushedSessions.ApplyDelta(
-            DirectorId, connectionId, Interlocked.Increment(ref _pushSequence), SessionAt(bufferBytes));
+            TenantId.Local, DirectorId, connectionId, Interlocked.Increment(ref _pushSequence), SessionAt(bufferBytes));
         Assert.True(applied, "the test's own buffer report must actually land, or it proves nothing");
     }
 

--- a/src/CcDirector.Gateway.Tests/PushedSessionStoreTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/PushedSessionStoreTenantIsolationTests.cs
@@ -1,0 +1,118 @@
+using System;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Stage 3b: proves the <see cref="PushedSessionStore"/> is tenant-partitioned - one tenant can never
+/// read another's Directors or sessions, not even by presenting a real session id that exists in the
+/// other tenant. The production core is single-tenant (everything is <see cref="TenantId.Local"/>), so
+/// this test injects two distinct tenants directly to exercise the isolation the resolver will rely on.
+/// </summary>
+public sealed class PushedSessionStoreTenantIsolationTests
+{
+    private static readonly TenantId Acme = new("acme");
+    private static readonly TenantId Globex = new("globex");
+    private readonly DateTime _now = new(2026, 7, 16, 12, 0, 0, DateTimeKind.Utc);
+    private readonly TimeSpan _stale = TimeSpan.FromSeconds(20);
+
+    private PushedSessionStore NewStore() => new(() => _now);
+
+    private static SessionDto Session(string id) => new() { SessionId = id, ActivityState = "Working" };
+
+    private void Seed(PushedSessionStore store, TenantId tenant, string directorId, string connectionId, params string[] sessionIds)
+    {
+        store.RegisterConnection(tenant, directorId, connectionId);
+        var sessions = new SessionDto[sessionIds.Length];
+        for (var i = 0; i < sessionIds.Length; i++)
+            sessions[i] = Session(sessionIds[i]);
+        Assert.True(store.ApplySnapshot(tenant, directorId, connectionId, 0, sessions));
+    }
+
+    [Fact]
+    public void TryLocate_CannotFindAnotherTenantsSession_EvenWithTheRealSessionId()
+    {
+        var store = NewStore();
+        Seed(store, Acme, "dir-A", "conn-A", "s1");
+
+        // The real session id from Acme, presented as Globex, must resolve to nothing.
+        Assert.Null(store.TryLocate(Globex, "s1", _stale));
+
+        // ...and Acme still finds its own.
+        var located = store.TryLocate(Acme, "s1", _stale);
+        Assert.NotNull(located);
+        Assert.Equal("dir-A", located.Value.DirectorId);
+    }
+
+    [Fact]
+    public void SnapshotFresh_ReturnsOnlyTheCallingTenantsSessions()
+    {
+        var store = NewStore();
+        Seed(store, Acme, "dir-A", "conn-A", "s1", "s2");
+        Seed(store, Globex, "dir-B", "conn-B", "s3");
+
+        var acme = store.SnapshotFresh(Acme, _stale);
+        var globex = store.SnapshotFresh(Globex, _stale);
+
+        Assert.Equal(new[] { "s1", "s2" }, SortedSessionIds(acme));
+        Assert.Equal(new[] { "s3" }, SortedSessionIds(globex));
+    }
+
+    [Fact]
+    public void TryGetFresh_CannotReadADirectorThatLivesInAnotherTenant()
+    {
+        var store = NewStore();
+        Seed(store, Acme, "dir-A", "conn-A", "s1");
+
+        // dir-A exists, but not under Globex - so Globex sees nothing.
+        Assert.Null(store.TryGetFresh(Globex, "dir-A", _stale));
+        Assert.False(store.IsStreamConnected(Globex, "dir-A"));
+
+        Assert.NotNull(store.TryGetFresh(Acme, "dir-A", _stale));
+        Assert.True(store.IsStreamConnected(Acme, "dir-A"));
+    }
+
+    [Fact]
+    public void SameDirectorId_InTwoTenants_AreIndependentEntries()
+    {
+        var store = NewStore();
+        Seed(store, Acme, "dir-shared", "conn-acme", "acme-session");
+        Seed(store, Globex, "dir-shared", "conn-globex", "globex-session");
+
+        var acme = store.TryGetFresh(Acme, "dir-shared", _stale);
+        var globex = store.TryGetFresh(Globex, "dir-shared", _stale);
+
+        Assert.NotNull(acme);
+        Assert.NotNull(globex);
+        Assert.Equal("acme-session", Assert.Single(acme).SessionId);
+        Assert.Equal("globex-session", Assert.Single(globex).SessionId);
+
+        // The active connection is per-tenant too.
+        Assert.Equal("conn-acme", store.GetActiveConnectionId(Acme, "dir-shared"));
+        Assert.Equal("conn-globex", store.GetActiveConnectionId(Globex, "dir-shared"));
+    }
+
+    [Fact]
+    public void AnInvalidTenant_IsRejected_NeverDefaulted()
+    {
+        var store = NewStore();
+        TenantId invalid = default;
+
+        Assert.Throws<ArgumentException>(() => store.RegisterConnection(invalid, "dir-A", "conn-A"));
+        Assert.Throws<ArgumentException>(() => store.TryLocate(invalid, "s1", _stale));
+        Assert.Throws<ArgumentException>(() => store.SnapshotFresh(invalid, _stale));
+        Assert.Throws<ArgumentException>(() => store.TryGetFresh(invalid, "dir-A", _stale));
+    }
+
+    private static string[] SortedSessionIds(System.Collections.Generic.IReadOnlyList<(string DirectorId, SessionDto Session)> rows)
+    {
+        var ids = new string[rows.Count];
+        for (var i = 0; i < rows.Count; i++)
+            ids[i] = rows[i].Session.SessionId!;
+        Array.Sort(ids, StringComparer.Ordinal);
+        return ids;
+    }
+}

--- a/src/CcDirector.Gateway.Tests/PushedSessionStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/PushedSessionStoreTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Streaming;
 using Xunit;
@@ -28,11 +29,11 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-1");
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
 
         // Act
-        var applied = store.ApplySnapshot("dir-A", "conn-1", 0, new[] { Session("s1"), Session("s2") });
-        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        var applied = store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 0, new[] { Session("s1"), Session("s2") });
+        var fresh = store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
 
         // Assert
         Assert.True(applied);
@@ -47,12 +48,12 @@ public sealed class PushedSessionStoreTests
     {
         // Issue #1200: the auto-dismiss sweep enumerates every fresh session paired with its Director.
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-A");
-        store.RegisterConnection("dir-B", "conn-B");
-        store.ApplySnapshot("dir-A", "conn-A", 0, new[] { Session("s1") });
-        store.ApplySnapshot("dir-B", "conn-B", 0, new[] { Session("s2") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-A");
+        store.RegisterConnection(TenantId.Local, "dir-B", "conn-B");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-A", 0, new[] { Session("s1") });
+        store.ApplySnapshot(TenantId.Local, "dir-B", "conn-B", 0, new[] { Session("s2") });
 
-        var all = store.SnapshotFresh(_staleAfter);
+        var all = store.SnapshotFresh(TenantId.Local, _staleAfter);
 
         Assert.Equal(2, all.Count);
         Assert.Contains(all, t => t.DirectorId == "dir-A" && t.Session.SessionId == "s1");
@@ -63,13 +64,13 @@ public sealed class PushedSessionStoreTests
     public void SnapshotFresh_ExcludesStaleAndDisconnectedDirectors()
     {
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-A");
-        store.ApplySnapshot("dir-A", "conn-A", 0, new[] { Session("s1") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-A");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-A", 0, new[] { Session("s1") });
 
         // Advance past the stale window: the cache is now stale, so the sweep must not act on it.
         _now = _now.Add(_staleAfter).AddSeconds(1);
 
-        Assert.Empty(store.SnapshotFresh(_staleAfter));
+        Assert.Empty(store.SnapshotFresh(TenantId.Local, _staleAfter));
     }
 
     [Fact]
@@ -77,14 +78,14 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-1");
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
 
         // Act - a stale connection tries to push
-        var applied = store.ApplySnapshot("dir-A", "conn-OLD", 5, new[] { Session("s1") });
+        var applied = store.ApplySnapshot(TenantId.Local, "dir-A", "conn-OLD", 5, new[] { Session("s1") });
 
         // Assert
         Assert.False(applied);
-        Assert.Null(store.TryGetFresh("dir-A", _staleAfter));
+        Assert.Null(store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter));
     }
 
     [Fact]
@@ -92,15 +93,15 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-1");
-        store.ApplySnapshot("dir-A", "conn-1", 5, new[] { Session("s1") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 5, new[] { Session("s1") });
 
         // Act - sequence 5 already applied; 5 and below must be dropped
-        var stale = store.ApplyDelta("dir-A", "conn-1", 5, Session("s2"));
+        var stale = store.ApplyDelta(TenantId.Local, "dir-A", "conn-1", 5, Session("s2"));
 
         // Assert
         Assert.False(stale);
-        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        var fresh = store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(fresh);
         Assert.Single(fresh);
         Assert.Equal("s1", fresh[0].SessionId);
@@ -111,15 +112,15 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-1");
-        store.ApplySnapshot("dir-A", "conn-1", 1, new[] { Session("s1", "Working") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 1, new[] { Session("s1", "Working") });
 
         // Act
-        var applied = store.ApplyDelta("dir-A", "conn-1", 2, Session("s1", "WaitingForInput"));
+        var applied = store.ApplyDelta(TenantId.Local, "dir-A", "conn-1", 2, Session("s1", "WaitingForInput"));
 
         // Assert
         Assert.True(applied);
-        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        var fresh = store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(fresh);
         Assert.Single(fresh);
         Assert.Equal("WaitingForInput", fresh[0].ActivityState);
@@ -130,14 +131,14 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-1");
-        store.ApplySnapshot("dir-A", "conn-1", 1, new[] { Session("s1"), Session("s2"), Session("s3") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 1, new[] { Session("s1"), Session("s2"), Session("s3") });
 
         // Act - a later snapshot no longer contains s2
-        store.ApplySnapshot("dir-A", "conn-1", 2, new[] { Session("s1"), Session("s3") });
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 2, new[] { Session("s1"), Session("s3") });
 
         // Assert
-        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        var fresh = store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(fresh);
         Assert.Equal(2, fresh.Count);
         Assert.DoesNotContain(fresh, s => s.SessionId == "s2");
@@ -148,15 +149,15 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-1");
-        store.ApplySnapshot("dir-A", "conn-1", 1, new[] { Session("s1"), Session("s2") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 1, new[] { Session("s1"), Session("s2") });
 
         // Act
-        var removed = store.ApplyRemove("dir-A", "conn-1", 2, "s1");
+        var removed = store.ApplyRemove(TenantId.Local, "dir-A", "conn-1", 2, "s1");
 
         // Assert
         Assert.True(removed);
-        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        var fresh = store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(fresh);
         Assert.Single(fresh);
         Assert.Equal("s2", fresh[0].SessionId);
@@ -168,16 +169,16 @@ public sealed class PushedSessionStoreTests
         // Arrange - a first connection pushed a high sequence, then the Director process restarts and
         // dials a brand-new connection that (correctly) starts its own sequence at 0.
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-1");
-        store.ApplySnapshot("dir-A", "conn-1", 42, new[] { Session("old") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 42, new[] { Session("old") });
 
         // Act - the restart: new connection, first snapshot at sequence 0 must NOT be rejected.
-        store.RegisterConnection("dir-A", "conn-2");
-        var applied = store.ApplySnapshot("dir-A", "conn-2", 0, new[] { Session("fresh") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-2");
+        var applied = store.ApplySnapshot(TenantId.Local, "dir-A", "conn-2", 0, new[] { Session("fresh") });
 
         // Assert
         Assert.True(applied);
-        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        var fresh = store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(fresh);
         Assert.Single(fresh);
         Assert.Equal("fresh", fresh[0].SessionId);
@@ -188,16 +189,16 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange - a reconnect overlap: conn-2 becomes active, THEN conn-1 (superseded) disconnects.
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-1");
-        store.RegisterConnection("dir-A", "conn-2");
-        store.ApplySnapshot("dir-A", "conn-2", 0, new[] { Session("s1") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-2");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-2", 0, new[] { Session("s1") });
 
         // Act - the late disconnect of the old connection must be ignored.
-        store.UnregisterConnection("dir-A", "conn-1");
+        store.UnregisterConnection(TenantId.Local, "dir-A", "conn-1");
 
         // Assert - the active connection and its cache survive.
-        Assert.True(store.IsStreamConnected("dir-A"));
-        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        Assert.True(store.IsStreamConnected(TenantId.Local, "dir-A"));
+        var fresh = store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(fresh);
         Assert.Single(fresh);
     }
@@ -207,15 +208,15 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-1");
-        store.ApplySnapshot("dir-A", "conn-1", 0, new[] { Session("s1") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 0, new[] { Session("s1") });
 
         // Act
-        store.UnregisterConnection("dir-A", "conn-1");
+        store.UnregisterConnection(TenantId.Local, "dir-A", "conn-1");
 
         // Assert - no active connection => aggregation must fall back to pull.
-        Assert.False(store.IsStreamConnected("dir-A"));
-        Assert.Null(store.TryGetFresh("dir-A", _staleAfter));
+        Assert.False(store.IsStreamConnected(TenantId.Local, "dir-A"));
+        Assert.Null(store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter));
     }
 
     [Fact]
@@ -223,14 +224,14 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-1");
-        store.ApplySnapshot("dir-A", "conn-1", 0, new[] { Session("s1") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 0, new[] { Session("s1") });
 
         // Act - advance the clock past the stale window with no new push.
         _now = _now.AddSeconds(21);
 
         // Assert
-        Assert.Null(store.TryGetFresh("dir-A", _staleAfter));
+        Assert.Null(store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter));
     }
 
     [Fact]
@@ -238,18 +239,18 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-1");
-        store.ApplySnapshot("dir-A", "conn-1", 0, new[] { Session("s1", "Working") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 0, new[] { Session("s1", "Working") });
 
         // Act - the aggregation stamps fields on the returned object.
-        var first = store.TryGetFresh("dir-A", _staleAfter);
+        var first = store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(first);
         first[0].EffectiveColor = "red";
         first[0].DirectorId = "mutated";
         first[0].DriverCapabilities.Add("Interrupt");
 
         // Assert - a later read is pristine.
-        var second = store.TryGetFresh("dir-A", _staleAfter);
+        var second = store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
         Assert.NotNull(second);
         Assert.Null(second[0].EffectiveColor);
         Assert.Equal("", second[0].DirectorId);
@@ -261,13 +262,13 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange - a quiet session whose last activity was 10s before the snapshot.
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-1");
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
         var lastActivity = _now.AddSeconds(-10);
-        store.ApplySnapshot("dir-A", "conn-1", 0, new[] { Session("s1", "WaitingForInput", lastActivity) });
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 0, new[] { Session("s1", "WaitingForInput", lastActivity) });
 
         // Act - 5s later, served from cache with no new push.
         _now = _now.AddSeconds(5);
-        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        var fresh = store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter);
 
         // Assert - idle seconds reflect now - lastActivity (15s), not the frozen value at push time (10s).
         Assert.NotNull(fresh);
@@ -281,19 +282,19 @@ public sealed class PushedSessionStoreTests
         var store = NewStore();
 
         // Act - no RegisterConnection first.
-        var applied = store.ApplySnapshot("dir-A", "conn-1", 0, new[] { Session("s1") });
+        var applied = store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 0, new[] { Session("s1") });
 
         // Assert
         Assert.False(applied);
-        Assert.Null(store.TryGetFresh("dir-A", _staleAfter));
+        Assert.Null(store.TryGetFresh(TenantId.Local, "dir-A", _staleAfter));
     }
 
     [Fact]
     public void TryGetFresh_ForUnknownDirector_ReturnsNull()
     {
         var store = NewStore();
-        Assert.Null(store.TryGetFresh("nobody", _staleAfter));
-        Assert.False(store.IsStreamConnected("nobody"));
+        Assert.Null(store.TryGetFresh(TenantId.Local, "nobody", _staleAfter));
+        Assert.False(store.IsStreamConnected(TenantId.Local, "nobody"));
     }
 
     [Fact]
@@ -301,13 +302,13 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange - two Directors each pushing a distinct session.
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-A");
-        store.RegisterConnection("dir-B", "conn-B");
-        store.ApplySnapshot("dir-A", "conn-A", 0, new[] { Session("s-A") });
-        store.ApplySnapshot("dir-B", "conn-B", 0, new[] { Session("s-B") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-A");
+        store.RegisterConnection(TenantId.Local, "dir-B", "conn-B");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-A", 0, new[] { Session("s-A") });
+        store.ApplySnapshot(TenantId.Local, "dir-B", "conn-B", 0, new[] { Session("s-B") });
 
         // Act
-        var located = store.TryLocate("s-B", _staleAfter);
+        var located = store.TryLocate(TenantId.Local, "s-B", _staleAfter);
 
         // Assert - the session is resolved to its owning Director with zero HTTP pull.
         Assert.NotNull(located);
@@ -320,17 +321,17 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-A");
-        store.ApplySnapshot("dir-A", "conn-A", 0, new[] { Session("s1", "Working") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-A");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-A", 0, new[] { Session("s1", "Working") });
 
         // Act - a caller stamps fields on the located copy.
-        var located = store.TryLocate("s1", _staleAfter);
+        var located = store.TryLocate(TenantId.Local, "s1", _staleAfter);
         Assert.NotNull(located);
         located.Value.Session.EffectiveColor = "red";
         located.Value.Session.DirectorId = "mutated";
 
         // Assert - the cache is pristine on the next read.
-        var again = store.TryLocate("s1", _staleAfter);
+        var again = store.TryLocate(TenantId.Local, "s1", _staleAfter);
         Assert.NotNull(again);
         Assert.Null(again.Value.Session.EffectiveColor);
         Assert.Equal("", again.Value.Session.DirectorId);
@@ -341,14 +342,14 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-A");
-        store.ApplySnapshot("dir-A", "conn-A", 0, new[] { Session("s1") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-A");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-A", 0, new[] { Session("s1") });
 
         // Act - advance past the stale window with no re-push.
         _now = _now.AddSeconds(21);
 
         // Assert - a stale cache cannot locate (matching TryGetFresh's staleness rule).
-        Assert.Null(store.TryLocate("s1", _staleAfter));
+        Assert.Null(store.TryLocate(TenantId.Local, "s1", _staleAfter));
     }
 
     [Fact]
@@ -356,24 +357,24 @@ public sealed class PushedSessionStoreTests
     {
         // Arrange
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-A");
-        store.ApplySnapshot("dir-A", "conn-A", 0, new[] { Session("s1") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-A");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-A", 0, new[] { Session("s1") });
 
         // Act - the stream disconnects.
-        store.UnregisterConnection("dir-A", "conn-A");
+        store.UnregisterConnection(TenantId.Local, "dir-A", "conn-A");
 
         // Assert - no active connection => no location from the cache.
-        Assert.Null(store.TryLocate("s1", _staleAfter));
+        Assert.Null(store.TryLocate(TenantId.Local, "s1", _staleAfter));
     }
 
     [Fact]
     public void TryLocate_ForUnknownSession_ReturnsNull()
     {
         var store = NewStore();
-        store.RegisterConnection("dir-A", "conn-A");
-        store.ApplySnapshot("dir-A", "conn-A", 0, new[] { Session("s1") });
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-A");
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-A", 0, new[] { Session("s1") });
 
-        Assert.Null(store.TryLocate("nobody", _staleAfter));
-        Assert.Null(store.TryLocate("", _staleAfter));
+        Assert.Null(store.TryLocate(TenantId.Local, "nobody", _staleAfter));
+        Assert.Null(store.TryLocate(TenantId.Local, "", _staleAfter));
     }
 }

--- a/src/CcDirector.Gateway.Tests/StreamCommandTests.cs
+++ b/src/CcDirector.Gateway.Tests/StreamCommandTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -121,14 +122,14 @@ public sealed class StreamCommandTests : IAsyncLifetime
         await WaitForPushedSession(session.Id.ToString());
 
         // The verdict actually reached the Gateway UP the stream, on the pushed DTO.
-        var pushed = _gateway.PushedSessions.SnapshotFresh(TimeSpan.FromSeconds(30));
+        var pushed = _gateway.PushedSessions.SnapshotFresh(TenantId.Local, TimeSpan.FromSeconds(30));
         var mine = pushed.Single(t => t.Session.SessionId == session.Id.ToString());
         Assert.True(mine.Session.AutoDismiss);
         Assert.Equal("done", mine.Session.DismissVerdict);
 
         // The real Gateway sweep, wired exactly as GatewayHost wires it (pushed snapshot + SendCommandAsync).
         var sweeper = new AutoDismissSweeper(
-            () => _gateway.PushedSessions.SnapshotFresh(TimeSpan.FromSeconds(30)),
+            () => _gateway.PushedSessions.SnapshotFresh(TenantId.Local, TimeSpan.FromSeconds(30)),
             _gateway.SendCommandAsync);
 
         var closed = await sweeper.SweepAsync(CancellationToken.None);
@@ -152,7 +153,7 @@ public sealed class StreamCommandTests : IAsyncLifetime
         await WaitForPushedSession(session.Id.ToString());
 
         var sweeper = new AutoDismissSweeper(
-            () => _gateway.PushedSessions.SnapshotFresh(TimeSpan.FromSeconds(30)),
+            () => _gateway.PushedSessions.SnapshotFresh(TenantId.Local, TimeSpan.FromSeconds(30)),
             _gateway.SendCommandAsync);
 
         var closed = await sweeper.SweepAsync(CancellationToken.None);
@@ -638,7 +639,7 @@ public sealed class StreamCommandTests : IAsyncLifetime
         for (var i = 0; i < 12; i++)
         {
             await Task.Delay(100);
-            Assert.NotNull(_gateway.PushedSessions.TryGetFresh(DirectorId, stale));
+            Assert.NotNull(_gateway.PushedSessions.TryGetFresh(TenantId.Local, DirectorId, stale));
         }
     }
 
@@ -909,7 +910,7 @@ public sealed class StreamCommandTests : IAsyncLifetime
         var deadline = DateTime.UtcNow.AddSeconds(15);
         while (DateTime.UtcNow < deadline)
         {
-            if (_gateway.PushedSessions.TryLocate(sessionId, TimeSpan.FromSeconds(30)) is not null) return;
+            if (_gateway.PushedSessions.TryLocate(TenantId.Local, sessionId, TimeSpan.FromSeconds(30)) is not null) return;
             await Task.Delay(100);
         }
         throw new TimeoutException("Timed out waiting for the session to appear in the pushed cache");

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Nodes;
 using CcDirector.Core.Diagnostics;
 using CcDirector.Core.Network;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
@@ -284,7 +285,8 @@ internal static class GatewayEndpoints
             // fresh pushed snapshot is not connected to the tunnel and contributes zero.
             int totalSessions = directors.Sum(d =>
             {
-                var cached = pushedSessions?.TryGetFresh(d.DirectorId, streamStaleResolved);
+                // Stage 3b: single-tenant core serves the Local tenant (the request's tenant in Stage 3c).
+                var cached = pushedSessions?.TryGetFresh(TenantId.Local, d.DirectorId, streamStaleResolved);
                 return cached?.Count ?? 0;
             });
 
@@ -550,7 +552,7 @@ internal static class GatewayEndpoints
                 // a pushed snapshot, so exited rows are simply absent - there is no HTTP pull to fetch them.)
                 if (pushedSessions is not null)
                 {
-                    var cached = pushedSessions.TryGetFresh(d.DirectorId, streamStale);
+                    var cached = pushedSessions.TryGetFresh(TenantId.Local, d.DirectorId, streamStale);
                     if (cached is not null)
                     {
                         FileLog.Write($"[GatewayEndpoints] /sessions director={d.DirectorId} served=pushed-cache ({cached.Count} sessions)");
@@ -1986,7 +1988,7 @@ internal static class GatewayEndpoints
             // Post-cut: read the live session list from the push store (it carries the same SessionDto incl.
             // Status). A Director with no fresh push is not connected to the tunnel, so the live count is
             // unknowable and the session gate is skipped below.
-            var cachedSessions = pushedSessions?.TryGetFresh(director.DirectorId, streamStaleResolved);
+            var cachedSessions = pushedSessions?.TryGetFresh(TenantId.Local, director.DirectorId, streamStaleResolved);
             var sessions = cachedSessions?.ToList();
             if (sessions is not null)
             {
@@ -2548,7 +2550,7 @@ internal static class GatewayEndpoints
         if (pushedSessions is null) return byDirector;
         foreach (var d in registry.ListDirectors())
         {
-            var cached = pushedSessions.TryGetFresh(d.DirectorId, streamStale);
+            var cached = pushedSessions.TryGetFresh(TenantId.Local, d.DirectorId, streamStale);
             if (cached is not null) byDirector[d.DirectorId] = cached;
         }
         return byDirector;
@@ -2809,7 +2811,7 @@ internal static class GatewayEndpoints
     {
         if (pushedSessions is not null)
         {
-            var located = pushedSessions.TryLocate(sid, streamStale);
+            var located = pushedSessions.TryLocate(TenantId.Local, sid, streamStale);
             if (located is not null)
             {
                 var (directorId, pushedSession) = located.Value;

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -7,6 +7,7 @@ using CcDirector.Core;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Dictation;
 using CcDirector.Core.HostedAi;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Core.Voice.Services;
 using CcDirector.Gateway.Contracts;
@@ -138,7 +139,7 @@ internal static class GatewayWingmanVoiceEndpoint
         // the honest answer and simply means no title is spoken; see GatewayHost.ResolveSessionTitle.
         string? SessionTitle(string sid)
         {
-            var name = pushedSessions?.TryLocate(sid, stale)?.Session.Name;
+            var name = pushedSessions?.TryLocate(TenantId.Local, sid, stale)?.Session.Name;
             return string.IsNullOrWhiteSpace(name) ? null : name;
         }
 

--- a/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using Microsoft.AspNetCore.Builder;
@@ -58,7 +59,7 @@ internal static class SessionWsProxyEndpoints
         // terminal-input unary verbs. See TunnelStreamLegs for the wire translation.
         app.MapGet("/sessions/{sid}/stream", async (string sid, HttpContext ctx) =>
         {
-            if (pushedSessions.TryLocate(sid, stale) is { } loc)
+            if (pushedSessions.TryLocate(TenantId.Local, sid, stale) is { } loc)
             {
                 await tunnel.ServeTerminalAsync(ctx, sid, loc.DirectorId);
                 return;
@@ -70,7 +71,7 @@ internal static class SessionWsProxyEndpoints
         // a Range request re-fetches the whole file (tracked follow-up); never a silent truncation.
         app.MapGet("/sessions/{sid}/file", async (string sid, HttpContext ctx) =>
         {
-            if (pushedSessions.TryLocate(sid, stale) is { } loc)
+            if (pushedSessions.TryLocate(TenantId.Local, sid, stale) is { } loc)
             {
                 ctx.Response.Headers["X-Content-Type-Options"] = "nosniff";
                 if (await tunnel.TryServeFileAsync(ctx, sid, loc.DirectorId, ctx.Request.Query["path"].ToString()))
@@ -84,7 +85,7 @@ internal static class SessionWsProxyEndpoints
         // routing key for the machine-wide screenshots folder on the owning Director.
         app.Map("/sessions/{sid}/screenshots/file", async (string sid, HttpContext ctx) =>
         {
-            if (pushedSessions.TryLocate(sid, stale) is not { } loc)
+            if (pushedSessions.TryLocate(TenantId.Local, sid, stale) is not { } loc)
             {
                 await RejectAsync(ctx, sid, "shot");
                 return;
@@ -106,7 +107,7 @@ internal static class SessionWsProxyEndpoints
         // caps the newest-first rows.
         app.MapGet("/sessions/{sid}/screenshots", async (string sid, HttpContext ctx) =>
         {
-            if (pushedSessions.TryLocate(sid, stale) is not { } loc)
+            if (pushedSessions.TryLocate(TenantId.Local, sid, stale) is not { } loc)
             {
                 await RejectAsync(ctx, sid, "shots");
                 return;
@@ -142,7 +143,7 @@ internal static class SessionWsProxyEndpoints
         var catchAll = new TunnelCatchAllDispatch(sendCommand);
         app.Map("/sessions/{sid}/{**rest}", async (string sid, string? rest, HttpContext ctx) =>
         {
-            if (pushedSessions.TryLocate(sid, stale) is not { } loc)
+            if (pushedSessions.TryLocate(TenantId.Local, sid, stale) is not { } loc)
             {
                 await RejectAsync(ctx, sid, "verb");
                 return;

--- a/src/CcDirector.Gateway/Briefing/TurnEndWatcher.cs
+++ b/src/CcDirector.Gateway/Briefing/TurnEndWatcher.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
@@ -143,7 +144,10 @@ public sealed class TurnEndWatcher : IDisposable
         _ = sweepAll;
         if (_pushedSessions is not null)
         {
-            foreach (var (directorId, session) in _pushedSessions.SnapshotFresh(_streamStale))
+            // Stage 3b: the single-tenant core sweeps the one Local tenant. When more than one tenant
+            // exists (Stage 3c), this background sweep iterates every tenant and addresses each session
+            // with its owning tenant - it never reaches across tenants.
+            foreach (var (directorId, session) in _pushedSessions.SnapshotFresh(TenantId.Local, _streamStale))
             {
                 if (_disposed) return Task.CompletedTask;
                 Observe(session.SessionId, session.ActivityState, directorId);

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -5,6 +5,7 @@ using CcDirector.Core;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Drivers;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Api;
 using CcDirector.Gateway.Briefing;
@@ -604,7 +605,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // which matters here more than anywhere: the instance holds the change gate that stops the stamp
         // echoing back up and re-triggering itself forever.
         FleetRoles = new Fleet.FleetRoleObserver(
-            () => PushedSessions.SnapshotFresh(AutoDismissStaleAfter),
+            () => PushedSessions.SnapshotFresh(TenantId.Local, AutoDismissStaleAfter),
             SendCommandAsync);
         // The fold push seam: stamps each session's folded display state down to its owning Director, so the
         // desktop rail stops re-folding from local facts it cannot see. Folds through the SAME method the
@@ -612,7 +613,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // the answer pushed to the desktop is byte-identical to the answer every browser gets - one fold, one
         // authority. Like FleetRoles it holds the change gate that stops the stamp echoing back up forever.
         FleetDisplayState = new Fleet.FleetDisplayStateObserver(
-            () => PushedSessions.SnapshotFresh(AutoDismissStaleAfter),
+            () => PushedSessions.SnapshotFresh(TenantId.Local, AutoDismissStaleAfter),
             sessions => Api.GatewayEndpoints.StampFleetRolesAndFold(
                 sessions,
                 sessions,
@@ -951,7 +952,7 @@ public sealed class GatewayHost : IAsyncDisposable
     /// </summary>
     private string? ResolveSessionTitle(string sessionId)
     {
-        var located = PushedSessions.TryLocate(sessionId, _streamStaleAfter);
+        var located = PushedSessions.TryLocate(TenantId.Local, sessionId, _streamStaleAfter);
         var name = located?.Session.Name;
         return string.IsNullOrWhiteSpace(name) ? null : name;
     }
@@ -1787,7 +1788,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // sending the kill verb DOWN the Director stream. The close has no REST fallback by design (the
         // Gateway owns session lifecycle and reaches the Director through its stream).
         _autoDismissSweeper = new Running.AutoDismissSweeper(
-            () => PushedSessions.SnapshotFresh(AutoDismissStaleAfter),
+            () => PushedSessions.SnapshotFresh(TenantId.Local, AutoDismissStaleAfter),
             SendCommandAsync);
         _autoDismissTimer = new System.Threading.Timer(_ => SweepAutoDismiss(), null, AutoDismissSweepInterval, AutoDismissSweepInterval);
         FileLog.Write($"[GatewayHost] auto-dismiss sweep started: every {AutoDismissSweepInterval.TotalSeconds:0}s");
@@ -1931,7 +1932,7 @@ public sealed class GatewayHost : IAsyncDisposable
     /// </summary>
     public async Task<string?> PingDirectorAsync(string directorId, string message, CancellationToken ct = default)
     {
-        var connectionId = PushedSessions.GetActiveConnectionId(directorId);
+        var connectionId = PushedSessions.GetActiveConnectionId(TenantId.Local, directorId);
         var hub = _app?.Services.GetService(typeof(Microsoft.AspNetCore.SignalR.IHubContext<Streaming.DirectorHub>))
             as Microsoft.AspNetCore.SignalR.IHubContext<Streaming.DirectorHub>;
         if (connectionId is null || hub is null)
@@ -1960,7 +1961,7 @@ public sealed class GatewayHost : IAsyncDisposable
     {
         if (command is null) throw new ArgumentNullException(nameof(command));
 
-        var connectionId = PushedSessions.GetActiveConnectionId(directorId);
+        var connectionId = PushedSessions.GetActiveConnectionId(TenantId.Local, directorId);
         var hub = _app?.Services.GetService(typeof(Microsoft.AspNetCore.SignalR.IHubContext<Streaming.DirectorHub>))
             as Microsoft.AspNetCore.SignalR.IHubContext<Streaming.DirectorHub>;
         if (connectionId is null || hub is null)

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
@@ -26,6 +27,7 @@ namespace CcDirector.Gateway.Streaming;
 public sealed class DirectorHub : Hub
 {
     private const string DirectorIdItemKey = "cc.directorId";
+    private const string TenantIdItemKey = "cc.tenantId";
 
     private readonly PushedSessionStore _store;
     private readonly DirectorRegistry _registry;
@@ -83,7 +85,12 @@ public sealed class DirectorHub : Hub
         }
 
         Context.Items[DirectorIdItemKey] = directorId;
-        _store.RegisterConnection(directorId, Context.ConnectionId);
+        // Stage 3b: resolve the tenant this Director's connection belongs to, ONCE, here at bind time, and
+        // carry it on the connection like the directorId. The single-tenant core resolves to Local; the
+        // resolver (Stage 3c) supplies the real tenant from the Director's device key at exactly this point.
+        var tenant = TenantId.Local;
+        Context.Items[TenantIdItemKey] = tenant;
+        _store.RegisterConnection(tenant, directorId, Context.ConnectionId);
         // Gateway Cleanup mission (tunnel-only): the stream IS the registration now (HTTP register is gone).
         // Register this Director from the Hello identity so registry.Get(id) - the gate on create-session and
         // the other director-level routes - resolves it. Source="stream", no dialable endpoint.
@@ -96,7 +103,7 @@ public sealed class DirectorHub : Hub
     {
         var directorId = RequireBoundDirector();
         var set = sessions ?? Array.Empty<SessionDto>();
-        _store.ApplySnapshot(directorId, Context.ConnectionId, sequence, set);
+        _store.ApplySnapshot(RequireBoundTenant(), directorId, Context.ConnectionId, sequence, set);
         // DevThrottle Stats: fold each session's input tally into the always-available aggregate.
         _inputStats.ObserveSnapshot(set);
         // Defect 20: a deferred snooze whose hold landed while this Director was disconnected arrives in
@@ -122,7 +129,7 @@ public sealed class DirectorHub : Hub
             FileLog.Write($"[DirectorHub] PushDelta ignored (no session id): director={directorId}, conn={Short(Context.ConnectionId)}");
             return;
         }
-        _store.ApplyDelta(directorId, Context.ConnectionId, sequence, session);
+        _store.ApplyDelta(RequireBoundTenant(), directorId, Context.ConnectionId, sequence, session);
         // DevThrottle Stats: fold this session's tally into the always-available aggregate.
         _inputStats.Observe(session);
         // Defect 20: THE landing seam. Session.HoldStateChanged fires on DeferredHold -> Held and the
@@ -150,7 +157,7 @@ public sealed class DirectorHub : Hub
             FileLog.Write($"[DirectorHub] RemoveSession ignored (no session id): director={directorId}, conn={Short(Context.ConnectionId)}");
             return;
         }
-        _store.ApplyRemove(directorId, Context.ConnectionId, sequence, sessionId);
+        _store.ApplyRemove(RequireBoundTenant(), directorId, Context.ConnectionId, sequence, sessionId);
         // DevThrottle Stats: its contribution stays in the totals; drop only its high-water entry.
         _inputStats.Forget(sessionId);
         // A DEPARTURE RE-ROLES THE SURVIVORS, exactly as an arrival does: a controller leaving should stop
@@ -170,14 +177,16 @@ public sealed class DirectorHub : Hub
     public override Task OnDisconnectedAsync(Exception? exception)
     {
         var directorId = BoundDirectorId();
-        if (directorId is not null)
+        var tenant = BoundTenant();
+        if (directorId is not null && tenant is { } t)
         {
             // Clear the active connection so aggregation falls back to the cached roster. Gateway Cleanup
             // mission (tunnel-only): do NOT drop the registry entry here - a dead Director's cached roster must
             // survive the sweep window (so a Gateway-owned snooze still fires it back to "needs you" from the
             // cache) and a brief reconnect blip must not flap the roster. The stale sweeper ages out a Director
             // that stops refreshing LastSeen (HttpHeartbeatTimeout); a reconnect re-Hellos and refreshes it.
-            _store.UnregisterConnection(directorId, Context.ConnectionId);
+            // The tenant is the one bound at Hello (Hello sets both, so a bound director always has a tenant).
+            _store.UnregisterConnection(t, directorId, Context.ConnectionId);
         }
         FileLog.Write($"[DirectorHub] disconnected: conn={Short(Context.ConnectionId)}, director={directorId ?? "(unbound)"} ({exception?.Message ?? "clean"})");
         return base.OnDisconnectedAsync(exception);
@@ -188,6 +197,12 @@ public sealed class DirectorHub : Hub
 
     private string RequireBoundDirector() =>
         BoundDirectorId() ?? throw new HubException("Director stream not initialized: send Hello first.");
+
+    private TenantId? BoundTenant() =>
+        Context.Items.TryGetValue(TenantIdItemKey, out var value) && value is TenantId t ? t : null;
+
+    private TenantId RequireBoundTenant() =>
+        BoundTenant() ?? throw new HubException("Director stream not initialized: send Hello first.");
 
     private static string Short(string? id) =>
         string.IsNullOrEmpty(id) ? "(none)" : (id.Length <= 8 ? id : id[..8]);

--- a/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
+++ b/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -8,6 +9,14 @@ namespace CcDirector.Gateway.Streaming;
 /// Issue #1176 (Phase 1a): the Gateway's in-memory cache of the session state each Director pushes UP
 /// over its persistent stream, replacing the on-demand pull for stream-connected Directors. One entry
 /// per Director (keyed by directorId), holding the sessions that Director last pushed.
+///
+/// Tenant partitioning (Stage 3b of the multi-tenant plan): entries are partitioned by
+/// <see cref="TenantId"/> first, then by directorId. A Director belongs to exactly one tenant, and the
+/// cross-tenant scans (<see cref="TryLocate"/>, <see cref="SnapshotFresh"/>) only ever walk one
+/// tenant's partition, so a session id from one tenant can never resolve a Director in another. Today the
+/// core is single-tenant: callers pass <see cref="TenantId.Local"/> and behavior is unchanged. When the
+/// resolver lands, the tenant is the one resolved for the Director's connection (ingest) or the request
+/// (reads); nothing in this store changes.
 ///
 /// Correctness rules this store enforces (Phase 1 plan, section 4.4):
 ///  - CONNECTION GENERATION: each stream connection is identified by its SignalR connection id. A new
@@ -27,12 +36,12 @@ namespace CcDirector.Gateway.Streaming;
 /// contaminating the cache, and recompute relative time fields (idle seconds) from the absolute
 /// LastActivityAt so a quiet session's idle clock keeps advancing between pushes.
 ///
-/// Thread-safe: a <see cref="ConcurrentDictionary{TKey,TValue}"/> of per-Director entries, each guarded
-/// by its own lock.
+/// Thread-safe: a <see cref="ConcurrentDictionary{TKey,TValue}"/> per tenant of per-Director entries,
+/// each entry guarded by its own lock.
 /// </summary>
 public sealed class PushedSessionStore
 {
-    private readonly ConcurrentDictionary<string, DirectorEntry> _byDirector = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<TenantId, ConcurrentDictionary<string, DirectorEntry>> _byTenant = new();
     private readonly Func<DateTime> _utcNow;
 
     /// <summary>
@@ -44,27 +53,35 @@ public sealed class PushedSessionStore
         _utcNow = utcNow ?? (() => DateTime.UtcNow);
     }
 
+    /// <summary>The per-Director map for one tenant, created on first use. Fails loud on an invalid tenant.</summary>
+    private ConcurrentDictionary<string, DirectorEntry> DirectorsFor(TenantId tenant)
+    {
+        if (!tenant.IsValid)
+            throw new ArgumentException("A valid TenantId is required.", nameof(tenant));
+        return _byTenant.GetOrAdd(tenant, _ => new ConcurrentDictionary<string, DirectorEntry>(StringComparer.OrdinalIgnoreCase));
+    }
+
     /// <summary>
-    /// Mark <paramref name="connectionId"/> as the active stream connection for <paramref name="directorId"/>.
-    /// Existing cached sessions are kept (so a fast reconnect keeps roster continuity), but the sequence
-    /// baseline resets so the new connection's first message - at any sequence - is authoritative. The
-    /// last-received timestamp is deliberately NOT refreshed here: until the new connection actually pushes
-    /// a snapshot, the cache is treated as stale so aggregation falls back to pull.
+    /// Mark <paramref name="connectionId"/> as the active stream connection for <paramref name="directorId"/>
+    /// within <paramref name="tenant"/>. Existing cached sessions are kept (so a fast reconnect keeps roster
+    /// continuity), but the sequence baseline resets so the new connection's first message - at any sequence -
+    /// is authoritative. The last-received timestamp is deliberately NOT refreshed here: until the new
+    /// connection actually pushes a snapshot, the cache is treated as stale so aggregation falls back to pull.
     /// </summary>
-    public void RegisterConnection(string directorId, string connectionId)
+    public void RegisterConnection(TenantId tenant, string directorId, string connectionId)
     {
         if (string.IsNullOrWhiteSpace(directorId))
             throw new ArgumentException("directorId is required", nameof(directorId));
         if (string.IsNullOrWhiteSpace(connectionId))
             throw new ArgumentException("connectionId is required", nameof(connectionId));
 
-        var entry = _byDirector.GetOrAdd(directorId, _ => new DirectorEntry());
+        var entry = DirectorsFor(tenant).GetOrAdd(directorId, _ => new DirectorEntry());
         lock (entry.Gate)
         {
             entry.ActiveConnectionId = connectionId;
             entry.LastSequence = -1;
         }
-        FileLog.Write($"[PushedSessionStore] RegisterConnection: director={directorId}, conn={Short(connectionId)} is now the active connection");
+        FileLog.Write($"[PushedSessionStore] RegisterConnection: tenant={tenant}, director={directorId}, conn={Short(connectionId)} is now the active connection");
     }
 
     /// <summary>
@@ -79,21 +96,21 @@ public sealed class PushedSessionStore
     /// the Director is unknown. Gateway Cleanup mission (tunnel-only): the caller uses this to decide whether
     /// to drop the Director from the registry - only a genuine last-connection close should.
     /// </returns>
-    public bool UnregisterConnection(string directorId, string connectionId)
+    public bool UnregisterConnection(TenantId tenant, string directorId, string connectionId)
     {
-        if (!_byDirector.TryGetValue(directorId, out var entry))
+        if (!DirectorsFor(tenant).TryGetValue(directorId, out var entry))
             return false;
 
         lock (entry.Gate)
         {
             if (!string.Equals(entry.ActiveConnectionId, connectionId, StringComparison.Ordinal))
             {
-                FileLog.Write($"[PushedSessionStore] UnregisterConnection IGNORED (not active): director={directorId}, conn={Short(connectionId)}, active={Short(entry.ActiveConnectionId)}");
+                FileLog.Write($"[PushedSessionStore] UnregisterConnection IGNORED (not active): tenant={tenant}, director={directorId}, conn={Short(connectionId)}, active={Short(entry.ActiveConnectionId)}");
                 return false;
             }
             entry.ActiveConnectionId = null;
         }
-        FileLog.Write($"[PushedSessionStore] UnregisterConnection: director={directorId}, conn={Short(connectionId)} cleared; aggregation will fall back to pull");
+        FileLog.Write($"[PushedSessionStore] UnregisterConnection: tenant={tenant}, director={directorId}, conn={Short(connectionId)} cleared; aggregation will fall back to pull");
         return true;
     }
 
@@ -101,16 +118,16 @@ public sealed class PushedSessionStore
     /// Apply a full snapshot: replace the Director's whole session set, pruning any session not present.
     /// </summary>
     /// <returns>true if applied; false if rejected (not the active connection, or a stale sequence).</returns>
-    public bool ApplySnapshot(string directorId, string connectionId, long sequence, IReadOnlyList<SessionDto> sessions)
+    public bool ApplySnapshot(TenantId tenant, string directorId, string connectionId, long sequence, IReadOnlyList<SessionDto> sessions)
     {
         if (sessions is null)
             throw new ArgumentNullException(nameof(sessions));
-        if (!_byDirector.TryGetValue(directorId, out var entry))
+        if (!DirectorsFor(tenant).TryGetValue(directorId, out var entry))
             return false;
 
         lock (entry.Gate)
         {
-            if (!IsAcceptable(entry, directorId, connectionId, sequence, "snapshot"))
+            if (!IsAcceptable(entry, tenant, directorId, connectionId, sequence, "snapshot"))
                 return false;
 
             entry.Sessions.Clear();
@@ -130,18 +147,18 @@ public sealed class PushedSessionStore
 
     /// <summary>Apply a single-session delta: upsert one session.</summary>
     /// <returns>true if applied; false if rejected.</returns>
-    public bool ApplyDelta(string directorId, string connectionId, long sequence, SessionDto session)
+    public bool ApplyDelta(TenantId tenant, string directorId, string connectionId, long sequence, SessionDto session)
     {
         if (session is null)
             throw new ArgumentNullException(nameof(session));
         if (string.IsNullOrEmpty(session.SessionId))
             throw new ArgumentException("session.SessionId is required", nameof(session));
-        if (!_byDirector.TryGetValue(directorId, out var entry))
+        if (!DirectorsFor(tenant).TryGetValue(directorId, out var entry))
             return false;
 
         lock (entry.Gate)
         {
-            if (!IsAcceptable(entry, directorId, connectionId, sequence, "delta"))
+            if (!IsAcceptable(entry, tenant, directorId, connectionId, sequence, "delta"))
                 return false;
 
             DiscardInboundRole(session);
@@ -175,16 +192,16 @@ public sealed class PushedSessionStore
 
     /// <summary>Apply a remove/tombstone: drop one session from the Director's set.</summary>
     /// <returns>true if applied; false if rejected.</returns>
-    public bool ApplyRemove(string directorId, string connectionId, long sequence, string sessionId)
+    public bool ApplyRemove(TenantId tenant, string directorId, string connectionId, long sequence, string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId))
             throw new ArgumentException("sessionId is required", nameof(sessionId));
-        if (!_byDirector.TryGetValue(directorId, out var entry))
+        if (!DirectorsFor(tenant).TryGetValue(directorId, out var entry))
             return false;
 
         lock (entry.Gate)
         {
-            if (!IsAcceptable(entry, directorId, connectionId, sequence, "remove"))
+            if (!IsAcceptable(entry, tenant, directorId, connectionId, sequence, "remove"))
                 return false;
 
             entry.Sessions.Remove(sessionId);
@@ -201,9 +218,9 @@ public sealed class PushedSessionStore
     /// seconds) are recomputed from the absolute LastActivityAt at serve time so a quiet session's idle
     /// clock keeps advancing between pushes.
     /// </summary>
-    public IReadOnlyList<SessionDto>? TryGetFresh(string directorId, TimeSpan staleAfter)
+    public IReadOnlyList<SessionDto>? TryGetFresh(TenantId tenant, string directorId, TimeSpan staleAfter)
     {
-        if (!_byDirector.TryGetValue(directorId, out var entry))
+        if (!DirectorsFor(tenant).TryGetValue(directorId, out var entry))
             return null;
 
         lock (entry.Gate)
@@ -226,23 +243,25 @@ public sealed class PushedSessionStore
 
     /// <summary>
     /// Issue #1177 (Phase 4a): find the Director that currently owns <paramref name="sessionId"/> in a FRESH
-    /// pushed cache, without any HTTP pull. Scans each Director's cache (under its own lock) and returns the
-    /// first fresh match as (directorId, deep-copied session). Returns null when no stream-connected Director's
-    /// fresh cache holds the session, which post-cut means the session cannot be located at all - the pushed
-    /// cache is the ONLY roster source, so the caller reports "not found" rather than dialling anything.
+    /// pushed cache, without any HTTP pull. Scans <paramref name="tenant"/>'s Directors only (each under its
+    /// own lock) and returns the first fresh match as (directorId, deep-copied session). Returns null when no
+    /// stream-connected Director in this tenant holds the session, which post-cut means the session cannot be
+    /// located at all - the pushed cache is the ONLY roster source, so the caller reports "not found" rather
+    /// than dialling anything.
     ///
     /// This is the portless session-location primitive: a remotely-unreachable Director has an empty control
     /// endpoint, so an HTTP pull can never locate its sessions, but the pushed cache already records which
     /// Director pushed each session. Freshness and idle-clock recompute follow the same rules as
-    /// <see cref="TryGetFresh"/>.
+    /// <see cref="TryGetFresh"/>. Because it only walks one tenant's partition, a session id can never
+    /// resolve a Director in a different tenant.
     /// </summary>
-    public (string DirectorId, SessionDto Session)? TryLocate(string sessionId, TimeSpan staleAfter)
+    public (string DirectorId, SessionDto Session)? TryLocate(TenantId tenant, string sessionId, TimeSpan staleAfter)
     {
         if (string.IsNullOrEmpty(sessionId))
             return null;
 
         var now = _utcNow();
-        foreach (var kvp in _byDirector)
+        foreach (var kvp in DirectorsFor(tenant))
         {
             var entry = kvp.Value;
             lock (entry.Gate)
@@ -261,17 +280,18 @@ public sealed class PushedSessionStore
     }
 
     /// <summary>
-    /// Issue #1200 (auto-dismiss sweep): enumerate every FRESH pushed session across all stream-connected
-    /// Directors, each paired with its owning directorId so the caller can address a command DOWN that
-    /// Director's stream. Applies the same active-connection + freshness rules as <see cref="TryGetFresh"/>
-    /// and returns deep COPIES with recomputed idle clocks, so a caller may inspect them without touching the
-    /// cache. A Director with no active connection or a stale cache contributes nothing.
+    /// Issue #1200 (auto-dismiss sweep): enumerate every FRESH pushed session across <paramref name="tenant"/>'s
+    /// stream-connected Directors, each paired with its owning directorId so the caller can address a command
+    /// DOWN that Director's stream. Applies the same active-connection + freshness rules as
+    /// <see cref="TryGetFresh"/> and returns deep COPIES with recomputed idle clocks, so a caller may inspect
+    /// them without touching the cache. A Director with no active connection or a stale cache contributes
+    /// nothing. Scoped to one tenant - a sweep for one tenant never sees another's sessions.
     /// </summary>
-    public IReadOnlyList<(string DirectorId, SessionDto Session)> SnapshotFresh(TimeSpan staleAfter)
+    public IReadOnlyList<(string DirectorId, SessionDto Session)> SnapshotFresh(TenantId tenant, TimeSpan staleAfter)
     {
         var now = _utcNow();
         var result = new List<(string, SessionDto)>();
-        foreach (var kvp in _byDirector)
+        foreach (var kvp in DirectorsFor(tenant))
         {
             var entry = kvp.Value;
             lock (entry.Gate)
@@ -290,31 +310,31 @@ public sealed class PushedSessionStore
     }
 
     /// <summary>True when this Director currently has an active stream connection (used for diagnostics).</summary>
-    public bool IsStreamConnected(string directorId) =>
-        _byDirector.TryGetValue(directorId, out var entry) && entry.ActiveConnectionId is not null;
+    public bool IsStreamConnected(TenantId tenant, string directorId) =>
+        DirectorsFor(tenant).TryGetValue(directorId, out var entry) && entry.ActiveConnectionId is not null;
 
     /// <summary>
     /// The active stream connection id for a Director, or null when none. The Gateway uses it to address a
     /// message DOWN the stream to that Director (issue #1176, Phase 1b down-channel).
     /// </summary>
-    public string? GetActiveConnectionId(string directorId)
+    public string? GetActiveConnectionId(TenantId tenant, string directorId)
     {
-        if (!_byDirector.TryGetValue(directorId, out var entry))
+        if (!DirectorsFor(tenant).TryGetValue(directorId, out var entry))
             return null;
         lock (entry.Gate)
             return entry.ActiveConnectionId;
     }
 
-    private static bool IsAcceptable(DirectorEntry entry, string directorId, string connectionId, long sequence, string kind)
+    private static bool IsAcceptable(DirectorEntry entry, TenantId tenant, string directorId, string connectionId, long sequence, string kind)
     {
         if (!string.Equals(entry.ActiveConnectionId, connectionId, StringComparison.Ordinal))
         {
-            FileLog.Write($"[PushedSessionStore] {kind} DROPPED (not the active connection): director={directorId}, conn={Short(connectionId)}, active={Short(entry.ActiveConnectionId)}");
+            FileLog.Write($"[PushedSessionStore] {kind} DROPPED (not the active connection): tenant={tenant}, director={directorId}, conn={Short(connectionId)}, active={Short(entry.ActiveConnectionId)}");
             return false;
         }
         if (sequence <= entry.LastSequence)
         {
-            FileLog.Write($"[PushedSessionStore] {kind} DROPPED (stale sequence {sequence} <= last {entry.LastSequence}): director={directorId}, conn={Short(connectionId)}");
+            FileLog.Write($"[PushedSessionStore] {kind} DROPPED (stale sequence {sequence} <= last {entry.LastSequence}): tenant={tenant}, director={directorId}, conn={Short(connectionId)}");
             return false;
         }
         return true;


### PR DESCRIPTION
## What

Make the Gateway's fleet-picture store (`PushedSessionStore`) tenant-partitioned - the first store threaded in the tenancy work, and the one whose global scans were the real cross-tenant risk.

- Entries are partitioned by tenant first, then directorId (nested dictionaries), so the cross-tenant scans (`TryLocate`, `SnapshotFresh`) structurally only ever walk one tenant's partition.
- Every method takes an explicit tenant (no ambient tenant context); an invalid tenant is rejected, never defaulted.
- `DirectorHub` resolves the connection's tenant once at `Hello` and carries it on the connection, exactly like the directorId, then passes it into every ingest call.
- Every read call site (endpoints, host, the turn-end sweep) passes the tenant.

## Why

`TryLocate(sessionId)` and `SnapshotFresh()` previously scanned every Director globally, so a session id from one tenant could resolve a Director in another. Partitioning by tenant closes that by construction.

## Behavior change

**None.** The single-tenant core resolves to `Local`, so every call passes `Local` and behavior is unchanged for a self-hosted Gateway. The resolver supplies the real per-connection/per-request tenant at these same points in a later step; the store is already correct.

## Proof

- `CcDirector.Gateway` builds clean (0 warnings, 0 errors).
- Full `CcDirector.Gateway.Tests` suite green: **2540 passed, 0 failed**.
- New `PushedSessionStoreTenantIsolationTests` proves a tenant cannot locate, read, or enumerate another tenant's sessions even with a real session id; that the same directorId in two tenants stays independent; and that an invalid tenant throws.
