### PR TITLE
docs(release-notes): correct the v1.5.0 Linux/macOS Gateway claim

### DIFF
--- a/docs/public/release-notes/v1.5.0.md
+++ b/docs/public/release-notes/v1.5.0.md
@@ -1,11 +1,11 @@
 ## v1.5.0 - July 16, 2026
 
-The Gateway becomes the single source of truth for what each session is doing, the Gateway itself now runs on Linux and macOS, and you can install and sign in from the command line with no wizard.
+The Gateway becomes the single source of truth for what each session is doing, you can install from the command line with no wizard, and the Gateway core gains the groundwork to run beyond Windows.
 
 ### Highlights
 - One honest picture of every session: the Gateway now decides each session's state and pushes it out, so the desktop rail, the Cockpit, and the mobile roster all show the same thing - including how long a session has been on hold and when it is winding down - instead of each surface guessing on its own.
-- Run the Gateway on Linux and macOS: the Gateway is no longer Windows-only, so you can host it on a plain Linux or macOS machine and drive your fleet from there.
-- Install and sign in with no wizard: a new command-line installer lets an agent set up DevThrottle, sign in, and enroll a machine entirely from the terminal, and macOS gets a curl-based install that Gatekeeper cannot block.
+- Install from the terminal, no wizard: a new command-line installer lets an agent set DevThrottle up end to end from the terminal on Windows and macOS, and macOS gets a curl-based install that Gatekeeper cannot block. Signing a machine in from the command line is Windows-only today; on macOS a machine joins your gateway with `enroll` instead.
+- Groundwork for running the Gateway anywhere: the Gateway now runs headless on Linux and macOS, proven in a Linux container, and ships with a Dockerfile you can build yourself. This is foundation work rather than a supported install - the Gateway downloads in this release are still Windows-only, and the installer's Gateway role stays Windows-only for now.
 - See what you have spent: new governance screens show your usage by day, week, and month, and each session's token spend is stored and sliced by hour and model.
 
 ### Also in this release


### PR DESCRIPTION
The committed v1.5.0 release notes overstated cross-platform support - they read as if the Gateway can already be hosted on Linux or macOS. In reality the Gateway downloads in this release are Windows-only, and the installer's Gateway role stays Windows-only.

This edits `docs/public/release-notes/v1.5.0.md` to match the wording already published on the GitHub v1.5.0 release:

- Linux/macOS is described as groundwork (headless run proven in a container, Dockerfile provided), not a supported install.
- Command-line sign-in is noted as Windows-only today; on macOS a machine joins a gateway with `enroll`.
- The summary line and highlight order match the published body.

Docs-only; no code change.