### PR TITLE
docs(architecture): preserve the Gateway SQLite mission record

### DIFF
--- a/docs/architecture/gateway-sqlite-handover-2026-07-16.md
+++ b/docs/architecture/gateway-sqlite-handover-2026-07-16.md
@@ -1,0 +1,113 @@
+# Gateway SQLite - handover to a clean Architect
+
+Written 2026-07-16 by the outgoing Architect (session 8c17dc1c) at the owner's instruction. He
+judged this session had made a lot of mistakes and wanted the work continued from a clean context on
+a newer Director. He is right. This is short on purpose.
+
+## What shipped, and it is live
+
+**The Gateway's input statistics are in SQLite. Done, merged, deployed, and growing.**
+
+- `#1694` merged the fold. The owner's Gateway runs `1.3.0+01a248b4`, which is that exact merge
+  commit on `origin/main` - not a hand-placed build.
+- `gateway-stats.db` at `%LOCALAPPDATA%\cc-director`, `user_version=1`, rows landing from his real
+  fleet and rising on their own (43 turns -> 67 while I watched).
+- `gateway-input-stats.json` is renamed aside UNREAD to `.retired-*` and never read. Proven, not
+  asserted: a store seeded with 999 turns was retired beside a database reporting zero.
+- Cockpit and mobile both read it - `apps/mobile/src/pages/YourThrottle.tsx` and the Cockpit both go
+  through `packages/client-core/src/stats/statsClient.ts`, which fetches `GET /stats/data`. One
+  feed, both surfaces.
+- Fresh installs self-create: directory, file, tables, `user_version` - all on first run, and the
+  retire step is guarded by a file-exists check so a machine with no JSON skips it cleanly.
+
+Also merged tonight and worth knowing: `#1658` stops the Gateway test suite writing into the owner's
+live `cc-director` folder (a test run had renamed his live stats file aside; only timing prevented
+total loss), and `#1696` puts the no-agent-attribution rule into `FleetPreamble` so every agent on
+every machine is told the code is his and does not get signed.
+
+## What is NOT built - this is your work
+
+The owner asked for **far more logging than exists**, for governance: *"I want to know everything I
+do, whatever I've done in a day or a week or a month and what I spend my time on. If in doubt, log
+more."* Gigabytes are fine; a rolling retention is acceptable to him.
+
+Today's rows carry: session id, hour, modality, surface, `is_voice`, repo, wingman, turns,
+characters, plus separate agent and agent-driven lanes.
+
+The gaps, in the order I would do them:
+
+1. **Model.** `SessionDto.CurrentModel` merged tonight (#1651), so the producer is live and this is a
+   column plus a migration. Do this first: it is cheap AND it is the first real proof the
+   `user_version` migration path works, which is the whole justification for this mission.
+2. **Tokens.** The real gap. `SessionTokenUsage`, `ClaudeResponseParser` and `CodexContextUsage`
+   parse them in Core, but **nothing carries them to the Gateway** - `SessionDto` has no token field.
+   Build the wire before the column. Do not add a column nothing emits.
+3. **Prompts / governance views.** The day/week/month "what did I spend my time on" screens do not
+   exist. `/stats` is a self-contained embedded HTML page, not a Cockpit route.
+
+**Read `docs/architecture/gateway-sqlite-mission-2026-07-15.md` on branch `feat/gateway-sqlite`
+before designing any of it.** It is long and it is the one genuinely valuable artifact of this
+mission - it records the decisions and, more usefully, why several obvious-looking designs are
+wrong.
+
+## The five things most likely to bite you
+
+1. **The model dimension is a phase, not a column.** `CurrentModel` is free text with unbounded
+   cardinality; a Claude session reports its launch alias (`opus[1m]`) before its first turn and the
+   concrete id after, which is two names for one model - the same shape as the repository separator
+   split below. It also needs a since-stamp in the `_agentsSinceUtc` mould, and three display states
+   (predates-the-dimension / unknown-at-fold-time / concrete), because records-only means every
+   session's FIRST turn folds with no model, forever. Session `60ffd96b` owns the producer and has
+   the context.
+2. **Do not normalize repository path separators.** Three repositories are stored twice on his
+   machine - `D:\ReposFred\devthrottle` (324 turns) and `D:/ReposFred/devthrottle` (21).
+   `OrdinalIgnoreCase` folds case but not slashes. It looks like a bug. "Fixing" it changes his
+   numbers.
+3. **`agent_id` is deliberately NOT on `stat_delta`.** `AttributeToAgentLocked` has two call sites
+   and the back-fill one has no totals counterpart, so deriving agents from `stat_delta` has *no*
+   correct behaviour. The agent lane has its own table. Do not merge it back.
+4. **The migration machinery is not scaffolding.** `PRAGMA user_version` is the point of the
+   mission. "The import is gone so the migration can go too" is a sentence that sounds reasonable
+   and would gut the whole thing.
+5. **A check that cannot find a thing will report the thing is absent.** This happened three times in
+   one day here: an assertion that could not match the defect, a red-watch that failed for the wrong
+   reason, and a grep whose filter excluded the only lines that could match. Empty output is not
+   evidence until you have shown the check can produce output.
+
+## How this mission runs
+
+- **Worktree:** `D:\ReposFred\devthrottle-gateway-sqlite`, branch `feat/gateway-sqlite`. Never the
+  shared checkout.
+- **A Codex reviewer gates every commit**, as a REAL DevThrottle session (`--agent Codex`), never a
+  background process - the owner has rejected that explicitly. Reviews go to FILES under
+  `docs/architecture/`, never a terminal: the buffer captures only spinner redraw.
+- **Merged to `origin/main` is the only done.** This mission learned that the hard way - the fold was
+  deployed by hand, and another agent shipped from main 17 minutes later and wiped it. The owner's
+  stats silently fell back to JSON.
+- **No agent attribution** in any commit, pull request, issue or document. Ever.
+- Plain ASCII, plain English, no abbreviations.
+
+## What the outgoing session got wrong - learn from it rather than repeat it
+
+- **I spent a full day producing an excellent design document and almost no code.** Fifteen revisions
+  of a brief before one line of product code existed. Ship increments.
+- **I never checked the premise.** I designed a careful migration to preserve his old statistics for
+  most of a day. He then said, unprompted, that he did not want them kept - which deleted the hardest
+  half of the design. **Ask.**
+- **I reported "deployed" when I had not merged**, which made it temporary and it was gone in 17
+  minutes.
+- **I over-reported.** He told me twice to stop narrating every finding. He wants the decision, not
+  the process.
+
+## Cleanup outstanding
+
+- Sessions to reap: the Manager `f3599eba` and the Codex reviewer `7068ec90`, both idle.
+- Dead worktrees: `devthrottle-testroot-fix`, `devthrottle-sqlite-land`, `devthrottle-no-attrib`,
+  `devthrottle-gw-deploy` - all merged, all removable.
+- `gateway-stats.db.stale-reverted-deploy-*` in his storage root - dead weight from the reverted
+  deploy, safe to delete.
+- **One unexplained test failure**, one in 2435, never diagnosed and never reproduced. It is an OPEN
+  unknown in the record, not a resolved one. Do not close it because it did not recur.
+- `feat/gateway-sqlite` carries the brief and the review records but must NOT merge to main as-is -
+  Codex flagged that its review files describe an import and legacy reader that were later deleted,
+  which would land as contradictory architecture.

--- a/docs/architecture/gateway-sqlite-mission-2026-07-15.md
+++ b/docs/architecture/gateway-sqlite-mission-2026-07-15.md
@@ -1,0 +1,1125 @@
+# Mission Brief: SQLite on the Gateway
+
+Status: PROPOSED - revised twice after Codex review, awaiting the Codex reviewer's final sign-off
+and the owner's approval. No code is written until both approve this document.
+
+Written 2026-07-15 by the Architect session ("Gateway SQLite - Architect", session 8c17dc1c,
+machine SOREN_NORTH). This document is the Architect's handover to the Manager. The Manager owns
+execution from here; the Architect settles the design and then lets the Manager drive.
+
+Revision 2 folded in the Codex reviewer's round-one findings, recorded in full at
+`docs/architecture/gateway-sqlite-review-codex-2026-07-15.md`. That review returned CHANGES
+REQUIRED and was right to: it found that the original import design promised something the existing
+data cannot deliver. The design is materially different as a result. The section "What the
+historical data cannot tell us" is the most important section in this document.
+
+Revision 3 folds in the round-two findings, recorded at
+`docs/architecture/gateway-sqlite-review-codex-round2-2026-07-15.md`, which approved the baseline
+design and then found three more holes in it. The sharpest: the row schema had no way to express a
+wingman turn, because wingman turns are **not** voice-modality turns (Decision 2 explains). The
+other two: a fold is not "one row write" and the brief should stop claiming it, and archive rows
+sharing a table with real rows need an explicit query rule or they invent a phantom bucket in the
+working-day series. All three are folded in below.
+
+Two reviews, eleven accepted defects. That is the reviewer doing its job on a document, which is
+the cheapest place in this mission for it to happen.
+
+Every claim below carries a file and line citation. Revision 1 asserted that all of its citations
+had been verified against `origin/main`; the Codex review proved that claim was itself overstated -
+two citations did not resolve to what revision 1 said they did, and both are corrected here.
+
+**Every citation in this document was re-checked, line by line, against `origin/main` at commit
+1c1fa17c, after rebasing this branch onto it on 2026-07-15.** This matters: the branch was cut at
+8c64a049 and `origin/main` moved six commits underneath it while this document was being reviewed.
+One of those commits (#1624) reshaped `GatewayEndpoints.cs`, which moved the two fold citations in
+point 3 below from lines 813 and 820 to 842 and 849. The mechanism was unchanged, but the line
+numbers had quietly become fiction - which is precisely the failure this repository has a standing
+rule against, and it happened to this document during its own review. It is recorded here rather
+than quietly fixed, because the next person to leave a branch sitting while it is reviewed should
+expect the same. Any future revision of this brief must re-verify against `origin/main` at the time
+of writing, not trust this line.
+
+Disk measurements were taken on SOREN_NORTH on 2026-07-15, independently by the Architect and the
+Codex reviewer.
+
+## OWNER RULING, 2026-07-15: the old data is not being carried over
+
+**Read this before anything below it. It deletes about half of this document.**
+
+The owner, asked directly, said: "I do not care about carrying over the old data. You can throw
+away all the old data if you want, it doesn't really matter." He said it twice, unprompted, and it
+is not ambiguous. It is not to be re-litigated, and nobody is to build a smaller, safer version of
+the import to hedge against it.
+
+**This brief spent fourteen revisions on a premise the owner did not hold.** Every hard problem in
+it - the three projections that cannot be cross-multiplied, the baseline design, the `HighWater`
+import and its 60 per cent inflation, the `AgentsSeeded` null rule, the legacy-reader lift, the
+parity check, the frozen snapshot - existed to carry his old numbers across safely. He does not want
+them carried. The Architect never asked whether the data was worth preserving; the mission simply
+assumed it, and the owner approved a document whose central premise was buried in it. Check the
+premise before doing the work, not after doing it well.
+
+**Deleted outright** - do not adapt, do not shrink, delete: the import; the legacy reader; the
+parity check; the baseline tables; the `AgentsSeeded`-null rule; the `HighWater` import; the
+synthetic import fixture; acceptance criterion 1; and all four legs of criterion 6. The `HighWater`
+inflation finding no longer applies at all - there is no baseline left to double against.
+
+**Kept, unchanged, and still load-bearing:** the database and schema; `stat_delta` with its
+surrogate ids, `is_voice` and `wingman` columns; `session_highwater` as live operational state that
+simply starts empty; the separate agent-driven tables; Decision 6's membership mirror; the archive
+rule and prune safety; and criteria 3, 3a, 5 and 7.
+
+**Kept and now MORE important, not less:** do not revert anything #1647 did. The agent-driven lane
+and the back-fill are live *product behaviour*, not old data. "Throw away the data" is not
+permission to throw away a shipped bug fix.
+
+**The filter to apply, because the Architect's first delete list got it wrong twice.** The owner's
+ruling is about **data**, not about **behaviour**. The question for every table and rule is not "is
+this in the baseline neighbourhood?" but **"is this a stored historical number, or is this something
+the running product does?"** Two things sit next to the baseline and are emphatically behaviour. The
+Manager caught both before cutting, and a literal reading of the first delete list would have
+shipped both defects:
+
+- **`agents_since_utc` is NOT a baseline and must survive.** It is stamped at *runtime* by
+  `StampAgentsSinceLocked`, called on every observe (`:148` and `:163`), not loaded from history. It
+  needs a home - `meta(name, value)` is the natural one now that the import marker it was built for
+  is gone. Delete it with the rest of `baseline_scalar` and the Agents page silently starts claiming
+  its numbers reconcile with the totals, which is the exact lie that field exists to prevent.
+  (`wingman_turns` in the same table *is* a baseline and does go.)
+- **`agents_seeded` must survive, and this is not obvious under the new premise.** With a fresh
+  database the first-fold back-fill contributes nothing, because high-water starts empty - so it
+  looks redundant. But `session_highwater` **persists across Gateway restarts**, so once sessions
+  have accumulated high-water, a restart without `agents_seeded` re-runs the back-fill for every
+  live session and doubles the agent numbers - precisely what the `:80` comment warns about. It is
+  live behaviour that happens to look like migration scaffolding.
+
+**THE MIGRATION MACHINERY IS NOT SCAFFOLDING. DO NOT DELETE IT.** `PRAGMA user_version`, the
+version check, and the migration path stay. The Manager flagged this as the next fast delete waiting
+to happen, and it is the most dangerous one left, because the sentence that kills it sounds
+*reasonable*: "the import is gone, so the migration machinery goes with it." It does not. **The
+migration machinery is the entire point of the mission.** The import was how old numbers were to be
+carried across once; the migration is how the *next* shape change keeps the owner's numbers instead
+of quarantining the file and losing them the way #1376 lost the concurrency peak of 35. Delete the
+import and the mission gets simpler. Delete `user_version` and the mission has no reason to exist -
+it becomes a lateral move from one store that loses data on a shape change to another one.
+
+**The general trap, one level up from the filter above:** the danger zone is anything whose *name*
+sounds like migration. "Import", "legacy", "baseline", "parity" and "migration" all read as
+scaffolding, and four of those five genuinely were. `user_version` is the one that is load-bearing
+product behaviour wearing the same word. Judge by what a thing *does*, never by what its name
+suggests it was for.
+
+**New cutover behaviour:** on first run, rename `gateway-input-stats.json` aside and start empty. No
+parse, no read, no import path. **Rename, never delete** - discarding the numbers is the owner's
+call, destroying the file irreversibly is not, and a rename costs nothing and keeps the door open.
+
+**One consequence, accepted:** with `session_highwater` starting empty, the first roster poll folds
+each live session's whole current tally as fresh activity, so day one lands with a few hundred turns
+in a lump rather than at zero, then counts normally. A high-water-only import would avoid the lump;
+it is not worth the code. Less code is now the right trade, because the reason to write careful code
+here was to protect data nobody is protecting.
+
+Everything below this section is retained as the record of how the design was reached, and much of
+it still governs the parts that survive. Where it conflicts with this section, this section wins.
+
+## The why
+
+The Gateway keeps its statistics in a set of hand-rolled JSON files. That was the right call when
+there was one store. There are several now, and the pattern has started to cost real money in three
+specific ways:
+
+1. **Every new question costs a schema change and a deploy.** `GatewayInputStatsAggregator` keeps a
+   separate dictionary per question: `_totals`, `_highWater`, `_hourly`, `_wingmanSessions`,
+   `_repos`, `_agents` (`src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs:31-66`). Each
+   new dimension the owner asks for is a new dictionary, a new field on the store file, a new
+   data-transfer object field, and a redeploy. Per-repository and per-agent tallies were both added
+   this way after the Stats mission was declared finished, which is the evidence that the questions
+   keep coming.
+
+2. **A shape change has already silently destroyed live data.** There is no schema versioning
+   anywhere in these stores. When the store file fails to deserialize, or deserializes to null, it
+   is renamed to `.corrupt-{timestamp}` and the store restarts empty (the load path is
+   `GatewaySessionConcurrencyStats.cs:205-227`; the quarantine method itself is `:249-254`). That
+   path is how pull request #1376 wiped the all-time fleet concurrency peak of 35 on deploy. It was
+   noticed only because someone happened to be looking.
+
+   The precise statement matters, because the reality is worse than "a shape change is treated as
+   corrupt". A shape change is quarantined only when deserialization *throws* or returns null. A
+   change that merely removes or renames a field does not throw - it deserializes to defaults, and
+   the store silently comes up with zeros where real numbers used to be, with no `.corrupt` file to
+   notice. Loud quarantine is the *detectable* failure mode; silent default-filling is the one that
+   could pass unremarked.
+
+3. **The write is a whole-document rewrite on a request path.** The input stats store re-serializes
+   the entire document and rewrites the file whenever any counter moves
+   (`GatewayInputStatsAggregator.cs:123` and `:137` call `Save()`; `Save()` builds the full
+   document, serializes it, writes a temporary file, and moves it over the original at `:555-583`),
+   and the fold runs on **every** `GET /sessions` read
+   (`src/CcDirector.Gateway/Api/GatewayEndpoints.cs:842` for input stats, `:849` for concurrency).
+   That is O(all history) of synchronous work under a lock, per roster poll. It compounds with the
+   deliberately unbounded distinct-session sets described below: the file grows forever *and* is
+   rewritten constantly.
+
+SQLite makes all three go away: a narrow table of rows answers new questions with a `GROUP BY`
+instead of a deploy, `PRAGMA user_version` gives real migrations instead of quarantine-and-lose,
+and a counter move becomes one delta row plus a little bounded bookkeeping, instead of a rewrite of
+the entire file. (Revision 1 said "one row write". That was too strong, and Decision 2 below states
+what a fold actually costs.)
+
+The cost is near zero. `Microsoft.Data.Sqlite` 9.0.2 is already a package reference in
+`src/CcDirector.Core/CcDirector.Core.csproj:18`, the Gateway already references Core
+(`src/CcDirector.Gateway/CcDirector.Gateway.csproj:49`), and the house pattern for using it
+already exists in `src/CcDirector.Core/Communications/Services/DatabaseService.cs:47-60` (raw
+`SqliteConnection`, `CREATE TABLE IF NOT EXISTS`). There is no Entity Framework, no Dapper, and no
+LiteDB in this repository, and this mission does not introduce one.
+
+**This mission is a refactor. It ships no new user-visible feature.** The honest justification is
+the three costs above, not disk space. Anyone who reads this document and concludes "we are storing
+a lot of statistics, so we need a database" has the wrong reason - see the next section.
+
+## What is actually stored today, and what is NOT in scope
+
+Measured on SOREN_NORTH, 2026-07-15, independently by both the Architect and the Codex reviewer
+(the two measurements agree to within a few hundred bytes; these are live files). All paths resolve
+through `CcStorage.Root()` (`src/CcDirector.Core/Storage/CcStorage.cs:28-38`) to
+`%LOCALAPPDATA%\cc-director`.
+
+| Store | Class | Size | Shape |
+|---|---|---|---|
+| `gateway-input-stats.json` | `Stats/GatewayInputStatsAggregator.cs:107` | 59 KB | Counters, hourly buckets, all-time sets |
+| `carmode-telemetry.json` | `CarMode/CarModeTelemetryStore.cs:45-47` | 32 KB | Per-turn events in a rewritten list |
+| `netdiag-rollup.json` | network diagnostics | 22 KB | Rollup |
+| `netdiag-devices.json` | network diagnostics | 20 KB | Rollup |
+| `gateway-concurrency-stats.json` | `Stats/GatewaySessionConcurrencyStats.cs:68-70` | 16 KB | Hourly buckets, all-time peaks |
+| `cronruns.json` | scheduler | 16 KB | Run history |
+| `voice-sessions.json` | `Wingman/WingmanVoiceService.cs:105` | 13 KB | A flat array of session id strings |
+
+That is about 178 KB in total. **Size is not the problem and must not be used to argue this
+mission.** These are rolled-up aggregates, and aggregates stay small.
+
+**A premise from revision 1 that was wrong, corrected here.** Revision 1 said these were seven
+files "each with its own copy of the same load, serialize, atomic temp-write-and-rename, and
+quarantine-on-corrupt code". That is not true of all of them, and `voice-sessions.json` is the
+clearest counter-example: it is a flat `string[]` of session ids, loaded at
+`WingmanVoiceService.cs:113-122` and saved with a direct `File.WriteAllText` at `:125-128`. It has
+no atomic temporary-write-and-rename, no quarantine, and it is not a statistics rollup at all - it
+is an operational set of which sessions have voice mode on. It should never have been listed as one
+of the "same pattern" stores. It is dealt with under Phase 4 below on its own merit, and the honest
+default for it is "leave it alone".
+
+**Explicitly out of scope - the append-only logs stay exactly as they are.** Two stores are
+JSON Lines files rather than rewritten documents:
+
+- `prompt-log/conversation-yyyyMMdd.jsonl`, 3.3 MB across 5 days
+  (`src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs:51-55`)
+- `transcription-log/transcription-YYYYMMDD.jsonl`, 1.7 MB across 7 days
+  (`src/CcDirector.Gateway/Transcription/TranscriptionTelemetryLog.cs:49-54`, appending one line at
+  `:67-70`)
+
+An earlier read of this ground called their lack of pruning a retention gap that should be fixed
+before this mission. **That was wrong, and the correction is recorded here so nobody re-opens it.**
+The prompt log's unbounded retention is a deliberate, documented decision:
+`GatewayPromptLog.cs:26-27` reads "Retention is unbounded. The point is looking back across weeks
+and months, and the text is small. Nothing prunes this." JSON Lines is the correct format for an
+append-only event stream: it does not rewrite the file, and it is trivially inspectable. Moving
+these to SQLite would solve a problem they do not have.
+
+The transcription log carries no stated retention policy either way. It grows about 1.7 MB a week
+on one machine and holds transcript text. That is a real open question but it is **not** this
+mission, and it is not a blocker. It is recorded in the follow-ups section.
+
+Likewise, the all-time distinct-session sets in the input aggregator (`_repos[].Sessions`,
+`_agents[].Sessions`, `_wingmanSessions`) are **deliberately** never pruned - the code says so at
+`GatewayInputStatsAggregator.cs:45-47`, `:51-54`, and `:57-61`. They back all-time distinct counts.
+They are not a bug to fix; they are a requirement to preserve. What is wrong is only *where* they
+live: inside a document that is fully rewritten on every roster read.
+
+**The scope line for this mission, stated once.** Revision 1 said "a store moves to SQLite if and
+only if it rewrites its whole document to record an incremental change". Read literally that sweeps
+in most of the Gateway - `WorkListStore`, `SnoozeRegistry`, `PushSubscriptionStore` and other
+operational stores all persist that way and have nothing to do with statistics. The rewrite test is
+necessary but not sufficient. The scope line is therefore narrowed to both conditions:
+
+> A store is in scope only if (a) it is one of the statistics, diagnostics, scheduler-history, or
+> Car Mode telemetry files named in the table above, **and** (b) it rewrites its whole document to
+> record an incremental change.
+
+Append-only JSON Lines logs stay on disk as JSON Lines. Operational stores outside the table are
+not touched by this mission, whatever their write pattern.
+
+## What the historical data cannot tell us
+
+**This section is new in revision 2 and it changes the design. It is the single most important
+thing in this document.**
+
+Revision 1 promised: import the existing JSON into `stat_delta` rows so that all-time totals,
+peaks, and distinct counts read identically before and after. The Codex reviewer showed that the
+first half of that promise cannot be kept, and reading the code confirms it.
+
+The existing store does not hold history. It holds **three independent projections of history,
+each already collapsed on a different dimension** (`GatewayInputStatsAggregator.cs:448-457` defines
+the persisted document; `:460-481` define the shapes):
+
+- `Hourly`: keyed by clock hour, holding `VoiceTurns`, `TypedTurns`, `Characters`. It does not know
+  which session, repository, or agent.
+- `Repos`: keyed by repository path, holding the same three counters plus a `Sessions` list. It
+  does not know which hour.
+- `Agents`: keyed by agent name, holding the same three counters plus a `Sessions` list. It does
+  not know which hour.
+- `Totals`: keyed by modality and surface (`:31-32`). It does not know hour, repository, or agent.
+
+A single past turn contributed to a bucket in each projection, but **which** hour goes with
+**which** repository with **which** agent was never written down. The cross-product does not exist
+on disk and cannot be recovered. Therefore a row of the form
+`(hour_utc, session_id, modality, surface, repo, agent, turns, chars)` **cannot be reconstructed
+for any historical turn.** Any attempt to synthesize such rows would be inventing data, and summing
+the synthetic rows across one dimension would disagree with the real totals in another.
+
+This is not a novel discovery about this codebase so much as a rediscovery. The code already hit
+exactly this wall and already answered it honestly. `_agentsSinceUtc` exists for this reason, and
+its comment (`GatewayInputStatsAggregator.cs:63-66`) says it plainly:
+
+> "When the per-agent tally started counting. The totals predate this breakdown, so the agent
+> numbers do NOT reconcile with them and the page must say so rather than imply the earlier turns
+> had no agent."
+
+That is the precedent, set by this repository, for the correct answer: when a dimension did not
+exist before a date, you record the date and you say so. You do not back-fill a guess.
+
+**The design consequence, stated plainly:** the past is a baseline, and only the future is rows.
+The mission still delivers its point - the next question the owner asks becomes a query rather than
+a deploy - but it delivers it **for data from the cutover forward**, not retroactively. Any brief,
+this one included, that implies otherwise is promising something the disk cannot supply. The owner
+should approve this mission knowing that.
+
+## The design
+
+Five decisions the Architect is settling. The Manager owns everything below this line's detail.
+
+**Decision 1 - One database file, raw Microsoft.Data.Sqlite.** `gateway-stats.db` under
+`CcStorage.Root()`, beside the stores it replaces. Raw `SqliteConnection` with
+`CREATE TABLE IF NOT EXISTS`, matching `DatabaseService.cs:47-60`. No Entity Framework, no Dapper.
+Write-ahead logging mode. The Gateway is a single process and therefore a single writer, so no
+cross-process write contention exists. The Gateway must gain its own explicit `PackageReference`
+rather than leaning on the transitive one through Core.
+
+**Decision 2 - Rows, not counters, from the cutover forward. This is the point of the mission.**
+Do NOT port the existing dictionaries into six tables; that would buy nothing but a new dependency.
+For every delta observed **after** the cutover, store one narrow row carrying its dimensions as
+columns:
+
+```
+stat_delta(hour_utc, session_id, modality, surface, is_voice, repo_id, agent_id, wingman, turns, chars)
+```
+
+**The `wingman` column is load-bearing and is not the same thing as `modality = 'voice'`.** It
+records `SessionDto.VoiceMode` as observed at fold time. The distinction is easy to miss and the
+Codex reviewer caught the brief missing it: `GatewayInputStatsAggregator.cs:425-427` folds the
+session's **entire** turn delta into `_wingmanTurns` whenever `s.VoiceMode` is true, and that delta
+includes typed turns. A turn typed while voice mode is on is a wingman turn today. The owner's
+definition, recorded at `:44-47`, is "a session uses the wingman when it has voice mode on" - it is
+a property of the session's mode, not of how any single turn was entered. Without this column,
+post-cutover wingman turns could not be derived from rows at all, and no `GROUP BY modality` would
+recover them. Wingman turns become `SUM(turns) WHERE wingman = 1`.
+
+**Capture `VoiceMode` once per fold and hand it to every row that fold emits.** Wingman is a
+property of the *session's mode* for the whole observation, not of any individual bucket, so it is
+constant across every row a single fold writes. Read it once into a local at the top of the fold
+and pass it as a required argument to the one function that emits rows. Then no row can carry a
+different flag than its siblings, and - the failure that actually matters - no row can have its
+flag *derived from its own modality*, because the emitting code never sees a path to compute it
+that way. This is the same move as the surrogate id: make the wrong answer unreachable rather than
+merely untaken.
+
+Each dashboard number becomes a baseline value plus a query over the rows recorded since:
+
+- all-time totals by modality and surface - baseline plus `SUM(...) GROUP BY modality, surface`
+- the working-day series - baseline hourly buckets, plus `GROUP BY hour_utc` over real hour keys
+  for recent hours (see the archive-marker rule in Decision 4)
+- the per-repository page - baseline plus `GROUP BY repo`
+- the per-agent page - baseline plus `GROUP BY agent`
+- wingman turns - baseline plus `SUM(turns) WHERE wingman = 1`
+
+Three honest qualifications, all raised by the Codex reviewer and all accepted:
+
+- **Equality must be decided in C#, not by SQLite's collation - and the schema must make that
+  structural, not a discipline.** `_repos` and `_agents` are keyed `OrdinalIgnoreCase`
+  (`GatewayInputStatsAggregator.cs:55`, `:61`), while SQLite's default `BINARY` collation is
+  case-sensitive. A naive `GROUP BY repo` would split buckets that are one bucket today. The live
+  store happens to contain no case collisions, which is exactly what makes it dangerous: parity
+  passes green and the split appears later, silently, the first time a path is reported with
+  different casing. `COLLATE NOCASE` is not the answer either - it folds only ASCII, so it agrees
+  with `OrdinalIgnoreCase` right up until a non-ASCII repository path and then quietly disagrees.
+
+  **The repository and agent keys are surrogate integers, resolved in C#. `stat_delta` stores
+  `repo_id` and `agent_id`, never a repository or agent string in any form - not raw, not folded.**
+  An earlier draft of this decision said "fold the key in C# and store the folded key", and the
+  Manager implemented exactly that before raising a naming question that exposed the flaw
+  underneath it. A folded **string** column requires a normalizing function, and no such function
+  exists: `StringComparer.OrdinalIgnoreCase` is a *comparer*, not a normalizer. There is no
+  `Fold(x)` that is exactly equivalent to it. The candidates are `ToLowerInvariant`, which is
+  forbidden and can even change a string's length (`U+0130`), and `ToUpperInvariant`, which is
+  close enough that it would almost certainly never bite - and "almost certainly never" is the
+  standard this mission has rejected at every other turn.
+
+  With a surrogate id there is no normalizer, because there is no folded string. A
+  `Dictionary<string, long>` constructed with `StringComparer.OrdinalIgnoreCase` resolves a
+  display spelling to an id in memory (Decision 6 already permits exactly this - "the repository
+  and agent identity maps"). That dictionary **is** today's comparer, the same object with the same
+  semantics, so parity holds by construction rather than by care. SQLite never compares a
+  repository string, so its collation cannot be wrong about one. `repo_identity(repo_id, display)`
+  keeps the first-seen spelling, which is what a `Dictionary` with that comparer does today.
+
+  The general principle, worth stating because it generalises past this column: **prefer the design
+  where the mistake is impossible over the design where the mistake is merely avoided.** Codex's
+  guardrail forbidding `ToLowerInvariant` was correct, but a rule you must remember is weaker than
+  a schema that cannot express the error. This choice deletes the rule.
+
+  **And the limit on that principle, because it is not a licence to redesign everything.** Spend
+  structure on making a mistake impossible when the mistake would be **silent** and the cost of
+  being wrong is the owner's data. That is why it was worth a schema change here: a case-split
+  repository bucket would pass every check green and surface weeks later as numbers that quietly
+  stopped adding up. Where a mistake would instead fail **loudly**, or a cheap test catches it at
+  the moment it is made, a test is the proportionate answer and the elaborate design is waste. The
+  question to ask is not "could this be made impossible?" - almost anything could - but "if this
+  went wrong, would anyone find out?" Design against the silent ones. Test the loud ones.
+
+  The same reasoning gives `stat_delta` an explicit `is_voice` column computed in C# at fold time
+  rather than re-derived from a string comparison in SQL, because `_totals` is keyed
+  case-sensitively (`:31-32`) while the voice test is not (`:366`), and that asymmetry must be
+  preserved rather than reproduced in the query layer.
+- **A fold is not "one row write", and it is not one row either.** A fold walks the session's input
+  buckets (`foreach (var b in s.InputStats.Buckets)`, `GatewayInputStatsAggregator.cs:343`), so a
+  correct post-cutover fold is one `INSERT` into `stat_delta` **per changed bucket** - a session
+  reporting movement on three modality-and-surface pairs writes three rows, not one - plus one
+  upsert into `session_highwater`, plus possibly an `INSERT OR IGNORE` into a distinct-id table
+  when a repository, agent, or wingman session is seen for the first time.
+
+  **The work is bounded by what changed, not by how much history exists**, and that - not any
+  particular statement count - is the actual win over an O(all history) document rewrite. Be
+  careful with the word "bounded": it describes the write cost of a fold. It does **not** describe
+  the distinct-id tables, which are deliberately never pruned (Decision 2,
+  `GatewayInputStatsAggregator.cs:45-61`) and grow forever by design. Both facts are true at once
+  and the brief means the first one.
+
+- **"A new question is a query, not a deploy" holds only for dimensions already carried on the
+  row.** A question about a dimension `stat_delta` does not capture still needs a schema change and
+  a deploy - it is just that the migration is now a real migration instead of a quarantine. The
+  win is real but it is narrower than revision 1 implied.
+- **Distinct counts are not `COUNT(DISTINCT session_id)` over `stat_delta`.** That is exact only
+  while every contributing row is still present, so it stops being exact the moment pruning starts
+  (see Decision 4), and it cannot see pre-cutover sessions at all. The all-time distinct sets keep
+  their own narrow, never-pruned identifier tables, seeded from the existing `Sessions` lists and
+  `_wingmanSessions`, and extended with `INSERT OR IGNORE`. This preserves exactly the semantics
+  the code documents at `GatewayInputStatsAggregator.cs:45-61`.
+
+**Decision 3 - The high-water logic survives unchanged, because SQL does not replace it.** The
+idempotent fold (`FoldLocked`, `GatewayInputStatsAggregator.cs:320`, comparing reported counters
+against previous high-water at `:336-354` and handling counter reset at `:350-354`) is what makes
+re-reading a roster safe and what lets counts survive a Director or Gateway restart without
+double-counting. It is the hard part of this code and it is correct. It moves to a
+`session_highwater` table (operational state for live sessions, cleared by `Forget`) and keeps its
+exact current semantics. **A worker who "simplifies" the high-water fold has broken the mission.**
+
+**Decision 4 - Pruning must not cost an all-time number.** Today `PruneLocked`
+(`GatewayInputStatsAggregator.cs:310-315`) prunes only the hourly buckets, at `RetentionDays = 90`,
+and the all-time totals live in separate dictionaries so they survive. With a delta table, naively
+deleting rows past the cutoff would silently shrink the all-time totals - the same class of failure
+as #1376. So, on prune, departing rows are folded into archive rows before deletion.
+
+Revision 1 said "an archive row", singular, which is not enough and would itself have lost data.
+The archive must **preserve every grouping dimension that any all-time answer is derived from** -
+modality, surface, repository, agent, and the `wingman` flag. Concretely: pruning collapses the
+hour and the session identifier, and nothing else. An archive row is a `stat_delta` row with its
+`hour_utc` and `session_id` replaced by archive markers and every other column preserved, so that
+every all-time `GROUP BY` over the remaining dimensions still returns the same sum. Distinct counts
+are unaffected because they never read `stat_delta` (Decision 2).
+
+**The archive-marker query rule, stated explicitly because leaving it implicit is how this design
+breaks.** Archive rows and real rows share one table, so every query must declare which it wants:
+
+- **All-time aggregate queries include archive rows.** That is the entire point of archiving - the
+  totals must not shrink when detail is pruned.
+- **Hourly and working-day queries filter to real hour keys and exclude the archive marker.**
+  `HourlyTurns()` (`GatewayInputStatsAggregator.cs:185-203`) returns an ordered hour series today,
+  and pruning drops old hours from it rather than folding them into a catch-all bucket
+  (`:310-315`). A plain `GROUP BY hour_utc` over a table containing archive rows would invent a
+  fake bucket in that series and change what the user sees. It must not.
+
+Whether an all-time answer survives pruning is a testable property, and Acceptance criterion 7
+pins it. That the working-day series does **not** grow a phantom bucket is equally testable, and
+criterion 7 pins that too.
+
+**Decision 5 - The import is a baseline, not a reconstruction, and it is fail-loud.** This decision
+is rewritten from revision 1, per the section "What the historical data cannot tell us".
+
+On first run against an existing JSON store, each historical projection is imported **as the store
+REPORTS it** into its own baseline table. No historical `stat_delta` rows are synthesized, ever.
+Every reported number is then baseline plus post-cutover rows, which is exact by construction and
+matches the existing `_agentsSinceUtc` precedent for a dimension that starts partway through.
+
+**"As the store reports it", NOT "as the bytes say" - and the difference is not academic, it is live
+on the owner's machine right now.** Revisions 1 through 14 said "as it stands", which reads as *the
+document's contents*. The Manager found that reading would corrupt this mission's central proof.
+
+The owner's real store contains an `Agents` section with real numbers. It does **not** contain
+`AgentsSeeded` - it has twelve sections' worth of schema and eight sections on disk, because it
+predates #1647. And `Load` treats a null `AgentsSeeded` as a signal that the stored agent tally is
+untrustworthy: it logs "discarding N partially-attributed agent tally/tallies and rebuilding from
+the high-water", calls `_agents.Clear()`, and lets the ordinary back-fill rebuild the tally from the
+persisted high-water on the next fold. **So the running Gateway already reports different agent
+numbers than the document contains.** The document is not the truth. It is an input to the truth.
+
+An import that copied the `Agents` section verbatim would therefore have faithfully preserved a
+tally the product had already decided was wrong and thrown away. Parity against a running Gateway
+would then have **failed** - and the tempting repair, comparing against the stored section instead
+of against what the Gateway reports, would have locked the rejected tally in permanently and called
+it success.
+
+So the rule: **the import must reproduce what the product does with the document, not what the
+document literally says.** Where `Load` discards, the import discards. Concretely, when
+`AgentsSeeded` is null the import writes `baseline_agent` as **zero** and lets the ordinary first
+fold rebuild it from the imported `session_highwater`, exactly as `Load` does today.
+
+**And do not re-implement that rule - inherit it.** Re-stating `Load`'s semantics inside a new
+importer means two implementations of "what does this document mean", which can drift, and the
+reflection test in criterion 6a cannot catch a drift because it checks that every *section* is
+handled, not that each is handled *correctly*. Instead lift the existing `Load` verbatim into a
+dedicated legacy reader used only by the import, and have the import consume its resulting in-memory
+state rather than parsing the document itself. Then "as the store reports it" holds by construction,
+and any quirk `Load` already has - including ones nobody has noticed - is inherited rather than
+mirrored. This is the surrogate-id move again, applied to semantics instead of to a column, and it
+earns its keep by the same test: a drifting importer fails **silently**, and the cost is the owner's
+data.
+
+One wrinkle to handle rather than inherit: `Load` quarantines its own file on a parse failure. The
+import must not - it fails loudly and leaves the document untouched until parity passes. The legacy
+reader needs its quarantine path replaced, not copied.
+
+**The Architect's explicit authority for the one number the import deliberately does not preserve.**
+The Manager declined to assume this and was right to ask, so it is stated here rather than left to
+inference: **for the owner's current store, `baseline_agent` imports as ZERO**, and the agent tally
+the Agents page shows after cutover is rebuilt by the ordinary first-fold back-fill from the
+imported `session_highwater` - not carried across by the import. This is the only place in the
+mission where a number that exists on disk is deliberately not preserved, and it is correct
+precisely *because* it is what the running Gateway already does with that same file today: `Load`
+clears the tally, and the next fold rebuilds it. Preserving the on-disk tally would make the port
+disagree with the product it is replacing. **Sanctioned by the Architect, on the record.**
+
+Two consequences that follow, and both matter:
+
+- **The window where the Agents page reads zero already exists today**, between `Load` and the first
+  fold. The port reproduces it rather than introducing it. If it is ever reported as a regression,
+  the answer is to compare against the current build's behaviour, not against the document.
+- **This rule and the `HighWater` finding are interlocked.** The back-fill rebuilds the tally *from
+  the imported high-water*, so if the high-water import were ever dropped or damaged, the agent
+  tally would rebuild from nothing and read zero permanently. Two of this mission's largest findings
+  depend on each other, and criterion 6 legs (b) and (d) are what hold them together.
+
+**Import EVERY section of `StoreFile`. Do not trust any count - including one written in this
+document.**
+
+Revision 4 of this brief said: "Import all eight sections of `StoreFile`. Not six. This is stated as
+a count because the count is how the omission was caught." Within hours that sentence was false.
+Pull request #1647 landed on `origin/main` and `StoreFile` gained three more sections -
+`AgentDrivenTurns`, `AgentDrivenCharacters`, and `AgentDrivenHighWater`. **Eleven, not eight.** The
+count was written *as the defence against dropping a section*, and the count itself went stale and
+became the defect. A number in a document cannot defend a schema that moves.
+
+So the requirement is structural, not numeric: **a test must reflect over `StoreFile`'s properties
+and assert that the import handles every one of them.** When someone adds a twelfth section, that
+test fails until the import covers it. Nobody has to remember a number, notice a pull request, or
+re-read this brief. This is the same move as the surrogate id and it is made for the same reason -
+prefer the design where the mistake is impossible over the design where it is merely avoided, and
+this is squarely a *silent* failure whose cost is the owner's data, which is where the principle
+says to spend.
+
+The count is deliberately not restated here. If you want to know how many sections there are, read
+`StoreFile`. If you want to know that the import covers them, run the test.
+
+The omission that started this is still worth recording, because it is what a dropped section costs.
+Revisions 1 through 3 listed six sections and silently dropped `HighWater` and `AgentsSinceUtc`. The
+Manager caught it before any code was written. Measured on the owner's real store on 2026-07-15:
+
+> All-time totals hold **1404** turns. `HighWater` holds **842** turns across **115** live
+> sessions. Start `session_highwater` empty and the very first `GET /sessions` poll refolds every
+> one of those sessions from zero - `FoldLocked` treats a missing high-water entry as
+> `prevTurns = 0` and folds the session's **entire** tally as fresh activity
+> (`GatewayInputStatsAggregator.cs:336-354`). The owner's totals become **2246**. A silent 60 per
+> cent inflation of every number this mission promised to preserve.
+>
+> (These counts are a snapshot of a live, moving store - see criterion 1 below. The exact figures
+> drift by the minute; the ratio is the point, and the ratio is roughly three fifths.)
+
+**`session_highwater` is not a baseline. It is live operational state, and it must be imported so
+that the fold's idempotency survives the cutover.** The high-water map is precisely what makes
+re-reading a roster safe (Decision 3). An import that restores the aggregates but not the
+high-water has not preserved the numbers - it has armed a bomb on the next poll.
+
+**This omission also proves the endpoint-field parity check is necessary but NOT sufficient**, and
+that is the more important lesson. `/stats/data` exposes no high-water field
+(`Stats/StatsPageEndpoint.cs:40-71`), so the parity check specified below would have read every
+exposed field, found every one of them correct, passed green, and renamed the JSON aside - and the
+damage would have landed on the *next* roster poll, after the only copy of the truth was already
+moved. **A parity check can only see what the endpoint exposes. State that a store's internal
+operational state is invisible to it, and check that separately.** Acceptance criterion 6 gains an
+idempotent-re-observe leg for exactly this reason.
+
+`AgentsSinceUtc` is the other dropped section. It is a single string, it is load-bearing for an
+honest page (`GatewayInputStatsAggregator.cs:63-66`), and losing it would silently re-stamp the
+agent breakdown as starting at the cutover - making the agent numbers look like they reconcile with
+the totals when they do not. Import it verbatim.
+
+The import sequence is fixed and is not open to a worker's interpretation:
+
+1. Import inside a **single transaction**, and stamp an import marker plus `PRAGMA user_version` in
+   that same transaction, so a crash cannot double-import or strand a partial import.
+2. Read every affected endpoint field back **out of SQLite** and compare it field by field against
+   what the JSON store reported before the import.
+3. Only on a complete match, rename the JSON aside (never delete it).
+4. **On any mismatch, fail loudly**: leave the JSON in place as the source of truth, do not mark
+   the import done, and surface a clear error. Never come up empty, never come up with partial
+   numbers, never silently fall back. This follows the house rule against fallback programming, and
+   it is the direct antidote to the failure mode in point 2 of "The why": the existing code's
+   default-filling comes up quietly with zeros, and this must not.
+
+`PRAGMA user_version` carries the schema version from day one, so the next shape change is a
+migration rather than a quarantine. Pull request #1376 reset the concurrency peak on deploy and
+#1379 got the same class of change right by not reshaping the existing fields; this mission does
+not get to be the third data point.
+
+**Decision 6 - The in-memory mirror holds MEMBERSHIP, never a TALLY.** Raised by the Manager, who
+was right to refuse to guess at it, because it decides real behaviour on the hot path.
+
+`ObserveSnapshot` folds every session on every `GET /sessions`. Today an *idle* poll costs zero
+input-output: nothing changed, so nothing is written. That property must survive this mission, and
+one detail decides whether it does. The wingman set is added to **before** the empty-bucket early
+return (`GatewayInputStatsAggregator.cs:330-334`), so a voice-mode session with no input still
+registers every single poll:
+
+```
+if (s.VoiceMode && _wingmanSessions.Add(s.SessionId))
+    changed = true;
+
+if (s.InputStats?.Buckets is null || s.InputStats.Buckets.Count == 0)
+    return changed;
+```
+
+`HashSet.Add` returning `false` on a repeat is precisely what makes that free today. Without an
+in-memory membership mirror, the same code path becomes an `INSERT OR IGNORE` per voice-mode
+session per poll - bounded per fold, but a permanent write storm where there is currently silence.
+
+**So the rule, stated once and not open to reinterpretation:**
+
+> The mirror may hold **identity and membership** - the high-water map, the distinct-session id
+> sets, and the repository and agent identity maps. It answers exactly one kind of question: *have
+> I already recorded this?* It must **never** hold a **tally** - no total, no count, no sum. Every
+> aggregate stays a real query against the database. Cache an aggregate and you have rebuilt the
+> in-memory-dictionaries-plus-a-file design this mission exists to delete.
+
+This is not fallback programming, and the distinction matters enough to write down: a fallback
+hides a failure by quietly substituting a worse answer. A write-through mirror hides nothing.
+SQLite is the sole source of truth, the mirror is populated **from** it at startup and never the
+reverse, and a failed database write is a loud failure - never a silent mirror-only success.
+
+Note on cardinality, so nobody reports it as a regression: the distinct-id sets are deliberately
+never pruned (Decision 2), so their lifetime cardinality is unbounded. Mirroring them keeps exactly
+today's memory profile, because the running code already holds those same sets in memory. This
+mission's win is on the **write** path, not the memory footprint, and it is not obliged to change
+what it did not come to change.
+
+## Phases
+
+Each phase is a self-contained increment that builds, tests green, and is reviewed by the Codex
+reviewer before it is committed. Per the owner's instruction for this mission, phases accumulate on
+`feat/gateway-sqlite` and are **not** merged to `origin/main` (see Constraints).
+
+- **Phase 1 - Foundation plus the input store.** The database file, the connection and migration
+  helper, `PRAGMA user_version`, the `stat_delta`, `session_highwater`, baseline, and distinct-id
+  tables, the one-time baseline import with its parity check, and `GatewayInputStatsAggregator`
+  rewritten onto it. This is the proof: the largest, worst-behaved store, ported with its numbers
+  intact.
+
+  **Phase 1 got bigger on 2026-07-15 and this brief is not pretending otherwise.** Pull request
+  #1647 landed mid-mission and added 211 lines to the aggregator, fixing real defects: real Codex
+  turns were locked out, restored sessions lied about their agent, and agent-to-agent turns were
+  never counted. Three consequences the port must handle, none of which the original design covers:
+
+  - **The agent-driven lane gets its OWN high-water and delta tables.** Not a discriminator column
+    on the shared ones. Two reasons, and the Manager established both against the code.
+    `AgentDrivenHighWater` is keyed by **session id alone**, while `session_highwater` is keyed by
+    session *and* bucket, so they cannot share a table without one of them lying about its own key.
+    And `:102` states these turns must **never** enter `_totals` or `_hourly` - which, on a shared
+    table, becomes a rule that every human-facing query must remember forever. That is the
+    archive-marker problem again, and forgetting it fails **silently** with the owner's numbers as
+    the cost, so by this brief's own calibration it earns structure rather than a convention.
+    Separate tables make the mistake unreachable.
+  - This also resolves the `FoldAgentDrivenLocked` ordering problem for free. It folds **before** the
+    empty-buckets guard because a session driven only by other agents has no human buckets at all;
+    with its own delta table, its rows no longer depend on a human bucket existing, so nothing
+    vanishes.
+  - **`AgentsSeeded` is persisted, and revision 14 was wrong to say otherwise.** It is the twelfth
+    `StoreFile` section, and the field comment states "MUST be persisted: without it a Gateway
+    restart would back-fill every live session a second time and double the agent numbers". #1647
+    already decided this correctly; there is nothing here to choose, only something to preserve.
+    Revision 15 required it to have a schema home in which **null and empty remain
+    distinguishable**. **That requirement is withdrawn - the Manager showed the lift dissolves it.**
+    The null-versus-empty distinction is resolved *inside* `Load`: null gives `_agents.Clear()` plus
+    an empty seeded set, present gives the tally kept plus the set populated. Since the import
+    consumes `Load`'s **resolved in-memory state** and never the raw key, nothing downstream can
+    observe which it was, and `Save` writes the list unconditionally (`:736`), so null is a one-time
+    upgrade path that ends at the first save. The one case that would break the argument - an empty
+    seeded list alongside a non-empty tally, which `Load` would *keep* rather than clear - is
+    unreachable, because every folded session is added to the seeded set in the same pass that
+    populates the tally. So `agents_seeded` is a plain membership table and the schema never encodes
+    absent-versus-empty.
+
+    Worth naming the shape: the requirement did not need to be met, it needed to **stop existing** -
+    the same move as the surrogate id, arrived at by the Manager applying the principle back at the
+    Architect who wrote it. A requirement that dissolves is better than one that is satisfied.
+
+  **Do not "fix" anything #1647 does, including anything that looks wrong.** Same rule as the path
+  separators. A port that reverts a shipped bug fix is the worst outcome available to this mission -
+  worse than not shipping - because it would restore a defect the owner already saw fixed while
+  claiming the numbers were preserved.
+- **Phase 2 - The concurrency store.** `GatewaySessionConcurrencyStats` onto the same database,
+  same import discipline. Restores the all-time peak that #1376 destroyed if the quarantined file
+  is still on disk; if it is not, say so plainly rather than inventing a number.
+- **Phase 3 - Car Mode telemetry.** The worst *shape* of the three: per-turn events held in a JSON
+  list that is rewritten in full on every append. The retention policy itself is sound and is not
+  the problem - `RetentionDays = 90` is what the owner asked for and does the real limiting, and
+  `MaxRecords = 10000` is documented as an unbounded-growth guard set far above any realistic
+  90-day volume (`CarModeTelemetryStore.cs:26-31`). Both carry over: retention becomes a
+  `DELETE WHERE recorded_at < ...`, and the guard stays as the same cheap safety net it is today.
+  What changes is only the shape - events belong in rows, appended one at a time, instead of a
+  document rewritten from scratch on every turn. Note this store genuinely does hold per-event
+  records, so unlike the input store its history ports across as real rows.
+- **Phase 4 - The remainder, only if Phases 1 to 3 prove out.** `netdiag-rollup`, `netdiag-devices`,
+  `cronruns`, and `voice-sessions`, each judged against the narrowed scope line on its own merit.
+  `voice-sessions` in particular is an operational set of identifiers, not statistics, and the
+  expected answer for it is "leave it alone" unless a specific reason appears. This phase may
+  correctly end in "leave them all alone."
+
+Phase 1 must be complete and verified before Phase 2 starts. A phase is not done because the code
+compiles; it is done when the numbers are proven unchanged.
+
+Phase 1 proves the input-store design, the baseline import discipline, and the migration mechanism.
+It does **not** prove concurrency-peak restoration or any Phase 4 store choice; those are proven in
+their own phases and must not be waved through on Phase 1's evidence.
+
+## Acceptance
+
+The mission succeeds when all of the following hold. Each is falsifiable; a criterion that cannot
+fail is not a criterion.
+
+**How to watch a test go red, stated once and binding on every criterion below that asks for it.**
+Several criteria say "proven by watching it go red". That instruction is necessary and, on its own,
+**not sufficient** - and the mission has already proved it. The Manager wrote a shape test, reverted
+the schema to watch it fail, saw red, and reported the test validated. The Codex reviewer found that
+the revert had *renamed* a column, so the test died on a `KeyNotFoundException` before ever
+evaluating the assertion it existed to make - and separately, that the assertion itself was an
+exact-element check that would have passed against `repo_raw`. It went red for a reason that does
+not generalise, so the red proved nothing about the invariant. **A hollow test passes a red-check
+too.**
+
+So a red-watch counts only when all three hold:
+
+1. **Induce the failure the test is FOR**, not merely some failure. Break the specific invariant
+   the test claims to protect, in the way it would actually break in production.
+2. **The failure MODE must be the reported symptom** - the assertion the test exists to make must
+   be the thing that fails. A test that dies on an exception before reaching its assertion has told
+   you nothing, and neither has one that fails on setup.
+3. **The other tests stay green** as controls. A revert that reddens everything has located
+   nothing.
+
+If you cannot make a test fail for the right reason, you do not have a test. You have a line of
+code that has never been asked a question.
+
+**And the rule is not about tests. It is about CHECKS - including the one-line `grep` you ran to
+prove something is gone.** This mission has now produced the same defect three times in one day, in
+three different disguises, and the third one landed while quoting the evidence at the Architect:
+
+1. `Assert.DoesNotContain("repo", keys)` - an exact-element check that would have passed against
+   `repo_raw`. It could not see the thing it was for.
+2. A red-watch that died on a `KeyNotFoundException` before ever reaching its assertion. It went red
+   for a reason that does not generalise.
+3. A `grep` for surviving references, piped through a filter that **excluded comment lines** - while
+   every surviving reference was a comment. It printed nothing, and the nothing was reported as
+   proof.
+
+All three are one failure: **a check that cannot find the thing it is looking for will report that
+the thing is not there.** Empty output is not evidence. It is evidence *only* once you have shown
+the check can produce non-empty output for the case you care about.
+
+So: **red-watch your `grep` the same way you red-watch your test.** Before believing that a search
+found nothing, make it find something - point it at a case you know exists and watch it print. If
+it cannot print, it was never searching.
+
+The Manager's own diagnosis of the third instance is the most useful sentence in this document, and
+it generalises well past this mission: *"The filter existed because I wanted to suppress the noise of
+my own comment prose; suppressing the noise suppressed the signal, and I never re-read the filter I
+wrote."* A filter written to hide noise will hide signal, and its author is the last person who will
+notice, because they are the one who decided what counted as noise.
+
+1. `GET /stats/data` returns the same numbers after the port as before it, for the owner's real
+   data on this machine. Captured before, captured after, compared field by field
+   (`Stats/StatsPageEndpoint.cs:40-71` maps this response from the aggregator outputs). This is the
+   primary proof and it is not negotiable.
+
+   **The BEFORE capture must come from the current post-#1647 build.** Not from the snapshot taken
+   earlier in this mission. That snapshot's agent numbers are the pre-#1647 ones the current code
+   would *discard on load* (see Decision 5), so comparing an old-build BEFORE against a new-build
+   AFTER would compare two different products and prove nothing about the port. The snapshot remains
+   valid as the verified backup; it is not a criterion 1 baseline.
+
+   **Run it with the Gateway STOPPED, against a frozen copy of the store.** The live store is a
+   moving target: the Manager observed it go from 1401 to 1404 turns while reading it twice, partly
+   because this mission's own sessions are generating turns into the very store it is porting. A
+   before-and-after comparison against a running Gateway will therefore differ for reasons that
+   have nothing to do with the port, and the tempting response - loosen the comparison until it
+   passes - would throw away the only real proof this phase has. An exact comparison against a
+   frozen snapshot is worth more than a fuzzy one against live data. If this criterion is ever
+   reported as passing with a tolerance, it did not pass.
+
+   The import's own parity check (Decision 5) is unaffected by this and stays exact: it compares
+   what SQLite reports against the same single in-memory load of the JSON document, so nothing can
+   move underneath it.
+2. The `/stats` page (`Stats/StatsPageEndpoint.cs:74-79`), the cockpit "Your Throttle" view
+   (`apps/cockpit/src/throttle/YourThrottleView.tsx`), and the mobile "Your Throttle" view
+   (`apps/mobile/src/pages/YourThrottle.tsx`) render unchanged. **Evidence, not opinion:** the
+   captured `/stats/data` payload from criterion 1, plus a before-and-after screenshot of each of
+   the three surfaces, attached to the phase report. "Looks fine" is not acceptance.
+3. A counter move costs work bounded by what changed, and that cost does not grow with history,
+   rather than a whole-document rewrite. **Demonstrated by:** an integration test that observes a
+   delta and asserts the expected statement mix for the real schema - one `INSERT` into
+   `stat_delta` **per changed bucket**, one upsert into `session_highwater`, and at most one
+   `INSERT OR IGNORE` per distinct-id table - plus an assertion that no JSON store file's
+   last-write timestamp changes after the import has completed.
+
+   Two things this test must get right, both of which a careless version gets wrong:
+   - **Expect one row per changed bucket, not one per fold.** A session reporting movement on three
+     modality-and-surface pairs must write three rows. A test asserting "one row per fold" pins the
+     wrong behaviour and would go green against a fold that silently drops buckets.
+   - **Pin that the mix is unchanged when the table already holds a large number of historical
+     rows.** "Does not grow with history" is the actual claim being proven, and a test against an
+     empty table proves nothing about it.
+3a. **An idle poll writes nothing.** A regression test observes a roster in which nothing has
+   changed - including at least one voice-mode session with no input, which is the case that
+   exercises `GatewayInputStatsAggregator.cs:330-334` - and asserts **zero** write statements reach
+   the database. This is a property the current code has and the port could silently lose
+   (Decision 6). It must be proven by watching it go red: remove the membership mirror, see the
+   writes appear, restore it.
+4. A new question that uses dimensions already carried on `stat_delta` is answered by a query with
+   no schema change, for data recorded since the cutover. The Manager picks one the owner has not
+   asked for yet and shows the query and its result.
+5. Tests are green across all seven test projects in `cc-director.sln` (Avalonia, Core, Engine,
+   Gateway, HostedAgent, Launcher, and Terminal.Avalonia), not only Core and Gateway.
+6. Regression tests pin the baseline import, on three legs:
+
+   (a) Given a **synthetic** fixture that is structurally faithful to a real store, every imported
+   value matches the value the fixture reported - across **every** `StoreFile` section, not only the
+   ones `/stats/data` exposes.
+
+   **This leg must include a reflection test that enumerates `StoreFile`'s properties and fails if
+   the import does not handle one of them.** Not a list of sections written by hand, and not a
+   count: the test reads the type. `StoreFile` grew from eight sections to eleven during this
+   mission's own review (#1647), which is exactly how a hand-written list rots. A future section
+   added by someone who has never read this document must break this test, or the import will
+   silently drop it and the parity check will pass green - because parity only compares what the
+   fixture and the import both know about, and neither knows about a section nobody handled.
+
+   **The fixture must be synthetic. Never commit the owner's real store.** Earlier revisions said
+   "a real JSON store as a fixture", which was dangerous and nearly shipped:
+   `thefrederiksen/devthrottle` is a **public** repository, and the real store holds 20 repository
+   paths - including client and employer project names like `ReposMindzie/mindzieWeb`,
+   `cc-consult`, and `mw-enrich-facade-impl` - plus session identifiers and the owner's personal
+   usage counts. Committing it as a fixture would publish all of that permanently into public git
+   history, where deleting it later does not remove it.
+
+   Structurally faithful means: every `StoreFile` section present, the real shapes, and the awkward
+   cases
+   deliberately included - a voice-mode session with no input buckets, a session with several
+   changed buckets in one fold, a typed turn under voice mode, and a pair of repository keys
+   differing only by case. A synthetic fixture is in fact **better** than the real store for this
+   test, because the real store contains no case collision at all and therefore cannot exercise the
+   very folding the fixture is meant to pin.
+
+   The owner's real data is still used - by criterion 1, run locally against a frozen snapshot with
+   the Gateway stopped, with the result recorded in the phase report and the snapshot never
+   committed.
+
+   (b) **The idempotent re-observe leg.** After importing, observe the *same* roster the store was
+   already carrying high-water for, and assert every all-time number is **unchanged**. This is the
+   leg that catches a dropped or mis-imported `session_highwater`, and it exists because nothing
+   else can: `/stats/data` exposes no high-water field, so the endpoint parity check passes green
+   while the totals are one poll away from inflating by three fifths. A test that only compares
+   exposed endpoint fields is not sufficient and this criterion does not accept one.
+
+   (c) The import refuses to complete on an induced mismatch, leaving the JSON as the source of
+   truth.
+
+   (d) **The pre-back-fill store rebuilds correctly.** Given a fixture shaped like the owner's real
+   store - an `Agents` tally present, `AgentsSeeded` absent - the import writes `baseline_agent` as
+   zero, and the first fold then rebuilds the tally to **exactly** what the current build's
+   `GatewayInputStatsAggregator` reports for the same fixture. Compare against the product's
+   behaviour, never against the document's bytes (Decision 5). This leg is what proves the one
+   number the import deliberately does not preserve is nevertheless correct, and it must be red-
+   watched by damaging the imported `session_highwater` and confirming the symptom is the agent
+   tally rebuilding to zero - which is also what pins the interlock between this rule and leg (b).
+
+   Legs (b) and (c) must be proven by watching them go red - revert the fix, see the reported
+   symptom, restore it - not asserted. A test that has never failed on purpose is not evidence.
+7. Regression tests pin pruning, on both legs: given rows spanning the retention boundary, (a) every
+   all-time answer - including wingman turns and every per-repository and per-agent tally - is
+   identical before and after a prune runs, and (b) the working-day series contains exactly the
+   real hours it contained before, with no phantom bucket from an archive marker.
+8. A regression test pins wingman-turn semantics: a turn **typed** while the session has voice mode
+   on is counted as a wingman turn, matching `GatewayInputStatsAggregator.cs:425-427` today. This
+   is pinned because the distinction is subtle enough that the first draft of this brief missed it,
+   and a worker who assumes wingman turns means `modality = 'voice'` would silently change the
+   owner's numbers.
+
+## Constraints
+
+- **Owner override on merging.** The owner's explicit instruction for this mission: the Architect
+  may commit freely, but this work is **not** pushed and **not** merged to `origin/main`. This
+  deliberately suspends the usual trunk rule that merged-to-main is the only "done" for the
+  duration of this mission. The mission accumulates on `feat/gateway-sqlite` in the worktree
+  `D:\ReposFred\devthrottle-gateway-sqlite`.
+- **One worktree for the whole mission.** All roles work in
+  `D:\ReposFred\devthrottle-gateway-sqlite`. The shared checkout `D:\ReposFred\devthrottle` is
+  never used for this work and never holds uncommitted mission files.
+- **The Codex reviewer gates every commit.** No code is committed until the Codex reviewer has
+  reviewed it. Reviews are written to files under `docs/architecture/`, never left in a terminal -
+  the session terminal buffer captures only spinner redraw and the findings are unrecoverable from
+  it. See Roles.
+- **Preserve the semantics, do not improve them. Specifically: do NOT normalize repository path
+  separators.** Measured on the owner's real store on 2026-07-15: three repositories are stored
+  **twice**, under both separator spellings - `D:\ReposFred\devthrottle` holds 324 turns while
+  `D:/ReposFred/devthrottle` holds 21, and the same split affects `cc-consult` (77 and 3) and
+  `mw-enrich-facade-impl` (7 and 2). There are 20 distinct repository keys today; normalizing
+  separators would collapse them to 17.
+
+  `OrdinalIgnoreCase` folds case but not `/` against `\`, so these are genuinely different keys
+  today and the Repos page already shows them as separate rows. **A worker who sees this and
+  "fixes" it has broken the mission**, because merging those buckets changes the owner's numbers -
+  and the only way to make criterion 1 pass afterwards is to loosen it until it no longer proves
+  anything. This mission moves where the numbers are stored and changes nothing about what they
+  mean, including the parts that look wrong. If the port ever produces 17 repository rows where
+  today there are 20, that is a defect, not a cleanup.
+
+  Whether the Repos page *should* merge separator variants is a real question and a good one. It is
+  the owner's to answer, it is recorded in the follow-ups, and it is not this mission.
+- **Do not touch the Director-side counting seam.** The honest count happens at
+  `Session.SendInput` and `Session.SendTextAsync`, pinned by
+  `src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs`. This mission changes
+  where the Gateway *stores* what it is told, and nothing about what is counted or what it means.
+- **No fallback programming.** A database that fails to open is a loud failure with a clear
+  message, never a silent fall back to the JSON store. An import that does not reconcile is a loud
+  failure, never a partial import.
+- **No Unicode characters anywhere** - plain ASCII in all code, comments, output, and documents.
+- **Plain English, no abbreviations** in all output.
+
+## Roles
+
+- **Architect** - session 8c17dc1c, "Gateway SQLite - Architect". Settles the design in this
+  document, then lets the Manager drive without gating it. Does not implement.
+- **Manager** - one session, "Gateway SQLite - Manager", spawned once this document is approved.
+  Owns execution and drives the phases. Reset per phase.
+- **Codex reviewer** - session 7068ec90, "Gateway SQLite - Codex Reviewer", running the `codex`
+  command line tool as a real DevThrottle session. Reviewed this document before work started, and
+  reviews every code change before it is committed. Its concerns are addressed or explicitly
+  answered - not ignored. Revision 2 of this document exists because it was right.
+- **Workers** - as many as the Manager needs, all in the one mission worktree.
+
+## Gate
+
+Work starts only when both are true:
+
+1. The Codex reviewer has reviewed and approved this document.
+2. The owner has approved this document.
+
+After both, the mission runs autonomously through the phases without bothering the owner again
+until the quality-assurance report.
+
+## Follow-ups, deliberately not in this mission
+
+- The transcription log has no retention policy, stated either way, and grows about 1.7 MB per week
+  per machine while holding transcript text. Worth an owner decision at some point. Not a blocker.
+- The `/stats` page is a self-contained embedded HTML document
+  (`Stats/StatsPageEndpoint.cs:74-79`) rather than a cockpit route. Deliberate. Not touched here.
+- An agent-facing `cc-devthrottle throttle` verb was owed by the earlier Stats mission and never
+  built. Unrelated to storage. Not picked up here.
+- **The model dimension - the likely first new question, and deliberately NOT built here.** Pull
+  request #1637 landed drivers reporting the model each agent is currently using, and collecting
+  that into statistics is a known open follow-up. That makes "which model do you actually drive?"
+  the most likely next question asked of this schema, and it is tempting to add a `model` column to
+  `stat_delta` now to get ahead of it. **Do not.** Checked against `origin/main` on 2026-07-15:
+  `src/CcDirector.Gateway.Contracts/SessionDto.cs` carries no model field, so nothing the Gateway
+  folds would populate that column. It would be a column nothing emits, and the test proving it
+  would have to inject a value the product never produces - the exact shape of bug this repository
+  keeps finding. The model dimension needs its producer first: a field on `SessionDto`, fed from the
+  driver report, and only then a column and a migration.
+
+  **Update, 2026-07-15T18:59Z - the producer has merged.** `SessionDto.CurrentModel` is live on
+  `origin/main` via #1651: records-only, with the null floor described below. The
+  producer-does-not-exist objection is satisfied, and the paragraph above is now history rather
+  than instruction. **The hold on Phase 1 stands regardless, on the three grounds that were never
+  about the merge:** Phase 1's whole job is proving the owner's numbers survive the move and it must
+  not widen mid-proof; the dimension needs its own since-stamp design in the `_agentsSinceUtc`
+  mould; and the three-state null handling below must be settled first. The model dimension opens
+  *after* Phase 1 proves out, as this mission's first real migration. #1651 merging does not make it
+  a Phase 1 column - it only means the phase can start when Phase 1 is done.
+
+  This is worth stating because it is a fair test of the mission's honesty. The mission does not
+  claim that question becomes free - Decision 2 says plainly that a genuinely new dimension still
+  costs a schema change. What the mission delivers is that the change is a `PRAGMA user_version`
+  migration that keeps the owner's numbers, instead of a shape change that quarantines the file and
+  loses them. That is the whole point, and the model dimension will be its first real exercise.
+
+  **What the producer's own authors say about it, recorded here so the future phase inherits it
+  rather than rediscovering it.** Session 60ffd96b, who is building `SessionDto.CurrentModel`,
+  reports that the value is **free text** taken from each tool's own records - `claude-fable-5`,
+  `gpt-5.5`, `grok-4.5` - with unbounded cardinality over time and casing by convention only. They
+  recommend the `repo_id` / `agent_id` identity-table treatment, and for cardinality and casing
+  they are right.
+
+  **But the identity table does not solve the harder half they described, and the future phase must
+  not assume it does.** A Claude session can legitimately report its launch *alias* before its
+  first turn (`opus[1m]`, stamped from the `--model` flag) and the concrete id afterwards
+  (`claude-opus-4-8`, without the suffix). Those are two names for one model, and no
+  case-insensitive comparer maps one to the other - they are different strings by any equality
+  function, so an identity table faithfully records them as two distinct models and the page splits
+  one session across both. That is not a casing problem. It is **structurally the same problem as
+  the repository separator split** documented in Constraints: two spellings, one real thing, and a
+  merge rule that only a human can authorise because it silently rewrites what was recorded.
+
+  There is a plausible reason it may not bite - `stat_delta` rows are written only per *changed
+  bucket*, so a session with no turns yet writes no row, and the alias may never accompany a
+  non-zero delta. **Do not rely on that without checking it.** It depends on the ordering of
+  turn-end stamping against the roster poll that folds the delta, and a poll landing between turn
+  submission and turn-end stamping would attribute a real turn to the alias. That ordering is a
+  question to answer with evidence, not reasoning, when the phase starts.
+
+  **Update, same day: the aliasing half was fixed at the producer before merge, and it was real.**
+  Session 60ffd96b checked the ordering in code rather than reasoning about it and found the window
+  was live: the bucket increments at *submission* (`InputStats.RecordTurn`, `Session.cs:2031` on
+  `origin/main`, inside `SendTextAsync` - "a SendTextAsync is always a submitted turn"), while the
+  model stamp was at turn-*end*. A poll landing between them paired `opus[1m]` with a non-zero
+  delta. Their fix makes the producer records-only, so it never reports a launch alias and only
+  concrete recorded ids reach the wire. That is the right trade: an unknown that is visibly unknown
+  beats a wrong id that looks real and splits silently.
+
+  **The consequence that fix creates, which the model phase must handle and must not wave through.**
+  Records-only means a fresh session reports **null** until its first turn-end - and because the
+  bucket increments at submission, *every session's first turn folds with no model*. The producer's
+  authors say this is "the same as pre-dimension turns". **It is not, and the difference is exactly
+  the honesty problem `_agentsSinceUtc` exists to prevent.** Pre-dimension turns are a fixed
+  historical set that stops growing. Fresh-session first turns are an ongoing null that grows by one
+  per session forever, *after* the since-stamp date. Put them in one bucket and the page tells the
+  owner "model data starts at date X" while the unknown bucket keeps growing after X, and nobody can
+  tell "unknown because it is old" from "unknown because we had not stamped it yet".
+
+  This design already separates them, and the phase must keep it that way: pre-dimension turns live
+  in the **baseline** tables and carry no model at all, while post-cutover turns of unknown model are
+  **`stat_delta` rows with a null model id**. Three display states, not two: predates the dimension,
+  unknown at fold time, and a concrete model. Merging the first two would be the `_agentsSinceUtc`
+  mistake with a new coat of paint.
+
+  **The proposed cure is worse than the disease, and the fold does not want it.** To close the null
+  floor, session 60ffd96b proposed a Director-side **per-model turn tally** attributed at turn-end,
+  riding the data-transfer object alongside the `InputStats` buckets. It would indeed put turn one
+  on its real model. It should not be built, for two reasons, and the second is fatal.
+
+  *It would not reconcile.* Turns are counted at submission and the tally would be counted at
+  turn-end, so the model totals would always trail the turn totals by whatever is in flight - and a
+  session killed mid-turn would be missing from the model dimension **permanently**, which its own
+  authors acknowledge. The model page's total would silently differ from the totals page forever.
+  That is the third instance in this one mission of the same failure: two numbers that look
+  comparable, are not, and say nothing about it. The null floor by contrast **reconciles exactly** -
+  every turn is present and attributed either to a model or to a visible unknown.
+
+  *It would destroy the cross-product - the entire point of this mission.* A separate per-model
+  tally is **a second projection**. The Gateway would learn that a session's model tally rose by
+  three without learning which of that session's modality-and-surface buckets those three turns were
+  in, so `model` could never be a column on `stat_delta`. It would need its own table, collapsed on
+  its own dimension, and "how many voice turns did I take on Opus?" would be unanswerable forever -
+  by construction, not by omission. That is precisely the wall documented in "What the historical
+  data cannot tell us", rebuilt deliberately, in new code, after twelve revisions spent escaping it.
+
+  `CurrentModel` on the data-transfer object is the right shape *because* the fold reads it at fold
+  time and stamps it on every row that fold emits, giving the full cross-product. It costs one null
+  turn per session. That is a cheap, honest, visible price for a dimension that composes with every
+  other dimension. **Recommendation to the owner: keep the null floor; do not build the tally.**
+
+  If turn-one attribution is genuinely wanted later, the answer is not a parallel tally but putting
+  the model on the *same record as the turn* - which means recording at turn-end and therefore
+  touching the Director-side counting seam this brief protects in Constraints. That is a separate
+  mission with its own proof obligations, not an addition to this one.
+
+  So the model dimension needs its own design pass covering: the identity table, a since-stamp in
+  the `_agentsSinceUtc` mould, the three-state null handling above, and the accepted one-turn lag on
+  a mid-session model switch. It is a phase, not a column.
+- **The Repos page splits the same repository across path-separator spellings.** Measured
+  2026-07-15: `D:\ReposFred\devthrottle` (324 turns) and `D:/ReposFred/devthrottle` (21 turns) are
+  two rows, as are two spellings each of `cc-consult` and `mw-enrich-facade-impl` - 20 rows where
+  17 repositories exist. `OrdinalIgnoreCase` folds case but not separators. Whether those rows
+  should merge is a genuine owner decision with a real trade-off: merging is what a human means by
+  "the same repository", but it silently rewrites history that was recorded as two. This mission
+  deliberately preserves the split (see Constraints) because changing it would break the one proof
+  Phase 1 has. Worth raising with the owner separately.
+- **RULING for whoever builds the fold: the agent tally gets its OWN `agent_delta` table, and
+  `agent_id` comes OFF `stat_delta`.** The Manager raised this and was right to refuse to decide it
+  alone - it changes the schema this brief mandated, and the brief could not answer it because the
+  brief predates #1647.
+
+  The fact: `AttributeToAgentLocked` has **two** call sites. The ordinary path (`:460`) attributes
+  the *same* delta that feeds totals, hourly and repos. The first-fold back-fill (`:395`) attributes
+  a session's **prior high-water**, which has **no totals counterpart at all**. So
+  "agent totals = `stat_delta GROUP BY agent_id`" holds only while the back-fill contributes nothing.
+
+  It is inert in a fresh database - `hw` is created empty immediately before the seed block, so a
+  session's first fold back-fills zero, always. But that is a *coincidence of the empty start*, not
+  a structural guarantee, and "true today" has been wrong three times in this mission alone.
+
+  **The decisive point is that Option A has no correct behaviour if the back-fill ever fires.** If
+  the back-fill wrote a `stat_delta` row, its turns would land in the totals - but those turns are
+  *already* in the totals from before, so the totals would inflate. If it wrote no row, the agent
+  tally would miss them. There is no right answer available, only two wrong ones. That is not a
+  trade-off; it is a design that cannot express the situation.
+
+  Option B mirrors the code: `AttributeToAgentLocked` writes `agent_delta` from **both** call sites,
+  one source, no divergence possible. The cost is real and worth stating - `stat_delta` no longer
+  carries the agent dimension, so "turns by agent by hour" becomes a schema change rather than a
+  query. **Pay it.** Carrying `agent_id` on `stat_delta` would advertise a cross-product the code
+  does not actually maintain, and answering that question from it would silently omit every
+  back-fill attribution. That is the same lie as "What the historical data cannot tell us", written
+  fresh into a new schema: do not claim a cross-product you do not have.
+
+- **The test suite writing into the owner's live storage is a REPEAT, not a first, and the repeat is
+  the finding.** On 2026-07-15 a full test run imported the owner's live `gateway-input-stats.json`
+  and renamed it aside. No data was lost - the running Gateway held its state in memory and rewrote
+  the file - but a Gateway restart in that window would have found no file, started empty, and saved
+  empty over it. The mechanism that saved it was timing, not a safeguard. Root cause:
+  `GatewayHost.cs:476-478` defaults its stores to `CcStorage.Root()`, and 26 of the 48 Gateway test
+  files that construct a `GatewayHost` never redirect `CC_DIRECTOR_ROOT`. That root holds
+  `missions.json`, `cronjobs.json`, and `keyvault.json` - live fleet state, not just statistics.
+
+  **This repository had already learned this exact lesson and fixed it too narrowly.** The
+  pre-existing `ModuleInitializer` in `TestEnvironment.cs` exists for issue #322, where a test wrote
+  an instance file into the real Director instances directory and the production Gateway's watcher
+  discovered it and painted a phantom Director in the owner's real Cockpit. The diagnosis was right
+  and the fix was scoped to the *one directory that had been noticed*, leaving the general hazard -
+  tests resolving to the real storage root - fully live. It bit again today, harder, because the
+  import added the first operation that **moves** a file rather than overwriting it with equivalent
+  state.
+
+  The lesson is not "add an initializer". It is that **a fix scoped to the instance you noticed
+  leaves the class alive**, and the class will return wearing a worse costume. #322's fix protected
+  one directory; the correct blast radius was the storage root. Worth an owner decision on whether
+  the other test assemblies - Core, Engine, Launcher - have the same exposure, since only the
+  Gateway suite is guarded now.
+- The silent default-filling failure mode described in point 2 of "The why" affects every remaining
+  hand-rolled JSON store in the Gateway, not only the ones this mission ports. The stores this
+  mission moves are protected by `PRAGMA user_version`; the others are not. Worth an owner decision
+  once this mission proves the pattern.

--- a/docs/architecture/gateway-sqlite-phase1-manager-plan.md
+++ b/docs/architecture/gateway-sqlite-phase1-manager-plan.md
@@ -1,0 +1,380 @@
+# Phase 1 Plan: Foundation plus the input store
+
+**Built against brief revision 6 (`6327fcd7`).** This plan was written against revision 3. All four
+findings it raised were accepted by the Architect and are now in the brief itself: revision 4
+(`a4e74b76`) imports all eight sections and fixes the parity hole, revision 5 (`c89b9171`) fixes the
+one-row-per-fold defect, and revision 6 (`6327fcd7`) adds Decision 6, the membership mirror. Where
+this plan and the brief now differ, **the brief wins** - it is the authority and it has absorbed
+everything below.
+
+Written 2026-07-15 by the Manager session ("Gateway SQLite - Manager", session f3599eba, machine
+SOREN_NORTH). This is the Manager's execution plan for Phase 1 of the mission recorded in
+`docs/architecture/gateway-sqlite-mission-2026-07-15.md`. It is written to a file rather than held
+in the Manager's head because the Manager is reset before Phase 2.
+
+The brief is the authority. Where this plan elaborates the brief it says so and explains why; where
+it disagrees with the brief it does not proceed until the Architect and the Codex reviewer have
+settled it. Three such points are raised below and are the reason this plan exists before any code.
+
+## Freshness check, done first
+
+`origin/main` was at `1c1fa17c` when the brief was written. It is at `6848bf69` now - **seven
+commits have landed underneath this branch since the brief was approved**, which is the same thing
+that happened to the brief during its own review. Re-verified, file by file, on 2026-07-15:
+
+- `src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs` - **byte-identical** to
+  `origin/main`. Every line citation in the brief that points into this file still resolves. This is
+  the file Phase 1 rewrites, so this is the citation that mattered most.
+- `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:842` is `inputStats?.ObserveSnapshot(all, DateTime.UtcNow)`
+  and `:849` is `concurrency?.Observe(all, DateTime.UtcNow)`. Both still resolve.
+- `src/CcDirector.Core/CcDirector.Core.csproj:18` still references `Microsoft.Data.Sqlite` 9.0.2.
+- `src/CcDirector.Core/Storage/CcStorage.cs` **did change** (+5 lines) on `origin/main`. The brief
+  cites `:28-38` for `Root()`. `Root()` is now line 28 and `Base()` spans 30-38, so the citation
+  still resolves, but it moved and the next reader should re-check rather than trust this line.
+
+None of the seven commits touch the input store. Phase 1's ground is unchanged.
+
+## What the live data actually looks like
+
+Read from `%LOCALAPPDATA%\cc-director\gateway-input-stats.json` on SOREN_NORTH, 2026-07-15. This is
+the fixture Phase 1 must import without losing a number:
+
+| Section | Content |
+|---|---|
+| `Totals` | 7 buckets: typed/cockpit, typed/desktop, typed/phone, typed/unknown, voice/cockpit, voice/desktop, voice/phone |
+| `HighWater` | **116 live sessions** |
+| `Hourly` | 71 hour buckets |
+| `WingmanTurns` | 517 |
+| `WingmanSessions` | 80 distinct ids |
+| `Repos` | 20 keys |
+| `Agents` | 2 keys (`ClaudeCode`, `Codex`) |
+| `AgentsSinceUtc` | `2026-07-15T16:03:53.6255973Z` |
+
+All-time totals when first read: 1401 turns, 568,580 characters. Re-read a few minutes later: 1404
+turns, 569,144 characters, wingman turns 517 -> 520, wingman sessions 80 -> 81, high-water 116 ->
+115. See Finding 4 - the store is live and moving, including because this mission's own sessions are
+generating turns into it.
+
+A verified copy is held at
+`<scratchpad>\phase1-before\gateway-input-stats.snapshot.json` (61,307 bytes, parses clean, all
+eight sections present). The concurrency store is copied beside it for Phase 2's benefit. This is
+taken now because the import runs once against data that has no other backup.
+
+### Finding 4 - The store is a moving target, so acceptance criterion 1 cannot be read literally
+
+Criterion 1 says `GET /stats/data` "returns the same numbers after the port as before it ...
+Captured before, captured after, compared field by field". Against a **running** Gateway those two
+captures will legitimately differ, because real turns land in between - the numbers above moved
+three turns in the minutes it took to read them twice. A field-by-field comparison would fail on
+data that is perfectly correct, and the obvious way to "fix" a failing comparison is to loosen it
+until it passes, which would throw away the only real proof this phase has.
+
+This does not weaken the criterion; it pins down how to execute it:
+
+- **The import's own parity check is self-consistent and unaffected.** Decision 5 step 2 compares
+  what SQLite reports against what the JSON store reported *from the same load* - one in-memory
+  document, not two captures separated by time. That is exact regardless of what the live Gateway is
+  doing.
+- **Criterion 1's before-and-after capture is done with the Gateway stopped**, against the frozen
+  snapshot above, so the only thing that changes between the two captures is the port itself. A
+  before-and-after taken across a live Gateway proves nothing and must not be offered as evidence.
+
+## Three findings that change Phase 1
+
+### Finding 1 - The import list omits the high-water map, and the parity check cannot catch it
+
+**This is the most dangerous thing found so far and it is a genuine hole in the brief.**
+
+Decision 5 lists what the import covers: "baseline totals by modality and surface, baseline hourly
+buckets, baseline per-repository tallies, baseline per-agent tallies, baseline wingman turns, and
+the distinct-session identifier tables". **The high-water map is not on that list.** Decision 3
+mentions `session_highwater` as the table the fold logic moves to, but nothing says the existing
+`HighWater` section is imported into it.
+
+Why that is severe. `HighWater` holds 116 live sessions right now. The high-water fold
+(`GatewayInputStatsAggregator.cs:336-354`) adds only the *increase* over the last-seen count, and
+treats a reported count *lower* than last-seen as a fresh tally from zero (`:353`). If
+`session_highwater` starts empty, then on the first `GET /sessions` after cutover every live session
+has no previous high-water, so its **entire** current count is folded in as new activity - on top of
+the baseline that already contains it. The all-time totals roughly double. This is the exact
+double-count the high-water logic exists to prevent, re-introduced by an import that forgot it.
+
+Why the brief's parity check does not catch it. Step 2 of Decision 5 compares "every affected
+endpoint field" read back out of SQLite against what the JSON reported. `/stats/data`
+(`Stats/StatsPageEndpoint.cs:40-71`) exposes buckets, hourlyTurns, wingman, repos, agents, and
+agentsSinceUtc. **It does not expose the high-water map.** At import time `stat_delta` is empty, so
+every endpoint field equals its baseline and parity **passes**. The import is marked done, the JSON
+is renamed aside, and the damage happens on the next roster poll - after the source of truth has
+been moved aside. Parity green, data destroyed.
+
+**Proposed resolution.** Two changes, both inside Phase 1:
+
+1. The import imports **all eight** sections of `StoreFile`
+   (`GatewayInputStatsAggregator.cs:448-457`), not six. `HighWater` imports into `session_highwater`
+   and `AgentsSinceUtc` into a baseline scalar. Nothing in that document is left behind.
+2. Parity gains a leg the endpoint fields cannot express, because the endpoint cannot see this:
+   **after the import, re-observe the exact roster the JSON store last saw and assert every all-time
+   number is unchanged.** That is the idempotency property the high-water fold exists to provide,
+   and it is the only check that actually fails when high-water is missing. Watch it fail first:
+   with the high-water import removed, this test must go red with a doubled total.
+
+This is proposed as an addition to acceptance criterion 6, not a change to the design.
+
+### Finding 2 - Case folding: the .NET dictionaries and SQLite do not group the same way
+
+`_repos` (`:55`) and `_agents` (`:61`) are `Dictionary<string, _>(StringComparer.OrdinalIgnoreCase)`.
+SQLite's default text comparison is `BINARY` - case-sensitive. A plain `GROUP BY repo` therefore
+**splits** what the current code **merges**. Two further wrinkles in the same area:
+
+- `_totals` (`:32`) is keyed by a `(string, string)` tuple with the **default** comparer, which is
+  ordinal and case-**sensitive**. So totals are case-sensitive while repos and agents are not. The
+  two must not be given the same treatment.
+- The voice test at `:366` is
+  `string.Equals(key.Item1, "voice", StringComparison.OrdinalIgnoreCase)` - case-**insensitive**. So
+  a modality of `Voice` is its own totals bucket but still counts as voice in the hourly, repository,
+  and agent splits. That asymmetry is current behaviour and must survive.
+
+**This is the sneaky one.** Checked against the owner's live store: there are **no** case-variant
+collisions today (20 repo keys, 2 agent keys, all distinct case-insensitively). So the import parity
+check **passes** either way, and the divergence appears only later, the first time a repository path
+is reported with different casing. Parity would have signed off on a defect that had not happened
+yet. It is worth noting the keys are already not normalised in other ways - `D:/ReposFred/devthrottle`
+and `D:\ReposFred\devthrottle` are separate buckets today, and that is faithful and stays.
+
+**Proposed resolution: do the folding in C#, never in SQL.** SQLite's `NOCASE` collation folds ASCII
+only, while .NET's `OrdinalIgnoreCase` folds the full Unicode range, so leaning on the collation
+would be *nearly* right - which is not a standard this mission accepts.
+
+- `stat_delta` carries `repo_folded` and `agent_folded` as its grouping keys, computed in C# with
+  the same `StringComparer.OrdinalIgnoreCase` semantics the dictionaries use today.
+- `repo_identity(repo_folded PRIMARY KEY, repo_display)` and `agent_identity(...)` map the folded key
+  to the **first-seen** spelling, extended with `INSERT OR IGNORE`. First-seen-wins is exactly what
+  a .NET `Dictionary` does with an `OrdinalIgnoreCase` comparer, so the displayed spelling is
+  unchanged. These are the same shape as the distinct-id tables Decision 2 already requires.
+- `stat_delta` carries `is_voice` as an explicit column, computed in C# by the same
+  `OrdinalIgnoreCase` test at `:366`. The voice/typed split becomes `SUM(CASE WHEN is_voice = 1 ...)`,
+  with no dependence on any SQL collation. (It is derivable as `LOWER(modality) = 'voice'`, which for
+  this one ASCII literal happens to be exactly equivalent - but storing it removes the argument.)
+- `modality` and `surface` stay as plain columns grouped with the default `BINARY` collation, which
+  is exactly the case-sensitive ordinal grouping `_totals` uses today.
+
+This elaborates the brief's row schema. The brief states
+`stat_delta(hour_utc, session_id, modality, surface, repo, agent, wingman, turns, chars)`. **The
+Architect and the reviewer should confirm** that `repo`/`agent` becoming folded grouping keys plus an
+identity table, and the addition of `is_voice`, is a faithful elaboration rather than a deviation.
+The intent it serves is the brief's own: the numbers do not change.
+
+### Finding 3 - The hot path must not query SQLite when nothing changed
+
+`ObserveSnapshot` folds the **entire** roster on **every** `GET /sessions`
+(`GatewayEndpoints.cs:842`) - 116 live sessions per poll. Today an unchanged poll costs pure
+in-memory dictionary reads and **zero** input/output: `Save()` is called only `if (changed)`
+(`:123`). A naive port that reads `session_highwater` from SQLite per session per poll would make
+the common case *slower* than the JSON it replaces, which would be a real regression dressed up as
+a refactor.
+
+**Proposed resolution:** the bounded operational state - the high-water map, the wingman session set,
+the repository and agent identity maps, and the distinct-id sets - keeps an in-memory mirror loaded
+once at startup, and writes through to SQLite only when it actually changes. The aggregates -
+totals, hourly, repos, agents - are **not** cached; they become real queries, because that is the
+point of the mission and because they are read on `/stats/data` (a dashboard refresh), never on the
+hot roster path.
+
+This is not fallback programming: SQLite is the single source of truth on disk, the mirror is a
+write-through cache of bounded operational state loaded from it, and there is no second code path
+and nothing to silently fall back to. It is also what makes acceptance criterion 3 land exactly as
+written - an unchanged poll issues **zero** statements, and a changed one issues the bounded mix.
+
+## The schema
+
+```sql
+PRAGMA user_version = 1;   -- real migrations from day one; never quarantine-and-lose
+
+-- Post-cutover rows only. Never synthesized for history (see "What the historical data
+-- cannot tell us"): the cross-product of hour x repo x agent was never written down.
+CREATE TABLE IF NOT EXISTS stat_delta (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  hour_utc     TEXT    NOT NULL,   -- 'yyyy-MM-ddTHH', or the archive marker
+  session_id   TEXT    NOT NULL,   -- or the archive marker
+  modality     TEXT    NOT NULL,   -- BINARY grouping, matching case-sensitive _totals
+  surface      TEXT    NOT NULL,
+  is_voice     INTEGER NOT NULL,   -- computed in C#; never LOWER() in SQL
+  repo_folded  TEXT    NOT NULL,   -- OrdinalIgnoreCase-folded in C#; display via repo_identity
+  agent_folded TEXT    NOT NULL,
+  wingman      INTEGER NOT NULL,   -- SessionDto.VoiceMode at fold time; NOT modality='voice'
+  turns        INTEGER NOT NULL,
+  chars        INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS ix_stat_delta_hour ON stat_delta(hour_utc);
+
+-- Operational state for live sessions. The idempotent fold, semantics unchanged. Cleared by Forget.
+CREATE TABLE IF NOT EXISTS session_highwater (
+  session_id TEXT NOT NULL, modality TEXT NOT NULL, surface TEXT NOT NULL,
+  turns INTEGER NOT NULL, chars INTEGER NOT NULL,
+  PRIMARY KEY (session_id, modality, surface)
+);
+
+-- The past, imported as it stands. Every reported number is baseline + rows since.
+CREATE TABLE IF NOT EXISTS baseline_total (modality TEXT NOT NULL, surface TEXT NOT NULL,
+  turns INTEGER NOT NULL, chars INTEGER NOT NULL, PRIMARY KEY (modality, surface));
+CREATE TABLE IF NOT EXISTS baseline_hour (hour_utc TEXT PRIMARY KEY,
+  voice_turns INTEGER NOT NULL, typed_turns INTEGER NOT NULL, chars INTEGER NOT NULL);
+CREATE TABLE IF NOT EXISTS baseline_repo (repo_folded TEXT PRIMARY KEY,
+  voice_turns INTEGER NOT NULL, typed_turns INTEGER NOT NULL, chars INTEGER NOT NULL);
+CREATE TABLE IF NOT EXISTS baseline_agent (agent_folded TEXT PRIMARY KEY,
+  voice_turns INTEGER NOT NULL, typed_turns INTEGER NOT NULL, chars INTEGER NOT NULL);
+CREATE TABLE IF NOT EXISTS baseline_scalar (name TEXT PRIMARY KEY, value TEXT NOT NULL);
+  -- wingman_turns, agents_since_utc
+
+-- All-time distinct sets. Deliberately never pruned (:45-61). NOT COUNT(DISTINCT) over stat_delta.
+CREATE TABLE IF NOT EXISTS wingman_session (session_id TEXT PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS repo_session (repo_folded TEXT NOT NULL, session_id TEXT NOT NULL,
+  PRIMARY KEY (repo_folded, session_id));
+CREATE TABLE IF NOT EXISTS agent_session (agent_folded TEXT NOT NULL, session_id TEXT NOT NULL,
+  PRIMARY KEY (agent_folded, session_id));
+
+-- Folded key -> first-seen display spelling (what a .NET OrdinalIgnoreCase Dictionary does).
+CREATE TABLE IF NOT EXISTS repo_identity (repo_folded TEXT PRIMARY KEY, repo_display TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS agent_identity (agent_folded TEXT PRIMARY KEY, agent_display TEXT NOT NULL);
+
+-- Import marker, stamped in the same transaction as the import.
+CREATE TABLE IF NOT EXISTS meta (name TEXT PRIMARY KEY, value TEXT NOT NULL);
+```
+
+The archive marker is the literal `ARCHIVE`, which cannot collide with a real `yyyy-MM-ddTHH` key.
+Per Decision 4: all-time aggregates include archive rows; hourly and working-day queries carry
+`WHERE hour_utc <> 'ARCHIVE'`. Pruning collapses **only** `hour_utc` and `session_id` and preserves
+`modality`, `surface`, `is_voice`, `repo_folded`, `agent_folded`, and `wingman`.
+
+## Semantics that must survive, each pinned by a test
+
+Read out of the current code, and each one is a way this port could silently change the owner's
+numbers:
+
+1. **A typed turn while voice mode is on is a wingman turn** (`:425-427` folds the session's whole
+   turn delta when `s.VoiceMode`). Acceptance criterion 8.
+2. **A voice-mode session with no input still counts as a wingman session.** `:330` adds to
+   `_wingmanSessions` *before* the `:333` early return on empty buckets. So `wingman_session` is
+   written even when no delta row is. This asymmetry is easy to lose.
+3. **A repository or agent session id is only recorded when there is a real delta** (`:398`, `:416`,
+   inside the `if (deltaTurns > 0 || deltaChars > 0)` block) - unlike the wingman set. The two are
+   deliberately different.
+4. **A counter reset means the whole current count is fresh activity** (`:353-354`), not a negative
+   delta.
+5. **A delta with zero turns but non-zero characters still folds** (`:356`).
+6. **`_agentsSinceUtc` is stamped once, from either entry point, and then never moves** (`:146-151`).
+7. **An unrecognised agent token is shown verbatim; an empty one is `(unknown)`** (`:284-290`) -
+   never dropped, never guessed.
+
+## Order of work
+
+Each step builds, keeps all seven test projects green, and goes to the Codex reviewer as a diff
+before it is committed. Nothing is pushed and nothing is merged to `origin/main` (Constraints).
+
+1. **Settle the three findings above** with the Architect and the Codex reviewer. No code first.
+2. **Capture the before picture.** `GET /stats/data` from the live Gateway, saved to a file, plus
+   screenshots of `/stats`, the cockpit Your Throttle, and the mobile Your Throttle. This is
+   acceptance criteria 1 and 2 and it is unrecoverable once the store is touched - so it happens
+   before anything else. A copy of the live `gateway-input-stats.json` becomes the test fixture.
+3. **The database helper.** `Microsoft.Data.Sqlite` as an explicit `PackageReference` on
+   `CcDirector.Gateway.csproj` (Decision 1 - not leaning on the transitive one through Core), a
+   connection and migration helper with `PRAGMA user_version`, write-ahead logging, and the schema
+   above. Modelled on `DatabaseService.cs:47-60`. Tests: fresh file, re-open, version stamp.
+4. **The fold onto SQLite.** `GatewayInputStatsAggregator` rewritten with the high-water fold
+   **semantically unchanged** (Decision 3 - a worker who simplifies it has broken the mission), the
+   in-memory write-through mirror from Finding 3, and the aggregate reads as queries. The seven
+   semantics above get their tests here, each watched failing first.
+5. **The baseline import.** All eight `StoreFile` sections, one transaction, marker plus
+   `PRAGMA user_version` stamped inside it, full field-by-field parity read back out of SQLite, the
+   idempotent-re-observe leg from Finding 1, rename the JSON aside only on a complete match, and
+   fail loudly on any mismatch with the JSON left as the source of truth. The refusal leg is proven
+   by watching it fail on an induced mismatch, not asserted.
+6. **Pruning and the archive.** Both legs of acceptance criterion 7: all-time answers identical
+   across a prune, and no phantom bucket in the working-day series.
+7. **The after picture, compared field by field** against step 2. Plus acceptance criterion 4: a new
+   question answered by a query with no schema change. Candidate the owner has not asked for:
+   "which surface do you drive each repository from?" - `GROUP BY repo_folded, surface` over
+   `stat_delta`, which no dictionary in the current code can answer at all.
+8. **The phase report**, written to
+   `docs/architecture/gateway-sqlite-phase1-report-2026-07-15.md` - in a file, because the Manager is
+   reset before Phase 2.
+
+## Risks the Manager is holding
+
+- **The import runs once against real, irreplaceable data.** The owner's 1401 turns and 568,580
+  characters have no backup other than the renamed-aside file. The import is developed and proven
+  against a **copy** of the live store as a fixture; the real cutover happens only after the fixture
+  round-trips exactly.
+- **Phase 1 does not prove Phase 2 or Phase 4.** Concurrency-peak restoration and the Phase 4 store
+  choices are their own phases and must not be waved through on this phase's evidence (the brief is
+  explicit, and round-two finding 9 approved that bound).
+- **`GatewayInputStatsAggregator`'s constructor signature changes** from a JSON path to a database
+  path. Three call sites move with it: `GatewayHost.cs:478`, `DirectorHubTests.cs:32`, and
+  `GatewayInputStatsAggregatorTests.cs`. `StatsPageEndpointTests` also constructs one.
+
+## Reviewer verdict and the guardrails it attached
+
+The Codex reviewer reviewed this plan on 2026-07-15 and returned **APPROVED**, recorded in full at
+`docs/architecture/gateway-sqlite-review-codex-phase1-plan-2026-07-15.md`. It confirmed Finding 1
+("If `session_highwater` starts empty after importing baselines, the first post-cutover
+`GET /sessions` can refold every live session's whole current tally on top of the baseline") and
+Finding 2 ("The live store having no current case collisions does not make the design safe"), and
+confirmed that importing all eight sections, the folded identity keys, and the explicit `is_voice`
+column are **faithful elaborations of the brief, not deviations**. Finding 3 is not fallback
+programming so long as SQLite stays the single durable source of truth.
+
+Three guardrails came attached. They are binding on the implementation and are restated here so the
+code is written against them rather than against a review file nobody re-reads:
+
+- **Guardrail A (review finding 5) - the folding must be exact, not approximate.** Do **not**
+  implement identity folding as `ToLowerInvariant`, `ToUpperInvariant`, SQLite `NOCASE`, or any
+  SQL-side collation that is only approximately `StringComparer.OrdinalIgnoreCase`. It resolves
+  through C# using `StringComparer.OrdinalIgnoreCase` itself, or an equivalently exact mechanism.
+  Tests must include case-variant repository and agent keys and must prove the **first-seen** display
+  spelling wins.
+- **Guardrail B (review finding 7) - the statement-count test must not overfit to one bucket.** One
+  `stat_delta` insert and one high-water upsert is the expected mix only when exactly one
+  `(modality, surface)` bucket changes. A session with several changed buckets legitimately produces
+  one delta row and one high-water upsert **per changed bucket**. The invariant to pin is therefore
+  "bounded by changed buckets and distinct-id first sightings, **not** by stored history size" -
+  which is the claim acceptance criterion 3 actually makes.
+- **Guardrail C (review finding 9) - do not call the distinct-id sets bounded.** Per-fold *work* is
+  bounded. The lifetime cardinality of the all-time distinct identifier sets is **not** - they are
+  deliberately never pruned (`:45-61`) and the implementation must never treat them as prunable. The
+  wording in Finding 3 above is corrected by this guardrail: the mirror is of operational state whose
+  per-fold cost is bounded, not of state whose size is bounded.
+
+Finding 4 (the moving target) was raised after this review was requested and is not covered by it.
+It changes no design, only how criterion 1 is executed.
+
+## Open questions - all four settled
+
+1. **Finding 1** (import all eight sections including `HighWater`, plus the idempotent-re-observe
+   parity leg) - **SETTLED.** Codex reviewer findings 1, 2, and 3: approved, and confirmed as a real
+   hole the endpoint-field parity check cannot detect.
+2. **Finding 2** (`repo_folded` / `agent_folded` plus identity tables, and the explicit `is_voice`
+   column) - **SETTLED.** Codex reviewer findings 4, 5, and 6: approved as a faithful elaboration,
+   subject to Guardrail A.
+3. **Finding 3** (the in-memory write-through mirror) - **SETTLED.** Codex reviewer finding 8: not
+   fallback programming, subject to Guardrail C's correction on the word "bounded".
+4. **Finding 4** (the moving target, and criterion 1 executed against a stopped Gateway) -
+   **SETTLED.** Architect accepted; criterion 1 now says so in the brief, exactly and with no
+   tolerance: "If this criterion is ever reported as passing with a tolerance, it did not pass."
+
+All four were accepted by the Architect with none disputed, and each is now in the brief rather than
+only in this plan. The Architect measured Finding 1's cost on the live store and it was worse than
+the Manager estimated: `HighWater` holds 842 turns across 115 sessions against all-time totals of
+1404, so the first poll after a high-water-less import would have taken the owner's totals to 2246 -
+a silent 60 per cent inflation of every number this mission promised to preserve.
+
+**Decision 6 settled the one thing this plan deliberately refused to guess at.** The Architect's
+first statement of the mirror rule said "high-water only", which would have made every idle poll
+write one `INSERT OR IGNORE` per voice-mode session forever, because `:330` registers the wingman
+session *before* the `:333` empty-bucket early return. The Manager put the tension up rather than
+resolving it quietly, and the Architect adopted the recommendation verbatim: **the mirror holds
+identity and membership - never a tally.** The test to apply to any future case is the one that
+settled this one: *the count stays a query, so no aggregate is cached.* New acceptance criterion 3a
+pins it - an idle poll writes nothing, including for a voice-mode session with no input, proven by
+removing the mirror and watching the writes appear.
+
+Phase 1 proceeds to code from here.

--- a/docs/architecture/gateway-sqlite-phase1-rebase-1647-findings.md
+++ b/docs/architecture/gateway-sqlite-phase1-rebase-1647-findings.md
@@ -1,0 +1,127 @@
+# Phase 1: what the #1647 rebase costs, and what the new shape means
+
+Written 2026-07-15 by the Manager ("Gateway SQLite - Manager", session f3599eba) after the Architect
+stopped the fold rewrite. Read against `origin/main` at `6cc49d25`, on the rebased branch.
+
+The Architect was right to stop it. Pull request #1647 rewrote the file Phase 1 ports:
+`GatewayInputStatsAggregator.cs` is +193/-18 lines since the base this work started from. Finishing
+the port against the old shape would have silently reverted a real bug fix - the worst thing this
+mission could do.
+
+## What the rebase cost
+
+Almost nothing, which is the good news:
+
+- The rebase was clean. Nineteen commits replayed with no conflicts.
+- **Step 3 survived intact** (now `bad2c3a6`). The database, the schema, and the migration touch
+  nothing #1647 touched. Its nine tests pass unchanged on the new base.
+- **The fold rewrite is discarded.** It ported the pre-#1647 shape. It is saved at
+  `<scratchpad>\phase1-fold-wip-PRE-REBASE.patch` and in `git stash` for reference only. Its
+  *structure* still stands - the batch-then-commit design, the membership mirror, the surrogate ids,
+  the archive rule - but the fold body and the import must be rewritten against the real shape.
+
+Roughly half a step's work, and it bought correctness. Cheap.
+
+## Correction: the section count is TWELVE, not eleven
+
+The Architect's message says `StoreFile` gained three sections and now has eleven. **It has twelve.**
+Derived, not asserted - counting the properties on `origin/main`:
+
+```
+git show origin/main:src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs \
+  | sed -n '/private sealed class StoreFile/,/^    }/p' \
+  | grep -cE '^\s+public .* \{ get; set; \}'
+-> 12
+```
+
+The twelfth is `AgentsSeeded`, and this matters because of the next finding.
+
+## Correction: `AgentsSeeded` IS persisted, and the code says it must be
+
+The Architect wrote that `_agentsSeeded` "is in-memory only and NOT in StoreFile, so whether you
+persist it changes behaviour ... I think there may be a live defect in it".
+
+It is in `StoreFile` (`:577`), it is written by `Save` (`:736`), it is read by `Load` (`:686-687`),
+and the field's own comment (`:80-81`) states the reason:
+
+> "MUST be persisted: without it a Gateway restart would back-fill every live session a second time
+> and double the agent numbers."
+
+So the decision the Architect asked me not to make by taste has already been made, correctly, by
+#1647. There is nothing for Phase 1 to choose here - only something to preserve.
+
+**Is there a live defect?** I looked rather than guessed. There is a latent coupling but not a live
+defect:
+
+`Load` (`:677-683`) discards `_agents` entirely when `AgentsSeeded` is null. That clear also zeroes
+each agent's `AgentDrivenTurns`/`AgentDrivenCharacters` (#1636), while the global `_agentDrivenTurns`
+is loaded from the store and is **not** cleared, and `_agentDrivenHighWater` is preserved - so no
+delta would ever re-attribute them. The per-agent and global agent-driven numbers would disagree
+permanently.
+
+That state is unreachable today: `AgentsSeeded` (#1633) and the agent-driven lane (#1636) shipped in
+the same pull request, so a store with agent-driven data but no `AgentsSeeded` key cannot exist. It
+is a real coupling worth knowing about, not a bug to fix, and per the standing rule this mission does
+not touch it.
+
+## The finding that actually changes the import
+
+**The owner's live store has `AgentsSeeded` absent** - it is 8 sections, confirmed on disk today, with
+no `AgentDriven*` either. Under `Load`, absent means null, and null means:
+
+> "the partial tally is DISCARDED and rebuilt from the high-water" (`:668-683`)
+
+**So the first time the current Gateway loads the owner's real store, the JSON store itself reports
+DIFFERENT agent numbers than the document contains.** The `Agents` section on disk is a partial,
+hybrid tally that #1647 deliberately throws away and rebuilds from the high-water via the first-fold
+back-fill.
+
+This breaks the import as designed, in a way that would have passed straight through review:
+
+- Decision 5 says import each projection **as it stands**. Importing the `Agents` section verbatim
+  would import a projection the production code has decided is **wrong and must be discarded**.
+- The parity check compares SQLite against "what the JSON store reported". The JSON store reports the
+  **rebuilt** agent tally, not the stored one. A verbatim import would therefore *fail* parity - and
+  the tempting fix would be to compare against the stored section instead, which would make the
+  import faithfully preserve a tally the product has already rejected.
+
+**Proposal:** the import must reproduce `Load`'s decision, because "as it stands" means "as the store
+*reports* it", not "as the bytes on disk say". Concretely: when `AgentsSeeded` is null, do **not**
+import `baseline_agent` from the `Agents` section - import zero, and let the ordinary first-fold
+back-fill rebuild the agent tally from the imported `session_highwater`, exactly as `Load` does. When
+`AgentsSeeded` is present, import both it and the `Agents` section verbatim.
+
+That also means **`_agentsSeeded` needs a home in the schema** - it is a membership set ("have I
+already attributed this session's prior turns?"), so it is a distinct-id table and a mirror set, and
+its null-versus-empty distinction must survive: absent and empty are different states and conflating
+them re-runs or skips a back-fill.
+
+## Two more things the new shape needs from the design
+
+1. **The agent-driven lane is a SECOND high-water lane.** `_agentDrivenHighWater` is keyed by session
+   id alone (`:106`), not by modality and surface, so `session_highwater` cannot hold it without a
+   discriminator. **Recommendation: a separate `agent_driven_highwater` table**, and a separate
+   `agent_driven_delta` table rather than a lane flag on `stat_delta`. The reason is the Architect's
+   own principle applied where it earns its keep: the comment at `:102-105` says these turns "never
+   enter `_totals`, `_hourly` or the buckets, because the human voice-versus-typed numbers must stay
+   about the human". If agent-driven rows share `stat_delta`, then every human aggregate query must
+   remember to exclude them - a rule to obey, and exactly the archive-marker problem again. In a
+   separate table they **cannot** be summed into the human totals by accident. This is a silent
+   failure if it goes wrong (the voice-versus-typed share would quietly include agent traffic), so it
+   earns structure rather than a test.
+
+2. **`FoldAgentDrivenLocked` runs BEFORE the empty-buckets guard** (`:352-357`), because "a session
+   driven only by other agents has no human buckets at all - and those are exactly the sessions this
+   tally is about". My design emitted rows only inside the bucket loop, so those sessions would have
+   produced no row and their turns would have vanished. The separate agent-driven table fixes this
+   too: its rows are emitted from the agent-driven fold, independent of any human bucket.
+
+## Consequence for acceptance criterion 1
+
+The "before" capture must be taken from the **current** build (post-#1647), not from the snapshot
+taken earlier today. That snapshot predates the rebase and its agent numbers are the pre-#1647 ones,
+which the current code would discard and rebuild on load. Capturing "before" from the old build and
+"after" from the new one would compare two different products and prove nothing about this port.
+
+The snapshot remains valid and verified-restorable as a **backup**. It is not valid as a criterion 1
+baseline.

--- a/docs/architecture/gateway-sqlite-phase1-report.md
+++ b/docs/architecture/gateway-sqlite-phase1-report.md
@@ -1,0 +1,161 @@
+# Phase 1 report: SQLite on the Gateway
+
+Written 2026-07-15 by the Manager ("Gateway SQLite - Manager", session f3599eba, machine SOREN_NORTH).
+Written to a file rather than held in the Manager's head, because the Manager is reset before Phase 2.
+
+Status at the time of writing: **the foundation is built and green; the fold is not built.** The
+owner is deciding whether Phase 1 finishes or stops here.
+
+## What exists
+
+Two code commits on `feat/gateway-sqlite`, neither pushed and neither merged, per the owner's
+standing instruction for this mission.
+
+| Commit | What it is | Tests |
+|---|---|---|
+| `bad2c3a6` | The statistics database, its schema, and `PRAGMA user_version` | 9 new; all seven projects green (5864) |
+| `48aad7ad` | Test isolation: the suite no longer writes into the owner's live storage | 3 new; Gateway suite green (2438) |
+
+**`48aad7ad` should be merged whether or not this mission continues.** It is not SQLite work. It
+fixes a live hazard in which 26 of the 48 Gateway test files that construct a `GatewayHost` can write
+the owner's real `missions.json`, `cronjobs.json` and `keyvault.json`. See "The incident" below.
+
+## What does NOT exist
+
+**The fold.** `GatewayInputStatsAggregator` is byte-identical to `origin/main` and still writes
+`gateway-input-stats.json`. Nothing writes a single statistic to SQLite. The database is real,
+correct, versioned and tested - and nothing populates it.
+
+Also not built, and deliberately so after the owner's ruling: the import, the parity check, the
+baseline tables, and the legacy reader. See "The premise change".
+
+## The schema, and why each part is shaped the way it is
+
+Eleven tables. The reasoning matters more than the shape, because the shape was wrong three times.
+
+- `stat_delta(id, hour_utc, session_id, modality, surface, is_voice, repo_id, agent_id, wingman,
+  turns, chars)` - one row per **changed bucket**, not per fold. Post-cutover only.
+- `session_highwater(session_id, modality, surface, turns, chars)` - live operational state. The
+  idempotent fold. **Starts empty** under the new premise, which is why day one lands with a lump.
+- `agent_driven_delta`, `agent_driven_highwater` - the agent-to-agent lane (#1636), in **their own
+  tables**. They must never enter the human totals, and a separate table makes that impossible rather
+  than a rule every query must remember.
+- `repo_identity(repo_id, repo_display)`, `agent_identity(agent_id, agent_display)` - surrogate
+  integer identity, resolved in C#.
+- `repo_session`, `agent_session`, `wingman_session` - all-time distinct sets, deliberately never
+  pruned.
+- `agents_seeded(session_id)` - the #1633 back-fill guard. **Live behaviour, not scaffolding.**
+- `meta(name, value)` - runtime scalars. Today only `agents_since_utc`.
+
+### The three decisions worth inheriting
+
+1. **`repo_id` and `agent_id` are surrogate INTEGERS, never a repository or agent string in any form,
+   raw or folded.** The dictionaries being replaced group with `StringComparer.OrdinalIgnoreCase`
+   while SQLite's default collation is case-sensitive `BINARY`, so a raw string column would split
+   what the code merges - silently, and only weeks later, since the live store holds no case collision
+   today. The obvious repair - a *folded* string column - **cannot be built**: it needs a normalizer
+   exactly equivalent to `OrdinalIgnoreCase`, and no such function exists. A comparer is not a
+   normalizer. `ToLowerInvariant` is forbidden and can change a string's length at `U+0130`;
+   `ToUpperInvariant` is merely close enough to "almost certainly never" bite. With a surrogate id
+   there is no folded string, an in-memory `Dictionary<string, long>` built with that same comparer
+   resolves display to id, and parity holds **by construction rather than by care**.
+2. **`is_voice` is stored, not derived.** `_totals` is keyed case-sensitively while the voice test is
+   case-insensitive. Storing the flag preserves that asymmetry rather than reproducing it in SQL.
+3. **`wingman` records `SessionDto.VoiceMode` at fold time and is NOT `modality = 'voice'`.** A turn
+   **typed** while voice mode is on is a wingman turn. `VoiceMode` must be read **once** per fold and
+   passed as a required argument to the row-emitting code, so no row can derive the flag from its own
+   modality.
+
+## The premise change
+
+Mid-mission the owner ruled that **the old numbers are not carried across**. That deleted the
+import, the legacy reader, the parity check, the baseline tables, and acceptance criteria 1 and 6 -
+the hardest and most dangerous half of Phase 1. New first-run behaviour: **rename
+`gateway-input-stats.json` aside, unread. Rename, never delete.**
+
+Two things nearly went with it that must not, and both are recorded here because they are behaviour
+wearing migration scaffolding's clothes:
+
+- **`agents_since_utc`** is stamped at **runtime** on first observation. It is not history. Deleting
+  it with the baselines would have made the Agents page silently imply its numbers reconcile with the
+  totals when they do not.
+- **`agents_seeded`** looks like dead weight on a fresh database, because the first-fold back-fill
+  contributes nothing when high-water is empty. But `session_highwater` **persists across a
+  restart**, so without it the back-fill fires again with real turns and **doubles every agent's
+  numbers**.
+
+The filter that catches both: *is this a stored historical number, or something the running product
+does?* The owner's ruling is about **data**, not **behaviour**.
+
+**The most dangerous remaining delete is `PRAGMA user_version`.** "The import is gone, so the
+migration machinery goes with it" is a sentence someone could say and it would sound reasonable.
+Delete the import and the mission gets simpler; delete `user_version` and **the mission has no reason
+to exist** - it becomes a lateral move from one store that loses data on a shape change to another
+one. The danger zone is anything whose *name* sounds like migration.
+
+## The ruling for whoever builds the fold
+
+**The agent tally needs its OWN `agent_delta` table; `stat_delta` must NOT carry `agent_id`**
+(Architect ruling, `f8f1bbd8`).
+
+`AttributeToAgentLocked` has two call sites: the ordinary delta path (`:460`, same delta that feeds
+the totals) and the first-fold back-fill (`:395`, which attributes prior high-water with **no totals
+counterpart**). So the agent tally is not derivable from the same deltas as the totals. Deriving it
+from `stat_delta` has **no correct behaviour** if the back-fill ever fires: emitting a row inflates
+the totals (those turns are already in them), and omitting one leaves the agent tally short. Two
+wrong answers and no right one is not a trade-off - it is a schema that cannot express the situation.
+
+The cost is real and was accepted: `stat_delta` cannot answer turns-by-agent-by-hour. Carrying
+`agent_id` would advertise a cross-product the code does not maintain.
+
+## The incident, recorded in full
+
+A full test-suite run drove the then-current import against the owner's **live**
+`gateway-input-stats.json` and **renamed it aside**. Nothing was lost - verified, not assumed: his
+store is healthy at 1463 turns / 593,268 characters. But **only by luck**: the running Gateway held
+its state in memory and rewrote the file on its next save. A Gateway restart inside that window would
+have found no file, started empty, and saved empty over it.
+
+Root cause: `GatewayHost` resolves store paths from `CcStorage.Root()` when given none, and 26 of 48
+test files pass none. **The exposure was never about statistics** - that root holds `missions.json`
+(live fleet state, including this mission's own record), `cronjobs.json` and `keyvault.json`. The
+import did not create the exposure; it added the first operation that **moved** a file rather than
+overwriting it with equivalent content.
+
+This was the **second** instance of the class. Issue #322 fixed the same bug - a test wrote into the
+real Director instances directory and painted a phantom Director in the owner's live Cockpit - and
+scoped the fix to the one directory that had been noticed. **A fix scoped to the instance you noticed
+leaves the class alive, and the class comes back worse.**
+
+`48aad7ad` redirects `CcStorage.Root()` for the whole test assembly. The hazard was already known and
+already mitigated - by a **convention**, followed by 22 of 48 sites. A convention followed by fewer
+than half the sites that need it is not a mitigation, it is a folk memory.
+
+## Open unknown - do not close this
+
+**One test failure in 2435, never identified.** A full Gateway run reported 1 failure; the immediate
+rerun was green, and the failing run's results were not captured, so it could not be diagnosed. The
+plausible explanation is an orphaned `testhost` that had to be cleared mid-run - and *plausible* is
+exactly how a real defect gets waved through, so it is **not** recorded as resolved. It has not
+recurred across several full runs since.
+
+The real defect was in the evidence chain: only the green rerun produced a `trx`. Runs now use
+`--logger trx` so a failing run's results survive. **A thing that happened once and was never
+explained is not the same as a thing that did not happen.**
+
+## What this mission cost, and what it caught
+
+Twelve brief revisions before a line of code. Four defects found in an approved document before any
+code was written, all accepted. Three separate occasions where a check could not see the thing it was
+looking for and reported that the thing was not there:
+
+- `Assert.DoesNotContain("repo", keys)` is an exact-element check and would have passed against
+  `repo_raw`.
+- A red-watch that died on a `KeyNotFoundException` before reaching its assertion - it went red for a
+  reason that does not generalise.
+- A `grep` whose filter excluded comment lines, when every surviving reference was a comment.
+
+All three are one failure. **Empty output is not evidence; it is evidence only once you have shown
+the check CAN produce non-empty output for the case you care about.** Red-watch your grep the same
+way you red-watch your test: point it at a case you know exists and watch it print. If it cannot
+print, it was never searching.

--- a/docs/architecture/gateway-sqlite-review-codex-2026-07-15.md
+++ b/docs/architecture/gateway-sqlite-review-codex-2026-07-15.md
@@ -1,0 +1,249 @@
+# Codex Review: Gateway SQLite Mission Brief
+
+Reviewed 2026-07-15 by the Codex reviewer session for the mission "SQLite on the Gateway".
+
+Verdict: CHANGES REQUIRED.
+
+## Numbered Findings
+
+1. DEFECT: The brief contradicts itself on exact all-time distinct counts.
+
+   Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:123`
+
+   Brief claim: `stat_delta(hour_utc, session_id, modality, surface, repo, agent, turns, chars)` is the row schema.
+
+   Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:132`
+
+   Brief claim: distinct session counts become `COUNT(DISTINCT session_id)`, exact, with no persisted `HashSet`.
+
+   Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:148-151`
+
+   Brief claim: pruning folds departing rows into an archive row before deleting them, and distinct-session sets keep their own narrow unpruned table.
+
+   What the code says today: exact distinct session counts are deliberately persisted as unpruned sets. `GatewayInputStatsAggregator.cs:45-49` stores all-time wingman session ids, `GatewayInputStatsAggregator.cs:51-55` stores all-time per-repository session sets, and `GatewayInputStatsAggregator.cs:57-61` stores all-time per-agent session sets. `GatewayInputStatsAggregator.cs:562-577` writes those sets to JSON.
+
+   Required fix: The brief must define the durable distinct-count schema explicitly. `COUNT(DISTINCT session_id)` over `stat_delta` is exact only while all relevant detail rows remain. It stops being exact after pruning unless the distinct ids are preserved elsewhere. The brief should stop implying that `stat_delta` alone replaces the all-time sets.
+
+2. DEFECT: The archive-row pruning design is too vague to preserve all existing all-time answers.
+
+   Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:145-151`
+
+   Brief claim: pruning old delta rows is safe if departing rows are folded into an archive row before deletion.
+
+   What the code says today: hourly data is the only pruned input data. `GatewayInputStatsAggregator.cs:310-315` removes stale hourly buckets only. All-time totals, wingman sessions, repository tallies, and agent tallies survive because they live in separate structures. The query surfaces read those structures through `CurrentTotals`, `WingmanUsage`, `RepoTotals`, and `AgentTotals`.
+
+   Required fix: "An archive row" is not enough. If old detail rows are deleted, archived data must preserve all grouping dimensions needed for all-time sums: modality, surface, repository, agent, and wingman-turn attribution if that remains derived from rows. Exact distinct counts still need unpruned id tables.
+
+3. DEFECT: The one-time JSON import cannot reconstruct true historical delta rows from the current aggregate JSON.
+
+   Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:153-157`
+
+   Brief claim: on first run, import the existing JSON store into the database and make all-time totals, peaks, and distinct counts read identically before and after.
+
+   What the code says today: the input JSON contains aggregate sections, not historical per-event or per-delta rows. `GatewayInputStatsAggregator.cs:448-457` defines `StoreFile` as totals, high-water, hourly buckets, wingman turns, wingman sessions, repository tallies, agent tallies, and `AgentsSinceUtc`. `GatewayInputStatsAggregator.cs:507-533` loads each aggregate back into separate in-memory structures. There is no persisted row containing the full tuple `hour_utc, session_id, modality, surface, repo, agent, turns, chars`.
+
+   Required fix: The brief must specify a lossless import contract for the existing aggregate document. If it creates synthetic rows, it must say which rows are synthetic, which historical cross-dimensional questions they cannot answer, and how before/after parity is proven for every existing endpoint field before the JSON file is renamed aside.
+
+4. DEFECT: The import plan must protect the owner's real numbers before moving the JSON aside.
+
+   Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:153-157`
+
+   Brief claim: import existing JSON into SQLite, then rename JSON aside rather than deleting it.
+
+   What the code says today: current load paths start empty when a JSON file is missing or quarantined. `GatewayInputStatsAggregator.cs:483-489` starts empty when the input store file is absent. `GatewaySessionConcurrencyStats.cs:205-211` starts empty when the concurrency store file is absent.
+
+   Required fix: The brief should require an import transaction, a complete parity read from SQLite, and only then a JSON rename. On parity failure, the gateway should fail loudly or leave JSON as the source, not mark it imported. It should also define an import marker or version gate so a crash between database writes and JSON rename cannot double-import or strand partial data.
+
+5. APPROVAL POINT: SQLite is the right answer for the hot rewritten statistics stores.
+
+   Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:40-49`
+
+   Brief claim: the justification is schema evolution, migration safety, and avoiding whole-document rewrites, not disk size.
+
+   What the code says today: `GatewayInputStatsAggregator.cs:123` and `GatewayInputStatsAggregator.cs:137` call `Save()` after changed folds, and `GatewayInputStatsAggregator.cs:555-583` serializes and rewrites the whole document. `GatewayEndpoints.cs:813` folds input stats on every `GET /sessions` roster read, and `GatewayEndpoints.cs:820` folds concurrency on the same path. The premise is real; this is not database ceremony over a non-problem.
+
+6. APPROVAL POINT: The scope line is directionally correct for append-only JSON Lines logs.
+
+   Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:80-85`
+
+   Brief claim: prompt and transcription JSON Lines logs stay out of scope.
+
+   What the code says today: `GatewayPromptLog.cs:51-55` writes daily `conversation-yyyyMMdd.jsonl` files. `GatewayPromptLog.cs:26-27` explicitly says retention is unbounded and nothing prunes it. `TranscriptionTelemetryLog.cs:49-54` writes daily `transcription-yyyyMMdd.jsonl` files, and `TranscriptionTelemetryLog.cs:67-70` appends one line. These logs do not have the whole-document rewrite problem.
+
+7. DEFECT: The scope line is overbroad if read literally.
+
+   Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:96-97`
+
+   Brief claim: a store moves to SQLite if and only if it rewrites its whole document to record an incremental change.
+
+   What the code says today: many Gateway JSON stores use whole-document persistence but are not part of this statistics mission. For example, `WorkListStore`, `SnoozeRegistry`, `PushSubscriptionStore`, and other operational stores appear in the same repository with rewrite-style persistence.
+
+   Required fix: Narrow the scope line to the listed Gateway statistics, diagnostics, scheduler history, car mode telemetry, and voice-session files, or say Phase 4 evaluates only the named remaining files.
+
+8. DEFECT: `voice-sessions.json` is inaccurately described as one of the seven hand-rolled JSON stat stores with the same atomic and quarantine pattern.
+
+   Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:60`
+
+   Brief claim: there are seven hand-rolled JSON files, each with the same load, serialize, atomic temp-write-and-rename, and quarantine-on-corrupt code.
+
+   Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:72`
+
+   Brief claim: `voice-sessions.json` is one of those seven stores, described as "Session records".
+
+   What the code says today: `WingmanVoiceService.cs:105` sets the file path to `voice-sessions.json`. `WingmanVoiceService.cs:113-122` loads it, catches every exception, logs, and does not quarantine. `WingmanVoiceService.cs:125-128` saves it with direct `File.WriteAllText` and catches every exception. It is not atomic temp-write-and-rename, not quarantine-on-corrupt, and not a statistics rollup like the other cited files.
+
+   Required fix: Remove `voice-sessions.json` from the "same pattern" premise or describe it separately. If it remains in Phase 4, the brief should explain why a persisted set of voice session ids belongs in this SQLite statistics mission.
+
+9. DEFECT: The concurrency quarantine citation is imprecise and partially points at unrelated save code.
+
+   Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:31-35`
+
+   Brief claim: a shape change is treated as corrupt, renamed to `.corrupt-{timestamp}`, and the store restarts empty, citing `GatewaySessionConcurrencyStats.cs:249-298`.
+
+   What the code says today: `GatewaySessionConcurrencyStats.cs:205-227` is the load path that starts empty on missing, null, or JSON parse failure. `GatewaySessionConcurrencyStats.cs:249-254` is the quarantine method. `GatewaySessionConcurrencyStats.cs:256-298` is save code, not corrupt-load behavior. Also, a shape change is treated as corrupt only if deserialization fails or returns null; missing fields can deserialize as defaults.
+
+   Required fix: Cite `GatewaySessionConcurrencyStats.cs:205-227` and `GatewaySessionConcurrencyStats.cs:249-254`, and qualify the shape-change statement.
+
+10. APPROVAL POINT: The input-store dictionary citation is accurate.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:21-25`
+
+    Brief claim: `GatewayInputStatsAggregator` keeps separate dictionaries for totals, high-water, hourly, wingman sessions, repositories, and agents.
+
+    What the code says today: `GatewayInputStatsAggregator.cs:31-66` contains `_totals`, `_highWater`, `_hourly`, `_wingmanSessions`, `_repos`, `_agents`, and `_agentsSinceUtc`. The claim resolves.
+
+11. APPROVAL POINT: The whole-document rewrite citations for the input store are accurate.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:36-39`
+
+    Brief claim: the stats stores reserialize and rewrite the file whenever counters move.
+
+    What the code says today: `GatewayInputStatsAggregator.cs:123` and `GatewayInputStatsAggregator.cs:137` call `Save()` when changed. `GatewayInputStatsAggregator.cs:555-583` builds the full `StoreFile`, serializes it, writes a temp file, and moves it over the original. The claim resolves for the input store.
+
+12. APPROVAL POINT: The `GET /sessions` fold citations are accurate.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:39`
+
+    Brief claim: folding runs on every `GET /sessions` read.
+
+    What the code says today: `GatewayEndpoints.cs:813` calls `inputStats?.ObserveSnapshot(all, DateTime.UtcNow)`, and `GatewayEndpoints.cs:820` calls `concurrency?.Observe(all, DateTime.UtcNow)`. The claim resolves.
+
+13. APPROVAL POINT: The SQLite dependency and house-pattern citations are accurate.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:51-58`
+
+    Brief claim: `Microsoft.Data.Sqlite` is already referenced in Core, Gateway references Core, and the repository has a raw `SqliteConnection` plus `CREATE TABLE IF NOT EXISTS` pattern.
+
+    What the code says today: `CcDirector.Core.csproj:18` references `Microsoft.Data.Sqlite` 9.0.2. `CcDirector.Gateway.csproj:49` references Core. `DatabaseService.cs:47-60` opens a raw `SqliteConnection` and begins `CREATE TABLE IF NOT EXISTS communications`. The claim resolves.
+
+14. APPROVAL POINT: The storage-root citation is accurate.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:64-65`
+
+    Brief claim: these files resolve through `CcStorage.Root()` to `%LOCALAPPDATA%\cc-director`.
+
+    What the code says today: `CcStorage.cs:28` returns `Base()`, and `CcStorage.cs:36-37` returns `%LOCALAPPDATA%\cc-director` when no override is set. The claim resolves.
+
+15. APPROVAL POINT: The store-size table is consistent with the current machine.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:66-72`
+
+    Brief claim: the seven listed files total roughly 174 KB.
+
+    What the local files say today: `gateway-input-stats.json` is 60,538 bytes, `carmode-telemetry.json` is 33,013 bytes, `netdiag-rollup.json` is 22,440 bytes, `netdiag-devices.json` is 20,459 bytes, `gateway-concurrency-stats.json` is 15,869 bytes, `cronruns.json` is 15,907 bytes, and `voice-sessions.json` is 13,261 bytes. The total is close to the brief's rounded 174 KB.
+
+16. APPROVAL POINT: The Car Mode telemetry citations are accurate.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:67`
+
+    Brief claim: `CarModeTelemetryStore.cs:46` defaults to `carmode-telemetry.json`.
+
+    What the code says today: `CarModeTelemetryStore.cs:45-47` sets the default path to `Path.Combine(CcStorage.Root(), "carmode-telemetry.json")`.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:176-180`
+
+    Brief claim: `RetentionDays = 90` and `MaxRecords = 10000` are intentional and should carry over.
+
+    What the code says today: `CarModeTelemetryStore.cs:26-31` defines exactly those constants with the stated comments. The claim resolves.
+
+17. APPROVAL POINT: The concurrency-store path citation is accurate.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:70`
+
+    Brief claim: `GatewaySessionConcurrencyStats.cs:69` defaults to `gateway-concurrency-stats.json`.
+
+    What the code says today: `GatewaySessionConcurrencyStats.cs:68-70` sets the default path to `Path.Combine(CcStorage.Root(), "gateway-concurrency-stats.json")`. The claim resolves.
+
+18. APPROVAL POINT: The all-time distinct-session set citations are accurate and must remain requirements.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:91-94`
+
+    Brief claim: `_repos[].Sessions`, `_agents[].Sessions`, and `_wingmanSessions` are deliberately never pruned and must be preserved.
+
+    What the code says today: `GatewayInputStatsAggregator.cs:45-47`, `GatewayInputStatsAggregator.cs:51-54`, and `GatewayInputStatsAggregator.cs:57-61` state all-time and never-pruned semantics. The claim resolves.
+
+19. APPROVAL POINT: The high-water design requirement is correct.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:137-142`
+
+    Brief claim: `FoldLocked` is the idempotent high-water fold and should move to `session_highwater` without semantic simplification.
+
+    What the code says today: `GatewayInputStatsAggregator.cs:336-354` compares current reported counters against previous high-water counters, and `GatewayInputStatsAggregator.cs:350-354` handles reset by treating the current count as fresh activity. `GatewayInputStatsAggregator.cs:422` updates the high-water value. This logic is the core correctness path and should be preserved.
+
+20. DEFECT: The row-not-counter design is sound for new observations but the "no schema change" claim is overbroad.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:121-134`
+
+    Brief claim: one narrow delta row lets the next owner question be a query rather than a deploy.
+
+    What the code says today: new observations can supply session id, modality, surface, repository, and agent through `SessionDto` and `InputStats`. `GatewayInputStatsAggregator.cs:343-417` already folds deltas across those dimensions.
+
+    Required fix: The brief should qualify that new questions are query-only when they use dimensions already captured in `stat_delta`. A new dimension still requires a schema change.
+
+21. APPROVAL POINT: Phase 1 is the right proof target, with one caveat.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:166-170`
+
+    Brief claim: Phase 1 proves the database foundation by porting the largest, worst-behaved input store with numbers intact.
+
+    What the code says today: the input store has the most complex aggregate shape and is folded on the frequent `/sessions` path. That makes it the right first proof. The caveat is that Phase 1 proves only the input-store design and import discipline, not concurrency-peak restoration or Phase 4 store choices.
+
+22. DEFECT: Acceptance criterion 2 is not fully falsifiable as written.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:192-193`
+
+    Brief claim: `/stats`, cockpit Your Throttle, and mobile Your Throttle render unchanged.
+
+    What the code says today: the surfaces exist. `StatsPageEndpoint.cs:74-79` maps `/stats`, `apps/cockpit/src/throttle/YourThrottleView.tsx` implements cockpit Your Throttle, and `apps/mobile/src/pages/YourThrottle.tsx` implements mobile Your Throttle.
+
+    Required fix: Require concrete evidence, such as captured JSON plus screenshots or route smoke checks, so "render unchanged" is not subjective.
+
+23. DEFECT: Acceptance criterion 3 needs a concrete demonstration method.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:194`
+
+    Brief claim: a counter move performs one row write, not a document rewrite, demonstrated not asserted.
+
+    Required fix: Define the demonstration. Examples: instrument the SQLite command path in a test seam, assert no JSON store file timestamp changes after import, or use a focused integration test that counts `INSERT` or `UPDATE` statements for one observed delta.
+
+24. APPROVAL POINT: Acceptance criteria 1, 5, and 6 are strong and falsifiable.
+
+    Citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:189-201`
+
+    Brief claim: compare `GET /stats/data` before and after field by field, keep all seven solution test projects green, and pin migration with a real JSON fixture.
+
+    What the code says today: `StatsPageEndpoint.cs:40-71` maps `/stats/data` from the aggregator outputs. The solution contains seven test projects under `cc-director.sln`: Avalonia, Core, Engine, Gateway, HostedAgent, Launcher, and Terminal.Avalonia tests. These criteria are measurable.
+
+25. APPROVAL POINT: The prompt-log and all-time distinct-session issues explicitly excluded by the owner are correctly preserved in this review.
+
+    Citation: `GatewayPromptLog.cs:26-27`
+
+    What the code says today: prompt-log retention is deliberately unbounded.
+
+    Citation: `GatewayInputStatsAggregator.cs:45-61`
+
+    What the code says today: all-time distinct-session sets are deliberately never pruned.
+
+    Review stance: These are not defects to fix. The SQLite design must preserve their semantics.
+
+Final verdict: CHANGES REQUIRED.

--- a/docs/architecture/gateway-sqlite-review-codex-final-2026-07-15.md
+++ b/docs/architecture/gateway-sqlite-review-codex-final-2026-07-15.md
@@ -1,0 +1,48 @@
+# Codex Final Review - Gateway SQLite Branch
+
+Date: 2026-07-15
+Reviewer: Codex
+Scope: full diff of `feat/gateway-sqlite` against `origin/main` as reviewed from branch head `230185ef`.
+
+## Verdict
+
+CHANGES REQUIRED for merging this branch as-is.
+
+The test storage-root redirect should land. The unused Gateway SQLite database foundation should not land on `main` until the production fold actually calls it.
+
+## Findings
+
+1. **Blocking - `GatewayStatsDatabase` is dead production code on this branch.**
+
+   Evidence: `rg -n "GatewayStatsDatabase" src -g "*.cs"` finds production references only inside `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs`; every construction is in `src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs`. `GatewayInputStatsAggregator` still has zero references to the database and still writes `gateway-input-stats.json`.
+
+   This is not a harmless foundation under this repo's dead-code rule. Merging it would add a new production class, a direct `Microsoft.Data.Sqlite` package reference in `src/CcDirector.Gateway/CcDirector.Gateway.csproj`, and a detailed schema contract that no shipped code exercises. The branch's highest-risk behavior - the #1647 fold/back-fill and separate agent-driven lane - is precisely the part not built, so the schema tests only prove a disconnected table shape.
+
+   Required fix: do not merge `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs`, `src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs`, or the Gateway `Microsoft.Data.Sqlite` package reference until the fold is wired and the product has a caller. Keep that work on the phase branch, or merge it together with the first production caller and caller-level tests.
+
+2. **Blocking - stale design/review records in the branch would put deleted plans on `main` without a clear supersession boundary.**
+
+   The current mission brief does record the owner ruling near the top: delete the import, legacy reader, parity check, baseline tables, `AgentsSeeded`-null rule, and old `HighWater` import. But the branch also adds review records and manager-plan text that approve or describe the now-deleted import/baseline/legacy-reader path. The clearest example is `docs/architecture/gateway-sqlite-review-codex-phase1-legacy-store-2026-07-15.md`, whose scope names `GatewayInputStatsLegacyStore.cs`; that file is not in the final diff.
+
+   Historical review artifacts are useful inside the mission, but on `main` this reads as contradictory architecture: one file says the legacy reader was approved, another says it was deleted outright, and the product code contains neither the reader nor the fold. Required fix: either exclude the superseded review/plan documents from the main merge, or mark them explicitly as superseded at the top of each affected file. At minimum, the legacy-store review must not land as an unqualified approval for a file that no longer exists.
+
+## ModuleInitializer
+
+`src/CcDirector.Gateway.Tests/TestStorageRootRedirect.cs` should land independently.
+
+The hazard it fixes is real and not specific to the abandoned SQLite import: many Gateway tests resolve default stores through `CcStorage.Root()`, and without an assembly-level redirect those writes can hit the owner's live `%LOCALAPPDATA%\cc-director` state. The initializer runs before test bodies, unconditionally points `CC_DIRECTOR_ROOT` at a temp directory, and has a guard test proving the redirect is active. The filtered test run for `GatewayStatsDatabaseTests|TestStorageRootRedirectTests` passed all 12 tests.
+
+One caveat: this does not make process-wide `CC_DIRECTOR_ROOT` mutation generally race-free; many existing tests still temporarily change the environment variable. It does, however, change the default and restored value from the owner's live root to a disposable temp root, which is the important live-data protection.
+
+## Verification
+
+- Reviewed `git diff --stat origin/main...HEAD` and `git diff --name-status origin/main...HEAD`.
+- Confirmed the database has no production caller with `rg -n "GatewayStatsDatabase" src -g "*.cs"`.
+- Ran `dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --no-restore --filter "FullyQualifiedName~GatewayStatsDatabaseTests|FullyQualifiedName~TestStorageRootRedirectTests"`: passed, 12 tests.
+- Ran `dotnet build src/CcDirector.Gateway/CcDirector.Gateway.csproj --no-restore`: passed.
+
+## Merge Recommendation
+
+Split this branch.
+
+Merge the test storage-root redirect and its tests now. Do not merge the unused SQLite database class, its package reference, or disconnected schema tests until the aggregator fold is implemented against it. Clean or supersede the architecture records before main so the branch does not leave deleted import/baseline machinery looking approved.

--- a/docs/architecture/gateway-sqlite-review-codex-fold-2026-07-15.md
+++ b/docs/architecture/gateway-sqlite-review-codex-fold-2026-07-15.md
@@ -1,0 +1,52 @@
+# Codex Review - SQLite Fold Final
+
+Date: 2026-07-15
+Reviewer: Codex
+Scope: blocking-only review of `fold-final.diff` and current worktree, focused on #1647 fold fidelity, aggregate isolation, and mirror/commit ordering.
+
+## Verdict
+
+APPROVED.
+
+## Blocking Findings
+
+None.
+
+## Blocking Checks
+
+1. #1647 fold fidelity holds.
+
+- `FoldAgentDrivenLocked` is called before the empty-buckets guard, so sessions driven only by other agents are still counted.
+- Agent back-fill reads `_highWater` before the loop records the new bucket high-water, and `agents_seeded` is persisted/reloaded to stop restart double-counting.
+- `VoiceMode` is read once into `wingman` and written to `stat_delta.wingman`; wingman usage is not derived from modality.
+- Human agent attribution and agent-driven attribution share agent identity/session membership but write separate delta lanes.
+
+2. Human aggregates cannot accidentally include agent-driven rows.
+
+- Human totals, hourly, wingman turns, and repo totals read from `stat_delta`.
+- Human agent totals read from `agent_delta`.
+- Agent-driven totals read only from `agent_driven_delta`.
+- `agent_driven_delta` is a separate table, so the human queries cannot include it by forgetting a filter.
+
+3. Archive rows are handled deliberately, not accidentally.
+
+- All-time totals, repo totals, and wingman turns include archive rows by reading `stat_delta` without excluding `ARCHIVE`.
+- Hourly working-day series excludes `ARCHIVE` explicitly.
+- Agent and agent-driven tables are not pruned and have no archive lane.
+
+4. The mirror is not advanced before commit.
+
+- `FoldBatch` collects intended writes first.
+- `CommitLocked` writes inside one SQLite transaction and calls `tx.Commit()` before updating `_agentsSinceUtc`, identity maps, high-water maps, `agents_seeded`, wingman sessions, and identity-session sets.
+- If a statement fails before commit, transaction disposal rolls back and the mirror remains unchanged, so the next poll can retry instead of silently losing a delta.
+
+## Non-Blocking Note
+
+`FoldAgentDrivenLocked` queues an `agent_driven_highwater` upsert for repeated nonzero snapshots even when the delta is zero. That can cost an unnecessary write on an otherwise idle agent-driven poll, but it does not change totals, include the wrong lane, or advance the mirror before a commit. I would not hold the owner's stats landing on this.
+
+## Verification
+
+- Inspected `GatewayInputStatsAggregator.cs` fold, commit, query, prune, and mirror-load paths.
+- Inspected `GatewayStatsDatabase.cs` schema changes: `stat_delta` has no `agent_id`, `agent_delta` and `agent_driven_delta` are separate.
+- Ran `dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --no-restore --filter "FullyQualifiedName~GatewayInputStatsAggregatorTests|FullyQualifiedName~GatewayStatsDatabaseTests|FullyQualifiedName~StatsPageEndpointTests"`: passed, 42 tests.
+- Ran `dotnet build src/CcDirector.Gateway/CcDirector.Gateway.csproj --no-restore`: passed.

--- a/docs/architecture/gateway-sqlite-review-codex-phase1-legacy-store-2026-07-15.md
+++ b/docs/architecture/gateway-sqlite-review-codex-phase1-legacy-store-2026-07-15.md
@@ -1,0 +1,36 @@
+# Codex Review - Phase 1 Legacy Store Reader
+
+Date: 2026-07-15
+Reviewer: Codex
+Scope: `src/CcDirector.Gateway/Stats/GatewayInputStatsLegacyStore.cs`, with spot checks against `GatewayInputStatsAggregator.Load`, `GatewayStatsDatabase`'s `agents_seeded` home, and the Phase 1 mission text.
+
+## Verdict
+
+APPROVED.
+
+## Findings
+
+No blocking findings.
+
+## Review Notes
+
+The legacy reader's `Load` path matches the current JSON aggregator's post-deserialization semantics for the sections that matter to import parity:
+
+- `Totals`, `HighWater`, `Hourly`, `WingmanTurns`, `WingmanSessions`, `Repos`, `Agents`, `AgentsSinceUtc`, `AgentDrivenTurns`, `AgentDrivenCharacters`, and `AgentDrivenHighWater` are read into the same in-memory shapes.
+- The issue #1633 branch is preserved: when `AgentsSeeded` is absent/null, the already-read `_agents` tally is cleared; when `AgentsSeeded` is present, the stored tally is retained and the seed set is populated.
+- The deliberate quarantine deviation is correctly constrained to unreadable JSON/null documents: the aggregator's `Quarantine(...)` calls are replaced with loud `InvalidOperationException`s that leave the legacy JSON in place. There is no `Quarantine`, `File.Move`, `File.Replace`, or `Save` path in `GatewayInputStatsLegacyStore`.
+
+On the Architect's `AgentsSeeded` schema question: I do not see a post-`Load` consumer that needs the raw absent-versus-empty key. The distinction is consumed inside `Load` itself:
+
+- Raw `AgentsSeeded: null` resolves to `_agents.Clear()` plus an empty `_agentsSeeded`.
+- Raw `AgentsSeeded: []` resolves to the stored `_agents` tally being kept plus an empty `_agentsSeeded`.
+
+Those outcomes remain distinguishable through the resolved `Agents`/`AgentsSeeded` state that the importer will consume, without encoding raw null-vs-empty in SQLite. The existing `agents_seeded(session_id TEXT PRIMARY KEY)` membership table is therefore sufficient for the post-`Load` state, assuming the importer continues to use `GatewayInputStatsLegacyStore` rather than reparsing the JSON document directly.
+
+## Verification
+
+- Inspected `GatewayInputStatsAggregator.Load` lines 605-689 and `GatewayInputStatsLegacyStore.Load` lines 96-180.
+- Confirmed `GatewayInputStatsAggregator.Save` writes `AgentsSeeded` unconditionally, so raw null is a one-time legacy upgrade state.
+- Confirmed no quarantine/write path remains in `GatewayInputStatsLegacyStore` with `rg -n "Quarantine|File\.Move|File\.Replace|Save\(|Unreadable|corrupt"`.
+- Ran `dotnet build src/CcDirector.Gateway/CcDirector.Gateway.csproj --no-restore`: passed.
+- Attempted `dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --no-restore`; the command timed out after 124 seconds, so no full test result is available from this review pass.

--- a/docs/architecture/gateway-sqlite-review-codex-phase1-plan-2026-07-15.md
+++ b/docs/architecture/gateway-sqlite-review-codex-phase1-plan-2026-07-15.md
@@ -1,0 +1,93 @@
+# Codex Review: Phase 1 Manager Plan
+
+Reviewed 2026-07-15 by the Codex reviewer session for the mission "SQLite on the Gateway".
+
+Reviewed plan: `docs/architecture/gateway-sqlite-phase1-manager-plan.md`.
+
+Repository state observed during review: `624948698da8fb61fb0f284b184564bd1af9ee1c`.
+
+Verdict: APPROVED, with the implementation guardrails below.
+
+## Findings
+
+1. APPROVAL POINT: Finding 1 is real. `HighWater` must be imported.
+
+   Plan claim: Decision 5 imports baseline totals, hourly buckets, repository tallies, agent tallies, wingman turns, and distinct-session tables, but does not explicitly import the existing `HighWater` map into `session_highwater`.
+
+   Code check: `GatewayInputStatsAggregator.cs:448-457` persists eight logical sections: `Totals`, `HighWater`, `Hourly`, `WingmanTurns`, `WingmanSessions`, `Repos`, `Agents`, and `AgentsSinceUtc`. `GatewayInputStatsAggregator.cs:507-533` restores all of them today. `GatewayInputStatsAggregator.cs:336-354` uses high-water state to convert repeated roster observations into only the increase, and `GatewayInputStatsAggregator.cs:422` updates that high-water state.
+
+   Review result: approved. If `session_highwater` starts empty after importing baselines, the first post-cutover `GET /sessions` can refold every live session's whole current tally on top of the baseline. `/stats/data` cannot catch this at import time because `StatsPageEndpoint.cs:40-71` does not expose high-water. The plan is right to import `HighWater`.
+
+2. APPROVAL POINT: The idempotent re-observe leg belongs in the import tests.
+
+   Plan proposal: after import, re-observe the same roster and prove every all-time number is unchanged; prove the test fails when high-water import is removed.
+
+   Review result: approved. This is the right test because it exercises the invariant high-water exists to protect. The production import should still be driven by the stored `HighWater` section, not by assuming the live roster can always be reconstructed from `/stats/data`. In tests, a controlled fixture can create the JSON store by observing a roster, import it, and re-observe that same roster.
+
+3. APPROVAL POINT: Importing all eight `StoreFile` sections is the correct Phase 1 rule.
+
+   Plan proposal: import all eight sections, including `HighWater` into `session_highwater` and `AgentsSinceUtc` into a baseline scalar.
+
+   Review result: approved. This is a faithful elaboration of the brief, not a deviation. The brief's core rule is parity plus no synthetic historical rows. Importing `HighWater` preserves idempotency; it does not synthesize history.
+
+4. APPROVAL POINT: Finding 2 is real. SQLite default grouping does not match the current .NET dictionaries.
+
+   Plan claim: `_repos` and `_agents` are case-insensitive dictionaries, while SQLite default text grouping is case-sensitive. `_totals` is case-sensitive. The voice split is case-insensitive.
+
+   Code check: `GatewayInputStatsAggregator.cs:55` creates `_repos` with `StringComparer.OrdinalIgnoreCase`. `GatewayInputStatsAggregator.cs:61` creates `_agents` with `StringComparer.OrdinalIgnoreCase`. `GatewayInputStatsAggregator.cs:32` creates `_totals` with the default tuple comparer. `GatewayInputStatsAggregator.cs:366` computes `isVoice` with `StringComparison.OrdinalIgnoreCase`.
+
+   Review result: approved. A plain SQL `GROUP BY repo` or `GROUP BY agent` would be a semantic change. The live store having no current case collisions does not make the design safe.
+
+5. APPROVAL POINT WITH GUARDRAIL: `repo_folded` and `agent_folded` plus identity tables are a faithful elaboration only if the C# comparer semantics are exact.
+
+   Plan proposal: use folded grouping keys plus first-seen display identity tables, matching a .NET `Dictionary<string, ...>(StringComparer.OrdinalIgnoreCase)`.
+
+   Review result: approved as an elaboration of the brief's `repo` and `agent` dimensions, not a deviation. The intent is exactly right: preserve current grouping and current display spelling.
+
+   Guardrail: do not implement this as casual `ToLowerInvariant`, `ToUpperInvariant`, SQLite `NOCASE`, or any SQL-side collation that is only approximately `StringComparer.OrdinalIgnoreCase`. The implementation must resolve identities through C# using `StringComparer.OrdinalIgnoreCase`, or an equivalently exact mechanism. Tests must include case-variant repository and agent keys and prove first-seen display spelling wins.
+
+6. APPROVAL POINT: `is_voice` is a faithful and useful elaboration.
+
+   Plan proposal: store `is_voice` computed in C# from the same case-insensitive test at `GatewayInputStatsAggregator.cs:366`.
+
+   Review result: approved. It preserves the current asymmetry: totals by modality remain case-sensitive, while hourly, repository, and agent voice-versus-typed splits use a case-insensitive voice test. The explicit column also prevents future SQL collation drift.
+
+7. APPROVAL POINT WITH CLARIFICATION: The bounded statement-count tests must account for multiple changed buckets.
+
+   Plan claim: a changed fold issues the bounded write mix.
+
+   Review result: approved, but the tests should be precise. A "single delta" test can assert one `stat_delta` insert and one high-water upsert only when exactly one `(modality, surface)` bucket changes. A session observation with multiple changed buckets legitimately produces one delta row and one high-water upsert per changed bucket. The invariant to pin is "bounded by changed buckets and distinct-id first sightings, not by stored history size."
+
+8. APPROVAL POINT: Finding 3 is not fallback programming.
+
+   Plan proposal: keep an in-memory write-through mirror of operational state, loaded from SQLite once and written through on changes, while aggregate reads come from SQLite queries.
+
+   Review result: approved. This is not fallback programming as long as SQLite remains the single durable source of truth, database open/import failures remain loud failures, and there is no JSON fallback path after import. It is the right way to keep unchanged `GET /sessions` roster polls at zero database writes.
+
+9. CLARIFICATION: Do not call all mirrored operational state bounded.
+
+   Plan text describes the mirrored operational state as bounded, including distinct-id sets.
+
+   Code check: `GatewayInputStatsAggregator.cs:45-61` documents all-time distinct sets that are deliberately never pruned. The approved brief also preserves those never-pruned semantics.
+
+   Review result: not a blocker because the plan later says distinct sets are deliberately never pruned, but the implementation must not treat wingman, repository, or agent distinct-id sets as bounded or prunable. The bounded claim applies to per-fold work, not to the lifetime cardinality of all-time distinct identifiers.
+
+10. APPROVAL POINT: The schema respects the "no synthetic historical rows" rule.
+
+    Plan proposal: post-cutover data goes to `stat_delta`; historical data goes to baseline tables and distinct-id tables; no historical `stat_delta` rows are synthesized.
+
+    Review result: approved. This preserves the core design approved in the brief.
+
+11. APPROVAL POINT: The plan correctly keeps the model dimension out.
+
+    Plan schema has no model column.
+
+    Review result: approved. The approved brief records that `SessionDto` on `origin/main` has no model field for the Gateway to fold. Adding model now would create an unpopulated statistics dimension and would be a defect.
+
+12. APPROVAL POINT: The seven semantic tests listed in the plan are the right tests.
+
+    Plan list includes: typed turn under voice mode is a wingman turn; voice-mode session with no input still counts as a wingman session; repository and agent session ids are recorded only on real deltas; counter reset folds current count as fresh activity; zero-turn non-zero-character deltas fold; `AgentsSinceUtc` stamps once; unknown or empty agent tokens are preserved correctly.
+
+    Review result: approved. These are exactly the edge cases likely to change silently during the port.
+
+Final verdict: APPROVED.

--- a/docs/architecture/gateway-sqlite-review-codex-phase1-step3-2026-07-15.md
+++ b/docs/architecture/gateway-sqlite-review-codex-phase1-step3-2026-07-15.md
@@ -1,0 +1,94 @@
+# Codex Review: Phase 1 Step 3 Database Helper And Schema
+
+Reviewed 2026-07-15 by the Codex reviewer session for the mission "SQLite on the Gateway".
+
+Reviewed changes:
+
+- `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs`
+- `src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs`
+- `src/CcDirector.Gateway/CcDirector.Gateway.csproj`
+
+Repository state observed during review: `6327fcd7eb781297b0fcf921495d7a19cae812a7`.
+
+Verdict: APPROVED.
+
+## Findings
+
+1. APPROVAL POINT: The schema matches the approved Phase 1 shape.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:157-170`
+
+   Review result: approved. `stat_delta` includes `hour_utc`, `session_id`, `modality`, `surface`, `is_voice`, `repo_folded`, `agent_folded`, `wingman`, `turns`, and `chars`. This preserves the approved revision 6 requirements: no synthetic historical rows, explicit voice split, folded repository and agent grouping keys, and wingman attribution independent of modality.
+
+2. APPROVAL POINT: `repo_folded` and `agent_folded` are protective names, not a deviation.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:143-147`, `:164-166`, `:205-218`, `:233-258`
+
+   Review result: approved. The approved brief used `repo` and `agent` as conceptual dimensions, but the Phase 1 plan correctly found that the persisted grouping keys must match `StringComparer.OrdinalIgnoreCase` semantics from `GatewayInputStatsAggregator.cs:55` and `:61`. Naming the stored keys `repo_folded` and `agent_folded` prevents a later reader from displaying folded keys as user-facing repository or agent names. The identity tables are the right place for first-seen display spelling.
+
+3. APPROVAL POINT: `is_voice` is present and correctly documented.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:149-151`, `:164`
+
+   Review result: approved. This preserves the current asymmetry: totals by modality are case-sensitive, while the voice split used by hourly, repository, and agent tallies follows the case-insensitive check at `GatewayInputStatsAggregator.cs:366`. This avoids SQL collation drift.
+
+4. APPROVAL POINT: `wingman` is present and correctly documented.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:153-156`, `:167`
+
+   Review result: approved. The code records that wingman means `SessionDto.VoiceMode` at fold time, not `modality = voice`. This preserves the behavior at `GatewayInputStatsAggregator.cs:425-427`, where the whole session turn delta counts as wingman turns when voice mode is on.
+
+5. APPROVAL POINT: Baseline tables do not synthesize history.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:133-141`, `:187-224`
+
+   Review result: approved. Historical data has baseline projection tables, and post-cutover data has rows. This follows the approved design and does not attempt to reconstruct a historical cross-product that the JSON store never persisted.
+
+6. APPROVAL POINT: The all-time distinct-id tables are modeled separately from `stat_delta`.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:226-244`
+
+   Review result: approved. `wingman_session`, `repo_session`, and `agent_session` preserve the never-pruned distinct set semantics documented at `GatewayInputStatsAggregator.cs:45-61`. They are not derived from `COUNT(DISTINCT session_id)` over prunable delta rows.
+
+7. APPROVAL POINT: Archive marker rules are captured at the database layer.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:40-47`
+
+   Review result: approved. The helper exposes the marker and documents the required query rule: all-time aggregates include archive rows, while hourly and working-day queries exclude the marker.
+
+8. APPROVAL POINT: The migration version guard is correct.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:99-127`
+
+   Review result: approved. Older files migrate forward; files from newer builds throw rather than being opened by an older binary. `GatewayStatsDatabaseTests.Open_FileFromNewerBuild_FailsLoudlyRatherThanDowngrading` pins the guard.
+
+9. APPROVAL POINT: The migration transaction claim is acceptable.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:117-125`
+
+   Review result: approved. I specifically checked whether schema commands executed on the same open SQLite connection, without assigning `cmd.Transaction`, still roll back under the surrounding connection transaction. They do. A temporary probe created a table inside a transaction, rolled back, and the table count was zero. Passing the transaction into every schema helper call would make the intent more obvious, but this implementation is not a blocker.
+
+10. APPROVAL POINT: Fail-loud open paths name the database and reject JSON fallback.
+
+    Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:86-95`
+
+    Review result: approved. Open failure logs and throws with the database path and says the Gateway will not fall back to old JSON stores. `GatewayStatsDatabaseTests.Open_UnusableFile_FailsLoudlyAndNamesThePath` pins this.
+
+11. APPROVAL POINT: The Gateway package reference is correct.
+
+    Code citation: `src/CcDirector.Gateway/CcDirector.Gateway.csproj`
+
+    Review result: approved. `Microsoft.Data.Sqlite` is now an explicit Gateway dependency at version 9.0.2, matching Core. `dotnet restore src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj` completed without downgrade warnings.
+
+12. APPROVAL POINT: Test coverage is appropriate for this foundation step.
+
+    Code citation: `src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs`
+
+    Review result: approved. The tests cover new file creation, schema tables, reopen without data loss, newer-build rejection, write-ahead logging, archive marker parse safety, and fail-loud unusable-file behavior. Fold, import, parity, pruning, and statement-count tests correctly remain for later Phase 1 steps because this diff intentionally has no fold, import, or prune code yet.
+
+## Verification
+
+- `dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter GatewayStatsDatabaseTests --no-restore`
+- `dotnet restore src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj`
+
+Final verdict: APPROVED.

--- a/docs/architecture/gateway-sqlite-review-codex-phase1-step3-gate-2026-07-15.md
+++ b/docs/architecture/gateway-sqlite-review-codex-phase1-step3-gate-2026-07-15.md
@@ -1,0 +1,55 @@
+# Codex Review: Phase 1 Step 3 Final Gate
+
+Reviewed 2026-07-15 by the Codex reviewer session for the mission "SQLite on the Gateway".
+
+Reviewed changes:
+
+- `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs`
+- `src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs`
+- `src/CcDirector.Gateway/CcDirector.Gateway.csproj`
+
+Repository state observed during review: `40d0ec60db0d80fbc1fc16455c7d186e7a3e4b06`.
+
+Verdict: APPROVED.
+
+## Findings
+
+1. APPROVAL POINT: The test weakness from the revision 7 review is fixed.
+
+   Code citation: `src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs:134-182`
+
+   Review result: approved. `StatDelta_CarriesSurrogateIds_AndNoRepositoryOrAgentStringInAnyForm` now uses an exhaustive whitelist for the complete `stat_delta` column set:
+
+   ```
+   id, hour_utc, session_id, modality, surface, is_voice, repo_id, agent_id, wingman, turns, chars
+   ```
+
+   This correctly fails if any extra repository or agent string column is added, including names like `repo_raw`, `repo_text`, or `repository`.
+
+2. APPROVAL POINT: The surrogate-id schema remains sound.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:173-186`, `:221-234`, `:249-260`, `:279-305`
+
+   Review result: approved. The row and aggregate tables use `repo_id` and `agent_id`, not raw or folded strings. `repo_identity` and `agent_identity` store display strings only, with no uniqueness or grouping semantics delegated to SQLite.
+
+3. ANSWER TO MANAGER QUESTION: I still see no remaining schema path by which SQLite is asked to compare a repository or agent string.
+
+   The only repository and agent strings are `repo_identity.repo_display` and `agent_identity.agent_display`. They are display values, not keys in `stat_delta`, `baseline_repo`, `baseline_agent`, `repo_session`, or `agent_session`. Later implementation must keep semantic equality, membership, grouping, distinctness, and display ordering out of SQL for these strings, as recorded in the guardrail.
+
+4. APPROVAL POINT: Migration transaction threading remains correct.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:119-125`, `:137-317`
+
+   Review result: approved. Every schema statement is explicitly executed with the migration transaction.
+
+5. APPROVAL POINT: Focused tests pass.
+
+   Verification run:
+
+   ```
+   dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter GatewayStatsDatabaseTests --no-restore
+   ```
+
+   Result: 9 passed.
+
+Final verdict: APPROVED.

--- a/docs/architecture/gateway-sqlite-review-codex-phase1-step3-rev7-2026-07-15.md
+++ b/docs/architecture/gateway-sqlite-review-codex-phase1-step3-rev7-2026-07-15.md
@@ -1,0 +1,67 @@
+# Codex Review: Phase 1 Step 3 Revision 7
+
+Reviewed 2026-07-15 by the Codex reviewer session for the mission "SQLite on the Gateway".
+
+Reviewed changes:
+
+- `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs`
+- `src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs`
+- `src/CcDirector.Gateway/CcDirector.Gateway.csproj`
+
+Repository state observed during review: `7cf9f67152d5e2815d2f21192d4bc557f1e09ecd`.
+
+Verdict: CHANGES REQUIRED.
+
+## Findings
+
+1. DEFECT: The new shape test does not actually pin "no repository or agent string in any form".
+
+   Code citation: `src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs:134-168`
+
+   Test claim: `StatDelta_CarriesSurrogateIds_AndNoRepositoryOrAgentStringInAnyForm` pins that `stat_delta` cannot hold repository or agent strings.
+
+   What the test actually checks: it asserts that `repo_id` and `agent_id` are integers, that there is no exact column named `repo`, no exact column named `agent`, and no exact columns named `repo_folded` or `agent_folded`.
+
+   Why this is not enough: `Assert.DoesNotContain("repo", columns.Keys.Where(k => k != "repo_id"))` checks for an exact element named `repo`; it does not reject `repo_raw`, `repo_text`, `repository`, `repo_display`, or any other repository string column. Same issue for `agent`. The schema currently has the right shape, but the test does not enforce the invariant it says it enforces.
+
+   Required fix: make the assertion reject any non-identifier column whose name contains `repo`, `repository`, or `agent`, or otherwise explicitly whitelist the full expected `stat_delta` column set. A whitelist is preferable here because the schema shape is the thing being pinned:
+
+   ```
+   id, hour_utc, session_id, modality, surface, is_voice, repo_id, agent_id, wingman, turns, chars
+   ```
+
+2. APPROVAL POINT: The surrogate-id schema fixes the comparer problem.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:157-170`, `:205-218`, `:233-258`, `:249-317`
+
+   Review result: approved. `stat_delta`, `baseline_repo`, `baseline_agent`, `repo_session`, and `agent_session` now key by integer identifiers. `repo_identity` and `agent_identity` hold display strings but deliberately do not enforce uniqueness or grouping over those strings. That removes the impossible requirement to normalize strings exactly like `StringComparer.OrdinalIgnoreCase`.
+
+3. ANSWER TO MANAGER QUESTION: I see no remaining schema path that requires SQLite to compare repository or agent strings for correctness.
+
+   The only repository and agent strings in this schema are `repo_identity.repo_display` and `agent_identity.agent_display`. They are not unique, not primary keys, not foreign keys, and not used by `stat_delta` or baseline grouping. SQLite can store and retrieve them as display bytes. Equality and membership must be decided by the in-memory `Dictionary<string, long>` using `StringComparer.OrdinalIgnoreCase`, as the brief now states.
+
+   Guardrail for later implementation: do not introduce queries that `WHERE`, `GROUP BY`, `ORDER BY`, or `DISTINCT` over `repo_display` or `agent_display` for semantic decisions. Sorting for display should also stay in C# if it needs to match current .NET ordering.
+
+4. APPROVAL POINT: Explicit transaction threading is correct.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:119-125`, `:131-317`
+
+   Review result: approved. `MigrateToVersion1` now accepts `SqliteTransaction tx`, and every schema statement is explicitly executed with that transaction. This makes the migration atomicity visible at each call site.
+
+5. APPROVAL POINT: The schema still preserves the prior approved columns.
+
+   Code citation: `src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs:157-170`
+
+   Review result: approved. `is_voice` and `wingman` are still present. Historical data is still represented by baseline tables, not synthetic `stat_delta` rows. Archive marker handling remains documented at `GatewayStatsDatabase.cs:40-47`.
+
+6. APPROVAL POINT: Focused tests pass.
+
+   Verification run:
+
+   ```
+   dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter GatewayStatsDatabaseTests --no-restore
+   ```
+
+   Result: 9 passed.
+
+Final verdict: CHANGES REQUIRED.

--- a/docs/architecture/gateway-sqlite-review-codex-round2-2026-07-15.md
+++ b/docs/architecture/gateway-sqlite-review-codex-round2-2026-07-15.md
@@ -1,0 +1,129 @@
+# Codex Review Round 2: Gateway SQLite Mission Brief
+
+Reviewed 2026-07-15 by the Codex reviewer session for the mission "SQLite on the Gateway".
+
+Reviewed revision: `797707d7173058d5a0d8720569515725e0e7c69a`.
+
+Verdict: CHANGES REQUIRED.
+
+## Findings
+
+1. DEFECT: The revised `stat_delta` schema still does not preserve wingman-turn semantics.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:208`
+
+   Brief claim: post-cutover rows have this shape:
+
+   ```
+   stat_delta(hour_utc, session_id, modality, surface, repo, agent, turns, chars)
+   ```
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:247-250`
+
+   Brief claim: archive rows preserve all grouping dimensions, "plus wingman-turn attribution for as long as that stays derived from rows"; concretely, an archive row is a `stat_delta` row with only `hour_utc` and `session_id` replaced by archive markers.
+
+   What the code actually says: wingman turns are not the same as `modality = voice`. `GatewayInputStatsAggregator.cs:425-427` increments `_wingmanTurns` for every submitted turn folded while `s.VoiceMode` is true. The turns being folded are accumulated at `GatewayInputStatsAggregator.cs:342-382` from all input buckets, and those buckets only know modality and surface. Therefore a typed turn submitted while a session has voice mode on counts as a wingman turn today.
+
+   Why this matters: the proposed row does not carry `s.VoiceMode` at observation time, a wingman flag, or a wingman-turn count. Once only rows exist, the system cannot derive post-cutover wingman turns exactly. Once old rows are archived with `session_id` replaced, it also cannot recover wingman attribution from any live session table.
+
+   Required fix: add explicit wingman-turn attribution to the durable design. Acceptable shapes include a `wingman_turns` column on `stat_delta`, a boolean `wingman` flag on each delta row, or a separate wingman delta table. The archive design must preserve that field. The baseline import already calls out baseline wingman turns; the future rows need the same care.
+
+2. DEFECT: The "one row write" claim is no longer true under the revised design.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:63`
+
+   Brief claim: a counter move becomes one row write instead of a rewrite of the file.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:332-335`
+
+   Brief claim: acceptance criterion 3 demonstrates this by observing a single delta and asserting the exact count of `INSERT` and `UPDATE` statements.
+
+   What the code actually requires: the current implementation persists both the delta totals and the high-water state so repeated roster reads and restarts do not double-count. `GatewayInputStatsAggregator.cs:336-354` compares each reported bucket to high-water state, and `GatewayInputStatsAggregator.cs:422` updates that high-water state. The revised brief correctly moves this to `session_highwater` at `docs/architecture/gateway-sqlite-mission-2026-07-15.md:233-238`. The revised brief also correctly adds never-pruned distinct-id tables at `docs/architecture/gateway-sqlite-mission-2026-07-15.md:224-229`.
+
+   Why this matters: a correct post-cutover fold normally needs at least one insert into `stat_delta` and one upsert into `session_highwater`. It may also need `INSERT OR IGNORE` statements into distinct-id tables for repository, agent, or wingman-session identity. That is still a major improvement over rewriting the whole JSON document, but it is not "one row write".
+
+   Required fix: change the design and acceptance wording to "one delta row plus bounded operational bookkeeping" or similar. Acceptance criterion 3 should assert the expected statement mix for the real schema, not force the implementation into an impossible one-write promise.
+
+3. DEFECT: The archive marker needs an explicit query rule so archived rows do not pollute the working-day series.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:214`
+
+   Brief claim: the working-day series is baseline hourly buckets plus `GROUP BY hour_utc` for recent hours.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:248-250`
+
+   Brief claim: pruning collapses the hour and stores archive rows with `hour_utc` replaced by an archive marker.
+
+   What the code actually says today: `GatewayInputStatsAggregator.cs:185-203` returns hourly buckets as an hour series, and `GatewayInputStatsAggregator.cs:310-315` prunes old hourly buckets rather than turning them into an all-time bucket.
+
+   Why this matters: if archive rows live in `stat_delta`, a plain `GROUP BY hour_utc` can produce a fake archive bucket unless every hourly query explicitly excludes archive markers. That is probably intended, but the brief should say it because criterion 7 depends on pruning being provably safe.
+
+   Required fix: state that all time aggregate queries include archive rows, but hourly or working-day queries filter to real hour keys and exclude archive markers.
+
+4. APPROVAL POINT: The baseline import design is now the right answer.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:146-186`
+
+   Brief claim: historical input data imports as baseline projections, not synthetic `stat_delta` rows, because the existing JSON cannot reconstruct the full row tuple.
+
+   What the code actually says: `GatewayInputStatsAggregator.cs:448-457` stores independent projections: totals, high-water, hourly, wingman turns, wingman sessions, repository tallies, agent tallies, and `AgentsSinceUtc`. `GatewayInputStatsAggregator.cs:460-481` defines the projection shapes. Those persisted shapes cannot recover which hour went with which repository and agent for historical turns.
+
+   Review result: approved. This directly fixes the main round one defect. The `_agentsSinceUtc` precedent cited at `GatewayInputStatsAggregator.cs:63-66` is the right model: be honest about what starts at cutover instead of inventing history.
+
+5. APPROVAL POINT: The fail-loud import sequence is now strong enough.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:263-276`
+
+   Brief claim: import happens in one transaction with an import marker and `PRAGMA user_version`; every affected endpoint field is read back from SQLite and compared to JSON output; the JSON file is renamed aside only after a complete match; mismatches fail loudly and leave JSON as source of truth.
+
+   Review result: approved. This fixes the round one data-loss risk. It is specific enough for implementation and test review.
+
+6. APPROVAL POINT: Distinct counts are now modeled correctly.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:224-229`
+
+   Brief claim: all-time distinct counts do not come from `COUNT(DISTINCT session_id)` over `stat_delta`; they use narrow never-pruned identifier tables seeded from the existing lists and extended with `INSERT OR IGNORE`.
+
+   What the code actually says: `GatewayInputStatsAggregator.cs:45-49`, `GatewayInputStatsAggregator.cs:51-55`, and `GatewayInputStatsAggregator.cs:57-61` define all-time session sets for wingman, repositories, and agents. The revised design preserves that semantic.
+
+   Review result: approved.
+
+7. APPROVAL POINT: The citation fixes from round one are correct.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:36-45`
+
+   Brief claim: the concurrency load path is `GatewaySessionConcurrencyStats.cs:205-227`, quarantine is `:249-254`, and silent default-filling is a separate worse failure mode.
+
+   What the code actually says: `GatewaySessionConcurrencyStats.cs:205-227` starts empty on missing, null, or JSON parse failure; `GatewaySessionConcurrencyStats.cs:249-254` renames corrupt files. The claim now resolves.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:100-108`
+
+   Brief claim: `voice-sessions.json` is a flat string array loaded at `WingmanVoiceService.cs:113-122` and saved with direct `File.WriteAllText` at `:125-128`, with no atomic rename and no quarantine.
+
+   What the code actually says: `WingmanVoiceService.cs:113-128` matches that description. The claim now resolves.
+
+8. APPROVAL POINT: The narrowed scope line is correct.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:134-143`
+
+   Brief claim: a store is in scope only if it is one of the named statistics, diagnostics, scheduler-history, or Car Mode telemetry files and it rewrites a whole document for incremental changes.
+
+   Review result: approved. This fixes the overbroad round one scope line and keeps unrelated operational JSON stores out of the mission.
+
+9. APPROVAL POINT: Phase 1 is properly bounded now.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:288-316`
+
+   Brief claim: Phase 1 proves the input-store design, baseline import discipline, and migration mechanism, but does not prove concurrency-peak restoration or Phase 4 store choices.
+
+   Review result: approved.
+
+10. APPROVAL POINT: The revised acceptance criteria are mostly falsifiable.
+
+    Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:321-345`
+
+    Brief claim: acceptance requires captured `/stats/data` before and after, screenshots for all three surfaces, a statement-count test, all seven solution test projects, import refusal tests, and prune-safety tests.
+
+    Review result: approved with the exception of finding 2. The statement-count test is a good idea, but the expected count must match the real multi-table design rather than the obsolete "one row write" claim.
+
+Final verdict: CHANGES REQUIRED.

--- a/docs/architecture/gateway-sqlite-review-codex-round3-2026-07-15.md
+++ b/docs/architecture/gateway-sqlite-review-codex-round3-2026-07-15.md
@@ -1,0 +1,105 @@
+# Codex Review Round 3: Gateway SQLite Mission Brief
+
+Reviewed 2026-07-15 by the Codex reviewer session for the mission "SQLite on the Gateway".
+
+Reviewed revision: `c5cb174533efc76c8bb62f6dbd392cfb8c12c9f8`.
+
+Verdict: APPROVED.
+
+## Findings
+
+1. APPROVAL POINT: The wingman-turn defect is fixed.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:209`
+
+   Revised design: `stat_delta` now carries `wingman`:
+
+   ```
+   stat_delta(hour_utc, session_id, modality, surface, repo, agent, wingman, turns, chars)
+   ```
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:212-223`
+
+   Revised design: `wingman` records `SessionDto.VoiceMode` at fold time, not `modality = 'voice'`; wingman turns are `SUM(turns) WHERE wingman = 1`.
+
+   Code check: `GatewayInputStatsAggregator.cs:425-427` increments `_wingmanTurns` for the session's entire turn delta when `s.VoiceMode` is true. The session delta is accumulated at `GatewayInputStatsAggregator.cs:342-382`, across all changed input buckets. This means a typed turn while voice mode is on is a wingman turn today.
+
+   Review result: approved. The revised schema can preserve the current semantics.
+
+2. APPROVAL POINT: The archive design now preserves wingman attribution.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:272-280`
+
+   Revised design: archive rows preserve modality, surface, repository, agent, and the `wingman` flag. Pruning collapses only hour and session identifier.
+
+   Review result: approved. This keeps all-time groupings stable while bounding detailed rows.
+
+3. APPROVAL POINT: The archive-marker query rule is explicit and correct.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:282-295`
+
+   Revised design: all-time aggregates include archive rows; hourly and working-day queries filter to real hour keys and exclude the archive marker.
+
+   Code check: `GatewayInputStatsAggregator.cs:185-203` returns an ordered hour series today. `GatewayInputStatsAggregator.cs:310-315` prunes stale hourly buckets rather than folding them into a catch-all bucket.
+
+   Review result: approved. This prevents the phantom archive bucket problem.
+
+4. APPROVAL POINT: The write-cost claim is now accurate.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:232-237`
+
+   Revised design: a correct post-cutover fold is one insert into `stat_delta`, one upsert into `session_highwater`, and possibly one `INSERT OR IGNORE` per distinct-id table. The claim is bounded work independent of history length, not "one row write".
+
+   Code check: `GatewayInputStatsAggregator.cs:336-354` requires high-water comparison, and `GatewayInputStatsAggregator.cs:422` updates high-water state. The round-two objection is resolved.
+
+   Review result: approved.
+
+5. APPROVAL POINT: Acceptance criterion 3 now tests the real performance claim.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:363-371`
+
+   Revised acceptance: the integration test asserts the real statement mix, asserts no JSON store timestamp changes after import, and pins that the mix is unchanged when historical row volume is large.
+
+   Review result: approved. This is falsifiable and aligned with the schema.
+
+6. APPROVAL POINT: Acceptance criterion 7 now pins both prune-safety legs.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:381-385`
+
+   Revised acceptance: tests must prove all-time answers, including wingman turns and per-repository and per-agent tallies, are identical before and after prune; tests must also prove the working-day series has no phantom archive bucket.
+
+   Review result: approved.
+
+7. APPROVAL POINT: Acceptance criterion 8 pins the subtle wingman case.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:386-391`
+
+   Revised acceptance: a typed turn while voice mode is on must count as a wingman turn, matching `GatewayInputStatsAggregator.cs:425-427`.
+
+   Review result: approved. This is the right regression test for the schema change.
+
+8. APPROVAL POINT: The baseline import design remains sound.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:146-196`
+
+   Revised design: historical input data imports as baseline projections, not synthetic rows, because the existing JSON cannot reconstruct the full row tuple.
+
+   Code check: `GatewayInputStatsAggregator.cs:448-457` persists independent projections, and `GatewayInputStatsAggregator.cs:460-481` defines the projection shapes. The data needed to reconstruct historical cross-dimensional rows does not exist on disk.
+
+   Review result: approved.
+
+9. APPROVAL POINT: The fail-loud import sequence remains sound.
+
+   Brief citation: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:301-314`
+
+   Revised design: import is transactional, stamps the import marker and `PRAGMA user_version`, compares every affected endpoint field back out of SQLite before renaming JSON aside, and fails loudly on mismatch.
+
+   Review result: approved.
+
+10. APPROVAL POINT: The scope, phase boundaries, and constraints remain correct.
+
+    Brief citations: `docs/architecture/gateway-sqlite-mission-2026-07-15.md:134-143`, `:324-349`, `:393-411`
+
+    Review result: approved. Append-only logs remain out of scope, unrelated operational stores remain out of scope, Phase 1 proves only the input-store design and migration mechanism, and reviews are required before commits.
+
+Final verdict: APPROVED.

--- a/docs/architecture/review-governance-screens-2026-07-16.md
+++ b/docs/architecture/review-governance-screens-2026-07-16.md
@@ -1,0 +1,35 @@
+# Review: Governance Screens
+
+## Verdict
+
+No blocking findings. I would land this change.
+
+## Findings
+
+None.
+
+The prior blocking finding is fixed. The new activity and model-spend table rows are built through `trow`, which assigns cell text through `textContent`. The records-derived model name no longer reaches the page through string-concatenated `innerHTML`.
+
+## Review Notes
+
+The local date rollup looks correct for the intended hour-key shape. `localYmd` parses the stored UTC hour key as UTC, then asks `Intl.DateTimeFormat` for the configured display zone's calendar date. The week key is computed from that already-local calendar date, and the Monday calculation handles month and year boundaries through `setDate`.
+
+The page remains self-contained. I did not see any added external resource references, and the existing guard still checks for `http://` and `https://`.
+
+The period toggle state is stable across refreshes. `PERIOD` is module-level state, `load` refreshes `LAST` and rerenders with the current period, and a click rerenders the activity table from `LAST` without refetching. I do not see a path that snaps back to Day after a refresh.
+
+The null-model bucket is not filtered. `renderModelSpend` iterates every row in `tokenSpendByModel`; a null model displays as `Not recorded`, and the share denominator is the sum of all rendered rows. The fix keeps that behavior while making non-null model names inert text.
+
+## Verification
+
+Ran:
+
+```text
+dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter "FullyQualifiedName~StatsPageEndpointTests" --no-restore
+```
+
+Result: passed, 5 tests.
+
+Also checked that the served source contains `function trow(` and `textContent = c.t`, and no longer contains the exact vulnerable `"<td>" + name` concatenation.
+
+Residual test gap: a real browser-level guard for hostile model names and a JavaScript rollup test for local day, Monday week start, and year-boundary weeks would make this harder to regress. I agree that a source tripwire is not behavioral coverage.


### PR DESCRIPTION
The Gateway SQLite mission's code already reached main by another route. #1694
landed the input-statistics fold into SQLite on 2026-07-16, and #1698, #1706,
#1717, #1726, #1733 and #1738 built on top of it. Main's GatewayStatsDatabase.cs
is now 600 lines against the branch's 363, and contains everything the branch
has.

What never left the `feat/gateway-sqlite` branch was the mission's written
record. This carries those sixteen documents onto main unchanged: the brief, the
review rounds, the phase reports, the governance-screens review, and the
handover.

Documents only. No code, no test, no configuration is touched. Replaying the
branch would re-apply an older version of shipped code and resurrect eleven
files main has since deleted, so #1753 is being closed as superseded rather
than rebased.
