### PR TITLE
refactor(gateway): give durable stores host-owned injection points

### DIFF
--- a/src/CcDirector.Gateway.Tests/Account/GatewayInstallIdTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/GatewayInstallIdTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace CcDirector.Gateway.Tests.Account;
 
 /// <summary>
-/// Proves the Gateway's stable install identity (issue #857): <see cref="GatewayInstallId.LoadOrCreate(string)"/>
+/// Proves the Gateway's stable install identity (issue #857): <see cref="GatewayInstallId.LoadOrCreate()"/>
 /// mints a GUID once, persists it, and returns the SAME value on every later call - the idempotency anchor
 /// that keeps the cloud from creating a new device record on each launch. A malformed file regenerates.
 /// </summary>
@@ -19,11 +19,11 @@ public sealed class GatewayInstallIdTests
         var path = TempPath();
         try
         {
-            var first = GatewayInstallId.LoadOrCreate(path);
+            var first = new GatewayInstallId(path).LoadOrCreate();
             Assert.True(Guid.TryParse(first, out _), "the minted id must be a GUID");
             Assert.True(File.Exists(path));
 
-            var second = GatewayInstallId.LoadOrCreate(path);
+            var second = new GatewayInstallId(path).LoadOrCreate();
             Assert.Equal(first, second);
         }
         finally
@@ -41,7 +41,7 @@ public sealed class GatewayInstallIdTests
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             File.WriteAllText(path, "not-a-guid");
 
-            var id = GatewayInstallId.LoadOrCreate(path);
+            var id = new GatewayInstallId(path).LoadOrCreate();
             Assert.True(Guid.TryParse(id, out _));
             Assert.Equal(id, File.ReadAllText(path).Trim());
         }

--- a/src/CcDirector.Gateway.Tests/GatewayTranscriptionServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTranscriptionServiceTests.cs
@@ -42,10 +42,10 @@ public sealed class GatewayTranscriptionServiceTests : IDisposable
 
     /// <summary>
     /// A scratch archive under this test's own root. EVERY service built here must be given one:
-    /// falling back to TranscriptionAudioArchive.Shared writes clips into the REAL user's
-    /// transcription-audio folder. CC_DIRECTOR_ROOT alone does NOT protect against that - it is
-    /// process-wide, and xUnit runs other collections in parallel that clear it mid-test, so Shared
-    /// resolves to the real location. Injection is the only isolation that holds.
+    /// an omitted archive defaults to one over the REAL user's transcription-audio folder.
+    /// CC_DIRECTOR_ROOT alone does NOT protect against that - it is process-wide, and xUnit runs other
+    /// collections in parallel that clear it mid-test, so the default can resolve to the real location.
+    /// Injection is the only isolation that holds.
     /// </summary>
     private TranscriptionAudioArchive ScratchArchive() => new(Path.Combine(_root, "archive-scratch"));
 

--- a/src/CcDirector.Gateway/Account/GatewayDeviceRegistrationService.cs
+++ b/src/CcDirector.Gateway/Account/GatewayDeviceRegistrationService.cs
@@ -62,9 +62,10 @@ public sealed class GatewayDeviceRegistrationService
     /// <param name="platform">This device's platform string (for example "windows"). Required.</param>
     /// <param name="appVersion">The reporting app version, or null when omitted.</param>
     /// <param name="installIdProvider">
-    /// Resolves the stable Gateway install id; defaults to <see cref="GatewayInstallId.LoadOrCreate()"/>.
-    /// Tests inject a fixed provider so they never touch the real config root. Resolved lazily on first
-    /// use (never at construction) and cached, so constructing this service does no disk I/O.
+    /// Resolves the stable Gateway install id; in production the host owns one <see cref="GatewayInstallId"/>
+    /// instance and passes its resolver, and when omitted it defaults to a fresh instance over the default
+    /// path. Tests inject a fixed provider so they never touch the real config root. Resolved lazily on
+    /// first use (never at construction) and cached, so constructing this service does no disk I/O.
     /// </param>
     /// <param name="endpointUrlsProvider">
     /// Resolves THIS Gateway's own reachable front-door URLs in priority order to publish as the device's
@@ -91,7 +92,7 @@ public sealed class GatewayDeviceRegistrationService
         _machineName = machineName ?? throw new ArgumentNullException(nameof(machineName));
         _platform = platform ?? throw new ArgumentNullException(nameof(platform));
         _appVersion = appVersion;
-        _installIdProvider = installIdProvider ?? GatewayInstallId.LoadOrCreate;
+        _installIdProvider = installIdProvider ?? new GatewayInstallId().LoadOrCreate;
         _endpointUrlsProvider = endpointUrlsProvider;
     }
 

--- a/src/CcDirector.Gateway/Account/GatewayInstallId.cs
+++ b/src/CcDirector.Gateway/Account/GatewayInstallId.cs
@@ -22,7 +22,7 @@ namespace CcDirector.Gateway.Account;
 ///     %LOCALAPPDATA%\cc-director\config\director\gateway-install-id.txt
 /// Locked to the current user by living under that per-user root.
 /// </summary>
-public static class GatewayInstallId
+public sealed class GatewayInstallId
 {
     /// <summary>The file name that holds the persisted Gateway install id.</summary>
     public const string FileName = "gateway-install-id.txt";
@@ -30,21 +30,22 @@ public static class GatewayInstallId
     /// <summary>The default on-disk path of the install-id file under the config root.</summary>
     public static string DefaultPath => Path.Combine(CcStorage.Config(), "director", FileName);
 
-    /// <summary>
-    /// Reads the persisted Gateway install id, minting and writing a fresh GUID once if the file is
-    /// missing, empty, or malformed. Subsequent calls return the same id. Uses <see cref="DefaultPath"/>.
-    /// </summary>
-    public static string LoadOrCreate() => LoadOrCreate(DefaultPath);
+    private readonly string _path;
+
+    /// <param name="path">Override the install-id file path (tests). Defaults to <see cref="DefaultPath"/>.</param>
+    public GatewayInstallId(string? path = null)
+    {
+        _path = string.IsNullOrWhiteSpace(path) ? DefaultPath : path;
+    }
 
     /// <summary>
-    /// Reads the persisted Gateway install id from <paramref name="path"/>, minting and writing a fresh
-    /// GUID once if the file is missing, empty, or malformed. Public so tests can drive an isolated path.
+    /// Reads the persisted Gateway install id, minting and writing a fresh GUID once if the file is
+    /// missing, empty, or malformed. Subsequent calls return the same id. Instance-owned so the host
+    /// constructs one and hands its resolver down, instead of an ambient static method.
     /// </summary>
-    /// <param name="path">The install-id file path. Required.</param>
-    public static string LoadOrCreate(string path)
+    public string LoadOrCreate()
     {
-        if (string.IsNullOrWhiteSpace(path))
-            throw new ArgumentException("Install-id path is required", nameof(path));
+        var path = _path;
 
         var dir = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(dir))

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -102,7 +102,14 @@ internal static class GatewayEndpoints
         // POST/GET /missions routes are mapped and a mission-scoped spawn validates against it. Missions are
         // a fleet-level concept, so the source of truth lives here at the Gateway. Null (old callers, tests)
         // maps nothing, leaving missions to the Director's own /missions routes (unchanged this phase).
-        Core.Sessions.MissionStore? missions = null)
+        Core.Sessions.MissionStore? missions = null,
+        // Store injection points: the host owns a single key vault, transcription telemetry log, and audio
+        // archive and passes them here so the phone-recorder ingest transcriber (RecordingEndpoints) uses
+        // the host's instances rather than newing its own. Null (old callers, tests) leaves RecordingEndpoints
+        // to build its own defaults, byte-identical to before.
+        Core.KeyVault? recordingKeyVault = null,
+        Transcription.TranscriptionTelemetryLog? transcriptionTelemetry = null,
+        Transcription.TranscriptionAudioArchive? transcriptionAudioArchive = null)
     {
         // The old issue #1188 "session lock" (423 Locked on human input while a PENDING dictation record
         // existed) was removed deliberately (issue #1308). This is a single-operator tool: a collision
@@ -214,7 +221,7 @@ internal static class GatewayEndpoints
         var logoutVisibility = authEnabled ? "" : "style=\"display:none\"";
 
         // Phone recorder ingest (offline-recorded audio -> transcription -> vault).
-        RecordingEndpoints.Map(app);
+        RecordingEndpoints.Map(app, recordingKeyVault, transcriptionTelemetry, transcriptionAudioArchive);
 
         // Read-only view of the Communication Manager approval queue (see the phone's
         // pending drafts remotely). Step 1 of centralizing the comm queue on the Gateway.

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -116,7 +116,10 @@ internal static class GatewayWingmanVoiceEndpoint
         SessionOwnerCache? owners = null,
         TimeSpan? streamStale = null,
         Func<string>? instructionsProvider = null,
-        HttpClient? ttsHttpClient = null)
+        HttpClient? ttsHttpClient = null,
+        Voice.VoiceUploadStore? uploadStore = null,
+        Transcription.TranscriptionTelemetryLog? telemetry = null,
+        Transcription.TranscriptionAudioArchive? audioArchive = null)
     {
         // The speech transport: the shared static in production, an injected stub in a test. This is the
         // same seam WingmanVoiceService already exposes for its narration leg (ttsHttpClient) and it
@@ -147,7 +150,7 @@ internal static class GatewayWingmanVoiceEndpoint
         // (the resumable /wingman/utterance/complete and the one-shot /wingman/transcribe) go through
         // it, so they resolve the mode + key and pick the hosted endpoint exactly the same way every
         // other batch caller does - no second resolver.
-        var transcription = new Transcription.GatewayTranscriptionService(vault);
+        var transcription = new Transcription.GatewayTranscriptionService(vault, telemetry: telemetry, audioArchive: audioArchive);
 
         // Which voice sessions have a ready, playable spoken summary right now (the phone's list
         // shows a play button on these and can play without entering).
@@ -266,8 +269,9 @@ internal static class GatewayWingmanVoiceEndpoint
 
         // Resumable, idempotent piece-by-piece upload store (the same one the native app path uses):
         // chunks land on disk under a stable upload id and survive between retry attempts, so the
-        // phone can keep re-sending pieces until the whole recording is through.
-        var uploads = new VoiceUploadStore();
+        // phone can keep re-sending pieces until the whole recording is through. In production the host
+        // owns this instance and passes it; when omitted it defaults to a fresh one over the same root.
+        var uploads = uploadStore ?? new VoiceUploadStore();
 
         // ===== Resumable transcription upload (issue #531: drive-safe, keeps trying) =====
         // The phone records locally (works offline), then ships the recording in pieces here and

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -46,14 +46,20 @@ internal static class RecordingEndpoints
         PropertyNameCaseInsensitive = true,
     };
 
-    public static void Map(IEndpointRouteBuilder app)
+    public static void Map(
+        IEndpointRouteBuilder app,
+        KeyVault? keyVault = null,
+        TranscriptionTelemetryLog? telemetry = null,
+        TranscriptionAudioArchive? audioArchive = null)
     {
         // Lazily built on FIRST USE, not at host startup: constructing the service resolves
         // the OpenAI API key (the transcriber needs it), and the Gateway must boot on machines
         // without that key. A missing key then fails the individual recording request loudly
         // (500 with an explicit hosted-AI setup message) instead of preventing
         // the entire Gateway host from starting.
-        var lazyService = new Lazy<RecordingIngestService>(BuildService);
+        // In production the host owns the key vault + telemetry + audio archive and passes them, so the
+        // recording transcriber shares the host's single instances rather than newing its own copies.
+        var lazyService = new Lazy<RecordingIngestService>(() => BuildService(keyVault, telemetry, audioArchive));
 
         app.MapPost("/ingest/recording", async (HttpContext ctx) =>
         {
@@ -406,7 +412,10 @@ internal static class RecordingEndpoints
         """;
     }
 
-    private static RecordingIngestService BuildService()
+    private static RecordingIngestService BuildService(
+        KeyVault? keyVault,
+        TranscriptionTelemetryLog? telemetry,
+        TranscriptionAudioArchive? audioArchive)
     {
         // Local transient store for transcripts (audio + markdown). Transcripts
         // are NOT auto-filed into the vault; the user promotes the keepers.
@@ -434,7 +443,7 @@ internal static class RecordingEndpoints
         return new RecordingIngestService(
             root,
             transcriberFactory: () => new GatewayServiceRecordingTranscriber(
-                new GatewayTranscriptionService(new KeyVault())),
+                new GatewayTranscriptionService(keyVault ?? new KeyVault(), telemetry: telemetry, audioArchive: audioArchive)),
             filer,
             collectionDir);
     }

--- a/src/CcDirector.Gateway/Api/TranscriptionBatchEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionBatchEndpoint.cs
@@ -32,7 +32,11 @@ namespace CcDirector.Gateway.Api;
 /// </summary>
 internal static class TranscriptionBatchEndpoint
 {
-    public static void Map(IEndpointRouteBuilder app, KeyVault vault)
+    public static void Map(
+        IEndpointRouteBuilder app,
+        KeyVault vault,
+        TranscriptionTelemetryLog? telemetry = null,
+        TranscriptionAudioArchive? audioArchive = null)
     {
         app.MapPost("/transcription", async (HttpContext ctx) =>
         {
@@ -52,7 +56,7 @@ internal static class TranscriptionBatchEndpoint
 
             FileLog.Write($"[TranscriptionBatchEndpoint] POST /transcription: bytes={audio.Length}, contentType={contentType}, correct={correct}");
 
-            var service = new GatewayTranscriptionService(vault);
+            var service = new GatewayTranscriptionService(vault, telemetry: telemetry, audioArchive: audioArchive);
             var result = await service.TranscribeAsync(audio, fileName, contentType, correct, ctx.RequestAborted);
 
             return result.Outcome switch

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -401,6 +401,9 @@ public sealed class GatewayHost : IAsyncDisposable
     // The Gateway's stable per-machine install identity (issue #857), owned by the host and handed to the
     // device-registration service instead of the retired static GatewayInstallId.LoadOrCreate.
     private readonly Account.GatewayInstallId _installIdStore = new();
+    // The Gateway bearer token store, owned by the host and used to resolve the token below instead of the
+    // retired static GatewayAuth.LoadOrCreate. The tray's read-only path stays on GatewayAuth.DefaultTokenFile.
+    private readonly Util.GatewayAuth _gatewayAuth = new();
 
     /// <summary>
     /// THE PRODUCER of the dictation phase label - the three facts that decide whether a session paints
@@ -515,7 +518,7 @@ public sealed class GatewayHost : IAsyncDisposable
         BrainTool = Core.Configuration.BrainToolConfig.EnsureHostable(brainTool ?? Core.Configuration.BrainToolConfig.Get());
 
         Port = port;
-        Token = token ?? new GatewayAuth().LoadOrCreate();
+        Token = token ?? _gatewayAuth.LoadOrCreate();
         Registry = new DirectorRegistry(instancesDirectory);
         // Issue #1292: free a removed Director's session numbers so a Director that died without releasing
         // them does not leak the pool. OnDirectorRemoved fires on graceful unregister and on the registry's

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -389,6 +389,18 @@ public sealed class GatewayHost : IAsyncDisposable
     // terminal tombstone de-dupes the upload id forever until the client acknowledges it - so there is no
     // age sweep for dictation staging (only the unrelated voice-turn staging is age-swept).
     private readonly Voice.VoiceUploadStore _dictationUploads = new(CcDirector.Core.Storage.CcStorage.DictationUploads());
+    // Store injection points (Hosted Gateway, Step 1b): the host owns ONE instance of each durable store
+    // that was previously reached through a process-wide static, and hands it to the endpoint/service that
+    // uses it, so a tenant id can reach the storage layer in a later pull request. Same default paths as
+    // the retired statics; no behavior change. The voice-turn upload store (VoiceTurnUploads root) is
+    // distinct from _dictationUploads above (DictationUploads root) - two roots, two subsystems.
+    private readonly Prompts.GatewayPromptLog _promptLog = new();
+    private readonly Transcription.TranscriptionTelemetryLog _transcriptionTelemetry = new();
+    private readonly Transcription.TranscriptionAudioArchive _transcriptionAudioArchive = new();
+    private readonly Voice.VoiceUploadStore _voiceTurnUploads = new();
+    // The Gateway's stable per-machine install identity (issue #857), owned by the host and handed to the
+    // device-registration service instead of the retired static GatewayInstallId.LoadOrCreate.
+    private readonly Account.GatewayInstallId _installIdStore = new();
 
     /// <summary>
     /// THE PRODUCER of the dictation phase label - the three facts that decide whether a session paints
@@ -503,7 +515,7 @@ public sealed class GatewayHost : IAsyncDisposable
         BrainTool = Core.Configuration.BrainToolConfig.EnsureHostable(brainTool ?? Core.Configuration.BrainToolConfig.Get());
 
         Port = port;
-        Token = token ?? GatewayAuth.LoadOrCreate();
+        Token = token ?? new GatewayAuth().LoadOrCreate();
         Registry = new DirectorRegistry(instancesDirectory);
         // Issue #1292: free a removed Director's session numbers so a Director that died without releasing
         // them does not leak the pool. OnDirectorRemoved fires on graceful unregister and on the registry's
@@ -771,6 +783,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 machineName: Environment.MachineName,
                 platform: ResolvePlatform(),
                 appVersion: AppVersion.Semver,
+                installIdProvider: _installIdStore.LoadOrCreate,
                 endpointUrlsProvider: resolveEndpointUrls);
             _childMirror = new Account.ChildDeviceMirrorService(
                 Account,
@@ -1314,6 +1327,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // network-diagnostics rollup store is threaded in as a named argument on the tunnel-only signature.
         GatewayEndpoints.Map(_app, Registry, version, Token, AuthEnabled,
             netDiagRollup: _netDiagRollup,
+            // Store injection points: hand the phone-recorder ingest (RecordingEndpoints) the host's single
+            // key vault + transcription telemetry + audio archive, so it stops newing its own copies.
+            recordingKeyVault: _keyVault,
+            transcriptionTelemetry: _transcriptionTelemetry,
+            transcriptionAudioArchive: _transcriptionAudioArchive,
             requestShutdown: () =>
             {
                 var handler = OnShutdownRequested;
@@ -1491,7 +1509,12 @@ public sealed class GatewayHost : IAsyncDisposable
             pushedSessions: PushedSessions,
             sendCommand: SendCommandAsync,
             owners: SessionOwners,
-            instructionsProvider: () => _instructionsStore.ActiveContent);
+            instructionsProvider: () => _instructionsStore.ActiveContent,
+            // Store injection points: hand the endpoint the host's single voice-turn upload store and the
+            // host's transcription telemetry + audio archive, so it stops newing its own copies.
+            uploadStore: _voiceTurnUploads,
+            telemetry: _transcriptionTelemetry,
+            audioArchive: _transcriptionAudioArchive);
 
         // Car Mode brain (Car Mode mission, New build A): the fleet tool-calling loop behind
         // POST /carmode/turn. The chat transport resolves the fast wingman model + the vault key at CALL
@@ -1528,7 +1551,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // in resumable chunks and the Gateway assembles → transcribes → injects the turn into the
         // owning session itself, so a refresh / dropped connection cannot lose a recorded utterance.
         GatewayDictationEndpoint.Map(_app, Registry, SessionOwners, Token,
-            _dictationTranscription ?? new Transcription.GatewayTranscriptionService(_keyVault), _transcribingSessions, _dictationUploads, Devices,
+            _dictationTranscription ?? new Transcription.GatewayTranscriptionService(_keyVault, telemetry: _transcriptionTelemetry, audioArchive: _transcriptionAudioArchive), _transcribingSessions, _dictationUploads, Devices,
             pushedSessions: PushedSessions,
             sendCommand: SendCommandAsync);
         // Durable per-upload-id dictation record (issue #1183): a PENDING upload's chunks are retained
@@ -1658,7 +1681,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // through this one endpoint - it resolves the mode + key and runs the right provider (in-process
         // Whisper, or the resolved provider-compatible batch endpoint). Optional ?correct=true also runs
         // the validated dictionary correction, keeping that out of the callers too.
-        TranscriptionBatchEndpoint.Map(_app, _keyVault);
+        TranscriptionBatchEndpoint.Map(_app, _keyVault, _transcriptionTelemetry, _transcriptionAudioArchive);
 
         // Read-only analysis over the LOCAL transcription telemetry log: latency percentiles, cleanup
         // behaviour, most-corrected terms, and word frequencies, so any agent can query the Gateway to
@@ -1765,7 +1788,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // wanting history reads GET /prompts. It lives here, not on a Director, because the Gateway is
         // what the whole fleet reports to - so the history is already present rather than scattered
         // across machines - and because the Gateway is what moves to the server.
-        Prompts.PromptEndpoints.Map(_app);
+        Prompts.PromptEndpoints.Map(_app, _promptLog);
 
         Mobile.MobileApp.Map(_app, Token);
 

--- a/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
+++ b/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
@@ -30,9 +30,6 @@ namespace CcDirector.Gateway.Prompts;
 /// </summary>
 public sealed class GatewayPromptLog
 {
-    /// <summary>Process-wide shared log used by the Gateway's prompt endpoints.</summary>
-    public static readonly GatewayPromptLog Shared = new();
-
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,

--- a/src/CcDirector.Gateway/Prompts/PromptEndpoints.cs
+++ b/src/CcDirector.Gateway/Prompts/PromptEndpoints.cs
@@ -17,9 +17,9 @@ namespace CcDirector.Gateway.Prompts;
 /// </summary>
 public static class PromptEndpoints
 {
-    public static void Map(IEndpointRouteBuilder app, GatewayPromptLog? log = null)
+    public static void Map(IEndpointRouteBuilder app, GatewayPromptLog log)
     {
-        var store = log ?? GatewayPromptLog.Shared;
+        var store = log ?? throw new ArgumentNullException(nameof(log));
 
         app.MapPost("/prompts", (PromptIngestRequest? request) =>
         {

--- a/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
+++ b/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
@@ -52,11 +52,12 @@ public sealed class GatewayTranscriptionService
     /// dictionary-corrector POST (tests inject a stub). The pipeline creates and owns one when null.</param>
     /// <param name="cleanupModel">Cleanup identity used only for logging (the corrector is deterministic,
     /// not a model). Defaults to the dictation default when blank.</param>
-    /// <param name="telemetry">Local transcription telemetry sink. Defaults to the process-wide shared
-    /// log (<see cref="TranscriptionTelemetryLog.Shared"/>); tests inject their own.</param>
-    /// <param name="audioArchive">Rolling archive of the audio behind each turn. Defaults to the
-    /// process-wide shared archive (<see cref="TranscriptionAudioArchive.Shared"/>); tests inject their
-    /// own so they never write into the real user's archive.</param>
+    /// <param name="telemetry">Local transcription telemetry sink. In production the host owns one
+    /// instance and passes it here; when omitted it defaults to a fresh instance over the per-user
+    /// location, and tests inject their own.</param>
+    /// <param name="audioArchive">Rolling archive of the audio behind each turn. In production the host
+    /// owns one instance and passes it here; when omitted it defaults to a fresh instance over the
+    /// per-user location, and tests inject their own so they never write into the real user's archive.</param>
     public GatewayTranscriptionService(
         KeyVault vault,
         Func<DictationDictionary>? dictionaryProvider = null,
@@ -71,8 +72,8 @@ public sealed class GatewayTranscriptionService
         _modeProvider = modeProvider ?? TranscriptionModeConfig.Get;
         _http = http;
         _cleanupModel = string.IsNullOrWhiteSpace(cleanupModel) ? CleanupOrchestrator.DefaultModel : cleanupModel;
-        _telemetry = telemetry ?? TranscriptionTelemetryLog.Shared;
-        _audioArchive = audioArchive ?? TranscriptionAudioArchive.Shared;
+        _telemetry = telemetry ?? new TranscriptionTelemetryLog();
+        _audioArchive = audioArchive ?? new TranscriptionAudioArchive();
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Transcription/TranscriptionAudioArchive.cs
+++ b/src/CcDirector.Gateway/Transcription/TranscriptionAudioArchive.cs
@@ -34,9 +34,6 @@ namespace CcDirector.Gateway.Transcription;
 /// </summary>
 public sealed class TranscriptionAudioArchive
 {
-    /// <summary>Process-wide shared archive used by the transcription service.</summary>
-    public static readonly TranscriptionAudioArchive Shared = new();
-
     /// <summary>How long a clip is kept. A problem reported "yesterday" must still have its audio.</summary>
     public static readonly TimeSpan MaxAge = TimeSpan.FromHours(24);
 
@@ -51,12 +48,11 @@ public sealed class TranscriptionAudioArchive
 
     /// <summary>
     /// An explicit directory override, or null to use <see cref="DefaultDirectory"/>. Only the OVERRIDE
-    /// is stored; the default is resolved PER ACCESS by <see cref="ArchiveDirectory"/> and never captured here.
-    /// <see cref="Shared"/> is a static field, so anything this constructor resolves is baked at type
-    /// load - which happens once, before a test can set CC_DIRECTOR_ROOT, and no test can undo it. That
-    /// bug shipped: test clips landed in the real user's archive because the isolated tests fell back to
-    /// Shared, whose path had already been fixed to the real location. The tests were isolated
-    /// correctly; the static defeated them.
+    /// is stored; the default is resolved PER ACCESS by <see cref="ArchiveDirectory"/> and never captured
+    /// here, so CC_DIRECTOR_ROOT set after this instance is built still redirects where clips land. An
+    /// instance that captured the default in its constructor would bake the path at construction time and
+    /// defeat a test that sets CC_DIRECTOR_ROOT afterwards - which is how isolated tests once wrote clips
+    /// into the real user's archive.
     /// </summary>
     private readonly string? _directoryOverride;
 

--- a/src/CcDirector.Gateway/Transcription/TranscriptionTelemetryLog.cs
+++ b/src/CcDirector.Gateway/Transcription/TranscriptionTelemetryLog.cs
@@ -26,9 +26,6 @@ namespace CcDirector.Gateway.Transcription;
 /// </summary>
 public sealed class TranscriptionTelemetryLog
 {
-    /// <summary>Process-wide shared log used by the per-request transcription service.</summary>
-    public static readonly TranscriptionTelemetryLog Shared = new();
-
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,

--- a/src/CcDirector.Gateway/Util/GatewayAuth.cs
+++ b/src/CcDirector.Gateway/Util/GatewayAuth.cs
@@ -8,14 +8,29 @@ namespace CcDirector.Gateway.Util;
 /// Loads (or generates and stores) the gateway bearer token used to protect
 /// write endpoints. Stored in plain text at:
 ///     %LOCALAPPDATA%\cc-director\config\director\gateway-token.txt
+///
+/// Instance-owned so the host constructs one and hands it to the caller that needs it, rather than
+/// minting through a process-wide static. The on-disk path and the load-or-create semantics are
+/// unchanged. <see cref="DefaultTokenFile"/> stays a pure static path accessor for read-only callers
+/// (the self-update helper reads the file directly and must NEVER mint one).
 /// </summary>
-public static class GatewayAuth
+public sealed class GatewayAuth
 {
-    public static string TokenFile { get; } =
+    /// <summary>The default on-disk token path. A pure path - resolving it never reads or writes a token.</summary>
+    public static string DefaultTokenFile { get; } =
         Path.Combine(CcStorage.Config(), "director", "gateway-token.txt");
 
+    /// <summary>This store's token file path.</summary>
+    public string TokenFile { get; }
+
+    /// <param name="tokenFile">Override the token file (tests). Defaults to <see cref="DefaultTokenFile"/>.</param>
+    public GatewayAuth(string? tokenFile = null)
+    {
+        TokenFile = string.IsNullOrWhiteSpace(tokenFile) ? DefaultTokenFile : tokenFile;
+    }
+
     /// <summary>Read the existing token from disk or generate a new one and persist it.</summary>
-    public static string LoadOrCreate()
+    public string LoadOrCreate()
     {
         try
         {

--- a/src/CcDirector.GatewayApp/Program.cs
+++ b/src/CcDirector.GatewayApp/Program.cs
@@ -68,7 +68,7 @@ public static class Program
     {
         try
         {
-            var path = GatewayAuth.TokenFile;
+            var path = GatewayAuth.DefaultTokenFile;
             if (!File.Exists(path))
             {
                 FileLog.Write($"[Program] gateway token file not found at {path}");
@@ -116,7 +116,7 @@ public static class Program
                 //
                 // Reading the token is legitimate here: this helper is the Gateway's own exe, running as
                 // the same user on the same machine, and the file it reads is the very one the running
-                // Gateway loaded its token from (GatewayAuth.TokenFile).
+                // Gateway loaded its token from (GatewayAuth.DefaultTokenFile).
                 var request = new HttpRequestMessage(HttpMethod.Post, $"http://127.0.0.1:{port}/shutdown");
                 var token = TryReadGatewayToken();
                 if (token is null)


### PR DESCRIPTION
Give every durable store the Gateway reached through a process-wide static an
injection point owned by GatewayHost, so the host constructs one instance and
hands it down. This is the mechanical prerequisite that lets a tenant id reach
the storage layer in a later pull request.

Scope is instance ownership and single construction only. No storage interface,
no tenant id on any method, and no behavior change - same default file paths,
byte-identical on-disk behavior. The interface plus the data-access layer is the
next pull request.

What changed:
- Retired the three process-wide static Shared singletons (GatewayPromptLog,
  TranscriptionTelemetryLog, TranscriptionAudioArchive). GatewayHost owns one of
  each and passes it to the endpoints and services that use it.
- Retired the two static LoadOrCreate paths (GatewayAuth, GatewayInstallId) in
  favour of host-owned instances with the same load-or-create semantics and the
  same file paths. GatewayAuth keeps a pure static DefaultTokenFile accessor for
  the read-only tray caller, which reads the token file and must never mint one.
- Fixed the two stores that were constructed more than once so every production
  path uses the host's single instance: KeyVault (RecordingEndpoints no longer
  news its own) and the voice-turn VoiceUploadStore (GatewayWingmanVoiceEndpoint
  no longer news its own). The dictation upload store stays on its own separate
  root - two roots for two subsystems, one instance each.

Evidence (a run, not only a build):
- Full Windows solution test suite green across all seven test projects.
- CcDirector.Gateway.Tests green (2546 passed, 0 failed) after rebasing onto
  current main.
- Linux container built from the repo Dockerfile: GET /healthz 200, POST
  /gateway/brain/restart 200 with the warm brain reaching READY (pid and session
  id) through the Unix pseudo-terminal as a non-root user, the token minted
  through the new GatewayAuth instance store, and the stats database written
  under the non-root home.

The macOS native run is deferred - the Mac mini is offline - consistent with the
Step 1 and Step 2 precedent. Full evidence is recorded in the mission QA
document.
