### PR TITLE
feat(director,gateway): version-pinned seated sessions - spawns seat on workflow runs (Workflows phase 5b)

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -79,6 +79,7 @@ internal static class ControlEndpoints
                 var text = FleetPreamble.BuildForSession(
                     session.Id.ToString(), name, Environment.MachineName, session.RepoPath, user,
                     workflowIndex: new WorkflowIndexStore());
+                text = AppendSeatParagraph(text, session);
                 return Results.Text(text, "text/plain");
             }
             catch (Exception ex) when (ex is InjectedTextUnavailableException or FleetPreambleTemplateException)
@@ -127,6 +128,7 @@ internal static class ControlEndpoints
                 text = FleetPreamble.BuildForSession(
                     session.Id.ToString(), name, Environment.MachineName, session.RepoPath, user,
                     workflowIndex: new WorkflowIndexStore());
+                text = AppendSeatParagraph(text, session);
             }
             catch (Exception ex) when (ex is InjectedTextUnavailableException or FleetPreambleTemplateException)
             {
@@ -243,7 +245,7 @@ internal static class ControlEndpoints
         // Create a session LOCALLY through the shared SessionCommandExecutor (issue #1177 Phase 1), then build
         // the identity-stamped 201 response. Used by the local branch of POST /fleet/spawn; the Machine routing
         // field is advisory here (the routing decision is made before the request reaches this Director).
-        async Task<IResult> CreateLocalSessionAsync(NewSessionRequest? req)
+        async Task<IResult> CreateLocalSessionAsync(NewSessionRequest? req, Func<Session, Task>? onCreated = null)
         {
             var command = new DirectorCommand
             {
@@ -265,9 +267,15 @@ internal static class ControlEndpoints
             if (created is null || !Guid.TryParse(created.SessionId, out var newGuid))
                 return Results.Problem("created session id missing", statusCode: 500);
             var session = sessionManager.GetSession(newGuid);
-            return session is null
-                ? Results.Problem("created session not found", statusCode: 500)
-                : Results.Json(MapWithIdentity(session, turnSummaryCache), statusCode: 201);
+            if (session is null)
+                return Results.Problem("created session not found", statusCode: 500);
+            // Post-create hook (Workflows mission, phase 5b): lets the caller run follow-up work that
+            // needs the CREATED session - recording the run participant - without re-plumbing the
+            // create result. The session exists whether or not the hook succeeds; the hook owns its
+            // own error posture.
+            if (onCreated is not null)
+                await onCreated(session);
+            return Results.Json(MapWithIdentity(session, turnSummaryCache), statusCode: 201);
         }
 
         // Deliver a framed message to a LOCAL session, wait for the turn to SETTLE, and return its answer
@@ -642,7 +650,73 @@ internal static class ControlEndpoints
                     // resolve it exactly as it does today. That is the only store a Gateway-less Director has.
                 }
 
-                return await CreateLocalSessionAsync(req);
+                // Workflows mission (phase 5b): resolve the SEAT for a local spawn against the Gateway's
+                // run store, the same way the Gateway relay stamps a remote spawn - an explicit run id is
+                // validated (unknown -> 400, unreachable Gateway -> 502, never conflated), and a
+                // mission-scoped spawn with no explicit run auto-seats onto the mission's run. The run's
+                // workflow id + pinned version ride the create request; the floor stamps only what create
+                // carries. A Gateway-less Director seats nothing - runs live only on the Gateway.
+                WorkflowRunDto? seatRun = null;
+                var seatGw = gatewayClientProvider?.Invoke();
+                if (seatGw is { IsEnabled: true })
+                {
+                    try
+                    {
+                        if (req.WorkflowRunId is Guid explicitRunId)
+                        {
+                            seatRun = await seatGw.GetWorkflowRunAsync(explicitRunId, ct);
+                            if (seatRun is null)
+                                return Results.BadRequest(new
+                                {
+                                    error = $"unknown workflow run '{explicitRunId}'. "
+                                          + "List runs with: cc-devthrottle workflow runs",
+                                });
+                        }
+                        else if (req.MissionId is Guid seatMissionId)
+                        {
+                            seatRun = await seatGw.GetMissionWorkflowRunAsync(seatMissionId, ct);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        FileLog.Write($"[ControlEndpoints] POST /fleet/spawn: workflow-run lookup FAILED: {ex.Message}");
+                        return Results.Json(
+                            new { error = $"Cannot seat the new session on its workflow run: the Gateway could not be reached. {ex.Message}" },
+                            statusCode: StatusCodes.Status502BadGateway);
+                    }
+
+                    if (seatRun is not null)
+                    {
+                        req.WorkflowRunId = seatRun.Id;
+                        req.WorkflowId = seatRun.WorkflowId;
+                        req.WorkflowVersion = seatRun.WorkflowVersion;
+                    }
+                }
+
+                return await CreateLocalSessionAsync(req, onCreated: seatRun is null || seatGw is null
+                    ? null
+                    : async createdSession =>
+                    {
+                        // Record the created session as a run participant (persisted run-to-session
+                        // membership, issue #1771). The spawn has already succeeded; a failed record is
+                        // reported LOUDLY in the log rather than failing the session under the caller.
+                        try
+                        {
+                            await seatGw.AddWorkflowRunParticipantAsync(seatRun.Id, new WorkflowRunParticipantDto
+                            {
+                                SessionId = createdSession.Id.ToString(),
+                                AgentKind = req.Agent,
+                                Role = createdSession.ExplicitRole ?? "",
+                                Machine = Environment.MachineName,
+                            }, ct);
+                        }
+                        catch (Exception ex)
+                        {
+                            FileLog.Write($"[ControlEndpoints] POST /fleet/spawn: run-participant record FAILED for " +
+                                          $"session {createdSession.Id} on run {seatRun.Id}: {ex.Message}. The session " +
+                                          "is seated and running; governance is missing this membership row.");
+                        }
+                    });
             }
 
             FileLog.Write($"[ControlEndpoints] POST /fleet/spawn: machine={machine}, repo={req.RepoPath}, agent={req.Agent}");
@@ -1109,6 +1183,33 @@ internal static class ControlEndpoints
     /// through, BadRequest/NotFound/Conflict keep their meaning, and anything else is a 500. Shared by every
     /// /fleet session-control verb so they cannot drift apart from each other or from the tunnel path.
     /// </summary>
+    /// <summary>
+    /// Append the workflow SEAT paragraph to a session's preamble (Workflows mission, phase 5b): a
+    /// seated session is told, at launch, exactly which run it executes, at which PINNED version to
+    /// fetch its conduct, and to stop rather than proceed on remembered rules if the fetch fails
+    /// (the no-fallback law applied to conduct). Appended even when the preamble itself is empty -
+    /// the seat is the operational fact the session was spawned FOR, not our injectable prose - but
+    /// not on the unreadable-user-template failure path, which deliberately injects nothing at all.
+    /// Unseated sessions pass through untouched.
+    /// </summary>
+    private static string AppendSeatParagraph(string preamble, Session session)
+    {
+        if (session.WorkflowRunId is not Guid runId || string.IsNullOrWhiteSpace(session.WorkflowId))
+            return preamble;
+
+        var role = string.IsNullOrWhiteSpace(session.ExplicitRole) ? "a participant" : session.ExplicitRole;
+        var versionArg = session.WorkflowVersion is int v ? $" --version {v}" : "";
+        var paragraph =
+            $"[Workflow seat] You are seated as {role} on the '{session.WorkflowId}' workflow" +
+            (session.WorkflowVersion is int pv ? $" (pinned v{pv})" : "") +
+            $", run {runId}. Before doing anything else, fetch your conduct and FOLLOW it:\n" +
+            $"  cc-devthrottle workflow instructions {session.WorkflowId}{versionArg}\n" +
+            "If that command fails, STOP and report the failure - never proceed on remembered or " +
+            "reconstructed rules.";
+
+        return string.IsNullOrEmpty(preamble) ? paragraph : preamble + "\n\n" + paragraph;
+    }
+
     private static IResult CommandResultToHttp(DirectorCommandResult result) => result.Status switch
     {
         DirectorCommandStatus.Ok => Results.Content(result.BodyJson ?? "{}", "application/json"),
@@ -1346,6 +1447,12 @@ internal static class ControlEndpoints
             // in the Director's MissionStore.
             MissionId = s.MissionId,
             MissionName = s.MissionName,
+            // Workflow seat (Workflows mission, phase 5b): the run this session executes, with its
+            // cached workflow id + pinned version - stamped at spawn from the Gateway-validated
+            // create request.
+            WorkflowRunId = s.WorkflowRunId,
+            WorkflowId = s.WorkflowId,
+            WorkflowVersion = s.WorkflowVersion,
             SortOrder = s.SortOrder,
             StatusColor = s.StatusColor,
             LastStatusReason = s.LastStatusReason,

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1194,19 +1194,12 @@ internal static class ControlEndpoints
     /// </summary>
     private static string AppendSeatParagraph(string preamble, Session session)
     {
-        if (session.WorkflowRunId is not Guid runId || string.IsNullOrWhiteSpace(session.WorkflowId))
+        // ONE builder for every delivery channel (WorkflowSeatParagraph) - it also validates the
+        // workflow id against the catalog slug shape, so a forged seat renders nothing.
+        var paragraph = WorkflowSeatParagraph.Build(
+            session.WorkflowRunId, session.WorkflowId, session.WorkflowVersion, session.ExplicitRole);
+        if (paragraph is null)
             return preamble;
-
-        var role = string.IsNullOrWhiteSpace(session.ExplicitRole) ? "a participant" : session.ExplicitRole;
-        var versionArg = session.WorkflowVersion is int v ? $" --version {v}" : "";
-        var paragraph =
-            $"[Workflow seat] You are seated as {role} on the '{session.WorkflowId}' workflow" +
-            (session.WorkflowVersion is int pv ? $" (pinned v{pv})" : "") +
-            $", run {runId}. Before doing anything else, fetch your conduct and FOLLOW it:\n" +
-            $"  cc-devthrottle workflow instructions {session.WorkflowId}{versionArg}\n" +
-            "If that command fails, STOP and report the failure - never proceed on remembered or " +
-            "reconstructed rules.";
-
         return string.IsNullOrEmpty(preamble) ? paragraph : preamble + "\n\n" + paragraph;
     }
 

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -575,6 +575,92 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     }
 
     /// <summary>
+    /// Workflows mission (phase 5b): look a workflow RUN up by id in the Gateway's run store - the
+    /// source of truth for runs. A LOCAL seated spawn resolves the run through here so it stamps the
+    /// create request exactly the way the Gateway stamps a REMOTE spawn. Returns null ONLY on a
+    /// genuine 404; throws when the Gateway is disabled or unreachable (an unreachable Gateway is
+    /// never reported as "unknown run" - the GetMissionAsync posture).
+    /// </summary>
+    public async Task<WorkflowRunDto?> GetWorkflowRunAsync(Guid runId, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot look up a workflow run.");
+
+        FileLog.Write($"[GatewayClient] GetWorkflowRunAsync: GET /gateway/workflow-runs/{runId}");
+        using var resp = await _http.GetAsync($"gateway/workflow-runs/{runId}", ct);
+        if (resp.StatusCode == HttpStatusCode.NotFound)
+            return null;
+        if (!resp.IsSuccessStatusCode)
+        {
+            var detail = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(
+                $"Gateway could not look up workflow run '{runId}': HTTP {(int)resp.StatusCode} {resp.ReasonPhrase} {detail}".TrimEnd());
+        }
+        var run = await resp.Content.ReadFromJsonAsync<WorkflowRunDto>(ct);
+        if (run is null)
+            throw new InvalidOperationException($"Gateway workflow-run lookup for '{runId}' returned an unparsable body.");
+        return run;
+    }
+
+    /// <summary>The newest workflow run anchored to a mission, or null when the mission has none
+    /// (a mission predating the run spine). Same fail-loud posture as the id lookup.</summary>
+    public async Task<WorkflowRunDto?> GetMissionWorkflowRunAsync(Guid missionId, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot look up a mission's workflow run.");
+
+        FileLog.Write($"[GatewayClient] GetMissionWorkflowRunAsync: GET /gateway/workflow-runs?missionId={missionId}");
+        using var resp = await _http.GetAsync($"gateway/workflow-runs?missionId={missionId}&limit=1", ct);
+        if (resp.StatusCode == HttpStatusCode.NotFound)
+        {
+            // A Gateway that predates the run spine has no /gateway/workflow-runs route at all. That
+            // is the PRODUCTION state until the Gateway's next deployment, and a mission spawn must
+            // keep working against it - the session simply starts unseated, exactly as every session
+            // did before this feature. Never conflated with an error: a 5xx or auth failure below
+            // still throws.
+            FileLog.Write($"[GatewayClient] GetMissionWorkflowRunAsync {missionId}: the Gateway has no " +
+                          "workflow-run surface (predates the run spine) -> spawning unseated");
+            return null;
+        }
+        if (!resp.IsSuccessStatusCode)
+        {
+            var detail = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(
+                $"Gateway could not list workflow runs for mission '{missionId}': HTTP {(int)resp.StatusCode} {resp.ReasonPhrase} {detail}".TrimEnd());
+        }
+        var body = await resp.Content.ReadFromJsonAsync<WorkflowRunListResponse>(ct);
+        return body?.Runs?.FirstOrDefault();
+    }
+
+    /// <summary>Record a session as a participant on a workflow run (persisted run-to-session
+    /// membership, issue #1771). Throws on failure - the caller decides whether that fails the
+    /// operation or is reported loudly beside an already-successful spawn.</summary>
+    public async Task AddWorkflowRunParticipantAsync(
+        Guid runId, WorkflowRunParticipantDto participant, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot record a run participant.");
+
+        FileLog.Write($"[GatewayClient] AddWorkflowRunParticipantAsync: PATCH /gateway/workflow-runs/{runId} session={participant.SessionId}");
+        using var content = JsonContent.Create(new PatchWorkflowRunRequest
+        {
+            AddParticipants = new List<WorkflowRunParticipantDto> { participant },
+        });
+        using var resp = await _http.PatchAsync($"gateway/workflow-runs/{runId}", content, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var detail = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(
+                $"Gateway refused the run-participant record for '{runId}': HTTP {(int)resp.StatusCode} {resp.ReasonPhrase} {detail}".TrimEnd());
+        }
+    }
+
+    private sealed class WorkflowRunListResponse
+    {
+        public List<WorkflowRunDto>? Runs { get; set; }
+    }
+
+    /// <summary>
     /// Snooze Length mission (Phase 3): record or clear a Gateway-owned snooze/hold for a session by
     /// driving the Gateway's <c>POST /sessions/{sid}/hold</c> with the SAME authenticated client (already
     /// pointed at the resolved Gateway address and carrying the fleet token) the other Director-to-Gateway

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -575,6 +575,14 @@ internal static class SessionCommandExecutor
         if (attachMissionId is Guid stampMissionId)
             session.AttachToMission(stampMissionId, attachMissionName);
 
+        // Workflow seat at spawn (Workflows mission, phase 5b): the Director stamps the seat ONLY when
+        // the run id arrives with its Gateway-resolved workflow id and pinned version - the Gateway is
+        // the source of truth for runs, and the Director never resolves one itself. A run id arriving
+        // alone (a caller that skipped the Gateway relay) is stamped as nothing rather than guessed at.
+        if (req.WorkflowRunId is Guid seatRunId &&
+            !string.IsNullOrWhiteSpace(req.WorkflowId) && req.WorkflowVersion is int seatVersion)
+            session.SeatOnWorkflow(seatRunId, req.WorkflowId, seatVersion);
+
         // Issue #212: dispatch a supplied PrePrompt once the agent is actually READY, fire-and-forget so
         // create returns immediately. Readiness = a substantial startup burst followed by a quiet poll;
         // ActivityState alone is not a gate (a fresh session reads WaitingForInput from t=0, and seeding

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -434,6 +434,25 @@ internal static class SessionCommandExecutor
         if (req.Role is not null && !SessionRoles.IsValid(req.Role))
             return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unknown role '{req.Role}'. Valid: {string.Join(", ", SessionRoles.All)}");
 
+        // Workflow seat at spawn (Workflows mission, phase 5b): validated BEFORE creating the session,
+        // like the role above. The Director stamps the seat ONLY when the run id arrives with its
+        // Gateway-resolved workflow id and pinned version - the Gateway is the source of truth for
+        // runs and the Director never resolves one itself; a run id arriving alone (a caller that
+        // skipped the Gateway resolution) seats nothing rather than guessing. A workflow id that is
+        // not a catalog slug, or a non-positive version, is a forged or corrupted seat and is
+        // REFUSED - never launched and never rendered into a preamble.
+        var seatRequested = req.WorkflowRunId is Guid &&
+            !string.IsNullOrWhiteSpace(req.WorkflowId) && req.WorkflowVersion is int;
+        if (seatRequested)
+        {
+            if (WorkflowSeatParagraph.Build(req.WorkflowRunId, req.WorkflowId, req.WorkflowVersion, req.Role) is null)
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
+                    $"invalid workflow seat: workflow id '{req.WorkflowId}' is not a catalog slug.");
+            if (req.WorkflowVersion is int badVersion && badVersion < 1)
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
+                    $"invalid workflow seat: version {badVersion} is not a published version number.");
+        }
+
         // Mission attach at spawn. Missions are a FLEET-level concept and now live at the Gateway (source of
         // truth), so the mission name that binds the session into a pod arrives ON the create request:
         //   * GATEWAY path (MissionId AND MissionName both set): the Gateway already resolved+validated the
@@ -533,7 +552,20 @@ internal static class SessionCommandExecutor
                 nameFactory: id => SessionName.Compose(
                     repoFolderName, explicitName, purpose, SessionName.Disambiguator(id),
                     isWorker: controllerSessionId is not null),
-                controllerSessionId: controllerSessionId);
+                controllerSessionId: controllerSessionId,
+                // Pre-launch stamps (Workflows mission, phase 5b): the role and the workflow seat are
+                // applied BEFORE any launch-time channel reads the session - Pi's preamble file is
+                // written from it during create, and a startup hook can fetch the preamble the
+                // instant the agent boots. Stamping after create raced the earliest readers and
+                // missed Pi entirely. Both values were validated above.
+                beforeLaunch: s =>
+                {
+                    var preLaunchRole = SessionRoles.Normalize(req.Role);
+                    if (preLaunchRole is not null)
+                        s.SetExplicitRole(preLaunchRole);
+                    if (seatRequested)
+                        s.SeatOnWorkflow(req.WorkflowRunId, req.WorkflowId, req.WorkflowVersion);
+                });
         }
         catch (Exception ex)
         {
@@ -563,11 +595,9 @@ internal static class SessionCommandExecutor
         // --name. Marking it lets a later explicit rename win and never be re-auto-named.
         session.IsAutoNamed = string.IsNullOrWhiteSpace(explicitName);
 
-        // Automatic session roles (chunk 2.5): a spawn-time explicit role is sticky and WINS over the
-        // Gateway's auto-derivation (the only way to declare an Architect). Already validated above.
-        var explicitRole = SessionRoles.Normalize(req.Role);
-        if (explicitRole is not null)
-            session.SetExplicitRole(explicitRole);
+        // Automatic session roles (chunk 2.5): the spawn-time explicit role is stamped PRE-LAUNCH in
+        // the beforeLaunch hook above (the workflow-seat paragraph names it, and Pi's preamble file
+        // is written during create), sticky and winning over auto-derivation exactly as before.
 
         // Mission attach at spawn: stamp the session's MissionId and cache the display name (resolved above,
         // either carried by the Gateway or resolved via the transitional local-store bridge). This is the
@@ -575,13 +605,6 @@ internal static class SessionCommandExecutor
         if (attachMissionId is Guid stampMissionId)
             session.AttachToMission(stampMissionId, attachMissionName);
 
-        // Workflow seat at spawn (Workflows mission, phase 5b): the Director stamps the seat ONLY when
-        // the run id arrives with its Gateway-resolved workflow id and pinned version - the Gateway is
-        // the source of truth for runs, and the Director never resolves one itself. A run id arriving
-        // alone (a caller that skipped the Gateway relay) is stamped as nothing rather than guessed at.
-        if (req.WorkflowRunId is Guid seatRunId &&
-            !string.IsNullOrWhiteSpace(req.WorkflowId) && req.WorkflowVersion is int seatVersion)
-            session.SeatOnWorkflow(seatRunId, req.WorkflowId, seatVersion);
 
         // Issue #212: dispatch a supplied PrePrompt once the agent is actually READY, fire-and-forget so
         // create returns immediately. Readiness = a substantial startup burst followed by a quiet poll;

--- a/src/CcDirector.Core.Tests/Pi/PiPreambleWriterTests.cs
+++ b/src/CcDirector.Core.Tests/Pi/PiPreambleWriterTests.cs
@@ -24,6 +24,43 @@ public class PiPreambleWriterTests
         return store;
     }
 
+    // Workflows mission, phase 5b: a SEATED Pi session's preamble file carries the seat paragraph -
+    // Pi's file is immutable after launch, so this is Pi's only chance to learn its conduct fetch.
+    [Fact]
+    public void WriteForSession_WithASeat_AppendsTheSeatParagraph()
+    {
+        var dir = NewDir();
+        try
+        {
+            var runId = Guid.NewGuid();
+            var paragraph = WorkflowSeatParagraph.Build(runId, "mission", 3, "Architect");
+            Assert.NotNull(paragraph);
+
+            var path = PiPreambleWriter.WriteForSession(
+                "abc12345-1111-2222-3333-444455556666", "myrepo", "MACHINE_A", @"D:\repo\myrepo", dir,
+                user: null, OursStore(dir), paragraph);
+
+            var text = File.ReadAllText(path);
+            Assert.Contains("[Workflow seat]", text);
+            Assert.Contains("seated as Architect on the 'mission' workflow (pinned v3)", text);
+            Assert.Contains("cc-devthrottle workflow instructions mission --version 3", text);
+            Assert.Contains("STOP and report", text);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // The paragraph builder refuses a workflow id that is not a catalog slug - a forged or corrupted
+    // seat renders NOTHING rather than letting authored bytes ride into an agent's context.
+    [Fact]
+    public void SeatParagraph_RefusesANonSlugWorkflowId()
+    {
+        Assert.Null(WorkflowSeatParagraph.Build(Guid.NewGuid(), "evil\nid", 1, "Worker"));
+        Assert.Null(WorkflowSeatParagraph.Build(Guid.NewGuid(), "UPPER", 1, "Worker"));
+        Assert.Null(WorkflowSeatParagraph.Build(Guid.NewGuid(), null, 1, "Worker"));
+        Assert.Null(WorkflowSeatParagraph.Build(null, "mission", 1, "Worker"));
+        Assert.NotNull(WorkflowSeatParagraph.Build(Guid.NewGuid(), "standalone-with-review", 2, null));
+    }
+
     // Issue #1357: when a signed-in user is supplied, the Pi preamble file names that user.
     [Fact]
     public void WriteForSession_WithSignedInUser_WritesIdentityLine()

--- a/src/CcDirector.Core/Pi/PiPreambleWriter.cs
+++ b/src/CcDirector.Core/Pi/PiPreambleWriter.cs
@@ -24,10 +24,11 @@ public static class PiPreambleWriter
 
     /// <summary>
     /// Write the preamble for one session under the default per-user directory, naming the signed-in
-    /// DevThrottle user (issue #1357); returns the path.
+    /// DevThrottle user (issue #1357) and carrying the session's workflow-seat paragraph when it is
+    /// seated (Workflows mission, phase 5b); returns the path.
     /// </summary>
-    public static string WriteForSession(string sessionId, string? name, string machine, string repoPath, SignedInUser? user)
-        => WriteForSession(sessionId, name, machine, repoPath, DefaultDirectory(), user);
+    public static string WriteForSession(string sessionId, string? name, string machine, string repoPath, SignedInUser? user, string? seatParagraph = null)
+        => WriteForSession(sessionId, name, machine, repoPath, DefaultDirectory(), user, store: null, seatParagraph);
 
     /// <summary>Testable overload that writes under an explicit directory.</summary>
     public static string WriteForSession(string sessionId, string? name, string machine, string repoPath, string directory)
@@ -37,10 +38,15 @@ public static class PiPreambleWriter
     public static string WriteForSession(string sessionId, string? name, string machine, string repoPath, string directory, SignedInUser? user)
         => WriteForSession(sessionId, name, machine, repoPath, directory, user, store: null);
 
-    /// <summary>Testable overload that also pins the injected-text store.</summary>
+    /// <summary>Testable overload that also pins the injected-text store.
+    /// <paramref name="seatParagraph"/> (Workflows mission, phase 5b) is the pre-built workflow-seat
+    /// paragraph from <see cref="WorkflowSeatParagraph"/>, appended after the preamble so a seated Pi
+    /// session learns its conduct fetch at launch exactly like the hook-fed agents; null for an
+    /// unseated session. It is appended even when the preamble itself is empty - the seat is the
+    /// operational fact the session was spawned for, not our injectable prose.</summary>
     public static string WriteForSession(
         string sessionId, string? name, string machine, string repoPath, string directory,
-        SignedInUser? user, InjectedTextStore? store)
+        SignedInUser? user, InjectedTextStore? store, string? seatParagraph = null)
     {
         Directory.CreateDirectory(directory);
 
@@ -69,6 +75,9 @@ public static class PiPreambleWriter
                 $"is injected (the DevThrottle text is deliberately not substituted): {ex.Message}");
             text = "";
         }
+
+        if (!string.IsNullOrEmpty(seatParagraph))
+            text = string.IsNullOrEmpty(text) ? seatParagraph : text + "\n\n" + seatParagraph;
 
         var path = Path.Combine(directory, $"{sessionId}.txt");
         File.WriteAllText(path, text);

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -347,6 +347,33 @@ public sealed class Session : IDisposable
         FileLog.Write($"[Session] {Id} attached to mission {MissionId?.ToString() ?? "(none)"} (name={MissionName ?? "(none)"})");
     }
 
+    /// <summary>
+    /// The workflow RUN this session is seated on (Workflows mission, phase 5b), or null for an
+    /// unseated session. Stamped at spawn from the create request after the GATEWAY validated the run
+    /// (the source of truth); the Director never resolves a run itself. Persisted, like the mission
+    /// attachment beside it.
+    /// </summary>
+    public Guid? WorkflowRunId { get; internal set; }
+
+    /// <summary>The seated run's workflow id (e.g. "mission"), cached for rendering and for the
+    /// seated preamble paragraph. Null when unseated. Persisted.</summary>
+    public string? WorkflowId { get; internal set; }
+
+    /// <summary>The seated run's PINNED workflow version. The seated preamble tells the agent to
+    /// fetch its conduct at exactly this version - never a moving head. Null when unseated. Persisted.</summary>
+    public int? WorkflowVersion { get; internal set; }
+
+    /// <summary>Seat this session on a workflow run (all three values Gateway-resolved), or clear the
+    /// seat when <paramref name="workflowRunId"/> is null. Stores only what it is given.</summary>
+    public void SeatOnWorkflow(Guid? workflowRunId, string? workflowId, int? workflowVersion)
+    {
+        WorkflowRunId = workflowRunId;
+        WorkflowId = workflowRunId is null ? null : (string.IsNullOrWhiteSpace(workflowId) ? null : workflowId.Trim());
+        WorkflowVersion = workflowRunId is null ? null : workflowVersion;
+        FileLog.Write($"[Session] {Id} seated on workflow run {WorkflowRunId?.ToString() ?? "(none)"} " +
+                      $"({WorkflowId ?? "(none)"} v{WorkflowVersion?.ToString() ?? "-"})");
+    }
+
     public Guid Id { get; }
 
     /// <summary>

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -1118,6 +1118,9 @@ public sealed class SessionManager : IDisposable
                 IsAutoNamed = s.IsAutoNamed,
                 MissionId = s.MissionId,
                 MissionName = s.MissionName,
+                WorkflowRunId = s.WorkflowRunId,
+                WorkflowId = s.WorkflowId,
+                WorkflowVersion = s.WorkflowVersion,
                 RawStartupText = s.RawStartupText,
                 SelectedTabName = s.SelectedTabName,
                 WingmanEnabled = s.WingmanEnabled,
@@ -1164,6 +1167,9 @@ public sealed class SessionManager : IDisposable
         session.IsAutoNamed = ps.IsAutoNamed;
         session.MissionId = ps.MissionId;
         session.MissionName = ps.MissionName;
+        session.WorkflowRunId = ps.WorkflowRunId;
+        session.WorkflowId = ps.WorkflowId;
+        session.WorkflowVersion = ps.WorkflowVersion;
         session.WingmanEnabled = ps.WingmanEnabled;
         // No hold is restored here, because this Director never owned one. The Gateway holds the state and
         // persists it (SnoozeRegistry, an atomic write-through on every mutation), and it pushes the hold

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -397,7 +397,7 @@ public sealed class SessionManager : IDisposable
     /// Create a session by resolving the requested built-in CLI plugin and asking it for the
     /// launch strategy. This is the plugin-backed path new callers should use.
     /// </summary>
-    public Session CreateSession(string repoPath, AgentKind agentKind, string? userArgs, SessionBackendType backendType, string? resumeSessionId, Guid? groupId = null, string? groupRole = null, string? groupName = null, Func<Guid, string>? nameFactory = null, Guid? controllerSessionId = null)
+    public Session CreateSession(string repoPath, AgentKind agentKind, string? userArgs, SessionBackendType backendType, string? resumeSessionId, Guid? groupId = null, string? groupRole = null, string? groupName = null, Func<Guid, string>? nameFactory = null, Guid? controllerSessionId = null, Action<Session>? beforeLaunch = null)
     {
         return CreateSession(
             repoPath,
@@ -409,7 +409,8 @@ public sealed class SessionManager : IDisposable
             groupRole,
             groupName,
             nameFactory,
-            controllerSessionId);
+            controllerSessionId,
+            beforeLaunch);
     }
 
     /// <summary>
@@ -429,7 +430,12 @@ public sealed class SessionManager : IDisposable
     /// <param name="controllerSessionId">The controlling session's id (issue #815) when this
     /// session is spawned as a controlled sub-agent; null for a normal session. Set ONLY here at
     /// birth and immutable afterwards. Drives the recessive "Supporting" status color.</param>
-    public Session CreateSession(string repoPath, IAgent agent, string? userArgs, SessionBackendType backendType, string? resumeSessionId, Guid? groupId = null, string? groupRole = null, string? groupName = null, Func<Guid, string>? nameFactory = null, Guid? controllerSessionId = null)
+    /// <param name="beforeLaunch">Optional stamp hook (Workflows mission, phase 5b) invoked on the
+    /// constructed session BEFORE any launch-time context is materialized and BEFORE the process
+    /// starts. Anything a launch-time channel reads off the session - the Pi preamble file, the
+    /// preamble a startup hook fetches the instant the agent boots - must be stamped here, not
+    /// after create returns, or the earliest readers race the stamp and Pi misses it entirely.</param>
+    public Session CreateSession(string repoPath, IAgent agent, string? userArgs, SessionBackendType backendType, string? resumeSessionId, Guid? groupId = null, string? groupRole = null, string? groupName = null, Func<Guid, string>? nameFactory = null, Guid? controllerSessionId = null, Action<Session>? beforeLaunch = null)
     {
         if (agent is null)
             throw new ArgumentNullException(nameof(agent));
@@ -488,6 +494,11 @@ public sealed class SessionManager : IDisposable
         // ever displaying as the bare repository folder name.
         if (nameFactory is not null)
             session.CustomName = nameFactory(id);
+
+        // Pre-launch stamps (Workflows mission, phase 5b): applied BEFORE the per-agent launch
+        // channels below read the session (Pi's preamble file is written from it) and BEFORE the
+        // process starts (a startup hook can fetch the preamble the instant the agent boots).
+        beforeLaunch?.Invoke(session);
 
         try
         {
@@ -600,8 +611,13 @@ public sealed class SessionManager : IDisposable
                 // Issue #1357: name the signed-in user in Pi's preamble too, read synchronously from the
                 // host's cached snapshot (no network) so launch never blocks; null omits the line.
                 var signedInUser = SignedInUserAccessor?.Invoke();
+                // Workflows mission (phase 5b): a seated Pi session's preamble file carries the seat
+                // paragraph. The seat was stamped by beforeLaunch ABOVE, which is the whole reason
+                // that hook runs before this block - Pi's file is immutable after launch.
+                var piSeatParagraph = WorkflowSeatParagraph.Build(
+                    session.WorkflowRunId, session.WorkflowId, session.WorkflowVersion, session.ExplicitRole);
                 var preambleFile = CcDirector.Core.Pi.PiPreambleWriter.WriteForSession(
-                    id.ToString(), piName, Environment.MachineName, repoPath, signedInUser);
+                    id.ToString(), piName, Environment.MachineName, repoPath, signedInUser, piSeatParagraph);
                 args = $"{args} --append-system-prompt \"{preambleFile}\"".Trim();
                 _log?.Invoke("Wrote Pi fleet preamble and passed it via --append-system-prompt.");
             }

--- a/src/CcDirector.Core/Sessions/SessionStateStore.cs
+++ b/src/CcDirector.Core/Sessions/SessionStateStore.cs
@@ -64,6 +64,17 @@ public class PersistedSession
     /// <see cref="MissionId"/> so the name renders after a restart without re-resolving the Mission store.</summary>
     public string? MissionName { get; set; }
 
+    /// <summary>The workflow run this session is seated on (Workflows mission, phase 5b), or null.
+    /// Persisted with its cached workflow id + pinned version so the seat - and the seated preamble
+    /// paragraph - survives a Director restart. Null for sessions persisted before the field existed.</summary>
+    public Guid? WorkflowRunId { get; set; }
+
+    /// <summary>The seated run's cached workflow id, or null.</summary>
+    public string? WorkflowId { get; set; }
+
+    /// <summary>The seated run's pinned workflow version, or null.</summary>
+    public int? WorkflowVersion { get; set; }
+
     public DateTimeOffset CreatedAt { get; set; }
 
     /// <summary>Order in the session list, used to restore UI order after restart.</summary>

--- a/src/CcDirector.Core/Sessions/WorkflowSeatParagraph.cs
+++ b/src/CcDirector.Core/Sessions/WorkflowSeatParagraph.cs
@@ -1,0 +1,53 @@
+using System.Text.RegularExpressions;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// Builds the workflow SEAT paragraph a seated session receives at launch (Workflows mission, phase
+/// 5b): which run it executes, at which PINNED version to fetch its conduct, and the fail-closed
+/// rule (if the fetch fails, STOP - never proceed on remembered rules). ONE builder for every
+/// delivery channel - the hook preamble endpoints and Pi's preamble file - so no agent family can
+/// receive a differently-worded seat.
+///
+/// The workflow id is validated against the catalog's slug shape before it is interpolated. The
+/// Director stamps whatever the create request carried (the Gateway is the source of truth and the
+/// honest path always sends a real slug), so a value that is NOT a slug is a forged or corrupted
+/// seat - it renders NO paragraph and logs loudly rather than letting authored bytes ride into an
+/// agent's context as extra preamble lines.
+/// </summary>
+public static class WorkflowSeatParagraph
+{
+    /// <summary>The catalog's workflow id shape (parity with the Gateway's WorkflowValidation).</summary>
+    private static readonly Regex IdPattern = new("^[a-z0-9][a-z0-9-]{1,63}$", RegexOptions.Compiled);
+
+    /// <summary>The paragraph for one session, or null when the session is unseated (or the seat is
+    /// malformed - logged, never rendered).</summary>
+    public static string? Build(Guid? workflowRunId, string? workflowId, int? workflowVersion, string? role)
+    {
+        if (workflowRunId is not Guid runId || string.IsNullOrWhiteSpace(workflowId))
+            return null;
+        if (!IdPattern.IsMatch(workflowId))
+        {
+            FileLog.Write($"[WorkflowSeatParagraph] REFUSED: workflow id {Compact(workflowId)} is not a " +
+                          "catalog slug - a forged or corrupted seat renders no paragraph.");
+            return null;
+        }
+
+        var seatRole = string.IsNullOrWhiteSpace(role) ? "a participant" : role.Trim();
+        var versionArg = workflowVersion is int v ? $" --version {v}" : "";
+        return
+            $"[Workflow seat] You are seated as {seatRole} on the '{workflowId}' workflow" +
+            (workflowVersion is int pv ? $" (pinned v{pv})" : "") +
+            $", run {runId}. Before doing anything else, fetch your conduct and FOLLOW it:\n" +
+            $"  cc-devthrottle workflow instructions {workflowId}{versionArg}\n" +
+            "If that command fails, STOP and report the failure - never proceed on remembered or " +
+            "reconstructed rules.";
+    }
+
+    private static string Compact(string value)
+    {
+        var printable = new string(value.Where(ch => !char.IsControl(ch)).ToArray());
+        return printable.Length > 40 ? "'" + printable[..40] + "...'" : "'" + printable + "'";
+    }
+}

--- a/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
@@ -126,6 +126,29 @@ public sealed class NewSessionRequest
     public string? MissionName { get; set; }
 
     /// <summary>
+    /// Optional workflow RUN to SEAT the new session on (Workflows mission, phase 5b - the
+    /// governance outcome spine, issue #1771). Set explicitly by a caller seating a session onto a
+    /// known run, or resolved by the Gateway spawn relay from <see cref="MissionId"/> (a mission's
+    /// sessions auto-seat onto the mission's run). The Gateway validates the run and stamps
+    /// <see cref="WorkflowId"/> + <see cref="WorkflowVersion"/> beside it; after the spawn succeeds
+    /// the Gateway records the new session as a run PARTICIPANT. Null seats the session on nothing.
+    /// </summary>
+    public Guid? WorkflowRunId { get; set; }
+
+    /// <summary>
+    /// The seated run's workflow id (e.g. "mission"), stamped by the GATEWAY after validating
+    /// <see cref="WorkflowRunId"/> - the same resolved-by-the-source-of-truth pattern as
+    /// <see cref="MissionName"/>. The Director stamps the seat only when the run id, this, and
+    /// <see cref="WorkflowVersion"/> all arrive together.
+    /// </summary>
+    public string? WorkflowId { get; set; }
+
+    /// <summary>The seated run's PINNED workflow version, stamped by the Gateway beside
+    /// <see cref="WorkflowId"/>. A seated session fetches its conduct at exactly this version -
+    /// never a moving head, even if a newer version publishes mid-run.</summary>
+    public int? WorkflowVersion { get; set; }
+
+    /// <summary>
     /// Optional target machine for spawn routing ("start a session on another computer"). Null,
     /// empty, or the local machine name spawns on the LOCAL machine (the default, unchanged); a
     /// remote machine name routes the spawn via the Gateway to a Director on that machine (first

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -93,6 +93,19 @@ public sealed class SessionDto
     /// </summary>
     public string? MissionName { get; set; }
 
+    /// <summary>The workflow RUN this session is seated on (Workflows mission, phase 5b - issue
+    /// #1771), or null for an unseated session. Stamped at spawn from the Gateway-validated create
+    /// request; mirrors <c>Session.WorkflowRunId</c> on the owning Director.</summary>
+    public Guid? WorkflowRunId { get; set; }
+
+    /// <summary>The seated run's workflow id (e.g. "mission"), cached beside the run link. Null when
+    /// unseated.</summary>
+    public string? WorkflowId { get; set; }
+
+    /// <summary>The seated run's PINNED workflow version - the version the session's conduct is
+    /// fetched at, never a moving head. Null when unseated.</summary>
+    public int? WorkflowVersion { get; set; }
+
     /// <summary>
     /// The session's short, human-friendly three-digit number (100-999), or null when the session
     /// has no number (issue #820). Allocated by the owning Director at creation and stable for the

--- a/src/CcDirector.Gateway.Tests/WorkflowSeatTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowSeatTests.cs
@@ -1,0 +1,207 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Workflows mission, phase 5b: seated sessions, proven over the REAL local-spawn path (the
+/// FleetSpawnMissionAttachTests harness - a real Director Control API against a Gateway stub over
+/// loopback HTTP). The claims: a mission-scoped spawn AUTO-SEATS the new session on the mission's
+/// workflow run (run id + workflow id + PINNED version stamped on the session, straight from the
+/// Gateway, never resolved by the Director); the seated session's fleet preamble carries the seat
+/// paragraph telling the agent to fetch its conduct at exactly the pinned version and to STOP if the
+/// fetch fails; the new session is recorded as a run PARTICIPANT on the Gateway (the persisted
+/// run-to-session membership #1771 reads); an unknown explicit run id is refused in plain English;
+/// and an unseated spawn is byte-identical to before.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class WorkflowSeatTests : IAsyncLifetime
+{
+    private static readonly Guid KnownMissionId = Guid.NewGuid();
+    private static readonly Guid KnownRunId = Guid.NewGuid();
+    private const string KnownMissionName = "Seat Proof";
+    private const int PinnedVersion = 3;
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private WebApplication _gatewayStub = null!;
+    private ControlApiHost _host = null!;
+    private SessionManager _sm = null!;
+    private HttpClient _client = null!;
+    private string _repoDir = null!;
+
+    /// <summary>Participant PATCH bodies the stub captured, keyed by run id.</summary>
+    private readonly List<(Guid RunId, string Body)> _participantPatches = new();
+
+    public WorkflowSeatTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-seat-root-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    private static WorkflowRunDto KnownRun() => new()
+    {
+        Id = KnownRunId,
+        WorkflowId = "mission",
+        WorkflowVersion = PinnedVersion,
+        ContentHash = "hash-3",
+        Name = KnownMissionName,
+        MissionId = KnownMissionId,
+    };
+
+    public async Task InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, 0));
+        _gatewayStub = builder.Build();
+        _gatewayStub.MapGet("/missions/{mid}", (string mid) =>
+            Guid.TryParse(mid, out var id) && id == KnownMissionId
+                ? Results.Json(new MissionDto { MissionId = KnownMissionId, MissionName = KnownMissionName })
+                : Results.NotFound(new { error = "mission not found" }));
+        _gatewayStub.MapGet("/gateway/workflow-runs", (Guid? missionId) =>
+            Results.Json(new
+            {
+                runs = missionId == KnownMissionId
+                    ? new[] { KnownRun() }
+                    : Array.Empty<WorkflowRunDto>(),
+            }));
+        _gatewayStub.MapGet("/gateway/workflow-runs/{id:guid}", (Guid id) =>
+            id == KnownRunId
+                ? Results.Json(KnownRun())
+                : Results.NotFound(new { error = $"no workflow run '{id}'" }));
+        _gatewayStub.MapPatch("/gateway/workflow-runs/{id:guid}", async (Guid id, HttpContext ctx) =>
+        {
+            using var reader = new StreamReader(ctx.Request.Body);
+            _participantPatches.Add((id, await reader.ReadToEndAsync()));
+            return Results.Json(KnownRun());
+        });
+        await _gatewayStub.StartAsync();
+        var gatewayUrl = _gatewayStub.Urls.First();
+
+        Directory.CreateDirectory(Path.GetDirectoryName(CcStorage.ConfigJson())!);
+        await File.WriteAllTextAsync(CcStorage.ConfigJson(),
+            "{\"gateway\":{\"url\":\"" + gatewayUrl + "\"}}");
+
+        _repoDir = Path.Combine(Path.GetTempPath(), "ccd-seat-repo-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_repoDir);
+
+        _sm = new SessionManager(new AgentOptions());
+        _host = new ControlApiHost(_sm, "1.0.0-test", () => Task.CompletedTask, useEphemeralPort: true);
+        var port = await _host.StartAsync();
+        _client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}/") };
+        _client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", DirectorAuth.LoadOrCreateToken());
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _host.StopAsync();
+        _sm.Dispose();
+        await _gatewayStub.StopAsync();
+        try
+        {
+            var f = Path.Combine(InstanceRegistration.InstancesDirectory, $"{_host.DirectorId}.json");
+            if (File.Exists(f)) File.Delete(f);
+        }
+        catch { /* test cleanup, ignore */ }
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_repoDir)) Directory.Delete(_repoDir, true); } catch { /* best effort */ }
+    }
+
+    private NewSessionRequest CliSpawnBody() => new()
+    {
+        RepoPath = _repoDir,
+        Agent = "RawCli",
+        Command = "cmd",
+        CommandArgs = "/k",
+        Role = "Architect",
+    };
+
+    [Fact]
+    public async Task Mission_spawn_autoSeats_stampsThePin_recordsTheParticipant_andBriefsTheAgent()
+    {
+        var body = CliSpawnBody();
+        body.MissionId = KnownMissionId;
+
+        var resp = await _client.PostAsJsonAsync("fleet/spawn", body);
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<SessionDto>();
+        Assert.NotNull(dto);
+
+        // The seat: run id + workflow id + PINNED version, stamped from the Gateway's answer.
+        Assert.Equal(KnownRunId, dto!.WorkflowRunId);
+        Assert.Equal("mission", dto.WorkflowId);
+        Assert.Equal(PinnedVersion, dto.WorkflowVersion);
+
+        // The participant: the Gateway received the membership record with the canonical session id.
+        var patch = Assert.Single(_participantPatches);
+        Assert.Equal(KnownRunId, patch.RunId);
+        Assert.Contains(dto.SessionId!, patch.Body);
+        Assert.Contains("RawCli", patch.Body);
+        Assert.Contains("Architect", patch.Body);
+        Assert.Contains(Environment.MachineName, patch.Body,
+            StringComparison.OrdinalIgnoreCase);
+
+        // The briefing: the seated session's preamble tells the agent its seat, the PINNED fetch
+        // command, and the fail-closed rule - regardless of agent kind, because it rides the same
+        // preamble every agent family receives.
+        var preamble = await _client.GetStringAsync($"sessions/{dto.SessionId}/fleet-preamble");
+        Assert.Contains("[Workflow seat]", preamble);
+        Assert.Contains("seated as Architect on the 'mission' workflow", preamble);
+        Assert.Contains($"cc-devthrottle workflow instructions mission --version {PinnedVersion}", preamble);
+        Assert.Contains("STOP and report", preamble);
+
+        await _client.DeleteAsync($"sessions/{dto.SessionId}");
+    }
+
+    [Fact]
+    public async Task An_unknown_explicit_run_id_is_refused_inPlainEnglish()
+    {
+        var body = CliSpawnBody();
+        body.WorkflowRunId = Guid.NewGuid();
+
+        var resp = await _client.PostAsJsonAsync("fleet/spawn", body);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var text = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("unknown workflow run", text);
+        Assert.Contains("cc-devthrottle workflow runs", text);
+        Assert.Empty(_participantPatches);
+    }
+
+    [Fact]
+    public async Task An_unseated_spawn_isUnaffected_andCarriesNoSeatParagraph()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/spawn", CliSpawnBody());
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<SessionDto>();
+        Assert.NotNull(dto);
+        Assert.Null(dto!.WorkflowRunId);
+        Assert.Null(dto.WorkflowId);
+        Assert.Null(dto.WorkflowVersion);
+        Assert.Empty(_participantPatches);
+
+        var preamble = await _client.GetStringAsync($"sessions/{dto.SessionId}/fleet-preamble");
+        Assert.DoesNotContain("[Workflow seat]", preamble);
+
+        await _client.DeleteAsync($"sessions/{dto.SessionId}");
+    }
+}

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -196,22 +196,48 @@ internal static class MachineEndpoints
             }
 
             // Record the new session as a run participant - the persisted run-to-session membership
-            // (#1771). The session id is the canonical fleet GUID governance joins effort on.
+            // (#1771). The session id is the canonical fleet GUID governance joins effort on. Two
+            // guards, both from inspection findings:
+            //  - Record ONLY when the Director's reply proves the seat actually landed. An older
+            //    Director (rolling upgrade) ignores the seat fields and returns a DTO without them;
+            //    recording membership for a session whose agent never received its conduct would be
+            //    a governance lie.
+            //  - The spawn has already SUCCEEDED; a participant-write failure is reported loudly in
+            //    the log, never converted into an HTTP failure the caller would retry into a second
+            //    session.
             if (seatRun is not null && workflowRuns is not null && !string.IsNullOrWhiteSpace(dto.SessionId))
             {
-                workflowRuns.Patch(seatRun.Id, new Contracts.PatchWorkflowRunRequest
+                if (dto.WorkflowRunId != seatRun.Id)
                 {
-                    AddParticipants = new List<Contracts.WorkflowRunParticipantDto>
+                    FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: Director did NOT " +
+                                  $"stamp the seat (returned run={dto.WorkflowRunId?.ToString() ?? "none"}; it " +
+                                  "likely predates seated sessions). Session started UNSEATED; no participant recorded.");
+                }
+                else
+                {
+                    try
                     {
-                        new()
+                        workflowRuns.Patch(seatRun.Id, new Contracts.PatchWorkflowRunRequest
                         {
-                            SessionId = dto.SessionId,
-                            AgentKind = req.Agent,
-                            Role = req.Role ?? "",
-                            Machine = machine,
-                        },
-                    },
-                });
+                            AddParticipants = new List<Contracts.WorkflowRunParticipantDto>
+                            {
+                                new()
+                                {
+                                    SessionId = dto.SessionId,
+                                    AgentKind = req.Agent,
+                                    Role = req.Role ?? "",
+                                    Machine = machine,
+                                },
+                            },
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: run-participant " +
+                                      $"record FAILED for session {dto.SessionId} on run {seatRun.Id}: {ex.Message}. " +
+                                      "The session is seated and running; governance is missing this membership row.");
+                    }
+                }
             }
 
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: started sid={dto.SessionId}" +

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -60,7 +60,14 @@ internal static class MachineEndpoints
         // of truth - and the resolved mission NAME is stamped onto the create request so the Director stamps
         // the attachment without any local lookup. Null (old callers, tests) leaves MissionId to flow through
         // to the Director's transitional local-store bridge unchanged.
-        Core.Sessions.MissionStore? missions = null)
+        Core.Sessions.MissionStore? missions = null,
+        // Workflows mission (phase 5b, issue #1771): the workflow-run store. When non-null, a spawn is
+        // SEATED on a run: an explicit req.WorkflowRunId is validated here and the run's workflow id +
+        // pinned version are stamped onto the create request (the MissionName pattern); a mission-scoped
+        // spawn with no explicit run auto-seats onto the mission's run. After a successful spawn the new
+        // session is recorded as a run PARTICIPANT - the persisted run-to-session membership governance
+        // reads. Null (old callers, tests) seats nothing and changes nothing.
+        Workflows.WorkflowRunStore? workflowRuns = null)
     {
         if (spawner is null) throw new ArgumentNullException(nameof(spawner));
 
@@ -151,6 +158,36 @@ internal static class MachineEndpoints
                 req.MissionName = mission.MissionName;
             }
 
+            // Workflows mission (phase 5b): resolve the seat. An EXPLICIT run id must exist; a
+            // mission-scoped spawn with no explicit run auto-seats onto the mission's newest run (the
+            // one POST /missions opened). The run's workflow id + pinned version ride the create
+            // request so the Director stamps the seat with no lookup of its own - and the seated
+            // session's conduct is pinned to the run's version, never a moving head.
+            Contracts.WorkflowRunDto? seatRun = null;
+            if (workflowRuns is not null)
+            {
+                if (req.WorkflowRunId is Guid explicitRunId)
+                {
+                    seatRun = workflowRuns.Get(explicitRunId);
+                    if (seatRun is null)
+                    {
+                        FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: unknown workflow run {explicitRunId}");
+                        return Results.BadRequest(new { error = $"unknown workflow run '{explicitRunId}'." });
+                    }
+                }
+                else if (req.MissionId is Guid seatMissionId)
+                {
+                    seatRun = workflowRuns.List(missionId: seatMissionId, limit: 1).FirstOrDefault();
+                }
+
+                if (seatRun is not null)
+                {
+                    req.WorkflowRunId = seatRun.Id;
+                    req.WorkflowId = seatRun.WorkflowId;
+                    req.WorkflowVersion = seatRun.WorkflowVersion;
+                }
+            }
+
             var (ok, dto, error, _) = await spawner.SpawnOnMachineAsync(machine, req, ct);
             if (!ok || dto is null)
             {
@@ -158,7 +195,27 @@ internal static class MachineEndpoints
                 return Results.Json(new { error = error ?? $"could not start a session on '{machine}'", machine }, statusCode: 502);
             }
 
-            FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: started sid={dto.SessionId}");
+            // Record the new session as a run participant - the persisted run-to-session membership
+            // (#1771). The session id is the canonical fleet GUID governance joins effort on.
+            if (seatRun is not null && workflowRuns is not null && !string.IsNullOrWhiteSpace(dto.SessionId))
+            {
+                workflowRuns.Patch(seatRun.Id, new Contracts.PatchWorkflowRunRequest
+                {
+                    AddParticipants = new List<Contracts.WorkflowRunParticipantDto>
+                    {
+                        new()
+                        {
+                            SessionId = dto.SessionId,
+                            AgentKind = req.Agent,
+                            Role = req.Role ?? "",
+                            Machine = machine,
+                        },
+                    },
+                });
+            }
+
+            FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: started sid={dto.SessionId}" +
+                          (seatRun is null ? "" : $", seated on run {seatRun.Id} ({seatRun.WorkflowId} v{seatRun.WorkflowVersion})"));
             return Results.Json(dto, statusCode: 201);
         });
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1775,7 +1775,9 @@ public sealed class GatewayHost : IAsyncDisposable
         MachineEndpoints.Map(_app, Launchers, _machineSessionSpawner, SendLauncherCommandAsync,
             // Gateway Cleanup mission (Wave 4b): validate a mission-scoped spawn against the Gateway store and
             // stamp the resolved mission name onto the create request forwarded to the Director.
-            missions: Missions);
+            missions: Missions,
+            // Workflows mission (phase 5b): seat spawns on workflow runs and record participants.
+            workflowRuns: _workflowRuns);
 
         // The Cockpit Settings page surface (docs/architecture/gateway/SETTINGS_OWNERSHIP.md):
         // one snapshot GET plus brain-restart and autostart actions. Reads this host directly

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -647,13 +647,21 @@ def spawn(
         "--mission",
         help="Attach the new session to a Mission by its id at spawn (mission-as-first-class-unit-of-work). "
         "The Mission must already exist (create one with 'cc-devthrottle mission create'); an unknown "
-        "Mission is rejected by the Director.",
+        "Mission is rejected by the Director. A mission spawn also auto-seats the session on the "
+        "mission's workflow run.",
+    ),
+    workflow_run: Optional[str] = typer.Option(
+        None,
+        "--workflow-run",
+        help="Seat the new session on a workflow RUN by its id (Workflows phase 5b). The Gateway "
+        "validates the run and the session's preamble tells the agent to fetch the run's conduct at "
+        "its PINNED version. Unknown run ids are rejected.",
     ),
 ) -> None:
     """Open a new session on the local Director, or on another computer with --machine, and print its id."""
     spawn_session(
         repo, agent, prompt, name, purpose, command, command_args, controlled_by, args, standalone, role,
-        machine, mission,
+        machine, mission, workflow_run,
     )
 
 

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -499,6 +499,7 @@ def spawn_session(
     role: Optional[str] = None,
     machine: Optional[str] = None,
     mission: Optional[str] = None,
+    workflow_run: Optional[str] = None,
 ) -> None:
     """Open a new session on the local Director, or on another computer when a remote --machine is given."""
     # Automatic roles: a SESSION-initiated spawn (CC_SESSION_ID present) DEFAULTS to a Worker controlled by
@@ -560,6 +561,11 @@ def spawn_session(
     # Mission attach at spawn: forward the Mission id; the Director resolves+validates it (unknown -> 400).
     if mission:
         body["missionId"] = mission
+    # Workflow seat at spawn (Workflows phase 5b): forward the run id; the Gateway validates it and
+    # stamps the workflow id + pinned version, and the seated session's preamble tells the agent to
+    # fetch its conduct at exactly that version. A mission spawn auto-seats without this flag.
+    if workflow_run:
+        body["workflowRunId"] = workflow_run
 
     # "Start a session on another computer": both local and remote spawns now go through the Director's
     # loopback POST /fleet/spawn (issue #1490). With no --machine (or a --machine naming THIS machine) the


### PR DESCRIPTION
Phase 5b of the approved Workflows plan (mission 9a955739). 5a (#1780) gave every session the catalog index; this seats sessions on runs.

## What this does

- NewSessionRequest gains workflowRunId plus Gateway-stamped workflowId/workflowVersion. BOTH spawn legs seat: the Gateway relay (remote) validates and stamps like it already stamps MissionName; the local /fleet/spawn leg resolves through new GatewayClient run lookups with the thefrederiksen/devthrottle#1548 fail-loud posture (unreachable Gateway = 502, never 'unknown run').
- A mission spawn AUTO-SEATS onto the mission's governance run - no new flags; an explicit seat is available via session spawn --workflow-run (unknown ids refused in plain English).
- The spawned session is recorded as a run PARTICIPANT with the canonical fleet session GUID (the thefrederiksen/devthrottle_internal#856 run-to-session membership governance joins effort on).
- The seat persists on the session, surfaces on the SessionDto (additive fields), and the fleet preamble appends a [Workflow seat] paragraph: role, run, the conduct fetch command PINNED to the run's version (never a moving head), and the fail-closed rule. It rides the same preamble every agent family already receives.
- Backward compatible with the PRODUCTION Gateway: a Gateway predating the run spine (404 on the run routes) means spawn-unseated, exactly the pre-feature behavior. The existing mission-attach test - whose Gateway stub faithfully models that older Gateway - went red and caught this before it shipped; without the fix, a Director updated ahead of the Gateway would have 502'd every mission spawn.

## Proof

- Full solution suite: all seven projects, 6,306 passed, 0 failed - with the honest full Gateway count (2,620), after an earlier partial run was caught by the count check and re-run.
- New WorkflowSeatTests over the real local-spawn path (real Director Control API, real RawCli spawns, Gateway stub over loopback HTTP): the mission spawn stamps run id + workflow id + pinned version on the session; the participant PATCH reaches the Gateway with the session GUID, agent kind, role, and machine; the seated session's preamble carries the seat paragraph with the pinned --version fetch and the STOP rule; an unknown explicit run id 400s and records nothing; an unseated spawn is unchanged and carries no paragraph.

## Sequencing note

The fleet-LIVE cross-agent proof (a real Claude and a real Codex session fetching the conduct through the CLI) requires the production Gateway to run a binary with the workflow routes - it runs after the next Gateway deployment, and phase 6 (stubbing the old mission skill file) stays gated on it. Phase 7 (cockpit list + add) is independent and next.