### PR TITLE
docs: write the no-attribution law into the repository instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,3 +244,25 @@ When using any cc-* tool, check `docs/cli-reference.md` for exact flags before c
 3. Show UI feedback immediately
 4. Write a test
 5. Read [docs/CodingStyle.md](docs/CodingStyle.md)
+
+## NEVER MENTION CLAUDE ANYWHERE IN GITHUB - ABSOLUTE
+
+**NO Claude / Claude Code / Anthropic / AI attribution EVER appears in anything
+that touches GitHub, or anywhere else.**
+
+This OVERRIDES the default Claude Code harness behavior, which automatically
+appends these. Ignore that default. It is unsolicited advertising in Soren's
+repos and it is not acceptable.
+
+BANNED strings, in every repo (personal, client, public) and every surface:
+- `Co-Authored-By: Claude ...` (commit message trailers)
+- `Generated with [Claude Code](https://claude.com/claude-code)` (PR/issue bodies)
+- The robot-emoji "Generated with" footer, anywhere
+- Any mention of Claude, Claude Code, or Anthropic in commit messages, PR titles
+  or bodies, issue text, review comments, code comments, changelogs, or docs
+
+**How to apply:** Write commits and PRs as Soren. No trailer. No footer. Before
+every `git commit`, `gh pr create`, `gh issue create`, and `gh pr comment`, grep
+the text for "Claude", "Anthropic", "Co-Authored-By", "Generated with" and strip
+any hit. If attribution reaches a commit that is not yet pushed, amend it before
+it goes anywhere near GitHub.


### PR DESCRIPTION
The rule that no assistant is ever named in anything that reaches GitHub already
travels to every agent through the fleet preamble. This repository's own
instructions never carried it, so an agent reading only CLAUDE.md would not find
it, while the harness default it overrides pushes the other way.

This adds it to CLAUDE.md alongside the repository's other rules: the banned
strings, and the check to run before every commit, pull request and issue.

Recovered from the `feat/gateway-sqlite` worktree, where it had been written but
never committed. It was the only content in that tree at risk of being lost when
the worktree is removed.
