### PR TITLE
refactor(gateway): centralize the recoverable legacy-JSON import

### DIFF
--- a/src/CcDirector.Gateway.Tests/CronJobStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronJobStoreTests.cs
@@ -251,6 +251,47 @@ public sealed class CronJobStoreTests : IDisposable
     }
 
     [Fact]
+    public void LegacyJson_RenameFailsAfterImport_NextConstructionRecoversWithoutReimporting()
+    {
+        // The cron rename-recovery gap flagged in review on #1772: a rename that fails AFTER the import
+        // commits used to orphan the legacy file forever (the old cron path threw from RenameAside and had no
+        // recovery branch). The shared recoverable-import plumbing closes it: the first construction imports and
+        // commits, its rename-aside fails because the file is held open, and it does NOT throw; the next
+        // construction sees the table already populated and renames the lingering file aside WITHOUT
+        // re-importing.
+        var legacy = LegacyPath();
+        var seeded = ValidJob();
+        seeded.Id = "cj_recover1";
+        WriteLegacyJobsFile(legacy, seeded);
+
+        var dir = Path.GetDirectoryName(legacy)!;
+        var migratedGlob = Path.GetFileName(legacy) + ".migrated-*";
+
+        // Hold the legacy file open with a share mode that permits a read (so the import can parse it) but
+        // blocks a move (File.Move needs delete-sharing on the source), so the post-commit rename-aside fails.
+        using (new FileStream(legacy, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            // First construction: imports the job (committed), then the rename-aside fails on the locked file.
+            // Best-effort - it is logged, NOT thrown - so the store constructs and holds the imported data.
+            var store1 = new CronJobStore(_h.Open(), legacy);
+            Assert.NotNull(store1.Get("cj_recover1"));
+            Assert.Single(store1.ListAll());
+            // The rename failed, so the legacy file lingers and nothing has been renamed aside yet.
+            Assert.True(File.Exists(legacy));
+            Assert.Empty(Directory.GetFiles(dir, migratedGlob));
+        }
+
+        // The lock is released. The next construction sees the table already populated and the file still
+        // there: it renames the leftover aside (idempotent recovery) WITHOUT re-importing, and does not throw.
+        var store2 = new CronJobStore(_h.Open(), legacy);
+
+        Assert.Single(store2.ListAll());                      // no re-import - still exactly one job
+        Assert.NotNull(store2.Get("cj_recover1"));
+        Assert.False(File.Exists(legacy));                    // the lingering file was recovered (renamed aside)
+        Assert.Single(Directory.GetFiles(dir, migratedGlob)); // exactly one backup, renamed once
+    }
+
+    [Fact]
     public void CorruptLegacyJson_FailsLoud_AndLeavesTheFileInPlace()
     {
         var legacy = LegacyPath();

--- a/src/CcDirector.Gateway/CronJobStore.cs
+++ b/src/CcDirector.Gateway/CronJobStore.cs
@@ -300,20 +300,28 @@ public sealed class CronJobStore
     }
 
     /// <summary>
-    /// Import a legacy <c>cronjobs.json</c> exactly once: only when it exists AND the table is empty. Every
-    /// job is inserted inside one transaction, then the JSON file is renamed aside so it is never
-    /// re-imported and stays as a backup. Fail-loud and all-or-nothing - a parse or write error throws and
-    /// imports nothing (the transaction rolls back and the JSON is left in place), so no data is lost or
-    /// partially imported.
+    /// Import a legacy <c>cronjobs.json</c> exactly once, through the shared recoverable-import plumbing
+    /// (<see cref="LegacyJsonImport.Recoverable"/>): import only when the file exists AND the table is empty;
+    /// if the file lingers while the table is already populated, rename it aside idempotently (recovery from a
+    /// rename that failed after a prior commit); and rename aside best-effort after a successful import so a
+    /// briefly-locked file cannot brick startup. The parse/insert below is unchanged and stays fail-loud.
     /// </summary>
     private void ImportLegacyJsonIfNeeded()
-    {
-        if (!File.Exists(_legacyJsonPath))
-            return;
+        => LegacyJsonImport.Recoverable(
+            _legacyJsonPath,
+            "[CronJobStore]",
+            isPopulated: () => { using var ctx = _db.CreateContext(); return ctx.CronJobs.Any(); },
+            importCommitted: ImportRowsFromLegacyJson);
 
+    /// <summary>
+    /// Parse the legacy file and insert every job inside one transaction. Fail-loud and all-or-nothing - a
+    /// parse or write error throws and imports nothing (the transaction rolls back and the JSON is left in
+    /// place), so no data is lost or partially imported. Called by the recoverable-import plumbing only when
+    /// the file exists and the table is empty; the plumbing renames the file aside after this returns.
+    /// </summary>
+    private void ImportRowsFromLegacyJson()
+    {
         using var ctx = _db.CreateContext();
-        if (ctx.CronJobs.Any())
-            return; // already migrated (or already has data); never re-import over existing rows.
 
         StoreFile? parsed;
         try
@@ -351,7 +359,6 @@ public sealed class CronJobStore
         ctx.SaveChanges();
         tx.Commit();
 
-        LegacyJsonImport.RenameAside(_legacyJsonPath, "[CronJobStore]");
         FileLog.Write($"[CronJobStore] Import: {jobs.Count} job(s) imported from {_legacyJsonPath}");
     }
 }

--- a/src/CcDirector.Gateway/CronRunHistoryStore.cs
+++ b/src/CcDirector.Gateway/CronRunHistoryStore.cs
@@ -152,13 +152,20 @@ public sealed class CronRunHistoryStore
     /// order. All inside one transaction, then the JSON is renamed aside. Fail-loud and all-or-nothing.
     /// </summary>
     private void ImportLegacyJsonIfNeeded()
-    {
-        if (!File.Exists(_legacyJsonPath))
-            return;
+        => LegacyJsonImport.Recoverable(
+            _legacyJsonPath,
+            "[CronRunHistoryStore]",
+            isPopulated: () => { using var ctx = _db.CreateContext(); return ctx.CronRuns.Any(); },
+            importCommitted: ImportRowsFromLegacyJson);
 
+    /// <summary>
+    /// Parse the legacy file and insert every run inside one transaction. Fail-loud and all-or-nothing.
+    /// Called by the recoverable-import plumbing only when the file exists and the table is empty; the
+    /// plumbing renames the file aside after this returns.
+    /// </summary>
+    private void ImportRowsFromLegacyJson()
+    {
         using var ctx = _db.CreateContext();
-        if (ctx.CronRuns.Any())
-            return;
 
         StoreFile? parsed;
         try
@@ -196,7 +203,6 @@ public sealed class CronRunHistoryStore
         ctx.SaveChanges();
         tx.Commit();
 
-        LegacyJsonImport.RenameAside(_legacyJsonPath, "[CronRunHistoryStore]");
         FileLog.Write($"[CronRunHistoryStore] Import: {imported} run(s) across {runsByJob.Count} job(s) imported from {_legacyJsonPath}");
     }
 }

--- a/src/CcDirector.Gateway/Data/LegacyJsonImport.cs
+++ b/src/CcDirector.Gateway/Data/LegacyJsonImport.cs
@@ -6,19 +6,79 @@ namespace CcDirector.Gateway.Data;
 /// Shared helper for the one-time JSON-to-SQLite migration each structured store runs on first upgrade.
 /// After a store has imported a legacy JSON file into the EF database, it renames the file aside so the
 /// import never runs again and the original data stays on disk as a backup.
+///
+/// <see cref="Recoverable"/> owns the guard/rename/recovery plumbing that every migrated store shares, so
+/// there is ONE implementation of the recoverable, idempotent, best-effort rename-aside flow rather than an
+/// inline copy per store. Each store still owns its own populated-check, parse, and insert; only the
+/// surrounding plumbing lives here.
 /// </summary>
 public static class LegacyJsonImport
 {
     /// <summary>
+    /// Run a store's one-time legacy-JSON import with the shared recoverable, idempotent, best-effort
+    /// rename-aside plumbing:
+    /// <list type="bullet">
+    /// <item>No legacy file on disk - nothing to do.</item>
+    /// <item>The file exists but the table is ALREADY populated (a prior import committed but its rename-aside
+    /// did not complete - the file was briefly locked) - rename it aside now, NEVER re-importing over existing
+    /// rows, so the leftover self-heals. Best-effort (see <see cref="TryRenameAside"/>): a rename that fails
+    /// again leaves the data safe and lets the next boot retry.</item>
+    /// <item>First upgrade (file exists, table empty) - the store's <paramref name="importCommitted"/> parses
+    /// and inserts its own rows inside a transaction and commits. A parse error THROWS from there and the file
+    /// is left in place (fail-loud, all-or-nothing); this helper does not catch it. On success the imported
+    /// file is renamed aside, best-effort - the data is committed and the empty-table guard blocks any
+    /// re-import, so a briefly-locked file is logged and retried next boot rather than failing the Gateway.</item>
+    /// </list>
+    /// The <paramref name="isPopulated"/> check and <paramref name="importCommitted"/> import are the store's
+    /// own logic (they open their own scoped context); this helper only sequences them and owns the renames.
+    /// </summary>
+    public static void Recoverable(string path, string logPrefix, Func<bool> isPopulated, Action importCommitted)
+    {
+        if (!File.Exists(path))
+            return;
+
+        if (isPopulated())
+        {
+            // Idempotent recovery: the data is already in the database, so a lingering legacy file is a
+            // rename that failed after the commit. Rename it aside without touching the existing rows.
+            TryRenameAside(path, logPrefix);
+            return;
+        }
+
+        // First upgrade: the store parses and inserts its rows (fail-loud on a parse error propagates and
+        // leaves the file in place), then the imported file is renamed aside best-effort.
+        importCommitted();
+        TryRenameAside(path, logPrefix);
+    }
+
+    /// <summary>
     /// Rename an imported legacy file to <c>&lt;path&gt;.migrated-&lt;UTCstamp&gt;</c>. Called only AFTER a
-    /// successful, committed import, so the aside copy is a verified backup. Fail-loud: if the rename throws
-    /// the exception propagates - a store whose data is in the database but whose legacy file was NOT moved
-    /// aside would re-import on the next boot, so leaving it in place silently is not acceptable.
+    /// successful, committed import, so the aside copy is a verified backup. Throws if the rename fails - used
+    /// where the caller wants the failure surfaced. The recoverable flow uses <see cref="TryRenameAside"/>
+    /// instead, which swallows the failure because the empty-table guard prevents a re-import.
     /// </summary>
     public static void RenameAside(string path, string logPrefix)
     {
         var aside = $"{path}.migrated-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}";
         File.Move(path, aside);
         FileLog.Write($"{logPrefix} Import: renamed the imported legacy file {path} aside to {aside} (kept as a backup)");
+    }
+
+    /// <summary>
+    /// Rename the imported legacy file aside, best-effort. The data is already committed to the database and
+    /// the empty-table guard prevents any re-import, so a failed rename (for example a briefly-locked file)
+    /// must NOT fail the Gateway - it is logged and left for the next boot's recovery to retry.
+    /// </summary>
+    public static void TryRenameAside(string path, string logPrefix)
+    {
+        try
+        {
+            RenameAside(path, logPrefix);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"{logPrefix} Import: rename-aside of {path} failed (data is safe in the database; " +
+                          $"the next boot retries): {ex.Message}");
+        }
     }
 }

--- a/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
+++ b/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
@@ -494,16 +494,22 @@ public sealed class SnoozeRegistry
     /// aside idempotently (best-effort recovery) so a failed rename self-heals next boot without re-importing.
     /// </summary>
     private void ImportLegacyJsonIfNeeded()
-    {
-        if (!File.Exists(_legacyJsonPath))
-            return;
+        => LegacyJsonImport.Recoverable(
+            _legacyJsonPath,
+            "[SnoozeRegistry]",
+            isPopulated: () => { using var ctx = _db.CreateContext(); return ctx.Snoozes.Any(); },
+            importCommitted: ImportRowsFromLegacyJson);
 
+    /// <summary>
+    /// Parse the legacy file and insert every pending snooze inside one transaction (last-wins on a duplicate
+    /// session id, deadline normalized to UTC, a null DirectorId retained losslessly). Fail-loud and
+    /// all-or-nothing - a parse error or a null document throws and imports nothing (the file is left in
+    /// place). Called by the recoverable-import plumbing only when the file exists and the table is empty; the
+    /// plumbing renames the file aside after this returns.
+    /// </summary>
+    private void ImportRowsFromLegacyJson()
+    {
         using var ctx = _db.CreateContext();
-        if (ctx.Snoozes.Any())
-        {
-            TryRenameAside();
-            return;
-        }
 
         StoreFile? parsed;
         try
@@ -563,25 +569,6 @@ public sealed class SnoozeRegistry
         ctx.SaveChanges();
         tx.Commit();
 
-        TryRenameAside();
         FileLog.Write($"[SnoozeRegistry] Import: {toImport.Count} pending snooze(s) imported from {_legacyJsonPath}");
-    }
-
-    /// <summary>
-    /// Rename the imported legacy file aside, best-effort. The data is already committed and the empty-table
-    /// guard prevents any re-import, so a failed rename (a briefly-locked file) is logged and left for the
-    /// next boot to retry rather than failing the Gateway.
-    /// </summary>
-    private void TryRenameAside()
-    {
-        try
-        {
-            LegacyJsonImport.RenameAside(_legacyJsonPath, "[SnoozeRegistry]");
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[SnoozeRegistry] Import: rename-aside of {_legacyJsonPath} failed (data is safe in the " +
-                          $"database; the next boot retries): {ex.Message}");
-        }
     }
 }

--- a/src/CcDirector.Gateway/WorkListStore.cs
+++ b/src/CcDirector.Gateway/WorkListStore.cs
@@ -402,21 +402,21 @@ public sealed class WorkListStore
     /// AFTER this, so an imported claim is then released exactly as a restart would release it.
     /// </summary>
     private void ImportLegacyJsonIfNeeded()
-    {
-        if (!File.Exists(_legacyJsonPath))
-            return;
+        => LegacyJsonImport.Recoverable(
+            _legacyJsonPath,
+            "[WorkListStore]",
+            isPopulated: () => { using var ctx = _db.CreateContext(); return ctx.WorkLists.Any(); },
+            importCommitted: ImportRowsFromLegacyJson);
 
+    /// <summary>
+    /// Parse the legacy file and insert every list (name case preserved, items ORDER preserved,
+    /// consumer/claim preserved) inside one transaction. Fail-loud and all-or-nothing - a parse error throws
+    /// and imports nothing (the file is left in place). Called by the recoverable-import plumbing only when
+    /// the file exists and the table is empty; the plumbing renames the file aside after this returns.
+    /// </summary>
+    private void ImportRowsFromLegacyJson()
+    {
         using var ctx = _db.CreateContext();
-        if (ctx.WorkLists.Any())
-        {
-            // Recovery (idempotent): a prior import committed but its rename-aside did not complete (the file
-            // was briefly locked), so the legacy file lingers even though the data is already in the database.
-            // Rename it aside now - NEVER re-importing over existing rows - so the leftover file is cleaned up
-            // and can never be re-imported. Best-effort: if the rename fails again the data is safe and the
-            // next boot retries.
-            TryRenameAside();
-            return;
-        }
 
         StoreFile? parsed;
         try
@@ -456,25 +456,6 @@ public sealed class WorkListStore
         ctx.SaveChanges();
         tx.Commit();
 
-        TryRenameAside();
         FileLog.Write($"[WorkListStore] Import: {lists.Count} list(s) imported from {_legacyJsonPath}");
-    }
-
-    /// <summary>
-    /// Rename the imported legacy file aside, best-effort. The data is already committed to the database and
-    /// the empty-table guard prevents any re-import, so a failed rename (e.g. the file is briefly locked) must
-    /// NOT fail the Gateway - it is logged and left for the next boot's recovery to retry.
-    /// </summary>
-    private void TryRenameAside()
-    {
-        try
-        {
-            LegacyJsonImport.RenameAside(_legacyJsonPath, "[WorkListStore]");
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[WorkListStore] Import: rename-aside of {_legacyJsonPath} failed (data is safe in the " +
-                          $"database; the next boot retries): {ex.Message}");
-        }
     }
 }


### PR DESCRIPTION
Centralize the one-time legacy-JSON import into a single recoverable helper,
LegacyJsonImport.Recoverable, and route all four migrated stores (the two cron
stores, the work-list store, and the snooze registry) through it. One
implementation instead of three inline copies.

This also closes a gap the earlier reviews flagged: the cron stores predated the
idempotent rename-recovery and still used a throwing rename after the commit, so
a rename that failed after the data was committed orphaned the legacy file
forever. Now every store shares the same behavior:

- The successful import path is unchanged - each store keeps its own parse and
  insert logic (order, fields, the all-or-nothing transaction, per-store dedup
  and caps).
- A corrupt or unparseable file still fails loud with the actionable message and
  is left in place - no silent empty commit, no premature rename.
- The rename-aside is best-effort: a failure after the data is committed is
  logged, not thrown, so it cannot block startup, and the empty-table guard
  prevents any re-import.
- Recovery is idempotent: when the legacy file still exists but the table is
  already populated, it is renamed aside on the next boot without re-importing.

No database, entity, or migration change.

Evidence: full Gateway test suite green, the existing import and recovery tests
for all four stores unchanged, plus a new cron rename-recovery test - a locked
file so the first construction does not throw and the next construction renames
the file aside without re-importing. The new test was confirmed to fail with the
fix removed and pass with it in place.
