### PR TITLE
feat(gateway): migrate the push-subscription and wingman-instruction stores onto EF

### DIFF
--- a/src/CcDirector.Gateway.Tests/PushSubscriptionStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/PushSubscriptionStoreTests.cs
@@ -1,26 +1,28 @@
+using System.Text.Json;
 using CcDirector.Gateway.Push;
+using CcDirector.Gateway.Tests.Data;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// The push subscription store is the Gateway's set of subscribed devices, keyed by endpoint and
-/// persisted so opt-in survives a restart. These tests use an isolated temp store.
+/// The push subscription store is the Gateway's set of subscribed devices, keyed by endpoint and persisted
+/// (in the EF data layer's push_subscriptions table) so opt-in survives a restart. These tests run over an
+/// isolated on-disk SQLite database (a "restart" is a new store over the same file).
 /// </summary>
 public sealed class PushSubscriptionStoreTests : IDisposable
 {
-    private readonly string _storePath =
-        Path.Combine(Path.GetTempPath(), $"pushsub-{Guid.NewGuid():N}.json");
+    private readonly GatewayDbTestHarness _h = new();
 
-    public void Dispose()
-    {
-        if (File.Exists(_storePath)) File.Delete(_storePath);
-    }
+    public void Dispose() => _h.Dispose();
+
+    private string LegacyPath() => _h.LegacyPath("push-subscriptions-" + Guid.NewGuid().ToString("N") + ".json");
+    private PushSubscriptionStore NewStore() => new(_h.Open(), LegacyPath());
 
     [Fact]
     public void Add_NewEndpoint_ReturnsTrueAndStoresIt()
     {
-        var store = new PushSubscriptionStore(_storePath);
+        var store = NewStore();
 
         var isNew = store.Add("https://push.example/aaa", "p256-a", "auth-a");
 
@@ -35,7 +37,7 @@ public sealed class PushSubscriptionStoreTests : IDisposable
     [Fact]
     public void Add_SameEndpointAgain_RefreshesInPlace_ReturnsFalse()
     {
-        var store = new PushSubscriptionStore(_storePath);
+        var store = NewStore();
         store.Add("https://push.example/aaa", "p256-old", "auth-old");
 
         var isNew = store.Add("https://push.example/aaa", "p256-new", "auth-new");
@@ -50,7 +52,7 @@ public sealed class PushSubscriptionStoreTests : IDisposable
     [Fact]
     public void Remove_ExistingEndpoint_ReturnsTrueThenFalse()
     {
-        var store = new PushSubscriptionStore(_storePath);
+        var store = NewStore();
         store.Add("https://push.example/aaa", "p", "a");
 
         Assert.True(store.Remove("https://push.example/aaa"));
@@ -61,7 +63,7 @@ public sealed class PushSubscriptionStoreTests : IDisposable
     [Fact]
     public void Add_MissingKeys_Throws()
     {
-        var store = new PushSubscriptionStore(_storePath);
+        var store = NewStore();
 
         Assert.Throws<ArgumentException>(() => store.Add("", "p", "a"));
         Assert.Throws<ArgumentException>(() => store.Add("https://push.example/aaa", "", "a"));
@@ -71,14 +73,61 @@ public sealed class PushSubscriptionStoreTests : IDisposable
     [Fact]
     public void Subscriptions_SurviveAReload()
     {
-        var first = new PushSubscriptionStore(_storePath);
+        var first = NewStore();
         first.Add("https://push.example/aaa", "p256-a", "auth-a");
         first.Add("https://push.example/bbb", "p256-b", "auth-b");
 
-        var reloaded = new PushSubscriptionStore(_storePath);
+        var reloaded = new PushSubscriptionStore(_h.Open(), LegacyPath());
 
         Assert.Equal(2, reloaded.Count);
         Assert.Contains(reloaded.All(), s => s.Endpoint == "https://push.example/aaa" && s.P256dh == "p256-a");
         Assert.Contains(reloaded.All(), s => s.Endpoint == "https://push.example/bbb" && s.P256dh == "p256-b");
+    }
+
+    [Fact]
+    public void LegacyJson_ImportedOnce_Lossless_ThenRenamedAside()
+    {
+        // A legacy push-subscriptions.json written by the old store: a top-level array of subscriptions,
+        // each endpoint + keys + a created stamp.
+        var legacy = LegacyPath();
+        var created = new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+        WriteLegacyFile(legacy,
+            new StoredPushSubscription { Endpoint = "https://push.example/aaa", P256dh = "p256-a", Auth = "auth-a", CreatedAtUtc = created },
+            new StoredPushSubscription { Endpoint = "https://push.example/bbb", P256dh = "p256-b", Auth = "auth-b", CreatedAtUtc = created });
+
+        var store = new PushSubscriptionStore(_h.Open(), legacy);
+
+        Assert.Equal(2, store.Count);
+        var a = Assert.Single(store.All(), s => s.Endpoint == "https://push.example/aaa");
+        Assert.Equal("p256-a", a.P256dh);
+        Assert.Equal("auth-a", a.Auth);
+        Assert.Equal(created, a.CreatedAtUtc);
+
+        // The legacy file is renamed aside (kept as a backup), never left to re-import.
+        Assert.False(File.Exists(legacy));
+        Assert.Single(Directory.GetFiles(Path.GetDirectoryName(legacy)!, Path.GetFileName(legacy) + ".migrated-*"));
+
+        // A fresh store over the same DB does NOT re-import (the file is gone) and still has both.
+        Assert.Equal(2, new PushSubscriptionStore(_h.Open(), legacy).Count);
+    }
+
+    [Fact]
+    public void CorruptLegacyJson_FailsLoud_AndLeavesTheFileInPlace()
+    {
+        var legacy = LegacyPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(legacy)!);
+        const string corrupt = "{ this is not json !!!";
+        File.WriteAllText(legacy, corrupt);
+
+        Assert.Throws<InvalidOperationException>(() => new PushSubscriptionStore(_h.Open(), legacy));
+
+        Assert.True(File.Exists(legacy));
+        Assert.Equal(corrupt, File.ReadAllText(legacy));
+    }
+
+    private static void WriteLegacyFile(string path, params StoredPushSubscription[] subs)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, JsonSerializer.Serialize(subs, new JsonSerializerOptions { WriteIndented = true }));
     }
 }

--- a/src/CcDirector.Gateway.Tests/WebPushNeedsYouNotifierTests.cs
+++ b/src/CcDirector.Gateway.Tests/WebPushNeedsYouNotifierTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Push;
+using CcDirector.Gateway.Tests.Data;
 using Lib.Net.Http.WebPush;
 using Xunit;
 
@@ -12,13 +13,14 @@ namespace CcDirector.Gateway.Tests;
 /// </summary>
 public sealed class WebPushNeedsYouNotifierTests : IDisposable
 {
-    private readonly string _storePath =
-        Path.Combine(Path.GetTempPath(), $"pushsub-{Guid.NewGuid():N}.json");
+    private readonly GatewayDbTestHarness _h = new();
 
-    public void Dispose()
-    {
-        if (File.Exists(_storePath)) File.Delete(_storePath);
-    }
+    public void Dispose() => _h.Dispose();
+
+    // A subscription store over the isolated on-disk database (two NewStore() calls share the same DB, so a
+    // second store reloads the first's rows).
+    private PushSubscriptionStore NewStore()
+        => new(_h.Open(), _h.LegacyPath("push-subscriptions-" + Guid.NewGuid().ToString("N") + ".json"));
 
     // ---- Pure decision logic -------------------------------------------------------------------
 
@@ -175,7 +177,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
     [Fact]
     public async Task RunOnce_NewlyExpiredSnooze_AnnouncesOnceThenGoesQuiet()
     {
-        var store = new PushSubscriptionStore(_storePath);
+        var store = NewStore();
         store.Add("https://push.example/aaa", "p", "a");
         var sender = new FakeSender();
         var count = 1;
@@ -218,7 +220,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
     [Fact]
     public async Task RunOnce_NoSubscribers_DoesNotEvenReadTheRoster()
     {
-        var store = new PushSubscriptionStore(_storePath);
+        var store = NewStore();
         var reads = 0;
         var notifier = new WebPushNeedsYouNotifier(store, _ => { reads++; return Task.FromResult(Snap(5)); }, new FakeSender());
 
@@ -230,7 +232,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
     [Fact]
     public async Task RunOnce_FirstNonZeroCount_PushesToEverySubscription()
     {
-        var store = new PushSubscriptionStore(_storePath);
+        var store = NewStore();
         store.Add("https://push.example/aaa", "p", "a");
         store.Add("https://push.example/bbb", "p", "a");
         var sender = new FakeSender();
@@ -245,7 +247,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
     [Fact]
     public async Task RunOnce_UnchangedCount_DoesNotPushTwice()
     {
-        var store = new PushSubscriptionStore(_storePath);
+        var store = NewStore();
         store.Add("https://push.example/aaa", "p", "a");
         var sender = new FakeSender();
         var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(Snap(2)), sender);
@@ -259,7 +261,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
     [Fact]
     public async Task RunOnce_DropToZeroThenRise_PushesCountThenClearThenCount()
     {
-        var store = new PushSubscriptionStore(_storePath);
+        var store = NewStore();
         store.Add("https://push.example/aaa", "p", "a");
         var sender = new FakeSender();
         var count = 2;
@@ -281,7 +283,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
     [Fact]
     public async Task RunOnce_AllSessionsDone_SendsExactlyOneZeroClear()
     {
-        var store = new PushSubscriptionStore(_storePath);
+        var store = NewStore();
         store.Add("https://push.example/aaa", "p", "a");
         var sender = new FakeSender();
         var count = 1;
@@ -301,7 +303,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
     [Fact]
     public async Task RunOnce_GoneSubscription_IsPruned()
     {
-        var store = new PushSubscriptionStore(_storePath);
+        var store = NewStore();
         store.Add("https://push.example/alive", "p", "a");
         store.Add("https://push.example/dead", "p", "a");
         var sender = new FakeSender();
@@ -318,7 +320,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
     [Fact]
     public async Task ResetDedupe_RePushesTheCurrentCount()
     {
-        var store = new PushSubscriptionStore(_storePath);
+        var store = NewStore();
         store.Add("https://push.example/aaa", "p", "a");
         var sender = new FakeSender();
         var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(Snap(2)), sender);

--- a/src/CcDirector.Gateway.Tests/WingmanInstructionsStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanInstructionsStoreTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using CcDirector.Gateway.Tests.Data;
 using CcDirector.Gateway.Wingman;
 using Xunit;
 
@@ -7,14 +9,23 @@ namespace CcDirector.Gateway.Tests;
 /// Editable/versioned wingman instructions (issue #537): the wingman uses the active version
 /// (custom else deployed default); a non-customized user auto-tracks the latest default, while a
 /// customized user is told when the dev team ships a new default and can switch to it.
+///
+/// Over the EF data layer (Hosted Gateway mission, Step 1b): the whole state document is one row per tenant
+/// in wingman_instructions. A "reload" is a new store over the same database.
 /// </summary>
 public sealed class WingmanInstructionsStoreTests : IDisposable
 {
-    private readonly string _path = Path.Combine(Path.GetTempPath(), "wmi-" + Guid.NewGuid().ToString("N") + ".json");
-    public void Dispose() { try { File.Delete(_path); } catch { } }
+    private readonly GatewayDbTestHarness _h = new();
+    // A fixed legacy path per test - it never exists (so no import) except where a test seeds it explicitly.
+    private readonly string _legacyPath;
+
+    public WingmanInstructionsStoreTests()
+        => _legacyPath = _h.LegacyPath("wmi-legacy-" + Guid.NewGuid().ToString("N") + ".json");
+
+    public void Dispose() => _h.Dispose();
 
     private WingmanInstructionsStore New(string def, string ver = "1")
-        => new(defaultContent: def, defaultVersion: ver, path: _path);
+        => new(_h.Open(), _legacyPath, defaultContent: def, defaultVersion: ver);
 
     [Fact]
     public void Fresh_UsesDeployedDefault_NotCustomized_NoUpdate()
@@ -49,7 +60,7 @@ public sealed class WingmanInstructionsStoreTests : IDisposable
     public void CustomizedUser_NewDefaultShips_UpdateAvailable_WithOldDefaultForDiff()
     {
         New("DEFAULT v1").Save("MY custom", null);          // customize against v1
-        var s2 = New("DEFAULT v2 changed", "2");            // dev team ships a new default (same path)
+        var s2 = New("DEFAULT v2 changed", "2");            // dev team ships a new default (same database)
         Assert.True(s2.IsCustomized);
         Assert.Equal("MY custom", s2.ActiveContent);        // still on the user's version
         Assert.True(s2.UpdateAvailable);                    // but told a new default exists
@@ -95,9 +106,98 @@ public sealed class WingmanInstructionsStoreTests : IDisposable
     public void State_PersistsAcrossReload()
     {
         New("DEFAULT v1").Save("persisted custom", "keep");
-        var s2 = New("DEFAULT v1");                          // reload from the same file
+        var s2 = New("DEFAULT v1");                          // reload from the same database
         Assert.True(s2.IsCustomized);
         Assert.Equal("persisted custom", s2.ActiveContent);
         Assert.Single(s2.Versions());
+    }
+
+    [Fact]
+    public void LegacyJson_ImportedOnce_ActiveContentPinsTheSameVersion_ThenRenamedAside()
+    {
+        // A legacy wingman-instructions.json written by the old store: a state document with TWO saved
+        // versions and the active pointer aimed at the second. After the migration, ActiveContent must
+        // resolve to exactly the version the pointer names - not the latest, not the default.
+        var older = new DateTime(2026, 6, 1, 10, 0, 0, DateTimeKind.Utc);
+        var newer = new DateTime(2026, 6, 2, 10, 0, 0, DateTimeKind.Utc);
+        WriteLegacyState(_legacyPath, activeVersionId: "v-active", ackVersion: "1", ackContent: "DEFAULT v1",
+            versions: new[]
+            {
+                LegacyVersion("v-old", "old custom content", older, "old", "user", WingmanInstructionsStore.Hash("old custom content")),
+                LegacyVersion("v-active", "active custom content", newer, "active", "user", WingmanInstructionsStore.Hash("active custom content")),
+            });
+
+        var s = new WingmanInstructionsStore(_h.Open(), _legacyPath, defaultContent: "DEFAULT v1", defaultVersion: "1");
+
+        // The active pointer is honoured exactly.
+        Assert.True(s.IsCustomized);
+        Assert.Equal("active custom content", s.ActiveContent);
+        Assert.Equal("v-active", s.Active().Id);
+        // Both versions survived, newest-first.
+        var versions = s.Versions();
+        Assert.Equal(2, versions.Count);
+        Assert.Equal("v-active", versions[0].Id);
+        Assert.Equal("v-old", versions[1].Id);
+
+        // The legacy file is renamed aside and not re-imported.
+        Assert.False(File.Exists(_legacyPath));
+        Assert.Single(Directory.GetFiles(Path.GetDirectoryName(_legacyPath)!, Path.GetFileName(_legacyPath) + ".migrated-*"));
+
+        // A fresh store over the same database resolves the same active version (no re-import).
+        var reloaded = new WingmanInstructionsStore(_h.Open(), _legacyPath, defaultContent: "DEFAULT v1", defaultVersion: "1");
+        Assert.Equal("active custom content", reloaded.ActiveContent);
+    }
+
+    [Fact]
+    public void LegacyJson_Imported_AckDefaultStateRoundTrips_DrivingTheUpdateBanner()
+    {
+        // The acknowledged-default snapshot (what the user based their customization on) must survive the
+        // import exactly, because the update-available banner is computed from it. The user customized
+        // against "DEFAULT v1"; the dev team has since shipped "DEFAULT v2 changed".
+        var when = new DateTime(2026, 6, 1, 10, 0, 0, DateTimeKind.Utc);
+        WriteLegacyState(_legacyPath, activeVersionId: "v1", ackVersion: "1", ackContent: "DEFAULT v1",
+            versions: new[] { LegacyVersion("v1", "my custom", when, null, "user", WingmanInstructionsStore.Hash("my custom")) });
+
+        var s = new WingmanInstructionsStore(_h.Open(), _legacyPath, defaultContent: "DEFAULT v2 changed", defaultVersion: "2");
+
+        // The acknowledged default round-tripped exactly.
+        var (ackVersion, ackContent) = s.AcknowledgedDefault();
+        Assert.Equal("1", ackVersion);
+        Assert.Equal("DEFAULT v1", ackContent);
+        // And it drives the banner: customized, and the acknowledged default differs from the new one.
+        Assert.True(s.IsCustomized);
+        Assert.True(s.UpdateAvailable);
+        Assert.Equal("my custom", s.ActiveContent);
+    }
+
+    [Fact]
+    public void CorruptLegacyJson_FailsLoud_AndLeavesTheFileInPlace()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_legacyPath)!);
+        const string corrupt = "{ this is not json !!!";
+        File.WriteAllText(_legacyPath, corrupt);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            new WingmanInstructionsStore(_h.Open(), _legacyPath, defaultContent: "DEFAULT v1", defaultVersion: "1"));
+
+        Assert.True(File.Exists(_legacyPath));
+        Assert.Equal(corrupt, File.ReadAllText(_legacyPath));
+    }
+
+    // The legacy StateFile JSON shape, written with default (PascalCase) options exactly as the old store did.
+    private static object LegacyVersion(string id, string content, DateTime createdAtUtc, string? label, string source, string hash)
+        => new { Id = id, Content = content, CreatedAtUtc = createdAtUtc, Label = label, Source = source, Hash = hash };
+
+    private static void WriteLegacyState(string path, string? activeVersionId, string ackVersion, string ackContent, object[] versions)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var state = new
+        {
+            ActiveVersionId = activeVersionId,
+            AckDefaultVersion = ackVersion,
+            AckDefaultContent = ackContent,
+            Versions = versions,
+        };
+        File.WriteAllText(path, JsonSerializer.Serialize(state, new JsonSerializerOptions { WriteIndented = true }));
     }
 }

--- a/src/CcDirector.Gateway/Data/Entities/PushSubscriptionEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/PushSubscriptionEntity.cs
@@ -1,0 +1,29 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// The persisted form of one Web Push subscription (<see cref="Push.StoredPushSubscription"/>) in the EF data
+/// layer: one row in the <c>push_subscriptions</c> table, keyed by <see cref="Endpoint"/>.
+///
+/// <see cref="Endpoint"/> is the PRIMARY KEY directly - the browser push endpoint URL is unique per
+/// subscription and ordinally compared (the legacy store keyed a <c>Dictionary(StringComparer.Ordinal)</c> by
+/// it), so it is the natural key and there is no surrogate id. Re-subscribing the same device is an idempotent
+/// upsert on this key, exactly as before. The store carries NO per-user field (the legacy shape had none - a
+/// subscription is endpoint + keys; the Gateway's host-wide token is the only identity), so none is invented
+/// here; <c>tenant_id</c> is inherited from the base and scopes the tenant, nothing more.
+///
+/// <see cref="CreatedAtUtc"/> is UTC and round-trips through the backbone's UTC DateTime convention.
+/// </summary>
+public sealed class PushSubscriptionEntity : TenantScopedEntity
+{
+    /// <summary>The browser push endpoint URL. Primary key (an ordinal, unique-per-subscription string).</summary>
+    public string Endpoint { get; set; } = "";
+
+    /// <summary>The client P-256 ECDH public key (base64url), from <c>subscription.keys.p256dh</c>.</summary>
+    public string P256dh { get; set; } = "";
+
+    /// <summary>The client auth secret (base64url), from <c>subscription.keys.auth</c>.</summary>
+    public string Auth { get; set; } = "";
+
+    /// <summary>When the subscription was first recorded (UTC).</summary>
+    public DateTime CreatedAtUtc { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/Entities/WingmanInstructionEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/WingmanInstructionEntity.cs
@@ -1,0 +1,55 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// The persisted form of the wingman instructions state (issue #537) in the EF data layer: ONE row per
+/// tenant in the <c>wingman_instructions</c> table, holding the whole editable/versioned document exactly as
+/// the legacy <c>wingman-instructions.json</c> held it.
+///
+/// The store is a single state DOCUMENT, not a keyed collection: an active-version pointer, the acknowledged
+/// deployed-default snapshot, and the ordered list of saved versions. So it is modelled as one row carrying:
+/// <list type="bullet">
+/// <item><see cref="ActiveVersionId"/> - the nullable pointer to the active custom version (null = ride the
+/// deployed default). This is the exact "active" resolution the legacy store used: the version it points to
+/// when set and found, otherwise the deployed default. NOT "the latest version".</item>
+/// <item><see cref="AckDefaultVersion"/> / <see cref="AckDefaultContent"/> - the acknowledged (based-on)
+/// default snapshot, the left side of the "our changes" diff and the basis for the update-available banner.</item>
+/// <item><see cref="Versions"/> - the saved versions, an OWNED collection serialized to a JSON column (the
+/// cron/workflow "sub-doc -> JSON in a column" pattern), preserving each version's fields and the list order.</item>
+/// </list>
+/// A surrogate GUID <see cref="Id"/> is the key (the document has no external id); the store keeps exactly one
+/// row per tenant. <c>tenant_id</c> + the global query filter are inherited from the base.
+/// </summary>
+public sealed class WingmanInstructionEntity : TenantScopedEntity
+{
+    /// <summary>Surrogate primary key (code-generated). The document has no natural external id; the store
+    /// keeps a single row per tenant.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>The active custom version's id, or null to ride the deployed default. The active-version
+    /// pointer, reproduced exactly.</summary>
+    public string? ActiveVersionId { get; set; }
+
+    /// <summary>The acknowledged deployed-default version stamp (the based-on default for the diff/banner).</summary>
+    public string AckDefaultVersion { get; set; } = "";
+
+    /// <summary>The acknowledged deployed-default content snapshot (the left side of the "our changes" diff).</summary>
+    public string AckDefaultContent { get; set; } = "";
+
+    /// <summary>The saved versions, in stored order, as an owned JSON collection.</summary>
+    public List<WingmanInstructionVersionOwned> Versions { get; set; } = new();
+}
+
+/// <summary>
+/// One saved wingman instruction version, owned by <see cref="WingmanInstructionEntity"/> and serialized into
+/// its JSON column. Mirrors the legacy <c>InstructionVersion</c> field-for-field so the import is lossless and
+/// the store maps back to its unchanged public record.
+/// </summary>
+public sealed class WingmanInstructionVersionOwned
+{
+    public string Id { get; set; } = "";
+    public string Content { get; set; } = "";
+    public DateTime CreatedAtUtc { get; set; }
+    public string? Label { get; set; }
+    public string Source { get; set; } = "user";
+    public string Hash { get; set; } = "";
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -74,6 +74,12 @@ public sealed class GatewayDbContext : DbContext
     /// state transitions, the duration spine of issue #1771.</summary>
     public DbSet<GovernanceEventEntity> GovernanceEvents => Set<GovernanceEventEntity>();
 
+    /// <summary>Web Push subscriptions (<c>push_subscriptions</c>), keyed by browser push endpoint.</summary>
+    public DbSet<PushSubscriptionEntity> PushSubscriptions => Set<PushSubscriptionEntity>();
+
+    /// <summary>The wingman instructions state document (<c>wingman_instructions</c>), one row per tenant.</summary>
+    public DbSet<WingmanInstructionEntity> WingmanInstructions => Set<WingmanInstructionEntity>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -187,6 +193,25 @@ public sealed class GatewayDbContext : DbContext
             b.HasIndex(e => new { e.TenantId, e.OccurredUtc });
         });
 
+        modelBuilder.Entity<PushSubscriptionEntity>(b =>
+        {
+            b.ToTable("push_subscriptions");
+            // Endpoint is the natural key - a unique-per-subscription URL compared ordinally (SQLite's default
+            // BINARY collation), matching the legacy Dictionary(StringComparer.Ordinal) - so it is the primary
+            // key directly, no surrogate id. There is no per-user column: the legacy shape had none.
+            b.HasKey(e => e.Endpoint);
+        });
+
+        modelBuilder.Entity<WingmanInstructionEntity>(b =>
+        {
+            b.ToTable("wingman_instructions");
+            b.HasKey(e => e.Id);
+            // The document has no external id; the store keeps one row per tenant under its write lock.
+            // The saved versions are a bounded sub-document: an owned collection serialized to a JSON column
+            // (the cron/workflow "sub-doc -> JSON in a column" pattern), preserving each field and the order.
+            b.OwnsMany(e => e.Versions, o => o.ToJson());
+        });
+
         // Tenant scoping - the tenant_id column plus the global query filter - applied uniformly to every
         // entity that derives from TenantScopedEntity, so future stores inherit it by deriving from the base.
         ApplyTenantScope<CronJobEntity>(modelBuilder);
@@ -199,6 +224,8 @@ public sealed class GatewayDbContext : DbContext
         ApplyTenantScope<WorkflowRunEntity>(modelBuilder);
         ApplyTenantScope<SnoozeEntity>(modelBuilder);
         ApplyTenantScope<GovernanceEventEntity>(modelBuilder);
+        ApplyTenantScope<PushSubscriptionEntity>(modelBuilder);
+        ApplyTenantScope<WingmanInstructionEntity>(modelBuilder);
 
         ApplyCommonSubsetConventions(modelBuilder);
     }

--- a/src/CcDirector.Gateway/Data/Migrations/20260718031421_AddPushSubscriptionsAndWingmanInstructions.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718031421_AddPushSubscriptionsAndWingmanInstructions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718031421_AddPushSubscriptionsAndWingmanInstructions")]
+    partial class AddPushSubscriptionsAndWingmanInstructions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260718031421_AddPushSubscriptionsAndWingmanInstructions.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718031421_AddPushSubscriptionsAndWingmanInstructions.cs
@@ -1,0 +1,66 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPushSubscriptionsAndWingmanInstructions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "push_subscriptions",
+                columns: table => new
+                {
+                    Endpoint = table.Column<string>(type: "TEXT", nullable: false),
+                    P256dh = table.Column<string>(type: "TEXT", nullable: false),
+                    Auth = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_push_subscriptions", x => x.Endpoint);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "wingman_instructions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ActiveVersionId = table.Column<string>(type: "TEXT", nullable: true),
+                    AckDefaultVersion = table.Column<string>(type: "TEXT", nullable: false),
+                    AckDefaultContent = table.Column<string>(type: "TEXT", nullable: false),
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false),
+                    Versions = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_wingman_instructions", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_push_subscriptions_tenant_id",
+                table: "push_subscriptions",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_wingman_instructions_tenant_id",
+                table: "wingman_instructions",
+                column: "tenant_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "push_subscriptions");
+
+            migrationBuilder.DropTable(
+                name: "wingman_instructions");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -393,7 +393,8 @@ public sealed class GatewayHost : IAsyncDisposable
     private TurnEndWatcher? _turnEndWatcher;
     private Wingman.WingmanVoiceService? _voiceService;
     // Editable/versioned wingman instructions (issue #537); the voice translator reads the active set.
-    private readonly Wingman.WingmanInstructionsStore _instructionsStore = new();
+    // Constructed in the constructor body once the EF database is built (it persists to the data layer).
+    private readonly Wingman.WingmanInstructionsStore _instructionsStore;
     // Shared training-data store: the voice service WRITES captures, the instructions A/B test READS them.
     private readonly Wingman.WingmanTrainingStore _trainingStore = new();
     private System.Threading.Timer? _voiceSweepTimer;
@@ -522,7 +523,7 @@ public sealed class GatewayHost : IAsyncDisposable
     /// Shared instances that write to the real user's directories). Production omits it and the host builds
     /// the service over its own key vault, exactly as before.
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null, Core.Agents.AgentKind? brainTool = null)
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? pushSubscriptionsPath = null, string? wingmanInstructionsPath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null, Core.Agents.AgentKind? brainTool = null)
     {
         // Resolve and VALIDATE the warm-brain tool up front, before any resource is opened: a brain tool
         // that cannot be hosted is a configuration error that must fail loudly at construction, not
@@ -616,6 +617,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // path so they never touch the real legacy file. The registry is bounded by dropping a removed
         // Director's entries so they do not accumulate.
         _snoozeRegistry = new Snooze.SnoozeRegistry(_gatewayDb, snoozePath ?? Path.Combine(CcStorage.Root(), "snooze.json"));
+        // Editable/versioned wingman instructions (issue #537) now persist in the wingman_instructions table
+        // of the EF data layer. The path argument is the LEGACY wingman-instructions.json, imported once on
+        // first upgrade then renamed aside. Tests MUST pass an isolated path so they never touch the real file.
+        _instructionsStore = new Wingman.WingmanInstructionsStore(_gatewayDb, wingmanInstructionsPath ?? Path.Combine(CcStorage.Root(), "wingman-instructions.json"));
         Registry.OnDirectorRemoved += id => _snoozeRegistry.ClearForDirector(id);
         // THE PUSH SEAM where this Gateway drives the hold machine off the facts Directors report. The
         // DirectorHub (constructed per-invocation by SignalR) folds every pushed session through this one
@@ -762,7 +767,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // pair and the set of subscribed devices. The notifier that fans out to these is built and
         // started in StartAsync, once this Gateway's own /sessions endpoint is reachable on loopback.
         _vapidStore = new Push.WebPushVapidStore();
-        _pushSubscriptions = new Push.PushSubscriptionStore();
+        // Web Push subscriptions now persist in the push_subscriptions table of the EF data layer. The path
+        // argument is the LEGACY push-subscriptions.json, imported once on first upgrade then renamed aside.
+        // Tests MUST pass an isolated path so they never touch the real legacy file.
+        _pushSubscriptions = new Push.PushSubscriptionStore(_gatewayDb, pushSubscriptionsPath ?? Path.Combine(CcStorage.ToolConfig("gateway"), "push-subscriptions.json"));
 
         // Gateway device registration (issue #857): on sign-in (and as a first-launch/retry safety net on
         // the heartbeat) register THIS Gateway as a device with the cloud account and store the issued

--- a/src/CcDirector.Gateway/Push/PushSubscriptionStore.cs
+++ b/src/CcDirector.Gateway/Push/PushSubscriptionStore.cs
@@ -1,7 +1,8 @@
-using System.Collections.Concurrent;
 using System.Text.Json;
-using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
 
 namespace CcDirector.Gateway.Push;
 
@@ -11,39 +12,49 @@ namespace CcDirector.Gateway.Push;
 /// public keys (<c>p256dh</c> and <c>auth</c>) needed to encrypt a message to it, exactly the shape
 /// a browser's <c>PushSubscription.toJSON()</c> produces.
 ///
-/// Persisted to <c>%LOCALAPPDATA%\cc-director\config\gateway\push-subscriptions.json</c> so opt-in
-/// survives a Gateway restart. The endpoint URL is a capability (whoever holds it can ask the push
-/// service to deliver to that device), so the file is treated as a secret store - it lives under the
-/// per-user config root and the endpoint/keys are never written to the log (only counts are).
+/// PERSISTENCE (Hosted Gateway mission, Step 1b): subscriptions live in the EF data layer's
+/// <c>push_subscriptions</c> table (SQLite locally), NOT the old hand-rolled
+/// <c>push-subscriptions.json</c>. The public API and observable behavior are unchanged.
 ///
-/// Keyed by endpoint, which is unique per subscription, so re-subscribing the same device is an
-/// idempotent upsert rather than a duplicate. Thread-safe: subscribe/unsubscribe run on request
-/// threads while the background notifier enumerates the set.
+/// Keyed by endpoint, which is unique per subscription (SQLite's default BINARY collation compares it
+/// ordinally, matching the legacy <c>Dictionary(StringComparer.Ordinal)</c>), so re-subscribing the same
+/// device is an idempotent upsert rather than a duplicate. There is NO per-user column - the legacy shape
+/// had none; <c>tenant_id</c> scopes the tenant and nothing more.
+///
+/// ONE-TIME IMPORT: on first run after the upgrade, if a legacy <c>push-subscriptions.json</c> exists and
+/// the table is empty, every subscription is imported (through the shared recoverable-import helper), then
+/// the JSON is renamed aside as a backup.
+///
+/// Threading: the Gateway is a single writer. Every operation runs under this store's write lock over a
+/// fresh pooled context.
 /// </summary>
 public sealed class PushSubscriptionStore
 {
-    private readonly string _storePath;
-    private readonly object _saveLock = new();
-    private readonly ConcurrentDictionary<string, StoredPushSubscription> _byEndpoint =
-        new(StringComparer.Ordinal);
+    private readonly object _gate = new();
+    private readonly GatewayDatabase _db;
+    private readonly string _legacyJsonPath;
 
-    public PushSubscriptionStore() : this(null) { }
-
-    /// <param name="storePath">Override the store file (tests pass an isolated temp path); production
-    /// omits it for the shared default under the gateway config root.</param>
-    public PushSubscriptionStore(string? storePath)
+    /// <param name="db">The Gateway EF database this store reads and writes through.</param>
+    /// <param name="legacyJsonPath">The legacy <c>push-subscriptions.json</c> path to import ONCE if it
+    /// exists and the table is empty. REQUIRED (no silent default).</param>
+    /// <exception cref="ArgumentNullException">The database is null.</exception>
+    /// <exception cref="ArgumentException">The legacy path is null/empty/whitespace.</exception>
+    public PushSubscriptionStore(GatewayDatabase db, string legacyJsonPath)
     {
-        _storePath = string.IsNullOrWhiteSpace(storePath)
-            ? Path.Combine(CcStorage.ToolConfig("gateway"), "push-subscriptions.json")
-            : storePath;
-        Load();
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        if (string.IsNullOrWhiteSpace(legacyJsonPath))
+            throw new ArgumentException("legacy json path is required", nameof(legacyJsonPath));
+        _legacyJsonPath = legacyJsonPath;
+
+        lock (_gate)
+            ImportLegacyJsonIfNeeded();
     }
 
-    /// <summary>The on-disk store file path.</summary>
-    public string StorePath => _storePath;
-
     /// <summary>The number of registered subscriptions.</summary>
-    public int Count => _byEndpoint.Count;
+    public int Count
+    {
+        get { lock (_gate) { using var ctx = _db.CreateContext(); return ctx.PushSubscriptions.Count(); } }
+    }
 
     /// <summary>
     /// Record (or refresh) a subscription. A repeat of the same endpoint replaces the prior keys and
@@ -60,17 +71,34 @@ public sealed class PushSubscriptionStore
         if (string.IsNullOrWhiteSpace(auth))
             throw new ArgumentException("auth key is required", nameof(auth));
 
-        var isNew = !_byEndpoint.ContainsKey(endpoint);
-        _byEndpoint[endpoint] = new StoredPushSubscription
+        lock (_gate)
         {
-            Endpoint = endpoint,
-            P256dh = p256dh,
-            Auth = auth,
-            CreatedAtUtc = DateTime.UtcNow,
-        };
-        Save();
-        FileLog.Write($"[PushSubscriptionStore] {(isNew ? "Added" : "Refreshed")} a subscription, total={_byEndpoint.Count}");
-        return isNew;
+            using var ctx = _db.CreateContext();
+            var existing = ctx.PushSubscriptions.FirstOrDefault(e => e.Endpoint == endpoint);
+            var isNew = existing is null;
+            // A refresh replaces the keys AND restamps CreatedAtUtc, exactly as the legacy store did (it
+            // replaced the whole record on every Add).
+            if (existing is null)
+            {
+                ctx.PushSubscriptions.Add(new PushSubscriptionEntity
+                {
+                    Endpoint = endpoint,
+                    TenantId = ctx.ActiveTenant!,
+                    P256dh = p256dh,
+                    Auth = auth,
+                    CreatedAtUtc = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                existing.P256dh = p256dh;
+                existing.Auth = auth;
+                existing.CreatedAtUtc = DateTime.UtcNow;
+            }
+            ctx.SaveChanges();
+            FileLog.Write($"[PushSubscriptionStore] {(isNew ? "Added" : "Refreshed")} a subscription, total={ctx.PushSubscriptions.Count()}");
+            return isNew;
+        }
     }
 
     /// <summary>Drop a subscription by endpoint. Returns true when one was removed.</summary>
@@ -78,51 +106,114 @@ public sealed class PushSubscriptionStore
     {
         if (string.IsNullOrWhiteSpace(endpoint))
             return false;
-        if (!_byEndpoint.TryRemove(endpoint, out _))
-            return false;
-        Save();
-        FileLog.Write($"[PushSubscriptionStore] Removed a subscription, total={_byEndpoint.Count}");
-        return true;
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var existing = ctx.PushSubscriptions.FirstOrDefault(e => e.Endpoint == endpoint);
+            if (existing is null)
+                return false;
+            ctx.PushSubscriptions.Remove(existing);
+            ctx.SaveChanges();
+            FileLog.Write($"[PushSubscriptionStore] Removed a subscription, total={ctx.PushSubscriptions.Count()}");
+            return true;
+        }
     }
 
     /// <summary>A snapshot of every stored subscription.</summary>
-    public IReadOnlyList<StoredPushSubscription> All() => _byEndpoint.Values.ToList();
-
-    private void Load()
+    public IReadOnlyList<StoredPushSubscription> All()
     {
-        if (!File.Exists(_storePath)) return;
-        var json = File.ReadAllText(_storePath);
-        if (string.IsNullOrWhiteSpace(json)) return;
-
-        var records = JsonSerializer.Deserialize<List<StoredPushSubscription>>(json, new JsonSerializerOptions
+        lock (_gate)
         {
-            PropertyNameCaseInsensitive = true,
-        });
-        if (records is null) return;
-        foreach (var record in records)
-        {
-            if (string.IsNullOrWhiteSpace(record.Endpoint)) continue;
-            _byEndpoint[record.Endpoint] = record;
+            using var ctx = _db.CreateContext();
+            return ctx.PushSubscriptions.AsNoTracking().ToList().Select(ToRecord).ToList();
         }
-        FileLog.Write($"[PushSubscriptionStore] Loaded {_byEndpoint.Count} subscription(s) from {_storePath}");
     }
 
-    private void Save()
+    private static StoredPushSubscription ToRecord(PushSubscriptionEntity e) => new()
     {
-        lock (_saveLock)
+        Endpoint = e.Endpoint,
+        P256dh = e.P256dh,
+        Auth = e.Auth,
+        CreatedAtUtc = e.CreatedAtUtc,
+    };
+
+    // ---- one-time legacy JSON import --------------------------------------------------------------
+
+    /// <summary>
+    /// Import a legacy <c>push-subscriptions.json</c> exactly once, through the shared recoverable-import
+    /// plumbing (<see cref="LegacyJsonImport.Recoverable"/>): import only when the file exists AND the table
+    /// is empty; recover a lingering file idempotently; rename aside best-effort after a successful import.
+    /// </summary>
+    private void ImportLegacyJsonIfNeeded()
+        => LegacyJsonImport.Recoverable(
+            _legacyJsonPath,
+            "[PushSubscriptionStore]",
+            isPopulated: () => { using var ctx = _db.CreateContext(); return ctx.PushSubscriptions.Any(); },
+            importCommitted: ImportRowsFromLegacyJson);
+
+    /// <summary>
+    /// Parse the legacy file (a top-level array of subscriptions) and insert every one inside a transaction.
+    /// Mirrors the old load: skip an empty endpoint, last-wins on a duplicate endpoint. Fail-loud and
+    /// all-or-nothing - a parse error throws and imports nothing (the file is left in place).
+    /// </summary>
+    private void ImportRowsFromLegacyJson()
+    {
+        using var ctx = _db.CreateContext();
+
+        List<StoredPushSubscription>? parsed;
+        try
         {
-            var dir = Path.GetDirectoryName(_storePath);
-            if (!string.IsNullOrEmpty(dir))
-                Directory.CreateDirectory(dir);
-            var json = JsonSerializer.Serialize(_byEndpoint.Values.ToList(), new JsonSerializerOptions
-            {
-                WriteIndented = true,
-            });
-            // Atomic replace so a crash mid-write never leaves a half-written subscription file.
-            var temp = _storePath + ".tmp";
-            File.WriteAllText(temp, json);
-            File.Move(temp, _storePath, overwrite: true);
+            parsed = JsonSerializer.Deserialize<List<StoredPushSubscription>>(
+                File.ReadAllText(_legacyJsonPath),
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
         }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[PushSubscriptionStore] Import FAILED: legacy file {_legacyJsonPath} could not be read: {ex.Message}");
+            throw new InvalidOperationException(
+                $"The legacy push-subscriptions file '{_legacyJsonPath}' could not be parsed for the one-time " +
+                $"import: {ex.Message}. The Gateway will not start with a partial import. Fix or move the file " +
+                "aside and restart.", ex);
+        }
+
+        // A null root (the JSON literal "null") is unreadable, not an empty store - fail loud and leave the
+        // file in place, exactly like a parse error, matching the other stores' import contract.
+        if (parsed is null)
+        {
+            FileLog.Write($"[PushSubscriptionStore] Import FAILED: legacy file {_legacyJsonPath} deserialized to a null document");
+            throw new InvalidOperationException(
+                $"The legacy push-subscriptions file '{_legacyJsonPath}' could not be parsed for the one-time " +
+                "import: the document is null. The Gateway will not start with a partial import. Fix or move " +
+                "the file aside and restart.");
+        }
+
+        // Reproduce the old load's row handling, INCLUDING last-wins on a duplicate endpoint (the old
+        // in-memory Dictionary keyed by endpoint overwrote), so the imported set matches.
+        var toImport = new Dictionary<string, StoredPushSubscription>(StringComparer.Ordinal);
+        foreach (var s in parsed)
+        {
+            if (string.IsNullOrWhiteSpace(s.Endpoint))
+                continue;
+            toImport[s.Endpoint] = s;
+        }
+
+        using var tx = ctx.Database.BeginTransaction();
+        foreach (var s in toImport.Values)
+        {
+            ctx.PushSubscriptions.Add(new PushSubscriptionEntity
+            {
+                Endpoint = s.Endpoint,
+                TenantId = ctx.ActiveTenant!,
+                P256dh = s.P256dh,
+                Auth = s.Auth,
+                CreatedAtUtc = s.CreatedAtUtc,
+            });
+        }
+        ctx.SaveChanges();
+        tx.Commit();
+
+        FileLog.Write($"[PushSubscriptionStore] Import: {toImport.Count} subscription(s) imported from {_legacyJsonPath}");
     }
 }
 

--- a/src/CcDirector.Gateway/Wingman/WingmanInstructionsStore.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanInstructionsStore.cs
@@ -1,8 +1,11 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
-using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
+using CcDirector.Core.Storage;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
 
 namespace CcDirector.Gateway.Wingman;
 
@@ -19,7 +22,14 @@ namespace CcDirector.Gateway.Wingman;
 ///   content vs the new default) and offer a one-click switch - never silently overwriting the user's
 ///   prompt. Acknowledging (switch, or customizing afresh) snapshots the current default.
 ///
-/// Persisted as one JSON file under the gateway storage root. Thread-safe; best-effort on disk errors.
+/// PERSISTENCE (Hosted Gateway mission, Step 1b): the whole state document lives in the EF data layer's
+/// <c>wingman_instructions</c> table as ONE row per tenant (the active-version pointer, the acknowledged
+/// deployed-default snapshot, and the versions as an owned JSON collection) - NOT the old hand-rolled
+/// <c>wingman-instructions.json</c>. The public API and observable behavior are unchanged. The store keeps
+/// the working state in memory exactly as before; only the load/save primitive moved from a JSON file to the
+/// single row. On first run after the upgrade a legacy <c>wingman-instructions.json</c> is imported once
+/// (through the shared recoverable-import helper) then renamed aside. Thread-safe; fail-loud on a persist
+/// error (no silent best-effort fallback, matching the other migrated stores).
 /// </summary>
 public sealed class WingmanInstructionsStore
 {
@@ -45,18 +55,26 @@ public sealed class WingmanInstructionsStore
     /// <summary>Hard cap so a pasted prompt cannot bloat the brain call / file.</summary>
     public const int MaxContentChars = 20_000;
 
-    private readonly string _path;
+    private readonly GatewayDatabase _db;
+    private readonly string _legacyJsonPath;
     private readonly string _defaultContent;
     private readonly string _defaultVersion;
     private readonly object _lock = new();
     private StateFile _state = new();
     private int _seq;
 
-    public WingmanInstructionsStore(string? defaultContent = null, string? defaultVersion = null, string? path = null)
+    /// <param name="db">The Gateway EF database this store reads and writes through.</param>
+    /// <param name="legacyJsonPath">The legacy <c>wingman-instructions.json</c> path to import ONCE if it
+    /// exists and the table is empty. REQUIRED (no silent default).</param>
+    public WingmanInstructionsStore(GatewayDatabase db, string legacyJsonPath,
+        string? defaultContent = null, string? defaultVersion = null)
     {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        if (string.IsNullOrWhiteSpace(legacyJsonPath))
+            throw new ArgumentException("legacy json path is required", nameof(legacyJsonPath));
+        _legacyJsonPath = legacyJsonPath;
         _defaultContent = defaultContent ?? WingmanTranslator.FidelityPrompt;
         _defaultVersion = defaultVersion ?? WingmanTranslator.DefaultInstructionsVersion;
-        _path = path ?? Path.Combine(CcStorage.Root(), "wingman-instructions.json");
         Load();
     }
 
@@ -75,15 +93,10 @@ public sealed class WingmanInstructionsStore
     {
         lock (_lock)
         {
-            try
-            {
-                if (File.Exists(_path))
-                {
-                    var s = JsonSerializer.Deserialize<StateFile>(File.ReadAllText(_path));
-                    if (s is not null) _state = s;
-                }
-            }
-            catch (Exception ex) { FileLog.Write($"[WingmanInstructionsStore] load FAILED: {ex.Message}"); _state = new(); }
+            // One-time legacy import (fail-loud, all-or-nothing), then read the single persisted row into the
+            // in-memory working state. A missing row is a fresh store (new state).
+            ImportLegacyJsonIfNeeded();
+            _state = ReadStateFromDb() ?? new StateFile();
 
             // First run, or a user who has never customized: they ride the latest deployed default,
             // so acknowledge it (no stale "update available" banner).
@@ -94,16 +107,60 @@ public sealed class WingmanInstructionsStore
         }
     }
 
+    /// <summary>Persist the in-memory state to the single per-tenant row. Fail-loud: a persist error
+    /// propagates rather than silently dropping the change.</summary>
     private void Save()
     {
-        try
+        using var ctx = _db.CreateContext();
+        var row = ctx.WingmanInstructions.FirstOrDefault();
+        if (row is null)
         {
-            var tmp = _path + ".tmp";
-            File.WriteAllText(tmp, JsonSerializer.Serialize(_state, new JsonSerializerOptions { WriteIndented = true }));
-            File.Move(tmp, _path, overwrite: true);
+            row = new WingmanInstructionEntity { Id = Guid.NewGuid(), TenantId = ctx.ActiveTenant! };
+            ctx.WingmanInstructions.Add(row);
         }
-        catch (Exception ex) { FileLog.Write($"[WingmanInstructionsStore] save FAILED: {ex.Message}"); }
+        row.ActiveVersionId = _state.ActiveVersionId;
+        row.AckDefaultVersion = _state.AckDefaultVersion;
+        row.AckDefaultContent = _state.AckDefaultContent;
+        row.Versions = _state.Versions.Select(ToOwned).ToList();
+        ctx.SaveChanges();
     }
+
+    /// <summary>Read the single per-tenant state row into an in-memory <see cref="StateFile"/>, or null when
+    /// no row exists yet.</summary>
+    private StateFile? ReadStateFromDb()
+    {
+        using var ctx = _db.CreateContext();
+        var row = ctx.WingmanInstructions.AsNoTracking().FirstOrDefault();
+        if (row is null)
+            return null;
+        return new StateFile
+        {
+            ActiveVersionId = row.ActiveVersionId,
+            AckDefaultVersion = row.AckDefaultVersion,
+            AckDefaultContent = row.AckDefaultContent,
+            Versions = row.Versions.Select(ToPublic).ToList(),
+        };
+    }
+
+    private static InstructionVersion ToPublic(WingmanInstructionVersionOwned o) => new()
+    {
+        Id = o.Id,
+        Content = o.Content,
+        CreatedAtUtc = o.CreatedAtUtc,
+        Label = o.Label,
+        Source = o.Source,
+        Hash = o.Hash,
+    };
+
+    private static WingmanInstructionVersionOwned ToOwned(InstructionVersion v) => new()
+    {
+        Id = v.Id,
+        Content = v.Content,
+        CreatedAtUtc = v.CreatedAtUtc,
+        Label = v.Label,
+        Source = v.Source,
+        Hash = v.Hash,
+    };
 
     private void AcknowledgeDefaultNoLock()
     {
@@ -243,5 +300,64 @@ public sealed class WingmanInstructionsStore
             AcknowledgeDefaultNoLock();
             FileLog.Write($"[WingmanInstructionsStore] switched to deployed default v{_defaultVersion}");
         }
+    }
+
+    // ---- one-time legacy JSON import --------------------------------------------------------------
+
+    /// <summary>
+    /// Import a legacy <c>wingman-instructions.json</c> exactly once, through the shared recoverable-import
+    /// plumbing (<see cref="LegacyJsonImport.Recoverable"/>): import only when the file exists AND the table
+    /// is empty; recover a lingering file idempotently; rename aside best-effort after a successful import.
+    /// </summary>
+    private void ImportLegacyJsonIfNeeded()
+        => LegacyJsonImport.Recoverable(
+            _legacyJsonPath,
+            "[WingmanInstructionsStore]",
+            isPopulated: () => { using var ctx = _db.CreateContext(); return ctx.WingmanInstructions.Any(); },
+            importCommitted: ImportRowFromLegacyJson);
+
+    /// <summary>
+    /// Parse the legacy state file and insert it as the single per-tenant row - the active-version pointer,
+    /// the acknowledged default snapshot, and the versions (order preserved). Fail-loud and all-or-nothing -
+    /// a parse error (or a null document) throws and imports nothing (the file is left in place).
+    /// </summary>
+    private void ImportRowFromLegacyJson()
+    {
+        StateFile? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<StateFile>(File.ReadAllText(_legacyJsonPath));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[WingmanInstructionsStore] Import FAILED: legacy file {_legacyJsonPath} could not be read: {ex.Message}");
+            throw new InvalidOperationException(
+                $"The legacy wingman-instructions file '{_legacyJsonPath}' could not be parsed for the one-time " +
+                $"import: {ex.Message}. The Gateway will not start with a partial import. Fix or move the file " +
+                "aside and restart.", ex);
+        }
+
+        if (parsed is null)
+        {
+            FileLog.Write($"[WingmanInstructionsStore] Import FAILED: legacy file {_legacyJsonPath} deserialized to a null document");
+            throw new InvalidOperationException(
+                $"The legacy wingman-instructions file '{_legacyJsonPath}' could not be parsed for the one-time " +
+                "import: the document is null. The Gateway will not start with a partial import. Fix or move the " +
+                "file aside and restart.");
+        }
+
+        using var ctx = _db.CreateContext();
+        ctx.WingmanInstructions.Add(new WingmanInstructionEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = ctx.ActiveTenant!,
+            ActiveVersionId = parsed.ActiveVersionId,
+            AckDefaultVersion = parsed.AckDefaultVersion,
+            AckDefaultContent = parsed.AckDefaultContent,
+            Versions = (parsed.Versions ?? new List<InstructionVersion>()).Select(ToOwned).ToList(),
+        });
+        ctx.SaveChanges();
+
+        FileLog.Write($"[WingmanInstructionsStore] Import: state ({parsed.Versions?.Count ?? 0} version(s)) imported from {_legacyJsonPath}");
     }
 }


### PR DESCRIPTION
Migrate two more everyday stores onto the EF Core data layer (SQLite locally),
batched into one migration adding both tables, behind their unchanged public
APIs, with a lossless one-time JSON import through the shared recoverable helper.

Push subscriptions: keyed by the endpoint (a natural key), with the tenant-id
column. The store never had a per-user field, so the migration does not invent
one - it preserves exactly what the store held (endpoint, the two keys, the
created timestamp). Per-user push in the hosted multi-tenant world would be a
separate, deliberate feature.

Wingman instructions: one state row per tenant, with the versions as an owned
JSON collection and the stored active-version pointer and the acknowledged-
default columns beside them. This reproduces the active-content resolution
exactly - the stored pointer if it is set and found, otherwise the deployed
default (not simply the latest version) - and the update-available banner
behavior.

Both stores keep their public API and observable behavior unchanged, carry the
tenant-id column and the global query filter, and use the write lock and the
pooled context.

Evidence (a run, not only a build), recorded in the mission QA document:
- Full Windows solution test suite green across all seven projects, including
  the per-store lossless import round-trips - for wingman, that active-content
  resolves to the same version after the migration and the acknowledged-default
  state round-trips and drives the banner.
- A Linux container built from the repo Dockerfile applied the whole migration
  chain in order on a clean database as the non-root user, health returned 200,
  both new tables were present and writable, and the live wingman store wrote its
  own state row at startup (a null active pointer riding the deployed default).

The macOS native run is deferred - the Mac mini is offline.
