### PR TITLE
fix(mobile): centre the network pill on the roster header

### DIFF
--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -72,11 +72,16 @@ function GatedLayout() {
   // The file viewer was missed when the pill was first moved inline (caught in review of #1631) - it is
   // under /session/ but does not use SessionAppBar, so it silently lost its pill. Add a new /session/
   // route and you own its pill too.
-  const onSessionScreen = useLocation().pathname.startsWith("/session/");
+  // The roster (Home, "/") also gives the pill a real home on its header row now - an inline item in the
+  // middle of the bar, the same as the session screens - so the fixed overlay stands down there too. It
+  // used to sit fixed in the top-right corner and land on top of the roster's filter button.
+  const pathname = useLocation().pathname;
+  const onSessionScreen = pathname.startsWith("/session/");
+  const onHome = pathname === "/";
   return (
     <>
       <ConnectionBanner />
-      {!onSessionScreen && <StatusPill />}
+      {!onSessionScreen && !onHome && <StatusPill />}
       <Outlet />
     </>
   );

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -10,6 +10,7 @@ import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting"
 import { playClip, playingSid, rowVoiceInputs, stopPlayback, syncVoiceSessions, useVoiceClips } from "@devthrottle/client-core/voice/clips";
 import { isVoiceReady, voiceRowState } from "@devthrottle/client-core/voice/voiceRowState";
 import { NavDrawer } from "../components/NavDrawer";
+import { StatusPill } from "../components/StatusPill";
 import { SessionFilterPanel } from "../components/SessionFilterPanel";
 import { useSessionFilter } from "../hooks/useSessionFilter";
 import { enablePush, notificationPermission, pushSupported, reconcileBadge } from "@devthrottle/client-core/push/register";
@@ -134,7 +135,14 @@ export function Home() {
       <header className="app-bar">
         <NavDrawer />
         <h1>DevThrottle</h1>
-        <span className="app-bar-sub">Mission Control</span>
+        {/* Two spacers put the network pill in the MIDDLE of the bar, exactly as the session screens do
+            (see SessionAppBar). It used to be a fixed top-right overlay that landed on top of the filter
+            button in the corner; now it rides the row as an ordinary inline item. The "Mission Control"
+            subtitle was dropped to give the pill this room - the header title already says what screen
+            this is. GatedLayout stands the fixed pill down on the roster so it is not shown twice. */}
+        <div className="app-bar-spacer" />
+        <StatusPill inline />
+        <div className="app-bar-spacer" />
         {/* The funnel opens the full-screen filter panel and doubles as the "filter active" indicator
             (a dot appears when a machine/repo filter is applied), so it is both the one-tap entry point
             and the status light - no separate menu item needed. */}

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -59,6 +59,13 @@ body {
   color: var(--text-dim);
 }
 
+/* Splits the leftover width so the inline network pill sits in the MIDDLE of the roster header, the
+   same way .session-bar-spacer centres it on the session screens. Two of these, one each side. */
+.app-bar-spacer {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .back-link,
 .row-link {
   color: inherit;
@@ -478,7 +485,9 @@ a.banner-btn {
 /* The app-bar funnel button, pushed to the right of the title. margin-left:auto floats it to the far
    edge; it is a >=34px tap target with the same chrome as the hamburger for visual symmetry. */
 .filter-btn {
-  margin-left: auto;
+  /* The right .app-bar-spacer now pushes this to the edge. An auto left-margin here would instead
+     eat that spacer whole (auto margins consume free space before flex-grow), un-centring the pill. */
+  margin-left: 0;
   align-self: center;
   position: relative;
   display: inline-flex;


### PR DESCRIPTION
## What

On the roster (Home) screen the network status pill ("Fast") was a `position: fixed` overlay pinned to the top-right corner, so it rendered on top of the filter button - a white sliver of the button poked out beneath it.

This gives the pill a real home on the header row instead: an inline item in the **middle** of the bar, the same treatment `SessionAppBar` already uses on the session screens. Two flex spacers centre it between the title and the filter button.

## Changes

- `Home.tsx` - render `<StatusPill inline />` centred between the title and the filter button; drop the "Mission Control" subtitle to make the room (the "DevThrottle" title already names the screen).
- `main.tsx` - `GatedLayout` stands the fixed overlay pill down on the roster route (`/`) as well as the session subtree, so it is never shown twice.
- `styles.css` - add `.app-bar-spacer`; remove `margin-left: auto` from `.filter-btn` (the right spacer now pushes it to the edge; an auto margin would eat that spacer and un-centre the pill).

Layout-only change. `tsc --noEmit` and `vite build` both clean.