### PR TITLE
feat(gateway): workflow authoring API - drafts, If-Match, transactional publish, reset, archive (Workflows phase 2)

### DIFF
--- a/src/CcDirector.Gateway.Contracts/WorkflowDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/WorkflowDtos.cs
@@ -64,3 +64,79 @@ public sealed class WorkflowDto
     /// <summary>The canonical content hash of the published version (the exact bundle a run pins).</summary>
     public string ContentHash { get; set; } = "";
 }
+
+/// <summary>A helper file carried by a workflow version, with full content (authoring payloads).</summary>
+public sealed class WorkflowFileDto
+{
+    public string FileName { get; set; } = "";
+    public string Content { get; set; } = "";
+}
+
+/// <summary>A helper file reference without its content (detail responses; content is served raw by
+/// <c>GET /gateway/workflows/{id}/files/{fileName}</c>).</summary>
+public sealed class WorkflowFileInfoDto
+{
+    public string FileName { get; set; } = "";
+    public string ContentHash { get; set; } = "";
+}
+
+/// <summary>One row of a workflow's version history (no content bodies).</summary>
+public sealed class WorkflowVersionInfoDto
+{
+    public int Version { get; set; }
+    public string Status { get; set; } = "";
+    public string ContentHash { get; set; } = "";
+    public string AuthoredBy { get; set; } = "";
+    public string? ChangeNote { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public DateTime? PublishedUtc { get; set; }
+}
+
+/// <summary>The complete content snapshot of one workflow version (authoring reads).</summary>
+public sealed class WorkflowVersionDetailDto
+{
+    public string WorkflowId { get; set; } = "";
+    public int Version { get; set; }
+    public string Status { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string Summary { get; set; } = "";
+    public string WhenToUse { get; set; } = "";
+    public string HumanCheckpoint { get; set; } = "";
+    public List<WorkflowStepDto> Steps { get; set; } = new();
+    public string InstructionsMarkdown { get; set; } = "";
+    public List<WorkflowOutcomeCriterionDto> OutcomeCriteria { get; set; } = new();
+    public List<WorkflowFileInfoDto> Files { get; set; } = new();
+    public string ContentHash { get; set; } = "";
+    public string AuthoredBy { get; set; } = "";
+    public string? ChangeNote { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public DateTime? PublishedUtc { get; set; }
+}
+
+/// <summary>
+/// Body of <c>POST /gateway/workflows</c> (create a workflow as a draft) and
+/// <c>PUT /gateway/workflows/{id}/draft</c> (replace the draft's content wholesale). The draft is a
+/// FULL REPLACEMENT on every write - the CLI round-trips a complete directory, so there is no partial
+/// patch to reason about. Fields a minimal creation (the Cockpit's add dialog) does not supply may be
+/// empty on a DRAFT; publishing enforces the strict rules (instructions present, at least one step
+/// with a doer and a done).
+/// </summary>
+public sealed class WorkflowContentRequest
+{
+    /// <summary>Required on POST (the new workflow's slug id); ignored on PUT (the route id wins).</summary>
+    public string? Id { get; set; }
+
+    public string? Name { get; set; }
+    public string? Summary { get; set; }
+    public string? WhenToUse { get; set; }
+    public string? HumanCheckpoint { get; set; }
+    public List<WorkflowStepDto>? Steps { get; set; }
+    public string? InstructionsMarkdown { get; set; }
+    public List<WorkflowOutcomeCriterionDto>? OutcomeCriteria { get; set; }
+    public List<WorkflowFileDto>? Files { get; set; }
+
+    /// <summary>Who is authoring: a session id, an agent name, or "human:&lt;user&gt;".</summary>
+    public string? AuthoredBy { get; set; }
+
+    public string? ChangeNote { get; set; }
+}

--- a/src/CcDirector.Gateway.Tests/WorkflowAuthoringTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowAuthoringTests.cs
@@ -1,0 +1,263 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Workflows;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Store-level tests for workflow authoring (Workflows mission, phase 2): create-as-draft, the
+/// full-replacement draft write with If-Match concurrency, the strict publish gate, versioned reads
+/// (pinned history must resolve forever), reset-to-shipped on built-ins, and archive semantics.
+/// </summary>
+public sealed class WorkflowAuthoringTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    private WorkflowStore NewStore() => new(_h.Open());
+
+    private static WorkflowContentRequest Minimal(string id = "release-train") => new()
+    {
+        Id = id,
+        Name = "Release train",
+        Summary = "Cut, verify, and announce a release.",
+        AuthoredBy = "test-session",
+    };
+
+    private static WorkflowContentRequest Complete(string id = "release-train") => new()
+    {
+        Id = id,
+        Name = "Release train",
+        Summary = "Cut, verify, and announce a release.",
+        WhenToUse = "When a release is due.",
+        HumanCheckpoint = "Once, before the announcement goes out.",
+        Steps = new List<WorkflowStepDto>
+        {
+            new() { Name = "Cut", Description = "Cut the release.", Doer = "Worker", Reviewer = null, Done = "Tag pushed." },
+        },
+        InstructionsMarkdown = "# Release train\n\nCut the tag, verify, announce.",
+        OutcomeCriteria = new List<WorkflowOutcomeCriterionDto>
+        {
+            new() { CriterionId = "announced", Description = "The release notes went out.", ProofHint = "The announcement URL." },
+        },
+        Files = new List<WorkflowFileDto>
+        {
+            new() { FileName = "verify.py", Content = "print('verify')" },
+        },
+        AuthoredBy = "test-session",
+    };
+
+    // ---- create ------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Create_makes_a_draft_invisible_to_the_catalog_until_published()
+    {
+        var store = NewStore();
+
+        var draft = store.CreateDraft(Minimal());
+
+        Assert.Equal("release-train", draft.WorkflowId);
+        Assert.Equal(1, draft.Version);
+        Assert.Equal("draft", draft.Status);
+        Assert.Null(store.GetPublished("release-train"));
+        Assert.DoesNotContain(store.ListPublished(), w => w.Id == "release-train");
+        var versions = store.ListVersions("release-train");
+        Assert.NotNull(versions);
+        Assert.Single(versions);
+    }
+
+    [Fact]
+    public void Create_rejects_a_taken_id_and_a_bad_slug()
+    {
+        var store = NewStore();
+        store.CreateDraft(Minimal());
+
+        Assert.Throws<WorkflowConflictException>(() => store.CreateDraft(Minimal()));
+        Assert.Throws<WorkflowConflictException>(() => store.CreateDraft(Minimal("mission")));
+        Assert.Throws<WorkflowValidationException>(() => store.CreateDraft(Minimal("Not A Slug")));
+        Assert.Throws<WorkflowValidationException>(() =>
+            store.CreateDraft(new WorkflowContentRequest { Id = "x-flow", Name = "", Summary = "s" }));
+    }
+
+    // ---- draft writes + If-Match -------------------------------------------------------------------
+
+    [Fact]
+    public void UpdateDraft_is_a_full_replacement_and_recomputes_the_hash()
+    {
+        var store = NewStore();
+        var first = store.CreateDraft(Minimal());
+
+        var updated = store.UpdateDraft("release-train", Complete(), ifMatchHash: null)!;
+
+        Assert.Equal(1, updated.Version);
+        Assert.NotEqual(first.ContentHash, updated.ContentHash);
+        Assert.Single(updated.Files);
+        Assert.Equal("verify.py", updated.Files[0].FileName);
+        Assert.Equal("print('verify')",
+            store.GetFileContent("release-train", "verify.py", version: 1));
+    }
+
+    [Fact]
+    public void UpdateDraft_refuses_a_stale_IfMatch_and_accepts_the_current_one()
+    {
+        var store = NewStore();
+        var draft = store.CreateDraft(Minimal());
+
+        Assert.Throws<WorkflowConflictException>(() =>
+            store.UpdateDraft("release-train", Complete(), ifMatchHash: "stale-hash"));
+
+        var updated = store.UpdateDraft("release-train", Complete(), ifMatchHash: draft.ContentHash);
+        Assert.NotNull(updated);
+    }
+
+    [Fact]
+    public void UpdateDraft_on_a_published_workflow_mints_the_next_version_as_the_draft()
+    {
+        var store = NewStore();
+        store.CreateDraft(Complete());
+        store.Publish("release-train");
+
+        var draft = store.UpdateDraft("release-train", Complete(), ifMatchHash: null)!;
+
+        Assert.Equal(2, draft.Version);
+        Assert.Equal("draft", draft.Status);
+        Assert.True(store.GetPublished("release-train")!.HasDraft);
+        // The catalog still serves v1 until the draft publishes.
+        Assert.Equal(1, store.GetPublished("release-train")!.Version);
+    }
+
+    // ---- publish -----------------------------------------------------------------------------------
+
+    [Fact]
+    public void Publish_demands_instructions_and_at_least_one_complete_step()
+    {
+        var store = NewStore();
+        store.CreateDraft(Minimal()); // skeletal: no instructions, no steps
+
+        Assert.Throws<WorkflowValidationException>(() => store.Publish("release-train"));
+    }
+
+    [Fact]
+    public void Publish_supersedes_the_previous_version_atomically()
+    {
+        var store = NewStore();
+        store.CreateDraft(Complete());
+        store.Publish("release-train");
+        store.UpdateDraft("release-train", Complete(), ifMatchHash: null);
+        store.Publish("release-train");
+
+        var published = store.GetPublished("release-train")!;
+        Assert.Equal(2, published.Version);
+        var versions = store.ListVersions("release-train")!;
+        Assert.Equal("published", versions.Single(v => v.Version == 2).Status);
+        Assert.Equal("superseded", versions.Single(v => v.Version == 1).Status);
+        Assert.Throws<WorkflowValidationException>(() => store.Publish("release-train")); // no draft left
+    }
+
+    // ---- pinned history ----------------------------------------------------------------------------
+
+    [Fact]
+    public void An_explicit_version_read_resolves_forever_even_after_supersede_and_archive()
+    {
+        var store = NewStore();
+        store.CreateDraft(Complete());
+        store.Publish("release-train");
+        var v2 = Complete();
+        v2.InstructionsMarkdown = "# Release train v2\n\nNew conduct.";
+        store.UpdateDraft("release-train", v2, ifMatchHash: null);
+        store.Publish("release-train");
+        store.Archive("release-train");
+
+        // The default read follows catalog semantics: archived = gone.
+        Assert.Null(store.GetInstructions("release-train", version: null));
+        // A pinned read is immutable history: both versions resolve, archived or not.
+        Assert.Equal("# Release train\n\nCut the tag, verify, announce.",
+            store.GetInstructions("release-train", version: 1));
+        Assert.Equal("# Release train v2\n\nNew conduct.",
+            store.GetInstructions("release-train", version: 2));
+    }
+
+    // ---- built-ins: customize + reset --------------------------------------------------------------
+
+    [Fact]
+    public void A_built_in_can_be_customized_and_then_reset_to_shipped()
+    {
+        var store = NewStore();
+        var shipped = store.GetPublished("mission")!;
+
+        // Customize: draft from the published baseline, edit, publish.
+        var edit = new WorkflowContentRequest
+        {
+            Name = "Mission",
+            Summary = "The customized mission conduct.",
+            WhenToUse = shipped.WhenToUse,
+            HumanCheckpoint = shipped.HumanCheckpoint,
+            Steps = shipped.Steps,
+            InstructionsMarkdown = "# Custom mission conduct",
+            AuthoredBy = "test-session",
+        };
+        store.UpdateDraft("mission", edit, ifMatchHash: shipped.ContentHash);
+        var customized = store.Publish("mission")!;
+        Assert.Equal(2, customized.Version);
+        Assert.Equal("# Custom mission conduct", store.GetInstructions("mission", null));
+
+        // Reset: the shipped conduct comes back as a NEW version; nothing is rewritten.
+        var reset = store.ResetToShipped("mission")!;
+        Assert.Equal(3, reset.Version);
+        Assert.Equal(BuiltInWorkflows.InstructionsFor("mission"), store.GetInstructions("mission", null));
+        // The customized version remains pinned history.
+        Assert.Equal("# Custom mission conduct", store.GetInstructions("mission", version: 2));
+    }
+
+    [Fact]
+    public void Reset_only_applies_to_built_ins()
+    {
+        var store = NewStore();
+        store.CreateDraft(Complete());
+        store.Publish("release-train");
+
+        Assert.Throws<WorkflowValidationException>(() => store.ResetToShipped("release-train"));
+        Assert.Null(store.ResetToShipped("no-such-workflow"));
+    }
+
+    // ---- archive -----------------------------------------------------------------------------------
+
+    [Fact]
+    public void Archive_hides_a_user_workflow_but_never_a_built_in()
+    {
+        var store = NewStore();
+        store.CreateDraft(Complete());
+        store.Publish("release-train");
+
+        Assert.True(store.Archive("release-train"));
+        Assert.Null(store.GetPublished("release-train"));
+        Assert.DoesNotContain(store.ListPublished(), w => w.Id == "release-train");
+
+        Assert.Throws<WorkflowValidationException>(() => store.Archive("mission"));
+        Assert.False(store.Archive("no-such-workflow"));
+    }
+
+    // ---- file rules --------------------------------------------------------------------------------
+
+    [Fact]
+    public void File_rules_reject_paths_bad_extensions_and_duplicates()
+    {
+        var store = NewStore();
+
+        WorkflowContentRequest WithFile(string name) => new()
+        {
+            Id = "x-flow",
+            Name = "X",
+            Summary = "s",
+            Files = new List<WorkflowFileDto> { new() { FileName = name, Content = "x" } },
+        };
+
+        Assert.Throws<WorkflowValidationException>(() => store.CreateDraft(WithFile("../escape.py")));
+        Assert.Throws<WorkflowValidationException>(() => store.CreateDraft(WithFile("run.exe")));
+        var duplicate = WithFile("a.py");
+        duplicate.Files!.Add(new WorkflowFileDto { FileName = "a.py", Content = "y" });
+        Assert.Throws<WorkflowValidationException>(() => store.CreateDraft(duplicate));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WorkflowAuthoringTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowAuthoringTests.cs
@@ -95,8 +95,38 @@ public sealed class WorkflowAuthoringTests : IDisposable
         Assert.NotEqual(first.ContentHash, updated.ContentHash);
         Assert.Single(updated.Files);
         Assert.Equal("verify.py", updated.Files[0].FileName);
+
+        // A DRAFT is never served by the pinned-read routes (it is mutable, so it cannot be pinned
+        // history); the file becomes readable the moment the version publishes.
+        Assert.Null(store.GetFileContent("release-train", "verify.py", version: 1));
+        Assert.Null(store.GetInstructions("release-train", version: 1));
+        store.Publish("release-train");
         Assert.Equal("print('verify')",
             store.GetFileContent("release-train", "verify.py", version: 1));
+    }
+
+    [Fact]
+    public void Null_collection_entries_and_oversized_fields_are_rejected_not_crashes()
+    {
+        var store = NewStore();
+
+        var nullStep = Minimal("null-step");
+        nullStep.Steps = new List<WorkflowStepDto> { null! };
+        Assert.Throws<WorkflowValidationException>(() => store.CreateDraft(nullStep));
+
+        var nullFile = Minimal("null-file");
+        nullFile.Files = new List<WorkflowFileDto> { null! };
+        Assert.Throws<WorkflowValidationException>(() => store.CreateDraft(nullFile));
+
+        var hugeName = Minimal("huge-name");
+        hugeName.Name = new string('x', WorkflowValidation.MaxShortFieldChars + 1);
+        Assert.Throws<WorkflowValidationException>(() => store.CreateDraft(hugeName));
+
+        var tooManySteps = Minimal("many-steps");
+        tooManySteps.Steps = Enumerable.Range(0, WorkflowValidation.MaxStepsPerVersion + 1)
+            .Select(i => new WorkflowStepDto { Name = $"s{i}", Doer = "Worker", Done = "d" })
+            .ToList();
+        Assert.Throws<WorkflowValidationException>(() => store.CreateDraft(tooManySteps));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/WorkflowEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowEndpointsTests.cs
@@ -141,6 +141,63 @@ public sealed class WorkflowEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Authoring_round_trip_create_draft_publish_read_archive()
+    {
+        // Workflows mission, phase 2: the full agent authoring loop over real HTTP.
+        var create = await _http.PostAsJsonAsync("gateway/workflows", new
+        {
+            id = "smoke-flow",
+            name = "Smoke flow",
+            summary = "End-to-end authoring smoke.",
+            authoredBy = "endpoint-test",
+        });
+        Assert.Equal(HttpStatusCode.Created, create.StatusCode);
+
+        // A draft is invisible to the catalog and publish refuses a skeletal draft.
+        var listed = await _http.GetFromJsonAsync<JsonObject>("gateway/workflows");
+        Assert.DoesNotContain(listed!["workflows"]!.AsArray(), w => (string?)w!["id"] == "smoke-flow");
+        var earlyPublish = await _http.PostAsync("gateway/workflows/smoke-flow/publish", null);
+        Assert.Equal(HttpStatusCode.BadRequest, earlyPublish.StatusCode);
+
+        // Fill the draft (full replacement), then publish.
+        var put = await _http.PutAsJsonAsync("gateway/workflows/smoke-flow/draft", new
+        {
+            name = "Smoke flow",
+            summary = "End-to-end authoring smoke.",
+            steps = new[] { new { name = "Do", description = "d", doer = "Worker", done = "merged" } },
+            instructionsMarkdown = "# Smoke flow\n\nDo the thing.",
+            authoredBy = "endpoint-test",
+        });
+        Assert.Equal(HttpStatusCode.OK, put.StatusCode);
+        var publish = await _http.PostAsync("gateway/workflows/smoke-flow/publish", null);
+        Assert.Equal(HttpStatusCode.OK, publish.StatusCode);
+
+        // The agent read path serves the raw markdown.
+        var instructions = await _http.GetStringAsync("gateway/workflows/smoke-flow/instructions");
+        Assert.Equal("# Smoke flow\n\nDo the thing.", instructions);
+
+        // A stale If-Match is refused with a conflict.
+        var stale = new HttpRequestMessage(HttpMethod.Put, "gateway/workflows/smoke-flow/draft")
+        {
+            Content = JsonContent.Create(new { name = "Smoke flow", summary = "edit" }),
+        };
+        stale.Headers.TryAddWithoutValidation("If-Match", "\"stale-hash\"");
+        var conflict = await _http.SendAsync(stale);
+        Assert.Equal(HttpStatusCode.Conflict, conflict.StatusCode);
+
+        // A duplicate id is a conflict; archiving removes it from the catalog; built-ins refuse delete.
+        var duplicate = await _http.PostAsJsonAsync("gateway/workflows", new
+        {
+            id = "smoke-flow", name = "n", summary = "s",
+        });
+        Assert.Equal(HttpStatusCode.Conflict, duplicate.StatusCode);
+        var delete = await _http.DeleteAsync("gateway/workflows/smoke-flow");
+        Assert.Equal(HttpStatusCode.OK, delete.StatusCode);
+        var deleteBuiltIn = await _http.DeleteAsync("gateway/workflows/mission");
+        Assert.Equal(HttpStatusCode.BadRequest, deleteBuiltIn.StatusCode);
+    }
+
+    [Fact]
     public async Task The_api_does_not_squat_on_the_cockpit_page_path()
     {
         // Regression: the catalog was first mapped at a bare /workflows, which is the path the Cockpit's

--- a/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Workflows;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -23,9 +25,23 @@ namespace CcDirector.Gateway.Api;
 /// Director picks them up.
 ///
 /// The catalog is PERSISTED (Workflows mission, phase 1): reads come from the WorkflowStore (EF data
-/// layer), where the built-ins are seeded at startup and user-defined workflows will live beside
-/// them. The legacy read shape is frozen - fields are only ever ADDED. Authoring routes are the next
-/// phase. Inherits the host-wide token middleware, like every other Gateway route.
+/// layer), where the built-ins are seeded at startup and user-defined workflows live beside them.
+/// The legacy read shape is frozen - fields are only ever ADDED.
+///
+/// Authoring (phase 2) - drafts are the safety boundary, publish is the fleet-visible act:
+///
+///   POST   /gateway/workflows                        body WorkflowContentRequest -> 201 detail | 400 | 409
+///   PUT    /gateway/workflows/{id}/draft             body WorkflowContentRequest, optional If-Match
+///                                                    (content hash) -> 200 detail | 400 | 404 | 409
+///   POST   /gateway/workflows/{id}/publish           -> 200 WorkflowDto | 400 | 404
+///   POST   /gateway/workflows/{id}/reset             built-ins: republish shipped -> 200 | 400 | 404
+///   DELETE /gateway/workflows/{id}                   archive (never a built-in) -> 200 | 400 | 404
+///   GET    /gateway/workflows/{id}/versions          -> { versions: [...] } | 404
+///   GET    /gateway/workflows/{id}/versions/{n}      -> full content snapshot | 404
+///   GET    /gateway/workflows/{id}/instructions      raw text/markdown (agent read path) | 404
+///   GET    /gateway/workflows/{id}/files/{fileName}  raw text/plain | 404
+///
+/// Inherits the host-wide token middleware, like every other Gateway route.
 /// </summary>
 internal static class WorkflowEndpoints
 {
@@ -51,5 +67,140 @@ internal static class WorkflowEndpoints
             FileLog.Write($"[WorkflowEndpoints] get workflow: id={id}, result=found");
             return Results.Json(workflow);
         });
+
+        // ---- authoring (Workflows mission, phase 2) -----------------------------------------------
+        // Drafts are the safety boundary; publish is the fleet-visible act. Agents may publish (owner
+        // ruling, 2026-07-17) - authorship is recorded on every version and a bad publish is fixed by
+        // publishing again.
+
+        app.MapPost("/gateway/workflows", async (HttpContext ctx) =>
+        {
+            var content = await ReadBody(ctx);
+            if (content is null)
+                return Results.BadRequest(new { error = "a workflow body is required" });
+            return Guard(() =>
+            {
+                var created = store.CreateDraft(content);
+                FileLog.Write($"[WorkflowEndpoints] create workflow: id={created.WorkflowId}, draft v{created.Version}");
+                return Results.Json(created, statusCode: StatusCodes.Status201Created);
+            });
+        });
+
+        app.MapPut("/gateway/workflows/{id}/draft", async (string id, HttpContext ctx) =>
+        {
+            var content = await ReadBody(ctx);
+            if (content is null)
+                return Results.BadRequest(new { error = "a workflow body is required" });
+            var ifMatch = ReadIfMatch(ctx);
+            return Guard(() =>
+            {
+                var updated = store.UpdateDraft(id, content, ifMatch);
+                if (updated is null)
+                    return NotFound(id);
+                FileLog.Write($"[WorkflowEndpoints] update draft: id={id}, v{updated.Version}");
+                return Results.Json(updated);
+            });
+        });
+
+        app.MapPost("/gateway/workflows/{id}/publish", (string id) => Guard(() =>
+        {
+            var published = store.Publish(id);
+            if (published is null)
+                return NotFound(id);
+            FileLog.Write($"[WorkflowEndpoints] publish: id={id}, v{published.Version}");
+            return Results.Json(published);
+        }));
+
+        app.MapPost("/gateway/workflows/{id}/reset", (string id) => Guard(() =>
+        {
+            var reset = store.ResetToShipped(id);
+            if (reset is null)
+                return NotFound(id);
+            FileLog.Write($"[WorkflowEndpoints] reset to shipped: id={id}, v{reset.Version}");
+            return Results.Json(reset);
+        }));
+
+        app.MapDelete("/gateway/workflows/{id}", (string id) => Guard(() =>
+        {
+            if (!store.Archive(id))
+                return NotFound(id);
+            FileLog.Write($"[WorkflowEndpoints] archive: id={id}");
+            return Results.Json(new { id, archived = true });
+        }));
+
+        app.MapGet("/gateway/workflows/{id}/versions", (string id) =>
+        {
+            var versions = store.ListVersions(id);
+            return versions is null ? NotFound(id) : Results.Json(new { versions });
+        });
+
+        app.MapGet("/gateway/workflows/{id}/versions/{version:int}", (string id, int version) =>
+        {
+            var detail = store.GetVersionDetail(id, version);
+            return detail is null ? NotFound(id) : Results.Json(detail);
+        });
+
+        // The agent read path: raw markdown, no JSON envelope, so `cc-devthrottle workflow
+        // instructions <id>` can print it verbatim into an agent's context.
+        app.MapGet("/gateway/workflows/{id}/instructions", (string id, int? version) =>
+        {
+            var markdown = store.GetInstructions(id, version);
+            return markdown is null ? NotFound(id) : Results.Text(markdown, "text/markdown");
+        });
+
+        app.MapGet("/gateway/workflows/{id}/files/{fileName}", (string id, string fileName, int? version) =>
+        {
+            var content = store.GetFileContent(id, fileName, version);
+            return content is null
+                ? Results.Json(new { error = $"no file '{fileName}' on workflow '{id}'" },
+                    statusCode: StatusCodes.Status404NotFound)
+                : Results.Text(content, "text/plain");
+        });
     }
+
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    private static async Task<WorkflowContentRequest?> ReadBody(HttpContext ctx)
+    {
+        try
+        {
+            return await JsonSerializer.DeserializeAsync<WorkflowContentRequest>(
+                ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+        }
+        catch (JsonException ex)
+        {
+            FileLog.Write($"[WorkflowEndpoints] bad JSON body: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>The If-Match header as a bare hash (clients may send it RFC-quoted).</summary>
+    private static string? ReadIfMatch(HttpContext ctx)
+    {
+        string? raw = ctx.Request.Headers.IfMatch;
+        return string.IsNullOrWhiteSpace(raw) ? null : raw.Trim().Trim('"');
+    }
+
+    /// <summary>Translate the store's authoring exceptions to their status codes.</summary>
+    private static IResult Guard(Func<IResult> action)
+    {
+        try
+        {
+            return action();
+        }
+        catch (WorkflowValidationException ex)
+        {
+            FileLog.Write($"[WorkflowEndpoints] rejected: {ex.Message}");
+            return Results.BadRequest(new { error = ex.Message });
+        }
+        catch (WorkflowConflictException ex)
+        {
+            FileLog.Write($"[WorkflowEndpoints] conflict: {ex.Message}");
+            return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status409Conflict);
+        }
+    }
+
+    private static IResult NotFound(string id) =>
+        Results.Json(new { error = $"no workflow with id '{id}'" },
+            statusCode: StatusCodes.Status404NotFound);
 }

--- a/src/CcDirector.Gateway/Workflows/BuiltInWorkflowSeeder.cs
+++ b/src/CcDirector.Gateway/Workflows/BuiltInWorkflowSeeder.cs
@@ -42,39 +42,73 @@ public static class BuiltInWorkflowSeeder
         for (var i = 0; i < definitions.Count; i++)
         {
             var definition = definitions[i];
-            var instructions = BuiltInWorkflows.InstructionsFor(definition.Id);
-            var steps = definition.Steps.Select(s => new WorkflowStepDto
-            {
-                Name = s.Name,
-                Description = s.Description,
-                Doer = s.Doer,
-                Reviewer = s.Reviewer,
-                Done = s.Done,
-            }).ToList();
-            var shippedHash = WorkflowContentHash.ForBundle(
-                definition.Name, definition.Summary, definition.WhenToUse, definition.HumanCheckpoint,
-                steps, Array.Empty<WorkflowOutcomeCriterionDto>(), instructions,
-                Array.Empty<(string, string)>());
+            var shippedHash = ShippedHash(definition);
 
             var head = ctx.Workflows.FirstOrDefault(h => h.Id == definition.Id);
             if (head is null)
             {
-                SeedFresh(ctx, definition, steps, instructions, shippedHash, baseUtc.AddMilliseconds(i));
+                SeedFresh(ctx, definition, shippedHash, baseUtc.AddMilliseconds(i));
                 continue;
             }
 
             if (string.Equals(head.ShippedContentHash, shippedHash, StringComparison.Ordinal))
                 continue; // this binary ships exactly what was last recorded - nothing to do.
 
-            UpgradeShippedContent(ctx, head, definition, steps, instructions, shippedHash);
+            UpgradeShippedContent(ctx, head, definition, shippedHash);
         }
     }
+
+    /// <summary>The canonical bundle hash of what THIS binary ships for a built-in definition.</summary>
+    public static string ShippedHash(WorkflowDefinition definition)
+    {
+        var instructions = BuiltInWorkflows.InstructionsFor(definition.Id);
+        return WorkflowContentHash.ForBundle(
+            definition.Name, definition.Summary, definition.WhenToUse, definition.HumanCheckpoint,
+            ShippedSteps(definition), Array.Empty<WorkflowOutcomeCriterionDto>(), instructions,
+            Array.Empty<(string, string)>());
+    }
+
+    /// <summary>
+    /// Build a fully-populated PUBLISHED version row from the running binary's shipped content for a
+    /// built-in definition. Shared by the seeder (initial seed + uncustomized upgrade) and the
+    /// store's reset-to-shipped, so "what shipped content becomes as a version row" has exactly one
+    /// definition.
+    /// </summary>
+    public static WorkflowVersionEntity BuildShippedVersion(
+        GatewayDbContext ctx, WorkflowDefinition definition, int versionNumber, DateTime createdUtc) => new()
+    {
+        Id = Guid.NewGuid(),
+        TenantId = ctx.ActiveTenant!,
+        WorkflowId = definition.Id,
+        Version = versionNumber,
+        Status = WorkflowVersionStatus.Published,
+        Name = definition.Name,
+        Summary = definition.Summary,
+        WhenToUse = definition.WhenToUse,
+        HumanCheckpoint = definition.HumanCheckpoint,
+        Steps = ShippedSteps(definition),
+        InstructionsMarkdown = BuiltInWorkflows.InstructionsFor(definition.Id),
+        OutcomeCriteria = new List<WorkflowOutcomeCriterionDto>(),
+        ContentHash = ShippedHash(definition),
+        AuthoredBy = "gateway:shipped",
+        ChangeNote = "Shipped built-in content.",
+        CreatedUtc = createdUtc,
+        PublishedUtc = createdUtc,
+    };
+
+    private static List<WorkflowStepDto> ShippedSteps(WorkflowDefinition definition) =>
+        definition.Steps.Select(s => new WorkflowStepDto
+        {
+            Name = s.Name,
+            Description = s.Description,
+            Doer = s.Doer,
+            Reviewer = s.Reviewer,
+            Done = s.Done,
+        }).ToList();
 
     private static void SeedFresh(
         GatewayDbContext ctx,
         WorkflowDefinition definition,
-        List<WorkflowStepDto> steps,
-        string instructions,
         string shippedHash,
         DateTime createdUtc)
     {
@@ -91,8 +125,7 @@ public static class BuiltInWorkflowSeeder
             UpdatedUtc = createdUtc,
         };
         ctx.Workflows.Add(head);
-        ctx.WorkflowVersions.Add(NewVersionRow(ctx, definition, steps, instructions, shippedHash,
-            version: 1, createdUtc));
+        ctx.WorkflowVersions.Add(BuildShippedVersion(ctx, definition, versionNumber: 1, createdUtc));
         ctx.SaveChanges();
         FileLog.Write($"[BuiltInWorkflowSeeder] Seeded built-in workflow: id={definition.Id}, v1, hash={shippedHash[..12]}");
     }
@@ -101,8 +134,6 @@ public static class BuiltInWorkflowSeeder
         GatewayDbContext ctx,
         WorkflowEntity head,
         WorkflowDefinition definition,
-        List<WorkflowStepDto> steps,
-        string instructions,
         string shippedHash)
     {
         var published = ctx.WorkflowVersions.FirstOrDefault(
@@ -119,8 +150,7 @@ public static class BuiltInWorkflowSeeder
             var now = DateTime.UtcNow;
             published!.Status = WorkflowVersionStatus.Superseded;
             var nextVersion = head.LatestVersion + 1;
-            ctx.WorkflowVersions.Add(NewVersionRow(ctx, definition, steps, instructions, shippedHash,
-                nextVersion, now));
+            ctx.WorkflowVersions.Add(BuildShippedVersion(ctx, definition, nextVersion, now));
             head.LatestVersion = nextVersion;
             head.PublishedVersion = nextVersion;
             head.UpdatedUtc = now;
@@ -139,38 +169,4 @@ public static class BuiltInWorkflowSeeder
         ctx.SaveChanges();
     }
 
-    private static WorkflowVersionEntity NewVersionRow(
-        GatewayDbContext ctx,
-        WorkflowDefinition definition,
-        List<WorkflowStepDto> steps,
-        string instructions,
-        string contentHash,
-        int version,
-        DateTime createdUtc) => new()
-    {
-        Id = Guid.NewGuid(),
-        TenantId = ctx.ActiveTenant!,
-        WorkflowId = definition.Id,
-        Version = version,
-        Status = WorkflowVersionStatus.Published,
-        Name = definition.Name,
-        Summary = definition.Summary,
-        WhenToUse = definition.WhenToUse,
-        HumanCheckpoint = definition.HumanCheckpoint,
-        Steps = steps.Select(s => new WorkflowStepDto
-        {
-            Name = s.Name,
-            Description = s.Description,
-            Doer = s.Doer,
-            Reviewer = s.Reviewer,
-            Done = s.Done,
-        }).ToList(),
-        InstructionsMarkdown = instructions,
-        OutcomeCriteria = new List<WorkflowOutcomeCriterionDto>(),
-        ContentHash = contentHash,
-        AuthoredBy = "gateway:shipped",
-        ChangeNote = "Shipped built-in content.",
-        CreatedUtc = createdUtc,
-        PublishedUtc = createdUtc,
-    };
 }

--- a/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Data;
 using CcDirector.Gateway.Data.Entities;
@@ -101,6 +102,404 @@ public sealed class WorkflowStore
             return ToDto(head, version, hasDraft);
         }
     }
+
+    // ---- authoring (Workflows mission, phase 2) ---------------------------------------------------
+    // Drafts are the safety boundary: every write lands on the single mutable draft row; nothing the
+    // fleet reads changes until publish, and publish is one SaveChanges (atomic - the hash, the
+    // freeze, and the status flips commit together). The draft is a FULL REPLACEMENT on every write.
+
+    /// <summary>Create a new workflow as a draft (invisible to the catalog until published).</summary>
+    /// <exception cref="WorkflowValidationException">The content violates the rules (HTTP 400).</exception>
+    /// <exception cref="WorkflowConflictException">The id is already taken (HTTP 409).</exception>
+    public WorkflowVersionDetailDto CreateDraft(WorkflowContentRequest content)
+    {
+        WorkflowValidation.ValidateId(content?.Id);
+        WorkflowValidation.ValidateDraft(content!);
+        var id = content!.Id!.Trim();
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            if (ctx.Workflows.Any(h => h.Id == id))
+                throw new WorkflowConflictException($"A workflow with id '{id}' already exists.");
+
+            var now = DateTime.UtcNow;
+            var head = new WorkflowEntity
+            {
+                Id = id,
+                TenantId = ctx.ActiveTenant!,
+                IsBuiltIn = false,
+                Archived = false,
+                LatestVersion = 1,
+                PublishedVersion = null,
+                ShippedContentHash = null,
+                CreatedUtc = now,
+                UpdatedUtc = now,
+            };
+            ctx.Workflows.Add(head);
+            var (version, files) = BuildDraftRow(ctx, id, versionNumber: 1, content, now);
+            ctx.WorkflowVersions.Add(version);
+            ctx.WorkflowFiles.AddRange(files);
+            ctx.SaveChanges();
+
+            FileLog.Write($"[WorkflowStore] CreateDraft: id={id}, v1 draft, authoredBy={version.AuthoredBy}");
+            return ToVersionDetail(version, files);
+        }
+    }
+
+    /// <summary>
+    /// Replace the workflow's draft content wholesale, minting the draft version if none exists. The
+    /// optional If-Match hash is compared against the row the draft builds on (the current draft, or
+    /// the published version when the draft is being minted): a mismatch means the caller edited a
+    /// stale copy, and the write is refused rather than clobbering someone else's edit.
+    /// Null when no such workflow exists.
+    /// </summary>
+    public WorkflowVersionDetailDto? UpdateDraft(string id, WorkflowContentRequest content, string? ifMatchHash)
+    {
+        var key = NormalizeId(id);
+        WorkflowValidation.ValidateDraft(content);
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var head = ctx.Workflows.FirstOrDefault(h => h.Id == key);
+            if (head is null)
+                return null;
+            if (head.Archived)
+                throw new WorkflowValidationException($"Workflow '{key}' is archived.");
+
+            var draft = ctx.WorkflowVersions.FirstOrDefault(
+                v => v.WorkflowId == key && v.Status == WorkflowVersionStatus.Draft);
+            var baseline = draft ?? ctx.WorkflowVersions.FirstOrDefault(
+                v => v.WorkflowId == key && v.Status == WorkflowVersionStatus.Published);
+            if (ifMatchHash is not null && baseline is not null &&
+                !string.Equals(ifMatchHash, baseline.ContentHash, StringComparison.Ordinal))
+                throw new WorkflowConflictException(
+                    "The workflow changed since you read it (content hash mismatch). Pull the current " +
+                    "content and reapply your edit.");
+
+            var now = DateTime.UtcNow;
+            WorkflowVersionEntity row;
+            List<WorkflowFileEntity> files;
+            if (draft is not null)
+            {
+                (row, files) = BuildDraftRow(ctx, key, draft.Version, content, draft.CreatedUtc,
+                    existing: draft);
+                var oldFiles = ctx.WorkflowFiles.Where(f => f.VersionId == draft.Id).ToList();
+                ctx.WorkflowFiles.RemoveRange(oldFiles);
+                ctx.WorkflowFiles.AddRange(files);
+            }
+            else
+            {
+                var nextVersion = head.LatestVersion + 1;
+                (row, files) = BuildDraftRow(ctx, key, nextVersion, content, now);
+                ctx.WorkflowVersions.Add(row);
+                ctx.WorkflowFiles.AddRange(files);
+                head.LatestVersion = nextVersion;
+            }
+            head.UpdatedUtc = now;
+            ctx.SaveChanges();
+
+            FileLog.Write($"[WorkflowStore] UpdateDraft: id={key}, v{row.Version}, hash={row.ContentHash[..12]}");
+            return ToVersionDetail(row, files);
+        }
+    }
+
+    /// <summary>Publish the draft: the draft becomes the published version, the previous published
+    /// version is superseded, all in one atomic save. Null when no such workflow exists.</summary>
+    public WorkflowDto? Publish(string id)
+    {
+        var key = NormalizeId(id);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var head = ctx.Workflows.FirstOrDefault(h => h.Id == key);
+            if (head is null)
+                return null;
+            if (head.Archived)
+                throw new WorkflowValidationException($"Workflow '{key}' is archived.");
+
+            var draft = ctx.WorkflowVersions.FirstOrDefault(
+                v => v.WorkflowId == key && v.Status == WorkflowVersionStatus.Draft);
+            if (draft is null)
+                throw new WorkflowValidationException(
+                    $"Workflow '{key}' has no draft to publish.");
+            WorkflowValidation.ValidateForPublish(draft.InstructionsMarkdown, draft.Steps);
+
+            var now = DateTime.UtcNow;
+            var previous = ctx.WorkflowVersions.FirstOrDefault(
+                v => v.WorkflowId == key && v.Status == WorkflowVersionStatus.Published);
+            if (previous is not null)
+                previous.Status = WorkflowVersionStatus.Superseded;
+            draft.Status = WorkflowVersionStatus.Published;
+            draft.PublishedUtc = now;
+            head.PublishedVersion = draft.Version;
+            head.UpdatedUtc = now;
+            ctx.SaveChanges();
+
+            FileLog.Write($"[WorkflowStore] Publish: id={key}, v{draft.Version} published" +
+                          (previous is null ? "" : $", v{previous.Version} superseded"));
+            return ToDto(head, draft, hasDraft: false);
+        }
+    }
+
+    /// <summary>Built-ins only: publish the shipped content of the RUNNING binary as a new version
+    /// (the "reset to shipped" the ours/yours trade promises). Null when no such workflow exists.</summary>
+    public WorkflowDto? ResetToShipped(string id)
+    {
+        var key = NormalizeId(id);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var head = ctx.Workflows.FirstOrDefault(h => h.Id == key);
+            if (head is null)
+                return null;
+            if (!head.IsBuiltIn)
+                throw new WorkflowValidationException(
+                    $"Workflow '{key}' is not built in; reset-to-shipped only applies to built-ins.");
+
+            var definition = BuiltInWorkflows.All().FirstOrDefault(d => d.Id == key)
+                ?? throw new InvalidOperationException(
+                    $"Built-in workflow '{key}' is not shipped by this binary; cannot reset.");
+            var shippedRow = BuiltInWorkflowSeeder.BuildShippedVersion(ctx, definition,
+                versionNumber: head.LatestVersion + 1, DateTime.UtcNow);
+            shippedRow.AuthoredBy = "gateway:reset";
+            shippedRow.ChangeNote = "Reset to the shipped built-in content.";
+
+            var previous = ctx.WorkflowVersions.FirstOrDefault(
+                v => v.WorkflowId == key && v.Status == WorkflowVersionStatus.Published);
+            if (previous is not null)
+                previous.Status = WorkflowVersionStatus.Superseded;
+            ctx.WorkflowVersions.Add(shippedRow);
+            head.LatestVersion = shippedRow.Version;
+            head.PublishedVersion = shippedRow.Version;
+            head.ShippedContentHash = shippedRow.ContentHash;
+            head.UpdatedUtc = shippedRow.CreatedUtc;
+            ctx.SaveChanges();
+
+            FileLog.Write($"[WorkflowStore] ResetToShipped: id={key}, v{shippedRow.Version} published from shipped content");
+            var hasDraft = ctx.WorkflowVersions.Any(
+                v => v.WorkflowId == key && v.Status == WorkflowVersionStatus.Draft);
+            return ToDto(head, shippedRow, hasDraft);
+        }
+    }
+
+    /// <summary>Archive (soft-delete) a user-defined workflow. Its versions remain - a run that
+    /// pinned one must always resolve. False when no such workflow exists.</summary>
+    public bool Archive(string id)
+    {
+        var key = NormalizeId(id);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var head = ctx.Workflows.FirstOrDefault(h => h.Id == key);
+            if (head is null)
+                return false;
+            if (head.IsBuiltIn)
+                throw new WorkflowValidationException(
+                    $"Workflow '{key}' is built in and can never be deleted.");
+
+            head.Archived = true;
+            head.UpdatedUtc = DateTime.UtcNow;
+            ctx.SaveChanges();
+            FileLog.Write($"[WorkflowStore] Archive: id={key}");
+            return true;
+        }
+    }
+
+    /// <summary>The version history, newest first, no content bodies. Null when no such workflow.</summary>
+    public IReadOnlyList<WorkflowVersionInfoDto>? ListVersions(string id)
+    {
+        var key = NormalizeId(id);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            if (!ctx.Workflows.Any(h => h.Id == key))
+                return null;
+            return ctx.WorkflowVersions.AsNoTracking()
+                .Where(v => v.WorkflowId == key)
+                .ToList()
+                .OrderByDescending(v => v.Version)
+                .Select(v => new WorkflowVersionInfoDto
+                {
+                    Version = v.Version,
+                    Status = v.Status,
+                    ContentHash = v.ContentHash,
+                    AuthoredBy = v.AuthoredBy,
+                    ChangeNote = v.ChangeNote,
+                    CreatedUtc = v.CreatedUtc,
+                    PublishedUtc = v.PublishedUtc,
+                })
+                .ToList();
+        }
+    }
+
+    /// <summary>One version's complete content snapshot. Null when absent.</summary>
+    public WorkflowVersionDetailDto? GetVersionDetail(string id, int version)
+    {
+        var key = NormalizeId(id);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var row = ctx.WorkflowVersions.AsNoTracking().FirstOrDefault(
+                v => v.WorkflowId == key && v.Version == version);
+            if (row is null)
+                return null;
+            var files = ctx.WorkflowFiles.AsNoTracking().Where(f => f.VersionId == row.Id).ToList();
+            return ToVersionDetail(row, files);
+        }
+    }
+
+    /// <summary>
+    /// The raw instruction markdown - the agent read path. With an explicit version, any version row
+    /// serves (immutable history; a pinned run must always resolve, archived or not). Without one,
+    /// the published version of a live workflow serves; a draft-only or archived workflow yields null.
+    /// </summary>
+    public string? GetInstructions(string id, int? version)
+    {
+        var key = NormalizeId(id);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var row = ResolveVersionRow(ctx, key, version);
+            return row?.InstructionsMarkdown;
+        }
+    }
+
+    /// <summary>One helper file's raw content, resolved like <see cref="GetInstructions"/>.</summary>
+    public string? GetFileContent(string id, string fileName, int? version)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return null;
+        var key = NormalizeId(id);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var row = ResolveVersionRow(ctx, key, version);
+            if (row is null)
+                return null;
+            return ctx.WorkflowFiles.AsNoTracking()
+                .FirstOrDefault(f => f.VersionId == row.Id && f.FileName == fileName)?.Content;
+        }
+    }
+
+    private WorkflowVersionEntity? ResolveVersionRow(GatewayDbContext ctx, string key, int? version)
+    {
+        if (version.HasValue)
+            return ctx.WorkflowVersions.AsNoTracking().FirstOrDefault(
+                v => v.WorkflowId == key && v.Version == version.Value);
+
+        var head = ctx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == key);
+        if (head is null || head.Archived || head.PublishedVersion is null)
+            return null;
+        return ctx.WorkflowVersions.AsNoTracking().FirstOrDefault(
+            v => v.WorkflowId == key && v.Status == WorkflowVersionStatus.Published);
+    }
+
+    /// <summary>Build (or rebuild, for an existing draft) the draft version row + its file rows from a
+    /// full-replacement content request, computing the canonical bundle hash.</summary>
+    private static (WorkflowVersionEntity Row, List<WorkflowFileEntity> Files) BuildDraftRow(
+        GatewayDbContext ctx,
+        string workflowId,
+        int versionNumber,
+        WorkflowContentRequest content,
+        DateTime createdUtc,
+        WorkflowVersionEntity? existing = null)
+    {
+        var steps = (content.Steps ?? new List<WorkflowStepDto>()).Select(s => new WorkflowStepDto
+        {
+            Name = s.Name,
+            Description = s.Description,
+            Doer = s.Doer,
+            Reviewer = s.Reviewer,
+            Done = s.Done,
+        }).ToList();
+        var criteria = (content.OutcomeCriteria ?? new List<WorkflowOutcomeCriterionDto>())
+            .Select(c => new WorkflowOutcomeCriterionDto
+            {
+                CriterionId = c.CriterionId,
+                Description = c.Description,
+                ProofHint = c.ProofHint,
+            }).ToList();
+        var instructions = content.InstructionsMarkdown ?? "";
+        var filePayloads = content.Files ?? new List<WorkflowFileDto>();
+        var hashedFiles = filePayloads
+            .Select(f => (f.FileName, Content: f.Content ?? "", Hash: WorkflowContentHash.ForFile(f.Content ?? "")))
+            .ToList();
+        var contentHash = WorkflowContentHash.ForBundle(
+            content.Name!, content.Summary!, content.WhenToUse ?? "", content.HumanCheckpoint ?? "",
+            steps, criteria, instructions, hashedFiles.Select(f => (f.FileName, f.Hash)));
+
+        var row = existing ?? new WorkflowVersionEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = ctx.ActiveTenant!,
+            WorkflowId = workflowId,
+            Version = versionNumber,
+            Status = WorkflowVersionStatus.Draft,
+            CreatedUtc = createdUtc,
+        };
+        row.Name = content.Name!;
+        row.Summary = content.Summary!;
+        row.WhenToUse = content.WhenToUse ?? "";
+        row.HumanCheckpoint = content.HumanCheckpoint ?? "";
+        row.Steps = steps;
+        row.InstructionsMarkdown = instructions;
+        row.OutcomeCriteria = criteria;
+        row.ContentHash = contentHash;
+        row.AuthoredBy = string.IsNullOrWhiteSpace(content.AuthoredBy) ? "unknown" : content.AuthoredBy!;
+        row.ChangeNote = content.ChangeNote;
+
+        var files = hashedFiles.Select(f => new WorkflowFileEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = ctx.ActiveTenant!,
+            VersionId = row.Id,
+            FileName = f.FileName,
+            Content = f.Content,
+            ContentHash = f.Hash,
+        }).ToList();
+        return (row, files);
+    }
+
+    private static WorkflowVersionDetailDto ToVersionDetail(
+        WorkflowVersionEntity row, IReadOnlyList<WorkflowFileEntity> files) => new()
+    {
+        WorkflowId = row.WorkflowId,
+        Version = row.Version,
+        Status = row.Status,
+        Name = row.Name,
+        Summary = row.Summary,
+        WhenToUse = row.WhenToUse,
+        HumanCheckpoint = row.HumanCheckpoint,
+        Steps = row.Steps.Select(s => new WorkflowStepDto
+        {
+            Name = s.Name,
+            Description = s.Description,
+            Doer = s.Doer,
+            Reviewer = s.Reviewer,
+            Done = s.Done,
+        }).ToList(),
+        InstructionsMarkdown = row.InstructionsMarkdown,
+        OutcomeCriteria = row.OutcomeCriteria.Select(c => new WorkflowOutcomeCriterionDto
+        {
+            CriterionId = c.CriterionId,
+            Description = c.Description,
+            ProofHint = c.ProofHint,
+        }).ToList(),
+        Files = files.Select(f => new WorkflowFileInfoDto
+        {
+            FileName = f.FileName,
+            ContentHash = f.ContentHash,
+        }).ToList(),
+        ContentHash = row.ContentHash,
+        AuthoredBy = row.AuthoredBy,
+        ChangeNote = row.ChangeNote,
+        CreatedUtc = row.CreatedUtc,
+        PublishedUtc = row.PublishedUtc,
+    };
+
+    private static string NormalizeId(string id) => (id ?? "").Trim().ToLowerInvariant();
 
     private static WorkflowDto ToDto(WorkflowEntity head, WorkflowVersionEntity version, bool hasDraft) => new()
     {

--- a/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
@@ -351,9 +351,12 @@ public sealed class WorkflowStore
     }
 
     /// <summary>
-    /// The raw instruction markdown - the agent read path. With an explicit version, any version row
-    /// serves (immutable history; a pinned run must always resolve, archived or not). Without one,
-    /// the published version of a live workflow serves; a draft-only or archived workflow yields null.
+    /// The raw instruction markdown - the agent read path. With an explicit version, any PUBLISHED or
+    /// SUPERSEDED row serves (immutable history; a pinned run must always resolve, archived or not) -
+    /// but never the draft: a draft is mutable, so serving it as pinned history would be a lie, and
+    /// the publish boundary is exactly what makes content fleet-readable. (Authoring reads a draft
+    /// through the versions/{n} detail route, which states the status.) Without a version, the
+    /// published version of a live workflow serves; a draft-only or archived workflow yields null.
     /// </summary>
     public string? GetInstructions(string id, int? version)
     {
@@ -387,7 +390,8 @@ public sealed class WorkflowStore
     {
         if (version.HasValue)
             return ctx.WorkflowVersions.AsNoTracking().FirstOrDefault(
-                v => v.WorkflowId == key && v.Version == version.Value);
+                v => v.WorkflowId == key && v.Version == version.Value &&
+                     v.Status != WorkflowVersionStatus.Draft);
 
         var head = ctx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == key);
         if (head is null || head.Archived || head.PublishedVersion is null)

--- a/src/CcDirector.Gateway/Workflows/WorkflowValidation.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowValidation.cs
@@ -1,0 +1,126 @@
+using System.Text.RegularExpressions;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Workflows;
+
+/// <summary>A workflow authoring request violates the content rules. Maps to HTTP 400.</summary>
+public sealed class WorkflowValidationException : Exception
+{
+    public WorkflowValidationException(string message) : base(message) { }
+}
+
+/// <summary>A workflow authoring request lost a race (id already taken, If-Match hash stale). Maps to
+/// HTTP 409 so the caller re-reads and retries deliberately instead of clobbering.</summary>
+public sealed class WorkflowConflictException : Exception
+{
+    public WorkflowConflictException(string message) : base(message) { }
+}
+
+/// <summary>
+/// The workflow content rules, enforced at the store boundary (the endpoints translate the exceptions
+/// to status codes). Two tiers on purpose: a DRAFT may be skeletal (the Cockpit's add dialog supplies
+/// only a name and summary and hands authoring to an agent), while PUBLISHING demands the pieces a
+/// listed catalog entry cannot be without - the legacy read contract promises every listed workflow
+/// has steps with a doer and a done, and the whole feature is pointless without instructions.
+/// </summary>
+public static class WorkflowValidation
+{
+    /// <summary>Lowercase slug ids, matching the shipped built-in ids ("mission", "standalone-with-review").</summary>
+    public static readonly Regex IdPattern = new("^[a-z0-9][a-z0-9-]{1,63}$", RegexOptions.Compiled);
+
+    private static readonly Regex FileNamePattern = new("^[A-Za-z0-9._-]+$", RegexOptions.Compiled);
+    private static readonly string[] AllowedFileExtensions = { ".py", ".md", ".txt", ".json" };
+
+    public const int MaxInstructionsBytes = 200 * 1024;
+    public const int MaxFileBytes = 256 * 1024;
+    public const int MaxFilesPerVersion = 20;
+
+    /// <summary>Validate a workflow id (slug).</summary>
+    public static void ValidateId(string? id)
+    {
+        if (string.IsNullOrWhiteSpace(id) || !IdPattern.IsMatch(id))
+            throw new WorkflowValidationException(
+                "A workflow id must be a lowercase slug: letters, digits, and dashes, starting with a " +
+                "letter or digit, 2 to 64 characters (like \"release-train\").");
+    }
+
+    /// <summary>The draft-tier rules: identity fields present, every size cap and file rule honored.</summary>
+    public static void ValidateDraft(WorkflowContentRequest content)
+    {
+        if (content is null)
+            throw new WorkflowValidationException("A workflow body is required.");
+        if (string.IsNullOrWhiteSpace(content.Name))
+            throw new WorkflowValidationException("A workflow needs a name.");
+        if (string.IsNullOrWhiteSpace(content.Summary))
+            throw new WorkflowValidationException("A workflow needs a one-line summary.");
+
+        var instructions = content.InstructionsMarkdown ?? "";
+        if (System.Text.Encoding.UTF8.GetByteCount(instructions) > MaxInstructionsBytes)
+            throw new WorkflowValidationException(
+                $"The instructions are too large (limit {MaxInstructionsBytes / 1024} KB).");
+
+        var criteria = content.OutcomeCriteria ?? new List<WorkflowOutcomeCriterionDto>();
+        var criterionIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var criterion in criteria)
+        {
+            if (string.IsNullOrWhiteSpace(criterion.CriterionId) || !IdPattern.IsMatch(criterion.CriterionId))
+                throw new WorkflowValidationException(
+                    $"Outcome criterion id '{criterion.CriterionId}' must be a lowercase slug.");
+            if (string.IsNullOrWhiteSpace(criterion.Description))
+                throw new WorkflowValidationException(
+                    $"Outcome criterion '{criterion.CriterionId}' needs a description.");
+            if (!criterionIds.Add(criterion.CriterionId))
+                throw new WorkflowValidationException(
+                    $"Outcome criterion id '{criterion.CriterionId}' appears more than once.");
+        }
+
+        var files = content.Files ?? new List<WorkflowFileDto>();
+        if (files.Count > MaxFilesPerVersion)
+            throw new WorkflowValidationException(
+                $"A workflow version carries at most {MaxFilesPerVersion} helper files.");
+        var fileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var file in files)
+        {
+            ValidateFileName(file.FileName);
+            if (System.Text.Encoding.UTF8.GetByteCount(file.Content ?? "") > MaxFileBytes)
+                throw new WorkflowValidationException(
+                    $"Helper file '{file.FileName}' is too large (limit {MaxFileBytes / 1024} KB).");
+            if (!fileNames.Add(file.FileName))
+                throw new WorkflowValidationException(
+                    $"Helper file name '{file.FileName}' appears more than once.");
+        }
+    }
+
+    /// <summary>The publish-tier rules on top of the draft tier: a listed workflow must actually say
+    /// how to do the work.</summary>
+    public static void ValidateForPublish(
+        string instructionsMarkdown, IReadOnlyList<WorkflowStepDto> steps)
+    {
+        if (string.IsNullOrWhiteSpace(instructionsMarkdown))
+            throw new WorkflowValidationException(
+                "A workflow cannot publish without instructions - the instruction markdown is the " +
+                "conduct the fleet follows.");
+        if (steps.Count == 0)
+            throw new WorkflowValidationException(
+                "A workflow cannot publish without at least one step.");
+        foreach (var step in steps)
+        {
+            if (string.IsNullOrWhiteSpace(step.Doer) || string.IsNullOrWhiteSpace(step.Done))
+                throw new WorkflowValidationException(
+                    $"Step '{step.Name}' needs a doer and a definition of done - a step without them " +
+                    "is a wish, not a workflow step.");
+        }
+    }
+
+    private static void ValidateFileName(string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName) || !FileNamePattern.IsMatch(fileName))
+            throw new WorkflowValidationException(
+                $"Helper file name '{fileName}' is invalid: bare file names only (letters, digits, " +
+                "dot, dash, underscore), never a path.");
+        if (!AllowedFileExtensions.Any(ext => fileName.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
+            throw new WorkflowValidationException(
+                $"Helper file '{fileName}' has a disallowed extension. Allowed: " +
+                string.Join(", ", AllowedFileExtensions) + ".");
+    }
+}

--- a/src/CcDirector.Gateway/Workflows/WorkflowValidation.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowValidation.cs
@@ -34,6 +34,12 @@ public static class WorkflowValidation
     public const int MaxInstructionsBytes = 200 * 1024;
     public const int MaxFileBytes = 256 * 1024;
     public const int MaxFilesPerVersion = 20;
+    // Every other field is bounded too - an authenticated caller within the host body limit must not
+    // be able to persist megabytes into a name column or a ten-thousand-step list.
+    public const int MaxShortFieldChars = 200;
+    public const int MaxTextFieldChars = 4000;
+    public const int MaxStepsPerVersion = 50;
+    public const int MaxCriteriaPerVersion = 50;
 
     /// <summary>Validate a workflow id (slug).</summary>
     public static void ValidateId(string? id)
@@ -54,21 +60,52 @@ public static class WorkflowValidation
         if (string.IsNullOrWhiteSpace(content.Summary))
             throw new WorkflowValidationException("A workflow needs a one-line summary.");
 
+        CapLength("name", content.Name, MaxShortFieldChars);
+        CapLength("summary", content.Summary, MaxTextFieldChars);
+        CapLength("whenToUse", content.WhenToUse, MaxTextFieldChars);
+        CapLength("humanCheckpoint", content.HumanCheckpoint, MaxTextFieldChars);
+        CapLength("authoredBy", content.AuthoredBy, MaxShortFieldChars);
+        CapLength("changeNote", content.ChangeNote, MaxTextFieldChars);
+
         var instructions = content.InstructionsMarkdown ?? "";
         if (System.Text.Encoding.UTF8.GetByteCount(instructions) > MaxInstructionsBytes)
             throw new WorkflowValidationException(
                 $"The instructions are too large (limit {MaxInstructionsBytes / 1024} KB).");
 
+        var steps = content.Steps ?? new List<WorkflowStepDto>();
+        if (steps.Count > MaxStepsPerVersion)
+            throw new WorkflowValidationException(
+                $"A workflow version carries at most {MaxStepsPerVersion} steps.");
+        foreach (var step in steps)
+        {
+            // JSON like "steps":[null] deserializes to a null element - reject it as the bad input it
+            // is rather than letting it surface later as an unhandled 500.
+            if (step is null)
+                throw new WorkflowValidationException("The steps list contains a null entry.");
+            CapLength("step name", step.Name, MaxShortFieldChars);
+            CapLength("step description", step.Description, MaxTextFieldChars);
+            CapLength("step doer", step.Doer, MaxShortFieldChars);
+            CapLength("step reviewer", step.Reviewer, MaxShortFieldChars);
+            CapLength("step done", step.Done, MaxTextFieldChars);
+        }
+
         var criteria = content.OutcomeCriteria ?? new List<WorkflowOutcomeCriterionDto>();
+        if (criteria.Count > MaxCriteriaPerVersion)
+            throw new WorkflowValidationException(
+                $"A workflow version carries at most {MaxCriteriaPerVersion} outcome criteria.");
         var criterionIds = new HashSet<string>(StringComparer.Ordinal);
         foreach (var criterion in criteria)
         {
+            if (criterion is null)
+                throw new WorkflowValidationException("The outcome criteria list contains a null entry.");
             if (string.IsNullOrWhiteSpace(criterion.CriterionId) || !IdPattern.IsMatch(criterion.CriterionId))
                 throw new WorkflowValidationException(
                     $"Outcome criterion id '{criterion.CriterionId}' must be a lowercase slug.");
             if (string.IsNullOrWhiteSpace(criterion.Description))
                 throw new WorkflowValidationException(
                     $"Outcome criterion '{criterion.CriterionId}' needs a description.");
+            CapLength("criterion description", criterion.Description, MaxTextFieldChars);
+            CapLength("criterion proofHint", criterion.ProofHint, MaxTextFieldChars);
             if (!criterionIds.Add(criterion.CriterionId))
                 throw new WorkflowValidationException(
                     $"Outcome criterion id '{criterion.CriterionId}' appears more than once.");
@@ -81,6 +118,8 @@ public static class WorkflowValidation
         var fileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var file in files)
         {
+            if (file is null)
+                throw new WorkflowValidationException("The files list contains a null entry.");
             ValidateFileName(file.FileName);
             if (System.Text.Encoding.UTF8.GetByteCount(file.Content ?? "") > MaxFileBytes)
                 throw new WorkflowValidationException(
@@ -89,6 +128,13 @@ public static class WorkflowValidation
                 throw new WorkflowValidationException(
                     $"Helper file name '{file.FileName}' appears more than once.");
         }
+    }
+
+    private static void CapLength(string field, string? value, int maxChars)
+    {
+        if (value is not null && value.Length > maxChars)
+            throw new WorkflowValidationException(
+                $"The {field} is too long (limit {maxChars} characters).");
     }
 
     /// <summary>The publish-tier rules on top of the draft tier: a listed workflow must actually say


### PR DESCRIPTION
Phase 2 of the approved Workflows plan (mission 9a955739). Phase 1 (#1774) persisted the catalog; this makes it agent-authorable.

## What this does

- **Drafts are the safety boundary.** POST creates a workflow as a draft (invisible to the catalog); PUT {id}/draft replaces the draft's content wholesale, minting the next version number when drafting over a published workflow. An optional If-Match content hash refuses stale edits with 409 instead of clobbering a concurrent author.
- **Publish is the fleet-visible act**, and it is strict and atomic: it demands instructions and at least one step with a doer and a done, then flips draft to published and the previous published version to superseded in one save.
- **Pinned history resolves forever.** GET {id}/instructions?version=N and GET {id}/files/{name}?version=N serve any version row - superseded or archived - because a workflow run that pinned a version must always be able to answer what conduct governed it. The default (no version) read follows catalog semantics.
- **Built-ins are editable with reset-to-shipped** (owner ruling): customizing mission works like any edit; POST {id}/reset republishes the running binary's shipped content as a new version via the same builder the startup seeder uses, so shipped-content-as-a-version has exactly one definition.
- **Archive is soft** and never touches a built-in.
- Validation at the store boundary: slug ids, 200 KB instruction cap, bare validated helper-file names with an allow-listed extension set (.py .md .txt .json), 256 KB per file, 20 files per version, unique outcome-criterion slugs.

## Proof

- Full solution suite: all seven test projects, 6,286 passed, 0 failed.
- 14 new tests: store-level (create/conflict/slug rules, full-replacement draft writes with hash recompute, If-Match stale vs current, draft-over-published minting, the publish gate, supersede atomicity, pinned reads after supersede AND archive, built-in customize-then-reset round-trip, reset refused on user workflows, archive semantics, file rules) plus an HTTP round-trip covering create - skeletal publish refused - fill draft - publish - raw markdown read - stale If-Match 409 - duplicate id 409 - archive - built-in delete refused.

## Next

Phase 3: the cc-devthrottle workflow command group (list/show/instructions/pull/push/publish/versions/delete/reset/materialize).