### PR TITLE
Fleet-wide voice-mode switch: turn all sessions on or off at once (#1765)

### DIFF
--- a/apps/cockpit/src/sessions/SessionRoster.tsx
+++ b/apps/cockpit/src/sessions/SessionRoster.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
-import type { SessionDto } from "@devthrottle/client-core/api/client";
+import { setVoiceModeAllSessions, type SessionDto } from "@devthrottle/client-core/api/client";
 import {
   classify,
   contextLine,
@@ -88,6 +89,11 @@ export function SessionRoster({ sessions, directors, portByDirector, selectedId,
         </button>
       </div>
 
+      {/* The fleet-wide voice switch (issue #1765): one button turns voice mode on for every session,
+          or off again, so a person leaving their desk can put the whole fleet on voice and take it back
+          off later without touching each session. It reads the roster to pick its own direction. */}
+      {sessions !== null && total > 0 && <VoiceAllButton sessions={sessions} />}
+
       {error !== null && (
         <div className="roster-error" role="alert">
           {sessions !== null ? "Roster stale - showing last-known sessions" : error}
@@ -134,6 +140,56 @@ export function SessionRoster({ sessions, directors, portByDirector, selectedId,
           selectedId={selectedId}
         />
       )}
+    </div>
+  );
+}
+
+// The fleet-wide voice switch shown under the roster ordering toggle (issue #1765). One control for both
+// directions: while no session is a voice session it offers "Turn on voice for all N sessions"; the moment
+// any session is on, it offers "Turn voice off for all sessions". It calls the Gateway's single fan-out
+// endpoint, which walks the roster itself, then shows a plain summary of what changed and what was skipped
+// (a session whose owning computer is offline is passed over, never failing the batch). The next roster
+// poll repaints the "voice" tags and the button flips to its opposite direction.
+function VoiceAllButton({ sessions }: { sessions: SessionDto[] }) {
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const anyOn = sessions.some((s) => Boolean(s.voiceMode));
+  const enable = !anyOn;
+  const count = sessions.length;
+
+  const onClick = async () => {
+    setBusy(true);
+    setError(null);
+    setNote(null);
+    try {
+      const result = await setVoiceModeAllSessions(enable);
+      const changedLabel = `${result.changed} ${result.changed === 1 ? "session" : "sessions"} ${enable ? "on" : "off"}`;
+      setNote(result.skipped > 0 ? `${changedLabel}, ${result.skipped} skipped (computer offline)` : changedLabel);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not change voice mode for all sessions");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const label = enable ? `Turn on voice for all ${count}` : "Turn voice off for all";
+  const busyLabel = enable ? "Turning voice on..." : "Turning voice off...";
+
+  return (
+    <div className="roster-voice-all">
+      <button
+        type="button"
+        className={`roster-voice-all-btn${enable ? "" : " off"}`}
+        onClick={() => void onClick()}
+        disabled={busy}
+        title="Turn voice mode on or off for every session at once"
+      >
+        {busy ? busyLabel : label}
+      </button>
+      {note && <span className="roster-voice-all-note" role="status">{note}</span>}
+      {error && <span className="roster-voice-all-error" role="alert">{error}</span>}
     </div>
   );
 }

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -348,6 +348,54 @@ body {
   filter: brightness(1.08);
 }
 
+/* The fleet-wide voice switch under the roster ordering toggle (issue #1765). A full-width action so it
+   reads as a "do this to the whole fleet" control, with a status line beneath it for the result. */
+.roster-voice-all {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 8px 2px;
+}
+
+.roster-voice-all-btn {
+  width: 100%;
+  padding: 7px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #ffffff;
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 7px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+/* The return trip ("turn it all off"): muted fill with the accent outline, so on and off never look alike. */
+.roster-voice-all-btn.off {
+  color: var(--accent);
+  background: transparent;
+}
+
+.roster-voice-all-btn:hover {
+  filter: brightness(1.08);
+}
+
+.roster-voice-all-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.roster-voice-all-note {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.roster-voice-all-error {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--attention);
+}
+
 /* ---- New-session dialog (issue #1023): the dedicated machine/repo picker the roster opens. Shares
    the modal look of the Schedule create dialog, on the shared navy tokens. ---- */
 .newsess-backdrop {

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { type SessionDto } from "@devthrottle/client-core/api/client";
+import { setVoiceModeAllSessions, type SessionDto } from "@devthrottle/client-core/api/client";
 import { getSessionsEnvelope } from "@devthrottle/client-core/fleet/fleetClient";
 import { emptyRetentionCache, mergeRosterRetention, type RosterSessionMark } from "@devthrottle/client-core/fleet/rosterRetention";
 import { classify, contextLine, deletionReason, dotColor, effectiveColor, inBucket, inDesktopOrder, inWaitingOrder, isWorking, pendingDeletion, repoLeaf, snoozeCountdown, snoozeExpired } from "@devthrottle/client-core/sessions/ordering";
@@ -220,6 +220,15 @@ export function Home() {
         <p className="status-line">No sessions running.</p>
       )}
 
+      {/* The one-tap fleet-wide voice switch (issue #1765): "as I leave the house, put my whole fleet on
+          voice; when I get home, take it all off". It reads the roster to decide its own action - offer
+          "turn all on" while no session is a voice session, "turn all off" once any is - so the same
+          button covers both halves of the walk-out / come-home round trip. Lives in the Voice tab, the
+          voice-focused surface, and speaks to the Gateway which fans the change out to every session. */}
+      {tab === "voice" && sessions !== null && total > 0 && (
+        <VoiceAllControl sessions={sessions} />
+      )}
+
       {/* The Voice tab, empty. Said plainly and without alarm: nothing is ready to listen to yet. The
           way out is one tap, so an empty voice roster is never a dead end. */}
       {tab === "voice" && sessions !== null && total > 0 && voiceReady.length === 0 && (
@@ -314,6 +323,58 @@ function EnableAlerts() {
       <button type="button" className="banner-btn" onClick={() => void onEnable()} disabled={busy}>
         {busy ? "Enabling..." : "Enable notifications"}
       </button>
+    </div>
+  );
+}
+
+// The fleet-wide voice switch shown at the top of the Voice tab (issue #1765). One control for the whole
+// round trip: while no session is in voice mode it offers "Turn on voice for all N sessions"; the moment
+// any session is a voice session it offers "Turn voice off for all sessions". Tapping calls the Gateway's
+// one fan-out endpoint, which walks the roster itself, and shows a fail-loud summary of what changed and
+// what was skipped (the mobile rule: never fail silently - name the offline sessions that were passed
+// over). The next roster poll (5s) repaints each row's voice state, so the button flips to its opposite.
+function VoiceAllControl({ sessions }: { sessions: SessionDto[] }) {
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const anyOn = sessions.some((s) => Boolean(s.voiceMode));
+  // No session on voice yet -> the action is to turn the whole fleet ON; otherwise turn it all OFF.
+  const enable = !anyOn;
+  const count = sessions.length;
+
+  const onClick = async () => {
+    setBusy(true);
+    setError(null);
+    setNote(null);
+    try {
+      const result = await setVoiceModeAllSessions(enable);
+      const changedLabel = `${result.changed} ${result.changed === 1 ? "session" : "sessions"} ${enable ? "on" : "off"}`;
+      setNote(result.skipped > 0 ? `${changedLabel}, ${result.skipped} skipped (computer offline)` : changedLabel);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not change voice mode for all sessions");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const label = enable
+    ? `Turn on voice for all ${count} ${count === 1 ? "session" : "sessions"}`
+    : "Turn voice off for all sessions";
+  const busyLabel = enable ? "Turning voice on..." : "Turning voice off...";
+
+  return (
+    <div className="voice-all">
+      <button
+        type="button"
+        className={`voice-all-btn${enable ? "" : " voice-all-btn-off"}`}
+        onClick={() => void onClick()}
+        disabled={busy}
+      >
+        {busy ? busyLabel : label}
+      </button>
+      {note && <p className="voice-all-note" role="status">{note}</p>}
+      {error && <p className="voice-all-error" role="alert">{error}</p>}
     </div>
   );
 }

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2092,6 +2092,52 @@ a.banner-btn {
   line-height: 1;
 }
 
+/* The fleet-wide voice switch at the top of the Voice tab (issue #1765). A big, one-tap target - it is
+   reached for on the way out the door - full width, accent-filled for the "turn on" action and a muted
+   surface for the "turn off" return trip so the two directions read differently at a glance. */
+.voice-all {
+  margin: 14px 0 4px;
+}
+
+.voice-all-btn {
+  display: block;
+  width: 100%;
+  padding: 16px;
+  min-height: 56px;
+  border: none;
+  border-radius: 10px;
+  background: var(--accent);
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+/* The return trip ("turn it all off"): muted surface with an accent outline, so on/off never look alike. */
+.voice-all-btn-off {
+  background: var(--surface);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+.voice-all-btn:disabled {
+  opacity: 0.6;
+}
+
+.voice-all-note {
+  margin: 8px 2px 0;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
+.voice-all-error {
+  margin: 8px 2px 0;
+  font-size: 13px;
+  color: var(--attention);
+  font-weight: 600;
+}
+
 /* Machine / repo picker rows on the add screen. The row chrome reuses .row; .picker-link is the
    full-width button inside it (the roster uses an <a>, the pickers use <button> for the tap). */
 .picker-link {

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -1991,3 +1991,49 @@ export async function stopWingmanVoice(sessionId: string, signal?: AbortSignal):
     throw new GatewayError(res.status, `POST wingman/voice/stop failed: ${res.status}`);
   }
 }
+
+// The per-session outcome the fleet-wide voice-mode call reports back (issue #1765). `ok` sessions were
+// switched; a not-ok session was skipped (its owning computer was not reachable) and `reason` says so
+// in plain English.
+export interface VoiceModeAllSessionResult {
+  sessionId: string;
+  name: string | null;
+  ok: boolean;
+  reason: string | null;
+}
+
+// The whole-fleet result: what was asked for (enabled), how many sessions the Gateway saw, how many it
+// actually switched, how many it skipped, and the per-session detail.
+export interface VoiceModeAllResult {
+  enabled: boolean;
+  total: number;
+  changed: number;
+  skipped: number;
+  sessions: VoiceModeAllSessionResult[];
+}
+
+// POST /sessions/voice-mode/all { enabled } - turn voice mode on (enabled=true) or off (false) for EVERY
+// session at once (issue #1765). The Gateway walks the whole roster and fans the per-session voice-mode
+// write out itself, so this is ONE call for the caller. Sessions whose owning computer is offline are
+// skipped and reported, never failing the batch. Enabling spends per-turn narration credits on every
+// session it switches on, so a 402 (out of credits) surfaces the shared credits notice, once.
+export async function setVoiceModeAllSessions(enabled: boolean, signal?: AbortSignal): Promise<VoiceModeAllResult> {
+  const res = await gatewayFetch(`/sessions/voice-mode/all`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
+    body: JSON.stringify({ enabled }),
+    signal,
+  });
+  if (!res.ok) {
+    if (res.status === 402) throw creditsErrorFrom(await res.json().catch(() => ({})));
+    throw new GatewayError(res.status, `POST voice-mode/all failed: ${res.status}`);
+  }
+  const body = (await res.json()) as Partial<VoiceModeAllResult>;
+  return {
+    enabled: Boolean(body.enabled),
+    total: Number(body.total ?? 0),
+    changed: Number(body.changed ?? 0),
+    skipped: Number(body.skipped ?? 0),
+    sessions: Array.isArray(body.sessions) ? body.sessions : [],
+  };
+}

--- a/packages/client-core/src/api/voiceModeAll.test.ts
+++ b/packages/client-core/src/api/voiceModeAll.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The fleet-wide voice switch client (issue #1765): setVoiceModeAllSessions posts { enabled } to the
+// Gateway's one fan-out endpoint and hands back the whole-fleet result. These prove the request shape
+// (path, method, body), the parse of the per-session result, and that an out-of-credits 402 surfaces the
+// shared credits error rather than a raw GatewayError. The connection-health module is mocked so the
+// shared transport does not try to touch a real signal.
+const health = vi.hoisted(() => ({ reachable: vi.fn(), unreachable: vi.fn() }));
+vi.mock("../connection/health", () => ({
+  reportGatewayReachable: () => health.reachable(),
+  reportGatewayUnreachable: () => health.unreachable(),
+}));
+
+import { GatewayError, setVoiceModeAllSessions } from "./client";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("setVoiceModeAllSessions (issue #1765)", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("POSTs { enabled } to /sessions/voice-mode/all and parses the fleet result", async () => {
+    let seenUrl = "";
+    let seenInit: RequestInit | undefined;
+    globalThis.fetch = ((input: unknown, init?: RequestInit) => {
+      seenUrl = String(input);
+      seenInit = init;
+      return Promise.resolve(
+        jsonResponse({
+          enabled: true,
+          total: 3,
+          changed: 2,
+          skipped: 1,
+          sessions: [
+            { sessionId: "a", name: "Alpha", ok: true, reason: null },
+            { sessionId: "b", name: "Bravo", ok: true, reason: null },
+            { sessionId: "c", name: "Charlie", ok: false, reason: "SOREN_NORTH looks offline." },
+          ],
+        }),
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await setVoiceModeAllSessions(true);
+
+    expect(seenUrl).toContain("/sessions/voice-mode/all");
+    expect(seenInit?.method).toBe("POST");
+    expect(JSON.parse(String(seenInit?.body))).toEqual({ enabled: true });
+    expect(result.enabled).toBe(true);
+    expect(result.total).toBe(3);
+    expect(result.changed).toBe(2);
+    expect(result.skipped).toBe(1);
+    expect(result.sessions).toHaveLength(3);
+    expect(result.sessions[2]).toMatchObject({ sessionId: "c", ok: false });
+  });
+
+  it("sends enabled=false for the turn-everything-off direction", async () => {
+    let body: unknown;
+    globalThis.fetch = ((_input: unknown, init?: RequestInit) => {
+      body = JSON.parse(String(init?.body));
+      return Promise.resolve(jsonResponse({ enabled: false, total: 0, changed: 0, skipped: 0, sessions: [] }));
+    }) as unknown as typeof fetch;
+
+    const result = await setVoiceModeAllSessions(false);
+    expect(body).toEqual({ enabled: false });
+    expect(result.enabled).toBe(false);
+  });
+
+  it("defaults missing numeric fields to 0 and a missing sessions array to empty", async () => {
+    globalThis.fetch = (() => Promise.resolve(jsonResponse({ enabled: true }))) as unknown as typeof fetch;
+    const result = await setVoiceModeAllSessions(true);
+    expect(result.total).toBe(0);
+    expect(result.changed).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.sessions).toEqual([]);
+  });
+
+  it("surfaces an out-of-credits 402 as the shared credits error, not a raw GatewayError", async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(jsonResponse({ error: "out of credits" }, 402))) as unknown as typeof fetch;
+    await expect(setVoiceModeAllSessions(true)).rejects.toMatchObject({ name: "CreditsError", status: 402 });
+  });
+
+  it("throws a GatewayError on any other non-success status", async () => {
+    globalThis.fetch = (() => Promise.resolve(jsonResponse({}, 500))) as unknown as typeof fetch;
+    await expect(setVoiceModeAllSessions(true)).rejects.toBeInstanceOf(GatewayError);
+  });
+});

--- a/src/CcDirector.Gateway.Tests/VoiceModeAllEndpointProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceModeAllEndpointProofTests.cs
@@ -1,0 +1,177 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection; // AddMessagePackProtocol (client)
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1765 - the fleet-wide voice switch. POST /sessions/voice-mode/all walks the whole roster and, for
+/// each session, sends the owning Director the same "voice-mode" verb the per-session path sends, then marks
+/// (or unmarks) the session on the Gateway. This boots a REAL streamMode <see cref="GatewayHost"/>, dials the
+/// REAL DirectorHub with a REAL MessagePack client, PUSHES the sessions so their owner resolves with zero
+/// remote reach, and drives the batch endpoint.
+///
+/// TUNNEL-BY-CONSTRUCTION: the Director is registered UNREACHABLE and the sessions arrive ONLY via
+/// PushSnapshot, so a session that reports "on" can only have ridden the tunnel - an HTTP dial to the
+/// unreachable control endpoint would have failed and the owner would never have resolved. The two tests
+/// prove the happy path (every session switched, one voice-mode command per session carrying the enabled
+/// flag) and the skip path (a session whose Director rejects the write is skipped and reported, never
+/// failing the batch).
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class VoiceModeAllEndpointProofTests : IAsyncLifetime
+{
+    private const string Token = "test-token-voice-mode-all-proof";
+    private const string DirectorId = "dir-voice-mode-all";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-vmall-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private HubConnection _conn = null!;
+
+    // Every command the fake Director received, captured concurrently (the fan-out sends them in parallel).
+    private readonly ConcurrentBag<DirectorCommand> _commands = new();
+    // Session ids the fake Director should REJECT the voice-mode write for (to prove the skip path).
+    private readonly HashSet<string> _rejectSids = new(StringComparer.Ordinal);
+
+    public VoiceModeAllEndpointProofTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-vmall-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        _gateway.Registry.Upsert(new DirectorRegistrationRequest
+        {
+            DirectorId = DirectorId,
+            TailnetEndpoint = "http://127.0.0.1:59923/", // nothing listens here
+            MachineName = Environment.MachineName,
+            Pid = 1,
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        });
+
+        _conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/director-stream", o => o.AccessTokenProvider = () => Task.FromResult<string?>(Token))
+            .AddMessagePackProtocol()
+            .Build();
+        _conn.On<DirectorCommand, DirectorCommandResult>("Command", Dispatch);
+        await _conn.StartAsync();
+        await _conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = DirectorId, Version = "test" });
+    }
+
+    public async Task DisposeAsync()
+    {
+        try { await _conn.DisposeAsync(); } catch { /* best effort */ }
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        foreach (var dir in new[] { _instancesDir, _root })
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { /* best effort */ }
+    }
+
+    // The fake Director accepts the voice-mode write (Success) for every session except those in _rejectSids,
+    // which it fails - proving a rejected session is reported skipped without failing the whole batch.
+    private DirectorCommandResult Dispatch(DirectorCommand cmd)
+    {
+        _commands.Add(cmd);
+        if (cmd.Verb != "voice-mode")
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+        if (_rejectSids.Contains(cmd.SessionId))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+        return DirectorCommandResult.Success("{}");
+    }
+
+    private Task PushAsync(long sequence, params SessionDto[] sessions) =>
+        _conn.InvokeAsync("PushSnapshot", sequence, sessions);
+
+    private static SessionDto Session(string sid, string name) => new()
+    {
+        SessionId = sid,
+        Name = name,
+        Status = "WaitingForInput",
+        ActivityState = "WaitingForInput",
+        RepoPath = @"D:\repo",
+    };
+
+    [Fact]
+    public async Task VoiceModeAll_enable_switchesEverySession_overTheTunnel()
+    {
+        var sid1 = Guid.NewGuid().ToString();
+        var sid2 = Guid.NewGuid().ToString();
+        await PushAsync(1L, Session(sid1, "one"), Session(sid2, "two"));
+
+        var resp = await _http.PostAsJsonAsync("sessions/voice-mode/all", new { enabled = true });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.True(node?["enabled"]?.GetValue<bool>());
+        Assert.Equal(2, node?["total"]?.GetValue<int>());
+        Assert.Equal(2, node?["changed"]?.GetValue<int>());
+        Assert.Equal(0, node?["skipped"]?.GetValue<int>());
+
+        // Exactly one voice-mode write per session, each carrying enabled=true, and they rode the tunnel
+        // (an HTTP dial to the unreachable Director could never have resolved the owner).
+        var voiceModeCmds = _commands.Where(c => c.Verb == "voice-mode").ToList();
+        Assert.Equal(2, voiceModeCmds.Count);
+        Assert.Contains(voiceModeCmds, c => c.SessionId == sid1);
+        Assert.Contains(voiceModeCmds, c => c.SessionId == sid2);
+        foreach (var c in voiceModeCmds)
+            Assert.True(JsonNode.Parse(c.PayloadJson)?["enabled"]?.GetValue<bool>());
+    }
+
+    [Fact]
+    public async Task VoiceModeAll_skipsASessionWhoseDirectorRejects_withoutFailingTheBatch()
+    {
+        var ok = Guid.NewGuid().ToString();
+        var rejected = Guid.NewGuid().ToString();
+        _rejectSids.Add(rejected);
+        await PushAsync(1L, Session(ok, "keeps"), Session(rejected, "rejects"));
+
+        var resp = await _http.PostAsJsonAsync("sessions/voice-mode/all", new { enabled = true });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal(2, node?["total"]?.GetValue<int>());
+        Assert.Equal(1, node?["changed"]?.GetValue<int>());
+        Assert.Equal(1, node?["skipped"]?.GetValue<int>());
+
+        // The per-session report names the rejected one as not-ok with a reason, and the other as ok.
+        var sessions = node?["sessions"]?.AsArray() ?? new JsonArray();
+        var okRow = sessions.FirstOrDefault(s => s?["sessionId"]?.GetValue<string>() == ok);
+        var rejectedRow = sessions.FirstOrDefault(s => s?["sessionId"]?.GetValue<string>() == rejected);
+        Assert.True(okRow?["ok"]?.GetValue<bool>());
+        Assert.False(rejectedRow?["ok"]?.GetValue<bool>());
+        Assert.False(string.IsNullOrWhiteSpace(rejectedRow?["reason"]?.GetValue<string>()));
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -185,6 +185,85 @@ internal static class GatewayWingmanVoiceEndpoint
             voice.Unmark(sid);
             return Results.Json(new { stopped = true });
         });
+
+        // Turn voice mode on or off for EVERY session at once (issue #1765). The fleet-wide counterpart
+        // to the per-session pair the phone and Cockpit fire (POST /voice-mode on the owning Director,
+        // plus mark/unmark here): ONE call, and the Gateway walks the whole roster so the caller never
+        // loops it itself. The person's own use is "as I leave the house, put my whole fleet on voice;
+        // when I get home, take it all off". Each session gets the SAME two effects the single path gives:
+        //   - the owning Director's voice-mode flag is set over the tunnel (ViewMode = Voice, so the roster
+        //     flag flips and the session persists as a voice session across navigation), and
+        //   - the Gateway voice marker is set (enable) or cleared (disable), so the per-turn narration
+        //     starts or stops.
+        // A session whose owning computer is not tunnel-connected is SKIPPED and reported, never failing
+        // the whole batch - the same "that computer is offline" story the single path tells. The
+        // Director-side writes run concurrently (each is its own tunnel round-trip); the Gateway-side
+        // mark/unmark is then applied SEQUENTIALLY so the persisted voice-session file is written on one
+        // thread and never raced. Idempotent: enabling a session already on, or disabling one already off,
+        // is a harmless no-op. This endpoint sends NO prompt into any session - it only sets voice marking,
+        // exactly like the single-session /voice-mode and /wingman/voice/stop it fans out to.
+        app.MapPost("/sessions/voice-mode/all", async (VoiceModeAllRequest? req, CancellationToken ct) =>
+        {
+            var enabled = req?.Enabled ?? true;
+            FileLog.Write($"[GatewayWingmanVoice] voice-mode/all requested: enabled={enabled}");
+
+            // The machine each Director runs on, so a skipped session names where it lives in plain English.
+            var machineByDirector = registry.ListDirectors()
+                .ToDictionary(d => d.DirectorId, d => d.MachineName, StringComparer.Ordinal);
+
+            // Every session the Gateway can see right now, de-duplicated by id. A session belongs to exactly
+            // one Director, but the guard keeps a duplicated roster entry from being toggled (and counted) twice.
+            var byDirector = GatewayEndpoints.FleetByDirector(registry, pushedSessions, stale);
+            var targets = new List<(string DirectorId, string Machine, string Sid, string? Name)>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var (directorId, sessions) in byDirector)
+                foreach (var s in sessions)
+                    if (!string.IsNullOrEmpty(s.SessionId) && seen.Add(s.SessionId))
+                        targets.Add((directorId, machineByDirector.GetValueOrDefault(directorId, ""), s.SessionId, s.Name));
+
+            // Set the Director-side flag on every session concurrently: each is an independent tunnel
+            // round-trip, so the batch finishes in the slowest single session's time, not the sum.
+            var sends = await Task.WhenAll(targets.Select(async t =>
+            {
+                var result = await DirectorCommandRouter.TrySendAsync(
+                    sendCommand, t.DirectorId, "voice-mode", t.Sid, new { enabled }, ct,
+                    machineName: string.IsNullOrEmpty(t.Machine) ? null : t.Machine);
+                return (Target: t, Result: result);
+            }));
+
+            // Apply the Gateway-side mark/unmark sequentially (one thread writes the persisted set), and
+            // build the per-session report so the caller sees exactly what changed and what was skipped.
+            var sessionResults = new List<object>(sends.Length);
+            var changed = 0;
+            foreach (var (t, result) in sends)
+            {
+                var ok = result is { Ok: true };
+                if (ok)
+                {
+                    if (enabled) voice.Mark(t.Sid); else voice.Unmark(t.Sid);
+                    changed++;
+                }
+                var reason = ok
+                    ? null
+                    : result is null
+                        ? string.IsNullOrEmpty(t.Machine)
+                            ? "This session's computer looks offline."
+                            : $"{t.Machine} looks offline."
+                        : DirectorCommandRouter.DescribeFailure(result);
+                sessionResults.Add(new { sessionId = t.Sid, name = t.Name, ok, reason });
+            }
+
+            FileLog.Write($"[GatewayWingmanVoice] voice-mode/all done: enabled={enabled}, total={sends.Length}, changed={changed}, skipped={sends.Length - changed}");
+            return Results.Json(new
+            {
+                enabled,
+                total = sends.Length,
+                changed,
+                skipped = sends.Length - changed,
+                sessions = sessionResults,
+            });
+        });
+
         // Resumable, idempotent piece-by-piece upload store (the same one the native app path uses):
         // chunks land on disk under a stable upload id and survive between retry attempts, so the
         // phone can keep re-sending pieces until the whole recording is through.
@@ -854,6 +933,13 @@ internal static class GatewayWingmanVoiceEndpoint
 public sealed class WingmanVoiceTurnRequest
 {
     public string Text { get; set; } = "";
+}
+
+/// <summary>Body of the fleet-wide voice-mode route (issue #1765): <c>Enabled = true</c> turns voice
+/// mode on for every session at once, <c>false</c> turns it off. An absent body defaults to enabling.</summary>
+public sealed class VoiceModeAllRequest
+{
+    public bool Enabled { get; set; } = true;
 }
 
 /// <summary>Body of the menu-press route: the exact keystrokes that pick an option, and (for a


### PR DESCRIPTION
Closes #1765.

## What this adds

One Gateway call that turns voice mode on - or off - for **every session at once**, plus a one-tap control in the mobile app and the Cockpit. Turning voice on was a per-session job (two Gateway calls each, one at a time); this fans it out on the Gateway so the caller makes a single request.

The motivating use: put the whole fleet on voice when leaving to go mobile, take it all off when back at the desk.

## Changes

- **Gateway** - `POST /sessions/voice-mode/all { enabled }` walks the whole roster (`FleetByDirector`) and, per session, does the same two things the single-session path does: sends the owning Director the `voice-mode` verb over the tunnel, then marks (enable) or unmarks (disable) the session on the Gateway. Director writes run concurrently; the Gateway-side mark/unmark is applied sequentially so the persisted voice-session file is written on one thread and never raced. A session whose owning computer is not tunnel-connected is **skipped and reported**, never failing the batch. Idempotent, and it sends no prompt into any session. Returns `{ enabled, total, changed, skipped, sessions[] }`.
- **client-core** - `setVoiceModeAllSessions(enabled)` returning a typed fleet result; a 402 surfaces the shared credits notice, once.
- **Mobile** - a one-tap switch at the top of the Voice tab that reads the roster to pick its own direction: "Turn on voice for all N sessions" while none are on, "Turn voice off for all sessions" once any is. Fail-loud summary of what changed and what was skipped.
- **Cockpit** - the same control under the roster ordering toggle.

## Offline / cost handling

- A session whose computer is offline (the Director is not tunnel-connected, or rejects the write) is reported skipped with a plain reason; the batch still succeeds for everyone reachable.
- Out of credits (402) raises the shared credits notice once for the whole batch, not once per session.

## Tests

- **Gateway tunnel proof** (`VoiceModeAllEndpointProofTests`) on a real streamMode host + real MessagePack tunnel: happy path (every session switched, one `voice-mode` write per session carrying the enabled flag) and skip path (a rejected session is reported skipped without failing the batch).
- **client-core** (`voiceModeAll.test.ts`): request shape, result parse, both directions, the 402 credits path, and the generic error path.
- Full Gateway test suite green (2542 passed); full client-core suite green (546 + 5 new).
