### PR TITLE
fix(gateway): stop the wingman voice reading out commit hashes and id numbers

### DIFF
--- a/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
@@ -249,14 +249,22 @@ public sealed class WingmanTranslatorTests
         // Hearing "fe2ec700 dash 458e dash 420e" read out digit by digit is useless - you cannot write
         // it down or act on it. v4 had NO rule about this and told the wingman to preserve every
         // number, so it did. Prompt-only, so pin it or it regresses silently.
+        //
+        // v5.3 (2026-07-17): the rule already existed, yet a narration still spelled out a full 40-char
+        // commit sha one hex character at a time ("d zero six three zero a five c d ...") because the
+        // rule's only example was a DASHED guid and a bare hex sha did not match that shape. Pin BOTH
+        // shapes, the drop-it-entirely instruction, and the extension to reference numbers.
         var brain = new FakeBrain(_ => "ok");
         var translator = BuildTranslator(brain);
 
         await translator.TranslateAsync("q", "session fe2ec700-458e-420e used 5,254,730 bytes", sessionTitle: null);
 
         var prompt = Assert.Single(brain.Asks);
-        Assert.Contains("NEVER READ OUT IDENTIFIERS OR LONG NUMBERS", prompt);
-        Assert.Contains("about five million", prompt);   // the concrete rounding example
+        Assert.Contains("NEVER VOICE AN IDENTIFIER OR A HASH", prompt);
+        Assert.Contains("d0630a5cd517167516675e0299009", prompt); // the bare-hex sha shape that regressed
+        Assert.Contains("the changes were merged", prompt);       // DROP the hash, do not gloss it at length
+        Assert.Contains("REFERENCE NUMBERS ARE NOT SPOKEN NUMBERS", prompt); // issue/pr/bug numbers too
+        Assert.Contains("about five million", prompt);            // the concrete rounding example
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
@@ -71,6 +71,15 @@ public sealed class WingmanTranslator
     /// prepend would read it out as "slash" and "hashtag" - exactly what SPEAK FOR THE EAR forbids.
     /// The model naturalizes it; code cannot. It costs a few words against the ~30s budget, which is
     /// why the rule says the title and nothing else about the session.
+    ///
+    /// v5.3 hardens the "never voice an identifier" rule after a narration read a full 40-char
+    /// commit sha out one hex character at a time ("d zero six three zero a five c d ...") - about
+    /// fifteen seconds of useless noise. The old rule already forbade it, but its only example was
+    /// a DASHED guid; a bare continuous hex sha did not match that shape, so the model copied it
+    /// through. v5.3 shows both shapes, tells the model to DROP the reference entirely rather than
+    /// gloss it, and extends the ban to issue/pull-request/bug NUMBERS (say "three bug fixes are
+    /// done", never "eighty-one eleven, eighty-one twelve..."). Prompt-only, per the standing rule
+    /// that LLM behaviour is fixed in the prompt, not with a regex pass.
     /// </summary>
     internal const string FidelityPrompt = """
         You are the wingman: you turn a coding agent's written reply into words a person
@@ -112,15 +121,27 @@ public sealed class WingmanTranslator
           NEVER reduce a technical answer to a vague line like "the agent gave a technical
           explanation" or "it made some changes". Name the specific thing, the cause, and the
           fix - and stop. Depth is not length: three precise sentences beat a paragraph.
-        - NEVER READ OUT IDENTIFIERS OR LONG NUMBERS. A session id, commit hash, request id,
-          port, token, path or long digit string is USELESS to someone listening - they cannot
-          write it down or act on it, and hearing it read out digit by digit is the single
-          most irritating thing you can do. Say that it exists and what it is FOR: "the session
-          id", "a commit hash", "the request id" - never "fe2ec700 dash 458e dash 420e".
-          Round large numbers to what a person would really say out loud:
-          5,254,730 becomes "about five million"; 12,092,444 bytes becomes "about twelve
-          megabytes"; 84 stays 84. Keep a number when it IS the answer - a count, a version, a
-          price, a duration, a size that matters - and round or simply name the rest.
+        - NEVER VOICE AN IDENTIFIER OR A HASH. This is the rule listeners notice most when you
+          break it. A commit hash, session id, request id, token, port, file path, or any long
+          run of letters and digits is USELESS to someone listening: they cannot write it down
+          and cannot act on it, and spelling it out character by character is the single most
+          irritating thing you can do. Catch BOTH shapes: a dashed identifier like
+          "fe2ec700-458e-420e", AND a plain run of hex with no dashes like
+          "d0630a5cd517167516675e0299009" - a bare commit hash will not look like the first
+          example, but it is the same useless thing. Do not voice either. DROP it and say only
+          that the thing happened: "merged at commit d0630a5..." becomes just
+          "the changes were merged" - do not even say "at a commit", the hash adds nothing. If
+          you truly must refer to one, name what it is FOR and stop: "the session id" or
+          "a commit hash".
+        - REFERENCE NUMBERS ARE NOT SPOKEN NUMBERS. A listener cannot use an issue,
+          pull-request, or bug number; reading "eighty-one eleven, eighty-one twelve, eighty-one
+          thirteen" is the same noise as a hash. Say the WORK, counted, not the numbers: "three
+          bug fixes are done", "a pull request is open", "the deploy-protection fix landed".
+          Drop the number unless it genuinely IS the answer to what was asked.
+        - ROUND LARGE NUMBERS to what a person would really say out loud: 5,254,730 becomes
+          "about five million"; 12,092,444 bytes becomes "about twelve megabytes"; 84 stays 84.
+          Keep a number only when it IS the answer - a count, a version, a price, a duration, a
+          size that matters - and round or simply name the rest.
         - IF THE PERSON ASKED FOR SOMETHING TO BE READ IN FULL - a document, a file, a passage
           - read it in full. An explicit request for the whole thing overrides brevity. That is
           the ONLY reason a long narration should exist.
@@ -171,7 +192,7 @@ public sealed class WingmanTranslator
     /// instructions is shown that the recommended default changed and can switch to it. The content
     /// hash is the real identity; this is the human-facing label.
     /// </summary>
-    public const string DefaultInstructionsVersion = "7";
+    public const string DefaultInstructionsVersion = "8";
 
     private readonly Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> _brainProvider;
     private readonly Action<string> _log;


### PR DESCRIPTION
The Voice-mode narration spelled a full 40-character commit sha out one hex character at a time ("d zero six three zero a five c d ...") - about fifteen seconds of noise a listener cannot write down or act on. The same turn read out "bugs eighty-one eleven, eighty-one twelve, eighty-one thirteen".

The fidelity prompt already forbade voicing identifiers, but its only example was a dashed guid, so a bare continuous hex sha did not match the shape the model was told to suppress and got copied straight through. It also runs on the Fast model tier, which discounts a soft rule.

## The fix (FidelityPrompt v5.3, DefaultInstructionsVersion 8)

Prompt-only, per the standing rule that model behaviour is fixed in the prompt, not with a regex pass:

- Show BOTH shapes - the dashed guid AND a bare hex sha with no dashes.
- Tell the model to DROP the reference entirely rather than gloss it at length ("the changes were merged", not "at a commit whose hash is...").
- Extend the ban to issue, pull-request, and bug NUMBERS: say "three bug fixes are done", never "eighty-one eleven, eighty-one twelve...".

## Verification

The pinning test is updated to guard both hash shapes, the drop-it instruction, and the reference-number rule. All 35 WingmanTranslator tests pass; Gateway builds clean with 0 warnings.