### PR TITLE
feat(cli): the workflow command group - agents author fleet workflows end-to-end (Workflows phase 3)

### DIFF
--- a/src/CcDirector.Gateway.Contracts/WorkflowDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/WorkflowDtos.cs
@@ -72,12 +72,14 @@ public sealed class WorkflowFileDto
     public string Content { get; set; } = "";
 }
 
-/// <summary>A helper file reference without its content (detail responses; content is served raw by
-/// <c>GET /gateway/workflows/{id}/files/{fileName}</c>).</summary>
+/// <summary>A helper file in a version-detail response. Carries the full content: the detail route is
+/// the authoring read (the CLI pulls a complete directory from it, drafts included - the raw
+/// <c>files/{fileName}</c> route serves only pinned, non-draft versions).</summary>
 public sealed class WorkflowFileInfoDto
 {
     public string FileName { get; set; } = "";
     public string ContentHash { get; set; } = "";
+    public string Content { get; set; } = "";
 }
 
 /// <summary>One row of a workflow's version history (no content bodies).</summary>

--- a/src/CcDirector.Gateway.Tests/WorkflowAuthoringTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowAuthoringTests.cs
@@ -97,9 +97,13 @@ public sealed class WorkflowAuthoringTests : IDisposable
         Assert.Equal("verify.py", updated.Files[0].FileName);
 
         // A DRAFT is never served by the pinned-read routes (it is mutable, so it cannot be pinned
-        // history); the file becomes readable the moment the version publishes.
+        // history); the file becomes readable the moment the version publishes. The AUTHORING read
+        // (the version detail) does carry the draft's file content - that is what the CLI's pull
+        // round-trips, drafts included.
         Assert.Null(store.GetFileContent("release-train", "verify.py", version: 1));
         Assert.Null(store.GetInstructions("release-train", version: 1));
+        Assert.Equal("print('verify')",
+            store.GetVersionDetail("release-train", 1)!.Files.Single().Content);
         store.Publish("release-train");
         Assert.Equal("print('verify')",
             store.GetFileContent("release-train", "verify.py", version: 1));

--- a/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
@@ -495,6 +495,7 @@ public sealed class WorkflowStore
         {
             FileName = f.FileName,
             ContentHash = f.ContentHash,
+            Content = f.Content,
         }).ToList(),
         ContentHash = row.ContentHash,
         AuthoredBy = row.AuthoredBy,

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -858,9 +858,15 @@ def workflow_push(
     workflow_id: str = typer.Argument(..., help="The workflow id."),
     directory: str = typer.Option(..., "--dir", "-d", help="Directory holding the workflow files."),
     note: Optional[str] = typer.Option(None, "--note", help="One line describing what changed."),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Push an update WITHOUT the .workflow-hash sidecar (skips the stale-copy check; "
+        "may overwrite another author's edit).",
+    ),
 ) -> None:
     """Push a Workflow directory to the Gateway as a draft (creates the Workflow if new)."""
-    workflow_ops.push_workflow(workflow_id, directory, note)
+    workflow_ops.push_workflow(workflow_id, directory, note, force)
 
 
 @workflow_app.command("publish")

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -16,6 +16,7 @@ from . import mission_ops
 from . import schedule_ops
 from . import settings_ops
 from . import setup_ops
+from . import workflow_ops
 from .session_ops import (
     ask_session,
     hold_session,
@@ -51,6 +52,11 @@ settings_app = typer.Typer(
 schedule_app = typer.Typer(
     help="Manage Gateway schedules.", add_completion=False, no_args_is_help=True
 )
+workflow_app = typer.Typer(
+    help="Read and author fleet Workflows (cross-agent conduct stored on the Gateway).",
+    add_completion=False,
+    no_args_is_help=True,
+)
 setup_app = typer.Typer(
     help="Install, update, and repair DevThrottle.", add_completion=False, no_args_is_help=True
 )
@@ -67,6 +73,7 @@ app.add_typer(mission_app, name="mission")
 app.add_typer(message_app, name="message")
 app.add_typer(settings_app, name="settings")
 app.add_typer(schedule_app, name="schedule")
+app.add_typer(workflow_app, name="workflow")
 app.add_typer(setup_app, name="setup")
 app.add_typer(email_app, name="email")
 app.add_typer(diag_app, name="diag")
@@ -268,6 +275,76 @@ _ACTIONS = [
         "command": "cc-devthrottle schedule endpoint",
         "mutatesState": False,
         "args": [],
+    },
+    {
+        "id": "workflow-list",
+        "description": "List the fleet's Workflows (cross-agent conduct stored on the Gateway).",
+        "command": "cc-devthrottle workflow list",
+        "mutatesState": False,
+        "args": [],
+    },
+    {
+        "id": "workflow-instructions",
+        "description": "Print a Workflow's raw instruction markdown - fetch this and FOLLOW it as your conduct.",
+        "command": "cc-devthrottle workflow instructions <id>",
+        "mutatesState": False,
+        "args": [{"name": "id", "required": True}, {"name": "version", "required": False}],
+    },
+    {
+        "id": "workflow-show",
+        "description": "Show one Workflow's metadata, steps, and outcome criteria.",
+        "command": "cc-devthrottle workflow show <id>",
+        "mutatesState": False,
+        "args": [{"name": "id", "required": True}, {"name": "version", "required": False}],
+    },
+    {
+        "id": "workflow-versions",
+        "description": "Show a Workflow's version history.",
+        "command": "cc-devthrottle workflow versions <id>",
+        "mutatesState": False,
+        "args": [{"name": "id", "required": True}],
+    },
+    {
+        "id": "workflow-pull",
+        "description": "Pull a Workflow into a directory (workflow.json + instructions.md + helpers/) for editing.",
+        "command": 'cc-devthrottle workflow pull <id> --dir "<dir>"',
+        "mutatesState": False,
+        "args": [{"name": "id", "required": True}, {"name": "dir", "required": True}],
+    },
+    {
+        "id": "workflow-push",
+        "description": "Push an edited Workflow directory to the Gateway as a draft (creates the Workflow if new).",
+        "command": 'cc-devthrottle workflow push <id> --dir "<dir>" [--note "<what changed>"]',
+        "mutatesState": True,
+        "args": [{"name": "id", "required": True}, {"name": "dir", "required": True}],
+    },
+    {
+        "id": "workflow-publish",
+        "description": "Publish a Workflow's draft - it becomes the version every machine and agent reads.",
+        "command": "cc-devthrottle workflow publish <id>",
+        "mutatesState": True,
+        "args": [{"name": "id", "required": True}],
+    },
+    {
+        "id": "workflow-materialize",
+        "description": "Write a Workflow's instructions and helper files to this machine's cache and print the paths.",
+        "command": "cc-devthrottle workflow materialize <id>",
+        "mutatesState": True,
+        "args": [{"name": "id", "required": True}, {"name": "version", "required": False}],
+    },
+    {
+        "id": "workflow-reset",
+        "description": "Reset a built-in Workflow to the shipped content (published as a new version).",
+        "command": "cc-devthrottle workflow reset <id>",
+        "mutatesState": True,
+        "args": [{"name": "id", "required": True}],
+    },
+    {
+        "id": "workflow-delete",
+        "description": "Archive a custom Workflow (built-ins can never be deleted; history remains).",
+        "command": "cc-devthrottle workflow delete <id> --yes",
+        "mutatesState": True,
+        "args": [{"name": "id", "required": True}],
     },
     {
         "id": "email-owner",
@@ -710,6 +787,116 @@ def schedule_main(
 ) -> None:
     """Manage Gateway schedules."""
     schedule_ops.set_gateway_override(gateway)
+
+
+@workflow_app.callback()
+def workflow_main(
+    gateway: Optional[str] = typer.Option(
+        None,
+        "--gateway",
+        help="Override the Gateway base URL.",
+    ),
+) -> None:
+    """Read and author fleet Workflows (cross-agent conduct stored on the Gateway)."""
+    workflow_ops.set_gateway_override(gateway)
+
+
+@workflow_app.command("list")
+def workflow_list(
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """List every Workflow the fleet can run."""
+    workflow_ops.list_workflows(json_output)
+
+
+@workflow_app.command("show")
+def workflow_show(
+    workflow_id: str = typer.Argument(..., help="The workflow id (e.g. mission)."),
+    version: Optional[int] = typer.Option(
+        None, "--version", "-v", help="A specific version instead of the published one."
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """Show one Workflow's metadata, steps, and outcome criteria."""
+    workflow_ops.show_workflow(workflow_id, version, json_output)
+
+
+@workflow_app.command("instructions")
+def workflow_instructions(
+    workflow_id: str = typer.Argument(..., help="The workflow id (e.g. mission)."),
+    version: Optional[int] = typer.Option(
+        None, "--version", "-v", help="A specific pinned version instead of the published one."
+    ),
+) -> None:
+    """Print the Workflow's raw instruction markdown - fetch this and FOLLOW it as your conduct."""
+    workflow_ops.print_instructions(workflow_id, version)
+
+
+@workflow_app.command("versions")
+def workflow_versions(
+    workflow_id: str = typer.Argument(..., help="The workflow id."),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """Show a Workflow's version history, newest first."""
+    workflow_ops.list_versions(workflow_id, json_output)
+
+
+@workflow_app.command("pull")
+def workflow_pull(
+    workflow_id: str = typer.Argument(..., help="The workflow id."),
+    directory: str = typer.Option(..., "--dir", "-d", help="Directory to write the workflow into."),
+    version: Optional[int] = typer.Option(
+        None, "--version", "-v", help="A specific version (default: the draft if one exists, else the published version)."
+    ),
+) -> None:
+    """Pull a Workflow into a directory (workflow.json + instructions.md + helpers/) for editing."""
+    workflow_ops.pull_workflow(workflow_id, directory, version)
+
+
+@workflow_app.command("push")
+def workflow_push(
+    workflow_id: str = typer.Argument(..., help="The workflow id."),
+    directory: str = typer.Option(..., "--dir", "-d", help="Directory holding the workflow files."),
+    note: Optional[str] = typer.Option(None, "--note", help="One line describing what changed."),
+) -> None:
+    """Push a Workflow directory to the Gateway as a draft (creates the Workflow if new)."""
+    workflow_ops.push_workflow(workflow_id, directory, note)
+
+
+@workflow_app.command("publish")
+def workflow_publish(
+    workflow_id: str = typer.Argument(..., help="The workflow id."),
+) -> None:
+    """Publish the draft - it becomes the version every machine and agent reads."""
+    workflow_ops.publish_workflow(workflow_id)
+
+
+@workflow_app.command("materialize")
+def workflow_materialize(
+    workflow_id: str = typer.Argument(..., help="The workflow id."),
+    version: Optional[int] = typer.Option(
+        None, "--version", "-v", help="A specific published version (default: the current one)."
+    ),
+) -> None:
+    """Write the Workflow's instructions and helper files to this machine's cache and print the paths."""
+    workflow_ops.materialize_workflow(workflow_id, version)
+
+
+@workflow_app.command("reset")
+def workflow_reset(
+    workflow_id: str = typer.Argument(..., help="The built-in workflow id (e.g. mission)."),
+) -> None:
+    """Reset a built-in Workflow to the shipped content (published as a new version)."""
+    workflow_ops.reset_workflow(workflow_id)
+
+
+@workflow_app.command("delete")
+def workflow_delete(
+    workflow_id: str = typer.Argument(..., help="The workflow id."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt."),
+) -> None:
+    """Archive a custom Workflow (built-ins can never be deleted; version history remains)."""
+    workflow_ops.delete_workflow(workflow_id, yes)
 
 
 @schedule_app.command("list")

--- a/tools/cc-devthrottle/src/workflow_ops.py
+++ b/tools/cc-devthrottle/src/workflow_ops.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import socket
 import sys
 from pathlib import Path
@@ -222,6 +223,34 @@ def _client() -> WorkflowClient:
     return WorkflowClient(base_url=gateway_override)
 
 
+def _safe_file_name(name: str) -> str:
+    """Refuse any server-supplied file name that is not a bare name. The Gateway validates names on
+    write, but this CLI must not trust that: a misconfigured, older, or hostile server must not be
+    able to steer a write outside the pull or cache directory."""
+    if (
+        not name
+        or name in (".", "..")
+        or "/" in name
+        or "\\" in name
+        or ":" in name
+        or name != name.strip()
+    ):
+        raise GatewayError(f"The Gateway returned an unsafe helper file name: '{name}'.")
+    return name
+
+
+def _write_exact(path: Path, text: str) -> None:
+    """Write text with NO newline translation, so pull/push round-trips are value-faithful even for
+    content that already contains carriage returns."""
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        handle.write(text)
+
+
+def _read_exact(path: Path) -> str:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return handle.read()
+
+
 def _pick_authoring_version(versions: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """The version an author edits next: the draft when one exists, else the published head."""
     for row in versions:
@@ -323,15 +352,14 @@ def show_workflow(workflow_id: str, version: Optional[int], json_output: bool) -
 
 
 def print_instructions(workflow_id: str, version: Optional[int]) -> None:
-    """Print the raw conduct markdown, unmangled - this output goes into an agent's context."""
+    """Print the raw conduct markdown, verbatim - this output goes into an agent's context, so
+    nothing is appended, rendered, or wrapped."""
     try:
         markdown = _client().get_instructions(workflow_id, version)
     except GatewayError as ex:
         _fail(str(ex))
         return
     sys.stdout.write(markdown)
-    if markdown and not markdown.endswith("\n"):
-        sys.stdout.write("\n")
 
 
 def list_versions(workflow_id: str, json_output: bool) -> None:
@@ -390,15 +418,17 @@ def pull_workflow(workflow_id: str, directory: str, version: Optional[int]) -> N
         "outcomeCriteria": detail.get("outcomeCriteria") or [],
     }
     (target / WORKFLOW_JSON).write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
-    (target / INSTRUCTIONS_MD).write_text(
-        detail.get("instructionsMarkdown") or "", encoding="utf-8"
-    )
+    _write_exact(target / INSTRUCTIONS_MD, detail.get("instructionsMarkdown") or "")
+    # The helpers directory mirrors the SERVER exactly: clear it first, so a helper another author
+    # deleted on the Gateway does not survive locally and get resurrected by the next push.
+    helpers = target / HELPERS_DIR
+    if helpers.is_dir():
+        shutil.rmtree(helpers)
     files = detail.get("files") or []
     if files:
-        helpers = target / HELPERS_DIR
-        helpers.mkdir(exist_ok=True)
+        helpers.mkdir()
         for f in files:
-            (helpers / f["fileName"]).write_text(f.get("content") or "", encoding="utf-8")
+            _write_exact(helpers / _safe_file_name(f["fileName"]), f.get("content") or "")
     (target / HASH_SIDECAR).write_text(detail.get("contentHash", ""), encoding="utf-8")
 
     console.print(
@@ -422,6 +452,11 @@ def _read_directory(workflow_id: str, directory: str, note: Optional[str]) -> Di
             metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
         except ValueError as exc:
             raise GatewayError(f"{WORKFLOW_JSON} is not valid JSON: {exc}") from exc
+        if not isinstance(metadata, dict):
+            raise GatewayError(
+                f"{WORKFLOW_JSON} must be a JSON object with the workflow's metadata, "
+                f"not {type(metadata).__name__}."
+            )
     declared_id = (metadata.get("id") or "").strip()
     if declared_id and declared_id != workflow_id:
         raise GatewayError(
@@ -430,18 +465,14 @@ def _read_directory(workflow_id: str, directory: str, note: Optional[str]) -> Di
         )
 
     instructions_path = source / INSTRUCTIONS_MD
-    instructions = (
-        instructions_path.read_text(encoding="utf-8") if instructions_path.is_file() else ""
-    )
+    instructions = _read_exact(instructions_path) if instructions_path.is_file() else ""
 
     files: List[Dict[str, str]] = []
     helpers = source / HELPERS_DIR
     if helpers.is_dir():
         for path in sorted(helpers.iterdir()):
             if path.is_file():
-                files.append(
-                    {"fileName": path.name, "content": path.read_text(encoding="utf-8")}
-                )
+                files.append({"fileName": path.name, "content": _read_exact(path)})
 
     return {
         "id": workflow_id,
@@ -458,7 +489,7 @@ def _read_directory(workflow_id: str, directory: str, note: Optional[str]) -> Di
     }
 
 
-def push_workflow(workflow_id: str, directory: str, note: Optional[str]) -> None:
+def push_workflow(workflow_id: str, directory: str, note: Optional[str], force: bool = False) -> None:
     try:
         client = _client()
         body = _read_directory(workflow_id, directory, note)
@@ -471,6 +502,13 @@ def push_workflow(workflow_id: str, directory: str, note: Optional[str]) -> None
             if_match = (
                 sidecar.read_text(encoding="utf-8").strip() if sidecar.is_file() else None
             )
+            if not if_match and not force:
+                raise GatewayError(
+                    f"No {HASH_SIDECAR} sidecar in {directory}, so this push cannot prove it "
+                    "builds on the current content and could silently overwrite another "
+                    "author's edit. Pull first (which writes the sidecar), or pass --force to "
+                    "overwrite deliberately."
+                )
             result = client.update_draft(workflow_id, body, if_match)
             verb = "Updated"
     except GatewayError as ex:
@@ -479,7 +517,15 @@ def push_workflow(workflow_id: str, directory: str, note: Optional[str]) -> None
 
     new_hash = result.get("contentHash", "")
     if new_hash:
-        (Path(directory) / HASH_SIDECAR).write_text(new_hash, encoding="utf-8")
+        try:
+            (Path(directory) / HASH_SIDECAR).write_text(new_hash, encoding="utf-8")
+        except OSError as exc:
+            _fail(
+                f"The draft WAS updated on the Gateway (v{result.get('version')}), but the local "
+                f"hash sidecar could not be written: {exc}. Run 'cc-devthrottle workflow pull "
+                f"{workflow_id} --dir \"{directory}\"' to resynchronize before the next push."
+            )
+            return
     console.print(
         f"{verb} draft v{result.get('version')} of '{workflow_id}'. "
         "Nothing changes for the fleet until it publishes: "
@@ -553,19 +599,30 @@ def materialize_workflow(workflow_id: str, version: Optional[int]) -> None:
     root = Path(local_app_data) / "cc-director" / "workflows" / workflow_id / str(version)
     hash_file = root / HASH_SIDECAR
     expected = detail.get("contentHash", "")
-    if hash_file.is_file() and hash_file.read_text(encoding="utf-8").strip() == expected:
+    files = detail.get("files") or []
+    for f in files:
+        _safe_file_name(f["fileName"])
+
+    # The sidecar alone is not proof the bundle is intact - every listed file must actually exist,
+    # or a deleted/half-written cache would be reported as materialized forever.
+    intact = (
+        hash_file.is_file()
+        and hash_file.read_text(encoding="utf-8").strip() == expected
+        and (root / INSTRUCTIONS_MD).is_file()
+        and all((root / HELPERS_DIR / f["fileName"]).is_file() for f in files)
+    )
+    if intact:
         console.print(f"Already materialized: {root}")
     else:
         root.mkdir(parents=True, exist_ok=True)
-        (root / INSTRUCTIONS_MD).write_text(
-            detail.get("instructionsMarkdown") or "", encoding="utf-8"
-        )
-        files = detail.get("files") or []
+        _write_exact(root / INSTRUCTIONS_MD, detail.get("instructionsMarkdown") or "")
+        helpers = root / HELPERS_DIR
+        if helpers.is_dir():
+            shutil.rmtree(helpers)
         if files:
-            helpers = root / HELPERS_DIR
-            helpers.mkdir(exist_ok=True)
+            helpers.mkdir()
             for f in files:
-                (helpers / f["fileName"]).write_text(f.get("content") or "", encoding="utf-8")
+                _write_exact(helpers / _safe_file_name(f["fileName"]), f.get("content") or "")
         hash_file.write_text(expected, encoding="utf-8")
         console.print(f"Materialized '{workflow_id}' v{version} into {root}")
 

--- a/tools/cc-devthrottle/src/workflow_ops.py
+++ b/tools/cc-devthrottle/src/workflow_ops.py
@@ -1,0 +1,576 @@
+"""Gateway workflow operations for cc-devthrottle (Workflows mission, phase 3).
+
+A Workflow is a fleet-wide, cross-agent unit of conduct: markdown instructions plus optional
+helper files, stored and versioned on the Gateway, authored mostly by agents through this
+command group. The authoring loop round-trips a skill-like directory:
+
+    <dir>/workflow.json      metadata + steps + outcome criteria
+    <dir>/instructions.md    the authoritative conduct (markdown)
+    <dir>/helpers/*          optional helper files
+    <dir>/.workflow-hash     sidecar written by pull; sent as If-Match on push so a stale
+                             copy is refused instead of clobbering a concurrent author
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+import typer
+from rich import box
+from rich.console import Console
+from rich.table import Table
+from urllib.parse import urlparse
+
+_tools_dir = str(Path(__file__).resolve().parent.parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+from cc_shared.config import CCDirectorConfig  # noqa: E402
+
+LOOPBACK_DEFAULT = "http://127.0.0.1:7878"
+TIMEOUT_SECONDS = 15
+WORKFLOW_JSON = "workflow.json"
+INSTRUCTIONS_MD = "instructions.md"
+HELPERS_DIR = "helpers"
+HASH_SIDECAR = ".workflow-hash"
+
+console = Console()
+err_console = Console(stderr=True)
+gateway_override: Optional[str] = None
+
+
+class GatewayError(Exception):
+    """A handled, user-facing failure talking to the Gateway."""
+
+
+def set_gateway_override(value: Optional[str]) -> None:
+    global gateway_override
+    gateway_override = value.rstrip("/") if value else None
+
+
+def resolve_base_url() -> str:
+    config = CCDirectorConfig().load()
+    url = (config.gateway.url or "").strip()
+    return url.rstrip("/") if url else LOOPBACK_DEFAULT
+
+
+def _auth_token() -> str:
+    config = CCDirectorConfig().load()
+    return (config.gateway.token or "").strip()
+
+
+def _is_loopback(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    return host in ("127.0.0.1", "localhost", "::1")
+
+
+def default_authored_by() -> str:
+    session_id = (os.environ.get("CC_SESSION_ID") or "").strip()
+    if session_id:
+        return f"session:{session_id}"
+    return f"machine:{socket.gethostname()}"
+
+
+class WorkflowClient:
+    """Talks to one Gateway's workflow surface."""
+
+    def __init__(self, base_url: Optional[str] = None) -> None:
+        self.base_url = (base_url or resolve_base_url()).rstrip("/")
+        self._token = _auth_token()
+        if not self._token and not _is_loopback(self.base_url):
+            raise GatewayError(
+                f"Gateway URL {self.base_url} is remote but gateway.token is not set. "
+                "Set it with 'cc-devthrottle settings set gateway.token <token>' "
+                "(a loopback Gateway on this machine needs no token)."
+            )
+
+    def _headers(self, extra: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+        if extra:
+            headers.update(extra)
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        json_body: Optional[Dict[str, Any]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> requests.Response:
+        url = f"{self.base_url}{path}"
+        try:
+            return requests.request(
+                method,
+                url,
+                json=json_body,
+                headers=self._headers(extra_headers),
+                timeout=TIMEOUT_SECONDS,
+            )
+        except requests.exceptions.ConnectionError as exc:
+            raise GatewayError(
+                f"Gateway not reachable at {self.base_url}. "
+                "Is the Gateway tray app running on this machine? "
+                "If you target a remote Gateway, set gateway.url with "
+                "'cc-devthrottle settings set gateway.url <url>'."
+            ) from exc
+        except requests.exceptions.Timeout as exc:
+            raise GatewayError(
+                f"Gateway at {self.base_url} did not respond within {TIMEOUT_SECONDS}s."
+            ) from exc
+
+    @staticmethod
+    def _gateway_message(resp: requests.Response) -> str:
+        try:
+            data = resp.json()
+            if isinstance(data, dict) and data.get("error"):
+                return str(data["error"])
+        except ValueError:
+            pass
+        text = (resp.text or "").strip()
+        return text if text else f"Gateway returned HTTP {resp.status_code}"
+
+    def _json_or_raise(self, resp: requests.Response) -> Dict[str, Any]:
+        if 200 <= resp.status_code < 300:
+            if not resp.content:
+                return {}
+            return resp.json()
+        raise GatewayError(self._gateway_message(resp))
+
+    def _text_or_raise(self, resp: requests.Response) -> str:
+        if 200 <= resp.status_code < 300:
+            return resp.text
+        raise GatewayError(self._gateway_message(resp))
+
+    # ---- reads --------------------------------------------------------------------------------
+
+    def list_workflows(self) -> List[Dict[str, Any]]:
+        data = self._json_or_raise(self._request("GET", "/gateway/workflows"))
+        return list(data.get("workflows", []))
+
+    def get_workflow(self, workflow_id: str) -> Dict[str, Any]:
+        return self._json_or_raise(self._request("GET", f"/gateway/workflows/{workflow_id}"))
+
+    def list_versions(self, workflow_id: str) -> List[Dict[str, Any]]:
+        data = self._json_or_raise(
+            self._request("GET", f"/gateway/workflows/{workflow_id}/versions")
+        )
+        return list(data.get("versions", []))
+
+    def workflow_exists(self, workflow_id: str) -> bool:
+        """True when the workflow head exists at all - drafts included. GET /{id} cannot answer
+        this (it 404s for a draft-only workflow), so existence goes through the versions route."""
+        resp = self._request("GET", f"/gateway/workflows/{workflow_id}/versions")
+        if resp.status_code == 404:
+            return False
+        self._json_or_raise(resp)
+        return True
+
+    def get_version_detail(self, workflow_id: str, version: int) -> Dict[str, Any]:
+        return self._json_or_raise(
+            self._request("GET", f"/gateway/workflows/{workflow_id}/versions/{version}")
+        )
+
+    def get_instructions(self, workflow_id: str, version: Optional[int]) -> str:
+        path = f"/gateway/workflows/{workflow_id}/instructions"
+        if version is not None:
+            path += f"?version={version}"
+        return self._text_or_raise(self._request("GET", path))
+
+    # ---- writes -------------------------------------------------------------------------------
+
+    def create(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        return self._json_or_raise(self._request("POST", "/gateway/workflows", body))
+
+    def update_draft(
+        self, workflow_id: str, body: Dict[str, Any], if_match: Optional[str]
+    ) -> Dict[str, Any]:
+        extra = {"If-Match": if_match} if if_match else None
+        return self._json_or_raise(
+            self._request("PUT", f"/gateway/workflows/{workflow_id}/draft", body, extra)
+        )
+
+    def publish(self, workflow_id: str) -> Dict[str, Any]:
+        return self._json_or_raise(
+            self._request("POST", f"/gateway/workflows/{workflow_id}/publish")
+        )
+
+    def reset(self, workflow_id: str) -> Dict[str, Any]:
+        return self._json_or_raise(
+            self._request("POST", f"/gateway/workflows/{workflow_id}/reset")
+        )
+
+    def delete(self, workflow_id: str) -> Dict[str, Any]:
+        return self._json_or_raise(
+            self._request("DELETE", f"/gateway/workflows/{workflow_id}")
+        )
+
+
+def _fail(message: str) -> None:
+    err_console.print(f"[red]Error:[/red] {message}")
+    raise typer.Exit(1)
+
+
+def _client() -> WorkflowClient:
+    return WorkflowClient(base_url=gateway_override)
+
+
+def _pick_authoring_version(versions: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """The version an author edits next: the draft when one exists, else the published head."""
+    for row in versions:
+        if (row.get("status") or "").lower() == "draft":
+            return row
+    for row in versions:
+        if (row.get("status") or "").lower() == "published":
+            return row
+    return None
+
+
+# ---- commands -------------------------------------------------------------------------------------
+
+
+def list_workflows(json_output: bool) -> None:
+    try:
+        workflows = _client().list_workflows()
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+
+    if json_output:
+        print(json.dumps({"workflows": workflows}, indent=2))
+        return
+
+    table = Table(box=box.SIMPLE)
+    table.add_column("Id")
+    table.add_column("Name")
+    table.add_column("Version", justify="right")
+    table.add_column("Kind")
+    table.add_column("Draft?")
+    table.add_column("Summary", overflow="fold")
+    for wf in workflows:
+        table.add_row(
+            wf.get("id", ""),
+            wf.get("name", ""),
+            str(wf.get("version", "")),
+            "built-in" if wf.get("isBuiltIn") else "custom",
+            "yes" if wf.get("hasDraft") else "",
+            wf.get("summary", ""),
+        )
+    console.print(table)
+    console.print(
+        "Read one with: cc-devthrottle workflow instructions <id>   "
+        "(the raw conduct an agent follows)"
+    )
+
+
+def show_workflow(workflow_id: str, version: Optional[int], json_output: bool) -> None:
+    try:
+        client = _client()
+        if version is not None:
+            data = client.get_version_detail(workflow_id, version)
+        else:
+            data = client.get_workflow(workflow_id)
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+
+    if json_output:
+        print(json.dumps(data, indent=2))
+        return
+
+    console.print(f"[bold]{data.get('name', workflow_id)}[/bold]  ({workflow_id})")
+    if data.get("status"):
+        console.print(f"Status: {data['status']}  Version: {data.get('version')}")
+    else:
+        console.print(
+            f"Version: {data.get('version')}  "
+            f"Kind: {'built-in' if data.get('isBuiltIn') else 'custom'}  "
+            f"Draft waiting: {'yes' if data.get('hasDraft') else 'no'}"
+        )
+    console.print(f"Summary: {data.get('summary', '')}")
+    if data.get("whenToUse"):
+        console.print(f"When to use: {data['whenToUse']}")
+    if data.get("humanCheckpoint"):
+        console.print(f"Human checkpoint: {data['humanCheckpoint']}")
+    steps = data.get("steps") or []
+    if steps:
+        console.print("Steps:")
+        for step in steps:
+            reviewer = step.get("reviewer") or "no review"
+            console.print(
+                f"  - {step.get('name')}: doer {step.get('doer')}, {reviewer}; "
+                f"done when {step.get('done')}"
+            )
+    criteria = data.get("outcomeCriteria") or []
+    if criteria:
+        console.print("Outcome criteria:")
+        for criterion in criteria:
+            console.print(f"  - {criterion.get('criterionId')}: {criterion.get('description')}")
+    files = data.get("files") or []
+    if files:
+        console.print("Helper files: " + ", ".join(f.get("fileName", "") for f in files))
+    console.print(
+        f"Instructions: cc-devthrottle workflow instructions {workflow_id}"
+        + (f" --version {version}" if version is not None else "")
+    )
+
+
+def print_instructions(workflow_id: str, version: Optional[int]) -> None:
+    """Print the raw conduct markdown, unmangled - this output goes into an agent's context."""
+    try:
+        markdown = _client().get_instructions(workflow_id, version)
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+    sys.stdout.write(markdown)
+    if markdown and not markdown.endswith("\n"):
+        sys.stdout.write("\n")
+
+
+def list_versions(workflow_id: str, json_output: bool) -> None:
+    try:
+        versions = _client().list_versions(workflow_id)
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+
+    if json_output:
+        print(json.dumps({"versions": versions}, indent=2))
+        return
+
+    table = Table(box=box.SIMPLE)
+    table.add_column("Version", justify="right")
+    table.add_column("Status")
+    table.add_column("Authored by")
+    table.add_column("Created (UTC)")
+    table.add_column("Note", overflow="fold")
+    for row in versions:
+        table.add_row(
+            str(row.get("version", "")),
+            row.get("status", ""),
+            row.get("authoredBy", ""),
+            (row.get("createdUtc") or "").replace("T", " ")[:19],
+            row.get("changeNote") or "",
+        )
+    console.print(table)
+
+
+def pull_workflow(workflow_id: str, directory: str, version: Optional[int]) -> None:
+    try:
+        client = _client()
+        if version is None:
+            versions = client.list_versions(workflow_id)
+            picked = _pick_authoring_version(versions)
+            if picked is None:
+                _fail(f"Workflow '{workflow_id}' has no versions to pull.")
+                return
+            version = int(picked["version"])
+        detail = client.get_version_detail(workflow_id, version)
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+
+    target = Path(directory)
+    target.mkdir(parents=True, exist_ok=True)
+
+    metadata = {
+        "id": detail.get("workflowId", workflow_id),
+        "name": detail.get("name", ""),
+        "summary": detail.get("summary", ""),
+        "whenToUse": detail.get("whenToUse", ""),
+        "humanCheckpoint": detail.get("humanCheckpoint", ""),
+        "steps": detail.get("steps") or [],
+        "outcomeCriteria": detail.get("outcomeCriteria") or [],
+    }
+    (target / WORKFLOW_JSON).write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+    (target / INSTRUCTIONS_MD).write_text(
+        detail.get("instructionsMarkdown") or "", encoding="utf-8"
+    )
+    files = detail.get("files") or []
+    if files:
+        helpers = target / HELPERS_DIR
+        helpers.mkdir(exist_ok=True)
+        for f in files:
+            (helpers / f["fileName"]).write_text(f.get("content") or "", encoding="utf-8")
+    (target / HASH_SIDECAR).write_text(detail.get("contentHash", ""), encoding="utf-8")
+
+    console.print(
+        f"Pulled '{workflow_id}' v{version} ({detail.get('status')}) into {target.resolve()}"
+    )
+    console.print(
+        "Edit the files, then push with: "
+        f"cc-devthrottle workflow push {workflow_id} --dir \"{target}\""
+    )
+
+
+def _read_directory(workflow_id: str, directory: str, note: Optional[str]) -> Dict[str, Any]:
+    source = Path(directory)
+    if not source.is_dir():
+        raise GatewayError(f"Directory not found: {source}")
+
+    metadata: Dict[str, Any] = {}
+    metadata_path = source / WORKFLOW_JSON
+    if metadata_path.is_file():
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except ValueError as exc:
+            raise GatewayError(f"{WORKFLOW_JSON} is not valid JSON: {exc}") from exc
+    declared_id = (metadata.get("id") or "").strip()
+    if declared_id and declared_id != workflow_id:
+        raise GatewayError(
+            f"{WORKFLOW_JSON} declares id '{declared_id}' but the push targets '{workflow_id}'. "
+            "Make them agree before pushing."
+        )
+
+    instructions_path = source / INSTRUCTIONS_MD
+    instructions = (
+        instructions_path.read_text(encoding="utf-8") if instructions_path.is_file() else ""
+    )
+
+    files: List[Dict[str, str]] = []
+    helpers = source / HELPERS_DIR
+    if helpers.is_dir():
+        for path in sorted(helpers.iterdir()):
+            if path.is_file():
+                files.append(
+                    {"fileName": path.name, "content": path.read_text(encoding="utf-8")}
+                )
+
+    return {
+        "id": workflow_id,
+        "name": metadata.get("name") or workflow_id,
+        "summary": metadata.get("summary") or "",
+        "whenToUse": metadata.get("whenToUse") or "",
+        "humanCheckpoint": metadata.get("humanCheckpoint") or "",
+        "steps": metadata.get("steps") or [],
+        "outcomeCriteria": metadata.get("outcomeCriteria") or [],
+        "instructionsMarkdown": instructions,
+        "files": files,
+        "authoredBy": default_authored_by(),
+        "changeNote": note,
+    }
+
+
+def push_workflow(workflow_id: str, directory: str, note: Optional[str]) -> None:
+    try:
+        client = _client()
+        body = _read_directory(workflow_id, directory, note)
+
+        if not client.workflow_exists(workflow_id):
+            result = client.create(body)
+            verb = "Created"
+        else:
+            sidecar = Path(directory) / HASH_SIDECAR
+            if_match = (
+                sidecar.read_text(encoding="utf-8").strip() if sidecar.is_file() else None
+            )
+            result = client.update_draft(workflow_id, body, if_match)
+            verb = "Updated"
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+
+    new_hash = result.get("contentHash", "")
+    if new_hash:
+        (Path(directory) / HASH_SIDECAR).write_text(new_hash, encoding="utf-8")
+    console.print(
+        f"{verb} draft v{result.get('version')} of '{workflow_id}'. "
+        "Nothing changes for the fleet until it publishes: "
+        f"cc-devthrottle workflow publish {workflow_id}"
+    )
+
+
+def publish_workflow(workflow_id: str) -> None:
+    try:
+        result = _client().publish(workflow_id)
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+    console.print(
+        f"Published '{workflow_id}' v{result.get('version')}. "
+        "It is now the version every machine and agent reads."
+    )
+
+
+def reset_workflow(workflow_id: str) -> None:
+    try:
+        result = _client().reset(workflow_id)
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+    console.print(
+        f"Reset '{workflow_id}' to the shipped content as v{result.get('version')}. "
+        "Earlier versions remain as history."
+    )
+
+
+def delete_workflow(workflow_id: str, yes: bool) -> None:
+    if not yes:
+        confirmed = typer.confirm(
+            f"Archive workflow '{workflow_id}'? It leaves the catalog; its versions remain "
+            "as pinned history."
+        )
+        if not confirmed:
+            raise typer.Exit(0)
+    try:
+        _client().delete(workflow_id)
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+    console.print(f"Archived '{workflow_id}'.")
+
+
+def materialize_workflow(workflow_id: str, version: Optional[int]) -> None:
+    """Write a version's bundle to the per-machine cache and print the absolute paths, so an
+    agent can run helper files with its own shell. Version-stamped and hash-keyed: a bundle
+    already on disk with the right hash is not rewritten."""
+    try:
+        client = _client()
+        if version is None:
+            head = client.get_workflow(workflow_id)
+            version = int(head["version"])
+        detail = client.get_version_detail(workflow_id, version)
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+
+    status = (detail.get("status") or "").lower()
+    if status == "draft":
+        _fail(
+            f"Version {version} of '{workflow_id}' is a draft. Only published history can be "
+            "materialized - publish it first."
+        )
+        return
+
+    local_app_data = os.environ.get("LOCALAPPDATA") or str(Path.home() / ".local" / "share")
+    root = Path(local_app_data) / "cc-director" / "workflows" / workflow_id / str(version)
+    hash_file = root / HASH_SIDECAR
+    expected = detail.get("contentHash", "")
+    if hash_file.is_file() and hash_file.read_text(encoding="utf-8").strip() == expected:
+        console.print(f"Already materialized: {root}")
+    else:
+        root.mkdir(parents=True, exist_ok=True)
+        (root / INSTRUCTIONS_MD).write_text(
+            detail.get("instructionsMarkdown") or "", encoding="utf-8"
+        )
+        files = detail.get("files") or []
+        if files:
+            helpers = root / HELPERS_DIR
+            helpers.mkdir(exist_ok=True)
+            for f in files:
+                (helpers / f["fileName"]).write_text(f.get("content") or "", encoding="utf-8")
+        hash_file.write_text(expected, encoding="utf-8")
+        console.print(f"Materialized '{workflow_id}' v{version} into {root}")
+
+    console.print(f"Instructions: {root / INSTRUCTIONS_MD}")
+    helpers_dir = root / HELPERS_DIR
+    if helpers_dir.is_dir():
+        for path in sorted(helpers_dir.iterdir()):
+            console.print(f"Helper: {path}")

--- a/tools/cc-devthrottle/tests/test_workflow_ops.py
+++ b/tools/cc-devthrottle/tests/test_workflow_ops.py
@@ -1,0 +1,173 @@
+"""Tests for the cc-devthrottle workflow command group (Workflows mission, phase 3).
+
+The Gateway is mocked at the requests layer (the endpoint behavior itself is proven by the
+Gateway's own test suite); what these tests pin is the CLI's half of the contract: the
+directory round-trip (pull writes exactly what push reads), the create-versus-draft decision,
+the If-Match sidecar discipline, and the raw, unmangled instructions output an agent's
+context depends on.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import requests
+from typer.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src import workflow_ops  # noqa: E402
+from src.cli import app  # noqa: E402
+
+runner = CliRunner()
+
+
+def _fake_response(status_code: int, json_body=None, text: str = "") -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.content = b"x" if (json_body is not None or text) else b""
+    resp.text = text
+    if json_body is not None:
+        resp.json.return_value = json_body
+    else:
+        resp.json.side_effect = ValueError("no json")
+    return resp
+
+
+DETAIL = {
+    "workflowId": "release-train",
+    "version": 2,
+    "status": "draft",
+    "name": "Release train",
+    "summary": "Cut and announce.",
+    "whenToUse": "When a release is due.",
+    "humanCheckpoint": "Once.",
+    "steps": [{"name": "Cut", "description": "d", "doer": "Worker", "reviewer": None, "done": "Tag pushed."}],
+    "instructionsMarkdown": "# Release train\n\nDo it.",
+    "outcomeCriteria": [{"criterionId": "announced", "description": "Notes went out.", "proofHint": None}],
+    "files": [{"fileName": "verify.py", "contentHash": "abc", "content": "print('verify')"}],
+    "contentHash": "bundle-hash-2",
+}
+
+
+class TestActionsDiscoverability:
+    def test_actions_json_lists_the_workflow_commands(self):
+        result = runner.invoke(app, ["actions", "--json"])
+        assert result.exit_code == 0
+        ids = {action["id"] for action in json.loads(result.output)["actions"]}
+        assert {
+            "workflow-list",
+            "workflow-instructions",
+            "workflow-show",
+            "workflow-versions",
+            "workflow-pull",
+            "workflow-push",
+            "workflow-publish",
+            "workflow-materialize",
+            "workflow-reset",
+            "workflow-delete",
+        } <= ids
+
+
+class TestInstructionsOutput:
+    def test_instructions_prints_the_raw_markdown_unmangled(self, capsys):
+        client = MagicMock()
+        client.get_instructions.return_value = "# Conduct\n\n*follow me* [exactly](x)\n"
+        with patch.object(workflow_ops, "_client", return_value=client):
+            workflow_ops.print_instructions("mission", None)
+        out = capsys.readouterr().out
+        # Byte-identical: this output lands in an agent's context, so no rich rendering,
+        # no wrapping, no markup interpretation.
+        assert out == "# Conduct\n\n*follow me* [exactly](x)\n"
+
+
+class TestPullPushRoundTrip:
+    def test_pull_writes_the_directory_and_the_hash_sidecar(self, tmp_path):
+        client = MagicMock()
+        client.list_versions.return_value = [
+            {"version": 2, "status": "draft"},
+            {"version": 1, "status": "published"},
+        ]
+        client.get_version_detail.return_value = DETAIL
+        with patch.object(workflow_ops, "_client", return_value=client):
+            workflow_ops.pull_workflow("release-train", str(tmp_path), None)
+
+        # The draft wins as the authoring baseline.
+        client.get_version_detail.assert_called_once_with("release-train", 2)
+        metadata = json.loads((tmp_path / "workflow.json").read_text(encoding="utf-8"))
+        assert metadata["id"] == "release-train"
+        assert metadata["steps"][0]["doer"] == "Worker"
+        assert (tmp_path / "instructions.md").read_text(encoding="utf-8") == "# Release train\n\nDo it."
+        assert (tmp_path / "helpers" / "verify.py").read_text(encoding="utf-8") == "print('verify')"
+        assert (tmp_path / ".workflow-hash").read_text(encoding="utf-8") == "bundle-hash-2"
+
+    def test_push_reads_back_exactly_what_pull_wrote(self, tmp_path):
+        pull_client = MagicMock()
+        pull_client.list_versions.return_value = [{"version": 2, "status": "draft"}]
+        pull_client.get_version_detail.return_value = DETAIL
+        with patch.object(workflow_ops, "_client", return_value=pull_client):
+            workflow_ops.pull_workflow("release-train", str(tmp_path), None)
+
+        push_client = MagicMock()
+        push_client.workflow_exists.return_value = True
+        push_client.update_draft.return_value = {"version": 2, "contentHash": "bundle-hash-3"}
+        with patch.object(workflow_ops, "_client", return_value=push_client):
+            workflow_ops.push_workflow("release-train", str(tmp_path), "a note")
+
+        (_, body, if_match), _kwargs = (
+            push_client.update_draft.call_args.args,
+            push_client.update_draft.call_args.kwargs,
+        )
+        assert body["name"] == "Release train"
+        assert body["instructionsMarkdown"] == "# Release train\n\nDo it."
+        assert body["files"] == [{"fileName": "verify.py", "content": "print('verify')"}]
+        assert body["changeNote"] == "a note"
+        # The sidecar hash from pull rode along as If-Match, and the new hash replaced it.
+        assert if_match == "bundle-hash-2"
+        assert (tmp_path / ".workflow-hash").read_text(encoding="utf-8") == "bundle-hash-3"
+
+    def test_push_creates_the_workflow_when_it_does_not_exist(self, tmp_path):
+        (tmp_path / "workflow.json").write_text(
+            json.dumps({"id": "new-flow", "name": "New flow", "summary": "s"}), encoding="utf-8"
+        )
+        (tmp_path / "instructions.md").write_text("# New flow", encoding="utf-8")
+
+        client = MagicMock()
+        client.workflow_exists.return_value = False
+        client.create.return_value = {"version": 1, "contentHash": "h1"}
+        with patch.object(workflow_ops, "_client", return_value=client):
+            workflow_ops.push_workflow("new-flow", str(tmp_path), None)
+
+        client.create.assert_called_once()
+        client.update_draft.assert_not_called()
+        body = client.create.call_args.args[0]
+        assert body["id"] == "new-flow"
+        assert body["authoredBy"]  # authorship always travels
+
+    def test_push_refuses_a_directory_declaring_a_different_id(self, tmp_path):
+        (tmp_path / "workflow.json").write_text(
+            json.dumps({"id": "other-flow", "name": "n", "summary": "s"}), encoding="utf-8"
+        )
+        client = MagicMock()
+        with patch.object(workflow_ops, "_client", return_value=client):
+            result = runner.invoke(
+                app, ["workflow", "push", "new-flow", "--dir", str(tmp_path)]
+            )
+        assert result.exit_code == 1
+        client.create.assert_not_called()
+        client.update_draft.assert_not_called()
+
+
+class TestAuthoringVersionPick:
+    def test_draft_wins_over_published(self):
+        rows = [{"version": 3, "status": "published"}, {"version": 4, "status": "draft"}]
+        assert workflow_ops._pick_authoring_version(rows)["version"] == 4
+
+    def test_published_when_no_draft(self):
+        rows = [{"version": 3, "status": "published"}, {"version": 2, "status": "superseded"}]
+        assert workflow_ops._pick_authoring_version(rows)["version"] == 3
+
+    def test_none_when_empty(self):
+        assert workflow_ops._pick_authoring_version([]) is None

--- a/tools/cc-devthrottle/tests/test_workflow_ops.py
+++ b/tools/cc-devthrottle/tests/test_workflow_ops.py
@@ -160,6 +160,83 @@ class TestPullPushRoundTrip:
         client.update_draft.assert_not_called()
 
 
+class TestInspectionHardening:
+    def test_pull_refuses_an_unsafe_server_supplied_file_name(self, tmp_path):
+        detail = dict(DETAIL)
+        detail["files"] = [{"fileName": "..\\escape.py", "contentHash": "x", "content": "boom"}]
+        client = MagicMock()
+        client.list_versions.return_value = [{"version": 2, "status": "draft"}]
+        client.get_version_detail.return_value = detail
+        with patch.object(workflow_ops, "_client", return_value=client):
+            result = runner.invoke(
+                app, ["workflow", "pull", "release-train", "--dir", str(tmp_path)]
+            )
+        assert result.exit_code == 1
+        assert not (tmp_path.parent / "escape.py").exists()
+
+    def test_repull_removes_helpers_the_server_no_longer_has(self, tmp_path):
+        client = MagicMock()
+        client.list_versions.return_value = [{"version": 2, "status": "draft"}]
+        client.get_version_detail.return_value = DETAIL
+        with patch.object(workflow_ops, "_client", return_value=client):
+            workflow_ops.pull_workflow("release-train", str(tmp_path), None)
+        # Another author deletes the helper on the Gateway; the next pull must not leave the
+        # local copy behind to be resurrected by the next push.
+        no_files = dict(DETAIL)
+        no_files["files"] = []
+        client.get_version_detail.return_value = no_files
+        with patch.object(workflow_ops, "_client", return_value=client):
+            workflow_ops.pull_workflow("release-train", str(tmp_path), None)
+        assert not (tmp_path / "helpers" / "verify.py").exists()
+
+    def test_push_update_without_sidecar_is_refused_unless_forced(self, tmp_path):
+        (tmp_path / "workflow.json").write_text(
+            json.dumps({"id": "release-train", "name": "n", "summary": "s"}), encoding="utf-8"
+        )
+        client = MagicMock()
+        client.workflow_exists.return_value = True
+        client.update_draft.return_value = {"version": 3, "contentHash": "h"}
+        with patch.object(workflow_ops, "_client", return_value=client):
+            refused = runner.invoke(
+                app, ["workflow", "push", "release-train", "--dir", str(tmp_path)]
+            )
+            assert refused.exit_code == 1
+            client.update_draft.assert_not_called()
+
+            forced = runner.invoke(
+                app, ["workflow", "push", "release-train", "--dir", str(tmp_path), "--force"]
+            )
+            assert forced.exit_code == 0
+            client.update_draft.assert_called_once()
+
+    def test_wrong_shaped_workflow_json_fails_cleanly(self, tmp_path):
+        (tmp_path / "workflow.json").write_text("[]", encoding="utf-8")
+        client = MagicMock()
+        with patch.object(workflow_ops, "_client", return_value=client):
+            result = runner.invoke(
+                app, ["workflow", "push", "x-flow", "--dir", str(tmp_path)]
+            )
+        assert result.exit_code == 1
+        client.create.assert_not_called()
+
+    def test_round_trip_preserves_carriage_returns_exactly(self, tmp_path):
+        detail = dict(DETAIL)
+        detail["instructionsMarkdown"] = "line one\r\nline two\n"
+        client = MagicMock()
+        client.list_versions.return_value = [{"version": 2, "status": "draft"}]
+        client.get_version_detail.return_value = detail
+        with patch.object(workflow_ops, "_client", return_value=client):
+            workflow_ops.pull_workflow("release-train", str(tmp_path), None)
+
+        push_client = MagicMock()
+        push_client.workflow_exists.return_value = True
+        push_client.update_draft.return_value = {"version": 2, "contentHash": "h"}
+        with patch.object(workflow_ops, "_client", return_value=push_client):
+            workflow_ops.push_workflow("release-train", str(tmp_path), None)
+        body = push_client.update_draft.call_args.args[1]
+        assert body["instructionsMarkdown"] == "line one\r\nline two\n"
+
+
 class TestAuthoringVersionPick:
     def test_draft_wins_over_published(self):
         rows = [{"version": 3, "status": "published"}, {"version": 4, "status": "draft"}]


### PR DESCRIPTION
Phase 3 of the approved Workflows plan (mission 9a955739). Phase 1 (#1774) persisted the catalog, phase 2 (#1776) made it authorable over HTTP; this gives agents the CLI surface, which is the primary authoring path by design.

## What this does

- New cc-devthrottle workflow group: list / show / instructions / versions / pull / push / publish / materialize / reset / delete, all registered in the agent-discoverable actions list.
- instructions prints the RAW markdown, byte-identical - this output goes straight into an agent's context, so no rich rendering and no wrapping.
- Authoring round-trips a skill-like directory (workflow.json + instructions.md + helpers/). Pull writes a .workflow-hash sidecar; push sends it as If-Match so a stale copy gets a clean conflict instead of clobbering a concurrent author, and writes the new hash back on success.
- Push creates the workflow when new (existence checked via the versions route - the catalog read rightly 404s a draft-only workflow) and updates the draft otherwise. Authorship defaults from CC_SESSION_ID.
- materialize writes a published version's bundle to %LOCALAPPDATA%/cc-director/workflows/<id>/<version>/, hash-keyed and idempotent, printing absolute paths so any agent can run helpers with its own shell. Drafts are refused.
- Small Gateway addition: the version-detail response now carries helper-file content (the raw files route rightly refuses drafts, and pull must round-trip drafts for the authoring loop).

## Proof

- Full solution suite: all seven projects, 6,287 passed, 0 failed. CLI suite: 81 passed (9 new: actions discoverability, raw-markdown output pinning, pull directory shape + sidecar, push round-trips exactly what pull wrote with If-Match riding along, create-when-new, refusing a directory declaring a different id, authoring-version pick preferring the draft).
- LIVE end-to-end proof, run locally against a real isolated GatewayHost on an ephemeral port with the real Python CLI from source: list showed the built-ins; instructions mission returned the conduct with its sentinel strings (THE FOUR LAWS, merged-to-origin/main); pull -> edit -> push produced draft v2; publish made it the fleet-read version; reset restored the shipped conduct as v3 while the customized v2 stayed readable as pinned history; materialize wrote the machine cache and printed the paths; versions showed published/superseded/gateway:reset history. The throwaway proof harness was removed after the run (it shells out to python, which the committed suite must not depend on).

## Next

Phase 4: the workflow-run spine (#1771) - runs pinned to a version, lifecycle separate from acceptance, participants, criteria results.