### PR TITLE
feat(gateway): the workflow-run spine - every mission now opens a governance run (Workflows phase 4, #1771)

### DIFF
--- a/src/CcDirector.Gateway.Contracts/MissionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/MissionDto.cs
@@ -20,6 +20,12 @@ public sealed class MissionDto
 
     /// <summary>The parent Mission this one nests under (a tree of Missions), or null for a root Mission.</summary>
     public Guid? ParentMissionId { get; set; }
+
+    /// <summary>ADDITIVE (Workflows mission, phase 4, issue #1771): the workflow run opened beside
+    /// this Mission when it was created through the Gateway - a mission is a run of the built-in
+    /// "mission" workflow. Null on reads that do not resolve it and on missions predating the spine.
+    /// Existing clients ignore it.</summary>
+    public Guid? WorkflowRunId { get; set; }
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Contracts/WorkflowRunDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/WorkflowRunDtos.cs
@@ -46,6 +46,10 @@ public sealed class WorkflowRunProofLinkDto
 /// </summary>
 public sealed class WorkflowRunParticipantDto
 {
+    /// <summary>The CANONICAL fleet session id - the Director-minted session GUID every other
+    /// per-session record (token/spend statistics, transcripts, the roster) also keys on. This is
+    /// governance's join from a run to the effort it consumed (issue #1771, spine item 3); never put
+    /// any other identifier here.</summary>
     public string SessionId { get; set; } = "";
     public string AgentKind { get; set; } = "";
     public string Role { get; set; } = "";

--- a/src/CcDirector.Gateway.Contracts/WorkflowRunDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/WorkflowRunDtos.cs
@@ -1,0 +1,145 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// One criterion's standing on a workflow run. Seeded from the pinned version's declared outcome
+/// criteria (all "pending") when the run is created, so a run always answers "what did this workflow
+/// promise, and where does each promise stand" (the governance outcome spine, issue #1771).
+/// </summary>
+public sealed class WorkflowRunCriterionResultDto
+{
+    public string CriterionId { get; set; } = "";
+
+    /// <summary>"pending", "met", "not-met", or "waived".</summary>
+    public string Status { get; set; } = WorkflowRunCriterionStatus.Pending;
+
+    /// <summary>Evidence for the standing (a pull request, a report, an artifact). A link, never prose.</summary>
+    public string? ProofUrl { get; set; }
+
+    public string? Note { get; set; }
+
+    /// <summary>Who evaluated the criterion (a session id, an agent name, or "human:&lt;user&gt;").</summary>
+    public string? Evaluator { get; set; }
+
+    public DateTime? EvaluatedUtc { get; set; }
+}
+
+/// <summary>The legal criterion statuses.</summary>
+public static class WorkflowRunCriterionStatus
+{
+    public const string Pending = "pending";
+    public const string Met = "met";
+    public const string NotMet = "not-met";
+    public const string Waived = "waived";
+}
+
+/// <summary>A labelled evidence link on a run (pull requests, quality reports, deployments).</summary>
+public sealed class WorkflowRunProofLinkDto
+{
+    public string Label { get; set; } = "";
+    public string Url { get; set; } = "";
+}
+
+/// <summary>
+/// One session's membership in a run - the persisted run-to-session record #1771 asks for directly
+/// (standalone runs have no Mission to derive membership from). Leaving stamps <see cref="LeftUtc"/>;
+/// the row is never removed, because replacement history is part of the record.
+/// </summary>
+public sealed class WorkflowRunParticipantDto
+{
+    public string SessionId { get; set; } = "";
+    public string AgentKind { get; set; } = "";
+    public string Role { get; set; } = "";
+    public string Machine { get; set; } = "";
+    public DateTime JoinedUtc { get; set; }
+    public DateTime? LeftUtc { get; set; }
+}
+
+/// <summary>The legal run lifecycle statuses. Lifecycle is deliberately SEPARATE from acceptance:
+/// "the run completed" and "its outcome counts as delivered" are different questions.</summary>
+public static class WorkflowRunStatus
+{
+    public const string Created = "created";
+    public const string Active = "active";
+    public const string AwaitingHuman = "awaiting-human";
+    public const string Succeeded = "succeeded";
+    public const string Failed = "failed";
+    public const string Abandoned = "abandoned";
+
+    public static readonly string[] Terminal = { Succeeded, Failed, Abandoned };
+}
+
+/// <summary>The legal acceptance statuses.</summary>
+public static class WorkflowRunAcceptance
+{
+    public const string Pending = "pending";
+    public const string Accepted = "accepted";
+    public const string Rejected = "rejected";
+    public const string Waived = "waived";
+}
+
+/// <summary>
+/// One execution of a workflow definition. The run pins the exact published version (id, number,
+/// canonical content hash) that governed it at creation - published versions referenced by runs are
+/// never deleted, so a run can always answer what conduct it ran under.
+/// </summary>
+public sealed class WorkflowRunDto
+{
+    public Guid Id { get; set; }
+    public string WorkflowId { get; set; } = "";
+    public Guid WorkflowVersionId { get; set; }
+    public int WorkflowVersion { get; set; }
+    public string ContentHash { get; set; } = "";
+    public string Name { get; set; } = "";
+
+    public string Status { get; set; } = WorkflowRunStatus.Created;
+
+    public string AcceptanceStatus { get; set; } = WorkflowRunAcceptance.Pending;
+    public string? AcceptedBy { get; set; }
+    public DateTime? AcceptedUtc { get; set; }
+
+    /// <summary>A short closing statement of what the run produced (distinct from acceptance).</summary>
+    public string? Outcome { get; set; }
+
+    public List<WorkflowRunCriterionResultDto> CriteriaResults { get; set; } = new();
+    public List<WorkflowRunProofLinkDto> ProofLinks { get; set; } = new();
+    public List<WorkflowRunParticipantDto> Participants { get; set; } = new();
+
+    /// <summary>The Mission record this run is anchored to, when the run came from the mission path.
+    /// A reference, not a merge - standalone runs have no Mission.</summary>
+    public Guid? MissionId { get; set; }
+
+    public Guid? ParentRunId { get; set; }
+    public string? RepoPath { get; set; }
+
+    public DateTime CreatedUtc { get; set; }
+    public DateTime? StartedUtc { get; set; }
+    public DateTime? CompletedUtc { get; set; }
+}
+
+/// <summary>Body of POST /gateway/workflow-runs.</summary>
+public sealed class NewWorkflowRunRequest
+{
+    public string? WorkflowId { get; set; }
+    public string? Name { get; set; }
+    public Guid? MissionId { get; set; }
+    public Guid? ParentRunId { get; set; }
+    public string? RepoPath { get; set; }
+}
+
+/// <summary>
+/// Body of PATCH /gateway/workflow-runs/{id}. Every field is optional; present fields apply. Criteria
+/// entries update the seeded criterion with the same id (an unknown id is rejected). Participants in
+/// <see cref="AddParticipants"/> join; session ids in <see cref="LeaveSessionIds"/> get their
+/// <see cref="WorkflowRunParticipantDto.LeftUtc"/> stamped.
+/// </summary>
+public sealed class PatchWorkflowRunRequest
+{
+    public string? Status { get; set; }
+    public string? Outcome { get; set; }
+    public string? AcceptanceStatus { get; set; }
+    public string? AcceptedBy { get; set; }
+    public List<WorkflowRunCriterionResultDto>? Criteria { get; set; }
+    public List<WorkflowRunProofLinkDto>? ProofLinks { get; set; }
+    public List<WorkflowRunParticipantDto>? AddParticipants { get; set; }
+    public List<string>? LeaveSessionIds { get; set; }
+}

--- a/src/CcDirector.Gateway.Contracts/WorkflowRunDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/WorkflowRunDtos.cs
@@ -131,10 +131,30 @@ public sealed class NewWorkflowRunRequest
 }
 
 /// <summary>
+/// One criterion UPDATE in a run patch - deliberately a separate type from the stored result:
+/// every field except the id is nullable, and null means "unchanged", so adding a note to a met
+/// criterion can never silently reset its status. The evaluation timestamp is server-stamped and
+/// not accepted from the caller.
+/// </summary>
+public sealed class WorkflowRunCriterionUpdateDto
+{
+    public string CriterionId { get; set; } = "";
+
+    /// <summary>New status ("pending", "met", "not-met", "waived"), or null to leave it unchanged.</summary>
+    public string? Status { get; set; }
+
+    public string? ProofUrl { get; set; }
+    public string? Note { get; set; }
+    public string? Evaluator { get; set; }
+}
+
+/// <summary>
 /// Body of PATCH /gateway/workflow-runs/{id}. Every field is optional; present fields apply. Criteria
-/// entries update the seeded criterion with the same id (an unknown id is rejected). Participants in
-/// <see cref="AddParticipants"/> join; session ids in <see cref="LeaveSessionIds"/> get their
-/// <see cref="WorkflowRunParticipantDto.LeftUtc"/> stamped.
+/// entries update the seeded criterion with the same id (an unknown id is rejected, and one patch may
+/// name a criterion only once). Participants in <see cref="AddParticipants"/> join; session ids in
+/// <see cref="LeaveSessionIds"/> get their <see cref="WorkflowRunParticipantDto.LeftUtc"/> stamped.
+/// Setting a non-pending <see cref="AcceptanceStatus"/> REQUIRES <see cref="AcceptedBy"/> - the
+/// decision's actor is never inferred from a previous acceptance.
 /// </summary>
 public sealed class PatchWorkflowRunRequest
 {
@@ -142,7 +162,7 @@ public sealed class PatchWorkflowRunRequest
     public string? Outcome { get; set; }
     public string? AcceptanceStatus { get; set; }
     public string? AcceptedBy { get; set; }
-    public List<WorkflowRunCriterionResultDto>? Criteria { get; set; }
+    public List<WorkflowRunCriterionUpdateDto>? Criteria { get; set; }
     public List<WorkflowRunProofLinkDto>? ProofLinks { get; set; }
     public List<WorkflowRunParticipantDto>? AddParticipants { get; set; }
     public List<string>? LeaveSessionIds { get; set; }

--- a/src/CcDirector.Gateway.Tests/WorkflowEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowEndpointsTests.cs
@@ -198,6 +198,35 @@ public sealed class WorkflowEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Creating_a_mission_opens_a_workflow_run_pinned_to_the_mission_conduct()
+    {
+        // Workflows mission, phase 4 (issue #1771): a mission IS a run of the built-in "mission"
+        // workflow. The mission response carries the additive workflowRunId; the run is pinned to
+        // the published mission version and anchored back to the mission.
+        var created = await _http.PostAsJsonAsync("missions", new { missionName = "Spine proof" });
+        Assert.Equal(HttpStatusCode.Created, created.StatusCode);
+        var mission = await created.Content.ReadFromJsonAsync<JsonObject>();
+        var runId = (string?)mission!["workflowRunId"];
+        Assert.False(string.IsNullOrWhiteSpace(runId));
+
+        var run = await _http.GetFromJsonAsync<JsonObject>($"gateway/workflow-runs/{runId}");
+        Assert.Equal("mission", (string?)run!["workflowId"]);
+        Assert.Equal("Spine proof", (string?)run["name"]);
+        Assert.Equal("created", (string?)run["status"]);
+        Assert.Equal("pending", (string?)run["acceptanceStatus"]);
+        Assert.Equal((string?)mission["missionId"], (string?)run["missionId"]);
+
+        // The pinned hash is the published mission workflow's hash.
+        var workflow = await _http.GetFromJsonAsync<JsonObject>("gateway/workflows/mission");
+        Assert.Equal((string?)workflow!["contentHash"], (string?)run["contentHash"]);
+
+        // The run also lists by its mission anchor.
+        var listed = await _http.GetFromJsonAsync<JsonObject>(
+            $"gateway/workflow-runs?missionId={(string?)mission["missionId"]}");
+        Assert.Single(listed!["runs"]!.AsArray());
+    }
+
+    [Fact]
     public async Task The_api_does_not_squat_on_the_cockpit_page_path()
     {
         // Regression: the catalog was first mapped at a bare /workflows, which is the path the Cockpit's

--- a/src/CcDirector.Gateway.Tests/WorkflowRunStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowRunStoreTests.cs
@@ -145,8 +145,22 @@ public sealed class WorkflowRunStoreTests : IDisposable
         Assert.Null(pending.AcceptedUtc);
 
         // A non-pending acceptance is a ruling, and a ruling has a ruler: no accepter, no acceptance.
+        // Governance ask (#1771): this holds for EVERY non-pending status - a rejection and a waiver
+        // are decisions too, and who-decided-and-when must never be null.
         Assert.Throws<WorkflowValidationException>(() =>
             runs.Patch(run.Id, new PatchWorkflowRunRequest { AcceptanceStatus = "accepted" }));
+        Assert.Throws<WorkflowValidationException>(() =>
+            runs.Patch(run.Id, new PatchWorkflowRunRequest { AcceptanceStatus = "rejected" }));
+        Assert.Throws<WorkflowValidationException>(() =>
+            runs.Patch(run.Id, new PatchWorkflowRunRequest { AcceptanceStatus = "waived" }));
+
+        var waived = runs.Patch(run.Id, new PatchWorkflowRunRequest
+        {
+            AcceptanceStatus = "waived",
+            AcceptedBy = "human:owner",
+        })!;
+        Assert.Equal("human:owner", waived.AcceptedBy);
+        Assert.NotNull(waived.AcceptedUtc);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/WorkflowRunStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowRunStoreTests.cs
@@ -1,0 +1,228 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Workflows;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Store tests for the workflow-run spine (Workflows mission, phase 4 - issue #1771). The claims
+/// that matter: a run pins the exact published version at creation and keeps it as the catalog moves
+/// on; criteria are seeded from the pinned version's declared outcome criteria and cannot be
+/// invented on the run; lifecycle transitions are legal-moves-only with terminal FINAL; acceptance
+/// is independent of lifecycle; participants carry join/leave history.
+/// </summary>
+public sealed class WorkflowRunStoreTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    private (WorkflowStore Workflows, WorkflowRunStore Runs) NewStores()
+    {
+        var db = _h.Open();
+        return (new WorkflowStore(db), new WorkflowRunStore(db));
+    }
+
+    private static WorkflowContentRequest PublishableWorkflow(string id = "qa-loop") => new()
+    {
+        Id = id,
+        Name = "QA loop",
+        Summary = "Verify ready items.",
+        Steps = new List<WorkflowStepDto>
+        {
+            new() { Name = "Verify", Doer = "Reviewer", Done = "Issue passed QA." },
+        },
+        InstructionsMarkdown = "# QA loop",
+        OutcomeCriteria = new List<WorkflowOutcomeCriterionDto>
+        {
+            new() { CriterionId = "issue-passed", Description = "The issue passed QA." },
+            new() { CriterionId = "defect-filed", Description = "Failures got a written defect." },
+        },
+        AuthoredBy = "test",
+    };
+
+    [Fact]
+    public void Create_pins_the_published_version_and_seeds_pending_criteria()
+    {
+        var (workflows, runs) = NewStores();
+        workflows.CreateDraft(PublishableWorkflow());
+        var published = workflows.Publish("qa-loop")!;
+
+        var run = runs.Create("qa-loop", "Nightly QA");
+
+        Assert.Equal("qa-loop", run.WorkflowId);
+        Assert.Equal(1, run.WorkflowVersion);
+        Assert.Equal(published.ContentHash, run.ContentHash);
+        Assert.Equal("created", run.Status);
+        Assert.Equal("pending", run.AcceptanceStatus);
+        Assert.Equal(new[] { "issue-passed", "defect-filed" },
+            run.CriteriaResults.Select(c => c.CriterionId).ToArray());
+        Assert.All(run.CriteriaResults, c => Assert.Equal("pending", c.Status));
+    }
+
+    [Fact]
+    public void A_run_keeps_its_pinned_version_when_the_catalog_moves_on()
+    {
+        var (workflows, runs) = NewStores();
+        workflows.CreateDraft(PublishableWorkflow());
+        workflows.Publish("qa-loop");
+        var run = runs.Create("qa-loop", "Before the edit");
+
+        var v2 = PublishableWorkflow();
+        v2.InstructionsMarkdown = "# QA loop v2";
+        workflows.UpdateDraft("qa-loop", v2, ifMatchHash: null);
+        workflows.Publish("qa-loop");
+
+        var reread = runs.Get(run.Id)!;
+        Assert.Equal(1, reread.WorkflowVersion);
+        Assert.Equal(run.ContentHash, reread.ContentHash);
+        // A new run pins the new version.
+        Assert.Equal(2, runs.Create("qa-loop", "After the edit").WorkflowVersion);
+    }
+
+    [Fact]
+    public void Create_refuses_unknown_draft_only_and_archived_workflows()
+    {
+        var (workflows, runs) = NewStores();
+        workflows.CreateDraft(PublishableWorkflow("draft-only"));
+
+        Assert.Throws<WorkflowValidationException>(() => runs.Create("no-such", "x"));
+        Assert.Throws<WorkflowValidationException>(() => runs.Create("draft-only", "x"));
+
+        workflows.CreateDraft(PublishableWorkflow("gone"));
+        workflows.Publish("gone");
+        workflows.Archive("gone");
+        Assert.Throws<WorkflowValidationException>(() => runs.Create("gone", "x"));
+    }
+
+    [Fact]
+    public void Lifecycle_moves_are_legal_only_and_terminal_is_final()
+    {
+        var (_, runs) = NewStores();
+        var run = runs.Create("mission", "Lifecycle proof");
+
+        // created cannot jump straight to succeeded.
+        Assert.Throws<WorkflowValidationException>(() =>
+            runs.Patch(run.Id, new PatchWorkflowRunRequest { Status = "succeeded" }));
+
+        var active = runs.Patch(run.Id, new PatchWorkflowRunRequest { Status = "active" })!;
+        Assert.NotNull(active.StartedUtc);
+
+        var waiting = runs.Patch(run.Id, new PatchWorkflowRunRequest { Status = "awaiting-human" })!;
+        Assert.Equal("awaiting-human", waiting.Status);
+
+        var done = runs.Patch(run.Id, new PatchWorkflowRunRequest { Status = "succeeded" })!;
+        Assert.NotNull(done.CompletedUtc);
+
+        Assert.Throws<WorkflowValidationException>(() =>
+            runs.Patch(run.Id, new PatchWorkflowRunRequest { Status = "active" }));
+        Assert.Throws<WorkflowValidationException>(() =>
+            runs.Patch(run.Id, new PatchWorkflowRunRequest { Status = "not-a-status" }));
+    }
+
+    [Fact]
+    public void Acceptance_is_independent_of_lifecycle()
+    {
+        var (_, runs) = NewStores();
+        var run = runs.Create("mission", "Acceptance proof");
+        runs.Patch(run.Id, new PatchWorkflowRunRequest { Status = "active" });
+
+        // Accepted while still ACTIVE - lifecycle does not gate acceptance.
+        var accepted = runs.Patch(run.Id, new PatchWorkflowRunRequest
+        {
+            AcceptanceStatus = "accepted",
+            AcceptedBy = "human:owner",
+        })!;
+        Assert.Equal("active", accepted.Status);
+        Assert.Equal("accepted", accepted.AcceptanceStatus);
+        Assert.Equal("human:owner", accepted.AcceptedBy);
+        Assert.NotNull(accepted.AcceptedUtc);
+
+        // Back to pending clears the acceptance stamp.
+        var pending = runs.Patch(run.Id, new PatchWorkflowRunRequest { AcceptanceStatus = "pending" })!;
+        Assert.Null(pending.AcceptedBy);
+        Assert.Null(pending.AcceptedUtc);
+    }
+
+    [Fact]
+    public void Criteria_update_the_seeded_set_and_cannot_be_invented()
+    {
+        var (workflows, runs) = NewStores();
+        workflows.CreateDraft(PublishableWorkflow());
+        workflows.Publish("qa-loop");
+        var run = runs.Create("qa-loop", "Criteria proof");
+
+        var patched = runs.Patch(run.Id, new PatchWorkflowRunRequest
+        {
+            Criteria = new List<WorkflowRunCriterionResultDto>
+            {
+                new()
+                {
+                    CriterionId = "issue-passed",
+                    Status = "met",
+                    ProofUrl = "https://github.com/x/pull/1",
+                    Evaluator = "session:qa",
+                },
+            },
+        })!;
+
+        var criterion = patched.CriteriaResults.Single(c => c.CriterionId == "issue-passed");
+        Assert.Equal("met", criterion.Status);
+        Assert.Equal("https://github.com/x/pull/1", criterion.ProofUrl);
+        Assert.NotNull(criterion.EvaluatedUtc);
+        Assert.Equal("pending", patched.CriteriaResults.Single(c => c.CriterionId == "defect-filed").Status);
+
+        Assert.Throws<WorkflowValidationException>(() => runs.Patch(run.Id, new PatchWorkflowRunRequest
+        {
+            Criteria = new List<WorkflowRunCriterionResultDto>
+            {
+                new() { CriterionId = "invented", Status = "met" },
+            },
+        }));
+    }
+
+    [Fact]
+    public void Participants_join_once_and_leave_with_history()
+    {
+        var (_, runs) = NewStores();
+        var run = runs.Create("mission", "Participants proof");
+
+        var join = new WorkflowRunParticipantDto
+        {
+            SessionId = "abc123",
+            AgentKind = "ClaudeCode",
+            Role = "Architect",
+            Machine = "SOREN_NORTH",
+        };
+        runs.Patch(run.Id, new PatchWorkflowRunRequest
+        {
+            AddParticipants = new List<WorkflowRunParticipantDto> { join, join },
+        });
+        var afterJoin = runs.Get(run.Id)!;
+        var participant = Assert.Single(afterJoin.Participants); // duplicate join is a no-op
+        Assert.Equal("Architect", participant.Role);
+        Assert.Null(participant.LeftUtc);
+
+        runs.Patch(run.Id, new PatchWorkflowRunRequest
+        {
+            LeaveSessionIds = new List<string> { "abc123" },
+        });
+        Assert.NotNull(runs.Get(run.Id)!.Participants.Single().LeftUtc);
+    }
+
+    [Fact]
+    public void List_filters_by_workflow_status_and_mission()
+    {
+        var (_, runs) = NewStores();
+        var missionId = Guid.NewGuid();
+        var a = runs.Create("mission", "A", missionId: missionId);
+        runs.Create("standalone", "B");
+        runs.Patch(a.Id, new PatchWorkflowRunRequest { Status = "active" });
+
+        Assert.Single(runs.List(workflowId: "mission"));
+        Assert.Single(runs.List(status: "active"));
+        Assert.Single(runs.List(missionId: missionId));
+        Assert.Equal(2, runs.List().Count);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WorkflowRunStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowRunStoreTests.cs
@@ -161,6 +161,11 @@ public sealed class WorkflowRunStoreTests : IDisposable
         })!;
         Assert.Equal("human:owner", waived.AcceptedBy);
         Assert.NotNull(waived.AcceptedUtc);
+
+        // The actor is EXPLICIT per decision - flipping waived to rejected without naming who
+        // decided must refuse, never silently attribute the rejection to the previous accepter.
+        Assert.Throws<WorkflowValidationException>(() =>
+            runs.Patch(run.Id, new PatchWorkflowRunRequest { AcceptanceStatus = "rejected" }));
     }
 
     [Fact]
@@ -173,7 +178,7 @@ public sealed class WorkflowRunStoreTests : IDisposable
 
         var patched = runs.Patch(run.Id, new PatchWorkflowRunRequest
         {
-            Criteria = new List<WorkflowRunCriterionResultDto>
+            Criteria = new List<WorkflowRunCriterionUpdateDto>
             {
                 new()
                 {
@@ -191,11 +196,34 @@ public sealed class WorkflowRunStoreTests : IDisposable
         Assert.NotNull(criterion.EvaluatedUtc);
         Assert.Equal("pending", patched.CriteriaResults.Single(c => c.CriterionId == "defect-filed").Status);
 
+        // A partial update (note only, no status) must NEVER reset a met criterion to pending -
+        // null means unchanged, which is why the update type has no status default.
+        var noted = runs.Patch(run.Id, new PatchWorkflowRunRequest
+        {
+            Criteria = new List<WorkflowRunCriterionUpdateDto>
+            {
+                new() { CriterionId = "issue-passed", Note = "double-checked" },
+            },
+        })!;
+        var afterNote = noted.CriteriaResults.Single(c => c.CriterionId == "issue-passed");
+        Assert.Equal("met", afterNote.Status);
+        Assert.Equal("double-checked", afterNote.Note);
+
         Assert.Throws<WorkflowValidationException>(() => runs.Patch(run.Id, new PatchWorkflowRunRequest
         {
-            Criteria = new List<WorkflowRunCriterionResultDto>
+            Criteria = new List<WorkflowRunCriterionUpdateDto>
             {
                 new() { CriterionId = "invented", Status = "met" },
+            },
+        }));
+
+        // The same criterion twice in one patch would persist an inconsistent blend - refused.
+        Assert.Throws<WorkflowValidationException>(() => runs.Patch(run.Id, new PatchWorkflowRunRequest
+        {
+            Criteria = new List<WorkflowRunCriterionUpdateDto>
+            {
+                new() { CriterionId = "issue-passed", Status = "met" },
+                new() { CriterionId = "issue-passed", Status = "not-met" },
             },
         }));
     }

--- a/src/CcDirector.Gateway.Tests/WorkflowRunStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowRunStoreTests.cs
@@ -143,6 +143,10 @@ public sealed class WorkflowRunStoreTests : IDisposable
         var pending = runs.Patch(run.Id, new PatchWorkflowRunRequest { AcceptanceStatus = "pending" })!;
         Assert.Null(pending.AcceptedBy);
         Assert.Null(pending.AcceptedUtc);
+
+        // A non-pending acceptance is a ruling, and a ruling has a ruler: no accepter, no acceptance.
+        Assert.Throws<WorkflowValidationException>(() =>
+            runs.Patch(run.Id, new PatchWorkflowRunRequest { AcceptanceStatus = "accepted" }));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -104,6 +104,11 @@ internal static class GatewayEndpoints
         // a fleet-level concept, so the source of truth lives here at the Gateway. Null (old callers, tests)
         // maps nothing, leaving missions to the Director's own /missions routes (unchanged this phase).
         Core.Sessions.MissionStore? missions = null,
+        // Workflows mission (phase 4, issue #1771): when non-null, creating a mission also opens a
+        // workflow RUN of the built-in "mission" workflow, pinned to its published version, and the
+        // created mission's DTO carries the additive workflowRunId. Null (old callers, tests) leaves
+        // mission creation byte-identical to before.
+        Workflows.WorkflowRunStore? workflowRuns = null,
         // Store injection points: the host owns a single key vault, transcription telemetry log, and audio
         // archive and passes them here so the phone-recorder ingest transcriber (RecordingEndpoints) uses
         // the host's instances rather than newing its own. Null (old callers, tests) leaves RecordingEndpoints
@@ -174,7 +179,20 @@ internal static class GatewayEndpoints
                     return Results.BadRequest(new { error = "missionName is required" });
 
                 var mission = missions.Create(req.MissionName, req.ParentMissionId);
-                return Results.Json(ToMissionDto(mission), statusCode: StatusCodes.Status201Created);
+                var dto = ToMissionDto(mission);
+
+                // Workflows mission (phase 4, issue #1771): a mission IS a run of the built-in
+                // "mission" workflow. Open the run beside the Mission record, pinned to the published
+                // mission conduct, and hand the id back additively. Fail-loud: if the run cannot be
+                // opened the store is broken, and a mission without its governance record would be
+                // exactly the silent gap the outcome spine exists to close.
+                if (workflowRuns is not null)
+                {
+                    var run = workflowRuns.Create(
+                        "mission", mission.MissionName, missionId: mission.MissionId);
+                    dto.WorkflowRunId = run.Id;
+                }
+                return Results.Json(dto, statusCode: StatusCodes.Status201Created);
             });
 
             app.MapGet("/missions", () =>

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -178,14 +178,28 @@ internal static class GatewayEndpoints
                 if (req is null || string.IsNullOrWhiteSpace(req.MissionName))
                     return Results.BadRequest(new { error = "missionName is required" });
 
+                // Workflows mission (phase 4, issue #1771): a mission IS a run of the built-in
+                // "mission" workflow. The EXPECTED failure (mission workflow unrunnable) is checked
+                // BEFORE the Mission record is written, so it cannot leave a mission behind with no
+                // governance run. The Mission store and the run store are two different stores (JSON
+                // and EF), so a process death exactly between the two writes can still orphan a
+                // mission - a transition-era window that closes when the JSON mission store retires
+                // onto the EF layer; the pre-check removes every failure mode short of that.
+                if (workflowRuns is not null)
+                {
+                    try
+                    {
+                        workflowRuns.EnsureRunnable("mission");
+                    }
+                    catch (Workflows.WorkflowValidationException ex)
+                    {
+                        FileLog.Write($"[GatewayEndpoints] POST /missions refused: {ex.Message}");
+                        return Results.BadRequest(new { error = ex.Message });
+                    }
+                }
+
                 var mission = missions.Create(req.MissionName, req.ParentMissionId);
                 var dto = ToMissionDto(mission);
-
-                // Workflows mission (phase 4, issue #1771): a mission IS a run of the built-in
-                // "mission" workflow. Open the run beside the Mission record, pinned to the published
-                // mission conduct, and hand the id back additively. Fail-loud: if the run cannot be
-                // opened the store is broken, and a mission without its governance record would be
-                // exactly the silent gap the outcome spine exists to close.
                 if (workflowRuns is not null)
                 {
                     var run = workflowRuns.Create(

--- a/src/CcDirector.Gateway/Api/WorkflowRunEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/WorkflowRunEndpoints.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Workflows;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The workflow-run surface (Workflows mission, phase 4 - the governance outcome spine, issue #1771).
+/// A run is one execution of a workflow definition, pinned to the exact published version that
+/// governed it. Lifecycle and acceptance are separate fields on purpose.
+///
+///   POST  /gateway/workflow-runs        body NewWorkflowRunRequest -> 201 WorkflowRunDto | 400
+///   GET   /gateway/workflow-runs        ?workflowId=&amp;status=&amp;missionId= -> { runs: [...] }
+///   GET   /gateway/workflow-runs/{id}   -> WorkflowRunDto | 404
+///   PATCH /gateway/workflow-runs/{id}   body PatchWorkflowRunRequest -> 200 | 400 | 404
+///
+/// Inherits the host-wide token middleware, like every other Gateway route.
+/// </summary>
+internal static class WorkflowRunEndpoints
+{
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    public static void Map(IEndpointRouteBuilder app, WorkflowRunStore store)
+    {
+        app.MapPost("/gateway/workflow-runs", async (HttpContext ctx) =>
+        {
+            NewWorkflowRunRequest? req;
+            try
+            {
+                req = await JsonSerializer.DeserializeAsync<NewWorkflowRunRequest>(
+                    ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+            }
+            catch (JsonException ex)
+            {
+                FileLog.Write($"[WorkflowRunEndpoints] POST bad JSON: {ex.Message}");
+                return Results.BadRequest(new { error = "invalid JSON" });
+            }
+            if (req is null)
+                return Results.BadRequest(new { error = "a run body is required" });
+
+            return Guard(() =>
+            {
+                var run = store.Create(req.WorkflowId ?? "", req.Name ?? "", req.MissionId,
+                    req.ParentRunId, req.RepoPath);
+                FileLog.Write($"[WorkflowRunEndpoints] created run {run.Id} of {run.WorkflowId} v{run.WorkflowVersion}");
+                return Results.Json(run, statusCode: StatusCodes.Status201Created);
+            });
+        });
+
+        app.MapGet("/gateway/workflow-runs", (string? workflowId, string? status, Guid? missionId) =>
+            Results.Json(new { runs = store.List(workflowId, status, missionId) }));
+
+        app.MapGet("/gateway/workflow-runs/{id:guid}", (Guid id) =>
+        {
+            var run = store.Get(id);
+            return run is null
+                ? Results.Json(new { error = $"no workflow run '{id}'" },
+                    statusCode: StatusCodes.Status404NotFound)
+                : Results.Json(run);
+        });
+
+        app.MapPatch("/gateway/workflow-runs/{id:guid}", async (Guid id, HttpContext ctx) =>
+        {
+            PatchWorkflowRunRequest? patch;
+            try
+            {
+                patch = await JsonSerializer.DeserializeAsync<PatchWorkflowRunRequest>(
+                    ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+            }
+            catch (JsonException ex)
+            {
+                FileLog.Write($"[WorkflowRunEndpoints] PATCH bad JSON: {ex.Message}");
+                return Results.BadRequest(new { error = "invalid JSON" });
+            }
+            if (patch is null)
+                return Results.BadRequest(new { error = "a patch body is required" });
+
+            return Guard(() =>
+            {
+                var run = store.Patch(id, patch);
+                return run is null
+                    ? Results.Json(new { error = $"no workflow run '{id}'" },
+                        statusCode: StatusCodes.Status404NotFound)
+                    : Results.Json(run);
+            });
+        });
+
+        FileLog.Write("[WorkflowRunEndpoints] mapped /gateway/workflow-runs routes");
+    }
+
+    private static IResult Guard(Func<IResult> action)
+    {
+        try
+        {
+            return action();
+        }
+        catch (WorkflowValidationException ex)
+        {
+            FileLog.Write($"[WorkflowRunEndpoints] rejected: {ex.Message}");
+            return Results.BadRequest(new { error = ex.Message });
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/WorkflowRunEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/WorkflowRunEndpoints.cs
@@ -51,8 +51,8 @@ internal static class WorkflowRunEndpoints
             });
         });
 
-        app.MapGet("/gateway/workflow-runs", (string? workflowId, string? status, Guid? missionId) =>
-            Results.Json(new { runs = store.List(workflowId, status, missionId) }));
+        app.MapGet("/gateway/workflow-runs", (string? workflowId, string? status, Guid? missionId, int? limit) =>
+            Results.Json(new { runs = store.List(workflowId, status, missionId, limit ?? 200) }));
 
         app.MapGet("/gateway/workflow-runs/{id:guid}", (Guid id) =>
         {

--- a/src/CcDirector.Gateway/Data/Entities/WorkflowRunEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/WorkflowRunEntity.cs
@@ -1,0 +1,81 @@
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// One execution of a workflow definition, in the <c>workflow_runs</c> table - the governance outcome
+/// spine (issue #1771). The run pins the exact published version that governed it at creation
+/// (<see cref="WorkflowVersionId"/> + <see cref="WorkflowVersion"/> + <see cref="ContentHash"/>);
+/// published versions referenced by runs are never deleted, so the answer to "what conduct governed
+/// this run" survives supersede, archive, and reset.
+///
+/// Lifecycle <see cref="Status"/> is SEPARATE from <see cref="AcceptanceStatus"/> on purpose:
+/// "completed" and "counts as delivered" are different questions, and the verified-yield metric
+/// reads the second. Criteria results, proof links, and participants are bounded sub-documents
+/// mapped as owned JSON columns, reusing the wire contract types (the cron pattern).
+///
+/// Today's missions become runs of the built-in "mission" workflow: the Gateway's mission-create
+/// path opens a run beside the Mission record and references it (<see cref="MissionId"/>) - a
+/// reference, not a merge, because standalone runs have no Mission.
+/// </summary>
+public sealed class WorkflowRunEntity : TenantScopedEntity
+{
+    /// <summary>Primary key, minted in code - never a database default.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>The workflow definition this run executes. Indexed.</summary>
+    public string WorkflowId { get; set; } = "";
+
+    /// <summary>The exact published version row pinned at creation.</summary>
+    public Guid WorkflowVersionId { get; set; }
+
+    /// <summary>The pinned version number (denormalized for cheap display and CLI reads).</summary>
+    public int WorkflowVersion { get; set; }
+
+    /// <summary>The pinned version's canonical bundle hash.</summary>
+    public string ContentHash { get; set; } = "";
+
+    /// <summary>The run's display name (for a mission run, the mission name).</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>Lifecycle: created, active, awaiting-human, succeeded, failed, abandoned. Legal
+    /// transitions are enforced by the store; a terminal status is final.</summary>
+    public string Status { get; set; } = WorkflowRunStatus.Created;
+
+    /// <summary>Acceptance: pending, accepted, rejected, waived - independent of lifecycle.</summary>
+    public string AcceptanceStatus { get; set; } = WorkflowRunAcceptance.Pending;
+
+    /// <summary>Who accepted/rejected/waived (a human identity or a delegated agent seat).</summary>
+    public string? AcceptedBy { get; set; }
+
+    public DateTime? AcceptedUtc { get; set; }
+
+    /// <summary>A short closing statement of what the run produced.</summary>
+    public string? Outcome { get; set; }
+
+    /// <summary>Per-criterion standing, seeded pending from the pinned version's declared criteria.</summary>
+    public List<WorkflowRunCriterionResultDto> CriteriaResults { get; set; } = new();
+
+    /// <summary>Labelled evidence links (pull requests, reports, deployments).</summary>
+    public List<WorkflowRunProofLinkDto> ProofLinks { get; set; } = new();
+
+    /// <summary>Persisted run-to-session membership with join/leave history.</summary>
+    public List<WorkflowRunParticipantDto> Participants { get; set; } = new();
+
+    /// <summary>The Mission record anchoring this run, when it came from the mission path. Indexed;
+    /// not a foreign key (independent lifecycle).</summary>
+    public Guid? MissionId { get; set; }
+
+    public Guid? ParentRunId { get; set; }
+
+    /// <summary>The repository the run works in, when known.</summary>
+    public string? RepoPath { get; set; }
+
+    public DateTime CreatedUtc { get; set; }
+
+    /// <summary>Stamped on the first transition to active.</summary>
+    public DateTime? StartedUtc { get; set; }
+
+    /// <summary>Stamped on the transition to a terminal status.</summary>
+    public DateTime? CompletedUtc { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -64,6 +64,9 @@ public sealed class GatewayDbContext : DbContext
     /// <summary>Helper files belonging to a workflow version (<c>workflow_files</c>).</summary>
     public DbSet<WorkflowFileEntity> WorkflowFiles => Set<WorkflowFileEntity>();
 
+    /// <summary>Workflow runs (<c>workflow_runs</c>) - the governance outcome spine (issue #1771).</summary>
+    public DbSet<WorkflowRunEntity> WorkflowRuns => Set<WorkflowRunEntity>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -137,6 +140,19 @@ public sealed class GatewayDbContext : DbContext
             b.HasIndex(e => e.VersionId);
         });
 
+        modelBuilder.Entity<WorkflowRunEntity>(b =>
+        {
+            b.ToTable("workflow_runs");
+            b.HasKey(e => e.Id);
+            // The reporting cuts: per-workflow and per-mission run lists. Indexed, never foreign
+            // keys - a run outlives archives and mission cleanup.
+            b.HasIndex(e => e.WorkflowId);
+            b.HasIndex(e => e.MissionId);
+            b.OwnsMany(e => e.CriteriaResults, o => o.ToJson());
+            b.OwnsMany(e => e.ProofLinks, o => o.ToJson());
+            b.OwnsMany(e => e.Participants, o => o.ToJson());
+        });
+
         // Tenant scoping - the tenant_id column plus the global query filter - applied uniformly to every
         // entity that derives from TenantScopedEntity, so future stores inherit it by deriving from the base.
         ApplyTenantScope<CronJobEntity>(modelBuilder);
@@ -146,6 +162,7 @@ public sealed class GatewayDbContext : DbContext
         ApplyTenantScope<WorkflowEntity>(modelBuilder);
         ApplyTenantScope<WorkflowVersionEntity>(modelBuilder);
         ApplyTenantScope<WorkflowFileEntity>(modelBuilder);
+        ApplyTenantScope<WorkflowRunEntity>(modelBuilder);
 
         ApplyCommonSubsetConventions(modelBuilder);
     }

--- a/src/CcDirector.Gateway/Data/Migrations/20260718012437_AddWorkflowRuns.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718012437_AddWorkflowRuns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718012437_AddWorkflowRuns")]
+    partial class AddWorkflowRuns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260718012437_AddWorkflowRuns.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718012437_AddWorkflowRuns.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkflowRuns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "workflow_runs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    WorkflowId = table.Column<string>(type: "TEXT", nullable: false),
+                    WorkflowVersionId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    WorkflowVersion = table.Column<int>(type: "INTEGER", nullable: false),
+                    ContentHash = table.Column<string>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    Status = table.Column<string>(type: "TEXT", nullable: false),
+                    AcceptanceStatus = table.Column<string>(type: "TEXT", nullable: false),
+                    AcceptedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    AcceptedUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    Outcome = table.Column<string>(type: "TEXT", nullable: true),
+                    MissionId = table.Column<Guid>(type: "TEXT", nullable: true),
+                    ParentRunId = table.Column<Guid>(type: "TEXT", nullable: true),
+                    RepoPath = table.Column<string>(type: "TEXT", nullable: true),
+                    CreatedUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    StartedUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    CompletedUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false),
+                    CriteriaResults = table.Column<string>(type: "TEXT", nullable: true),
+                    Participants = table.Column<string>(type: "TEXT", nullable: true),
+                    ProofLinks = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_workflow_runs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_workflow_runs_MissionId",
+                table: "workflow_runs",
+                column: "MissionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_workflow_runs_tenant_id",
+                table: "workflow_runs",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_workflow_runs_WorkflowId",
+                table: "workflow_runs",
+                column: "WorkflowId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "workflow_runs");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -332,6 +332,9 @@ public sealed class GatewayHost : IAsyncDisposable
     // The persisted workflow catalog (Workflows mission, phase 1): built-ins seeded at startup,
     // user-defined workflows beside them, served by Api.WorkflowEndpoints.
     private readonly Workflows.WorkflowStore _workflows;
+    // Workflow runs (phase 4, issue #1771): one row per execution of a workflow definition, pinned to
+    // the version that governed it. The governance outcome spine.
+    private readonly Workflows.WorkflowRunStore _workflowRuns;
     private readonly CronJobStore _cronJobs;
     private readonly CronRunHistoryStore _cronRuns;
     private readonly Running.CronEngine _cronEngine;
@@ -597,6 +600,9 @@ public sealed class GatewayHost : IAsyncDisposable
         // shipped built-ins seeded/upgraded at construction. No legacy JSON - the previous catalog was
         // compiled-in C# literals, so there is nothing on disk to import.
         _workflows = new Workflows.WorkflowStore(_gatewayDb);
+        // Workflow runs (phase 4, issue #1771): built after the catalog store so the built-ins a run
+        // pins are already seeded.
+        _workflowRuns = new Workflows.WorkflowRunStore(_gatewayDb);
         // Snooze Length mission: the persisted snooze registry (sessionId -> SnoozeUntilUtc). Loaded here
         // so a Gateway restart re-arms every pending snooze; an entry already past its time simply fires
         // on the first sweep. Tests MUST pass an isolated path so they never touch the real store. The
@@ -1497,7 +1503,10 @@ public sealed class GatewayHost : IAsyncDisposable
             snoozeRegistry: _snoozeRegistry,
             // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store backs POST/GET /missions and
             // mission-scoped spawn validation. Missions are a fleet concept, so their source of truth is here.
-            missions: Missions);
+            missions: Missions,
+            // Workflows mission (phase 4, issue #1771): creating a mission also opens a workflow run of
+            // the built-in "mission" workflow, pinned to its published version - the outcome spine.
+            workflowRuns: _workflowRuns);
 
         // Issue #268: the two raw per-session WebSocket legs (live Terminal stream + dictation)
         // proxied through the Gateway so a remote Cockpit talks same-origin to the Gateway and
@@ -1604,6 +1613,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // each carrying a private copy. Served from the persisted store (built-ins seeded at startup);
         // authoring routes are the next phase. Inherits the host-wide token middleware above.
         Api.WorkflowEndpoints.Map(_app, _workflows);
+
+        // Workflow runs (phase 4, issue #1771): the outcome spine's REST surface. One row per
+        // execution of a workflow, pinned to the exact published version that governed it.
+        Api.WorkflowRunEndpoints.Map(_app, _workflowRuns);
 
         // Gateway Centralization Phase 1 (issue #628): the inbound login-telemetry RELAY. The Director
         // POSTs its login-telemetry event here (instead of the cloud) and the Gateway forwards it on,

--- a/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
@@ -254,17 +254,23 @@ public sealed class WorkflowRunStore
             throw new WorkflowValidationException(
                 $"'{acceptance}' is not an acceptance status. Legal values: " +
                 string.Join(", ", AcceptanceStatuses) + ".");
-        entity.AcceptanceStatus = acceptance;
         if (acceptance == WorkflowRunAcceptance.Pending)
         {
+            entity.AcceptanceStatus = acceptance;
             entity.AcceptedBy = null;
             entity.AcceptedUtc = null;
+            return;
         }
-        else
-        {
-            entity.AcceptedBy = string.IsNullOrWhiteSpace(acceptedBy) ? entity.AcceptedBy : acceptedBy;
-            entity.AcceptedUtc = now;
-        }
+
+        // A non-pending acceptance is a RULING, and a ruling has a ruler: the accepter identity is
+        // what the verified-yield metric audits (issue #1771), so it can never be blank.
+        var who = string.IsNullOrWhiteSpace(acceptedBy) ? entity.AcceptedBy : acceptedBy;
+        if (string.IsNullOrWhiteSpace(who))
+            throw new WorkflowValidationException(
+                $"Setting acceptance to '{acceptance}' requires acceptedBy - who made the call.");
+        entity.AcceptanceStatus = acceptance;
+        entity.AcceptedBy = who;
+        entity.AcceptedUtc = now;
     }
 
     private static void ApplyCriteria(

--- a/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
@@ -1,0 +1,364 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Workflows;
+
+/// <summary>
+/// The Gateway's workflow-run store (Workflows mission, phase 4 - the governance outcome spine,
+/// issue #1771). A run is one execution of a workflow definition: it pins the exact published
+/// version at creation, seeds its criteria results from that version's declared outcome criteria,
+/// records participants (persisted run-to-session membership), and keeps lifecycle and acceptance
+/// as two separate questions. Today's missions become runs of the built-in "mission" workflow via
+/// the Gateway's mission-create path.
+///
+/// Lifecycle transitions are enforced here, in one place: created can start or be abandoned; an
+/// active run can wait on a human and come back; any live run can end succeeded, failed, or
+/// abandoned; a terminal status is FINAL. Acceptance never gates lifecycle and lifecycle never
+/// implies acceptance.
+///
+/// Threading: the Gateway is a single writer. Every operation runs under this store's write lock
+/// over a fresh pooled context.
+/// </summary>
+public sealed class WorkflowRunStore
+{
+    private readonly object _gate = new();
+    private readonly GatewayDatabase _db;
+
+    private static readonly Dictionary<string, string[]> LegalTransitions = new(StringComparer.Ordinal)
+    {
+        [WorkflowRunStatus.Created] = new[] { WorkflowRunStatus.Active, WorkflowRunStatus.Abandoned },
+        [WorkflowRunStatus.Active] = new[]
+        {
+            WorkflowRunStatus.AwaitingHuman, WorkflowRunStatus.Succeeded,
+            WorkflowRunStatus.Failed, WorkflowRunStatus.Abandoned,
+        },
+        [WorkflowRunStatus.AwaitingHuman] = new[]
+        {
+            WorkflowRunStatus.Active, WorkflowRunStatus.Succeeded,
+            WorkflowRunStatus.Failed, WorkflowRunStatus.Abandoned,
+        },
+        [WorkflowRunStatus.Succeeded] = Array.Empty<string>(),
+        [WorkflowRunStatus.Failed] = Array.Empty<string>(),
+        [WorkflowRunStatus.Abandoned] = Array.Empty<string>(),
+    };
+
+    private static readonly string[] AcceptanceStatuses =
+    {
+        WorkflowRunAcceptance.Pending, WorkflowRunAcceptance.Accepted,
+        WorkflowRunAcceptance.Rejected, WorkflowRunAcceptance.Waived,
+    };
+
+    private static readonly string[] CriterionStatuses =
+    {
+        WorkflowRunCriterionStatus.Pending, WorkflowRunCriterionStatus.Met,
+        WorkflowRunCriterionStatus.NotMet, WorkflowRunCriterionStatus.Waived,
+    };
+
+    public WorkflowRunStore(GatewayDatabase db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    /// <summary>
+    /// Open a run of a workflow, pinned to its currently published version, with criteria seeded
+    /// pending from that version's declared outcome criteria.
+    /// </summary>
+    /// <exception cref="WorkflowValidationException">The workflow is missing, archived, or has no
+    /// published version - a run cannot execute conduct that is not fleet-readable.</exception>
+    public WorkflowRunDto Create(
+        string workflowId, string name, Guid? missionId = null, Guid? parentRunId = null,
+        string? repoPath = null)
+    {
+        if (string.IsNullOrWhiteSpace(workflowId))
+            throw new WorkflowValidationException("A run needs a workflow id.");
+        if (string.IsNullOrWhiteSpace(name))
+            throw new WorkflowValidationException("A run needs a name.");
+        var key = workflowId.Trim().ToLowerInvariant();
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var head = ctx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == key);
+            if (head is null || head.Archived || head.PublishedVersion is null)
+                throw new WorkflowValidationException(
+                    $"Workflow '{key}' has no published version to run.");
+            var version = ctx.WorkflowVersions.AsNoTracking().First(
+                v => v.WorkflowId == key && v.Status == WorkflowVersionStatus.Published);
+
+            var now = DateTime.UtcNow;
+            var entity = new WorkflowRunEntity
+            {
+                Id = Guid.NewGuid(),
+                TenantId = ctx.ActiveTenant!,
+                WorkflowId = key,
+                WorkflowVersionId = version.Id,
+                WorkflowVersion = version.Version,
+                ContentHash = version.ContentHash,
+                Name = name.Trim(),
+                Status = WorkflowRunStatus.Created,
+                AcceptanceStatus = WorkflowRunAcceptance.Pending,
+                CriteriaResults = version.OutcomeCriteria.Select(c => new WorkflowRunCriterionResultDto
+                {
+                    CriterionId = c.CriterionId,
+                    Status = WorkflowRunCriterionStatus.Pending,
+                }).ToList(),
+                MissionId = missionId,
+                ParentRunId = parentRunId,
+                RepoPath = repoPath,
+                CreatedUtc = now,
+            };
+            ctx.WorkflowRuns.Add(entity);
+            ctx.SaveChanges();
+
+            FileLog.Write($"[WorkflowRunStore] Create: run={entity.Id}, workflow={key} v{version.Version}, " +
+                          $"name=\"{entity.Name}\", mission={missionId?.ToString() ?? "-"}");
+            return ToDto(entity);
+        }
+    }
+
+    /// <summary>One run by id, or null.</summary>
+    public WorkflowRunDto? Get(Guid id)
+    {
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var entity = ctx.WorkflowRuns.AsNoTracking().FirstOrDefault(r => r.Id == id);
+            return entity is null ? null : ToDto(entity);
+        }
+    }
+
+    /// <summary>Runs, newest first, optionally filtered by workflow, lifecycle status, or mission.</summary>
+    public IReadOnlyList<WorkflowRunDto> List(
+        string? workflowId = null, string? status = null, Guid? missionId = null)
+    {
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            IQueryable<WorkflowRunEntity> query = ctx.WorkflowRuns.AsNoTracking();
+            if (!string.IsNullOrWhiteSpace(workflowId))
+            {
+                var key = workflowId.Trim().ToLowerInvariant();
+                query = query.Where(r => r.WorkflowId == key);
+            }
+            if (!string.IsNullOrWhiteSpace(status))
+            {
+                var wanted = status.Trim().ToLowerInvariant();
+                query = query.Where(r => r.Status == wanted);
+            }
+            if (missionId.HasValue)
+                query = query.Where(r => r.MissionId == missionId.Value);
+
+            return query.ToList()
+                .OrderByDescending(r => r.CreatedUtc)
+                .Select(ToDto)
+                .ToList();
+        }
+    }
+
+    /// <summary>
+    /// Apply a patch: lifecycle transition (legal moves only; terminal is final), outcome text,
+    /// acceptance, criterion results (ids must exist on the run), proof links, and participant
+    /// joins/leaves. Null when no such run exists.
+    /// </summary>
+    public WorkflowRunDto? Patch(Guid id, PatchWorkflowRunRequest patch)
+    {
+        if (patch is null)
+            throw new WorkflowValidationException("A patch body is required.");
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var entity = ctx.WorkflowRuns.FirstOrDefault(r => r.Id == id);
+            if (entity is null)
+                return null;
+
+            var now = DateTime.UtcNow;
+
+            if (!string.IsNullOrWhiteSpace(patch.Status))
+                ApplyStatus(entity, patch.Status.Trim().ToLowerInvariant(), now);
+
+            if (patch.Outcome is not null)
+                entity.Outcome = patch.Outcome;
+
+            if (!string.IsNullOrWhiteSpace(patch.AcceptanceStatus))
+                ApplyAcceptance(entity, patch.AcceptanceStatus.Trim().ToLowerInvariant(),
+                    patch.AcceptedBy, now);
+
+            if (patch.Criteria is not null)
+                ApplyCriteria(entity, patch.Criteria, now);
+
+            if (patch.ProofLinks is not null)
+            {
+                foreach (var link in patch.ProofLinks)
+                {
+                    if (link is null || string.IsNullOrWhiteSpace(link.Url))
+                        throw new WorkflowValidationException("A proof link needs a url.");
+                    entity.ProofLinks.Add(new WorkflowRunProofLinkDto
+                    {
+                        Label = link.Label ?? "",
+                        Url = link.Url,
+                    });
+                }
+            }
+
+            if (patch.AddParticipants is not null)
+                ApplyJoins(entity, patch.AddParticipants, now);
+
+            if (patch.LeaveSessionIds is not null)
+            {
+                foreach (var sessionId in patch.LeaveSessionIds)
+                {
+                    var active = entity.Participants.FirstOrDefault(
+                        p => p.SessionId == sessionId && p.LeftUtc is null);
+                    if (active is not null)
+                        active.LeftUtc = now;
+                }
+            }
+
+            ctx.SaveChanges();
+            FileLog.Write($"[WorkflowRunStore] Patch: run={id}, status={entity.Status}, " +
+                          $"acceptance={entity.AcceptanceStatus}");
+            return ToDto(entity);
+        }
+    }
+
+    private static void ApplyStatus(WorkflowRunEntity entity, string next, DateTime now)
+    {
+        if (!LegalTransitions.TryGetValue(next, out _))
+            throw new WorkflowValidationException(
+                $"'{next}' is not a run status. Legal values: {string.Join(", ", LegalTransitions.Keys)}.");
+        if (string.Equals(entity.Status, next, StringComparison.Ordinal))
+            return; // idempotent no-move
+        var allowed = LegalTransitions[entity.Status];
+        if (!allowed.Contains(next, StringComparer.Ordinal))
+            throw new WorkflowValidationException(
+                $"A run cannot move from '{entity.Status}' to '{next}'" +
+                (allowed.Length == 0
+                    ? " - a terminal status is final."
+                    : $". Legal moves: {string.Join(", ", allowed)}."));
+
+        entity.Status = next;
+        if (next == WorkflowRunStatus.Active && entity.StartedUtc is null)
+            entity.StartedUtc = now;
+        if (WorkflowRunStatus.Terminal.Contains(next, StringComparer.Ordinal))
+            entity.CompletedUtc = now;
+    }
+
+    private static void ApplyAcceptance(
+        WorkflowRunEntity entity, string acceptance, string? acceptedBy, DateTime now)
+    {
+        if (!AcceptanceStatuses.Contains(acceptance, StringComparer.Ordinal))
+            throw new WorkflowValidationException(
+                $"'{acceptance}' is not an acceptance status. Legal values: " +
+                string.Join(", ", AcceptanceStatuses) + ".");
+        entity.AcceptanceStatus = acceptance;
+        if (acceptance == WorkflowRunAcceptance.Pending)
+        {
+            entity.AcceptedBy = null;
+            entity.AcceptedUtc = null;
+        }
+        else
+        {
+            entity.AcceptedBy = string.IsNullOrWhiteSpace(acceptedBy) ? entity.AcceptedBy : acceptedBy;
+            entity.AcceptedUtc = now;
+        }
+    }
+
+    private static void ApplyCriteria(
+        WorkflowRunEntity entity, List<WorkflowRunCriterionResultDto> updates, DateTime now)
+    {
+        foreach (var update in updates)
+        {
+            if (update is null || string.IsNullOrWhiteSpace(update.CriterionId))
+                throw new WorkflowValidationException("A criterion update needs a criterionId.");
+            var existing = entity.CriteriaResults.FirstOrDefault(
+                c => string.Equals(c.CriterionId, update.CriterionId, StringComparison.Ordinal));
+            if (existing is null)
+                throw new WorkflowValidationException(
+                    $"This run has no criterion '{update.CriterionId}' - criteria come from the " +
+                    "pinned workflow version and cannot be invented on the run.");
+            if (!string.IsNullOrWhiteSpace(update.Status))
+            {
+                var status = update.Status.Trim().ToLowerInvariant();
+                if (!CriterionStatuses.Contains(status, StringComparer.Ordinal))
+                    throw new WorkflowValidationException(
+                        $"'{update.Status}' is not a criterion status. Legal values: " +
+                        string.Join(", ", CriterionStatuses) + ".");
+                existing.Status = status;
+            }
+            if (update.ProofUrl is not null) existing.ProofUrl = update.ProofUrl;
+            if (update.Note is not null) existing.Note = update.Note;
+            if (update.Evaluator is not null) existing.Evaluator = update.Evaluator;
+            existing.EvaluatedUtc = update.EvaluatedUtc ?? now;
+        }
+    }
+
+    private static void ApplyJoins(
+        WorkflowRunEntity entity, List<WorkflowRunParticipantDto> joins, DateTime now)
+    {
+        foreach (var join in joins)
+        {
+            if (join is null || string.IsNullOrWhiteSpace(join.SessionId))
+                throw new WorkflowValidationException("A participant needs a sessionId.");
+            var alreadyActive = entity.Participants.Any(
+                p => p.SessionId == join.SessionId && p.LeftUtc is null);
+            if (alreadyActive)
+                continue; // joining twice is a no-op, not an error - spawn paths may retry.
+            entity.Participants.Add(new WorkflowRunParticipantDto
+            {
+                SessionId = join.SessionId,
+                AgentKind = join.AgentKind ?? "",
+                Role = join.Role ?? "",
+                Machine = join.Machine ?? "",
+                JoinedUtc = join.JoinedUtc == default ? now : join.JoinedUtc,
+            });
+        }
+    }
+
+    private static WorkflowRunDto ToDto(WorkflowRunEntity e) => new()
+    {
+        Id = e.Id,
+        WorkflowId = e.WorkflowId,
+        WorkflowVersionId = e.WorkflowVersionId,
+        WorkflowVersion = e.WorkflowVersion,
+        ContentHash = e.ContentHash,
+        Name = e.Name,
+        Status = e.Status,
+        AcceptanceStatus = e.AcceptanceStatus,
+        AcceptedBy = e.AcceptedBy,
+        AcceptedUtc = e.AcceptedUtc,
+        Outcome = e.Outcome,
+        CriteriaResults = e.CriteriaResults.Select(c => new WorkflowRunCriterionResultDto
+        {
+            CriterionId = c.CriterionId,
+            Status = c.Status,
+            ProofUrl = c.ProofUrl,
+            Note = c.Note,
+            Evaluator = c.Evaluator,
+            EvaluatedUtc = c.EvaluatedUtc,
+        }).ToList(),
+        ProofLinks = e.ProofLinks.Select(p => new WorkflowRunProofLinkDto
+        {
+            Label = p.Label,
+            Url = p.Url,
+        }).ToList(),
+        Participants = e.Participants.Select(p => new WorkflowRunParticipantDto
+        {
+            SessionId = p.SessionId,
+            AgentKind = p.AgentKind,
+            Role = p.Role,
+            Machine = p.Machine,
+            JoinedUtc = p.JoinedUtc,
+            LeftUtc = p.LeftUtc,
+        }).ToList(),
+        MissionId = e.MissionId,
+        ParentRunId = e.ParentRunId,
+        RepoPath = e.RepoPath,
+        CreatedUtc = e.CreatedUtc,
+        StartedUtc = e.StartedUtc,
+        CompletedUtc = e.CompletedUtc,
+    };
+}

--- a/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
@@ -130,10 +130,17 @@ public sealed class WorkflowRunStore
         }
     }
 
-    /// <summary>Runs, newest first, optionally filtered by workflow, lifecycle status, or mission.</summary>
+    /// <summary>The hard ceiling on one list read; the default page is 200. Runs accumulate forever
+    /// (they are never hard-deleted - the reporting horizon depends on it), so an unbounded list
+    /// would eventually materialize the whole history per request.</summary>
+    public const int MaxListLimit = 1000;
+
+    /// <summary>Runs, newest first, optionally filtered by workflow, lifecycle status, or mission.
+    /// Ordered and bounded in the database.</summary>
     public IReadOnlyList<WorkflowRunDto> List(
-        string? workflowId = null, string? status = null, Guid? missionId = null)
+        string? workflowId = null, string? status = null, Guid? missionId = null, int limit = 200)
     {
+        var take = Math.Clamp(limit, 1, MaxListLimit);
         lock (_gate)
         {
             using var ctx = _db.CreateContext();
@@ -151,10 +158,33 @@ public sealed class WorkflowRunStore
             if (missionId.HasValue)
                 query = query.Where(r => r.MissionId == missionId.Value);
 
-            return query.ToList()
+            return query
                 .OrderByDescending(r => r.CreatedUtc)
+                .Take(take)
+                .ToList()
                 .Select(ToDto)
                 .ToList();
+        }
+    }
+
+    /// <summary>
+    /// Throws the same validation error <see cref="Create"/> would when the workflow cannot be run
+    /// (missing, archived, or never published), WITHOUT creating anything. The mission-create path
+    /// checks this BEFORE writing the Mission record, so the expected failure mode cannot leave a
+    /// mission behind with no governance run.
+    /// </summary>
+    public void EnsureRunnable(string workflowId)
+    {
+        if (string.IsNullOrWhiteSpace(workflowId))
+            throw new WorkflowValidationException("A run needs a workflow id.");
+        var key = workflowId.Trim().ToLowerInvariant();
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var head = ctx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == key);
+            if (head is null || head.Archived || head.PublishedVersion is null)
+                throw new WorkflowValidationException(
+                    $"Workflow '{key}' has no published version to run.");
         }
     }
 
@@ -263,30 +293,38 @@ public sealed class WorkflowRunStore
         }
 
         // A non-pending acceptance is a RULING, and a ruling has a ruler: the accepter identity is
-        // what the verified-yield metric audits (issue #1771), so it can never be blank.
-        var who = string.IsNullOrWhiteSpace(acceptedBy) ? entity.AcceptedBy : acceptedBy;
-        if (string.IsNullOrWhiteSpace(who))
+        // what the verified-yield metric audits (issue #1771), so it must be EXPLICIT on every
+        // decision - never inherited from a previous acceptance, or a later rejection would be
+        // silently attributed to whoever accepted earlier.
+        if (string.IsNullOrWhiteSpace(acceptedBy))
             throw new WorkflowValidationException(
                 $"Setting acceptance to '{acceptance}' requires acceptedBy - who made the call.");
         entity.AcceptanceStatus = acceptance;
-        entity.AcceptedBy = who;
+        entity.AcceptedBy = acceptedBy;
         entity.AcceptedUtc = now;
     }
 
     private static void ApplyCriteria(
-        WorkflowRunEntity entity, List<WorkflowRunCriterionResultDto> updates, DateTime now)
+        WorkflowRunEntity entity, List<WorkflowRunCriterionUpdateDto> updates, DateTime now)
     {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
         foreach (var update in updates)
         {
             if (update is null || string.IsNullOrWhiteSpace(update.CriterionId))
                 throw new WorkflowValidationException("A criterion update needs a criterionId.");
+            if (!seen.Add(update.CriterionId))
+                throw new WorkflowValidationException(
+                    $"Criterion '{update.CriterionId}' appears more than once in one patch - the " +
+                    "result would be an inconsistent blend of the two updates.");
             var existing = entity.CriteriaResults.FirstOrDefault(
                 c => string.Equals(c.CriterionId, update.CriterionId, StringComparison.Ordinal));
             if (existing is null)
                 throw new WorkflowValidationException(
                     $"This run has no criterion '{update.CriterionId}' - criteria come from the " +
                     "pinned workflow version and cannot be invented on the run.");
-            if (!string.IsNullOrWhiteSpace(update.Status))
+            // Null means UNCHANGED (the update type has no defaults on purpose): a patch adding only
+            // a note to a met criterion never resets its status.
+            if (update.Status is not null)
             {
                 var status = update.Status.Trim().ToLowerInvariant();
                 if (!CriterionStatuses.Contains(status, StringComparer.Ordinal))
@@ -298,7 +336,8 @@ public sealed class WorkflowRunStore
             if (update.ProofUrl is not null) existing.ProofUrl = update.ProofUrl;
             if (update.Note is not null) existing.Note = update.Note;
             if (update.Evaluator is not null) existing.Evaluator = update.Evaluator;
-            existing.EvaluatedUtc = update.EvaluatedUtc ?? now;
+            // Server-stamped: the evaluation time is when the Gateway applied it, never caller-supplied.
+            existing.EvaluatedUtc = now;
         }
     }
 

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -333,6 +333,20 @@ _ACTIONS = [
         "args": [{"name": "id", "required": True}, {"name": "version", "required": False}],
     },
     {
+        "id": "workflow-runs",
+        "description": "List workflow runs (one row per execution; the governance outcome spine).",
+        "command": "cc-devthrottle workflow runs",
+        "mutatesState": False,
+        "args": [{"name": "workflow", "required": False}, {"name": "status", "required": False}],
+    },
+    {
+        "id": "workflow-run-show",
+        "description": "Show one workflow run: pinned version, lifecycle, acceptance, criteria, participants.",
+        "command": "cc-devthrottle workflow run <run id>",
+        "mutatesState": False,
+        "args": [{"name": "run_id", "required": True}],
+    },
+    {
         "id": "workflow-reset",
         "description": "Reset a built-in Workflow to the shipped content (published as a new version).",
         "command": "cc-devthrottle workflow reset <id>",
@@ -886,6 +900,30 @@ def workflow_materialize(
 ) -> None:
     """Write the Workflow's instructions and helper files to this machine's cache and print the paths."""
     workflow_ops.materialize_workflow(workflow_id, version)
+
+
+@workflow_app.command("runs")
+def workflow_runs(
+    workflow: Optional[str] = typer.Option(
+        None, "--workflow", "-w", help="Only runs of this workflow id."
+    ),
+    status: Optional[str] = typer.Option(
+        None, "--status", "-s",
+        help="Only runs in this lifecycle status (created, active, awaiting-human, succeeded, failed, abandoned).",
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """List workflow runs (one row per execution of a workflow), newest first."""
+    workflow_ops.list_runs(workflow, status, json_output)
+
+
+@workflow_app.command("run")
+def workflow_run(
+    run_id: str = typer.Argument(..., help="The run id."),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """Show one workflow run: pinned version, lifecycle, acceptance, criteria, participants, proof."""
+    workflow_ops.show_run(run_id, json_output)
 
 
 @workflow_app.command("reset")

--- a/tools/cc-devthrottle/src/workflow_ops.py
+++ b/tools/cc-devthrottle/src/workflow_ops.py
@@ -213,6 +213,23 @@ class WorkflowClient:
             self._request("DELETE", f"/gateway/workflows/{workflow_id}")
         )
 
+    # ---- runs (the governance outcome spine, issue #1771) -------------------------------------
+
+    def list_runs(
+        self, workflow_id: Optional[str], status: Optional[str]
+    ) -> List[Dict[str, Any]]:
+        params = []
+        if workflow_id:
+            params.append(f"workflowId={workflow_id}")
+        if status:
+            params.append(f"status={status}")
+        path = "/gateway/workflow-runs" + (("?" + "&".join(params)) if params else "")
+        data = self._json_or_raise(self._request("GET", path))
+        return list(data.get("runs", []))
+
+    def get_run(self, run_id: str) -> Dict[str, Any]:
+        return self._json_or_raise(self._request("GET", f"/gateway/workflow-runs/{run_id}"))
+
 
 def _fail(message: str) -> None:
     err_console.print(f"[red]Error:[/red] {message}")
@@ -571,6 +588,83 @@ def delete_workflow(workflow_id: str, yes: bool) -> None:
         _fail(str(ex))
         return
     console.print(f"Archived '{workflow_id}'.")
+
+
+def list_runs(workflow_id: Optional[str], status: Optional[str], json_output: bool) -> None:
+    try:
+        runs = _client().list_runs(workflow_id, status)
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+
+    if json_output:
+        print(json.dumps({"runs": runs}, indent=2))
+        return
+
+    table = Table(box=box.SIMPLE)
+    table.add_column("Run id")
+    table.add_column("Workflow")
+    table.add_column("V", justify="right")
+    table.add_column("Name", overflow="fold")
+    table.add_column("Status")
+    table.add_column("Acceptance")
+    table.add_column("Created (UTC)")
+    for run in runs:
+        table.add_row(
+            (run.get("id") or "")[:8],
+            run.get("workflowId", ""),
+            str(run.get("workflowVersion", "")),
+            run.get("name", ""),
+            run.get("status", ""),
+            run.get("acceptanceStatus", ""),
+            (run.get("createdUtc") or "").replace("T", " ")[:19],
+        )
+    console.print(table)
+    console.print("Details with: cc-devthrottle workflow run <run id>")
+
+
+def show_run(run_id: str, json_output: bool) -> None:
+    try:
+        run = _client().get_run(run_id)
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+
+    if json_output:
+        print(json.dumps(run, indent=2))
+        return
+
+    console.print(f"[bold]{run.get('name', '')}[/bold]  (run {run.get('id')})")
+    console.print(
+        f"Workflow: {run.get('workflowId')} v{run.get('workflowVersion')}  "
+        f"Status: {run.get('status')}  Acceptance: {run.get('acceptanceStatus')}"
+    )
+    if run.get("acceptedBy"):
+        console.print(f"Accepted by: {run['acceptedBy']} at {run.get('acceptedUtc')}")
+    if run.get("outcome"):
+        console.print(f"Outcome: {run['outcome']}")
+    if run.get("missionId"):
+        console.print(f"Mission: {run['missionId']}")
+    criteria = run.get("criteriaResults") or []
+    if criteria:
+        console.print("Criteria:")
+        for c in criteria:
+            proof = f"  proof {c['proofUrl']}" if c.get("proofUrl") else ""
+            console.print(f"  - {c.get('criterionId')}: {c.get('status')}{proof}")
+    participants = run.get("participants") or []
+    if participants:
+        console.print("Participants:")
+        for p in participants:
+            left = f" (left {p['leftUtc']})" if p.get("leftUtc") else ""
+            console.print(
+                f"  - {p.get('role') or '?'} {p.get('sessionId')} "
+                f"[{p.get('agentKind')}] on {p.get('machine')}{left}"
+            )
+    links = run.get("proofLinks") or []
+    if links:
+        console.print("Proof links:")
+        for link in links:
+            console.print(f"  - {link.get('label') or 'link'}: {link.get('url')}")
 
 
 def materialize_workflow(workflow_id: str, version: Optional[int]) -> None:

--- a/tools/cc-devthrottle/tests/test_workflow_ops.py
+++ b/tools/cc-devthrottle/tests/test_workflow_ops.py
@@ -68,6 +68,8 @@ class TestActionsDiscoverability:
             "workflow-materialize",
             "workflow-reset",
             "workflow-delete",
+            "workflow-runs",
+            "workflow-run-show",
         } <= ids
 
 


### PR DESCRIPTION
Phase 4 of the approved Workflows plan (mission 9a955739), and the foundation issue thefrederiksen/devthrottle_internal#856 asked for: the outcome spine attaches to workflow RUNS, with Mission as the built-in workflow's run.

## What this does

- New workflow_runs table (tenant-scoped, one migration). A run pins the exact published version that governed it at creation - version row id, number, canonical content hash - and published versions referenced by runs are never deleted, so what conduct governed this run is answerable forever.
- Lifecycle and acceptance are SEPARATE: lifecycle is created / active / awaiting-human / succeeded / failed / abandoned with legal transitions enforced in one place (terminal is final; started/completed timestamps stamp automatically), acceptance is pending / accepted / rejected / waived with accepter identity and timestamp. Verified yield reads acceptance, never mere completion.
- Criteria results seed pending from the pinned version's declared outcome criteria and CANNOT be invented on a run. Proof links carry evidence. Participants are persisted run-to-session membership (session, agent kind, role, machine, join/leave history) recorded on the run directly - standalone runs have no Mission to derive membership from.
- Creating a mission through the Gateway now opens a run of the built-in mission workflow and returns the additive workflowRunId on the mission DTO. Mission stays the grouping record; the run is the governance object (reference, not merge).
- REST: POST/GET/GET{id}/PATCH /gateway/workflow-runs with workflow/status/mission filters. CLI: workflow runs (list) and workflow run <id> (detail), in the agent-discoverable actions.

## Proof

- Full solution suite: all seven projects, 6,296 passed, 0 failed. CLI suite: 86 passed.
- Eight new run-store tests: version pinning survives the catalog moving on; unknown/draft-only/archived workflows refuse runs; legal-moves-only lifecycle with terminal final; acceptance independent of lifecycle (accepted while active; back-to-pending clears the stamp); criteria update the seeded set only; duplicate participant join is a no-op and leave stamps history; list filters.
- One new HTTP test: POST /missions returns workflowRunId; the run is pinned to the published mission conduct's hash, anchored to the mission, and lists by missionId.

## Next

Phase 5: discoverability index + version-pinned seated sessions + the cross-agent live proof.