### PR TITLE
feat(gateway): honest driver-normalized spend (governance spine item 3, #1771)

### DIFF
--- a/src/CcDirector.Gateway.Contracts/AccountHostedAiSpendDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/AccountHostedAiSpendDtos.cs
@@ -1,0 +1,61 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// One mirrored hosted-AI service debit - real account-level dollars the account spent on DevThrottle's
+/// hosted AI services (text-to-speech, transcription, wingman translation), from the cloud credit-debit
+/// ledger (issue #1771, spine item 3). Account-level only: it carries NO session id and NO run id, because
+/// the cloud ledger attributes a debit to neither and a fabricated attribution would be a lie.
+/// </summary>
+public sealed class AccountHostedAiSpendDto
+{
+    /// <summary>The debit magnitude in micro-dollars (1_000_000 = $1), positive.</summary>
+    public long AmountMicros { get; set; }
+
+    /// <summary>The cloud ledger entry kind ("debit").</summary>
+    public string Kind { get; set; } = "";
+
+    /// <summary>When the cloud recorded the transaction.</summary>
+    public DateTime TransactionCreatedUtc { get; set; }
+
+    /// <summary>When the Gateway observed and mirrored it.</summary>
+    public DateTime ObservedUtc { get; set; }
+}
+
+/// <summary>
+/// The account-level hosted-AI service spend over a window - the honest, disclosed "Hosted-AI services: $X"
+/// figure the weekly report shows (issue #1771). It is NEVER blended into per-session or per-run spend: this
+/// is a separate account-level axis, and the report labels it as such.
+/// </summary>
+public sealed class AccountHostedAiSpendSummaryDto
+{
+    /// <summary>Total mirrored hosted-AI service spend in the window, in micro-dollars.</summary>
+    public long TotalMicros { get; set; }
+
+    /// <summary>How many debit entries the total is composed of.</summary>
+    public int DebitCount { get; set; }
+
+    /// <summary>The window start (inclusive) the total was computed over.</summary>
+    public DateTime SinceUtc { get; set; }
+
+    /// <summary>The window end (exclusive) the total was computed over.</summary>
+    public DateTime UntilUtc { get; set; }
+}
+
+/// <summary>
+/// One observed credit-ledger debit handed to the Gateway from a credit-ledger snapshot, for mirroring into
+/// the account-level spend record. The Gateway de-duplicates against what it has already mirrored (by kind +
+/// amount + transaction time), so re-reading the cloud's rolling "recent transactions" window is safe.
+/// A debit the cloud returns without a transaction time is skipped (it cannot be de-duplicated), rather than
+/// risk double-counting real money.
+/// </summary>
+public sealed class ObservedAccountDebit
+{
+    /// <summary>The debit magnitude in micro-dollars, positive.</summary>
+    public long AmountMicros { get; set; }
+
+    /// <summary>The cloud ledger entry kind ("debit").</summary>
+    public string Kind { get; set; } = "";
+
+    /// <summary>When the cloud recorded the transaction; null means the entry is skipped (cannot de-dup).</summary>
+    public DateTime? TransactionCreatedUtc { get; set; }
+}

--- a/src/CcDirector.Gateway.Contracts/SessionSpendDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionSpendDtos.cs
@@ -1,0 +1,107 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// How a session's usage is billed - the LABEL that keeps the three spend buckets separate (issue #1771,
+/// spine item 3). Subscription traffic is never turned into a dollar figure; only metered traffic carries a
+/// dollar cost.
+/// </summary>
+public static class SessionBillingMode
+{
+    /// <summary>Covered by a subscription (a Claude Max/Pro plan, a ChatGPT plan): no marginal dollar cost,
+    /// so NEVER a dollar figure. The usage counts in tokens, labelled as subscription-included.</summary>
+    public const string SubscriptionIncluded = "subscription-included";
+
+    /// <summary>Billed per token in real dollars (an API key): a metered dollar cost may be attached when a
+    /// price is known.</summary>
+    public const string Metered = "metered";
+
+    /// <summary>Billing mode not determined. Treated like subscription for the no-fabricated-dollars rule
+    /// (no dollar figure), and disclosed as unknown so it is never silently counted as free or as metered.</summary>
+    public const string Unknown = "unknown";
+
+    public static readonly string[] All = { SubscriptionIncluded, Metered, Unknown };
+}
+
+/// <summary>
+/// A session's cumulative effort and honest spend. Three separate, labelled things: raw tokens (always the
+/// truth of what the model processed), the billing-mode label, and metered dollars (only for metered traffic
+/// with a known price). <see cref="TokensCaptured"/> discloses whether additive token spend was available at
+/// all - false for drivers that report only a context gauge, whose token sums are UNKNOWN, not zero.
+/// </summary>
+public sealed class SessionSpendDto
+{
+    public string SessionId { get; set; } = "";
+    public string AgentKind { get; set; } = "";
+    public string? Model { get; set; }
+    public string? RepoPath { get; set; }
+
+    /// <summary>False when the driver reports no additive token spend (context gauge only): the token sums
+    /// are then UNKNOWN, and a report must disclose the gap rather than read them as zero.</summary>
+    public bool TokensCaptured { get; set; }
+
+    public long InputTokens { get; set; }
+    public long OutputTokens { get; set; }
+    public long CacheReadTokens { get; set; }
+    public long CacheCreationTokens { get; set; }
+
+    /// <summary>"subscription-included", "metered", or "unknown" - see <see cref="SessionBillingMode"/>.</summary>
+    public string BillingMode { get; set; } = "";
+
+    /// <summary>Metered dollar cost in micro-dollars, for metered traffic with a known price only; null means
+    /// no dollar figure (subscription, unknown, or no price) - never a fabricated zero.</summary>
+    public long? MeteredCostMicros { get; set; }
+
+    public DateTime FirstObservedUtc { get; set; }
+    public DateTime LastObservedUtc { get; set; }
+}
+
+/// <summary>
+/// Body of a session-spend record/refresh. A Director reads the driver's cumulative usage locally and pushes
+/// it here; the Gateway upserts the one row for the session (cumulative totals overwrite - they are running
+/// sums, not deltas to add). The metered-dollar column is deliberately not settable here: per-session dollars
+/// wait on the #1608 rate card, and subscription traffic has no dollar figure at all.
+/// </summary>
+public sealed class RecordSessionSpendRequest
+{
+    public string? SessionId { get; set; }
+    public string? AgentKind { get; set; }
+    public string? Model { get; set; }
+    public string? RepoPath { get; set; }
+
+    /// <summary>False when the driver reports no additive token spend (a context-gauge-only driver): the token
+    /// sums are then recorded as UNKNOWN coverage, not as real zeros.</summary>
+    public bool TokensCaptured { get; set; }
+
+    public long InputTokens { get; set; }
+    public long OutputTokens { get; set; }
+    public long CacheReadTokens { get; set; }
+    public long CacheCreationTokens { get; set; }
+
+    /// <summary>"subscription-included", "metered", or "unknown". A coding-agent session on a subscription is
+    /// "subscription-included" (never "unknown"), so a reader sees WHY there is no per-session dollar figure.</summary>
+    public string? BillingMode { get; set; }
+}
+
+/// <summary>
+/// A coverage summary over a set of sessions - the disclosure every spend report must carry so a low number
+/// is never mistaken for a good one (issue #1771). Says how much of the fleet's spend is actually captured in
+/// dollars versus tokens-only versus not captured at all.
+/// </summary>
+public sealed class SpendCoverageDto
+{
+    /// <summary>Total sessions in the slice.</summary>
+    public int Sessions { get; set; }
+
+    /// <summary>Sessions whose additive token spend was captured (<see cref="SessionSpendDto.TokensCaptured"/>).</summary>
+    public int SessionsWithTokens { get; set; }
+
+    /// <summary>Sessions with a metered dollar figure.</summary>
+    public int SessionsWithMeteredDollars { get; set; }
+
+    /// <summary>Sessions whose spend is subscription-included (counted in tokens, no dollar figure).</summary>
+    public int SessionsSubscriptionIncluded { get; set; }
+
+    /// <summary>Sessions whose additive spend could NOT be captured (context-gauge-only drivers) - the gap
+    /// a report must show so the totals are read honestly.</summary>
+    public int SessionsWithoutTokenCapture { get; set; }
+}

--- a/src/CcDirector.Gateway.Tests/AccountHostedAiSpendStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/AccountHostedAiSpendStoreTests.cs
@@ -1,0 +1,119 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Governance;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Store tests for account-level hosted-AI spend (issue #1771, spine item 3). The claims that matter:
+/// re-observing the cloud's rolling window is idempotent (dedup on kind + amount + transaction-time); a
+/// debit with no transaction time is skipped (cannot dedup - undercount beats double-counting real money);
+/// non-debit or non-positive entries are ignored; the window sum is honest; and the store is tenant-scoped.
+/// </summary>
+public sealed class AccountHostedAiSpendStoreTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    private AccountHostedAiSpendStore NewStore() => new(_h.Open());
+
+    private static readonly DateTime T0 = new(2026, 7, 18, 12, 0, 0, DateTimeKind.Utc);
+
+    private static ObservedAccountDebit Debit(long micros, DateTime? at) => new()
+    {
+        AmountMicros = micros,
+        Kind = AccountHostedAiSpendStore.DebitKind,
+        TransactionCreatedUtc = at,
+    };
+
+    [Fact]
+    public void RecordObservedDebits_mirrors_new_debits()
+    {
+        var store = NewStore();
+        var added = store.RecordObservedDebits(new List<ObservedAccountDebit>
+        {
+            Debit(556, T0),
+            Debit(1200, T0.AddMinutes(5)),
+        });
+
+        Assert.Equal(2, added);
+        Assert.Equal(2, store.List().Count);
+    }
+
+    [Fact]
+    public void Re_observing_the_rolling_window_is_idempotent()
+    {
+        var store = NewStore();
+        store.RecordObservedDebits(new List<ObservedAccountDebit> { Debit(556, T0), Debit(1200, T0.AddMinutes(5)) });
+        // The cloud returns the same two debits again next snapshot, plus a new one.
+        var addedSecond = store.RecordObservedDebits(new List<ObservedAccountDebit>
+        {
+            Debit(556, T0),
+            Debit(1200, T0.AddMinutes(5)),
+            Debit(999, T0.AddMinutes(10)),
+        });
+
+        Assert.Equal(1, addedSecond); // only the genuinely new debit
+        Assert.Equal(3, store.List().Count);
+    }
+
+    [Fact]
+    public void A_debit_without_a_transaction_time_is_skipped()
+    {
+        var store = NewStore();
+        // No created_at means it cannot be de-duplicated - skip it rather than risk double-counting money.
+        var added = store.RecordObservedDebits(new List<ObservedAccountDebit> { Debit(556, at: null) });
+
+        Assert.Equal(0, added);
+        Assert.Empty(store.List());
+    }
+
+    [Fact]
+    public void Non_debit_and_non_positive_entries_are_ignored()
+    {
+        var store = NewStore();
+        var added = store.RecordObservedDebits(new List<ObservedAccountDebit>
+        {
+            new() { Kind = "credit", AmountMicros = 5_000_000, TransactionCreatedUtc = T0 }, // a top-up, not spend
+            new() { Kind = AccountHostedAiSpendStore.DebitKind, AmountMicros = 0, TransactionCreatedUtc = T0 },
+            new() { Kind = AccountHostedAiSpendStore.DebitKind, AmountMicros = -10, TransactionCreatedUtc = T0 },
+        });
+
+        Assert.Equal(0, added);
+        Assert.Empty(store.List());
+    }
+
+    [Fact]
+    public void SumOverWindow_totals_the_debits_in_range()
+    {
+        var store = NewStore();
+        store.RecordObservedDebits(new List<ObservedAccountDebit>
+        {
+            Debit(556, T0),
+            Debit(1200, T0.AddHours(1)),
+            Debit(9999, T0.AddDays(2)), // outside the one-day window below
+        });
+
+        var summary = store.SumOverWindow(T0.AddMinutes(-1), T0.AddDays(1));
+        Assert.Equal(556 + 1200, summary.TotalMicros);
+        Assert.Equal(2, summary.DebitCount);
+    }
+
+    [Fact]
+    public void The_store_is_tenant_scoped()
+    {
+        var alpha = new AccountHostedAiSpendStore(_h.Open(new FixedTenantContext(new TenantId("alpha"))));
+        var beta = new AccountHostedAiSpendStore(_h.Open(new FixedTenantContext(new TenantId("beta"))));
+
+        alpha.RecordObservedDebits(new List<ObservedAccountDebit> { Debit(500, T0) });
+        beta.RecordObservedDebits(new List<ObservedAccountDebit> { Debit(700, T0) });
+
+        Assert.Single(alpha.List());
+        Assert.Single(beta.List());
+        Assert.Equal(500, alpha.List()[0].AmountMicros);
+        Assert.Equal(700, beta.SumOverWindow(T0.AddDays(-1), T0.AddDays(1)).TotalMicros);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/SessionSpendStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionSpendStoreTests.cs
@@ -1,0 +1,151 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Governance;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Store tests for per-session honest spend (issue #1771, spine item 3). The claims that matter: cumulative
+/// totals upsert (overwrite, not add); the billing-mode label is validated and a subscription session is
+/// labelled subscription-included (never "unknown"); the metered-dollar column is never set from a record;
+/// the coverage summary counts token-captured vs subscription vs no-capture; and the store is tenant-scoped.
+/// </summary>
+public sealed class SessionSpendStoreTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    private SessionSpendStore NewStore() => new(_h.Open());
+
+    private static RecordSessionSpendRequest ClaudeSession(
+        string session = "sess-1", long output = 100, string billing = SessionBillingMode.SubscriptionIncluded) => new()
+    {
+        SessionId = session,
+        AgentKind = "claude",
+        Model = "claude-opus-4-8",
+        RepoPath = "D:/repo",
+        TokensCaptured = true,
+        InputTokens = 10,
+        OutputTokens = output,
+        CacheReadTokens = 5,
+        CacheCreationTokens = 3,
+        BillingMode = billing,
+    };
+
+    [Fact]
+    public void Record_stores_a_session_with_raw_tokens_and_no_dollar_figure()
+    {
+        var store = NewStore();
+        var dto = store.Record(ClaudeSession());
+
+        Assert.Equal("sess-1", dto.SessionId);
+        Assert.Equal("claude", dto.AgentKind);
+        Assert.True(dto.TokensCaptured);
+        Assert.Equal(100, dto.OutputTokens);
+        Assert.Equal(SessionBillingMode.SubscriptionIncluded, dto.BillingMode);
+        // Subscription traffic never carries a fabricated dollar figure - the column is null this phase.
+        Assert.Null(dto.MeteredCostMicros);
+    }
+
+    [Fact]
+    public void Record_upserts_cumulative_totals_by_overwrite_not_add()
+    {
+        var store = NewStore();
+        store.Record(ClaudeSession(output: 100));
+        var second = store.Record(ClaudeSession(output: 250)); // a later cumulative read
+
+        // Totals are running sums from the driver, so the newer read overwrites - it is not added to the old.
+        Assert.Equal(250, second.OutputTokens);
+        Assert.Single(store.List());
+    }
+
+    [Fact]
+    public void Record_rejects_an_unknown_billing_mode()
+    {
+        var store = NewStore();
+        var ex = Assert.Throws<GovernanceValidationException>(
+            () => store.Record(ClaudeSession(billing: "invoice")));
+        Assert.Contains("billing mode", ex.Message);
+    }
+
+    [Fact]
+    public void Record_rejects_a_missing_session_or_agent()
+    {
+        var store = NewStore();
+        Assert.Throws<GovernanceValidationException>(
+            () => store.Record(new RecordSessionSpendRequest { AgentKind = "claude", BillingMode = SessionBillingMode.Metered }));
+        Assert.Throws<GovernanceValidationException>(
+            () => store.Record(new RecordSessionSpendRequest { SessionId = "s", BillingMode = SessionBillingMode.Metered }));
+    }
+
+    [Fact]
+    public void A_context_gauge_only_driver_records_as_no_token_capture()
+    {
+        var store = NewStore();
+        // Codex reports occupancy, not additive spend: token sums are UNKNOWN, disclosed via TokensCaptured=false.
+        store.Record(new RecordSessionSpendRequest
+        {
+            SessionId = "codex-1",
+            AgentKind = "codex",
+            TokensCaptured = false,
+            BillingMode = SessionBillingMode.Unknown,
+        });
+
+        var dto = store.Get("codex-1")!;
+        Assert.False(dto.TokensCaptured);
+        Assert.Null(dto.MeteredCostMicros);
+    }
+
+    [Fact]
+    public void Coverage_discloses_token_capture_and_billing_split()
+    {
+        var store = NewStore();
+        store.Record(ClaudeSession(session: "sub-1"));                                    // subscription, tokens
+        store.Record(ClaudeSession(session: "sub-2"));                                    // subscription, tokens
+        store.Record(new RecordSessionSpendRequest                                        // codex, no capture
+        {
+            SessionId = "codex-1", AgentKind = "codex", TokensCaptured = false,
+            BillingMode = SessionBillingMode.Unknown,
+        });
+
+        var coverage = store.Coverage();
+        Assert.Equal(3, coverage.Sessions);
+        Assert.Equal(2, coverage.SessionsWithTokens);
+        Assert.Equal(2, coverage.SessionsSubscriptionIncluded);
+        Assert.Equal(1, coverage.SessionsWithoutTokenCapture);
+        Assert.Equal(0, coverage.SessionsWithMeteredDollars);
+    }
+
+    [Fact]
+    public void List_filters_by_agent_and_billing_mode()
+    {
+        var store = NewStore();
+        store.Record(ClaudeSession(session: "c1"));
+        store.Record(new RecordSessionSpendRequest
+        {
+            SessionId = "x1", AgentKind = "codex", TokensCaptured = false, BillingMode = SessionBillingMode.Unknown,
+        });
+
+        Assert.Single(store.List(agentKind: "claude"));
+        Assert.Single(store.List(billingMode: SessionBillingMode.SubscriptionIncluded));
+        Assert.Single(store.List(billingMode: SessionBillingMode.Unknown));
+    }
+
+    [Fact]
+    public void The_store_is_tenant_scoped()
+    {
+        var alpha = new SessionSpendStore(_h.Open(new FixedTenantContext(new TenantId("alpha"))));
+        var beta = new SessionSpendStore(_h.Open(new FixedTenantContext(new TenantId("beta"))));
+
+        alpha.Record(ClaudeSession(session: "alpha-sess"));
+        beta.Record(ClaudeSession(session: "beta-sess"));
+
+        Assert.Single(alpha.List());
+        Assert.Single(beta.List());
+        Assert.Equal("alpha-sess", alpha.List()[0].SessionId);
+        Assert.Null(alpha.Get("beta-sess"));
+    }
+}

--- a/src/CcDirector.Gateway/Api/GovernanceSpendEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GovernanceSpendEndpoints.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Governance;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The governance spend surface (issue #1771, spine item 3) - honest, driver-normalized spend.
+///
+/// Per-session token effort + billing-mode label (metered dollars stay null until the #1608 rate card):
+///   POST  /gateway/governance/session-spend           body RecordSessionSpendRequest -> 200 SessionSpendDto | 400
+///   GET   /gateway/governance/session-spend           ?agentKind=&amp;billingMode=&amp;since=&amp;until=&amp;limit=
+///   GET   /gateway/governance/session-spend/{id}      -> SessionSpendDto | 404
+///   GET   /gateway/governance/session-spend/coverage  ?since=&amp;until= -> SpendCoverageDto
+///
+/// Account-level hosted-AI service dollars from the credit-debit ledger (read-only here; the mirroring is a
+/// Gateway-internal snapshot, never an external write):
+///   GET   /gateway/governance/hosted-ai-spend         ?since=&amp;until=&amp;limit=
+///   GET   /gateway/governance/hosted-ai-spend/summary ?since=&amp;until= -> AccountHostedAiSpendSummaryDto
+///
+/// Inherits the host-wide token middleware, like every other Gateway route.
+/// </summary>
+internal static class GovernanceSpendEndpoints
+{
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    public static void Map(IEndpointRouteBuilder app, SessionSpendStore sessionSpend, AccountHostedAiSpendStore hostedAiSpend)
+    {
+        app.MapPost("/gateway/governance/session-spend", async (HttpContext ctx) =>
+        {
+            RecordSessionSpendRequest? req;
+            try
+            {
+                req = await JsonSerializer.DeserializeAsync<RecordSessionSpendRequest>(
+                    ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+            }
+            catch (JsonException ex)
+            {
+                FileLog.Write($"[GovernanceSpendEndpoints] POST bad JSON: {ex.Message}");
+                return Results.BadRequest(new { error = "invalid JSON" });
+            }
+            if (req is null)
+                return Results.BadRequest(new { error = "a spend body is required" });
+
+            return Guard(() => Results.Json(sessionSpend.Record(req)));
+        });
+
+        app.MapGet("/gateway/governance/session-spend",
+            (string? agentKind, string? billingMode, DateTime? since, DateTime? until, int? limit) =>
+                Results.Json(new
+                {
+                    sessions = sessionSpend.List(agentKind, billingMode, since, until, limit ?? 500),
+                }));
+
+        app.MapGet("/gateway/governance/session-spend/coverage",
+            (DateTime? since, DateTime? until) => Results.Json(sessionSpend.Coverage(since, until)));
+
+        app.MapGet("/gateway/governance/session-spend/{sessionId}", (string sessionId) =>
+        {
+            var dto = sessionSpend.Get(sessionId);
+            return dto is null
+                ? Results.Json(new { error = $"no spend for session '{sessionId}'" },
+                    statusCode: StatusCodes.Status404NotFound)
+                : Results.Json(dto);
+        });
+
+        app.MapGet("/gateway/governance/hosted-ai-spend",
+            (DateTime? since, DateTime? until, int? limit) =>
+                Results.Json(new { debits = hostedAiSpend.List(since, until, limit ?? 500) }));
+
+        app.MapGet("/gateway/governance/hosted-ai-spend/summary", (DateTime? since, DateTime? until) =>
+        {
+            // A summary needs a bounded window; default to the trailing 7 days when the caller omits it.
+            var untilUtc = until ?? DateTime.UtcNow;
+            var sinceUtc = since ?? untilUtc.AddDays(-7);
+            return Results.Json(hostedAiSpend.SumOverWindow(sinceUtc, untilUtc));
+        });
+
+        FileLog.Write("[GovernanceSpendEndpoints] mapped /gateway/governance/session-spend + hosted-ai-spend routes");
+    }
+
+    private static IResult Guard(Func<IResult> action)
+    {
+        try
+        {
+            return action();
+        }
+        catch (GovernanceValidationException ex)
+        {
+            FileLog.Write($"[GovernanceSpendEndpoints] rejected: {ex.Message}");
+            return Results.BadRequest(new { error = ex.Message });
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Data/Entities/AccountHostedAiSpendEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/AccountHostedAiSpendEntity.cs
@@ -1,0 +1,44 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// One observed hosted-AI service debit, in the <c>account_hosted_ai_spend</c> table - the ACCOUNT-level
+/// metered-dollar record of the governance spine (issue #1771, spine item 3). This is real money the account
+/// spent on DevThrottle's hosted AI services (text-to-speech, transcription, wingman translation), mirrored
+/// from the cloud credit-debit ledger (<c>GET /api/v1/account/credits</c>).
+///
+/// It is deliberately ACCOUNT-LEVEL and carries NO SessionId and NO RunId, ever. The cloud ledger attributes
+/// a debit to neither - a transaction is only {kind, amount, created_at} - so pinning one to a session or run
+/// would be a fabricated attribution. The weekly report reads this as a disclosed account-level line
+/// ("Hosted-AI services: $X this week"), never blended into per-session or per-run spend.
+///
+/// This is a SEPARATE axis from <see cref="SessionSpendEntity"/>: that table is the coding sessions' token
+/// effort (subscription-included on a Claude Max plan, so no debits and no per-session dollar figure until
+/// the #1608 rate card); this table is the hosted-AI service spend that actually draws real dollars.
+///
+/// The source ledger has no stable transaction id, so re-reads of the rolling "recent transactions" window
+/// would re-observe the same debit. De-duplication is by (tenant, kind, amount, transaction-time); a debit
+/// the cloud returns without a created_at cannot be de-duplicated and is therefore skipped rather than risk
+/// double-counting real money (the honest choice - an undercount that is disclosed, never a silent overcount).
+/// </summary>
+public sealed class AccountHostedAiSpendEntity : TenantScopedEntity
+{
+    /// <summary>Primary key, minted in code - never a database default.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>The debit magnitude in micro-dollars (1_000_000 = $1), stored POSITIVE (the cloud returns a
+    /// debit as a negative amount; we mirror its magnitude). Integer smallest-units, never a bare decimal.</summary>
+    public long AmountMicros { get; set; }
+
+    /// <summary>The cloud ledger entry kind, for provenance ("debit"). Only debits are mirrored here - this
+    /// is a SPEND record, not the full ledger; top-ups are not hosted-AI spend.</summary>
+    public string Kind { get; set; } = "";
+
+    /// <summary>When the cloud recorded the transaction (its <c>created_at</c>). The de-duplication and the
+    /// weekly-window bucketing both key on this, so a debit the cloud returns without it is skipped rather
+    /// than double-counted.</summary>
+    public DateTime TransactionCreatedUtc { get; set; }
+
+    /// <summary>When the Gateway observed and mirrored this debit (server-stamped). Distinct from
+    /// <see cref="TransactionCreatedUtc"/>: the audit fact of when we learned of the spend.</summary>
+    public DateTime ObservedUtc { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/Entities/SessionSpendEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/SessionSpendEntity.cs
@@ -1,0 +1,71 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// A session's cumulative effort and honest spend, in the <c>session_spend</c> table - the driver-normalized
+/// spend layer of the governance outcome spine (issue #1771, spine item 3). One row per fleet session, keyed
+/// on the canonical Director-minted session GUID - the SAME id <c>workflow_runs.Participants[].SessionId</c>
+/// uses, so a run's spend is the sum over the sessions that joined it (the run -> effort join governance needs).
+///
+/// The row keeps THREE things separate and labelled, and never blends them - the governance rule that a low
+/// number must never be mistaken for a good one (issue #1771):
+///  1. RAW TOKENS (<see cref="InputTokens"/> etc.) - the additive token sums, captured for any driver that
+///     reports cumulative usage. This is always the truth of "how much did the model process".
+///  2. SUBSCRIPTION-INCLUDED vs METERED - <see cref="BillingMode"/> LABELS which bucket the raw tokens fall
+///     in. Subscription traffic has no marginal dollar cost, so it is never turned into a dollar figure.
+///  3. METERED DOLLARS (<see cref="MeteredCostMicros"/>) - a real dollar cost ONLY for metered (API-key)
+///     traffic with a known price. Micro-dollars (integer smallest-units), never a bare decimal. NULL means
+///     "no dollar figure" (subscription, unknown mode, or no price) - which is NOT the same as zero.
+///
+/// Coverage is explicit: <see cref="TokensCaptured"/> is false for a driver that reports only a context
+/// gauge (Codex, Pi) and not additive spend. When it is false the token sums are not real zeros - they are
+/// UNKNOWN, and every report must disclose the gap rather than read it as "this agent was free".
+/// </summary>
+public sealed class SessionSpendEntity : TenantScopedEntity
+{
+    /// <summary>The canonical fleet session GUID - the natural primary key (one row per session, one agent
+    /// kind per session for its life). The same id run participants and the event ledger key on.</summary>
+    public string SessionId { get; set; } = "";
+
+    /// <summary>The agent family that ran this session ("claude", "codex", "pi", ...). Spend is never
+    /// compared across families without <see cref="TokensCaptured"/> disclosed - additive spend is not
+    /// available for every driver.</summary>
+    public string AgentKind { get; set; } = "";
+
+    /// <summary>The model the session was last observed running (the driver's current-model report, which can
+    /// change mid-session). Null when the driver does not report a model.</summary>
+    public string? Model { get; set; }
+
+    /// <summary>The repository the session worked in, when known - for repo-sliced spend reporting.</summary>
+    public string? RepoPath { get; set; }
+
+    /// <summary>True when the driver reports additive cumulative token usage (capability TokenUsage). When
+    /// false (Codex, Pi - context gauge only) the token sums below are UNKNOWN, not zero: disclose the gap.</summary>
+    public bool TokensCaptured { get; set; }
+
+    /// <summary>Cumulative input tokens. Meaningful only when <see cref="TokensCaptured"/> is true.</summary>
+    public long InputTokens { get; set; }
+
+    /// <summary>Cumulative output tokens. Meaningful only when <see cref="TokensCaptured"/> is true.</summary>
+    public long OutputTokens { get; set; }
+
+    /// <summary>Cumulative cache-read input tokens. Meaningful only when <see cref="TokensCaptured"/> is true.</summary>
+    public long CacheReadTokens { get; set; }
+
+    /// <summary>Cumulative cache-creation input tokens. Meaningful only when <see cref="TokensCaptured"/> is true.</summary>
+    public long CacheCreationTokens { get; set; }
+
+    /// <summary>Which bucket the raw tokens fall in: "subscription-included", "metered", or "unknown". This
+    /// LABEL is what keeps subscription usage from ever being rendered as a dollar figure.</summary>
+    public string BillingMode { get; set; } = "";
+
+    /// <summary>The metered dollar cost in micro-dollars (integer smallest-units), for METERED traffic with a
+    /// known price ONLY. NULL for subscription, unknown mode, or when no price is available - a null is "no
+    /// dollar figure", deliberately distinct from a real zero. Never fabricated for subscription traffic.</summary>
+    public long? MeteredCostMicros { get; set; }
+
+    /// <summary>When this session's spend was first recorded.</summary>
+    public DateTime FirstObservedUtc { get; set; }
+
+    /// <summary>When the cumulative totals were last refreshed from the driver.</summary>
+    public DateTime LastObservedUtc { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -80,6 +80,14 @@ public sealed class GatewayDbContext : DbContext
     /// <summary>The wingman instructions state document (<c>wingman_instructions</c>), one row per tenant.</summary>
     public DbSet<WingmanInstructionEntity> WingmanInstructions => Set<WingmanInstructionEntity>();
 
+    /// <summary>Per-session token effort and honest spend (<c>session_spend</c>) - raw tokens + billing-mode
+    /// label, the driver-normalized spend of issue #1771 (spine item 3).</summary>
+    public DbSet<SessionSpendEntity> SessionSpend => Set<SessionSpendEntity>();
+
+    /// <summary>Account-level hosted-AI service dollars (<c>account_hosted_ai_spend</c>) mirrored from the
+    /// cloud credit-debit ledger - real metered dollars, never pinned to a session or run (issue #1771).</summary>
+    public DbSet<AccountHostedAiSpendEntity> AccountHostedAiSpend => Set<AccountHostedAiSpendEntity>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -212,6 +220,28 @@ public sealed class GatewayDbContext : DbContext
             b.OwnsMany(e => e.Versions, o => o.ToJson());
         });
 
+        modelBuilder.Entity<SessionSpendEntity>(b =>
+        {
+            b.ToTable("session_spend");
+            // SessionId is the natural key - one row per session, globally-unique GUID string - so it is the
+            // primary key directly (the snoozes-table pattern), no surrogate id.
+            b.HasKey(e => e.SessionId);
+            // The reporting cut is a last-observed time window, tenant-leading for the global filter.
+            b.HasIndex(e => new { e.TenantId, e.LastObservedUtc });
+        });
+
+        modelBuilder.Entity<AccountHostedAiSpendEntity>(b =>
+        {
+            b.ToTable("account_hosted_ai_spend");
+            b.HasKey(e => e.Id);
+            // The dedup lookup (kind + amount + transaction-time) and the weekly window sum, both tenant-
+            // leading for the global filter. NOT unique on the dedup tuple on purpose: two genuinely distinct
+            // debits of the same amount at the same instant are rare but real, and a unique index would throw
+            // on one; the store de-duplicates in code and discloses the (rare) undercount instead of crashing.
+            b.HasIndex(e => new { e.TenantId, e.Kind, e.AmountMicros, e.TransactionCreatedUtc });
+            b.HasIndex(e => new { e.TenantId, e.TransactionCreatedUtc });
+        });
+
         // Tenant scoping - the tenant_id column plus the global query filter - applied uniformly to every
         // entity that derives from TenantScopedEntity, so future stores inherit it by deriving from the base.
         ApplyTenantScope<CronJobEntity>(modelBuilder);
@@ -226,6 +256,8 @@ public sealed class GatewayDbContext : DbContext
         ApplyTenantScope<GovernanceEventEntity>(modelBuilder);
         ApplyTenantScope<PushSubscriptionEntity>(modelBuilder);
         ApplyTenantScope<WingmanInstructionEntity>(modelBuilder);
+        ApplyTenantScope<SessionSpendEntity>(modelBuilder);
+        ApplyTenantScope<AccountHostedAiSpendEntity>(modelBuilder);
 
         ApplyCommonSubsetConventions(modelBuilder);
     }

--- a/src/CcDirector.Gateway/Data/Migrations/20260718034806_AddSpendTables.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718034806_AddSpendTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718034806_AddSpendTables")]
+    partial class AddSpendTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260718034806_AddSpendTables.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718034806_AddSpendTables.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSpendTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "account_hosted_ai_spend",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    AmountMicros = table.Column<long>(type: "INTEGER", nullable: false),
+                    Kind = table.Column<string>(type: "TEXT", nullable: false),
+                    TransactionCreatedUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    ObservedUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_account_hosted_ai_spend", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "session_spend",
+                columns: table => new
+                {
+                    SessionId = table.Column<string>(type: "TEXT", nullable: false),
+                    AgentKind = table.Column<string>(type: "TEXT", nullable: false),
+                    Model = table.Column<string>(type: "TEXT", nullable: true),
+                    RepoPath = table.Column<string>(type: "TEXT", nullable: true),
+                    TokensCaptured = table.Column<bool>(type: "INTEGER", nullable: false),
+                    InputTokens = table.Column<long>(type: "INTEGER", nullable: false),
+                    OutputTokens = table.Column<long>(type: "INTEGER", nullable: false),
+                    CacheReadTokens = table.Column<long>(type: "INTEGER", nullable: false),
+                    CacheCreationTokens = table.Column<long>(type: "INTEGER", nullable: false),
+                    BillingMode = table.Column<string>(type: "TEXT", nullable: false),
+                    MeteredCostMicros = table.Column<long>(type: "INTEGER", nullable: true),
+                    FirstObservedUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    LastObservedUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_session_spend", x => x.SessionId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_account_hosted_ai_spend_tenant_id",
+                table: "account_hosted_ai_spend",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_account_hosted_ai_spend_tenant_id_Kind_AmountMicros_TransactionCreatedUtc",
+                table: "account_hosted_ai_spend",
+                columns: new[] { "tenant_id", "Kind", "AmountMicros", "TransactionCreatedUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_account_hosted_ai_spend_tenant_id_TransactionCreatedUtc",
+                table: "account_hosted_ai_spend",
+                columns: new[] { "tenant_id", "TransactionCreatedUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_session_spend_tenant_id",
+                table: "session_spend",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_session_spend_tenant_id_LastObservedUtc",
+                table: "session_spend",
+                columns: new[] { "tenant_id", "LastObservedUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "account_hosted_ai_spend");
+
+            migrationBuilder.DropTable(
+                name: "session_spend");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -338,6 +338,10 @@ public sealed class GatewayHost : IAsyncDisposable
     // The append-only governance event ledger (issue #1771, spine item 2): immutable session/run state
     // transitions, the duration spine no run row can give.
     private readonly Governance.GovernanceEventLedger _governanceEvents;
+    // Honest driver-normalized spend (issue #1771, spine item 3): per-session token effort + billing-mode
+    // label, and the account-level hosted-AI service dollars mirrored from the credit-debit ledger.
+    private readonly Governance.SessionSpendStore _sessionSpend;
+    private readonly Governance.AccountHostedAiSpendStore _hostedAiSpend;
     private readonly CronJobStore _cronJobs;
     private readonly CronRunHistoryStore _cronRuns;
     private readonly Running.CronEngine _cronEngine;
@@ -610,6 +614,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // The governance event ledger (issue #1771, spine item 2): append-only session/run transitions on
         // the EF data layer, so a Gateway restart never loses a recorded transition.
         _governanceEvents = new Governance.GovernanceEventLedger(_gatewayDb);
+        // Honest spend (issue #1771, spine item 3): per-session token effort + billing-mode label, and the
+        // account-level hosted-AI service dollars mirrored from the credit-debit ledger.
+        _sessionSpend = new Governance.SessionSpendStore(_gatewayDb);
+        _hostedAiSpend = new Governance.AccountHostedAiSpendStore(_gatewayDb);
         // Snooze Length mission: the persisted snooze registry (sessionId -> SnoozeUntilUtc), now in the
         // snoozes table of the EF data layer - a Gateway restart re-arms every pending snooze from the
         // database; an entry already past its time simply fires on the first sweep. The path argument is the
@@ -1637,6 +1645,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // The governance event ledger (issue #1771, spine item 2): append-only session/run state
         // transitions - the duration timeline the weekly Outcome Ledger reads. Append and read only.
         Api.GovernanceEventEndpoints.Map(_app, _governanceEvents);
+
+        // Honest driver-normalized spend (issue #1771, spine item 3): per-session token effort + billing-mode
+        // label, and the account-level hosted-AI service dollars read from the mirrored credit-debit ledger.
+        Api.GovernanceSpendEndpoints.Map(_app, _sessionSpend, _hostedAiSpend);
 
         // Gateway Centralization Phase 1 (issue #628): the inbound login-telemetry RELAY. The Director
         // POSTs its login-telemetry event here (instead of the cloud) and the Gateway forwards it on,

--- a/src/CcDirector.Gateway/Governance/AccountHostedAiSpendStore.cs
+++ b/src/CcDirector.Gateway/Governance/AccountHostedAiSpendStore.cs
@@ -1,0 +1,162 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Governance;
+
+/// <summary>
+/// The Gateway's account-level hosted-AI spend store (issue #1771, spine item 3) over the
+/// <c>account_hosted_ai_spend</c> table. It mirrors the REAL dollars the account spent on DevThrottle's
+/// hosted AI services (text-to-speech, transcription, wingman translation) from the cloud credit-debit
+/// ledger, so the weekly report can show an honest "Hosted-AI services: $X this week" line.
+///
+/// It is ACCOUNT-LEVEL by contract: a mirrored debit carries no session id and no run id, because the cloud
+/// ledger attributes a debit to neither. Never pin one to a session or run.
+///
+/// De-duplication without a stable id: the cloud returns a rolling "recent transactions" window, so re-reads
+/// re-observe the same debit. <see cref="RecordObservedDebits"/> mirrors only debits it has not already
+/// stored, matched on (kind, amount, transaction-time). A debit the cloud returns WITHOUT a transaction time
+/// is skipped - it cannot be de-duplicated, and an honest disclosed undercount beats a silent double-count of
+/// real money.
+///
+/// Threading matches the rest of the data layer: single writer, write lock, fresh pooled context per operation.
+/// </summary>
+public sealed class AccountHostedAiSpendStore
+{
+    private readonly object _gate = new();
+    private readonly GatewayDatabase _db;
+
+    /// <summary>The cloud ledger entry kind this store mirrors - only debits are hosted-AI spend.</summary>
+    public const string DebitKind = "debit";
+
+    /// <summary>The hard ceiling on one list read; the default page is 500.</summary>
+    public const int MaxListLimit = 5000;
+
+    public AccountHostedAiSpendStore(GatewayDatabase db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    /// <summary>
+    /// Mirror a batch of observed credit-ledger debits, skipping any already stored (dedup on kind + amount +
+    /// transaction-time) and any without a transaction time (cannot dedup) or that are not positive debits.
+    /// Returns the number of NEW debits mirrored. Idempotent: re-observing the cloud's rolling window is safe.
+    /// </summary>
+    public int RecordObservedDebits(IReadOnlyList<ObservedAccountDebit> debits)
+    {
+        if (debits is null || debits.Count == 0)
+            return 0;
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var now = DateTime.UtcNow;
+            var tenant = ctx.ActiveTenant!;
+            var added = 0;
+
+            foreach (var debit in debits)
+            {
+                if (debit is null)
+                    continue;
+                // Only positive-magnitude debits with a transaction time are mirrorable - a null time cannot
+                // be de-duplicated, and a top-up or a zero is not hosted-AI spend.
+                if (!string.Equals(debit.Kind, DebitKind, StringComparison.Ordinal))
+                    continue;
+                if (debit.AmountMicros <= 0)
+                    continue;
+                if (debit.TransactionCreatedUtc is null)
+                    continue;
+
+                var txTime = DateTime.SpecifyKind(debit.TransactionCreatedUtc.Value, DateTimeKind.Utc);
+
+                var already = ctx.AccountHostedAiSpend.Any(
+                    e => e.Kind == DebitKind &&
+                         e.AmountMicros == debit.AmountMicros &&
+                         e.TransactionCreatedUtc == txTime);
+                if (already)
+                    continue;
+
+                ctx.AccountHostedAiSpend.Add(new AccountHostedAiSpendEntity
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = tenant,
+                    AmountMicros = debit.AmountMicros,
+                    Kind = DebitKind,
+                    TransactionCreatedUtc = txTime,
+                    ObservedUtc = now,
+                });
+                added++;
+            }
+
+            if (added > 0)
+                ctx.SaveChanges();
+
+            FileLog.Write($"[AccountHostedAiSpendStore] RecordObservedDebits: observed {debits.Count}, mirrored {added} new");
+            return added;
+        }
+    }
+
+    /// <summary>
+    /// The total mirrored hosted-AI service spend over a window (by transaction time,
+    /// <paramref name="sinceUtc"/> inclusive, <paramref name="untilUtc"/> exclusive) - the account-level
+    /// figure the weekly report shows. Summed in the database.
+    /// </summary>
+    public AccountHostedAiSpendSummaryDto SumOverWindow(DateTime sinceUtc, DateTime untilUtc)
+    {
+        var since = DateTime.SpecifyKind(sinceUtc, DateTimeKind.Utc);
+        var until = DateTime.SpecifyKind(untilUtc, DateTimeKind.Utc);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var rows = ctx.AccountHostedAiSpend.AsNoTracking()
+                .Where(e => e.TransactionCreatedUtc >= since && e.TransactionCreatedUtc < until)
+                .ToList();
+            return new AccountHostedAiSpendSummaryDto
+            {
+                TotalMicros = rows.Sum(e => e.AmountMicros),
+                DebitCount = rows.Count,
+                SinceUtc = since,
+                UntilUtc = until,
+            };
+        }
+    }
+
+    /// <summary>Mirrored debits, newest transaction first, over an optional window. Ordered and bounded.</summary>
+    public IReadOnlyList<AccountHostedAiSpendDto> List(
+        DateTime? sinceUtc = null, DateTime? untilUtc = null, int limit = 500)
+    {
+        var take = Math.Clamp(limit, 1, MaxListLimit);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            IQueryable<AccountHostedAiSpendEntity> query = ctx.AccountHostedAiSpend.AsNoTracking();
+            if (sinceUtc.HasValue)
+            {
+                var since = DateTime.SpecifyKind(sinceUtc.Value, DateTimeKind.Utc);
+                query = query.Where(e => e.TransactionCreatedUtc >= since);
+            }
+            if (untilUtc.HasValue)
+            {
+                var until = DateTime.SpecifyKind(untilUtc.Value, DateTimeKind.Utc);
+                query = query.Where(e => e.TransactionCreatedUtc < until);
+            }
+
+            return query
+                .OrderByDescending(e => e.TransactionCreatedUtc)
+                .Take(take)
+                .ToList()
+                .Select(ToDto)
+                .ToList();
+        }
+    }
+
+    private static AccountHostedAiSpendDto ToDto(AccountHostedAiSpendEntity e) => new()
+    {
+        AmountMicros = e.AmountMicros,
+        Kind = e.Kind,
+        TransactionCreatedUtc = e.TransactionCreatedUtc,
+        ObservedUtc = e.ObservedUtc,
+    };
+}

--- a/src/CcDirector.Gateway/Governance/SessionSpendStore.cs
+++ b/src/CcDirector.Gateway/Governance/SessionSpendStore.cs
@@ -1,0 +1,209 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Governance;
+
+/// <summary>
+/// The Gateway's per-session spend store (issue #1771, spine item 3) over the <c>session_spend</c> table -
+/// one row per fleet session keyed on the canonical session GUID, so a run's effort is the sum over the
+/// sessions that joined it (via <c>workflow_runs.Participants</c>).
+///
+/// It keeps three things separate and labelled and never blends them:
+///  - RAW TOKENS - the additive token sums, the truth of what the model processed. Captured for any driver
+///    that reports cumulative usage; recorded as UNKNOWN coverage (not zero) for a context-gauge-only driver.
+///  - BILLING MODE - the label that says which bucket the tokens fall in. A coding-agent subscription session
+///    is "subscription-included", which is WHY it carries no per-session dollar figure.
+///  - METERED DOLLARS - left NULL in this phase on purpose: per-session dollars need the #1608 rate card, and
+///    subscription traffic has no marginal dollar cost to record. The column exists so #1608 can fill it
+///    without a schema change; a null is "no dollar figure", never a fabricated zero.
+///
+/// Cumulative totals OVERWRITE on record (they are running sums from the driver, not deltas), so a refresh is
+/// an idempotent upsert. Threading matches the rest of the data layer: single writer, write lock, fresh
+/// pooled context per operation.
+/// </summary>
+public sealed class SessionSpendStore
+{
+    private readonly object _gate = new();
+    private readonly GatewayDatabase _db;
+
+    /// <summary>The hard ceiling on one list read; the default page is 500.</summary>
+    public const int MaxListLimit = 5000;
+
+    public SessionSpendStore(GatewayDatabase db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    /// <summary>
+    /// Upsert a session's cumulative spend. The totals overwrite (running sums, not deltas). Never sets the
+    /// metered-dollar column - that is not caller-supplied. Returns the stored row.
+    /// </summary>
+    public SessionSpendDto Record(RecordSessionSpendRequest request)
+    {
+        if (request is null)
+            throw new GovernanceValidationException("A spend body is required.");
+        if (string.IsNullOrWhiteSpace(request.SessionId))
+            throw new GovernanceValidationException("A spend record needs a sessionId.");
+        if (string.IsNullOrWhiteSpace(request.AgentKind))
+            throw new GovernanceValidationException("A spend record needs an agentKind.");
+
+        var billingMode = (request.BillingMode ?? "").Trim().ToLowerInvariant();
+        if (!SessionBillingMode.All.Contains(billingMode, StringComparer.Ordinal))
+            throw new GovernanceValidationException(
+                $"'{request.BillingMode}' is not a billing mode. Legal values: " +
+                string.Join(", ", SessionBillingMode.All) + ".");
+
+        if (request.InputTokens < 0 || request.OutputTokens < 0 ||
+            request.CacheReadTokens < 0 || request.CacheCreationTokens < 0)
+            throw new GovernanceValidationException("Token counts cannot be negative.");
+
+        var sessionId = request.SessionId.Trim();
+        var agentKind = request.AgentKind.Trim();
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var now = DateTime.UtcNow;
+            var entity = ctx.SessionSpend.FirstOrDefault(s => s.SessionId == sessionId);
+            if (entity is null)
+            {
+                entity = new SessionSpendEntity
+                {
+                    SessionId = sessionId,
+                    TenantId = ctx.ActiveTenant!,
+                    FirstObservedUtc = now,
+                };
+                ctx.SessionSpend.Add(entity);
+            }
+
+            entity.AgentKind = agentKind;
+            entity.Model = string.IsNullOrWhiteSpace(request.Model) ? null : request.Model.Trim();
+            entity.RepoPath = string.IsNullOrWhiteSpace(request.RepoPath) ? null : request.RepoPath.Trim();
+            entity.TokensCaptured = request.TokensCaptured;
+            entity.InputTokens = request.InputTokens;
+            entity.OutputTokens = request.OutputTokens;
+            entity.CacheReadTokens = request.CacheReadTokens;
+            entity.CacheCreationTokens = request.CacheCreationTokens;
+            entity.BillingMode = billingMode;
+            // MeteredCostMicros is intentionally never set here - see the class remarks.
+            entity.LastObservedUtc = now;
+
+            ctx.SaveChanges();
+            FileLog.Write($"[SessionSpendStore] Record: session={sessionId}, agent={agentKind}, " +
+                          $"tokensCaptured={request.TokensCaptured}, billing={billingMode}");
+            return ToDto(entity);
+        }
+    }
+
+    /// <summary>One session's spend, or null.</summary>
+    public SessionSpendDto? Get(string sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+            return null;
+        var id = sessionId.Trim();
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var entity = ctx.SessionSpend.AsNoTracking().FirstOrDefault(s => s.SessionId == id);
+            return entity is null ? null : ToDto(entity);
+        }
+    }
+
+    /// <summary>Session spend rows, newest-observed first, optionally filtered by agent kind, billing mode,
+    /// and last-observed time window (<paramref name="sinceUtc"/> inclusive, <paramref name="untilUtc"/>
+    /// exclusive). Ordered and bounded in the database.</summary>
+    public IReadOnlyList<SessionSpendDto> List(
+        string? agentKind = null, string? billingMode = null,
+        DateTime? sinceUtc = null, DateTime? untilUtc = null, int limit = 500)
+    {
+        var take = Math.Clamp(limit, 1, MaxListLimit);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            IQueryable<SessionSpendEntity> query = ctx.SessionSpend.AsNoTracking();
+
+            if (!string.IsNullOrWhiteSpace(agentKind))
+            {
+                var kind = agentKind.Trim();
+                query = query.Where(s => s.AgentKind == kind);
+            }
+            if (!string.IsNullOrWhiteSpace(billingMode))
+            {
+                var mode = billingMode.Trim().ToLowerInvariant();
+                query = query.Where(s => s.BillingMode == mode);
+            }
+            if (sinceUtc.HasValue)
+            {
+                var since = DateTime.SpecifyKind(sinceUtc.Value, DateTimeKind.Utc);
+                query = query.Where(s => s.LastObservedUtc >= since);
+            }
+            if (untilUtc.HasValue)
+            {
+                var until = DateTime.SpecifyKind(untilUtc.Value, DateTimeKind.Utc);
+                query = query.Where(s => s.LastObservedUtc < until);
+            }
+
+            return query
+                .OrderByDescending(s => s.LastObservedUtc)
+                .Take(take)
+                .ToList()
+                .Select(ToDto)
+                .ToList();
+        }
+    }
+
+    /// <summary>
+    /// The coverage disclosure over a last-observed window: how many sessions have captured token spend, a
+    /// metered dollar figure, subscription-included billing, and how many have NO token capture at all (the
+    /// context-gauge-only gap). The weekly report shows this so a low spend number is never read as a good one.
+    /// </summary>
+    public SpendCoverageDto Coverage(DateTime? sinceUtc = null, DateTime? untilUtc = null)
+    {
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            IQueryable<SessionSpendEntity> query = ctx.SessionSpend.AsNoTracking();
+            if (sinceUtc.HasValue)
+            {
+                var since = DateTime.SpecifyKind(sinceUtc.Value, DateTimeKind.Utc);
+                query = query.Where(s => s.LastObservedUtc >= since);
+            }
+            if (untilUtc.HasValue)
+            {
+                var until = DateTime.SpecifyKind(untilUtc.Value, DateTimeKind.Utc);
+                query = query.Where(s => s.LastObservedUtc < until);
+            }
+
+            var rows = query.ToList();
+            return new SpendCoverageDto
+            {
+                Sessions = rows.Count,
+                SessionsWithTokens = rows.Count(s => s.TokensCaptured),
+                SessionsWithMeteredDollars = rows.Count(s => s.MeteredCostMicros.HasValue),
+                SessionsSubscriptionIncluded =
+                    rows.Count(s => s.BillingMode == SessionBillingMode.SubscriptionIncluded),
+                SessionsWithoutTokenCapture = rows.Count(s => !s.TokensCaptured),
+            };
+        }
+    }
+
+    private static SessionSpendDto ToDto(SessionSpendEntity e) => new()
+    {
+        SessionId = e.SessionId,
+        AgentKind = e.AgentKind,
+        Model = e.Model,
+        RepoPath = e.RepoPath,
+        TokensCaptured = e.TokensCaptured,
+        InputTokens = e.InputTokens,
+        OutputTokens = e.OutputTokens,
+        CacheReadTokens = e.CacheReadTokens,
+        CacheCreationTokens = e.CacheCreationTokens,
+        BillingMode = e.BillingMode,
+        MeteredCostMicros = e.MeteredCostMicros,
+        FirstObservedUtc = e.FirstObservedUtc,
+        LastObservedUtc = e.LastObservedUtc,
+    };
+}


### PR DESCRIPTION
## Honest driver-normalized spend (governance spine item 3, thefrederiksen/devthrottle_internal#856)

Spine item 3 of the governance outcome-spine: per-session token effort and honest spend, sitting beside the workflow-run spine (#1779) and the event ledger (#1782). Two additive, tenant-scoped tables that keep **three things separate and labelled and never blend them** — the thefrederiksen/devthrottle_internal#856 rule that a low number must never be mistaken for a good one.

### `session_spend` — per-session token effort
Keyed on the canonical Director-minted session GUID (the same id `workflow_runs.Participants[].SessionId` uses), so a run's effort is the sum over the sessions that joined it.
- **Raw tokens** (input / output / cache) — the truth of what the model processed, for any driver that reports cumulative usage.
- **Billing-mode label** — a coding-agent Claude session is `subscription-included` (never `unknown`), so a reader sees *why* it carries no per-session dollar figure. Codex / Pi report only a context gauge, so they record `TokensCaptured = false` — an honest, disclosed coverage gap, never read as zero.
- **Metered dollars** — the `MeteredCostMicros` column exists but stays **null** this phase: per-session dollars need the thefrederiksen/devthrottle_internal#812 rate card, and subscription traffic has no marginal dollar cost. Null is "no dollar figure", deliberately distinct from a real zero. Never fabricated.

### `account_hosted_ai_spend` — account-level real dollars
Mirrors the real dollars the account spent on DevThrottle's hosted AI services (TTS, transcription, wingman translation) from the cloud credit-debit ledger, so the weekly report can show an honest "Hosted-AI services: $X this week" line.
- **Account-level only** — no session id, no run id, ever. The cloud ledger attributes a debit to neither, so pinning one to a session would be a fabricated attribution.
- **De-dup without a stable id** — the cloud returns a rolling "recent transactions" window, so re-reads re-observe the same debit. Mirroring de-duplicates on kind + amount + transaction-time; a debit the cloud returns *without* a transaction time is skipped — an honest disclosed undercount beats a silent double-count of real money.

### Conventions & coordination
- Both tables derive from `TenantScopedEntity`; composite indexes lead with `tenant_id` for the Phase B multi-tenant filter. Money as integer micro-units, UTC DateTime, GUID/natural keys generated in code, snake_case — provider-agnostic.
- Migration `AddSpendTables` (both tables, one migration) generated as the chain tail after `AddPushSubscriptionsAndWingmanInstructions`, serialized through the single fleet migration slot with the Hosted Gateway Architect. The clean-DB migrate applies all eight migrations in order.
- The design decision (defer the per-token rate card to thefrederiksen/devthrottle_internal#812; source account-level metered dollars from the debit ledger; label subscription traffic honestly rather than fabricate) was settled with the owner.

### Deliberately a follow-on (not this PR)
The live capture wiring — reading a driver's cumulative usage at turn-end into `session_spend`, and a periodic credit-ledger snapshot into `account_hosted_ai_spend` — is a separate step, exactly as the event ledger's emitters are. This PR is the persistence spine + stores + REST reads + tests.

Next: the weekly Outcome Ledger report (spine item 4) reads the run tables + this spend layer + the event ledger.
