### PR TITLE
feat(cockpit): the workflows page becomes a list + detail + agent-handoff add dialog (Workflows phase 7)

### DIFF
--- a/apps/cockpit/src/main.tsx
+++ b/apps/cockpit/src/main.tsx
@@ -18,6 +18,7 @@ import { DirectorsView } from "./fleet/DirectorsView";
 import { DirectorDetailView } from "./fleet/DirectorDetailView";
 import { ScheduleView } from "./schedule/ScheduleView";
 import { WorkflowsView } from "./workflows/WorkflowsView";
+import { WorkflowDetail } from "./workflows/WorkflowDetail";
 import { DictionaryView } from "./dictionary/DictionaryView";
 import { TranscriptsView } from "./transcripts/TranscriptsView";
 import { YourThrottleView } from "./throttle/YourThrottleView";
@@ -156,6 +157,9 @@ const router = createBrowserRouter(
             // so the page renders what the Gateway serves rather than a list baked into this bundle.
             // It sits beside Schedule in the rail: Schedule is what runs when, Workflows is how work runs.
             { path: "/workflows", element: <WorkflowsView /> },
+            // One workflow in full (Workflows mission, phase 7): the step summary plus the
+            // instruction markdown - the authoritative conduct agents fetch - rendered read-only.
+            { path: "/workflows/:id", element: <WorkflowDetail /> },
             // The tools + data pages (issue #977): one-to-one ports of the Blazor Dictionary.razor and
             // Transcripts.razor over the same Gateway REST surface. Each has a nav entry (issue #1247,
             // which exposed Voice Recorder by address only before). Pages deleted rather than left as

--- a/apps/cockpit/src/workflows/WorkflowDetail.tsx
+++ b/apps/cockpit/src/workflows/WorkflowDetail.tsx
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  getWorkflow,
+  getWorkflowInstructions,
+  type WorkflowDefinition,
+} from "@devthrottle/client-core/workflows/workflowsClient";
+import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+import { markdownToHtml } from "@devthrottle/client-core/history/historyMarkdown";
+import { ErrorBanner, LoadingState } from "../components";
+
+// One workflow, in full (Workflows mission, phase 7). The list row answered "what exists"; this page
+// answers "what does it actually say": the metadata and step summary up top (the machine-readable
+// SHAPE), then the instruction markdown rendered read-only - the AUTHORITATIVE conduct, the exact
+// text an agent fetches with `cc-devthrottle workflow instructions <id>` and follows. Rendered
+// through the same sanitized renderer the file viewer trusts; read-only on purpose, because
+// authoring is agent-driven and a half-editable page would lie about where edits really happen.
+export function WorkflowDetail() {
+  const { id } = useParams<{ id: string }>();
+  const [workflow, setWorkflow] = useState<WorkflowDefinition | null>(null);
+  const [instructions, setInstructions] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (signal?: AbortSignal) => {
+      if (id === undefined) return;
+      try {
+        const [wf, md] = await Promise.all([
+          getWorkflow(id, signal),
+          getWorkflowInstructions(id, signal),
+        ]);
+        setWorkflow(wf);
+        setInstructions(md);
+        setError(null);
+      } catch (err) {
+        if (signal?.aborted === true) return;
+        setError(gatewayErrorMessage(err));
+      }
+    },
+    [id],
+  );
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    void load(ctrl.signal);
+    return () => ctrl.abort();
+  }, [load]);
+
+  return (
+    <div className="page wf">
+      <header className="ui-page-header">
+        <div className="ui-page-header-text">
+          <p className="wf-crumb">
+            <Link to="/workflows">Workflows</Link>
+          </p>
+          <h1 className="ui-page-title">{workflow?.name ?? id}</h1>
+          {workflow ? <p className="ui-page-subtitle">{workflow.summary}</p> : null}
+        </div>
+      </header>
+
+      {error !== null ? (
+        <ErrorBanner message={error} onRetry={() => void load()} />
+      ) : workflow === null || instructions === null ? (
+        <LoadingState message="Loading workflow..." />
+      ) : (
+        <>
+          <div className="wf-detail-facts">
+            <span className={workflow.isBuiltIn === true ? "wf-badge wf-badge-builtin" : "wf-badge wf-badge-custom"}>
+              {workflow.isBuiltIn === true ? "Built-in" : "Custom"}
+            </span>
+            {typeof workflow.version === "number" ? <span className="wf-badge">v{workflow.version}</span> : null}
+            {workflow.hasDraft === true ? <span className="wf-badge wf-badge-draft">Draft waiting</span> : null}
+          </div>
+
+          <dl className="wf-facts">
+            <dt>When to use it</dt>
+            <dd>{workflow.whenToUse}</dd>
+            <dt>You are asked</dt>
+            <dd>{workflow.humanCheckpoint}</dd>
+          </dl>
+
+          <ol className="wf-detail-steps">
+            {workflow.steps.map((step, i) => (
+              <li key={step.name}>
+                <span className="wf-detail-step-num">{i + 1}.</span> <strong>{step.name}</strong>{" "}
+                - {step.doer}
+                {step.reviewer !== null ? `, reviewed by ${step.reviewer}` : ", no review"}; done when{" "}
+                {step.done}
+              </li>
+            ))}
+          </ol>
+
+          <section className="wf-conduct">
+            <h2 className="wf-conduct-title">The conduct</h2>
+            <p className="wf-conduct-hint">
+              This is the exact text an agent fetches and follows:{" "}
+              <code>cc-devthrottle workflow instructions {workflow.id}</code>
+            </p>
+            <div
+              className="wf-conduct-body"
+              dangerouslySetInnerHTML={{ __html: markdownToHtml(instructions) }}
+            />
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/cockpit/src/workflows/WorkflowDetail.tsx
+++ b/apps/cockpit/src/workflows/WorkflowDetail.tsx
@@ -25,10 +25,11 @@ export function WorkflowDetail() {
     async (signal?: AbortSignal) => {
       if (id === undefined) return;
       try {
-        const [wf, md] = await Promise.all([
-          getWorkflow(id, signal),
-          getWorkflowInstructions(id, signal),
-        ]);
+        // Sequential on purpose: the metadata names a version, and the conduct is fetched PINNED to
+        // that exact version - two concurrent unpinned fetches can straddle a publish and render v1
+        // steps over v2 conduct (a torn read the inspection caught).
+        const wf = await getWorkflow(id, signal);
+        const md = await getWorkflowInstructions(id, wf.version, signal);
         setWorkflow(wf);
         setInstructions(md);
         setError(null);

--- a/apps/cockpit/src/workflows/WorkflowsView.tsx
+++ b/apps/cockpit/src/workflows/WorkflowsView.tsx
@@ -85,9 +85,10 @@ function WorkflowRow({ workflow }: { workflow: WorkflowDefinition }) {
     <Link className="wf-row" to={`/workflows/${encodeURIComponent(workflow.id)}`}>
       <div className="wf-row-main">
         <span className="wf-row-name">{workflow.name}</span>
-        <span className={workflow.isBuiltIn === true ? "wf-badge wf-badge-builtin" : "wf-badge wf-badge-custom"}>
-          {workflow.isBuiltIn === true ? "Built-in" : "Custom"}
-        </span>
+        {/* The kind badge renders only when the Gateway REPORTS the field - an older Gateway that
+            omits it must not see every built-in mislabeled "Custom". Absent field, absent badge. */}
+        {workflow.isBuiltIn === true ? <span className="wf-badge wf-badge-builtin">Built-in</span> : null}
+        {workflow.isBuiltIn === false ? <span className="wf-badge wf-badge-custom">Custom</span> : null}
         {workflow.hasDraft === true ? <span className="wf-badge wf-badge-draft">Draft waiting</span> : null}
       </div>
       <p className="wf-row-summary">{workflow.summary}</p>
@@ -131,8 +132,16 @@ function AddWorkflowDialog({ onClose, onCreated }: { onClose: () => void; onCrea
     }
   };
 
+  // The backdrop dismisses only while the form is idle: dismissing DURING the create leaves the
+  // draft half-born on the Gateway with its handoff prompt never shown (and a retry then hits an
+  // id conflict), and dismissing the success state would lose the prompt - both are click-through
+  // traps the inspection caught.
   return (
-    <div className="wf-dialog-backdrop" role="presentation" onClick={createdId === null ? onClose : undefined}>
+    <div
+      className="wf-dialog-backdrop"
+      role="presentation"
+      onClick={createdId === null && !busy ? onClose : undefined}
+    >
       <div
         className="wf-dialog"
         role="dialog"
@@ -186,11 +195,18 @@ function AddWorkflowDialog({ onClose, onCreated }: { onClose: () => void; onCrea
               Hand this to any agent - it authors the workflow and publishes it to the whole fleet:
             </p>
             <pre className="wf-dialog-handoff">{handoff}</pre>
+            {error !== null ? <p className="wf-dialog-error">{error}</p> : null}
             <div className="wf-dialog-actions">
               <Button
                 variant="secondary"
                 onClick={() => {
-                  void navigator.clipboard.writeText(handoff).then(() => setCopied(true));
+                  // Clipboard access can be absent (insecure remote origin) or denied. The prompt is
+                  // fully visible in the box above, so the honest degrade is to SAY the copy failed
+                  // and let the person select the text - never an unhandled rejection.
+                  navigator.clipboard?.writeText(handoff).then(
+                    () => setCopied(true),
+                    () => setError("Copy failed - select the text above and copy it manually."),
+                  ) ?? setError("Copy is unavailable here - select the text above and copy it manually.");
                 }}
               >
                 {copied ? "Copied" : "Copy prompt"}

--- a/apps/cockpit/src/workflows/WorkflowsView.tsx
+++ b/apps/cockpit/src/workflows/WorkflowsView.tsx
@@ -1,25 +1,31 @@
 import { useCallback, useEffect, useState } from "react";
-import { getWorkflows, type WorkflowDefinition } from "@devthrottle/client-core/workflows/workflowsClient";
+import { Link } from "react-router-dom";
+import {
+  createWorkflow,
+  getWorkflows,
+  suggestWorkflowId,
+  type WorkflowDefinition,
+} from "@devthrottle/client-core/workflows/workflowsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
-import { ErrorBanner, LoadingState } from "../components";
+import { Button, ErrorBanner, LoadingState } from "../components";
 
-// The Workflows page (issue #1617): the shapes of work this fleet knows how to run.
+// The Workflows page (issue #1617; rebuilt by the Workflows mission, phase 7): the named ways of
+// working this fleet defines - Mission and its siblings, plus every workflow the user's agents author.
 //
-// A workflow is a named, saved definition of how a piece of work gets done by agents - which seats
-// exist, which one starts, which one reviews, and where the human is asked. Until now that lived
-// implicitly in whichever skill file an agent happened to read, which meant there was no place to look
-// to see how the team works. This page is that place.
+// The page's job is to LIST and BROWSE. One compact row per workflow; the conduct itself lives on the
+// detail page. Authoring is AGENT-driven by design - workflows are markdown + optional helper files
+// that agents pull, edit, and push through the cc-devthrottle workflow commands - so "Add workflow"
+// deliberately asks only for a name and a summary, creates a DRAFT, and hands you the exact prompt to
+// give an agent. No markdown box, no step builder: a form that pretended to be the authoring surface
+// would be worse than the one that already exists in every agent.
 //
-// The definitions come from the GATEWAY, not from this bundle. That is the whole architectural point:
-// the Gateway is the home, every Director asks it, and later an administrator sets an organisation's
-// workflows once there and every machine picks them up. A page that hardcoded the list would read the
-// same today and be a lie tomorrow.
-//
-// Read-only at this step. Choosing a workflow when starting work, and authoring them here, are later
-// steps - so this page deliberately ships no buttons it cannot honour.
+// The definitions come from the GATEWAY, not this bundle: the Gateway is the home, every Director and
+// every agent asks it, and the catalog this page shows is the same catalog every session's preamble
+// indexes.
 export function WorkflowsView() {
   const [workflows, setWorkflows] = useState<WorkflowDefinition[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
 
   const load = useCallback(async (signal?: AbortSignal) => {
     try {
@@ -46,81 +52,154 @@ export function WorkflowsView() {
         <div className="ui-page-header-text">
           <h1 className="ui-page-title">Workflows</h1>
           <p className="ui-page-subtitle">
-            How work gets done by your agents. A workflow decides which agent starts, which one reviews,
-            and where you get asked.
+            Named ways of working, stored on the Gateway and usable by every agent on every machine.
           </p>
         </div>
+        <Button variant="primary" onClick={() => setAdding(true)}>Add workflow</Button>
       </header>
-
-      <p className="wf-intro">
-        These are served by the Gateway, so every Director on every machine runs the same set. Editing
-        them here is not built yet.
-      </p>
 
       {error !== null ? (
         <ErrorBanner message={error} onRetry={() => void load()} />
       ) : workflows === null ? (
         <LoadingState message="Loading workflows..." />
       ) : (
-        <div className="wf-list">
+        <div className="wf-rows">
           {workflows.map((wf) => (
-            <WorkflowCard key={wf.id} workflow={wf} />
+            <WorkflowRow key={wf.id} workflow={wf} />
           ))}
         </div>
       )}
+
+      {adding ? (
+        <AddWorkflowDialog
+          onClose={() => setAdding(false)}
+          onCreated={() => void load()}
+        />
+      ) : null}
     </div>
   );
 }
 
-function WorkflowCard({ workflow }: { workflow: WorkflowDefinition }) {
+function WorkflowRow({ workflow }: { workflow: WorkflowDefinition }) {
   return (
-    <section className="wf-card">
-      <div className="wf-card-head">
-        <h2 className="wf-name">{workflow.name}</h2>
-        <span className="wf-steps-count">
+    <Link className="wf-row" to={`/workflows/${encodeURIComponent(workflow.id)}`}>
+      <div className="wf-row-main">
+        <span className="wf-row-name">{workflow.name}</span>
+        <span className={workflow.isBuiltIn === true ? "wf-badge wf-badge-builtin" : "wf-badge wf-badge-custom"}>
+          {workflow.isBuiltIn === true ? "Built-in" : "Custom"}
+        </span>
+        {workflow.hasDraft === true ? <span className="wf-badge wf-badge-draft">Draft waiting</span> : null}
+      </div>
+      <p className="wf-row-summary">{workflow.summary}</p>
+      <div className="wf-row-facts">
+        {typeof workflow.version === "number" ? <span>v{workflow.version}</span> : null}
+        <span>
           {workflow.steps.length} {workflow.steps.length === 1 ? "step" : "steps"}
         </span>
       </div>
-      <p className="wf-summary">{workflow.summary}</p>
+    </Link>
+  );
+}
 
-      <dl className="wf-facts">
-        <dt>When to use it</dt>
-        <dd>{workflow.whenToUse}</dd>
-        <dt>You are asked</dt>
-        <dd>{workflow.humanCheckpoint}</dd>
-      </dl>
+// The add dialog: name + one-line summary, nothing else. Submitting creates a DRAFT on the Gateway
+// (invisible to the fleet until an agent fleshes it out and publishes) and shows the copyable handoff
+// prompt. Errors surface inline and the dialog stays open - the failure is never swallowed.
+function AddWorkflowDialog({ onClose, onCreated }: { onClose: () => void; onCreated: () => void }) {
+  const [name, setName] = useState("");
+  const [summary, setSummary] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [createdId, setCreatedId] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
-      <ol className="wf-steps">
-        {workflow.steps.map((step, i) => (
-          <li className="wf-step" key={step.name}>
-            <div className="wf-step-num" aria-hidden="true">
-              {i + 1}
+  const id = suggestWorkflowId(name);
+  const handoff = createdId === null
+    ? ""
+    : `Author the '${name.trim()}' workflow (id ${createdId}). Pull it with: cc-devthrottle workflow pull ${createdId} --dir <a working directory> - write its instructions.md (the conduct agents will follow), fill workflow.json (steps, outcome criteria), then push and publish: cc-devthrottle workflow push ${createdId} --dir <the directory> && cc-devthrottle workflow publish ${createdId}`;
+
+  const submit = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const draft = await createWorkflow({ id, name: name.trim(), summary: summary.trim() });
+      setCreatedId(draft.workflowId);
+      onCreated();
+    } catch (err) {
+      setError(gatewayErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="wf-dialog-backdrop" role="presentation" onClick={createdId === null ? onClose : undefined}>
+      <div
+        className="wf-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Add workflow"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {createdId === null ? (
+          <>
+            <h2 className="wf-dialog-title">Add workflow</h2>
+            <p className="wf-dialog-hint">
+              This creates a DRAFT. Your agents do the actual authoring - you will get the exact
+              prompt to hand one after this step.
+            </p>
+            <label className="wf-dialog-field">
+              <span>Name</span>
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Release train"
+                autoFocus
+              />
+            </label>
+            <label className="wf-dialog-field">
+              <span>One-line summary</span>
+              <input
+                value={summary}
+                onChange={(e) => setSummary(e.target.value)}
+                placeholder="Cut, verify, and announce a release."
+              />
+            </label>
+            {id.length > 1 ? <p className="wf-dialog-id">Id: {id}</p> : null}
+            {error !== null ? <p className="wf-dialog-error">{error}</p> : null}
+            <div className="wf-dialog-actions">
+              <Button variant="secondary" onClick={onClose} disabled={busy}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => void submit()}
+                disabled={busy || id.length < 2 || summary.trim().length === 0}
+              >
+                {busy ? "Creating..." : "Create draft"}
+              </Button>
             </div>
-            <div className="wf-step-body">
-              <div className="wf-step-name">{step.name}</div>
-              <p className="wf-step-desc">{step.description}</p>
-              <div className="wf-seats">
-                <span className="wf-seat">
-                  <span className="wf-seat-label">Does it</span>
-                  <span className="wf-seat-who">{step.doer}</span>
-                </span>
-                <span className="wf-seat">
-                  <span className="wf-seat-label">Reviews it</span>
-                  {/* "No review" is a real statement the workflow is making - show it, do not leave a gap
-                      that reads as missing data. */}
-                  <span className={step.reviewer === null ? "wf-seat-who wf-seat-none" : "wf-seat-who"}>
-                    {step.reviewer ?? "No review"}
-                  </span>
-                </span>
-                <span className="wf-seat wf-seat-done">
-                  <span className="wf-seat-label">Done when</span>
-                  <span className="wf-seat-who">{step.done}</span>
-                </span>
-              </div>
+          </>
+        ) : (
+          <>
+            <h2 className="wf-dialog-title">Draft created</h2>
+            <p className="wf-dialog-hint">
+              Hand this to any agent - it authors the workflow and publishes it to the whole fleet:
+            </p>
+            <pre className="wf-dialog-handoff">{handoff}</pre>
+            <div className="wf-dialog-actions">
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  void navigator.clipboard.writeText(handoff).then(() => setCopied(true));
+                }}
+              >
+                {copied ? "Copied" : "Copy prompt"}
+              </Button>
+              <Button variant="primary" onClick={onClose}>Done</Button>
             </div>
-          </li>
-        ))}
-      </ol>
-    </section>
+          </>
+        )}
+      </div>
+    </div>
   );
 }

--- a/apps/cockpit/src/workflows/workflows.css
+++ b/apps/cockpit/src/workflows/workflows.css
@@ -195,7 +195,7 @@
 }
 
 .wf-row:hover {
-  border-color: var(--accent, #4a9eff);
+  border-color: var(--accent);
 }
 
 .wf-row-main {
@@ -219,13 +219,13 @@
 }
 
 .wf-badge-builtin {
-  color: var(--accent, #4a9eff);
-  border-color: var(--accent, #4a9eff);
+  color: var(--accent);
+  border-color: var(--accent);
 }
 
 .wf-badge-draft {
-  color: var(--warning, #d9a133);
-  border-color: var(--warning, #d9a133);
+  color: var(--warn);
+  border-color: var(--warn);
 }
 
 .wf-row-summary {
@@ -299,7 +299,7 @@
 
 .wf-dialog-error {
   margin: 0 0 10px;
-  color: var(--danger, #e5534b);
+  color: var(--attention);
   font-size: 13px;
 }
 

--- a/apps/cockpit/src/workflows/workflows.css
+++ b/apps/cockpit/src/workflows/workflows.css
@@ -173,3 +173,222 @@
   color: var(--text-dim);
   font-style: italic;
 }
+
+/* ---- Workflows mission, phase 7: the compact list, the add dialog, and the detail page. The list
+   answers "what exists" in one row per workflow; the conduct lives on the detail page; the dialog
+   asks only what a DRAFT needs, because authoring is agent-driven by design. ---- */
+
+.wf-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.wf-row {
+  display: block;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 16px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.wf-row:hover {
+  border-color: var(--accent, #4a9eff);
+}
+
+.wf-row-main {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.wf-row-name {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.wf-badge {
+  font-size: 11px;
+  padding: 1px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.wf-badge-builtin {
+  color: var(--accent, #4a9eff);
+  border-color: var(--accent, #4a9eff);
+}
+
+.wf-badge-draft {
+  color: var(--warning, #d9a133);
+  border-color: var(--warning, #d9a133);
+}
+
+.wf-row-summary {
+  margin: 6px 0 4px;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.wf-row-facts {
+  display: flex;
+  gap: 14px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+/* The add dialog. */
+.wf-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.wf-dialog {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 20px 22px;
+  width: min(560px, calc(100vw - 40px));
+}
+
+.wf-dialog-title {
+  margin: 0 0 6px;
+  font-size: 17px;
+}
+
+.wf-dialog-hint {
+  margin: 0 0 14px;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.wf-dialog-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+  font-size: 13px;
+}
+
+.wf-dialog-field input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 7px 10px;
+  color: inherit;
+  font-size: 14px;
+}
+
+.wf-dialog-id {
+  margin: 0 0 10px;
+  font-size: 12px;
+  color: var(--text-dim);
+  font-family: var(--mono, monospace);
+}
+
+.wf-dialog-error {
+  margin: 0 0 10px;
+  color: var(--danger, #e5534b);
+  font-size: 13px;
+}
+
+.wf-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.wf-dialog-handoff {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 220px;
+  overflow-y: scroll;
+}
+
+/* The detail page. */
+.wf-crumb {
+  margin: 0 0 2px;
+  font-size: 12px;
+}
+
+.wf-crumb a {
+  color: var(--text-dim);
+  text-decoration: none;
+}
+
+.wf-crumb a:hover {
+  color: inherit;
+}
+
+.wf-detail-facts {
+  display: flex;
+  gap: 8px;
+  margin: 0 0 14px;
+}
+
+.wf-detail-steps {
+  margin: 0 0 20px;
+  padding-left: 0;
+  list-style: none;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.wf-detail-step-num {
+  color: inherit;
+}
+
+.wf-conduct {
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+}
+
+.wf-conduct-title {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+
+.wf-conduct-hint {
+  margin: 0 0 14px;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.wf-conduct-body {
+  font-size: 14px;
+  line-height: 1.6;
+  max-width: 78ch;
+}
+
+.wf-conduct-body pre {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  overflow-x: scroll;
+}
+
+.wf-conduct-body blockquote {
+  border-left: 3px solid var(--border);
+  margin: 10px 0;
+  padding: 2px 14px;
+  color: var(--text-dim);
+}

--- a/packages/client-core/src/workflows/workflowsClient.test.ts
+++ b/packages/client-core/src/workflows/workflowsClient.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { suggestWorkflowId } from "./workflowsClient";
+
+// The add dialog derives the workflow id from the display name; the Gateway enforces the slug shape
+// server-side, so what matters here is that the suggestion always PASSES that shape (or comes out
+// empty for a hopeless name, which the dialog treats as not-yet-submittable).
+describe("suggestWorkflowId", () => {
+  it("slugifies a display name", () => {
+    expect(suggestWorkflowId("Release Train")).toBe("release-train");
+    expect(suggestWorkflowId("  QA Loop!  ")).toBe("qa-loop");
+    expect(suggestWorkflowId("Standalone, with review")).toBe("standalone-with-review");
+  });
+
+  it("never produces leading or trailing dashes", () => {
+    expect(suggestWorkflowId("--weird--")).toBe("weird");
+    expect(suggestWorkflowId("!!!")).toBe("");
+  });
+
+  it("caps at the catalog's 64-character id limit", () => {
+    expect(suggestWorkflowId("x".repeat(200)).length).toBeLessThanOrEqual(64);
+  });
+
+  it("matches the Gateway's slug pattern for every non-empty suggestion", () => {
+    const pattern = /^[a-z0-9][a-z0-9-]{1,63}$/;
+    for (const name of ["Release Train", "a b c", "Fix #1771 spine", "My WORKFLOW 2"]) {
+      const id = suggestWorkflowId(name);
+      expect(id).toMatch(pattern);
+    }
+  });
+});

--- a/packages/client-core/src/workflows/workflowsClient.ts
+++ b/packages/client-core/src/workflows/workflowsClient.ts
@@ -31,6 +31,25 @@ export interface WorkflowDefinition {
   /** Where the human is asked - the interruption budget this workflow spends. */
   humanCheckpoint: string;
   steps: WorkflowStep[];
+  /** ADDITIVE fields from the persisted catalog (Workflows mission). Optional so this client keeps
+   *  reading an older Gateway that serves only the legacy shape. */
+  /** The published version number this projection reflects. */
+  version?: number;
+  /** True for the workflows the Gateway ships (mission, standalone, ...). Editable, never deletable. */
+  isBuiltIn?: boolean;
+  /** True when an unpublished draft exists beside the published version. */
+  hasDraft?: boolean;
+  /** The canonical content hash of the published version. */
+  contentHash?: string;
+  /** When the workflow head last changed (UTC, ISO). */
+  updatedUtc?: string;
+}
+
+/** The response of creating a workflow: the new draft's snapshot (subset this client reads). */
+export interface WorkflowDraft {
+  workflowId: string;
+  version: number;
+  status: string;
 }
 
 async function gatewayErrorFrom(res: Response, label: string): Promise<GatewayError> {
@@ -64,4 +83,55 @@ export async function getWorkflows(signal?: AbortSignal): Promise<WorkflowDefini
   const workflows = body?.workflows;
   if (workflows === undefined) throw new GatewayError(res.status, "GET /gateway/workflows returned no workflows field");
   return workflows;
+}
+
+// GET /gateway/workflows/{id} - one workflow's published projection. 404 throws (the detail page
+// shows the error, never a blank card pretending the workflow exists).
+export async function getWorkflow(id: string, signal?: AbortSignal): Promise<WorkflowDefinition> {
+  const res = await fetch(`/gateway/workflows/${encodeURIComponent(id)}`, {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) throw await gatewayErrorFrom(res, `GET /gateway/workflows/${id}`);
+  return (await res.json()) as WorkflowDefinition;
+}
+
+// GET /gateway/workflows/{id}/instructions - the authoritative conduct, raw markdown. This is the
+// same text an agent fetches and follows; the detail page renders it read-only.
+export async function getWorkflowInstructions(id: string, signal?: AbortSignal): Promise<string> {
+  const res = await fetch(`/gateway/workflows/${encodeURIComponent(id)}/instructions`, {
+    method: "GET",
+    headers: { Accept: "text/markdown" , ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) throw await gatewayErrorFrom(res, `GET /gateway/workflows/${id}/instructions`);
+  return await res.text();
+}
+
+// POST /gateway/workflows - create a workflow as a DRAFT (invisible to the catalog until an agent
+// fleshes it out and publishes). The add dialog sends only a name and summary; authoring is
+// agent-driven by design, so the write surface here is deliberately this thin.
+export async function createWorkflow(
+  input: { id: string; name: string; summary: string },
+  signal?: AbortSignal,
+): Promise<WorkflowDraft> {
+  const res = await fetch("/gateway/workflows", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
+    body: JSON.stringify({ ...input, authoredBy: "cockpit:add-dialog" }),
+    signal,
+  });
+  if (!res.ok) throw await gatewayErrorFrom(res, "POST /gateway/workflows");
+  return (await res.json()) as WorkflowDraft;
+}
+
+/** A workflow id slug from a display name: "Release Train" -> "release-train". The Gateway enforces
+ *  the same shape server-side; this just makes the dialog's default id readable. */
+export function suggestWorkflowId(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
 }

--- a/packages/client-core/src/workflows/workflowsClient.ts
+++ b/packages/client-core/src/workflows/workflowsClient.ts
@@ -98,9 +98,16 @@ export async function getWorkflow(id: string, signal?: AbortSignal): Promise<Wor
 }
 
 // GET /gateway/workflows/{id}/instructions - the authoritative conduct, raw markdown. This is the
-// same text an agent fetches and follows; the detail page renders it read-only.
-export async function getWorkflowInstructions(id: string, signal?: AbortSignal): Promise<string> {
-  const res = await fetch(`/gateway/workflows/${encodeURIComponent(id)}/instructions`, {
+// same text an agent fetches and follows; the detail page renders it read-only. Pass the version
+// from the workflow projection you already hold so the metadata and the conduct are guaranteed to
+// be the SAME version - two unpinned fetches can straddle a publish and show a torn read.
+export async function getWorkflowInstructions(
+  id: string,
+  version?: number,
+  signal?: AbortSignal,
+): Promise<string> {
+  const versionQuery = typeof version === "number" ? `?version=${version}` : "";
+  const res = await fetch(`/gateway/workflows/${encodeURIComponent(id)}/instructions${versionQuery}`, {
     method: "GET",
     headers: { Accept: "text/markdown" , ...authHeaders() },
     signal,


### PR DESCRIPTION
Phase 7 of the approved Workflows plan (mission 9a955739): the UI replacement. TypeScript and CSS only - no Gateway or Director changes.

## What was wrong

The old page rendered every workflow fully expanded: a wall at three workflows, unusable at ten; fed by what used to be C# literals, it could not show a user workflow, a version, or a draft; no add; and the actual conduct - the thing the whole feature distributes - was invisible.

## What this does

- LIST: one compact row per workflow (name, Built-in/Custom badge, Draft-waiting badge, version, step count, one-line summary), linking to the detail page.
- DETAIL (/workflows/:id): metadata + the step summary rendered small (the machine-readable shape, demoted), then the instruction markdown rendered read-only via the existing sanitized markdownToHtml from client-core - the exact text an agent fetches with cc-devthrottle workflow instructions, and labelled as such.
- ADD: a dialog asking ONLY name + one-line summary. Submit creates a DRAFT on the Gateway (invisible to the fleet until an agent publishes) and shows a copyable handoff prompt covering the pull, edit, push, publish loop. No markdown box, no step builder - authoring is agent-driven by design.
- Client: getWorkflow / getWorkflowInstructions / createWorkflow added beside the existing read; additive catalog fields typed optional so an older Gateway still reads; suggestWorkflowId pinned by tests to always produce the Gateway's slug shape.

## Proof

- Strict workspace typecheck green (the build gate every configuration runs).
- client-core: 540 tests passed including the new suggestWorkflowId suite; cockpit bundles cleanly.
- The wire endpoints this page consumes are covered by the Gateway suite from phases 1-2 (legacy shape pinned; create-draft and instructions routes proven over HTTP).

## Remaining phases

Phase 6 (stub the old mission skill file) stays gated on the fleet-live cross-agent proof, which needs the production Gateway's next deployment. Phase 8 (distribution extras) is owner-gated.