### PR TITLE
Check for updates hourly by default instead of every six hours

### DIFF
--- a/tools/cc-director-setup-engine.Tests/AutoUpdateConfigTests.cs
+++ b/tools/cc-director-setup-engine.Tests/AutoUpdateConfigTests.cs
@@ -33,7 +33,7 @@ public class AutoUpdateConfigTests : IDisposable
     {
         var c = AutoUpdateConfig.Load(_layout);
         Assert.True(c.Enabled);
-        Assert.Equal(6, c.IntervalHours);
+        Assert.Equal(1, c.IntervalHours);
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class AutoUpdateConfigTests : IDisposable
         WriteConfig("""{ "llm": {}, "gateway": {} }""");
         var c = AutoUpdateConfig.Load(_layout);
         Assert.True(c.Enabled);
-        Assert.Equal(6, c.IntervalHours);
+        Assert.Equal(1, c.IntervalHours);
     }
 
     [Fact]
@@ -71,9 +71,9 @@ public class AutoUpdateConfigTests : IDisposable
     }
 
     [Fact]
-    public void Interval_ClampsTinyValuesToSixHours()
+    public void Interval_ClampsTinyValuesToDefault()
     {
         WriteConfig("""{ "autoUpdate": { "intervalHours": 0 } }""");
-        Assert.Equal(TimeSpan.FromHours(6), AutoUpdateConfig.Load(_layout).Interval);
+        Assert.Equal(TimeSpan.FromHours(1), AutoUpdateConfig.Load(_layout).Interval);
     }
 }

--- a/tools/cc-director-setup-engine/AutoUpdateConfig.cs
+++ b/tools/cc-director-setup-engine/AutoUpdateConfig.cs
@@ -6,16 +6,16 @@ namespace CcDirector.Setup.Engine;
 /// Auto-update settings, read from the shared config.json "autoUpdate" section. Controls whether the
 /// resident apps (Director, Gateway) silently pull newer releases and how often they check.
 ///
-/// Defaults: enabled, every 6 hours. A missing section, a missing file, or a parse error all fall back
+/// Defaults: enabled, every 1 hour. A missing section, a missing file, or a parse error all fall back
 /// to the defaults (no config required to get auto-update). The env var CC_AUTOUPDATE=0 is a global
 /// kill switch that overrides the config (handy for a machine you never want auto-updating).
 /// </summary>
 public sealed record AutoUpdateConfig(bool Enabled, double IntervalHours)
 {
-    public static readonly AutoUpdateConfig Default = new(Enabled: true, IntervalHours: 6);
+    public static readonly AutoUpdateConfig Default = new(Enabled: true, IntervalHours: 1);
 
     /// <summary>The check interval, clamped to a sane floor so a bad config can't cause a hammering loop.</summary>
-    public TimeSpan Interval => TimeSpan.FromHours(IntervalHours < 0.25 ? 6 : IntervalHours);
+    public TimeSpan Interval => TimeSpan.FromHours(IntervalHours < 0.25 ? Default.IntervalHours : IntervalHours);
 
     public static AutoUpdateConfig Load(InstallLayout layout)
     {


### PR DESCRIPTION
## What

Lower the resident Director's default auto-update check interval from six hours to one hour.

The auto-update loop in `App.StartUpdateService` reads its cadence from `AutoUpdateConfig`, whose default was `IntervalHours: 6`. An installed build now checks GitHub for a new release (and refreshes the cc-* tools) every hour by default, so updates land far sooner without anyone touching config.

## Changes

- `AutoUpdateConfig.Default` interval: 6 -> 1 hour.
- The sub-floor clamp fallback now points at `Default.IntervalHours` instead of a separate hardcoded 6, so the default is single-sourced and the two can't drift.
- Doc comment updated ("every 6 hours" -> "every 1 hour").
- Tests updated: the two default-assertion tests now expect 1, and `Interval_ClampsTinyValuesToSixHours` becomes `Interval_ClampsTinyValuesToDefault`.

## Unchanged

- 0.25h floor against a hammering loop.
- Kill switches: `CC_AUTOUPDATE=0` and `autoUpdate.enabled=false`.
- Any explicit `autoUpdate.intervalHours` in config still wins.

## Test

`dotnet test` on `CcDirector.Setup.Engine.Tests` filtered to `AutoUpdateConfigTests`: 14 passed, 0 failed.