### PR TITLE
feat(gateway): persist the workflow catalog and extract the mission conduct (Workflows phase 1)

### DIFF
--- a/src/CcDirector.Gateway.Contracts/WorkflowDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/WorkflowDtos.cs
@@ -1,0 +1,66 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// One step of a workflow on the wire: a named piece of work, who does it, who reviews it, and what
+/// finishing it means. Reviewer is null when the step has no separate review seat - which is itself a
+/// statement the workflow is making, not an omission. The field names and shape are FROZEN as the
+/// legacy catalog contract (issue #1617); the Cockpit's workflowsClient.ts types mirror them.
+/// </summary>
+public sealed class WorkflowStepDto
+{
+    public string Name { get; set; } = "";
+    public string Description { get; set; } = "";
+    public string Doer { get; set; } = "";
+    public string? Reviewer { get; set; }
+    public string Done { get; set; } = "";
+}
+
+/// <summary>
+/// One declared outcome criterion of a workflow: what "done and accepted" means for a run of it. The
+/// workflow AUTHOR declares these; a run seeds its per-criterion results from them (the governance
+/// outcome spine, issue #1771). Structured on purpose - governance needs per-criterion evaluation -
+/// while the conduct itself stays in the instruction markdown.
+/// </summary>
+public sealed class WorkflowOutcomeCriterionDto
+{
+    /// <summary>Stable slug identifying the criterion within its workflow (e.g. "merged-pr").</summary>
+    public string CriterionId { get; set; } = "";
+
+    /// <summary>What must be true for a run to count as delivered on this criterion.</summary>
+    public string Description { get; set; } = "";
+
+    /// <summary>Optional hint about what evidence proves the criterion (e.g. "the merged pull request URL").</summary>
+    public string? ProofHint { get; set; }
+}
+
+/// <summary>
+/// A workflow on the wire: the legacy catalog fields (id, name, summary, whenToUse, humanCheckpoint,
+/// steps - frozen since issue #1617, the Cockpit reads them) plus the ADDITIVE fields the persisted
+/// store carries (version, isBuiltIn, updatedUtc, hasDraft, contentHash). Existing clients ignore the
+/// additions; nothing may rename or remove a legacy field.
+/// </summary>
+public sealed class WorkflowDto
+{
+    public string Id { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string Summary { get; set; } = "";
+    public string WhenToUse { get; set; } = "";
+    public string HumanCheckpoint { get; set; } = "";
+    public List<WorkflowStepDto> Steps { get; set; } = new();
+
+    /// <summary>The published version number this projection reflects.</summary>
+    public int Version { get; set; }
+
+    /// <summary>True for the workflows the Gateway ships (mission, standalone, ...). Built-ins are
+    /// editable and versioned like any workflow but can never be deleted.</summary>
+    public bool IsBuiltIn { get; set; }
+
+    /// <summary>When the workflow head last changed (UTC).</summary>
+    public DateTime UpdatedUtc { get; set; }
+
+    /// <summary>True when an unpublished draft version exists beside the published one.</summary>
+    public bool HasDraft { get; set; }
+
+    /// <summary>The canonical content hash of the published version (the exact bundle a run pins).</summary>
+    public string ContentHash { get; set; } = "";
+}

--- a/src/CcDirector.Gateway.Tests/WorkflowEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowEndpointsTests.cs
@@ -118,6 +118,21 @@ public sealed class WorkflowEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task The_persisted_catalog_adds_its_fields_without_touching_the_legacy_shape()
+    {
+        // Workflows mission, phase 1: the catalog is served from the persisted store. The legacy
+        // fields are frozen (the tests above pin them); the store may only ADD fields. These are the
+        // additions the Cockpit and CLI will read.
+        var body = await _http.GetFromJsonAsync<JsonObject>("gateway/workflows/mission");
+
+        Assert.Equal(1, (int?)body!["version"]);
+        Assert.True((bool?)body["isBuiltIn"]);
+        Assert.False((bool?)body["hasDraft"]);
+        Assert.False(string.IsNullOrWhiteSpace((string?)body["contentHash"]));
+        Assert.NotNull(body["updatedUtc"]);
+    }
+
+    [Fact]
     public async Task Get_unknown_workflow_reports_not_found()
     {
         // No fallback to "the first workflow" or an empty object: an unknown id is an explicit 404.

--- a/src/CcDirector.Gateway.Tests/WorkflowStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowStoreTests.cs
@@ -151,22 +151,74 @@ public sealed class WorkflowStoreTests : IDisposable
         }
     }
 
+    // ---- the content-hash invariant ----------------------------------------------------------------
+    // The whole ours/yours upgrade trade rides on the bundle hash: "uncustomized" is a hash equality
+    // and "this binary ships something different" is a hash inequality. A hash function that returned
+    // any CONSTANT would leave every store test above green while silently breaking upgrade detection
+    // forever - so the function's two invariants are pinned directly.
+
+    [Fact]
+    public void Bundle_hash_is_deterministic_and_sensitive_to_every_content_change()
+    {
+        var steps = new List<Contracts.WorkflowStepDto>
+        {
+            new() { Name = "Do", Description = "d", Doer = "Worker", Reviewer = null, Done = "merged" },
+        };
+        string Hash(string name = "n", string summary = "s", string instructions = "i") =>
+            WorkflowContentHash.ForBundle(name, summary, "w", "h", steps,
+                Array.Empty<Contracts.WorkflowOutcomeCriterionDto>(), instructions,
+                Array.Empty<(string, string)>());
+
+        // Deterministic: the same bundle always hashes the same.
+        Assert.Equal(Hash(), Hash());
+
+        // Sensitive: any changed piece - metadata, instructions, steps, files - changes the hash.
+        Assert.NotEqual(Hash(), Hash(name: "other"));
+        Assert.NotEqual(Hash(), Hash(summary: "other"));
+        Assert.NotEqual(Hash(), Hash(instructions: "other"));
+        var reviewedSteps = new List<Contracts.WorkflowStepDto>
+        {
+            new() { Name = "Do", Description = "d", Doer = "Worker", Reviewer = "Reviewer", Done = "merged" },
+        };
+        Assert.NotEqual(Hash(),
+            WorkflowContentHash.ForBundle("n", "s", "w", "h", reviewedSteps,
+                Array.Empty<Contracts.WorkflowOutcomeCriterionDto>(), "i", Array.Empty<(string, string)>()));
+        Assert.NotEqual(Hash(),
+            WorkflowContentHash.ForBundle("n", "s", "w", "h", steps,
+                Array.Empty<Contracts.WorkflowOutcomeCriterionDto>(), "i",
+                new[] { ("helpers.py", WorkflowContentHash.ForFile("print()")) }));
+    }
+
     // ---- the mission-extraction fidelity test ------------------------------------------------------
 
     /// <summary>
     /// The two mechanical self-reference edits the extraction is allowed (each listed in the plan and
     /// shown in the pull request): the document stops calling itself "this file" where that would now
     /// be a lie, and the brief checklist points at the workflow instead of linking the file.
-    /// Everything else must match byte-for-byte (modulo line endings).
+    /// Everything else must match byte-for-byte (modulo line endings). Each replacement ASSERTS that
+    /// its source phrase was actually present - a silent no-op Replace (the phrase drifted in the
+    /// skill file) would otherwise let an unedited embedded copy pass.
     /// </summary>
-    private static string ApplyListedEdits(string skillBody) => skillBody
-        .Replace(
+    private static string ApplyListedEdits(string skillBody)
+    {
+        var edited = ReplaceExactlyOnce(skillBody,
             "> **THIS FILE IS THE ONLY PLACE THE RULES LIVE.",
-            "> **THIS WORKFLOW IS THE ONLY PLACE THE RULES LIVE.")
-        .Replace(
+            "> **THIS WORKFLOW IS THE ONLY PLACE THE RULES LIVE.");
+        return ReplaceExactlyOnce(edited,
             "5. **A link to this file** for how to conduct itself.",
             "5. **A pointer to this workflow** - `cc-devthrottle workflow instructions mission` - for how to\n" +
             "   conduct itself.");
+    }
+
+    private static string ReplaceExactlyOnce(string text, string from, string to)
+    {
+        var first = text.IndexOf(from, StringComparison.Ordinal);
+        Assert.True(first >= 0,
+            $"Expected the skill file to contain the listed-edit source phrase: \"{from}\". " +
+            "If the skill file changed, update the listed edits deliberately.");
+        Assert.Equal(first, text.LastIndexOf(from, StringComparison.Ordinal));
+        return text.Replace(from, to);
+    }
 
     [Fact]
     public void Mission_instructions_are_a_faithful_extraction_of_the_skill_file()

--- a/src/CcDirector.Gateway.Tests/WorkflowStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowStoreTests.cs
@@ -1,0 +1,203 @@
+using System.Runtime.CompilerServices;
+using CcDirector.Gateway.Data.Entities;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Workflows;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="WorkflowStore"/> and <see cref="BuiltInWorkflowSeeder"/> (Workflows
+/// mission, phase 1). Covers: fresh seeding of the shipped built-ins, idempotent re-seeding (a
+/// restart mints nothing), the ours/yours upgrade trade (newer shipped content auto-publishes ONLY
+/// while the user has not customized the workflow), and the read projections' legacy-shape fields.
+///
+/// The FIDELITY test is the load-bearing one for the mission extraction: the embedded mission
+/// instruction body must equal the body of <c>.claude/skills/mission/SKILL.md</c> modulo exactly the
+/// two listed mechanical self-reference edits. It guards the "faithful extraction, not a rewrite"
+/// requirement until the skill file is stubbed (phase 6), at which point the embedded copy becomes
+/// canonical and this test retires.
+/// </summary>
+public sealed class WorkflowStoreTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    [Fact]
+    public void Seeds_the_three_built_ins_in_shipped_order()
+    {
+        var store = new WorkflowStore(_h.Open());
+
+        var workflows = store.ListPublished();
+
+        Assert.Equal(new[] { "mission", "standalone", "standalone-with-review" },
+            workflows.Select(w => w.Id).ToArray());
+        Assert.All(workflows, w =>
+        {
+            Assert.True(w.IsBuiltIn);
+            Assert.Equal(1, w.Version);
+            Assert.False(w.HasDraft);
+            Assert.False(string.IsNullOrWhiteSpace(w.ContentHash));
+            Assert.NotEmpty(w.Steps);
+        });
+    }
+
+    [Fact]
+    public void Reseeding_on_restart_mints_nothing_new()
+    {
+        _ = new WorkflowStore(_h.Open());
+
+        // A "restart" is a brand-new database + store over the same file.
+        var store = new WorkflowStore(_h.Open());
+
+        var workflows = store.ListPublished();
+        Assert.Equal(3, workflows.Count);
+        Assert.All(workflows, w => Assert.Equal(1, w.Version));
+
+        using var ctx = _h.Open().CreateContext();
+        Assert.Equal(3, ctx.WorkflowVersions.Count());
+    }
+
+    [Fact]
+    public void GetPublished_is_case_insensitive_and_null_for_unknown()
+    {
+        var store = new WorkflowStore(_h.Open());
+
+        Assert.NotNull(store.GetPublished("MISSION"));
+        Assert.Equal("Mission", store.GetPublished("mission")!.Name);
+        Assert.Null(store.GetPublished("does-not-exist"));
+        Assert.Null(store.GetPublished(""));
+    }
+
+    [Fact]
+    public void Every_built_in_version_row_stores_its_instruction_body()
+    {
+        _ = new WorkflowStore(_h.Open());
+
+        using var ctx = _h.Open().CreateContext();
+        foreach (var id in new[] { "mission", "standalone", "standalone-with-review" })
+        {
+            var version = ctx.WorkflowVersions.Single(v => v.WorkflowId == id);
+            Assert.Equal(BuiltInWorkflows.InstructionsFor(id), version.InstructionsMarkdown);
+            Assert.Equal(WorkflowVersionStatus.Published, version.Status);
+        }
+    }
+
+    [Fact]
+    public void Uncustomized_built_in_auto_publishes_newer_shipped_content()
+    {
+        var db = _h.Open();
+        _ = new WorkflowStore(db);
+
+        // Simulate a database seeded by an OLDER binary: what is published matches what that binary
+        // shipped, but both differ from what THIS binary ships.
+        using (var ctx = db.CreateContext())
+        {
+            var head = ctx.Workflows.Single(h => h.Id == "mission");
+            var published = ctx.WorkflowVersions.Single(
+                v => v.WorkflowId == "mission" && v.Status == WorkflowVersionStatus.Published);
+            head.ShippedContentHash = "old-shipped-hash";
+            published.ContentHash = "old-shipped-hash";
+            ctx.SaveChanges();
+        }
+
+        var store = new WorkflowStore(_h.Open());
+
+        var mission = store.GetPublished("mission")!;
+        Assert.Equal(2, mission.Version);
+        using (var ctx = _h.Open().CreateContext())
+        {
+            var head = ctx.Workflows.Single(h => h.Id == "mission");
+            Assert.Equal(2, head.LatestVersion);
+            Assert.Equal(2, head.PublishedVersion);
+            var superseded = ctx.WorkflowVersions.Single(
+                v => v.WorkflowId == "mission" && v.Version == 1);
+            Assert.Equal(WorkflowVersionStatus.Superseded, superseded.Status);
+        }
+    }
+
+    [Fact]
+    public void Customized_built_in_is_left_alone_but_the_shipped_hash_is_recorded()
+    {
+        var db = _h.Open();
+        _ = new WorkflowStore(db);
+
+        string customizedHash = "the-users-own-edit";
+        using (var ctx = db.CreateContext())
+        {
+            var head = ctx.Workflows.Single(h => h.Id == "mission");
+            var published = ctx.WorkflowVersions.Single(
+                v => v.WorkflowId == "mission" && v.Status == WorkflowVersionStatus.Published);
+            // The user published an edit under an older binary: the published hash is theirs, and the
+            // head remembers the OLD shipped hash - both differ from what THIS binary ships.
+            head.ShippedContentHash = "old-shipped-hash";
+            published.ContentHash = customizedHash;
+            ctx.SaveChanges();
+        }
+
+        var store = new WorkflowStore(_h.Open());
+
+        var mission = store.GetPublished("mission")!;
+        Assert.Equal(1, mission.Version);
+        Assert.Equal(customizedHash, mission.ContentHash);
+        using (var ctx = _h.Open().CreateContext())
+        {
+            var head = ctx.Workflows.Single(h => h.Id == "mission");
+            Assert.Equal(1, head.LatestVersion);
+            // The shipped hash still advances so a later reset-to-shipped knows what this binary ships.
+            Assert.NotEqual("old-shipped-hash", head.ShippedContentHash);
+            Assert.NotEqual(customizedHash, head.ShippedContentHash);
+        }
+    }
+
+    // ---- the mission-extraction fidelity test ------------------------------------------------------
+
+    /// <summary>
+    /// The two mechanical self-reference edits the extraction is allowed (each listed in the plan and
+    /// shown in the pull request): the document stops calling itself "this file" where that would now
+    /// be a lie, and the brief checklist points at the workflow instead of linking the file.
+    /// Everything else must match byte-for-byte (modulo line endings).
+    /// </summary>
+    private static string ApplyListedEdits(string skillBody) => skillBody
+        .Replace(
+            "> **THIS FILE IS THE ONLY PLACE THE RULES LIVE.",
+            "> **THIS WORKFLOW IS THE ONLY PLACE THE RULES LIVE.")
+        .Replace(
+            "5. **A link to this file** for how to conduct itself.",
+            "5. **A pointer to this workflow** - `cc-devthrottle workflow instructions mission` - for how to\n" +
+            "   conduct itself.");
+
+    [Fact]
+    public void Mission_instructions_are_a_faithful_extraction_of_the_skill_file()
+    {
+        var skillPath = Path.Combine(RepoRoot(), ".claude", "skills", "mission", "SKILL.md");
+        Assert.True(File.Exists(skillPath),
+            $"The mission skill file was not found at {skillPath}. If it has been stubbed (phase 6), " +
+            "this fidelity test has done its job and should be retired.");
+
+        var skill = Normalize(File.ReadAllText(skillPath));
+
+        // The body is everything below the YAML frontmatter (between the first two "---" lines).
+        var frontmatterEnd = skill.IndexOf("\n---\n", skill.IndexOf("---\n", StringComparison.Ordinal) + 4,
+            StringComparison.Ordinal);
+        Assert.True(frontmatterEnd > 0, "SKILL.md has no YAML frontmatter fence.");
+        var body = skill[(frontmatterEnd + "\n---\n".Length)..].TrimStart('\n');
+
+        var expected = ApplyListedEdits(body).TrimEnd('\n');
+        var embedded = Normalize(BuiltInWorkflows.InstructionsFor("mission")).TrimEnd('\n');
+
+        Assert.Equal(expected, embedded);
+    }
+
+    private static string Normalize(string text) => text.Replace("\r\n", "\n");
+
+    /// <summary>The repository root, located from this source file's own path - the tests always run
+    /// from a checkout, and bin-relative paths would break under different runners.</summary>
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        // this file: <repo>/src/CcDirector.Gateway.Tests/WorkflowStoreTests.cs
+        var dir = Path.GetDirectoryName(thisFile)!;
+        return Path.GetFullPath(Path.Combine(dir, "..", ".."));
+    }
+}

--- a/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
@@ -22,24 +22,25 @@ namespace CcDirector.Gateway.Api;
 /// rollout possible later: an administrator defines the workflows once on their Gateway and every
 /// Director picks them up.
 ///
-/// The set is built in and read-only at this step (see BuiltInWorkflows); authoring and editing is a
-/// later step. Inherits the host-wide token middleware, like every other Gateway route.
+/// The catalog is PERSISTED (Workflows mission, phase 1): reads come from the WorkflowStore (EF data
+/// layer), where the built-ins are seeded at startup and user-defined workflows will live beside
+/// them. The legacy read shape is frozen - fields are only ever ADDED. Authoring routes are the next
+/// phase. Inherits the host-wide token middleware, like every other Gateway route.
 /// </summary>
 internal static class WorkflowEndpoints
 {
-    public static void Map(IEndpointRouteBuilder app)
+    public static void Map(IEndpointRouteBuilder app, WorkflowStore store)
     {
         app.MapGet("/gateway/workflows", () =>
         {
-            var workflows = BuiltInWorkflows.All();
+            var workflows = store.ListPublished();
             FileLog.Write($"[WorkflowEndpoints] list workflows: count={workflows.Count}");
             return Results.Json(new { workflows });
         });
 
         app.MapGet("/gateway/workflows/{id}", (string id) =>
         {
-            var workflow = BuiltInWorkflows.All()
-                .FirstOrDefault(w => string.Equals(w.Id, id, StringComparison.OrdinalIgnoreCase));
+            var workflow = store.GetPublished(id);
             if (workflow is null)
             {
                 FileLog.Write($"[WorkflowEndpoints] get workflow: id={id}, result=not found");

--- a/src/CcDirector.Gateway/CcDirector.Gateway.csproj
+++ b/src/CcDirector.Gateway/CcDirector.Gateway.csproj
@@ -76,6 +76,10 @@
     <!-- The Gateway serves NO UI (one-URL plan: docs/plans/one-url-cockpit.md). Every page
          lives in the Cockpit; only the token login page remains here. -->
     <EmbeddedResource Include="Web\login.html" />
+    <!-- The instruction bodies the built-in workflows ship with (Workflows mission). Kept as .md
+         files, not C# string literals, so the mission conduct stays diffable against its source
+         (.claude/skills/mission/SKILL.md) and cannot drift through escaping. -->
+    <EmbeddedResource Include="Workflows\Content\*.instructions.md" />
   </ItemGroup>
 
   <!-- ============================================================================

--- a/src/CcDirector.Gateway/Data/Entities/WorkflowEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/WorkflowEntity.cs
@@ -1,0 +1,42 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// The head record of a workflow in the <c>workflows</c> table: identity and lifecycle only, never
+/// content. Content lives on immutable <see cref="WorkflowVersionEntity"/> rows so a workflow run can
+/// pin the exact bundle that governed it (the governance outcome spine, issue #1771) and distribution
+/// can diff by content hash.
+///
+/// The key is the workflow's public slug id ("mission", "standalone", ...), minted by the author and
+/// validated by the store - never a database default. Built-in workflows (<see cref="IsBuiltIn"/>) are
+/// seeded from embedded resources at startup, are editable and versioned like any workflow (owner
+/// ruling, 2026-07-17), but can never be deleted; <see cref="ShippedContentHash"/> remembers what the
+/// running binary ships so upgrades auto-publish newer shipped content ONLY while the user has not
+/// customized the workflow (the injected-text ours/yours trade).
+/// </summary>
+public sealed class WorkflowEntity : TenantScopedEntity
+{
+    /// <summary>The workflow's slug id (primary key), e.g. "mission". Lowercase, validated in code.</summary>
+    public string Id { get; set; } = "";
+
+    /// <summary>True for the workflows the Gateway ships. Built-ins can never be deleted.</summary>
+    public bool IsBuiltIn { get; set; }
+
+    /// <summary>Soft delete for user-defined workflows. Archived workflows leave the catalog but their
+    /// versions remain - a run that pinned one must always be able to resolve it.</summary>
+    public bool Archived { get; set; }
+
+    /// <summary>The highest version number ever minted for this workflow (the draft counter).</summary>
+    public int LatestVersion { get; set; }
+
+    /// <summary>The currently published version number, or null when nothing is published yet (a
+    /// draft-only workflow, invisible to the legacy catalog list).</summary>
+    public int? PublishedVersion { get; set; }
+
+    /// <summary>Built-ins only: the canonical content hash of what THIS binary ships for the workflow.
+    /// The seeder compares the published hash against the previously recorded shipped hash to decide
+    /// whether an upgrade may auto-publish (uncustomized) or must leave the user's edit alone.</summary>
+    public string? ShippedContentHash { get; set; }
+
+    public DateTime CreatedUtc { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/Entities/WorkflowFileEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/WorkflowFileEntity.cs
@@ -1,0 +1,29 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// One helper file belonging to a workflow version, in the <c>workflow_files</c> table. Files are
+/// part of the version's immutable bundle (copied forward when a new draft is cut) and are DISTRIBUTED
+/// CONTENT ONLY: the Gateway and the Director never execute them. An agent that uses the workflow runs
+/// them in its own session under its own permission model, exactly like a skill's scripts.
+///
+/// File names are validated by the store (no path separators, a short allow-listed extension set,
+/// size-capped) so a bundle can always be materialized to disk safely.
+/// </summary>
+public sealed class WorkflowFileEntity : TenantScopedEntity
+{
+    /// <summary>Primary key, minted in code - never a database default.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>The <see cref="WorkflowVersionEntity"/> this file belongs to. Indexed; not a foreign
+    /// key (independent lifecycle, like cron runs to cron jobs).</summary>
+    public Guid VersionId { get; set; }
+
+    /// <summary>Validated bare file name, e.g. "helpers.py". Never a path.</summary>
+    public string FileName { get; set; } = "";
+
+    /// <summary>The file's full text content.</summary>
+    public string Content { get; set; } = "";
+
+    /// <summary>SHA-256 of <see cref="Content"/>, used in the version's canonical bundle hash.</summary>
+    public string ContentHash { get; set; } = "";
+}

--- a/src/CcDirector.Gateway/Data/Entities/WorkflowVersionEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/WorkflowVersionEntity.cs
@@ -1,0 +1,71 @@
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// One version of a workflow's content in the <c>workflow_versions</c> table. A version is a complete
+/// snapshot - metadata, steps, outcome criteria, and the instruction markdown - so nothing about a
+/// version can drift after publication: a published or superseded row is IMMUTABLE, and only the
+/// single draft row of a workflow may change. Runs pin a version row (issue #1771), which is why
+/// published content is frozen rather than audited.
+///
+/// The structured <see cref="Steps"/> are a display/reporting summary; the
+/// <see cref="InstructionsMarkdown"/> is the authoritative conduct. Both are versioned together.
+/// Steps and criteria reuse the wire contract types as EF owned types serialized to JSON columns
+/// (the cron store's "bulky sub-doc -> JSON in a column" pattern).
+/// </summary>
+public sealed class WorkflowVersionEntity : TenantScopedEntity
+{
+    /// <summary>Primary key, minted in code - never a database default.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>The workflow this version belongs to. (WorkflowId, Version) is unique.</summary>
+    public string WorkflowId { get; set; } = "";
+
+    /// <summary>1-based version number within the workflow.</summary>
+    public int Version { get; set; }
+
+    /// <summary>"draft", "published", or "superseded". At most ONE draft and ONE published row exist
+    /// per workflow; publish flips draft to published and published to superseded in one transaction.</summary>
+    public string Status { get; set; } = WorkflowVersionStatus.Draft;
+
+    // ---- content snapshot -------------------------------------------------------------------------
+
+    public string Name { get; set; } = "";
+    public string Summary { get; set; } = "";
+    public string WhenToUse { get; set; } = "";
+    public string HumanCheckpoint { get; set; } = "";
+
+    /// <summary>The structured step/seat summary. Owned type serialized to a JSON column.</summary>
+    public List<WorkflowStepDto> Steps { get; set; } = new();
+
+    /// <summary>The authoritative conduct text (markdown). Capped by the store at 200 KB.</summary>
+    public string InstructionsMarkdown { get; set; } = "";
+
+    /// <summary>The author-declared outcome criteria runs are judged against (issue #1771). Owned type
+    /// serialized to a JSON column.</summary>
+    public List<WorkflowOutcomeCriterionDto> OutcomeCriteria { get; set; } = new();
+
+    // ---- provenance -------------------------------------------------------------------------------
+
+    /// <summary>SHA-256 over the canonical complete bundle (metadata + steps + criteria + instructions
+    /// + ordered file hashes). Doubles as the optimistic-concurrency token for draft edits.</summary>
+    public string ContentHash { get; set; } = "";
+
+    /// <summary>Who authored this version: a session id, an agent name, or "human:&lt;user&gt;".</summary>
+    public string AuthoredBy { get; set; } = "";
+
+    /// <summary>Optional one-line note describing what changed in this version.</summary>
+    public string? ChangeNote { get; set; }
+
+    public DateTime CreatedUtc { get; set; }
+    public DateTime? PublishedUtc { get; set; }
+}
+
+/// <summary>The legal <see cref="WorkflowVersionEntity.Status"/> values.</summary>
+public static class WorkflowVersionStatus
+{
+    public const string Draft = "draft";
+    public const string Published = "published";
+    public const string Superseded = "superseded";
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -55,6 +55,15 @@ public sealed class GatewayDbContext : DbContext
     /// <summary>Work-list item references (<c>worklist_items</c>), ordered per list.</summary>
     public DbSet<WorkListItemEntity> WorkListItems => Set<WorkListItemEntity>();
 
+    /// <summary>Workflow head records (<c>workflows</c>) - identity and lifecycle, never content.</summary>
+    public DbSet<WorkflowEntity> Workflows => Set<WorkflowEntity>();
+
+    /// <summary>Immutable workflow content versions (<c>workflow_versions</c>).</summary>
+    public DbSet<WorkflowVersionEntity> WorkflowVersions => Set<WorkflowVersionEntity>();
+
+    /// <summary>Helper files belonging to a workflow version (<c>workflow_files</c>).</summary>
+    public DbSet<WorkflowFileEntity> WorkflowFiles => Set<WorkflowFileEntity>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -100,12 +109,43 @@ public sealed class GatewayDbContext : DbContext
             b.HasIndex(e => new { e.WorkListId, e.Position });
         });
 
+        modelBuilder.Entity<WorkflowEntity>(b =>
+        {
+            b.ToTable("workflows");
+            b.HasKey(e => e.Id);
+            b.Property(e => e.Id);
+        });
+
+        modelBuilder.Entity<WorkflowVersionEntity>(b =>
+        {
+            b.ToTable("workflow_versions");
+            b.HasKey(e => e.Id);
+            // A workflow's versions are unique per number; lookups go through (WorkflowId, Version).
+            b.HasIndex(e => new { e.WorkflowId, e.Version }).IsUnique();
+            // Steps and outcome criteria are bounded sub-documents: owned types serialized to a JSON
+            // column each (the cron store's "sub-doc -> JSON in a column" pattern).
+            b.OwnsMany(e => e.Steps, o => o.ToJson());
+            b.OwnsMany(e => e.OutcomeCriteria, o => o.ToJson());
+        });
+
+        modelBuilder.Entity<WorkflowFileEntity>(b =>
+        {
+            b.ToTable("workflow_files");
+            b.HasKey(e => e.Id);
+            // Files are read per version; indexed but deliberately NOT a foreign key (independent
+            // lifecycle, matching cron_runs -> cron_jobs).
+            b.HasIndex(e => e.VersionId);
+        });
+
         // Tenant scoping - the tenant_id column plus the global query filter - applied uniformly to every
         // entity that derives from TenantScopedEntity, so future stores inherit it by deriving from the base.
         ApplyTenantScope<CronJobEntity>(modelBuilder);
         ApplyTenantScope<CronRunEntity>(modelBuilder);
         ApplyTenantScope<WorkListEntity>(modelBuilder);
         ApplyTenantScope<WorkListItemEntity>(modelBuilder);
+        ApplyTenantScope<WorkflowEntity>(modelBuilder);
+        ApplyTenantScope<WorkflowVersionEntity>(modelBuilder);
+        ApplyTenantScope<WorkflowFileEntity>(modelBuilder);
 
         ApplyCommonSubsetConventions(modelBuilder);
     }

--- a/src/CcDirector.Gateway/Data/Migrations/20260717234820_AddWorkflows.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260717234820_AddWorkflows.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717234820_AddWorkflows")]
+    partial class AddWorkflows
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260717234820_AddWorkflows.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260717234820_AddWorkflows.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkflows : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "workflow_files",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    VersionId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    FileName = table.Column<string>(type: "TEXT", nullable: false),
+                    Content = table.Column<string>(type: "TEXT", nullable: false),
+                    ContentHash = table.Column<string>(type: "TEXT", nullable: false),
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_workflow_files", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "workflow_versions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    WorkflowId = table.Column<string>(type: "TEXT", nullable: false),
+                    Version = table.Column<int>(type: "INTEGER", nullable: false),
+                    Status = table.Column<string>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    Summary = table.Column<string>(type: "TEXT", nullable: false),
+                    WhenToUse = table.Column<string>(type: "TEXT", nullable: false),
+                    HumanCheckpoint = table.Column<string>(type: "TEXT", nullable: false),
+                    InstructionsMarkdown = table.Column<string>(type: "TEXT", nullable: false),
+                    ContentHash = table.Column<string>(type: "TEXT", nullable: false),
+                    AuthoredBy = table.Column<string>(type: "TEXT", nullable: false),
+                    ChangeNote = table.Column<string>(type: "TEXT", nullable: true),
+                    CreatedUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    PublishedUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false),
+                    OutcomeCriteria = table.Column<string>(type: "TEXT", nullable: true),
+                    Steps = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_workflow_versions", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "workflows",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "TEXT", nullable: false),
+                    IsBuiltIn = table.Column<bool>(type: "INTEGER", nullable: false),
+                    Archived = table.Column<bool>(type: "INTEGER", nullable: false),
+                    LatestVersion = table.Column<int>(type: "INTEGER", nullable: false),
+                    PublishedVersion = table.Column<int>(type: "INTEGER", nullable: true),
+                    ShippedContentHash = table.Column<string>(type: "TEXT", nullable: true),
+                    CreatedUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_workflows", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_workflow_files_tenant_id",
+                table: "workflow_files",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_workflow_files_VersionId",
+                table: "workflow_files",
+                column: "VersionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_workflow_versions_tenant_id",
+                table: "workflow_versions",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_workflow_versions_WorkflowId_Version",
+                table: "workflow_versions",
+                columns: new[] { "WorkflowId", "Version" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_workflows_tenant_id",
+                table: "workflows",
+                column: "tenant_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "workflow_files");
+
+            migrationBuilder.DropTable(
+                name: "workflow_versions");
+
+            migrationBuilder.DropTable(
+                name: "workflows");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -329,6 +329,9 @@ public sealed class GatewayHost : IAsyncDisposable
     // local install every row is the "local" tenant (SingleTenantContext), so behavior is unchanged.
     private readonly Core.Tenancy.SingleTenantContext _tenantContext = new();
     private readonly Data.GatewayDatabase _gatewayDb;
+    // The persisted workflow catalog (Workflows mission, phase 1): built-ins seeded at startup,
+    // user-defined workflows beside them, served by Api.WorkflowEndpoints.
+    private readonly Workflows.WorkflowStore _workflows;
     private readonly CronJobStore _cronJobs;
     private readonly CronRunHistoryStore _cronRuns;
     private readonly Running.CronEngine _cronEngine;
@@ -590,6 +593,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // claims released on load). The path argument is the LEGACY worklists.json, imported once on first
         // upgrade then renamed aside. Tests MUST pass an isolated path so they never touch the real legacy file.
         _workLists = new WorkListStore(_gatewayDb, workListsPath ?? Path.Combine(CcStorage.Root(), "worklists.json"));
+        // The workflow catalog (Workflows mission, phase 1): persisted in the workflows tables, the
+        // shipped built-ins seeded/upgraded at construction. No legacy JSON - the previous catalog was
+        // compiled-in C# literals, so there is nothing on disk to import.
+        _workflows = new Workflows.WorkflowStore(_gatewayDb);
         // Snooze Length mission: the persisted snooze registry (sessionId -> SnoozeUntilUtc). Loaded here
         // so a Gateway restart re-arms every pending snooze; an entry already past its time simply fires
         // on the first sweep. Tests MUST pass an isolated path so they never touch the real store. The
@@ -1591,11 +1598,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // models, test a chat model, save the chosen wingman/speech model). Uses the vault credential.
         Api.AiModelsEndpoint.Map(_app, _keyVault);
 
-        // The workflow catalog (issue #1617): the shapes of work the fleet knows how to run - Mission,
-        // Standalone, Standalone with review. The Gateway is the home for these; Directors and the
-        // Cockpit ask it rather than each carrying a private copy. Built in and read-only at this step.
-        // Inherits the host-wide token middleware above.
-        Api.WorkflowEndpoints.Map(_app);
+        // The workflow catalog (issue #1617; persisted by the Workflows mission): the shapes of work
+        // the fleet knows how to run - Mission, Standalone, Standalone with review, plus user-defined
+        // workflows. The Gateway is the home for these; Directors and the Cockpit ask it rather than
+        // each carrying a private copy. Served from the persisted store (built-ins seeded at startup);
+        // authoring routes are the next phase. Inherits the host-wide token middleware above.
+        Api.WorkflowEndpoints.Map(_app, _workflows);
 
         // Gateway Centralization Phase 1 (issue #628): the inbound login-telemetry RELAY. The Director
         // POSTs its login-telemetry event here (instead of the cloud) and the Gateway forwards it on,

--- a/src/CcDirector.Gateway/Workflows/BuiltInWorkflowSeeder.cs
+++ b/src/CcDirector.Gateway/Workflows/BuiltInWorkflowSeeder.cs
@@ -14,8 +14,10 @@ namespace CcDirector.Gateway.Workflows;
 ///
 ///  - Absent workflow: seeded as version 1, published, with the shipped content.
 ///  - Present and UNCUSTOMIZED (its published content hash equals the shipped hash we last recorded):
-///    a binary that ships newer content auto-publishes it as the next version - the user follows
-///    "ours" and gets updates.
+///    a binary that ships different content auto-publishes it as the next version - the user follows
+///    "ours" and the catalog tracks the RUNNING binary, in both directions. A rollback deliberately
+///    rolls the conduct back too (and mints a version recording that), exactly as the injected-text
+///    "ours" channel serves whatever the running binary carries.
 ///  - Present and CUSTOMIZED (the user published their own edit): left completely alone. The newly
 ///    shipped hash is still recorded on the head so a later "reset to shipped" knows what this binary
 ///    ships, but no version is created and nothing the user wrote is touched.
@@ -110,8 +112,10 @@ public static class BuiltInWorkflowSeeder
 
         if (uncustomized)
         {
-            // The user follows the shipped content - publish the newer shipped bundle as the next
-            // version so every Director picks it up, exactly like the injected-text "ours" channel.
+            // The user follows the shipped content - publish THIS binary's bundle as the next version
+            // so every Director picks it up, exactly like the injected-text "ours" channel. This is
+            // direction-agnostic on purpose: a rollback republishes the older conduct, and the minted
+            // version row is the honest record of what the fleet was served.
             var now = DateTime.UtcNow;
             published!.Status = WorkflowVersionStatus.Superseded;
             var nextVersion = head.LatestVersion + 1;

--- a/src/CcDirector.Gateway/Workflows/BuiltInWorkflowSeeder.cs
+++ b/src/CcDirector.Gateway/Workflows/BuiltInWorkflowSeeder.cs
@@ -1,0 +1,172 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Workflows;
+
+/// <summary>
+/// Writes the shipped built-in workflows (<see cref="BuiltInWorkflows"/> + their embedded instruction
+/// bodies) into the persisted workflow store at startup. The rules are the injected-text ours/yours
+/// trade, applied per workflow (owner ruling, 2026-07-17: built-ins are editable with
+/// reset-to-shipped):
+///
+///  - Absent workflow: seeded as version 1, published, with the shipped content.
+///  - Present and UNCUSTOMIZED (its published content hash equals the shipped hash we last recorded):
+///    a binary that ships newer content auto-publishes it as the next version - the user follows
+///    "ours" and gets updates.
+///  - Present and CUSTOMIZED (the user published their own edit): left completely alone. The newly
+///    shipped hash is still recorded on the head so a later "reset to shipped" knows what this binary
+///    ships, but no version is created and nothing the user wrote is touched.
+///
+/// Built-ins keep their shipped catalog order via deliberately staggered CreatedUtc stamps (the
+/// catalog lists in creation order).
+/// </summary>
+public static class BuiltInWorkflowSeeder
+{
+    /// <summary>Seed or upgrade every built-in workflow inside the given context. Called by the
+    /// store's constructor under its write lock; saves once per changed workflow.</summary>
+    public static void Seed(GatewayDbContext ctx)
+    {
+        if (ctx is null)
+            throw new ArgumentNullException(nameof(ctx));
+
+        var definitions = BuiltInWorkflows.All();
+        // Staggered creation stamps preserve the shipped order under the catalog's creation-order
+        // listing; existing rows keep the stamp they were first seeded with.
+        var baseUtc = DateTime.UtcNow;
+
+        for (var i = 0; i < definitions.Count; i++)
+        {
+            var definition = definitions[i];
+            var instructions = BuiltInWorkflows.InstructionsFor(definition.Id);
+            var steps = definition.Steps.Select(s => new WorkflowStepDto
+            {
+                Name = s.Name,
+                Description = s.Description,
+                Doer = s.Doer,
+                Reviewer = s.Reviewer,
+                Done = s.Done,
+            }).ToList();
+            var shippedHash = WorkflowContentHash.ForBundle(
+                definition.Name, definition.Summary, definition.WhenToUse, definition.HumanCheckpoint,
+                steps, Array.Empty<WorkflowOutcomeCriterionDto>(), instructions,
+                Array.Empty<(string, string)>());
+
+            var head = ctx.Workflows.FirstOrDefault(h => h.Id == definition.Id);
+            if (head is null)
+            {
+                SeedFresh(ctx, definition, steps, instructions, shippedHash, baseUtc.AddMilliseconds(i));
+                continue;
+            }
+
+            if (string.Equals(head.ShippedContentHash, shippedHash, StringComparison.Ordinal))
+                continue; // this binary ships exactly what was last recorded - nothing to do.
+
+            UpgradeShippedContent(ctx, head, definition, steps, instructions, shippedHash);
+        }
+    }
+
+    private static void SeedFresh(
+        GatewayDbContext ctx,
+        WorkflowDefinition definition,
+        List<WorkflowStepDto> steps,
+        string instructions,
+        string shippedHash,
+        DateTime createdUtc)
+    {
+        var head = new WorkflowEntity
+        {
+            Id = definition.Id,
+            TenantId = ctx.ActiveTenant!,
+            IsBuiltIn = true,
+            Archived = false,
+            LatestVersion = 1,
+            PublishedVersion = 1,
+            ShippedContentHash = shippedHash,
+            CreatedUtc = createdUtc,
+            UpdatedUtc = createdUtc,
+        };
+        ctx.Workflows.Add(head);
+        ctx.WorkflowVersions.Add(NewVersionRow(ctx, definition, steps, instructions, shippedHash,
+            version: 1, createdUtc));
+        ctx.SaveChanges();
+        FileLog.Write($"[BuiltInWorkflowSeeder] Seeded built-in workflow: id={definition.Id}, v1, hash={shippedHash[..12]}");
+    }
+
+    private static void UpgradeShippedContent(
+        GatewayDbContext ctx,
+        WorkflowEntity head,
+        WorkflowDefinition definition,
+        List<WorkflowStepDto> steps,
+        string instructions,
+        string shippedHash)
+    {
+        var published = ctx.WorkflowVersions.FirstOrDefault(
+            v => v.WorkflowId == head.Id && v.Status == WorkflowVersionStatus.Published);
+        var uncustomized = published is not null &&
+            string.Equals(published.ContentHash, head.ShippedContentHash, StringComparison.Ordinal);
+
+        if (uncustomized)
+        {
+            // The user follows the shipped content - publish the newer shipped bundle as the next
+            // version so every Director picks it up, exactly like the injected-text "ours" channel.
+            var now = DateTime.UtcNow;
+            published!.Status = WorkflowVersionStatus.Superseded;
+            var nextVersion = head.LatestVersion + 1;
+            ctx.WorkflowVersions.Add(NewVersionRow(ctx, definition, steps, instructions, shippedHash,
+                nextVersion, now));
+            head.LatestVersion = nextVersion;
+            head.PublishedVersion = nextVersion;
+            head.UpdatedUtc = now;
+            FileLog.Write($"[BuiltInWorkflowSeeder] Upgraded built-in workflow: id={head.Id}, " +
+                          $"v{nextVersion} published from shipped content, hash={shippedHash[..12]}");
+        }
+        else
+        {
+            // Customized: the user's published edit stays untouched. Record what this binary ships so
+            // a later reset-to-shipped can restore it.
+            FileLog.Write($"[BuiltInWorkflowSeeder] Built-in workflow {head.Id} is customized; shipped " +
+                          $"content NOT applied (recorded hash={shippedHash[..12]} for reset)");
+        }
+
+        head.ShippedContentHash = shippedHash;
+        ctx.SaveChanges();
+    }
+
+    private static WorkflowVersionEntity NewVersionRow(
+        GatewayDbContext ctx,
+        WorkflowDefinition definition,
+        List<WorkflowStepDto> steps,
+        string instructions,
+        string contentHash,
+        int version,
+        DateTime createdUtc) => new()
+    {
+        Id = Guid.NewGuid(),
+        TenantId = ctx.ActiveTenant!,
+        WorkflowId = definition.Id,
+        Version = version,
+        Status = WorkflowVersionStatus.Published,
+        Name = definition.Name,
+        Summary = definition.Summary,
+        WhenToUse = definition.WhenToUse,
+        HumanCheckpoint = definition.HumanCheckpoint,
+        Steps = steps.Select(s => new WorkflowStepDto
+        {
+            Name = s.Name,
+            Description = s.Description,
+            Doer = s.Doer,
+            Reviewer = s.Reviewer,
+            Done = s.Done,
+        }).ToList(),
+        InstructionsMarkdown = instructions,
+        OutcomeCriteria = new List<WorkflowOutcomeCriterionDto>(),
+        ContentHash = contentHash,
+        AuthoredBy = "gateway:shipped",
+        ChangeNote = "Shipped built-in content.",
+        CreatedUtc = createdUtc,
+        PublishedUtc = createdUtc,
+    };
+}

--- a/src/CcDirector.Gateway/Workflows/BuiltInWorkflows.cs
+++ b/src/CcDirector.Gateway/Workflows/BuiltInWorkflows.cs
@@ -126,6 +126,27 @@ public static class BuiltInWorkflows
             }),
     };
 
-    /// <summary>Every workflow the Gateway serves, in the order the Cockpit lists them.</summary>
+    /// <summary>Every workflow the Gateway ships, in the order the Cockpit lists them. Since the
+    /// catalog moved to the persisted workflow store these are the SEED SOURCE, not the served set:
+    /// the seeder writes them into the store at startup and the endpoints read the store.</summary>
     public static IReadOnlyList<WorkflowDefinition> All() => Definitions;
+
+    /// <summary>
+    /// The shipped instruction body (the authoritative conduct markdown) for a built-in workflow, read
+    /// from the embedded <c>Workflows/Content/&lt;id&gt;.instructions.md</c> resource. The mission body
+    /// is the faithful extraction of <c>.claude/skills/mission/SKILL.md</c> (guarded by a fidelity
+    /// test); kept as .md resources, not string literals, so the text stays diffable. Fail-loud on a
+    /// missing resource - a built-in without its conduct is a build defect, not a runtime condition.
+    /// </summary>
+    public static string InstructionsFor(string id)
+    {
+        var resourceName = $"CcDirector.Gateway.Workflows.Content.{id}.instructions.md";
+        var assembly = typeof(BuiltInWorkflows).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded workflow instructions '{resourceName}' are missing from the Gateway binary. " +
+                "Every built-in workflow must ship its instruction body.");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
 }

--- a/src/CcDirector.Gateway/Workflows/Content/mission.instructions.md
+++ b/src/CcDirector.Gateway/Workflows/Content/mission.instructions.md
@@ -1,0 +1,216 @@
+# How a mission runs
+
+A **mission** is a body of work too big for one session and too long for one sitting. This document
+is the run-book for how one is RUN. It is not about what a Mission *is* as an object in the product -
+that is `docs/new_architecture/mission-as-first-class-unit-of-work.md`, which defines the data model,
+the naming, and the attachment rules. Read that for the object. Read this for the conduct.
+
+> **THIS WORKFLOW IS THE ONLY PLACE THE RULES LIVE. A mission brief must never restate them, and must
+> never GRANT them.**
+>
+> Before this file existed, every brief wrote the rules out from memory. They drifted - they
+> contradicted each other on whether a mission could commit at all - and each one read like it was
+> handing out authority. Then one got merged to main, and a sentence granting that mission open
+> authority to commit came to rest in a permanent architecture document: imperative voice, addressed
+> to the reader, with the words that limited it to one branch and one week sitting in a different
+> paragraph. Retrieval does not fetch the other paragraph. That is how a mission-scoped grant becomes
+> a standing one that nobody ever decided to give.
+>
+> *The offending sentence is deliberately paraphrased here and not quoted. Quoting it would leave the
+> exact imperative string in this file, searchable, one retrieval away from being read as live - the
+> very failure being described. It is in git history on `backup/session-state-truth-2026-07-15` if it
+> is ever needed. The same reasoning is why that brief had the text deleted rather than struck
+> through: strike-through is a visual convention, and it means nothing to a grep.*
+>
+> A brief describes the WORK. This file describes the CONDUCT. A brief that grants a permission is
+> a bug in the brief.
+
+---
+
+## The house
+
+The analogy is the owner's and it is exact - use it when a question comes up that the rules below do
+not cover, and answer the way the house answers.
+
+- **The owner** wants a house. He says what it is for, answers the questions, and is otherwise left
+  alone.
+- **The Architect** owns the mission. Settles the design, writes the brief, hires the builder,
+  decides when it is done, and is the only one who signs anything off into `main`.
+- **The Manager** is the builder. Takes the work, gets it done - hiring Workers as needed - and
+  **leaves when the work is finished**. A Manager is a delivery vehicle, not a resident.
+- **The Workers** are the trades. One task each. They finish and go.
+- **The Inspector** is an independent agent, from a **different family** to the Manager, who comes in
+  after the builder has left and inspects the work. He does not build. He was not there when it was
+  built. That is the entire point of him.
+
+The Architect does not inspect his own building, and the builder does not inspect his own work. The
+Architect calls the inspection. Failures go back to the builder to fix, not to the inspector to
+patch.
+
+---
+
+## THE FOUR LAWS
+
+### 1. Ask everything UP FRONT, then run alone - and NEVER guess
+
+**Get your questions answered before you start, then run the whole mission without coming back - but
+NEVER guess. If something genuinely undecidable turns up mid-run, bring the owner in. Running alone
+is not the goal; it is what you get for having asked properly first.**
+
+The owner is not a reviewer and must not be used as one. A mission that stops at every step to ask
+"shall I do the next bit?" has moved the work into his lap and made him read a novel to say yes. He
+has said so plainly, more than once. If he has to follow along, the mission has failed at its job.
+
+- **Before you start:** think hard about what you genuinely do not know, and ask it all, in one go,
+  in plain words. Scope. Product calls. Anything where guessing wrong wastes the run.
+- **Then go.** No per-phase approval. No per-pull-request approval. No "just checking".
+- **Bother him ONCE at the end**, with the QA report: what changed, what it does for him, what is
+  proven, what is not.
+
+**The exception, and it is real: NEVER GUESS.** If something turns up that you genuinely cannot
+decide - a product question nobody has answered, a discovery that changes what the mission is for,
+a choice with a cost he should carry - bring him in. Say what you found, recommend one option, and
+ask. Guessing to preserve the appearance of autonomy is the worse failure by a distance. Autonomy
+means "do not ask permission for the work you were sent to do." It has never meant "do not tell him
+what you found."
+
+The test: *could I have known to ask this before I started?* If yes, you asked too late. If no,
+asking now is correct.
+
+### 2. The mission branch holds the work. Only the Architect lands it.
+
+**A seated mission has exactly one branch, and it is where the work lives. Nothing but the Architect
+puts anything on `main`.**
+
+*This section describes how a chartered mission operates. It is not a grant, and it authorises
+nothing. If you are not seated on a mission the owner has chartered, with a branch cut for it, none
+of this applies to you and the repository's ordinary rule stands unchanged: never commit without
+being asked, and having been asked once is not being asked again.*
+
+**Why the branch matters.** This repository has already lost a mission's worth of work to a machine
+crash - fourteen commits, complete and passing, stranded on one disk because they were never pushed
+anywhere. Work that exists in one place is work you are one crash away from losing. Keeping the
+mission branch current and pushed is mission hygiene, in the same way that leaving the site tidy is
+part of building, not a favour to anyone.
+
+**The authority chain, stated once:**
+
+- Work accumulates on the mission branch. That is the ordinary operation of a mission and the
+  Architect who chartered it has already accounted for it.
+- Landing anything on `main` is the irreversible act, and it is the **Architect's alone** - not the
+  Manager's, not a Worker's, and not via a merged pull request opened by anyone else.
+- This section never reaches outside a seated mission branch. It cannot be read as covering the
+  shared checkout, another mission's branch, or `main`.
+
+### 3. A DIFFERENT agent inspects before anything reaches main
+
+**No work reaches `main` un-inspected, and the inspector is not the one who wrote it.**
+
+Use a genuinely different agent family, not another instance of the same one - if the Manager is
+Claude Code, the Inspector is Codex. The operational requirement is simply *different family*: an
+agent reviewing its own family's work shares too much of its judgement to be a check on it. That is
+the whole mechanism, and it works:
+
+> On pull request 1598, an independent Codex inspector found **seven real defects across five
+> passes**, and not one was a false alarm. It found that the mission's headline feature **did not
+> work at all** - the value was computed correctly and nothing told the screen to re-read it - and
+> then found that the *fix for that* was itself half-done, and then that the same fault existed in
+> five more places. The author had verified the code, revert-tested the fixes, and watched the tests
+> fail on purpose. All of it green. All of it would have shipped.
+>
+> That is not lore: the review-driven commits on 1598 record it, one per finding, and pull requests
+> 1584, 1585, 1588 and 1596 carry the same shape. Check the branch history rather than take the
+> number on trust - which is, after all, the point of this law.
+
+- **The Architect calls the inspection**, not the Manager. The builder does not book his own
+  inspection, and does not get to mark his own work as passed.
+- **The Manager finishes and leaves. Then the inspection happens.** If it finds something, the
+  Architect brings the Manager back - or seats a fresh one - and hands it over. The Inspector never
+  fixes anything: an inspector who picks up a hammer is no longer an inspector.
+- **Tell the inspector to be adversarial, and tell it not to trust the mission's own report.** A
+  mission's QA report is self-testimony. It is written by the people who did the work, about their
+  own work, and it is exactly as persuasive as it is unreliable.
+- **Give it the sharp questions**: what does this claim that the code does not support? Where could
+  a constant be substituted and the suite stay green? What is unguarded?
+- **Fleet messages truncate at the first newline.** Have the inspector write its review to a FILE and
+  reply with one single line. Do not ask for a review in a message; you will get the first heading
+  and nothing else.
+
+### 4. Merged to origin/main is the only "done"
+
+Committed is not done. Pushed is not done. An open pull request is not done. The Architect drives
+each piece all the way to a merged pull request, deletes the branch, and parks the checkout back on
+`main`. A branch that cannot merge today was too big - split it.
+
+---
+
+## Roles, seats, and hygiene
+
+- **One Architect per mission.** It holds the design, the brief, the merge authority, and the whole
+  picture. It does not build.
+- **One Manager at a time**, seated per phase. A Manager that has finished its phase is **killed, not
+  kept** - a stale Manager burns context and starts inventing work. The Architect kills the Manager;
+  the Manager kills its Workers. Never ask a session to kill itself. Never kill uncommitted work -
+  make it commit and push first (law 2).
+- **Re-seat the Architect too**, at clean boundaries. It is not exempt from context rot.
+- **ONE worktree per mission**, cut from `origin/main`, never the shared checkout. Never
+  `git checkout -b` in the shared tree - other sessions are working in it.
+- **Name sessions `Mission - Role`**: `Session States - Architect`, `Session States - Manager`.
+  Mission first, dash, not slash.
+- **A message interrupts the receiving agent.** `message send all` reaches your own team. Never
+  broadcast to the whole fleet.
+
+---
+
+## Writing a mission brief
+
+The brief describes the WORK and nothing else. It does not grant, it does not restate these laws, it
+links here.
+
+Every brief needs:
+
+1. **THE WHY, front and centre.** Not the tasks - the reason. What is broken for the owner, in his
+   words where you have them, and what is true when this is finished. A mission without a why
+   produces work nobody wanted.
+2. **The design decisions already made**, as rulings, with a note on which were *inferred* rather
+   than stated. Putting words in the owner's mouth is the same defect as putting a cause in a log's
+   mouth.
+3. **The work**, in the order it lands.
+4. **What is explicitly out of scope**, so the Manager does not invent it.
+5. **A pointer to this workflow** - `cc-devthrottle workflow instructions mission` - for how to
+   conduct itself.
+
+**Mark the status honestly and keep it current.** A brief that says ACTIVE about a finished mission,
+or points at a worktree that no longer exists, is a lie the next agent will believe. When the mission
+ends, say so in the document, in the past tense.
+
+---
+
+## Landing the work
+
+**Slice it.** One pull request per coherent piece, in the order the work was built. A 95-file pull
+request does not get reviewed; it gets waved through. Six small ones get read.
+
+**A fix and the thing that stops it regressing are ONE unit.** Never land a fix in one slice and its
+guard in another - the window between them is exactly where the defect lives, and on one branch that
+gap is invisible.
+
+**Prove each fix can fail.** Revert it, watch the test go red *with the reported symptom*, watch the
+controls stay green, then restore. A test that has never been watched failing is decoration. In this
+repository a green suite has certified a fully broken feature for fourteen months - assume nothing
+from green.
+
+**Say what is NOT proven.** Write the gaps into the code as gaps. An unproven claim in a comment is
+worse than no comment, because the next reader spends their scepticism somewhere else.
+
+---
+
+## The QA report - the one time you bother the owner
+
+Written for the owner, not for the repository. Plain English, no abbreviations, no process.
+
+Lead with what it does for him. Then: what is proven and how you know; what is NOT proven, named
+honestly; what you got wrong along the way; and any decision that is genuinely his.
+
+Do not narrate the run. He does not want to know how the sausage was made - he wants to know whether
+he can eat it.

--- a/src/CcDirector.Gateway/Workflows/Content/standalone-with-review.instructions.md
+++ b/src/CcDirector.Gateway/Workflows/Content/standalone-with-review.instructions.md
@@ -1,0 +1,15 @@
+# How standalone work with review runs
+
+One agent does the work, a second and separate agent reviews it before it is called done.
+
+This is the default for ordinary work: small enough not to need an Architect, big enough that nobody
+should mark their own homework.
+
+## The conduct
+
+- One agent takes the work to a pull request, with the proof that it does what it is supposed to,
+  in its own worktree cut from the main branch.
+- A SEPARATE agent - never the one that wrote it - verifies the work against the reported symptom
+  rather than trusting the report, then passes it or sends it back with a written defect.
+- The reviewer passing it and the pull request merging is what "done" means.
+- The human is bothered once, when the review passes.

--- a/src/CcDirector.Gateway/Workflows/Content/standalone.instructions.md
+++ b/src/CcDirector.Gateway/Workflows/Content/standalone.instructions.md
@@ -1,0 +1,13 @@
+# How standalone work runs
+
+One agent picks up the work and finishes it. No manager, no review seat.
+
+Use this for work small enough that a second pair of eyes would cost more than it catches - a typo,
+a version bump, a one-line fix with a test already around it.
+
+## The conduct
+
+- One agent takes the work from the request to a merged pull request, in its own worktree cut from
+  the main branch.
+- Merged to origin/main is the only "done". Committed and pushed is still in progress.
+- The human is bothered once, when the work is merged.

--- a/src/CcDirector.Gateway/Workflows/WorkflowContentHash.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowContentHash.cs
@@ -1,0 +1,60 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Workflows;
+
+/// <summary>
+/// The canonical content hash of a workflow version: SHA-256 over one canonical JSON document holding
+/// the COMPLETE bundle - metadata, steps, outcome criteria, the instruction markdown, and the ordered
+/// (fileName, fileHash) list. One hash covers everything a version is, so "the content a run pinned",
+/// "has the user customized this built-in", and "did anything change" are all the same comparison, and
+/// nothing can drift between the pieces (a file edit changes the bundle hash even though the
+/// instructions did not move).
+///
+/// The canonical form is deliberately explicit anonymous objects (fixed property order, camelCase to
+/// match the wire) rather than serializing the DTOs, so a later DTO addition cannot silently change
+/// every stored hash.
+/// </summary>
+public static class WorkflowContentHash
+{
+    /// <summary>SHA-256 (lowercase hex) of one file's content.</summary>
+    public static string ForFile(string content)
+    {
+        if (content is null)
+            throw new ArgumentNullException(nameof(content));
+        return Sha256Hex(content);
+    }
+
+    /// <summary>The canonical bundle hash of a complete version snapshot.</summary>
+    public static string ForBundle(
+        string name,
+        string summary,
+        string whenToUse,
+        string humanCheckpoint,
+        IEnumerable<WorkflowStepDto> steps,
+        IEnumerable<WorkflowOutcomeCriterionDto> outcomeCriteria,
+        string instructionsMarkdown,
+        IEnumerable<(string FileName, string FileHash)> files)
+    {
+        var canonical = JsonSerializer.Serialize(new
+        {
+            name,
+            summary,
+            whenToUse,
+            humanCheckpoint,
+            steps = steps.Select(s => new { s.Name, s.Description, s.Doer, s.Reviewer, s.Done }).ToArray(),
+            outcomeCriteria = outcomeCriteria
+                .Select(c => new { c.CriterionId, c.Description, c.ProofHint }).ToArray(),
+            instructionsMarkdown,
+            files = files
+                .OrderBy(f => f.FileName, StringComparer.Ordinal)
+                .Select(f => new { f.FileName, f.FileHash }).ToArray(),
+        });
+        return Sha256Hex(canonical);
+    }
+
+    private static string Sha256Hex(string value) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
+}

--- a/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
@@ -1,0 +1,126 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Workflows;
+
+/// <summary>
+/// The Gateway's persisted workflow catalog (Workflows mission, phase 1). Workflows live in the EF
+/// data layer (<c>workflows</c> / <c>workflow_versions</c> / <c>workflow_files</c>), NOT as C#
+/// literals: the head row is identity/lifecycle, every piece of content is an immutable version row,
+/// and the built-in set (<see cref="BuiltInWorkflows"/>) is written in by
+/// <see cref="BuiltInWorkflowSeeder"/> at construction. The read surface serves the exact legacy
+/// catalog shape (issue #1617) plus additive fields; authoring (drafts, publish, files) is the next
+/// phase on this store.
+///
+/// Threading: the Gateway is a single writer. Every operation runs under this store's write lock over
+/// a fresh pooled context, preserving the single-writer invariant.
+/// </summary>
+public sealed class WorkflowStore
+{
+    private readonly object _gate = new();
+    private readonly GatewayDatabase _db;
+
+    /// <param name="db">The Gateway EF database this store reads and writes through.</param>
+    /// <exception cref="ArgumentNullException">The database is null.</exception>
+    public WorkflowStore(GatewayDatabase db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            BuiltInWorkflowSeeder.Seed(ctx);
+        }
+    }
+
+    /// <summary>
+    /// Every workflow with a published version, projected from that published version, in stable
+    /// catalog order (creation order; the seeder stamps the built-ins so they keep their shipped
+    /// order). Draft-only and archived workflows are omitted - the catalog lists what the fleet can
+    /// actually run.
+    /// </summary>
+    public IReadOnlyList<WorkflowDto> ListPublished()
+    {
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var heads = ctx.Workflows.AsNoTracking()
+                .Where(h => !h.Archived && h.PublishedVersion != null)
+                .ToList()
+                .OrderBy(h => h.CreatedUtc)
+                .ThenBy(h => h.Id, StringComparer.Ordinal)
+                .ToList();
+            if (heads.Count == 0)
+                return Array.Empty<WorkflowDto>();
+
+            var ids = heads.Select(h => h.Id).ToList();
+            var versions = ctx.WorkflowVersions.AsNoTracking()
+                .Where(v => ids.Contains(v.WorkflowId) && v.Status == WorkflowVersionStatus.Published)
+                .ToList()
+                .ToDictionary(v => v.WorkflowId, StringComparer.Ordinal);
+            var draftIds = ctx.WorkflowVersions.AsNoTracking()
+                .Where(v => v.Status == WorkflowVersionStatus.Draft)
+                .Select(v => v.WorkflowId)
+                .ToHashSet(StringComparer.Ordinal);
+
+            return heads
+                .Select(h => ToDto(h, versions[h.Id], draftIds.Contains(h.Id)))
+                .ToList();
+        }
+    }
+
+    /// <summary>
+    /// One workflow by id (case-insensitive, matching the legacy endpoint), projected from its
+    /// published version. Null when the workflow is absent, archived, or has never been published.
+    /// </summary>
+    public WorkflowDto? GetPublished(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return null;
+        var key = id.Trim().ToLowerInvariant();
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var head = ctx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == key);
+            if (head is null || head.Archived || head.PublishedVersion is null)
+                return null;
+
+            var version = ctx.WorkflowVersions.AsNoTracking().FirstOrDefault(
+                v => v.WorkflowId == head.Id && v.Status == WorkflowVersionStatus.Published);
+            if (version is null)
+                throw new InvalidOperationException(
+                    $"Workflow '{head.Id}' claims published version {head.PublishedVersion} but no " +
+                    "published version row exists. The workflow store is inconsistent; refusing to " +
+                    "serve a half-workflow.");
+
+            var hasDraft = ctx.WorkflowVersions.AsNoTracking().Any(
+                v => v.WorkflowId == head.Id && v.Status == WorkflowVersionStatus.Draft);
+            return ToDto(head, version, hasDraft);
+        }
+    }
+
+    private static WorkflowDto ToDto(WorkflowEntity head, WorkflowVersionEntity version, bool hasDraft) => new()
+    {
+        Id = head.Id,
+        Name = version.Name,
+        Summary = version.Summary,
+        WhenToUse = version.WhenToUse,
+        HumanCheckpoint = version.HumanCheckpoint,
+        Steps = version.Steps.Select(s => new WorkflowStepDto
+        {
+            Name = s.Name,
+            Description = s.Description,
+            Doer = s.Doer,
+            Reviewer = s.Reviewer,
+            Done = s.Done,
+        }).ToList(),
+        Version = version.Version,
+        IsBuiltIn = head.IsBuiltIn,
+        UpdatedUtc = head.UpdatedUtc,
+        HasDraft = hasDraft,
+        ContentHash = version.ContentHash,
+    };
+}


### PR DESCRIPTION
Phase 1 of the approved Workflows plan (mission 9a955739: Mission becomes the first built-in, user-defined, cross-agent Workflow).

## What this does

- The workflow catalog moves off the three hard-coded C# literals onto the EF data layer: a `workflows` head table (identity + lifecycle), immutable `workflow_versions` rows (draft/published/superseded, canonical bundle content hash, authorship), and `workflow_files` for helper files. All tenant-scoped, one new migration (`AddWorkflows`).
- The three built-ins (mission, standalone, standalone-with-review) are seeded at startup from embedded markdown resources. The mission body is a FAITHFUL extraction of `.claude/skills/mission/SKILL.md` - same conduct, new home. Two mechanical self-reference edits were made, each visible in this diff: the preservation warning now says "THIS WORKFLOW" instead of "THIS FILE", and the brief checklist points at `cc-devthrottle workflow instructions mission` instead of linking the file. The skill file itself is untouched (it is stubbed only in phase 6, after the live cross-agent proof).
- Built-ins follow the ours/yours trade (owner ruling): editable and versioned like any workflow, never deletable, and newer shipped content auto-publishes ONLY while the published content still matches what the previous binary shipped. A customized workflow is never touched; the newly shipped hash is still recorded so a later reset-to-shipped knows what this binary carries.
- `GET /gateway/workflows[/{id}]` keeps the exact legacy read shape and gains additive fields only (`version`, `isBuiltIn`, `updatedUtc`, `hasDraft`, `contentHash`). The cockpit workflows page is untouched.

## Proof

- Full solution suite: all seven test projects, 6,272 passed, 0 failed.
- Fidelity test compares the embedded mission body against the skill file modulo exactly the two listed edits - and was proven able to fail: a deliberate one-character drift in the embedded body turned it red; restoring turned it green.
- Existing endpoint tests pin the legacy wire shape (ids, order, seats, 404, case-insensitive lookup) and now run against the persisted store; a new test covers the additive fields; store tests cover fresh seeding, idempotent re-seeding across a restart, the uncustomized auto-upgrade path, and the customized-left-alone path.

## Not in this phase

Authoring routes (drafts, publish, If-Match), the `cc-devthrottle workflow` CLI, the run spine, seated sessions, the skill-file stub, and the cockpit UI replacement - phases 2 through 8 of the plan.