### PR TITLE
Bound the wingman model call so a stalled translation cannot freeze voice

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedInferenceBrainTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedInferenceBrainTests.cs
@@ -153,6 +153,59 @@ public sealed class HostedInferenceBrainTests
         Assert.IsAssignableFrom<InvalidOperationException>(caught);
     }
 
+    /// <summary>A handler that never answers until its token is cancelled - the shape a stalled hosted
+    /// worker takes. Drives the per-call deadline without a real 60-second (or 180-second) wait.</summary>
+    private sealed class HangingHandler : HttpMessageHandler
+    {
+        private int _calls;
+        public int Calls => _calls;
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Interlocked.Increment(ref _calls);
+            await Task.Delay(Timeout.Infinite, ct);   // answers only when the (linked) token cancels
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    [Fact]
+    public async Task AskAsync_WhenModelStalls_FailsFastAsTimeout_NotAfterThreeMinutes()
+    {
+        // THE FIX: the model leg used to carry a flat 180-second client timeout and nothing else, so a
+        // stalled hosted worker BLOCKED the whole voice generation for three minutes and then threw a raw
+        // cancellation - a silent FAILED on the auto path, a false "computer offline" 502 on the manual
+        // "generate" button. The call is now bounded per-attempt and fails fast as a clear TimeoutException
+        // the voice path maps to Retrying. A tiny injected deadline proves the bound without a real wait.
+        var handler = new HangingHandler();
+        using var http = new HttpClient(handler);
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { },
+            callTimeout: TimeSpan.FromMilliseconds(100));
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await Assert.ThrowsAsync<TimeoutException>(() => brain.AskAsync("translate this"));
+        sw.Stop();
+
+        Assert.Equal(1, handler.Calls);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(10), $"a bounded call must fail fast, but took {sw.Elapsed}");
+    }
+
+    [Fact]
+    public async Task AskAsync_WhenCallerCancels_SurfacesCancellation_NotMislabelledTimeout()
+    {
+        // The deadline and a real caller-cancel must be told apart: a caller cancelling (shutdown) is NOT
+        // the model failing to answer, so it surfaces as cancellation, never as a TimeoutException that the
+        // voice path would wrongly turn into a Retrying banner.
+        var handler = new HangingHandler();
+        using var http = new HttpClient(handler);
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { },
+            callTimeout: TimeSpan.FromMinutes(5));   // deadline far away, so only the caller-cancel can fire
+
+        using var cts = new CancellationTokenSource();
+        var task = brain.AskAsync("translate this", cts.Token);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+    }
+
     [Fact]
     public async Task AskAsync_EmptyContent_Throws()
     {

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
@@ -234,6 +234,66 @@ public sealed class WingmanVoiceServiceTests
         public void Dispose() { }
     }
 
+    /// <summary>A brain whose ask never answers - it throws <see cref="TimeoutException"/>, the shape a
+    /// bounded model-leg deadline (HostedInferenceBrain) now takes when the hosted worker stalls. Proves
+    /// the turn-end path maps a model NON-ANSWER to the calm Retrying state, not a silent FAILED.</summary>
+    private sealed class TimingOutBrain : IAgentBrain
+    {
+        private int _askCount;
+        public int AskCount => _askCount;
+        public string? SessionId => "timing-out-brain";
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref _askCount);
+            throw new TimeoutException("The wingman model call did not answer within 60 seconds.");
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth { IsAlive = true });
+        public void Dispose() { }
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WhenModelLegTimesOut_RecordsRetrying_NoAudio_NoSilentFailure()
+    {
+        // THE FIX (the owner's 2026-07-17 wedge): the MODEL leg (translation) stalling used to hang the
+        // whole generation for 180s and then die as a bare FAILED - the session sat red "needs you" with
+        // no audio and NO reason, so "half the fleet is stuck and generate does nothing". The model leg now
+        // mirrors the speech leg: a non-answer is Retrying (calm "voice on its way", the sweep retries),
+        // never a silent failure and never ServiceDown. Nothing plays, but the phone knows why.
+        var director = new TunnelReadStub("{\"widgets\":[{\"kind\":\"Text\",\"content\":\"the reply to narrate\"}]}");
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-modeltimeout-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new TimingOutBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 7, 7, 7 }, persistPath);
+
+            await svc.GenerateAsync("sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.Equal(1, brain.AskCount);                                          // it tried the model
+            Assert.False(svc.HasVoice("sid-1"));                                      // nothing to play
+            Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-1"));   // and it says WHY, calmly
+            Assert.NotEqual(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-1")); // a non-answer is not "down"
+            Assert.False(svc.IsGenerating("sid-1"));                                  // the yellow window closed
+            Assert.False(svc.SpeechCooldownArmed, "one slow model call must not silence the fleet");
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ } }
+    }
+
+    [Fact]
+    public void NoteRetrying_RecordsRetryingState_ForTheExplainPath()
+    {
+        // The on-demand "generate" (explain) path calls this when its translation times out, so the phone
+        // shows "voice on its way" instead of the old false 502 "this session's computer is offline".
+        var svc = NewService();
+        Assert.Null(svc.VoiceUnavailableFor("sid-1"));
+        svc.NoteRetrying("sid-1");
+        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-1"));
+    }
+
     /// <summary>A voice service wired to a recording brain and a text-to-speech stub that returns
     /// <paramref name="audio"/>, so the full turn-end path (fetch -> translate -> synthesize -> store)
     /// runs without a live model or provider.</summary>

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -670,6 +670,24 @@ internal static class GatewayWingmanVoiceEndpoint
                 _ = voice.CaptureTrainingAsync(route, sid, "explain", lastReply, recentContext, t.Spoken, t.ReplySeconds, CancellationToken.None);
                 return Results.Json(new { reply = lastReply, spoken = t.Spoken, replySeconds = t.ReplySeconds });
             }
+            catch (Exception ex) when (ex is TimeoutException or HttpRequestException)
+            {
+                // The model leg did not answer in time (bounded timeout) or the transport failed. This is
+                // the absence of an answer, not evidence the session's computer is offline - so record the
+                // calm Retrying state (the phone shows "voice on its way" and the sweep keeps trying) and
+                // return a benign 200, NOT the 502 the phone used to mislabel "this session's computer looks
+                // offline". Before this, a stalled model hung the request the full 180s and then 502'd, which
+                // is exactly the "I hit generate and nothing happens" the owner reported.
+                voice.NoteRetrying(sid);
+                FileLog.Write($"[GatewayWingmanVoice] explain sid={sid} model did not answer: {ex.Message} - Retrying (audio on its way)");
+                return Results.Json(new
+                {
+                    reply = "",
+                    spoken = "Voice is taking a moment - it will keep trying.",
+                    replySeconds = 0.0,
+                    retrying = true,
+                });
+            }
             catch (Exception ex)
             {
                 FileLog.Write($"[GatewayWingmanVoice] explain sid={sid} FAILED: {ex.Message}");

--- a/src/CcDirector.Gateway/Wingman/HostedInferenceBrain.cs
+++ b/src/CcDirector.Gateway/Wingman/HostedInferenceBrain.cs
@@ -25,22 +25,50 @@ namespace CcDirector.Gateway.Wingman;
 /// </summary>
 public sealed class HostedInferenceBrain : IAgentBrain
 {
-    /// <summary>Shared client with a generous timeout - a wingman summary is one model round trip and
-    /// the caller (voice turn) already bounds the overall wait.</summary>
-    private static readonly HttpClient SharedHttp = new() { Timeout = TimeSpan.FromMinutes(3) };
+    /// <summary>
+    /// The bound on ONE model round trip, and the whole reason this class owns a deadline at all.
+    ///
+    /// This client used to carry a flat <c>Timeout = TimeSpan.FromMinutes(3)</c> and nothing else. When
+    /// a hosted worker stalled (a cold start, a slow provider minute), the translation call did not fail
+    /// - it BLOCKED for the full three minutes and then threw. That is the wingman's model leg, which the
+    /// voice path runs on every turn-end and on the manual "generate" button, so a single stalled call
+    /// froze a session's voice for three minutes and then died with a raw cancellation - logged as a
+    /// silent FAILED on the auto path, and returned as a 502 the phone mislabelled "this session's
+    /// computer is offline" on the manual path. Measured on 2026-07-17: many translations finished in
+    /// ~10-20 seconds while the stalls went the full 180 (see the Gateway log's "HttpClient.Timeout of
+    /// 180 seconds elapsing" lines). The speech leg was already bounded and fast-failed to a Retrying
+    /// state (issue #1322 / the 2026-07-15 work); the model leg was left with this naive client and
+    /// skipped all of it.
+    ///
+    /// So the deadline is bounded and OWNED here (one timeout, one owner, matching TtsSynthesis and the
+    /// shared speech client): the static client's own timeout is INFINITE and each call is bounded by a
+    /// linked CancellationTokenSource. A stall now fails in <see cref="DefaultCallTimeout"/>, not 180s,
+    /// as a clear <see cref="TimeoutException"/> the caller maps to "audio on its way, retrying" and
+    /// retries on its own (the voice sweep). 60 seconds is deliberately generous over the ~10-20s a real
+    /// translation takes - the goal is to end the pathological three-minute hang without false-timing-out
+    /// a legitimately slow-but-working call; tune it down only with measurements.
+    /// </summary>
+    public static readonly TimeSpan DefaultCallTimeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>Shared client: the deadline is owned per-call by a linked token (see
+    /// <see cref="DefaultCallTimeout"/>), so the client itself never imposes a second, racing bound.</summary>
+    private static readonly HttpClient SharedHttp = new() { Timeout = Timeout.InfiniteTimeSpan };
 
     private readonly HttpClient _http;
     private readonly string _chatUrl;
     private readonly string _apiKey;
     private readonly string _model;
+    private readonly TimeSpan _callTimeout;
     private readonly Action<string> _log;
 
     /// <param name="baseUrl">The provider-compatible <c>/v1</c> base URL.</param>
     /// <param name="apiKey">The credential to present as the Bearer token. Must be non-empty.</param>
     /// <param name="model">The chat model id.</param>
-    /// <param name="http">HTTP client (tests inject a stub over a fake handler); a shared 3-minute client when null.</param>
+    /// <param name="http">HTTP client (tests inject a stub over a fake handler); a shared client when null.</param>
     /// <param name="log">Log sink; <see cref="FileLog.Write"/> when null.</param>
-    public HostedInferenceBrain(string baseUrl, string apiKey, string model, HttpClient? http = null, Action<string>? log = null)
+    /// <param name="callTimeout">Per-call deadline (tests pass a tiny value to prove the fast-fail without
+    /// a real wait); <see cref="DefaultCallTimeout"/> when null.</param>
+    public HostedInferenceBrain(string baseUrl, string apiKey, string model, HttpClient? http = null, Action<string>? log = null, TimeSpan? callTimeout = null)
     {
         if (string.IsNullOrWhiteSpace(baseUrl)) throw new ArgumentException("baseUrl is required", nameof(baseUrl));
         if (string.IsNullOrWhiteSpace(model)) throw new ArgumentException("model is required", nameof(model));
@@ -48,6 +76,7 @@ public sealed class HostedInferenceBrain : IAgentBrain
         _chatUrl = baseUrl.TrimEnd('/') + "/chat/completions";
         _apiKey = apiKey ?? "";
         _model = model.Trim();
+        _callTimeout = callTimeout ?? DefaultCallTimeout;
         _log = log ?? FileLog.Write;
     }
 
@@ -78,28 +107,51 @@ public sealed class HostedInferenceBrain : IAgentBrain
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
         req.Content = new StringContent(payload, Encoding.UTF8, "application/json");
 
-        using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseContentRead, ct);
-        var text = await resp.Content.ReadAsStringAsync(ct);
+        // Bound this one round trip (see DefaultCallTimeout). The linked source cancels on EITHER the
+        // caller's token or our deadline; we then tell the two apart below so a real caller-cancel is
+        // never mislabelled a timeout and vice versa.
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(_callTimeout);
+        HttpResponseMessage resp;
+        string text;
+        try
+        {
+            resp = await _http.SendAsync(req, HttpCompletionOption.ResponseContentRead, timeoutCts.Token);
+            text = await resp.Content.ReadAsStringAsync(timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            // Our deadline fired, not the caller's token. This is the stall the bound exists for: fail
+            // fast and clearly as a TimeoutException so the voice path maps it to Retrying ("audio on
+            // its way") and retries on its own, instead of blocking three minutes then dying.
+            sw.Stop();
+            _log($"[HostedInferenceBrain] chat/completions model={_model} did not answer within {_callTimeout.TotalSeconds:F0}s - giving up this attempt (the session retries on its own)");
+            throw new TimeoutException(
+                $"The wingman model call did not answer within {_callTimeout.TotalSeconds:F0} seconds.");
+        }
         sw.Stop();
 
-        if (!resp.IsSuccessStatusCode)
+        using (resp)
         {
-            _log($"[HostedInferenceBrain] chat/completions model={_model} -> {(int)resp.StatusCode} ({text.Length} bytes)");
-            // Out of credits / monthly cap (issue #939): use the ONE shared message, branched by the
-            // 402 code (insufficient_credits vs monthly_limit_reached) - not a hand-written string that
-            // can only say "out of credits" and drifts from the other surfaces.
-            var detail = resp.StatusCode == System.Net.HttpStatusCode.PaymentRequired
-                ? HostedAiMessages.For(HostedAiErrorMapper.Map402(text)).Text
-                : "Check the AI provider settings and that the account/key is valid.";
-            // Rate limited (issue #1324): surface a TYPED signal carrying the provider's Retry-After so
-            // the caller can back off for exactly as long as asked instead of hammering it into a 429
-            // storm. It extends InvalidOperationException, so every existing catch stays unchanged.
-            if ((int)resp.StatusCode == 429)
-                throw new WingmanModelRateLimitedException(
-                    $"The wingman model call failed: {(int)resp.StatusCode} {resp.StatusCode}. " + detail,
-                    CcDirector.Core.HostedAi.RetryAfterHeader.Parse(resp.Headers.RetryAfter));
-            throw new InvalidOperationException(
-                $"The wingman model call failed: {(int)resp.StatusCode} {resp.StatusCode}. " + detail);
+            if (!resp.IsSuccessStatusCode)
+            {
+                _log($"[HostedInferenceBrain] chat/completions model={_model} -> {(int)resp.StatusCode} ({text.Length} bytes)");
+                // Out of credits / monthly cap (issue #939): use the ONE shared message, branched by the
+                // 402 code (insufficient_credits vs monthly_limit_reached) - not a hand-written string that
+                // can only say "out of credits" and drifts from the other surfaces.
+                var detail = resp.StatusCode == System.Net.HttpStatusCode.PaymentRequired
+                    ? HostedAiMessages.For(HostedAiErrorMapper.Map402(text)).Text
+                    : "Check the AI provider settings and that the account/key is valid.";
+                // Rate limited (issue #1324): surface a TYPED signal carrying the provider's Retry-After so
+                // the caller can back off for exactly as long as asked instead of hammering it into a 429
+                // storm. It extends InvalidOperationException, so every existing catch stays unchanged.
+                if ((int)resp.StatusCode == 429)
+                    throw new WingmanModelRateLimitedException(
+                        $"The wingman model call failed: {(int)resp.StatusCode} {resp.StatusCode}. " + detail,
+                        CcDirector.Core.HostedAi.RetryAfterHeader.Parse(resp.Headers.RetryAfter));
+                throw new InvalidOperationException(
+                    $"The wingman model call failed: {(int)resp.StatusCode} {resp.StatusCode}. " + detail);
+            }
         }
 
         var content = ExtractContent(text);

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -275,6 +275,30 @@ public sealed class WingmanVoiceService
         => _voiceUnavailable.TryGetValue(sid, out var s) ? s : (HostedAiState?)null;
 
     /// <summary>
+    /// Record that a model/translation call did not answer in time (a bounded timeout or a transport
+    /// failure), so this session shows the calm "voice on its way" retrying state rather than a silent
+    /// failure or a false "this session's computer is offline". The on-demand explain path uses this
+    /// when its translation times out; the auto path sets the same state inline. Cleared on the next
+    /// successful generation, on the Working transition, and when voice is turned off - exactly like the
+    /// speech-leg unavailable state.
+    /// </summary>
+    public void NoteRetrying(string sid) => _voiceUnavailable[sid] = HostedAiState.Retrying;
+
+    /// <summary>
+    /// True when an exception from the model (translation) leg means it DID NOT ANSWER - a bounded
+    /// <see cref="TimeoutException"/> from <see cref="HostedInferenceBrain"/>, or an
+    /// <see cref="HttpRequestException"/> transport failure - as opposed to an answered failure (402,
+    /// 429, 5xx surface as typed/InvalidOperation exceptions and are handled elsewhere). A caller-cancel
+    /// (shutdown) is excluded: that is not the model's non-answer, it is us stopping. This is the model
+    /// leg's mirror of the "absence of evidence -> Retrying" rule the speech leg already applies.
+    /// </summary>
+    private static bool IsModelDidNotAnswer(Exception ex, CancellationToken ct)
+        => ex is not WingmanModelRateLimitedException
+           && (ex is TimeoutException
+               || ex is HttpRequestException
+               || (ex is OperationCanceledException && !ct.IsCancellationRequested));
+
+    /// <summary>
     /// Capture one wingman summary for the training dataset (no-op unless the setting is on).
     /// Best-effort and fire-and-forget at the call site so it never delays a voice turn; the
     /// store fetches up to 20,000 chars of the session terminal and appends the record itself.
@@ -530,7 +554,25 @@ public sealed class WingmanVoiceService
         if (showReadingWindow) BeginGenerating(sid);
         try
         {
-            var t = await _translator.TranslateAsync(recentContext, lastReply, _sessionTitleResolver?.Invoke(sid), ct);
+            WingmanTranslation t;
+            try
+            {
+                t = await _translator.TranslateAsync(recentContext, lastReply, _sessionTitleResolver?.Invoke(sid), ct);
+            }
+            catch (Exception ex) when (IsModelDidNotAnswer(ex, ct))
+            {
+                // The MODEL leg (the translation) did not answer - a bounded timeout or a transport
+                // failure - so we have no evidence about the service. This is the exact story the speech
+                // leg already tells (see TtsAsync): a non-answer is Retrying, NOT a silent FAILED and NOT
+                // ServiceDown. Recording Retrying makes the phone show the calm "voice on its way" state
+                // and the voice sweep retries on its own, instead of the session sitting red with no audio
+                // and no reason (the wedge the owner hit: half the fleet stuck, "generate" doing nothing).
+                // A rate-limit (WingmanModelRateLimitedException) is NOT caught here - it stays thrown so
+                // GenerateAsync's handler arms the model cooldown with the provider's Retry-After.
+                _voiceUnavailable[sid] = HostedAiState.Retrying;
+                FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - Retrying (audio on its way); the session retries on its own");
+                return false;   // nothing produced; the provider was not usefully reached, so report no success
+            }
             await StoreSpokenAsync(sid, t.Spoken, lastReply, ct);
             // Log the TRUE outcome: StoreSpokenAsync only makes the session playable when the
             // text-to-speech synthesis actually returned audio. Logging "voice ready"


### PR DESCRIPTION
## The problem (observed in the live Gateway log)

The wingman **translation** model call - the step that turns an agent's reply into speakable text - carried a flat 180-second HttpClient timeout and nothing else. When a hosted worker stalled, it blocked the full three minutes and then threw a raw cancellation:

```
[WingmanVoiceService] GenerateAsync sid=... FAILED: The request was canceled due to the configured HttpClient.Timeout of 180 seconds elapsing.
[GatewayWingmanVoice] explain sid=... FAILED: ...HttpClient.Timeout of 180 seconds elapsing.
```

- **Automatic turn-end path:** the timeout surfaced as a silent `FAILED`, so the session sat red "needs you" with no audio and no reason. A session swept every 45 seconds could never reach "voice ready".
- **Manual "generate" button:** it came back as a 502 the phone mislabelled "this session's computer looks offline".

Half a fleet of voice sessions could wedge this way, and pressing generate appeared to do nothing.

## Why it happened

The **speech** leg was already hardened for exactly this failure (bounded per-attempt deadline; a timeout mapped to the calm `Retrying` state the phone renders as "voice on its way" while the sweep retries). The **model** leg was left with the naive 180-second client and bypassed all of it.

## The fix

Extends the same, already-designed treatment to the model leg:

- **`HostedInferenceBrain`** bounds each call with a linked cancellation source (default 60 seconds, well over the ~10-20 seconds a real translation takes) and fails fast as a clear `TimeoutException` instead of hanging 180 seconds. A real caller-cancel is told apart from the deadline so it is never mislabelled.
- **`WingmanVoiceService`** maps a model non-answer (timeout / transport failure) to `HostedAiState.Retrying`, exactly like the speech leg - not a silent failure, not `ServiceDown`. A rate-limit still propagates so the model cooldown arms.
- **`/explain` endpoint** records `Retrying` and returns a calm response on a model non-answer, instead of the 502 the phone read as "offline".

## Tests

New regression tests: fast-fail on a stalled model, the caller-cancel distinction, and the turn-end path recording `Retrying` with no audio. Proven fail-on-purpose (revert the catch -> `Retrying` becomes `null` -> red). All seven test projects pass (~6,300 tests).