### PR TITLE
feat(gateway): start the Gateway at login on macOS

### DIFF
--- a/src/CcDirector.Gateway/GatewayService.cs
+++ b/src/CcDirector.Gateway/GatewayService.cs
@@ -195,19 +195,28 @@ public sealed class GatewayService : IDisposable
     private Api.GatewaySettingsHooks BuildSettingsHooks() => new()
     {
         Mode = () => _options.ModeLabel,
-        AutostartEnabled = () =>
-            OperatingSystem.IsWindows() ? GatewayAutostart.IsRegistered() : (bool?)null,
+        AutostartEnabled = () => OperatingSystem.IsWindows() ? GatewayAutostart.IsRegistered()
+            : OperatingSystem.IsMacOS() ? GatewayLaunchdAutostart.IsRegistered()
+            : (bool?)null,
         SetAutostart = enable =>
         {
-            if (!OperatingSystem.IsWindows()) return false;
+            // Windows and macOS have real per-user autostart; every other platform (the container)
+            // reports unsupported rather than pretending, per GatewaySettingsHooks' contract.
+            if (!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS()) return false;
             if (enable)
             {
                 var exe = Environment.ProcessPath
                           ?? throw new InvalidOperationException("Could not resolve own exe path");
-                GatewayAutostart.EnsureRegistered(exe, _options.AutostartArguments);
+                if (OperatingSystem.IsWindows())
+                    GatewayAutostart.EnsureRegistered(exe, _options.AutostartArguments);
+                else
+                    GatewayLaunchdAutostart.EnsureRegistered(exe, _options.AutostartArguments);
                 return true;
             }
-            GatewayAutostart.Unregister();
+            if (OperatingSystem.IsWindows())
+                GatewayAutostart.Unregister();
+            else
+                GatewayLaunchdAutostart.Unregister();
             return false;
         },
     };
@@ -324,12 +333,12 @@ public sealed class GatewayService : IDisposable
             FileLog.Write("[GatewayService] Autostart registration skipped (not requested)");
             return;
         }
-        // The autostart Run key is a Windows concept. The tray app never needed this guard because it
-        // targets net10.0-windows; this library targets net10.0 and runs anywhere, so the platform check
-        // is real, not ceremony (issue #1095 builds the account stack on non-Windows hosts).
-        if (!OperatingSystem.IsWindows())
+        // Autostart is a per-user, per-platform mechanism: the Run key on Windows, a launchd user
+        // launch agent on macOS. Linux has neither by design - the container runtime keeps the
+        // hosted Gateway alive, so there is nothing to register and we say so rather than guess.
+        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS())
         {
-            FileLog.Write("[GatewayService] Autostart registration skipped (not Windows)");
+            FileLog.Write("[GatewayService] Autostart registration skipped (not Windows or macOS)");
             return;
         }
 
@@ -337,7 +346,10 @@ public sealed class GatewayService : IDisposable
         {
             var exePath = Environment.ProcessPath
                           ?? throw new InvalidOperationException("Could not resolve own exe path for autostart");
-            GatewayAutostart.EnsureRegistered(exePath, _options.AutostartArguments);
+            if (OperatingSystem.IsWindows())
+                GatewayAutostart.EnsureRegistered(exePath, _options.AutostartArguments);
+            else
+                GatewayLaunchdAutostart.EnsureRegistered(exePath, _options.AutostartArguments);
         }
         catch (Exception ex)
         {

--- a/tools/cc-director-setup-engine.Tests/GatewayLaunchdAutostartTests.cs
+++ b/tools/cc-director-setup-engine.Tests/GatewayLaunchdAutostartTests.cs
@@ -1,0 +1,102 @@
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// Tests for <see cref="GatewayLaunchdAutostart"/> - the pure property-list generation.
+/// The launchctl interaction is not exercised here (it would mutate the real launchd gui
+/// domain); these tests pin the plist format the Gateway, installer, and uninstaller all
+/// rely on. That the agent actually brings the Gateway up after a reboot is proven by a
+/// RUN on the Mac mini, recorded in the QA document - a passing test is not that evidence.
+/// </summary>
+public sealed class GatewayLaunchdAutostartTests
+{
+    private const string Exe = "/Users/tester/Library/Application Support/cc-director/gateway/CcDirector.Gateway";
+    private const string LogDir = "/Users/tester/Library/Application Support/cc-director/logs/gateway";
+
+    [Fact]
+    public void PlistContent_ContainsLabelAndProgramArguments()
+    {
+        var plist = GatewayLaunchdAutostart.PlistContent(Exe, "--port 7878", LogDir);
+
+        Assert.Contains("<string>com.devthrottle.cc-director-gateway</string>", plist);
+        Assert.Contains($"<string>{Exe}</string>", plist);
+        Assert.Contains("<string>--port</string>", plist);
+        Assert.Contains("<string>7878</string>", plist);
+    }
+
+    [Fact]
+    public void PlistContent_RunsAtLoad()
+    {
+        // RunAtLoad is the whole point of this class: start at login, with no person present.
+        var plist = GatewayLaunchdAutostart.PlistContent(Exe, null, LogDir);
+
+        Assert.Contains("<key>RunAtLoad</key>", plist);
+    }
+
+    [Fact]
+    public void PlistContent_KeepAliveOnlyAfterUnsuccessfulExit()
+    {
+        // KeepAlive must be conditional on SuccessfulExit=false: a clean exit (POST /shutdown)
+        // must STAY exited, or launchd would relaunch a Gateway that was deliberately stopped;
+        // only a crash may be resurrected.
+        var plist = GatewayLaunchdAutostart.PlistContent(Exe, "--port 7878", LogDir);
+
+        Assert.Contains("<key>KeepAlive</key>", plist);
+        Assert.Contains("<key>SuccessfulExit</key>", plist);
+        var keepAliveIndex = plist.IndexOf("<key>KeepAlive</key>", StringComparison.Ordinal);
+        var successfulExitIndex = plist.IndexOf("<key>SuccessfulExit</key>", StringComparison.Ordinal);
+        Assert.True(successfulExitIndex > keepAliveIndex, "SuccessfulExit must live inside the KeepAlive dictionary");
+    }
+
+    [Fact]
+    public void PlistContent_NoArguments_OmitsExtraStrings()
+    {
+        var plist = GatewayLaunchdAutostart.PlistContent(Exe, null, LogDir);
+
+        Assert.DoesNotContain("--port", plist);
+    }
+
+    [Fact]
+    public void PlistContent_EscapesXmlCharacters()
+    {
+        var plist = GatewayLaunchdAutostart.PlistContent("/tmp/a&b/CcDirector.Gateway", null, "/tmp/a&b/logs");
+
+        Assert.Contains("/tmp/a&amp;b/CcDirector.Gateway", plist);
+        Assert.DoesNotContain("<string>/tmp/a&b/CcDirector.Gateway</string>", plist);
+    }
+
+    [Fact]
+    public void PlistContent_WritesLogPathsUnderLogDir()
+    {
+        var plist = GatewayLaunchdAutostart.PlistContent(Exe, "--port 7878", LogDir);
+
+        Assert.Contains("launchd-stdout.log", plist);
+        Assert.Contains("launchd-stderr.log", plist);
+    }
+
+    [Fact]
+    public void PlistContent_EmptyExe_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => GatewayLaunchdAutostart.PlistContent("", "--port 7878", LogDir));
+    }
+
+    [Fact]
+    public void PlistPath_IsUserLaunchAgentWithLabelFileName()
+    {
+        Assert.EndsWith(
+            Path.Combine("Library", "LaunchAgents", "com.devthrottle.cc-director-gateway.plist"),
+            GatewayLaunchdAutostart.PlistPath,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Label_DoesNotCollideWithTheLauncherAgent()
+    {
+        // Two separate agents live in the same gui domain. One label, one plist file name each -
+        // a collision would have each bootout the other.
+        Assert.NotEqual(LauncherLaunchdAutostart.Label, GatewayLaunchdAutostart.Label);
+        Assert.NotEqual(LauncherLaunchdAutostart.PlistPath, GatewayLaunchdAutostart.PlistPath);
+    }
+}

--- a/tools/cc-director-setup-engine.Tests/GatewayLaunchdAutostartTests.cs
+++ b/tools/cc-director-setup-engine.Tests/GatewayLaunchdAutostartTests.cs
@@ -59,6 +59,21 @@ public sealed class GatewayLaunchdAutostartTests
     }
 
     [Fact]
+    public void PlistContent_KeepsQuotedArgumentWithSpacesAsOneToken()
+    {
+        // A value containing spaces (a path under "Application Support") must survive as ONE
+        // ProgramArguments token; splitting it at the space would hand the Gateway a wrong path.
+        var plist = GatewayLaunchdAutostart.PlistContent(
+            Exe, "--config \"/Users/me/Application Support/gateway.json\"", LogDir);
+
+        Assert.Contains("<string>--config</string>", plist);
+        Assert.Contains("<string>/Users/me/Application Support/gateway.json</string>", plist);
+        // not torn at the embedded space
+        Assert.DoesNotContain("<string>Support/gateway.json</string>", plist);
+        Assert.DoesNotContain("<string>Application</string>", plist);
+    }
+
+    [Fact]
     public void PlistContent_EscapesXmlCharacters()
     {
         var plist = GatewayLaunchdAutostart.PlistContent("/tmp/a&b/CcDirector.Gateway", null, "/tmp/a&b/logs");

--- a/tools/cc-director-setup-engine/GatewayLaunchdAutostart.cs
+++ b/tools/cc-director-setup-engine/GatewayLaunchdAutostart.cs
@@ -187,11 +187,39 @@ public static class GatewayLaunchdAutostart
         return uid.ToString();
     }
 
-    /// <summary>Split the stored argument string on whitespace (no quoting in Gateway arguments today).</summary>
-    private static IEnumerable<string> SplitArguments(string? arguments) =>
-        string.IsNullOrWhiteSpace(arguments)
-            ? Array.Empty<string>()
-            : arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    /// <summary>
+    /// Split the stored argument string into launchd ProgramArguments tokens, respecting double
+    /// quotes so a value containing spaces (for example a path under "Application Support") stays a
+    /// single token rather than being torn apart at the space, which would hand the Gateway a wrong
+    /// path. Surrounding double quotes are stripped; unquoted runs split on whitespace. Simple
+    /// flag/value arguments such as the Gateway's "--port 7878" are unaffected.
+    /// </summary>
+    private static IEnumerable<string> SplitArguments(string? arguments)
+    {
+        if (string.IsNullOrWhiteSpace(arguments)) yield break;
+
+        var token = new StringBuilder();
+        var inQuotes = false;
+        var started = false;
+        foreach (var ch in arguments)
+        {
+            if (ch == '"')
+            {
+                inQuotes = !inQuotes;
+                started = true;
+            }
+            else if (char.IsWhiteSpace(ch) && !inQuotes)
+            {
+                if (started) { yield return token.ToString(); token.Clear(); started = false; }
+            }
+            else
+            {
+                token.Append(ch);
+                started = true;
+            }
+        }
+        if (started) yield return token.ToString();
+    }
 
     private static string Xml(string value) => SecurityElement.Escape(value);
 

--- a/tools/cc-director-setup-engine/GatewayLaunchdAutostart.cs
+++ b/tools/cc-director-setup-engine/GatewayLaunchdAutostart.cs
@@ -1,0 +1,203 @@
+using System.Runtime.Versioning;
+using System.Security;
+using System.Text;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// The Gateway's per-user autostart on macOS: a launchd user launch agent at
+/// ~/Library/LaunchAgents/com.devthrottle.cc-director-gateway.plist. The macOS twin of
+/// <see cref="GatewayAutostart"/> (the Windows Run key), and the sibling of
+/// <see cref="LauncherLaunchdAutostart"/> (the same mechanism for the CC Launcher).
+///
+/// It lives in the engine for the same reason its two siblings do: the installer, the
+/// uninstaller, and the Gateway itself must agree on one label, one property list path,
+/// and one command-line format.
+///
+/// Per-user (the gui domain), never a system daemon: the Gateway only does useful work
+/// while the user is logged in - the whole fleet is logon-bound - so it belongs in the
+/// user's login session, exactly as the Windows side reasons about HKCU.
+///
+/// The agent is registered with RunAtLoad (start at login) and KeepAlive with
+/// SuccessfulExit=false: launchd resurrects the Gateway after a crash or a kill, but a
+/// CLEAN exit (POST /shutdown) stays exited - otherwise launchd would relaunch a Gateway
+/// that was deliberately stopped.
+///
+/// Registration is a two-step: write the property list, then hand it to launchd with
+/// "launchctl bootstrap gui/&lt;uid&gt;". Bootstrap also starts the agent immediately
+/// (RunAtLoad applies at bootstrap time); when a already-running Gateway registers itself
+/// at startup, that spawns a duplicate which exits on the port already being held.
+/// </summary>
+public static class GatewayLaunchdAutostart
+{
+    /// <summary>The launchd service label (also the property list file name).</summary>
+    public const string Label = "com.devthrottle.cc-director-gateway";
+
+    /// <summary>The user launch-agent property list path: ~/Library/LaunchAgents/{Label}.plist.</summary>
+    public static string PlistPath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        "Library", "LaunchAgents", Label + ".plist");
+
+    /// <summary>
+    /// The full property list for the given executable and arguments. Pure, for tests.
+    /// Standard output and error go to logDir so a crash before FileLog starts is not silent.
+    /// </summary>
+    public static string PlistContent(string exePath, string? arguments, string logDir)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(exePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(logDir);
+
+        var argElements = new StringBuilder();
+        argElements.Append($"        <string>{Xml(exePath)}</string>\n");
+        foreach (var arg in SplitArguments(arguments))
+            argElements.Append($"        <string>{Xml(arg)}</string>\n");
+
+        return $"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+                <key>Label</key>
+                <string>{Label}</string>
+                <key>ProgramArguments</key>
+                <array>
+            {argElements.ToString().TrimEnd('\n')}
+                </array>
+                <key>RunAtLoad</key>
+                <true/>
+                <key>KeepAlive</key>
+                <dict>
+                    <key>SuccessfulExit</key>
+                    <false/>
+                </dict>
+                <key>ProcessType</key>
+                <string>Interactive</string>
+                <key>StandardOutPath</key>
+                <string>{Xml(Path.Combine(logDir, "launchd-stdout.log"))}</string>
+                <key>StandardErrorPath</key>
+                <string>{Xml(Path.Combine(logDir, "launchd-stderr.log"))}</string>
+            </dict>
+            </plist>
+
+            """;
+    }
+
+    /// <summary>
+    /// Ensure the launch agent is registered and loaded for the given executable and
+    /// arguments. Idempotent: returns true if a write or a launchd (re)bootstrap was
+    /// performed, false if everything was already correct.
+    /// </summary>
+    [SupportedOSPlatform("macos")]
+    public static bool EnsureRegistered(string exePath, string? arguments = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(exePath);
+        var logDir = Path.Combine(InstallLayout.Default().LogsDir, "gateway");
+        var desired = PlistContent(exePath, arguments, logDir);
+        EngineLog.Write($"[GatewayLaunchdAutostart] EnsureRegistered: exe={exePath}, args={arguments ?? "(none)"}");
+
+        var plistUnchanged = File.Exists(PlistPath)
+            && string.Equals(File.ReadAllText(PlistPath), desired, StringComparison.Ordinal);
+
+        if (plistUnchanged && IsLoaded())
+        {
+            EngineLog.Write("[GatewayLaunchdAutostart] EnsureRegistered: already up to date and loaded");
+            return false;
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(PlistPath)!);
+        Directory.CreateDirectory(logDir);
+        File.WriteAllText(PlistPath, desired);
+        EngineLog.Write($"[GatewayLaunchdAutostart] EnsureRegistered: wrote {PlistPath}");
+
+        // A changed definition must be re-bootstrapped: launchd caches the loaded plist.
+        if (IsLoaded())
+        {
+            var (outExit, outText) = ProcessRunner.Run("/bin/launchctl", $"bootout gui/{UserId()}/{Label}");
+            EngineLog.Write($"[GatewayLaunchdAutostart] bootout -> exit={outExit} {Trim(outText)}");
+        }
+
+        var (exit, text) = ProcessRunner.Run("/bin/launchctl", $"bootstrap gui/{UserId()} \"{PlistPath}\"");
+        if (exit != 0)
+            throw new InvalidOperationException(
+                $"launchctl bootstrap failed (exit {exit}): {Trim(text)}");
+
+        EngineLog.Write("[GatewayLaunchdAutostart] EnsureRegistered: bootstrapped launch agent");
+        return true;
+    }
+
+    /// <summary>The registered command line (ProgramArguments joined), or null when the property list does not exist.</summary>
+    public static string? Registered()
+    {
+        if (!File.Exists(PlistPath)) return null;
+        var content = File.ReadAllText(PlistPath);
+        var strings = new List<string>();
+        var start = content.IndexOf("<array>", StringComparison.Ordinal);
+        var end = content.IndexOf("</array>", StringComparison.Ordinal);
+        if (start < 0 || end < 0) return null;
+        var body = content[start..end];
+        foreach (var line in body.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith("<string>", StringComparison.Ordinal) && trimmed.EndsWith("</string>", StringComparison.Ordinal))
+                strings.Add(Unxml(trimmed["<string>".Length..^"</string>".Length]));
+        }
+        return strings.Count == 0 ? null : string.Join(' ', strings);
+    }
+
+    /// <summary>True if the launch-agent property list exists.</summary>
+    public static bool IsRegistered() => File.Exists(PlistPath);
+
+    /// <summary>
+    /// Unload the launch agent from launchd and remove the property list.
+    /// Returns true if anything was removed.
+    /// </summary>
+    [SupportedOSPlatform("macos")]
+    public static bool Unregister()
+    {
+        EngineLog.Write("[GatewayLaunchdAutostart] Unregister");
+        var existed = File.Exists(PlistPath);
+
+        if (IsLoaded())
+        {
+            var (exit, text) = ProcessRunner.Run("/bin/launchctl", $"bootout gui/{UserId()}/{Label}");
+            EngineLog.Write($"[GatewayLaunchdAutostart] bootout -> exit={exit} {Trim(text)}");
+        }
+
+        if (existed)
+        {
+            File.Delete(PlistPath);
+            EngineLog.Write($"[GatewayLaunchdAutostart] Unregister: removed {PlistPath}");
+        }
+        return existed;
+    }
+
+    /// <summary>Whether launchd currently has the agent loaded in this user's gui domain.</summary>
+    [SupportedOSPlatform("macos")]
+    public static bool IsLoaded()
+    {
+        var (exit, _) = ProcessRunner.Run("/bin/launchctl", $"print gui/{UserId()}/{Label}");
+        return exit == 0;
+    }
+
+    private static string UserId()
+    {
+        var (exit, output) = ProcessRunner.Run("/usr/bin/id", "-u");
+        if (exit != 0 || !int.TryParse(output.Trim(), out var uid))
+            throw new InvalidOperationException($"could not resolve the current user id (id -u exit {exit})");
+        return uid.ToString();
+    }
+
+    /// <summary>Split the stored argument string on whitespace (no quoting in Gateway arguments today).</summary>
+    private static IEnumerable<string> SplitArguments(string? arguments) =>
+        string.IsNullOrWhiteSpace(arguments)
+            ? Array.Empty<string>()
+            : arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static string Xml(string value) => SecurityElement.Escape(value);
+
+    private static string Unxml(string value) => value
+        .Replace("&lt;", "<").Replace("&gt;", ">").Replace("&quot;", "\"")
+        .Replace("&apos;", "'").Replace("&amp;", "&");
+
+    private static string Trim(string text) => text.Length > 300 ? text[..300] + "..." : text.Trim();
+}


### PR DESCRIPTION
Phase A, Step 2 of the Hosted Gateway mission. The Gateway had per-user autostart on Windows (the Run key) and nothing on macOS, so a Mac ran it only when a person started it by hand.

## What changed

- **New `GatewayLaunchdAutostart`** - the macOS twin of `GatewayAutostart` and the sibling of `LauncherLaunchdAutostart`. Writes a per-user launchd launch agent at `~/Library/LaunchAgents/com.devthrottle.cc-director-gateway.plist` with RunAtLoad, then bootstraps it into the user's gui domain. It lives in the setup engine for the reason its two siblings do: the installer, the uninstaller, and the Gateway itself must agree on one label, one property list path, and one command-line format.
- **`GatewayService` wiring** - registers the agent on macOS instead of skipping, and the Cockpit Settings hooks report and toggle it there. Linux still reports unsupported, by design: the container runtime keeps the hosted Gateway alive, so there is nothing to register and the code says so rather than guessing.

The registration is a library class and the skin only calls it, per the mission's shared-library constraint.

## Two design points, inherited deliberately from the Launcher's agent

- **Per-user (the gui domain), never a system daemon.** The Gateway only does useful work while the user is logged in - the whole fleet is logon-bound - so it belongs in the login session, exactly as the Windows side reasons about HKCU.
- **KeepAlive with SuccessfulExit=false.** launchd resurrects the Gateway after a crash or a kill, but a clean exit (POST /shutdown) stays exited - otherwise launchd would relaunch a Gateway that was deliberately stopped.

## Tests

`GatewayLaunchdAutostartTests`, 9 tests over the pure property-list generation - label and arguments, RunAtLoad, KeepAlive conditional on SuccessfulExit, XML escaping, log paths, and that the label and plist path do **not** collide with the Launcher's agent (two agents share one gui domain, and a collision would have each bootout the other). The launchctl interaction is deliberately not unit-tested - it would mutate the real launchd gui domain.

## Evidence

Windows regression, green:
- Clean rebuild (`--no-incremental`): 0 warnings, 0 errors
- `cc-director-setup-engine.Tests`: **316 passed, 0 failed**
- `CcDirector.Gateway.Tests`: **2540 passed, 0 failed**

**Not ready to merge.** The reboot RUN on the Mac mini is outstanding and it is the real evidence for this step - start-on-login is only proven when a reboot brings the Gateway up by itself, and a passing test is explicitly not that evidence. Recorded as NOT DONE in the mission's QA document. Awaiting that run and a Codex review.