### PR TITLE
feat(gateway): migrate the snooze registry onto the EF data layer

### DIFF
--- a/src/CcDirector.Gateway.Tests/SnoozeExpirySweepTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeExpirySweepTests.cs
@@ -1,5 +1,7 @@
 using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
 using CcDirector.Gateway.Snooze;
+using CcDirector.Gateway.Tests.Data;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
@@ -25,19 +27,18 @@ namespace CcDirector.Gateway.Tests;
 /// </summary>
 public sealed class SnoozeExpirySweepTests : IDisposable
 {
-    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cc-snoozesweep-" + Guid.NewGuid().ToString("N"));
+    private readonly GatewayDbTestHarness _h = new();
+    private GatewayDatabase? _db;
+    private GatewayDatabase Db => _db ??= _h.Open();
     private readonly DateTime _now = new(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
 
-    private string Path_ => System.IO.Path.Combine(_dir, "snooze.json");
+    private SnoozeRegistry NewReg() => new(Db, _h.LegacyPath(Guid.NewGuid().ToString("N") + ".json"));
 
-    public void Dispose()
-    {
-        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { }
-    }
+    public void Dispose() => _h.Dispose();
 
     private (SnoozeRegistry reg, SnoozeExpirySweep sweep) Make(DateTime now)
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         return (reg, new SnoozeExpirySweep(reg, utcNow: () => now));
     }
 
@@ -115,7 +116,7 @@ public sealed class SnoozeExpirySweepTests : IDisposable
     {
         // Compare-and-clear: the pass snapshots the entries, and a snooze that lands while it is running
         // must win over the decision the pass made from the older value.
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         reg.Snooze("s1", _now.AddMinutes(-1), "dir-1"); // expired as the pass begins
 
         var sweep = new SnoozeExpirySweep(reg, utcNow: () =>

--- a/src/CcDirector.Gateway.Tests/SnoozeLandingObserverTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeLandingObserverTests.cs
@@ -1,5 +1,7 @@
 using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
 using CcDirector.Gateway.Snooze;
+using CcDirector.Gateway.Tests.Data;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
@@ -17,19 +19,18 @@ namespace CcDirector.Gateway.Tests;
 /// </summary>
 public sealed class SnoozeLandingObserverTests : IDisposable
 {
-    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cc-snoozeland-" + Guid.NewGuid().ToString("N"));
+    private readonly GatewayDbTestHarness _h = new();
+    private GatewayDatabase? _db;
+    private GatewayDatabase Db => _db ??= _h.Open();
     private readonly DateTime _now = new(2026, 7, 14, 12, 0, 0, DateTimeKind.Utc);
 
-    private string Path_ => System.IO.Path.Combine(_dir, "snooze.json");
+    private SnoozeRegistry NewReg() => new(Db, _h.LegacyPath(Guid.NewGuid().ToString("N") + ".json"));
 
-    public void Dispose()
-    {
-        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { }
-    }
+    public void Dispose() => _h.Dispose();
 
     private (SnoozeRegistry reg, SnoozeLandingObserver obs) Make(DateTime? now = null)
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         return (reg, new SnoozeLandingObserver(reg, () => now ?? _now));
     }
 

--- a/src/CcDirector.Gateway.Tests/SnoozeRegistryTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeRegistryTests.cs
@@ -1,30 +1,33 @@
+using System.Text.Json;
+using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Snooze;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Tests.Data;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// Unit tests for the Gateway-owned snooze registry (Snooze Length mission): the persisted
-/// <c>sessionId -&gt; SnoozeUntilUtc</c> map that is the one piece of new Gateway state. Covers the
-/// expiry predicate, the clear paths, the two bound-guards (per-Director removal and per-Director
-/// live-set prune), and the persistence contract (write-through + re-arm on load + corrupt quarantine).
-/// Every test uses an isolated temp path so it never touches the real snooze.json.
+/// Unit tests for the Gateway-owned snooze registry (Snooze Length mission) over the EF data layer (Hosted
+/// Gateway mission, Step 1b): the persisted <c>sessionId -&gt; SnoozeUntilUtc</c> map that is the one piece of
+/// new Gateway state. Covers the expiry predicate, the clear paths, the two bound-guards (per-Director
+/// removal and per-Director live-set prune), the armed/deferred invariant, and the persistence contract
+/// (a fresh registry over the same database re-arms; the one-time JSON import and its fail-loud/drop rules).
 /// </summary>
 public sealed class SnoozeRegistryTests : IDisposable
 {
-    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cc-snooze-" + Guid.NewGuid().ToString("N"));
+    private readonly GatewayDbTestHarness _h = new();
+    private GatewayDatabase? _db;
+    private GatewayDatabase Db => _db ??= _h.Open();
 
-    private string Path_ => System.IO.Path.Combine(_dir, "snooze.json");
+    private SnoozeRegistry NewReg() => new(Db, _h.LegacyPath(Guid.NewGuid().ToString("N") + ".json"));
 
-    public void Dispose()
-    {
-        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { }
-    }
+    public void Dispose() => _h.Dispose();
 
     [Fact]
     public void IsExpired_is_false_for_a_future_snooze_and_true_once_the_time_passes()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         var now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
         reg.Snooze("s1", now.AddMinutes(60), "dir-1");
 
@@ -38,7 +41,7 @@ public sealed class SnoozeRegistryTests : IDisposable
     [Fact]
     public void IsExpired_is_false_for_a_session_with_no_entry()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         Assert.False(reg.IsExpired("nobody", DateTime.UtcNow));
         Assert.False(reg.Contains("nobody"));
     }
@@ -46,7 +49,7 @@ public sealed class SnoozeRegistryTests : IDisposable
     [Fact]
     public void SnoozeUntilFor_returns_the_armed_deadline()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         var now = new DateTime(2026, 7, 16, 12, 0, 0, DateTimeKind.Utc);
         var until = now.AddHours(4);
         reg.Snooze("s1", until, "dir-1");
@@ -60,7 +63,7 @@ public sealed class SnoozeRegistryTests : IDisposable
     [Fact]
     public void SnoozeUntilFor_is_null_for_a_deferred_snooze()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         // A deferral has no clock yet - it starts when the work ends - so there is no deadline to show.
         reg.SnoozeDeferred("s1", 720, "dir-1");
 
@@ -70,14 +73,14 @@ public sealed class SnoozeRegistryTests : IDisposable
     [Fact]
     public void SnoozeUntilFor_is_null_for_a_session_with_no_entry()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         Assert.Null(reg.SnoozeUntilFor("nobody"));
     }
 
     [Fact]
     public void Snooze_again_overwrites_the_prior_time_no_escalation()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         var now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
         reg.Snooze("s1", now.AddMinutes(1), "dir-1");
         Assert.True(reg.IsExpired("s1", now.AddMinutes(2)));   // first snooze would be expired
@@ -90,7 +93,7 @@ public sealed class SnoozeRegistryTests : IDisposable
     [Fact]
     public void Clear_removes_the_entry_and_reports_whether_there_was_one()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         reg.Snooze("s1", DateTime.UtcNow.AddMinutes(60), "dir-1");
 
         Assert.True(reg.Clear("s1"));
@@ -101,7 +104,7 @@ public sealed class SnoozeRegistryTests : IDisposable
     [Fact]
     public void ClearIfUnchanged_clears_only_when_the_time_has_not_moved()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         var now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
         var until = now.AddMinutes(60);
         reg.Snooze("s1", until, "dir-1");
@@ -119,7 +122,7 @@ public sealed class SnoozeRegistryTests : IDisposable
     [Fact]
     public void ClearForDirector_drops_only_that_directors_entries()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         var until = DateTime.UtcNow.AddMinutes(60);
         reg.Snooze("a1", until, "dir-1");
         reg.Snooze("a2", until, "dir-1");
@@ -134,7 +137,7 @@ public sealed class SnoozeRegistryTests : IDisposable
     [Fact]
     public void PruneNotLive_drops_only_that_directors_gone_sessions()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         var until = DateTime.UtcNow.AddMinutes(60);
         reg.Snooze("live", until, "dir-1");
         reg.Snooze("exited", until, "dir-1");
@@ -153,7 +156,7 @@ public sealed class SnoozeRegistryTests : IDisposable
     [Fact]
     public void Entries_returned_snapshot_is_detached_from_the_live_store()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         reg.Snooze("s1", DateTime.UtcNow.AddMinutes(60), "dir-1");
 
         var snapshot = reg.Entries();
@@ -167,11 +170,11 @@ public sealed class SnoozeRegistryTests : IDisposable
     public void Pending_snooze_survives_a_restart_re_armed_from_disk()
     {
         var now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
-        var reg1 = new SnoozeRegistry(Path_);
+        var reg1 = NewReg();
         reg1.Snooze("s1", now.AddMinutes(60), "dir-1");
 
         // A fresh registry over the same file = a Gateway restart. The pending snooze must re-arm.
-        var reg2 = new SnoozeRegistry(Path_);
+        var reg2 = NewReg();
         Assert.True(reg2.Contains("s1"));
         Assert.False(reg2.IsExpired("s1", now.AddMinutes(30)));
         Assert.True(reg2.IsExpired("s1", now.AddMinutes(90)));
@@ -181,10 +184,10 @@ public sealed class SnoozeRegistryTests : IDisposable
     public void An_already_past_snooze_reloads_as_expired_so_it_fires_immediately()
     {
         var now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
-        var reg1 = new SnoozeRegistry(Path_);
+        var reg1 = NewReg();
         reg1.Snooze("s1", now.AddMinutes(-5), "dir-1"); // already past when written
 
-        var reg2 = new SnoozeRegistry(Path_);          // restart
+        var reg2 = NewReg();          // restart
         Assert.True(reg2.IsExpired("s1", now));        // reads as expired -> the first sweep fires it
     }
 
@@ -196,7 +199,7 @@ public sealed class SnoozeRegistryTests : IDisposable
         // THE RULING (owner, 14 July 2026): the clock starts when the work ENDS. So a hold asked for
         // while the agent is working records what was ASKED FOR and nothing else - arming a clock at
         // request time is what let it be deleted (or expire) before the hold had even landed.
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
 
         reg.SnoozeDeferred("s1", 720, "dir-1");
 
@@ -209,7 +212,7 @@ public sealed class SnoozeRegistryTests : IDisposable
     [Fact]
     public void A_deferred_entry_is_never_expired_however_long_it_waits()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         var now = new DateTime(2026, 7, 14, 12, 0, 0, DateTimeKind.Utc);
         reg.SnoozeDeferred("s1", 1, "dir-1");   // a ONE-minute snooze...
 
@@ -219,7 +222,7 @@ public sealed class SnoozeRegistryTests : IDisposable
     [Fact]
     public void Land_starts_the_clock_from_the_landing_instant()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         var landedAt = new DateTime(2026, 7, 14, 12, 0, 0, DateTimeKind.Utc);
         reg.SnoozeDeferred("s1", 720, "dir-1");
 
@@ -237,7 +240,7 @@ public sealed class SnoozeRegistryTests : IDisposable
     public void Land_is_idempotent_and_never_restarts_a_running_clock()
     {
         // Two callers land a deferral: the push seam and the sweep backstop. Whichever is first wins.
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         var landedAt = new DateTime(2026, 7, 14, 12, 0, 0, DateTimeKind.Utc);
         reg.SnoozeDeferred("s1", 720, "dir-1");
         reg.Land("s1", landedAt);
@@ -249,7 +252,7 @@ public sealed class SnoozeRegistryTests : IDisposable
     [Fact]
     public void Land_on_an_absent_session_is_a_no_op()
     {
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         Assert.False(reg.Land("nobody", DateTime.UtcNow));
     }
 
@@ -259,7 +262,7 @@ public sealed class SnoozeRegistryTests : IDisposable
         // The sweep snapshots a DEFERRED entry, then the hold lands mid-pass and the clock starts. A
         // decision taken against the old snapshot must not delete the freshly-armed snooze - which is
         // defect 20 in miniature, one pass later.
-        var reg = new SnoozeRegistry(Path_);
+        var reg = NewReg();
         reg.SnoozeDeferred("s1", 720, "dir-1");
         reg.Land("s1", DateTime.UtcNow);
 
@@ -270,38 +273,138 @@ public sealed class SnoozeRegistryTests : IDisposable
     [Fact]
     public void A_deferred_entry_survives_a_restart_with_its_length_intact()
     {
-        var reg1 = new SnoozeRegistry(Path_);
+        var reg1 = NewReg();
         reg1.SnoozeDeferred("s1", 720, "dir-1");
 
-        var reg2 = new SnoozeRegistry(Path_);   // restart
+        var reg2 = NewReg();   // restart
         var e = Assert.Single(reg2.Entries());
         Assert.True(e.IsDeferred);
         Assert.Equal(720, e.PendingMinutes);
     }
 
     [Fact]
-    public void A_row_with_neither_a_deadline_nor_a_length_is_dropped_on_load()
+    public void Import_DropsARowWithNeitherADeadlineNorALength()
     {
-        // Such a row could never expire and never land - a snooze that would silently never return.
-        // Drop it loudly rather than keep a promise that cannot be kept.
-        Directory.CreateDirectory(_dir);
-        File.WriteAllText(Path_, """{"entries":[{"sessionId":"s1","snoozeUntilUtc":null,"directorId":"d","pendingMinutes":null}]}""");
+        // Such a row could never expire and never land - a snooze that would silently never return. The
+        // one-time import drops it loudly (mirroring the old load) rather than keep a promise it cannot keep.
+        var legacy = LegacyFile();
+        File.WriteAllText(legacy, """{"entries":[{"sessionId":"s1","snoozeUntilUtc":null,"directorId":"d","pendingMinutes":null}]}""");
 
-        var reg = new SnoozeRegistry(Path_);
+        var reg = new SnoozeRegistry(Db, legacy);
 
         Assert.Empty(reg.Entries());
     }
 
     [Fact]
-    public void A_corrupt_file_is_quarantined_and_the_registry_starts_empty()
+    public void Import_CorruptLegacyJson_FailsLoud_AndLeavesTheFileInPlace()
     {
-        Directory.CreateDirectory(_dir);
-        File.WriteAllText(Path_, "{ this is not valid json ");
+        var legacy = LegacyFile();
+        const string corrupt = "{ this is not valid json ";
+        File.WriteAllText(legacy, corrupt);
 
-        var reg = new SnoozeRegistry(Path_);   // must not throw - the Gateway still boots
-        Assert.Empty(reg.Entries());
+        // Fail-loud, no partial import, no silent quarantine (the EF data-layer contract).
+        Assert.Throws<InvalidOperationException>(() => new SnoozeRegistry(Db, legacy));
+        Assert.True(File.Exists(legacy));
+        Assert.Equal(corrupt, File.ReadAllText(legacy));
+    }
 
-        var quarantined = Directory.GetFiles(_dir, "snooze.json.corrupt-*");
-        Assert.Single(quarantined);            // the bad bytes were preserved, not overwritten
+    [Fact]
+    public void LegacyJson_ImportedOnce_ArmedAndDeferred_InvariantPreserved_ThenRenamedAside()
+    {
+        var now = new DateTime(2026, 7, 16, 12, 0, 0, DateTimeKind.Utc);
+        var baseline = new DateTime(2026, 7, 16, 11, 0, 0, DateTimeKind.Utc);
+        var legacy = LegacyFile();
+        // An ARMED entry (a deadline, no pending) and a DEFERRED entry (a length, no deadline), plus the
+        // owner-turn baseline - exactly the two shapes the old store wrote.
+        File.WriteAllText(legacy, JsonSerializer.Serialize(new
+        {
+            entries = new object[]
+            {
+                new { sessionId = "armed-1", snoozeUntilUtc = (DateTime?)now.AddHours(4), directorId = "dir-1", pendingMinutes = (int?)null, ownerTurnBaselineUtc = (DateTime?)baseline },
+                new { sessionId = "deferred-1", snoozeUntilUtc = (DateTime?)null, directorId = "dir-2", pendingMinutes = (int?)720, ownerTurnBaselineUtc = (DateTime?)null },
+            },
+        }));
+
+        var reg = new SnoozeRegistry(Db, legacy);
+
+        var armed = reg.Entries().Single(e => e.SessionId == "armed-1");
+        Assert.False(armed.IsDeferred);
+        Assert.Equal(now.AddHours(4), armed.SnoozeUntilUtc);
+        Assert.Equal(DateTimeKind.Utc, armed.SnoozeUntilUtc!.Value.Kind);
+        Assert.Null(armed.PendingMinutes);
+        Assert.Equal("dir-1", armed.DirectorId);
+        Assert.Equal(baseline, armed.OwnerTurnBaselineUtc);
+
+        var deferred = reg.Entries().Single(e => e.SessionId == "deferred-1");
+        Assert.True(deferred.IsDeferred);
+        Assert.Null(deferred.SnoozeUntilUtc);
+        Assert.Equal(720, deferred.PendingMinutes);
+        Assert.Equal("dir-2", deferred.DirectorId);
+        Assert.Null(deferred.OwnerTurnBaselineUtc);
+
+        // The armed/deferred invariant is reflected in the hold state for both.
+        Assert.Equal(HoldStates.Held, reg.HoldStateFor("armed-1", now));
+        Assert.Equal(HoldStates.DeferredHold, reg.HoldStateFor("deferred-1", now));
+
+        // Renamed aside (kept as a backup); a fresh registry does not re-import.
+        Assert.False(File.Exists(legacy));
+        Assert.Single(Directory.GetFiles(Path.GetDirectoryName(legacy)!, Path.GetFileName(legacy) + ".migrated-*"));
+        Assert.Equal(2, new SnoozeRegistry(Db, legacy).Entries().Count);
+    }
+
+    [Fact]
+    public void Import_NullRoot_FailsLoud_AndLeavesTheFileInPlace()
+    {
+        // The JSON literal "null" is an unreadable store, not an empty one: fail loud and leave the file in
+        // place, rather than committing zero rows and renaming an invalid store aside as if it had migrated.
+        var legacy = LegacyFile();
+        File.WriteAllText(legacy, "null");
+
+        Assert.Throws<InvalidOperationException>(() => new SnoozeRegistry(Db, legacy));
+        Assert.True(File.Exists(legacy));
+    }
+
+    [Fact]
+    public void Import_NullEntriesList_FailsLoud_AndLeavesTheFileInPlace()
+    {
+        var legacy = LegacyFile();
+        File.WriteAllText(legacy, """{"entries":null}""");
+
+        Assert.Throws<InvalidOperationException>(() => new SnoozeRegistry(Db, legacy));
+        Assert.True(File.Exists(legacy));
+    }
+
+    [Fact]
+    public void Import_RetainsANullDirectorId_ExactlyAsTheLegacyStoreHeld()
+    {
+        // The old store retained a null DirectorId exactly as read (it never coerced it to ""), so the import
+        // must too - a null stays null on round-trip through DirectorIdFor and Entries.
+        var legacy = LegacyFile();
+        File.WriteAllText(legacy, """{"entries":[{"sessionId":"s1","snoozeUntilUtc":"2026-07-16T16:00:00Z","directorId":null,"pendingMinutes":null}]}""");
+
+        var reg = new SnoozeRegistry(Db, legacy);
+
+        Assert.Null(reg.DirectorIdFor("s1"));
+        Assert.Null(Assert.Single(reg.Entries()).DirectorId);
+    }
+
+    [Fact]
+    public void Entries_IsOrderedBySessionId_Deterministic()
+    {
+        // The old Dictionary enumeration order was undefined; Entries() now returns a stable session-id order.
+        var reg = NewReg();
+        var until = new DateTime(2026, 7, 16, 12, 0, 0, DateTimeKind.Utc);
+        reg.Snooze("s-charlie", until, "d");
+        reg.Snooze("s-alpha", until, "d");
+        reg.Snooze("s-bravo", until, "d");
+
+        Assert.Equal(new[] { "s-alpha", "s-bravo", "s-charlie" }, reg.Entries().Select(e => e.SessionId).ToArray());
+    }
+
+    private string LegacyFile()
+    {
+        var legacy = _h.LegacyPath("snooze-" + Guid.NewGuid().ToString("N") + ".json");
+        Directory.CreateDirectory(Path.GetDirectoryName(legacy)!);
+        return legacy;
     }
 }

--- a/src/CcDirector.Gateway/Data/Entities/SnoozeEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/SnoozeEntity.cs
@@ -1,0 +1,37 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// The persisted form of one pending snooze (<see cref="Snooze.SnoozeRegistry.SnoozeEntry"/>) in the EF data
+/// layer: one row in the <c>snoozes</c> table, keyed by <see cref="SessionId"/>.
+///
+/// <see cref="SessionId"/> is the PRIMARY KEY directly - it is an externally supplied, globally unique GUID
+/// string (compared ordinally), the natural key, so there is no surrogate id and no case-fold question (the
+/// worklist name problem does not arise here). The armed-vs-deferred invariant (exactly one of
+/// <see cref="SnoozeUntilUtc"/> / <see cref="PendingMinutes"/> non-null) is maintained in the store logic,
+/// not by a database constraint - matching the legacy behaviour exactly and staying provider-agnostic.
+///
+/// <see cref="SnoozeUntilUtc"/> and <see cref="OwnerTurnBaselineUtc"/> are UTC and round-trip through the
+/// backbone's UTC DateTime convention (which registers converters for both DateTime and nullable DateTime,
+/// so a null stays null and a value comes back as UTC).
+/// </summary>
+public sealed class SnoozeEntity : TenantScopedEntity
+{
+    /// <summary>The session this snooze holds. Primary key (an ordinal, globally unique GUID string).</summary>
+    public string SessionId { get; set; } = "";
+
+    /// <summary>The absolute UTC return time of an ARMED snooze, or null for a DEFERRED one.</summary>
+    public DateTime? SnoozeUntilUtc { get; set; }
+
+    /// <summary>
+    /// The Director that owned the session when the snooze was set (used to bound the registry). NULLABLE:
+    /// the legacy store retained a null DirectorId exactly as read (it never coerced it to ""), so the
+    /// column is nullable and the import preserves the exact value - a null stays null on round-trip.
+    /// </summary>
+    public string? DirectorId { get; set; }
+
+    /// <summary>The remembered length of a DEFERRED snooze (clock starts on landing), or null when armed.</summary>
+    public int? PendingMinutes { get; set; }
+
+    /// <summary>The owning Director's own last-owner-turn stamp captured when the hold was asked for, or null.</summary>
+    public DateTime? OwnerTurnBaselineUtc { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -67,6 +67,9 @@ public sealed class GatewayDbContext : DbContext
     /// <summary>Workflow runs (<c>workflow_runs</c>) - the governance outcome spine (issue #1771).</summary>
     public DbSet<WorkflowRunEntity> WorkflowRuns => Set<WorkflowRunEntity>();
 
+    /// <summary>Pending session snoozes (<c>snoozes</c>), keyed by session id.</summary>
+    public DbSet<SnoozeEntity> Snoozes => Set<SnoozeEntity>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -153,6 +156,16 @@ public sealed class GatewayDbContext : DbContext
             b.OwnsMany(e => e.Participants, o => o.ToJson());
         });
 
+        modelBuilder.Entity<SnoozeEntity>(b =>
+        {
+            b.ToTable("snoozes");
+            // SessionId is the natural key - a globally unique, ordinally-compared GUID string - so it is the
+            // primary key directly (no surrogate id). SQLite's default BINARY text collation compares it
+            // ordinally, matching the legacy Dictionary(StringComparer.Ordinal). The armed-vs-deferred
+            // invariant is kept in the store, not as a database CHECK (provider-divergent), matching today.
+            b.HasKey(e => e.SessionId);
+        });
+
         // Tenant scoping - the tenant_id column plus the global query filter - applied uniformly to every
         // entity that derives from TenantScopedEntity, so future stores inherit it by deriving from the base.
         ApplyTenantScope<CronJobEntity>(modelBuilder);
@@ -163,6 +176,7 @@ public sealed class GatewayDbContext : DbContext
         ApplyTenantScope<WorkflowVersionEntity>(modelBuilder);
         ApplyTenantScope<WorkflowFileEntity>(modelBuilder);
         ApplyTenantScope<WorkflowRunEntity>(modelBuilder);
+        ApplyTenantScope<SnoozeEntity>(modelBuilder);
 
         ApplyCommonSubsetConventions(modelBuilder);
     }

--- a/src/CcDirector.Gateway/Data/Migrations/20260718021042_AddSnoozes.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718021042_AddSnoozes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718021042_AddSnoozes")]
+    partial class AddSnoozes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260718021042_AddSnoozes.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718021042_AddSnoozes.cs
@@ -1,0 +1,43 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSnoozes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "snoozes",
+                columns: table => new
+                {
+                    SessionId = table.Column<string>(type: "TEXT", nullable: false),
+                    SnoozeUntilUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    DirectorId = table.Column<string>(type: "TEXT", nullable: true),
+                    PendingMinutes = table.Column<int>(type: "INTEGER", nullable: true),
+                    OwnerTurnBaselineUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_snoozes", x => x.SessionId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_snoozes_tenant_id",
+                table: "snoozes",
+                column: "tenant_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "snoozes");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -603,11 +603,13 @@ public sealed class GatewayHost : IAsyncDisposable
         // Workflow runs (phase 4, issue #1771): built after the catalog store so the built-ins a run
         // pins are already seeded.
         _workflowRuns = new Workflows.WorkflowRunStore(_gatewayDb);
-        // Snooze Length mission: the persisted snooze registry (sessionId -> SnoozeUntilUtc). Loaded here
-        // so a Gateway restart re-arms every pending snooze; an entry already past its time simply fires
-        // on the first sweep. Tests MUST pass an isolated path so they never touch the real store. The
-        // registry is bounded by dropping a removed Director's entries so they do not accumulate on disk.
-        _snoozeRegistry = new Snooze.SnoozeRegistry(snoozePath ?? Path.Combine(CcStorage.Root(), "snooze.json"));
+        // Snooze Length mission: the persisted snooze registry (sessionId -> SnoozeUntilUtc), now in the
+        // snoozes table of the EF data layer - a Gateway restart re-arms every pending snooze from the
+        // database; an entry already past its time simply fires on the first sweep. The path argument is the
+        // LEGACY snooze.json, imported once on first upgrade then renamed aside. Tests MUST pass an isolated
+        // path so they never touch the real legacy file. The registry is bounded by dropping a removed
+        // Director's entries so they do not accumulate.
+        _snoozeRegistry = new Snooze.SnoozeRegistry(_gatewayDb, snoozePath ?? Path.Combine(CcStorage.Root(), "snooze.json"));
         Registry.OnDirectorRemoved += id => _snoozeRegistry.ClearForDirector(id);
         // THE PUSH SEAM where this Gateway drives the hold machine off the facts Directors report. The
         // DirectorHub (constructed per-invocation by SignalR) folds every pushed session through this one

--- a/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
+++ b/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
@@ -1,62 +1,67 @@
 using System.Text.Json;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
 
 namespace CcDirector.Gateway.Snooze;
 
 /// <summary>
 /// The Gateway-owned, restart-surviving snooze registry (Snooze Length mission,
 /// docs/architecture/snooze-length-mission-2026-07-11.md). A snooze is a time-bounded hold with a
-/// GUARANTEED return: the map <c>sessionId -&gt; SnoozeUntilUtc</c> is the one piece of new
-/// Gateway-owned state, and it is the thing that keeps a snoozed session from vanishing when its
-/// owning Director dies. The timer MUST live here (not on the Director) precisely so it survives a
-/// dead Director - the whole point of the mission.
+/// GUARANTEED return: the map <c>sessionId -&gt; SnoozeUntilUtc</c> is the one piece of new Gateway-owned
+/// state, and it is the thing that keeps a snoozed session from vanishing when its owning Director dies. The
+/// timer MUST live here (not on the Director) precisely so it survives a dead Director - the whole point of
+/// the mission.
 ///
-/// Each entry also carries the owning <see cref="SnoozeEntry.DirectorId"/> so the registry can be
-/// bounded: when a Director is removed from the fleet (<c>Registry.OnDirectorRemoved</c>), every
-/// entry it owned is dropped, so entries for sessions that permanently left the roster do not
-/// accumulate on disk.
+/// Each entry also carries the owning <see cref="SnoozeEntry.DirectorId"/> so the registry can be bounded:
+/// when a Director is removed from the fleet (<c>Registry.OnDirectorRemoved</c>), every entry it owned is
+/// dropped, so entries for sessions that permanently left the roster do not accumulate.
 ///
-/// PERSISTENCE (WorkListStore precedent): the whole registry lives in ONE plain JSON file at the
-/// path the constructor receives (production: snooze.json in the Gateway data dir). Every mutation
-/// writes through immediately with an atomic temp-file + rename, so a crash mid-write can never
-/// half-truncate the store. On construction the file is loaded back so every pending snooze is
-/// re-armed - an entry already past its time at startup simply reads as expired on the first sweep
-/// and fires immediately (the mission's "fire any already-past entry immediately" rule), rather than
-/// being lost. A corrupt file is quarantined (never silently overwritten) and the registry starts
-/// empty so the Gateway still boots.
+/// PERSISTENCE (Hosted Gateway mission, Step 1b): entries live in the EF data layer's <c>snoozes</c> table
+/// (SQLite locally), NOT the old hand-rolled <c>snooze.json</c>. The public API and observable behavior are
+/// unchanged. A pending snooze survives a restart because it is in the database; an entry already past its
+/// time reads as expired on the first sweep and fires immediately (the mission rule), exactly as before.
 ///
-/// NO FALLBACK (CLAUDE.md): a failed persist is a LOGGED error that PROPAGATES - a snooze that
-/// cannot be written to disk would not survive a restart, so the caller fails loudly rather than
-/// silently running a snooze that will not come back.
+/// ONE-TIME IMPORT: on first run after the upgrade, if a legacy <c>snooze.json</c> exists and the table is
+/// empty, every entry is imported inside one transaction - mirroring the old load exactly: a row with an
+/// empty session id is skipped, a row carrying neither a deadline nor a deferred length is dropped loudly
+/// (it could never expire or land), and a duplicate session id is last-wins - then the JSON is renamed aside.
+/// The rename-recovery is the idempotent, best-effort one the worklist store established. A parse error is
+/// fail-loud and all-or-nothing.
+///
+/// NO FALLBACK (the repository's no-fallback rule): a failed persist propagates - a snooze that cannot be written would not survive a
+/// restart, so the caller fails loudly rather than silently running a snooze that will not come back. The
+/// Gateway is single-writer: every operation runs under this registry's write lock over a fresh pooled
+/// context.
 /// </summary>
 public sealed class SnoozeRegistry
 {
     private readonly object _gate = new();
-    private readonly string _path;
-
-    // sessionId -> entry. Ordinal keys: a session id is an exact GUID string.
-    private readonly Dictionary<string, SnoozeEntry> _entries = new(StringComparer.Ordinal);
+    private readonly GatewayDatabase _db;
+    private readonly string _legacyJsonPath;
 
     private static readonly JsonSerializerOptions FileJsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         PropertyNameCaseInsensitive = true,
-        WriteIndented = true,
     };
 
-    /// <param name="path">
-    /// The JSON file the registry persists to. REQUIRED so no caller can silently land on the real
-    /// user's file: production (<see cref="GatewayHost"/>) passes snooze.json in the Gateway data
-    /// dir; tests pass an isolated temp path.
-    /// </param>
-    /// <exception cref="ArgumentException">The path is null/empty/whitespace.</exception>
-    public SnoozeRegistry(string path)
+    /// <param name="db">The Gateway EF database this registry reads and writes through.</param>
+    /// <param name="legacyJsonPath">The legacy <c>snooze.json</c> path to import ONCE if it exists and the
+    /// table is empty. REQUIRED (no silent default).</param>
+    /// <exception cref="ArgumentNullException">The database is null.</exception>
+    /// <exception cref="ArgumentException">The legacy path is null/empty/whitespace.</exception>
+    public SnoozeRegistry(GatewayDatabase db, string legacyJsonPath)
     {
-        if (string.IsNullOrWhiteSpace(path))
-            throw new ArgumentException("registry path is required", nameof(path));
-        _path = path;
-        Load();
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        if (string.IsNullOrWhiteSpace(legacyJsonPath))
+            throw new ArgumentException("legacy json path is required", nameof(legacyJsonPath));
+        _legacyJsonPath = legacyJsonPath;
+
+        lock (_gate)
+            ImportLegacyJsonIfNeeded();
     }
 
     /// <summary>
@@ -124,8 +129,9 @@ public sealed class SnoozeRegistry
 
         lock (_gate)
         {
-            _entries[sessionId] = new SnoozeEntry(sessionId, untilUtc.ToUniversalTime(), directorId ?? "", null, ownerTurnBaselineUtc);
-            Save();
+            using var ctx = _db.CreateContext();
+            Upsert(ctx, sessionId, untilUtc.ToUniversalTime(), directorId ?? "", null, ownerTurnBaselineUtc);
+            ctx.SaveChanges();
             FileLog.Write($"[SnoozeRegistry] Snooze: sid={sessionId}, untilUtc={untilUtc.ToUniversalTime():O}, director={directorId}");
         }
     }
@@ -150,8 +156,9 @@ public sealed class SnoozeRegistry
 
         lock (_gate)
         {
-            _entries[sessionId] = new SnoozeEntry(sessionId, null, directorId ?? "", minutes, ownerTurnBaselineUtc);
-            Save();
+            using var ctx = _db.CreateContext();
+            Upsert(ctx, sessionId, null, directorId ?? "", minutes, ownerTurnBaselineUtc);
+            ctx.SaveChanges();
             FileLog.Write($"[SnoozeRegistry] SnoozeDeferred: sid={sessionId}, minutes={minutes} (clock starts when the work ends), director={directorId}");
         }
     }
@@ -173,7 +180,10 @@ public sealed class SnoozeRegistry
         if (string.IsNullOrWhiteSpace(sessionId)) return false;
         lock (_gate)
         {
-            if (!_entries.TryGetValue(sessionId, out var e) || !e.IsDeferred)
+            using var ctx = _db.CreateContext();
+            var e = Find(ctx, sessionId);
+            // Only a deferred entry (no deadline yet) can land; a missing or already-armed one is a no-op.
+            if (e is null || e.SnoozeUntilUtc is not null)
                 return false;
             // A deferred entry always carries its length (the record's invariant), so a missing one is a
             // real defect, not something to paper over with a default. Fail loudly.
@@ -182,8 +192,9 @@ public sealed class SnoozeRegistry
                     $"deferred snooze entry for session {sessionId} has no PendingMinutes; the registry is corrupt");
 
             var untilUtc = nowUtc.ToUniversalTime().AddMinutes(minutes);
-            _entries[sessionId] = e with { SnoozeUntilUtc = untilUtc, PendingMinutes = null };
-            Save();
+            e.SnoozeUntilUtc = untilUtc;
+            e.PendingMinutes = null;
+            ctx.SaveChanges();
             FileLog.Write($"[SnoozeRegistry] Land: sid={sessionId}, deferred hold landed -> clock started, untilUtc={untilUtc:O} ({minutes} min)");
             return true;
         }
@@ -199,8 +210,11 @@ public sealed class SnoozeRegistry
         if (string.IsNullOrWhiteSpace(sessionId)) return false;
         lock (_gate)
         {
-            if (!_entries.Remove(sessionId)) return false;
-            Save();
+            using var ctx = _db.CreateContext();
+            var e = Find(ctx, sessionId);
+            if (e is null) return false;
+            ctx.Snoozes.Remove(e);
+            ctx.SaveChanges();
             FileLog.Write($"[SnoozeRegistry] Clear: sid={sessionId}");
             return true;
         }
@@ -209,22 +223,19 @@ public sealed class SnoozeRegistry
     /// <summary>
     /// Drop every entry owned by <paramref name="directorId"/>. Called from
     /// <c>Registry.OnDirectorRemoved</c> so entries for sessions whose Director permanently left the
-    /// fleet do not accumulate on disk. Returns the number of entries removed; persists once if any.
+    /// fleet do not accumulate. Returns the number of entries removed; persists once if any.
     /// </summary>
     public int ClearForDirector(string directorId)
     {
         if (string.IsNullOrWhiteSpace(directorId)) return 0;
         lock (_gate)
         {
-            var gone = _entries.Values
-                .Where(e => string.Equals(e.DirectorId, directorId, StringComparison.Ordinal))
-                .Select(e => e.SessionId)
-                .ToList();
-            foreach (var sid in gone)
-                _entries.Remove(sid);
+            using var ctx = _db.CreateContext();
+            var gone = ctx.Snoozes.Where(e => e.DirectorId == directorId).ToList();
             if (gone.Count > 0)
             {
-                Save();
+                ctx.Snoozes.RemoveRange(gone);
+                ctx.SaveChanges();
                 FileLog.Write($"[SnoozeRegistry] ClearForDirector: director={directorId}, removed={gone.Count}");
             }
             return gone.Count;
@@ -248,12 +259,14 @@ public sealed class SnoozeRegistry
         if (string.IsNullOrWhiteSpace(sessionId)) return false;
         lock (_gate)
         {
-            if (_entries.TryGetValue(sessionId, out var e)
+            using var ctx = _db.CreateContext();
+            var e = Find(ctx, sessionId);
+            if (e is not null
                 && e.SnoozeUntilUtc == expectedUntilUtc?.ToUniversalTime()
                 && e.PendingMinutes == expectedPendingMinutes)
             {
-                _entries.Remove(sessionId);
-                Save();
+                ctx.Snoozes.Remove(e);
+                ctx.SaveChanges();
                 FileLog.Write($"[SnoozeRegistry] ClearIfUnchanged: sid={sessionId} (unchanged since the sweep read it)");
                 return true;
             }
@@ -274,16 +287,14 @@ public sealed class SnoozeRegistry
         liveSessionIds ??= new HashSet<string>(StringComparer.Ordinal);
         lock (_gate)
         {
-            var gone = _entries.Values
-                .Where(e => string.Equals(e.DirectorId, directorId, StringComparison.Ordinal)
-                            && !liveSessionIds.Contains(e.SessionId))
-                .Select(e => e.SessionId)
+            using var ctx = _db.CreateContext();
+            var gone = ctx.Snoozes.Where(e => e.DirectorId == directorId).ToList()
+                .Where(e => !liveSessionIds.Contains(e.SessionId))
                 .ToList();
-            foreach (var sid in gone)
-                _entries.Remove(sid);
             if (gone.Count > 0)
             {
-                Save();
+                ctx.Snoozes.RemoveRange(gone);
+                ctx.SaveChanges();
                 FileLog.Write($"[SnoozeRegistry] PruneNotLive: director={directorId}, removed={gone.Count}");
             }
             return gone.Count;
@@ -304,9 +315,13 @@ public sealed class SnoozeRegistry
     {
         if (string.IsNullOrWhiteSpace(sessionId)) return false;
         lock (_gate)
-            return _entries.TryGetValue(sessionId, out var e)
+        {
+            using var ctx = _db.CreateContext();
+            var e = Find(ctx, sessionId, tracking: false);
+            return e is not null
                 && e.SnoozeUntilUtc is DateTime untilUtc
                 && nowUtc.ToUniversalTime() >= untilUtc;
+        }
     }
 
     /// <summary>
@@ -330,7 +345,9 @@ public sealed class SnoozeRegistry
         if (string.IsNullOrWhiteSpace(sessionId)) return HoldStates.None;
         lock (_gate)
         {
-            if (!_entries.TryGetValue(sessionId, out var e))
+            using var ctx = _db.CreateContext();
+            var e = Find(ctx, sessionId, tracking: false);
+            if (e is null)
                 return HoldStates.None;
             if (e.SnoozeUntilUtc is not DateTime untilUtc)
                 return HoldStates.DeferredHold;
@@ -350,7 +367,10 @@ public sealed class SnoozeRegistry
     {
         if (string.IsNullOrWhiteSpace(sessionId)) return null;
         lock (_gate)
-            return _entries.TryGetValue(sessionId, out var e) ? e.SnoozeUntilUtc : null;
+        {
+            using var ctx = _db.CreateContext();
+            return Find(ctx, sessionId, tracking: false)?.SnoozeUntilUtc;
+        }
     }
 
     /// <summary>
@@ -367,25 +387,28 @@ public sealed class SnoozeRegistry
         if (string.IsNullOrWhiteSpace(sessionId) || lastOwnerTurnAtUtc is null) return false;
         lock (_gate)
         {
-            if (!_entries.TryGetValue(sessionId, out var e)) return false;
-            if (!e.SupersededByOwnerTurn(lastOwnerTurnAtUtc)) return false;
-            _entries.Remove(sessionId);
-            Save();
+            using var ctx = _db.CreateContext();
+            var e = Find(ctx, sessionId);
+            if (e is null) return false;
+            if (!ToRecord(e).SupersededByOwnerTurn(lastOwnerTurnAtUtc)) return false;
+            ctx.Snoozes.Remove(e);
+            ctx.SaveChanges();
             FileLog.Write($"[SnoozeRegistry] ClearIfSupersededByOwnerTurn: sid={sessionId}, owner drove a turn at {lastOwnerTurnAtUtc:O}, past the baseline {e.OwnerTurnBaselineUtc:O} captured when the hold was set -> hold dropped");
             return true;
         }
     }
 
     /// <summary>
-    /// The Director that owned this session when its hold was set, or null when nothing is held. One
-    /// lookup under one lock: a Contains() followed by a separate scan of Entries() is two reads of a
-    /// mutable map with a gap in between, and the entry can vanish in the gap.
+    /// The Director that owned this session when its hold was set, or null when nothing is held.
     /// </summary>
     public string? DirectorIdFor(string sessionId)
     {
         if (string.IsNullOrWhiteSpace(sessionId)) return null;
         lock (_gate)
-            return _entries.TryGetValue(sessionId, out var e) ? e.DirectorId : null;
+        {
+            using var ctx = _db.CreateContext();
+            return Find(ctx, sessionId, tracking: false)?.DirectorId;
+        }
     }
 
     /// <summary>True when <paramref name="sessionId"/> has a pending entry (expired or not).</summary>
@@ -393,117 +416,172 @@ public sealed class SnoozeRegistry
     {
         if (string.IsNullOrWhiteSpace(sessionId)) return false;
         lock (_gate)
-            return _entries.ContainsKey(sessionId);
+        {
+            using var ctx = _db.CreateContext();
+            return ctx.Snoozes.Any(e => e.SessionId == sessionId);
+        }
     }
 
-    /// <summary>A snapshot of every pending entry, for the expiry sweep. A copy, so the sweep can
-    /// iterate and mutate the registry (Clear) without touching the live collection.</summary>
+    /// <summary>
+    /// A snapshot of every pending entry, for the expiry sweep. A copy detached from the store, ordered by
+    /// session id for a DETERMINISTIC result. The legacy store returned .NET Dictionary enumeration order,
+    /// which is undefined and unstable - never a guaranteed contract - and the sole caller (the expiry sweep)
+    /// handles each entry independently, so no order was ever observable; ordering here removes that
+    /// nondeterminism rather than reproducing an order nothing relied on.
+    /// </summary>
     public IReadOnlyList<SnoozeEntry> Entries()
     {
         lock (_gate)
-            return _entries.Values.ToList();
+        {
+            using var ctx = _db.CreateContext();
+            return ctx.Snoozes.AsNoTracking().OrderBy(e => e.SessionId).ToList().Select(ToRecord).ToList();
+        }
     }
 
-    // ---- persistence (WorkListStore precedent) -----------------------------------------------
+    // ---- mapping + helpers ------------------------------------------------------------------------
 
-    /// <summary>The on-disk shape: one document holding every pending snooze.</summary>
+    /// <summary>Find the entry for a session id (ordinal, the primary key). Tracked by default so a caller
+    /// can mutate and save it; pass tracking:false for a pure read.</summary>
+    private static SnoozeEntity? Find(GatewayDbContext ctx, string sessionId, bool tracking = true)
+        => (tracking ? ctx.Snoozes : ctx.Snoozes.AsNoTracking()).FirstOrDefault(e => e.SessionId == sessionId);
+
+    /// <summary>Insert or overwrite the entry for a session id (the old Dictionary indexer semantics).</summary>
+    private static void Upsert(GatewayDbContext ctx, string sessionId, DateTime? snoozeUntilUtc, string directorId,
+        int? pendingMinutes, DateTime? ownerTurnBaselineUtc)
+    {
+        var e = Find(ctx, sessionId);
+        if (e is null)
+        {
+            ctx.Snoozes.Add(new SnoozeEntity
+            {
+                SessionId = sessionId,
+                TenantId = ctx.ActiveTenant!,
+                SnoozeUntilUtc = snoozeUntilUtc,
+                DirectorId = directorId,
+                PendingMinutes = pendingMinutes,
+                OwnerTurnBaselineUtc = ownerTurnBaselineUtc,
+            });
+        }
+        else
+        {
+            e.SnoozeUntilUtc = snoozeUntilUtc;
+            e.DirectorId = directorId;
+            e.PendingMinutes = pendingMinutes;
+            e.OwnerTurnBaselineUtc = ownerTurnBaselineUtc;
+        }
+    }
+
+    // DirectorId is passed through exactly - including a null retained from a legacy import - so DirectorIdFor
+    // and Entries return precisely what the old store held (the record's DirectorId carried a runtime null the
+    // same way). The null-forgiving operator only silences the nullable-reference warning; the value flows as-is.
+    private static SnoozeEntry ToRecord(SnoozeEntity e)
+        => new(e.SessionId, e.SnoozeUntilUtc, e.DirectorId!, e.PendingMinutes, e.OwnerTurnBaselineUtc);
+
+    // ---- one-time legacy JSON import --------------------------------------------------------------
+
+    /// <summary>The on-disk shape of the legacy registry file: one document holding every pending snooze.</summary>
     private sealed class StoreFile
     {
         public List<SnoozeEntry> Entries { get; set; } = new();
     }
 
     /// <summary>
-    /// Load the registry file written by a previous Gateway run - this is the re-arm on startup.
-    /// Missing file = the normal first boot (empty registry, logged). A corrupt file is quarantined
-    /// (renamed next to the original with a timestamp suffix) so its bytes are preserved for the
-    /// operator and never silently overwritten; the registry then starts empty so the Gateway still
-    /// boots. An entry already past its time is kept as-is: the first sweep reads it as expired and
-    /// fires it immediately (mission rule), so nothing is dropped and nothing all-fires-at-once.
+    /// Import a legacy <c>snooze.json</c> exactly once: only when it exists AND the table is empty. Mirrors
+    /// the old load exactly - skip an empty session id, DROP loudly a row carrying neither a deadline nor a
+    /// deferred length (it could never expire or land), last-wins on a duplicate session id, and normalize
+    /// the deadline to UTC - then insert inside one transaction and rename the JSON aside. Fail-loud and
+    /// all-or-nothing on a parse error. When the file lingers but the table is already populated, rename it
+    /// aside idempotently (best-effort recovery) so a failed rename self-heals next boot without re-importing.
     /// </summary>
-    private void Load()
+    private void ImportLegacyJsonIfNeeded()
     {
-        if (!File.Exists(_path))
+        if (!File.Exists(_legacyJsonPath))
+            return;
+
+        using var ctx = _db.CreateContext();
+        if (ctx.Snoozes.Any())
         {
-            FileLog.Write($"[SnoozeRegistry] Load: no registry file at {_path}; starting empty");
+            TryRenameAside();
             return;
         }
 
         StoreFile? parsed;
         try
         {
-            parsed = JsonSerializer.Deserialize<StoreFile>(File.ReadAllText(_path), FileJsonOptions);
+            parsed = JsonSerializer.Deserialize<StoreFile>(File.ReadAllText(_legacyJsonPath), FileJsonOptions);
         }
-        catch (JsonException ex)
+        catch (Exception ex)
         {
-            Quarantine(ex.Message);
-            return;
+            FileLog.Write($"[SnoozeRegistry] Import FAILED: legacy file {_legacyJsonPath} could not be read: {ex.Message}");
+            throw new InvalidOperationException(
+                $"The legacy snooze file '{_legacyJsonPath}' could not be parsed for the one-time import: " +
+                $"{ex.Message}. The Gateway will not start with a partial import. Fix or move the file aside " +
+                "and restart.", ex);
         }
 
-        if (parsed is null)
+        // A null root (the JSON literal "null") or a null entries list is NOT a valid, empty store - it is an
+        // unreadable one. Fail loud and leave the file in place, exactly like a parse error, rather than
+        // committing zero rows and renaming the file aside (which would permanently mark an invalid legacy
+        // store as migrated). This matches the corrupt-JSON contract the cron and worklist imports use.
+        if (parsed is null || parsed.Entries is null)
         {
-            Quarantine("file deserialized to null (no registry document)");
-            return;
+            FileLog.Write($"[SnoozeRegistry] Import FAILED: legacy file {_legacyJsonPath} deserialized to a null document or a null entries list");
+            throw new InvalidOperationException(
+                $"The legacy snooze file '{_legacyJsonPath}' could not be parsed for the one-time import: the " +
+                "document is null or carries no entries list. The Gateway will not start with a partial import. " +
+                "Fix or move the file aside and restart.");
         }
 
-        var rearmed = 0;
+        // Reproduce the old load's row handling, INCLUDING last-wins on a duplicate session id (the old
+        // in-memory Dictionary keyed by session id overwrote), so the imported set matches byte-for-byte.
+        var toImport = new Dictionary<string, SnoozeEntry>(StringComparer.Ordinal);
         foreach (var e in parsed.Entries)
         {
             if (string.IsNullOrWhiteSpace(e.SessionId))
                 continue; // skip a malformed row rather than fail the whole boot
-            // A row must carry exactly one half of the clock (armed OR deferred, never both, never
-            // neither). A row that carries neither is unusable - it can never expire and can never land -
-            // so it is dropped loudly rather than kept as a snooze that would silently never return.
             if (e.SnoozeUntilUtc is null && e.PendingMinutes is null)
             {
-                FileLog.Write($"[SnoozeRegistry] Load: DROPPED malformed row sid={e.SessionId} (neither a deadline nor a deferred length)");
+                FileLog.Write($"[SnoozeRegistry] Import: DROPPED malformed row sid={e.SessionId} (neither a deadline nor a deferred length)");
                 continue;
             }
-            _entries[e.SessionId] = e with { SnoozeUntilUtc = e.SnoozeUntilUtc?.ToUniversalTime() };
-            rearmed++;
+            toImport[e.SessionId] = e with { SnoozeUntilUtc = e.SnoozeUntilUtc?.ToUniversalTime() };
         }
 
-        FileLog.Write($"[SnoozeRegistry] Load: re-armed {rearmed} pending snooze(s) from {_path}");
+        using var tx = ctx.Database.BeginTransaction();
+        foreach (var e in toImport.Values)
+        {
+            ctx.Snoozes.Add(new SnoozeEntity
+            {
+                SessionId = e.SessionId,
+                TenantId = ctx.ActiveTenant!,
+                SnoozeUntilUtc = e.SnoozeUntilUtc,
+                DirectorId = e.DirectorId, // retain the exact value, including a null (losslessness - do NOT coerce to "")
+                PendingMinutes = e.PendingMinutes,
+                OwnerTurnBaselineUtc = e.OwnerTurnBaselineUtc,
+            });
+        }
+        ctx.SaveChanges();
+        tx.Commit();
+
+        TryRenameAside();
+        FileLog.Write($"[SnoozeRegistry] Import: {toImport.Count} pending snooze(s) imported from {_legacyJsonPath}");
     }
 
     /// <summary>
-    /// Preserve an unreadable registry file as "&lt;path&gt;.corrupt-&lt;stamp&gt;" and log loudly.
-    /// The original path is then free for the next write-through. The move is not allowed to fail
-    /// silently: if even the quarantine fails, the exception propagates and the Gateway does not
-    /// start half-blind.
+    /// Rename the imported legacy file aside, best-effort. The data is already committed and the empty-table
+    /// guard prevents any re-import, so a failed rename (a briefly-locked file) is logged and left for the
+    /// next boot to retry rather than failing the Gateway.
     /// </summary>
-    private void Quarantine(string reason)
-    {
-        var quarantinePath = $"{_path}.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}";
-        File.Move(_path, quarantinePath);
-        FileLog.Write($"[SnoozeRegistry] Load FAILED: registry file at {_path} is corrupt ({reason}); quarantined to {quarantinePath}; starting empty. Operator action: inspect the quarantined file to recover pending snoozes.");
-    }
-
-    /// <summary>
-    /// Write-through: serialize the whole registry and atomically replace the file (temp + rename),
-    /// so a concurrent reader or a crash mid-write never sees a half-written registry. Called inside
-    /// the lock by every mutation. A failed save is a LOGGED error that PROPAGATES (the caller's
-    /// request fails loudly) - never a silent skip, because a snooze that did not persist would not
-    /// survive a restart.
-    /// </summary>
-    private void Save()
+    private void TryRenameAside()
     {
         try
         {
-            var dir = Path.GetDirectoryName(_path);
-            if (!string.IsNullOrEmpty(dir))
-                Directory.CreateDirectory(dir);
-
-            var file = new StoreFile { Entries = _entries.Values.ToList() };
-            var json = JsonSerializer.Serialize(file, FileJsonOptions);
-
-            var tmp = _path + ".tmp";
-            File.WriteAllText(tmp, json);
-            File.Move(tmp, _path, overwrite: true);
+            LegacyJsonImport.RenameAside(_legacyJsonPath, "[SnoozeRegistry]");
         }
         catch (Exception ex)
         {
-            FileLog.Write($"[SnoozeRegistry] Save FAILED: path={_path}: {ex.Message}");
-            throw;
+            FileLog.Write($"[SnoozeRegistry] Import: rename-aside of {_legacyJsonPath} failed (data is safe in the " +
+                          $"database; the next boot retries): {ex.Message}");
         }
     }
 }


### PR DESCRIPTION
Migrate the snooze registry off hand-rolled JSON onto the EF Core data layer
(SQLite locally), behind its unchanged public API, with a lossless one-time
JSON-to-SQLite import. Next store after cron and work lists, on the same
template.

This store drives session hold and defer state on the hot path, so behavior
parity was treated as load-bearing.

What shipped:
- SnoozeEntity keyed by the session id directly (an ordinal natural key, so no
  surrogate key and no case-fold question). It maps the deadline, the director,
  the deferred length, and the owner-turn baseline. The armed-versus-deferred
  invariant (exactly one of the deadline or the deferred length is set) stays in
  the store code exactly as before, with no database check constraint.
- The tenant-id column and the global query filter (inherited from the shared
  tenant-scoped base), and the two nullable UTC timestamps round-trip as UTC.
- The full public API and observable behavior are unchanged, including the
  counts and side effects of the hot-path methods (clear-for-director,
  prune-not-live, land, hold-state-for, clear-if-unchanged,
  clear-if-superseded-by-owner-turn); the existing snooze and hold tests pass
  unchanged.
- Entries are returned in a deterministic order (by session id); the old
  in-memory dictionary order was never a guaranteed contract, and the sole
  caller (the expiry sweep) handles each entry independently, so the outcome is
  unchanged.
- The lossless one-time import mirrors the old load exactly: skip an empty
  session id, drop a malformed row that carries neither a deadline nor a deferred
  length, last-wins on a duplicate session id, and normalize to UTC. A null
  document or a null entries list fails loud (it is not a valid empty store)
  rather than silently committing zero rows and renaming the file aside. A null
  director id is retained as null, not coerced. The import is all-or-nothing and
  renames the file aside once, with the idempotent best-effort recovery.

Evidence (a run, not only a build), recorded in the mission QA document:
- Full Windows solution test suite green across all seven projects, including the
  new fail-loud, null-director-id, deterministic-order, and lossless-import
  tests, and the existing hold tests unchanged.
- A Linux container built from the repo Dockerfile applied all five migrations in
  order on a clean database as the non-root user, health returned 200, the
  snoozes table and the other tables were present, and a non-root insert with a
  null director id round-tripped as null.

The macOS native run is deferred - the Mac mini is offline - consistent with the
earlier steps.
