### PR TITLE
feat(gateway): append-only governance event ledger (governance spine item 2, #1771)

### DIFF
--- a/src/CcDirector.Gateway.Contracts/GovernanceEventDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/GovernanceEventDtos.cs
@@ -1,0 +1,104 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>The kinds of subject a governance event describes. A session transition keys on the session GUID;
+/// a run transition keys on the workflow run id.</summary>
+public static class GovernanceEventSubject
+{
+    public const string Session = "session";
+    public const string Run = "run";
+
+    public static readonly string[] All = { Session, Run };
+}
+
+/// <summary>
+/// The state vocabulary of the append-only ledger (issue #1771, spine item 2). These are the transitions a
+/// duration report reads: the gap between entering "active" and the next state is active time; between
+/// "waiting-on-human" and "recovered" is attention-burden wait. Deliberately small and shared across session
+/// and run subjects - a run can be active, blocked, or waiting-on-human just as a session can.
+/// </summary>
+public static class GovernanceEventState
+{
+    /// <summary>Doing work - the agent is producing.</summary>
+    public const string Active = "active";
+
+    /// <summary>Alive but not producing - no active turn, not waiting on anyone.</summary>
+    public const string Idle = "idle";
+
+    /// <summary>Stopped, needs the owner - the attention-burden state.</summary>
+    public const string WaitingOnHuman = "waiting-on-human";
+
+    /// <summary>Stopped on a permission/approval prompt - waiting for a grant, not a human decision on the work.</summary>
+    public const string WaitingOnPermission = "waiting-on-permission";
+
+    /// <summary>Stuck - an error, a loop, an unmet dependency - not making progress and not waiting on a person.</summary>
+    public const string Blocked = "blocked";
+
+    /// <summary>Came back from a wait or a block - the close of a waiting/blocked interval.</summary>
+    public const string Recovered = "recovered";
+
+    public static readonly string[] All =
+    {
+        Active, Idle, WaitingOnHuman, WaitingOnPermission, Blocked, Recovered,
+    };
+}
+
+/// <summary>
+/// One immutable transition on the governance ledger. Append-only: there is no update or delete, so this DTO
+/// is both the write acknowledgement and the read row.
+/// </summary>
+public sealed class GovernanceEventDto
+{
+    public Guid Id { get; set; }
+
+    /// <summary>"session" or "run" - see <see cref="GovernanceEventSubject"/>.</summary>
+    public string SubjectKind { get; set; } = "";
+
+    /// <summary>The canonical fleet session GUID (set for a session subject; an optional join hint on a run subject).</summary>
+    public string? SessionId { get; set; }
+
+    /// <summary>The workflow run id (set for a run subject; an optional join hint on a session subject).</summary>
+    public Guid? RunId { get; set; }
+
+    /// <summary>The state entered - see <see cref="GovernanceEventState"/>.</summary>
+    public string State { get; set; } = "";
+
+    /// <summary>Why, in plain words. Never prompt content.</summary>
+    public string? Reason { get; set; }
+
+    /// <summary>When the transition happened.</summary>
+    public DateTime OccurredUtc { get; set; }
+
+    /// <summary>When the Gateway recorded it (server-stamped).</summary>
+    public DateTime RecordedUtc { get; set; }
+}
+
+/// <summary>
+/// Body of an append to the ledger. One request records one transition. <see cref="OccurredUtc"/> is optional:
+/// when the caller does not supply it, the Gateway stamps the append time. The recorded time is always
+/// server-stamped and never accepted from the caller.
+///
+/// Exactly one subject key is required, matching <see cref="SubjectKind"/>: a "session" event needs
+/// <see cref="SessionId"/>; a "run" event needs <see cref="RunId"/>. The other key is optional (a denormalized
+/// join hint).
+/// </summary>
+public sealed class AppendGovernanceEventRequest
+{
+    public string? SubjectKind { get; set; }
+    public string? SessionId { get; set; }
+    public Guid? RunId { get; set; }
+    public string? State { get; set; }
+    public string? Reason { get; set; }
+
+    /// <summary>When the transition happened; null to let the Gateway stamp the append time.</summary>
+    public DateTime? OccurredUtc { get; set; }
+}
+
+/// <summary>
+/// Body of a batched append: many transitions in one call. The Gateway writes them in one unit of work.
+/// A single invalid entry rejects the whole batch (the ledger never lands a half-batch), so a caller reporting
+/// a burst of transitions learns of a bad row rather than silently dropping it.
+/// </summary>
+public sealed class AppendGovernanceEventsBatchRequest
+{
+    public List<AppendGovernanceEventRequest> Events { get; set; } = new();
+}

--- a/src/CcDirector.Gateway.Tests/GovernanceEventLedgerTests.cs
+++ b/src/CcDirector.Gateway.Tests/GovernanceEventLedgerTests.cs
@@ -1,0 +1,217 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Governance;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Store tests for the append-only governance event ledger (issue #1771, spine item 2). The claims that
+/// matter: a transition is validated (subject/state vocabulary, the subject's own key required) and stamped
+/// (server RecordedUtc, occurred defaulted/clamped); the ledger is append-only and reads newest-first with a
+/// working session/run/state/time filter; the batch path lands all-or-nothing; and every row is tenant-scoped
+/// so one tenant never reads another's transitions.
+/// </summary>
+public sealed class GovernanceEventLedgerTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    private GovernanceEventLedger NewLedger() => new(_h.Open());
+
+    private static readonly Guid Run = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private const string Session = "session-guid-abc";
+
+    private static AppendGovernanceEventRequest SessionEvent(
+        string state, string? session = Session, DateTime? occurred = null, string? reason = null) => new()
+    {
+        SubjectKind = GovernanceEventSubject.Session,
+        SessionId = session,
+        State = state,
+        Reason = reason,
+        OccurredUtc = occurred,
+    };
+
+    private static AppendGovernanceEventRequest RunEvent(string state, Guid? run = null) => new()
+    {
+        SubjectKind = GovernanceEventSubject.Run,
+        RunId = run ?? Run,
+        State = state,
+    };
+
+    [Fact]
+    public void Append_records_a_session_transition_and_server_stamps_it()
+    {
+        var ledger = NewLedger();
+        var before = DateTime.UtcNow;
+
+        var dto = ledger.Append(SessionEvent(GovernanceEventState.WaitingOnHuman, reason: "owner not replied"));
+
+        Assert.NotEqual(Guid.Empty, dto.Id);
+        Assert.Equal(GovernanceEventSubject.Session, dto.SubjectKind);
+        Assert.Equal(Session, dto.SessionId);
+        Assert.Null(dto.RunId);
+        Assert.Equal(GovernanceEventState.WaitingOnHuman, dto.State);
+        Assert.Equal("owner not replied", dto.Reason);
+        Assert.True(dto.RecordedUtc >= before);
+        // Occurred defaults to the append time when the caller omits it.
+        Assert.True(dto.OccurredUtc >= before);
+    }
+
+    [Fact]
+    public void Append_defaults_occurred_to_now_and_clamps_a_future_clock()
+    {
+        var ledger = NewLedger();
+        var future = DateTime.UtcNow.AddHours(2);
+
+        var dto = ledger.Append(SessionEvent(GovernanceEventState.Active, occurred: future));
+
+        // A future occurred time is a skewed caller clock, not a real transition: clamp to now.
+        Assert.True(dto.OccurredUtc <= DateTime.UtcNow.AddMinutes(1));
+    }
+
+    [Fact]
+    public void Append_rejects_an_unknown_subject_kind()
+    {
+        var ledger = NewLedger();
+        var ex = Assert.Throws<GovernanceValidationException>(
+            () => ledger.Append(new AppendGovernanceEventRequest
+            {
+                SubjectKind = "cluster", SessionId = Session, State = GovernanceEventState.Active,
+            }));
+        Assert.Contains("subject kind", ex.Message);
+    }
+
+    [Fact]
+    public void Append_rejects_an_unknown_state()
+    {
+        var ledger = NewLedger();
+        var ex = Assert.Throws<GovernanceValidationException>(
+            () => ledger.Append(SessionEvent("napping")));
+        Assert.Contains("governance state", ex.Message);
+    }
+
+    [Fact]
+    public void A_session_event_requires_a_session_id()
+    {
+        var ledger = NewLedger();
+        var ex = Assert.Throws<GovernanceValidationException>(
+            () => ledger.Append(SessionEvent(GovernanceEventState.Idle, session: null)));
+        Assert.Contains("sessionId", ex.Message);
+    }
+
+    [Fact]
+    public void A_run_event_requires_a_run_id()
+    {
+        var ledger = NewLedger();
+        var ex = Assert.Throws<GovernanceValidationException>(
+            () => ledger.Append(new AppendGovernanceEventRequest
+            {
+                SubjectKind = GovernanceEventSubject.Run,
+                RunId = Guid.Empty,
+                State = GovernanceEventState.Active,
+            }));
+        Assert.Contains("runId", ex.Message);
+    }
+
+    [Fact]
+    public void An_oversize_reason_is_rejected()
+    {
+        var ledger = NewLedger();
+        var ex = Assert.Throws<GovernanceValidationException>(
+            () => ledger.Append(SessionEvent(GovernanceEventState.Blocked,
+                reason: new string('x', GovernanceEventLedger.MaxReasonChars + 1))));
+        Assert.Contains("reason", ex.Message);
+    }
+
+    [Fact]
+    public void List_returns_transitions_newest_first()
+    {
+        var ledger = NewLedger();
+        var t0 = DateTime.UtcNow.AddMinutes(-10);
+        ledger.Append(SessionEvent(GovernanceEventState.Active, occurred: t0));
+        ledger.Append(SessionEvent(GovernanceEventState.WaitingOnHuman, occurred: t0.AddMinutes(3)));
+        ledger.Append(SessionEvent(GovernanceEventState.Recovered, occurred: t0.AddMinutes(6)));
+
+        var all = ledger.List(sessionId: Session);
+
+        Assert.Equal(3, all.Count);
+        Assert.Equal(GovernanceEventState.Recovered, all[0].State);
+        Assert.Equal(GovernanceEventState.WaitingOnHuman, all[1].State);
+        Assert.Equal(GovernanceEventState.Active, all[2].State);
+    }
+
+    [Fact]
+    public void List_filters_by_session_run_state_and_time_window()
+    {
+        var ledger = NewLedger();
+        var t0 = DateTime.UtcNow.AddHours(-2);
+        ledger.Append(SessionEvent(GovernanceEventState.Active, occurred: t0));
+        ledger.Append(SessionEvent(GovernanceEventState.Blocked, occurred: t0.AddMinutes(30)));
+        ledger.Append(SessionEvent(GovernanceEventState.Active, session: "other-session", occurred: t0.AddMinutes(31)));
+        ledger.Append(RunEvent(GovernanceEventState.WaitingOnHuman));
+
+        Assert.Equal(2, ledger.List(sessionId: Session).Count);
+        Assert.Single(ledger.List(sessionId: Session, state: GovernanceEventState.Blocked));
+        Assert.Single(ledger.List(runId: Run));
+        Assert.Equal(GovernanceEventSubject.Run, ledger.List(runId: Run)[0].SubjectKind);
+
+        // Window: [t0+15m, t0+40m) excludes the t0 Active, includes the t0+30m Blocked.
+        var windowed = ledger.List(
+            sessionId: Session, sinceUtc: t0.AddMinutes(15), untilUtc: t0.AddMinutes(40));
+        Assert.Single(windowed);
+        Assert.Equal(GovernanceEventState.Blocked, windowed[0].State);
+    }
+
+    [Fact]
+    public void AppendBatch_writes_every_event_in_one_call()
+    {
+        var ledger = NewLedger();
+        var written = ledger.AppendBatch(new List<AppendGovernanceEventRequest>
+        {
+            SessionEvent(GovernanceEventState.Active),
+            SessionEvent(GovernanceEventState.Idle),
+            RunEvent(GovernanceEventState.WaitingOnHuman),
+        });
+
+        Assert.Equal(3, written);
+        Assert.Equal(2, ledger.List(sessionId: Session).Count);
+        Assert.Single(ledger.List(runId: Run));
+    }
+
+    [Fact]
+    public void AppendBatch_is_all_or_nothing_when_one_entry_is_invalid()
+    {
+        var ledger = NewLedger();
+        Assert.Throws<GovernanceValidationException>(() => ledger.AppendBatch(new List<AppendGovernanceEventRequest>
+        {
+            SessionEvent(GovernanceEventState.Active),
+            SessionEvent("bogus-state"),   // invalid - must abort the whole batch
+        }));
+
+        // Nothing landed - the ledger never holds a half-batch.
+        Assert.Empty(ledger.List(sessionId: Session));
+    }
+
+    [Fact]
+    public void The_ledger_is_tenant_scoped()
+    {
+        // Two ledgers over the SAME database file, each fixed to a different tenant. One tenant must never
+        // read the other's transitions (the global query filter), matching the rest of the data layer.
+        var alpha = new GovernanceEventLedger(_h.Open(new FixedTenantContext(new TenantId("alpha"))));
+        var beta = new GovernanceEventLedger(_h.Open(new FixedTenantContext(new TenantId("beta"))));
+
+        alpha.Append(SessionEvent(GovernanceEventState.Active, session: "alpha-session"));
+        beta.Append(SessionEvent(GovernanceEventState.Active, session: "beta-session"));
+
+        var alphaRows = alpha.List();
+        var betaRows = beta.List();
+
+        Assert.Single(alphaRows);
+        Assert.Single(betaRows);
+        Assert.Equal("alpha-session", alphaRows[0].SessionId);
+        Assert.Equal("beta-session", betaRows[0].SessionId);
+    }
+}

--- a/src/CcDirector.Gateway/Api/GovernanceEventEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GovernanceEventEndpoints.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Governance;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The governance event-ledger surface (issue #1771, spine item 2). The ledger is append-only: a
+/// transition can be recorded and read, never edited or removed - so there is a POST and a GET, and
+/// deliberately no PUT/PATCH/DELETE.
+///
+///   POST  /gateway/governance/events         body AppendGovernanceEventRequest       -> 201 GovernanceEventDto | 400
+///   POST  /gateway/governance/events/batch    body AppendGovernanceEventsBatchRequest -> 200 { written } | 400
+///   GET   /gateway/governance/events          ?sessionId=&amp;runId=&amp;subjectKind=&amp;state=&amp;since=&amp;until=&amp;limit=
+///                                             -> { events: [...] }
+///
+/// Inherits the host-wide token middleware, like every other Gateway route.
+/// </summary>
+internal static class GovernanceEventEndpoints
+{
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    public static void Map(IEndpointRouteBuilder app, GovernanceEventLedger ledger)
+    {
+        app.MapPost("/gateway/governance/events", async (HttpContext ctx) =>
+        {
+            AppendGovernanceEventRequest? req;
+            try
+            {
+                req = await JsonSerializer.DeserializeAsync<AppendGovernanceEventRequest>(
+                    ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+            }
+            catch (JsonException ex)
+            {
+                FileLog.Write($"[GovernanceEventEndpoints] POST bad JSON: {ex.Message}");
+                return Results.BadRequest(new { error = "invalid JSON" });
+            }
+            if (req is null)
+                return Results.BadRequest(new { error = "an event body is required" });
+
+            return Guard(() =>
+            {
+                var recorded = ledger.Append(req);
+                return Results.Json(recorded, statusCode: StatusCodes.Status201Created);
+            });
+        });
+
+        app.MapPost("/gateway/governance/events/batch", async (HttpContext ctx) =>
+        {
+            AppendGovernanceEventsBatchRequest? req;
+            try
+            {
+                req = await JsonSerializer.DeserializeAsync<AppendGovernanceEventsBatchRequest>(
+                    ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+            }
+            catch (JsonException ex)
+            {
+                FileLog.Write($"[GovernanceEventEndpoints] POST batch bad JSON: {ex.Message}");
+                return Results.BadRequest(new { error = "invalid JSON" });
+            }
+            if (req is null)
+                return Results.BadRequest(new { error = "a batch body is required" });
+
+            return Guard(() =>
+            {
+                var written = ledger.AppendBatch(req.Events ?? new List<AppendGovernanceEventRequest>());
+                return Results.Json(new { written });
+            });
+        });
+
+        app.MapGet("/gateway/governance/events",
+            (string? sessionId, Guid? runId, string? subjectKind, string? state,
+             DateTime? since, DateTime? until, int? limit) =>
+                Results.Json(new
+                {
+                    events = ledger.List(sessionId, runId, subjectKind, state, since, until, limit ?? 500),
+                }));
+
+        FileLog.Write("[GovernanceEventEndpoints] mapped /gateway/governance/events routes");
+    }
+
+    private static IResult Guard(Func<IResult> action)
+    {
+        try
+        {
+            return action();
+        }
+        catch (GovernanceValidationException ex)
+        {
+            FileLog.Write($"[GovernanceEventEndpoints] rejected: {ex.Message}");
+            return Results.BadRequest(new { error = ex.Message });
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Data/Entities/GovernanceEventEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/GovernanceEventEntity.cs
@@ -1,0 +1,56 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// One immutable state transition of a session or a run, in the <c>governance_events</c> table - the
+/// append-only event ledger of the governance outcome spine (issue #1771, spine item 2). A row is written
+/// once and never updated or deleted: the ledger is the durable record of WHEN a subject entered a state,
+/// which is what lets a report compute active / idle / waiting DURATIONS. The merged run row
+/// (<see cref="WorkflowRunEntity"/>) carries only started/completed timestamps; the questions "how long was
+/// this session idle" and "how long did the fleet wait on a human this week" have no answer without this
+/// ledger.
+///
+/// This is NOT the in-memory doorbell ring (<c>Events.DirectorEventLog</c>, issue #330), which is a capped
+/// debug snapshot with no persistence. This table is the persisted governance timeline.
+///
+/// A transition is about exactly one subject, named by <see cref="SubjectKind"/>:
+///  - a "session" transition keys on <see cref="SessionId"/> (the canonical Director-minted session GUID,
+///    the same id run participants and every per-session statistic key on);
+///  - a "run" transition keys on <see cref="RunId"/> (a value reference to <see cref="WorkflowRunEntity.Id"/> -
+///    NOT a foreign key, because a run outlives archive/cleanup and the ledger must survive it).
+/// The other key may also be stamped as a denormalized join hint (a session transition can carry the RunId
+/// of the run the session was working, so a per-run duration rollup needs no participant lookup), but the
+/// subject's own key is always present.
+/// </summary>
+public sealed class GovernanceEventEntity : TenantScopedEntity
+{
+    /// <summary>Primary key, minted in code - never a database default.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>What kind of thing transitioned: "session" or "run". The subject's own key
+    /// (<see cref="SessionId"/> for a session, <see cref="RunId"/> for a run) is required for that kind.</summary>
+    public string SubjectKind { get; set; } = "";
+
+    /// <summary>The canonical fleet session GUID. Required for a session subject; an optional denormalized
+    /// join hint on a run subject. Never any identifier other than the Director-minted session GUID.</summary>
+    public string? SessionId { get; set; }
+
+    /// <summary>The workflow run this transition belongs to (value reference to <see cref="WorkflowRunEntity.Id"/>,
+    /// never a foreign key). Required for a run subject; an optional denormalized join hint on a session
+    /// subject (the run the session was working when it transitioned).</summary>
+    public Guid? RunId { get; set; }
+
+    /// <summary>The state entered: active, idle, waiting-on-human, waiting-on-permission, blocked, recovered.</summary>
+    public string State { get; set; } = "";
+
+    /// <summary>Why the transition happened, in plain words (e.g. "permission prompt: bash", "owner replied").
+    /// NEVER prompt content - the ledger records control flow, not what anyone typed (issue #1771 principle).</summary>
+    public string? Reason { get; set; }
+
+    /// <summary>When the transition actually happened. Caller-supplied (a Director reports a transition it
+    /// observed a moment ago); defaults to the append time when the caller does not know it.</summary>
+    public DateTime OccurredUtc { get; set; }
+
+    /// <summary>When the Gateway appended the row. Server-stamped, never caller-supplied - it is the tie-breaker
+    /// that orders two transitions sharing an <see cref="OccurredUtc"/>, and the audit fact of when we learned.</summary>
+    public DateTime RecordedUtc { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -70,6 +70,10 @@ public sealed class GatewayDbContext : DbContext
     /// <summary>Pending session snoozes (<c>snoozes</c>), keyed by session id.</summary>
     public DbSet<SnoozeEntity> Snoozes => Set<SnoozeEntity>();
 
+    /// <summary>The append-only governance event ledger (<c>governance_events</c>) - immutable session/run
+    /// state transitions, the duration spine of issue #1771.</summary>
+    public DbSet<GovernanceEventEntity> GovernanceEvents => Set<GovernanceEventEntity>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -166,6 +170,23 @@ public sealed class GatewayDbContext : DbContext
             b.HasKey(e => e.SessionId);
         });
 
+        modelBuilder.Entity<GovernanceEventEntity>(b =>
+        {
+            b.ToTable("governance_events");
+            b.HasKey(e => e.Id);
+            // The duration-rollup read paths: a session's transitions over time, a run's, and the weekly
+            // whole-week scan across every subject. Each composite LEADS WITH tenant_id because the global
+            // query filter prepends "tenant_id = @t" to every query - a SessionId/RunId/OccurredUtc-leading
+            // index would force a cross-tenant scan under Phase B multi-tenant load, so these are the
+            // tenant-leading forms that actually serve the filtered query. (ApplyTenantScope adds a
+            // standalone tenant_id index too; these are the query-serving composites.)
+            // SessionId/RunId are value references, never foreign keys - the ledger outlives the run and
+            // the session it records.
+            b.HasIndex(e => new { e.TenantId, e.SessionId, e.OccurredUtc });
+            b.HasIndex(e => new { e.TenantId, e.RunId, e.OccurredUtc });
+            b.HasIndex(e => new { e.TenantId, e.OccurredUtc });
+        });
+
         // Tenant scoping - the tenant_id column plus the global query filter - applied uniformly to every
         // entity that derives from TenantScopedEntity, so future stores inherit it by deriving from the base.
         ApplyTenantScope<CronJobEntity>(modelBuilder);
@@ -177,6 +198,7 @@ public sealed class GatewayDbContext : DbContext
         ApplyTenantScope<WorkflowFileEntity>(modelBuilder);
         ApplyTenantScope<WorkflowRunEntity>(modelBuilder);
         ApplyTenantScope<SnoozeEntity>(modelBuilder);
+        ApplyTenantScope<GovernanceEventEntity>(modelBuilder);
 
         ApplyCommonSubsetConventions(modelBuilder);
     }

--- a/src/CcDirector.Gateway/Data/Migrations/20260718023346_AddGovernanceEvents.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718023346_AddGovernanceEvents.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718023346_AddGovernanceEvents")]
+    partial class AddGovernanceEvents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260718023346_AddGovernanceEvents.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718023346_AddGovernanceEvents.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGovernanceEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "governance_events",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    SubjectKind = table.Column<string>(type: "TEXT", nullable: false),
+                    SessionId = table.Column<string>(type: "TEXT", nullable: true),
+                    RunId = table.Column<Guid>(type: "TEXT", nullable: true),
+                    State = table.Column<string>(type: "TEXT", nullable: false),
+                    Reason = table.Column<string>(type: "TEXT", nullable: true),
+                    OccurredUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    RecordedUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_governance_events", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_governance_events_tenant_id",
+                table: "governance_events",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_governance_events_tenant_id_OccurredUtc",
+                table: "governance_events",
+                columns: new[] { "tenant_id", "OccurredUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_governance_events_tenant_id_RunId_OccurredUtc",
+                table: "governance_events",
+                columns: new[] { "tenant_id", "RunId", "OccurredUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_governance_events_tenant_id_SessionId_OccurredUtc",
+                table: "governance_events",
+                columns: new[] { "tenant_id", "SessionId", "OccurredUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "governance_events");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -335,6 +335,9 @@ public sealed class GatewayHost : IAsyncDisposable
     // Workflow runs (phase 4, issue #1771): one row per execution of a workflow definition, pinned to
     // the version that governed it. The governance outcome spine.
     private readonly Workflows.WorkflowRunStore _workflowRuns;
+    // The append-only governance event ledger (issue #1771, spine item 2): immutable session/run state
+    // transitions, the duration spine no run row can give.
+    private readonly Governance.GovernanceEventLedger _governanceEvents;
     private readonly CronJobStore _cronJobs;
     private readonly CronRunHistoryStore _cronRuns;
     private readonly Running.CronEngine _cronEngine;
@@ -603,6 +606,9 @@ public sealed class GatewayHost : IAsyncDisposable
         // Workflow runs (phase 4, issue #1771): built after the catalog store so the built-ins a run
         // pins are already seeded.
         _workflowRuns = new Workflows.WorkflowRunStore(_gatewayDb);
+        // The governance event ledger (issue #1771, spine item 2): append-only session/run transitions on
+        // the EF data layer, so a Gateway restart never loses a recorded transition.
+        _governanceEvents = new Governance.GovernanceEventLedger(_gatewayDb);
         // Snooze Length mission: the persisted snooze registry (sessionId -> SnoozeUntilUtc), now in the
         // snoozes table of the EF data layer - a Gateway restart re-arms every pending snooze from the
         // database; an entry already past its time simply fires on the first sweep. The path argument is the
@@ -1619,6 +1625,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // Workflow runs (phase 4, issue #1771): the outcome spine's REST surface. One row per
         // execution of a workflow, pinned to the exact published version that governed it.
         Api.WorkflowRunEndpoints.Map(_app, _workflowRuns);
+
+        // The governance event ledger (issue #1771, spine item 2): append-only session/run state
+        // transitions - the duration timeline the weekly Outcome Ledger reads. Append and read only.
+        Api.GovernanceEventEndpoints.Map(_app, _governanceEvents);
 
         // Gateway Centralization Phase 1 (issue #628): the inbound login-telemetry RELAY. The Director
         // POSTs its login-telemetry event here (instead of the cloud) and the Gateway forwards it on,

--- a/src/CcDirector.Gateway/Governance/GovernanceEventLedger.cs
+++ b/src/CcDirector.Gateway/Governance/GovernanceEventLedger.cs
@@ -1,0 +1,239 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Governance;
+
+/// <summary>
+/// The Gateway's append-only governance event ledger (issue #1771, spine item 2) over the
+/// <c>governance_events</c> table. Every row is one immutable state transition of a session or a run -
+/// active, idle, waiting-on-human, waiting-on-permission, blocked, recovered - stamped with when it
+/// happened. This is the durable timeline the merged run row cannot give: the run carries only
+/// started/completed, but "how long was this idle / waiting on me / blocked" needs the transitions between.
+///
+/// Append-only by contract: there is <b>no</b> update or delete. A ledger you can rewrite is not a ledger,
+/// and the weekly Outcome Ledger's duration and attention-burden figures are only trustworthy if the record
+/// they read from is immutable. Runs and sessions accumulate transitions for the whole reporting horizon.
+///
+/// Two write shapes:
+///  - <see cref="Append"/> writes one transition (the common case - a Director reports a single move).
+///  - <see cref="AppendBatch"/> writes many in one unit of work with change-tracking detection disabled -
+///    the batched append seam the migration protocol calls for, so a burst of reported transitions is one
+///    round trip, not one per row. It is still fully tenant-scoped (the base entity's tenant_id + the global
+///    query filter): the batched path lowers per-insert overhead, it does not bypass tenant isolation.
+///
+/// Threading matches the rest of the EF data layer: the Gateway is a single writer; every operation runs
+/// under this ledger's write lock over a fresh pooled context.
+/// </summary>
+public sealed class GovernanceEventLedger
+{
+    private readonly object _gate = new();
+    private readonly GatewayDatabase _db;
+
+    /// <summary>A reason is a short control-flow note, never prose or prompt content; cap it so an
+    /// authenticated caller cannot persist megabytes into the column.</summary>
+    public const int MaxReasonChars = 500;
+
+    /// <summary>The hard ceiling on one batched append, so a single request cannot ask the Gateway to
+    /// materialize an unbounded write set.</summary>
+    public const int MaxBatchSize = 1000;
+
+    /// <summary>The hard ceiling on one list read; the default page is 500. The ledger is append-only and
+    /// never trimmed, so an unbounded read would eventually materialize the whole history per request.</summary>
+    public const int MaxListLimit = 5000;
+
+    public GovernanceEventLedger(GatewayDatabase db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    /// <summary>Append one transition. Returns the recorded row (its id and server-stamped RecordedUtc).</summary>
+    public GovernanceEventDto Append(AppendGovernanceEventRequest request)
+    {
+        if (request is null)
+            throw new GovernanceValidationException("An event body is required.");
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var now = DateTime.UtcNow;
+            var entity = BuildEntity(request, ctx.ActiveTenant!, now);
+            ctx.GovernanceEvents.Add(entity);
+            ctx.SaveChanges();
+
+            FileLog.Write($"[GovernanceEventLedger] Append: id={entity.Id}, subject={entity.SubjectKind}, " +
+                          $"session={entity.SessionId ?? "-"}, run={entity.RunId?.ToString() ?? "-"}, " +
+                          $"state={entity.State}");
+            return ToDto(entity);
+        }
+    }
+
+    /// <summary>
+    /// Append many transitions in one unit of work. The whole batch is validated first: one invalid entry
+    /// rejects the entire batch (the ledger never lands a half-batch), so a caller reporting a burst learns
+    /// of a bad row instead of silently dropping it. Returns the number of rows written.
+    /// </summary>
+    public int AppendBatch(IReadOnlyList<AppendGovernanceEventRequest> requests)
+    {
+        if (requests is null)
+            throw new GovernanceValidationException("An events list is required.");
+        if (requests.Count == 0)
+            return 0;
+        if (requests.Count > MaxBatchSize)
+            throw new GovernanceValidationException(
+                $"A batch carries at most {MaxBatchSize} events (got {requests.Count}).");
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var now = DateTime.UtcNow;
+            var tenant = ctx.ActiveTenant!;
+
+            // Validate-then-build the whole batch before touching the context, so a bad entry aborts with
+            // nothing added.
+            var entities = new List<GovernanceEventEntity>(requests.Count);
+            foreach (var request in requests)
+            {
+                if (request is null)
+                    throw new GovernanceValidationException("The events list contains a null entry.");
+                entities.Add(BuildEntity(request, tenant, now));
+            }
+
+            // The batched append seam: with change detection off, AddRange + a single SaveChanges inserts the
+            // set in one round trip without EF scanning every entity for modifications (these are all fresh
+            // inserts - there is nothing to detect). Tenant scoping is unaffected: tenant_id is set on each row.
+            var previousAutoDetect = ctx.ChangeTracker.AutoDetectChangesEnabled;
+            ctx.ChangeTracker.AutoDetectChangesEnabled = false;
+            try
+            {
+                ctx.GovernanceEvents.AddRange(entities);
+                ctx.SaveChanges();
+            }
+            finally
+            {
+                ctx.ChangeTracker.AutoDetectChangesEnabled = previousAutoDetect;
+            }
+
+            FileLog.Write($"[GovernanceEventLedger] AppendBatch: wrote {entities.Count} events");
+            return entities.Count;
+        }
+    }
+
+    /// <summary>
+    /// Transitions, newest first, optionally filtered by session, run, subject kind, state, and time window
+    /// (<paramref name="sinceUtc"/> inclusive, <paramref name="untilUtc"/> exclusive on OccurredUtc). Ordered
+    /// and bounded in the database. The time window is how the weekly report reads a single week's slice.
+    /// </summary>
+    public IReadOnlyList<GovernanceEventDto> List(
+        string? sessionId = null, Guid? runId = null, string? subjectKind = null, string? state = null,
+        DateTime? sinceUtc = null, DateTime? untilUtc = null, int limit = 500)
+    {
+        var take = Math.Clamp(limit, 1, MaxListLimit);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            IQueryable<GovernanceEventEntity> query = ctx.GovernanceEvents.AsNoTracking();
+
+            if (!string.IsNullOrWhiteSpace(sessionId))
+            {
+                var id = sessionId.Trim();
+                query = query.Where(e => e.SessionId == id);
+            }
+            if (runId.HasValue)
+                query = query.Where(e => e.RunId == runId.Value);
+            if (!string.IsNullOrWhiteSpace(subjectKind))
+            {
+                var kind = subjectKind.Trim().ToLowerInvariant();
+                query = query.Where(e => e.SubjectKind == kind);
+            }
+            if (!string.IsNullOrWhiteSpace(state))
+            {
+                var wanted = state.Trim().ToLowerInvariant();
+                query = query.Where(e => e.State == wanted);
+            }
+            if (sinceUtc.HasValue)
+            {
+                var since = DateTime.SpecifyKind(sinceUtc.Value, DateTimeKind.Utc);
+                query = query.Where(e => e.OccurredUtc >= since);
+            }
+            if (untilUtc.HasValue)
+            {
+                var until = DateTime.SpecifyKind(untilUtc.Value, DateTimeKind.Utc);
+                query = query.Where(e => e.OccurredUtc < until);
+            }
+
+            return query
+                .OrderByDescending(e => e.OccurredUtc)
+                .ThenByDescending(e => e.RecordedUtc)
+                .Take(take)
+                .ToList()
+                .Select(ToDto)
+                .ToList();
+        }
+    }
+
+    /// <summary>Validate one request and build the immutable row (tenant + timestamps stamped here).</summary>
+    private static GovernanceEventEntity BuildEntity(
+        AppendGovernanceEventRequest request, string tenant, DateTime now)
+    {
+        var subject = (request.SubjectKind ?? "").Trim().ToLowerInvariant();
+        if (!GovernanceEventSubject.All.Contains(subject, StringComparer.Ordinal))
+            throw new GovernanceValidationException(
+                $"'{request.SubjectKind}' is not a subject kind. Legal values: " +
+                string.Join(", ", GovernanceEventSubject.All) + ".");
+
+        var state = (request.State ?? "").Trim().ToLowerInvariant();
+        if (!GovernanceEventState.All.Contains(state, StringComparer.Ordinal))
+            throw new GovernanceValidationException(
+                $"'{request.State}' is not a governance state. Legal values: " +
+                string.Join(", ", GovernanceEventState.All) + ".");
+
+        var sessionId = string.IsNullOrWhiteSpace(request.SessionId) ? null : request.SessionId.Trim();
+        var runId = request.RunId;
+
+        // The subject's OWN key is required; the other key is an optional denormalized join hint.
+        if (subject == GovernanceEventSubject.Session && sessionId is null)
+            throw new GovernanceValidationException("A session event needs a sessionId.");
+        if (subject == GovernanceEventSubject.Run && (runId is null || runId.Value == Guid.Empty))
+            throw new GovernanceValidationException("A run event needs a runId.");
+
+        if (request.Reason is not null && request.Reason.Length > MaxReasonChars)
+            throw new GovernanceValidationException(
+                $"The reason is too long (limit {MaxReasonChars} characters).");
+
+        // Caller-supplied occurred time, defaulting to the append time; a future timestamp is a clock error,
+        // not a real transition, so clamp it to now rather than trusting a caller's skewed clock.
+        var occurred = request.OccurredUtc.HasValue
+            ? DateTime.SpecifyKind(request.OccurredUtc.Value, DateTimeKind.Utc)
+            : now;
+        if (occurred > now)
+            occurred = now;
+
+        return new GovernanceEventEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenant,
+            SubjectKind = subject,
+            SessionId = sessionId,
+            RunId = runId,
+            State = state,
+            Reason = request.Reason,
+            OccurredUtc = occurred,
+            RecordedUtc = now,
+        };
+    }
+
+    private static GovernanceEventDto ToDto(GovernanceEventEntity e) => new()
+    {
+        Id = e.Id,
+        SubjectKind = e.SubjectKind,
+        SessionId = e.SessionId,
+        RunId = e.RunId,
+        State = e.State,
+        Reason = e.Reason,
+        OccurredUtc = e.OccurredUtc,
+        RecordedUtc = e.RecordedUtc,
+    };
+}

--- a/src/CcDirector.Gateway/Governance/GovernanceValidationException.cs
+++ b/src/CcDirector.Gateway/Governance/GovernanceValidationException.cs
@@ -1,0 +1,8 @@
+namespace CcDirector.Gateway.Governance;
+
+/// <summary>An append to the governance ledger violates the ledger rules (unknown subject or state, a
+/// missing subject key, an oversize reason). Maps to HTTP 400 at the endpoint boundary.</summary>
+public sealed class GovernanceValidationException : Exception
+{
+    public GovernanceValidationException(string message) : base(message) { }
+}


### PR DESCRIPTION
## The append-only governance event ledger (governance spine item 2, thefrederiksen/devthrottle_internal#856)

The workflow-run spine (#1779) gives governance *acceptance* and *started/completed* — but not *durations*. This adds the timeline the run row cannot: `governance_events`, a tenant-scoped, append-only table of immutable session/run state transitions, each stamped with when it happened. It is what lets a report answer "how long was this session idle / waiting on a human / blocked", none of which the run's two timestamps can reconstruct.

### How it hangs off the merged run contract
- **Session transitions** key on the canonical Director-minted session GUID — the same id `workflow_runs.Participants[].SessionId` uses. That is the join from a run to the sessions that did the work.
- **Run transitions** carry `RunId` as a plain-value reference to `workflow_runs.Id` — **no foreign key**, matching the run row's own no-FK stance and cron run history: an audit fact must outlive its run (no cascade, no restrict).

### State vocabulary
`active`, `idle`, `waiting-on-human`, `waiting-on-permission`, `blocked`, `recovered` — the transitions a duration/attention-burden report reads.

### What's here
- `GovernanceEventEntity` → `governance_events` (`: TenantScopedEntity`), provider-agnostic (no SQLite/Postgres-only construct), UTC DateTime, GUID PK `ValueGeneratedNever`, no bare decimals, snake_case.
- Composite indexes **lead with `tenant_id`** — `(tenant_id, SessionId, OccurredUtc)`, `(tenant_id, RunId, OccurredUtc)`, `(tenant_id, OccurredUtc)` — so they serve the globally-filtered query under Phase B multi-tenant load rather than forcing a cross-tenant scan.
- `GovernanceEventLedger` store: append-only by contract (no update/delete). `Append` writes one; `AppendBatch` writes many in one unit of work with change-detection disabled, still setting `tenant_id` per row. Reason capped, subject/state validated, occurred-time defaulted and future-clock-clamped, server-stamped `RecordedUtc`.
- REST: `POST /gateway/governance/events`, `POST .../batch`, `GET` with session/run/subject/state/time-window filters. Append-and-read only.
- Migration `AddGovernanceEvents` — additive `CreateTable` only, generated as the tail after `AddSnoozes`; the clean-DB migrate applies all six migrations in order.
- 11 store tests: validation, server-stamping, future-clock clamp, newest-first ordering, window filter, all-or-nothing batch, tenant isolation.

### Coordination
Migration serialized through the single fleet slot with the Hosted Gateway Architect (session 153e5390); indexes made tenant-id-leading and the non-FK `RunId` confirmed at their request. Retention/pruning for the append-only table is flagged for the hosted step (governance/audit data likely wants a longer horizon than the prompt log's 90 days — an owner call before the first hosted tenant).

Part of the thefrederiksen/devthrottle_internal#856 governance outcome-spine. Next: honest driver-normalized spend (spine item 3).
