### PR TITLE
feat(gateway): migrate the mission-notes store onto the EF data layer

### DIFF
--- a/src/CcDirector.Gateway.Tests/MissionNoteStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/MissionNoteStoreTests.cs
@@ -1,32 +1,33 @@
+using System.Text.Json;
 using CcDirector.Gateway.MissionNotes;
+using CcDirector.Gateway.Tests.Data;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
 /// Unit tests for the Gateway-owned mission-WHY store (Mission Screen mission, Phase 1b, issue #1405):
-/// the durable, shared <c>missionKey -&gt; why</c> map behind the Mission Screen. Covers set/get/all,
-/// the empty-why-unsets rule, key normalization (the same lower-cased grouping key the Cockpit derives),
-/// and the persistence contract (write-through + reload on a fresh store + corrupt quarantine). Every
-/// test uses an isolated temp path so it never touches the real mission-notes.json.
+/// the durable, shared <c>missionKey -&gt; why</c> map behind the Mission Screen, now over the EF data layer
+/// (Hosted Gateway mission, Step 1b). Covers set/get/all, the empty-why-unsets rule, key normalization (the
+/// same lower-cased grouping key the Cockpit derives), the persistence contract (write-through + reload on a
+/// fresh store over the same database), a lossless legacy-JSON import, and the deliberate corrupt-file
+/// QUARANTINE (a cosmetic store must not block boot). Every test runs over an isolated on-disk SQLite database.
 /// </summary>
 public sealed class MissionNoteStoreTests : IDisposable
 {
-    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cc-missionnotes-" + Guid.NewGuid().ToString("N"));
-
-    private string Path_ => System.IO.Path.Combine(_dir, "mission-notes.json");
+    private readonly GatewayDbTestHarness _h = new();
 
     private static readonly DateTime Now = new(2026, 7, 12, 12, 0, 0, DateTimeKind.Utc);
 
-    public void Dispose()
-    {
-        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { }
-    }
+    public void Dispose() => _h.Dispose();
+
+    private string LegacyPath() => _h.LegacyPath("mission-notes-" + Guid.NewGuid().ToString("N") + ".json");
+    private MissionNoteStore NewStore() => new(_h.Open(), LegacyPath());
 
     [Fact]
     public void Set_then_Get_returns_the_why_with_the_display_name_and_updated_time()
     {
-        var store = new MissionNoteStore(Path_);
+        var store = NewStore();
         var note = store.Set("Gateway Cleanup", "Kill Director remote REST; all traffic onto the tunnel.", Now);
 
         Assert.NotNull(note);
@@ -43,7 +44,7 @@ public sealed class MissionNoteStoreTests : IDisposable
     [Fact]
     public void Get_matches_case_insensitively_on_the_normalized_key()
     {
-        var store = new MissionNoteStore(Path_);
+        var store = NewStore();
         store.Set("Car Mode", "Hands-free fleet voice from the phone.", Now);
 
         // A different display casing resolves to the same note (the groupByMission key is lower-cased).
@@ -55,7 +56,7 @@ public sealed class MissionNoteStoreTests : IDisposable
     [Fact]
     public void Set_again_overwrites_the_same_key_and_refreshes_the_display_name_and_time()
     {
-        var store = new MissionNoteStore(Path_);
+        var store = NewStore();
         store.Set("mobile resilience", "first why", Now);
         var later = Now.AddMinutes(30);
         var note = store.Set("Mobile Resilience", "second why", later);
@@ -70,7 +71,7 @@ public sealed class MissionNoteStoreTests : IDisposable
     [Fact]
     public void An_empty_or_whitespace_why_unsets_the_note()
     {
-        var store = new MissionNoteStore(Path_);
+        var store = NewStore();
         store.Set("Snooze Length", "a real why", Now);
         Assert.NotNull(store.Get("Snooze Length"));
 
@@ -87,7 +88,7 @@ public sealed class MissionNoteStoreTests : IDisposable
     [Fact]
     public void Set_trims_outer_whitespace_from_the_stored_why()
     {
-        var store = new MissionNoteStore(Path_);
+        var store = NewStore();
         var note = store.Set("Local Files", "   clickable remote viewer   ", Now);
         Assert.Equal("clickable remote viewer", note!.Why);
     }
@@ -95,14 +96,14 @@ public sealed class MissionNoteStoreTests : IDisposable
     [Fact]
     public void Set_with_a_blank_mission_is_rejected()
     {
-        var store = new MissionNoteStore(Path_);
+        var store = NewStore();
         Assert.Throws<ArgumentException>(() => store.Set("   ", "why", Now));
     }
 
     [Fact]
     public void All_returns_a_stable_snapshot_detached_from_the_live_store()
     {
-        var store = new MissionNoteStore(Path_);
+        var store = NewStore();
         store.Set("Alpha", "a", Now);
         store.Set("Beta", "b", Now);
 
@@ -117,11 +118,11 @@ public sealed class MissionNoteStoreTests : IDisposable
     [Fact]
     public void A_set_why_survives_a_restart_reloaded_from_disk()
     {
-        var store1 = new MissionNoteStore(Path_);
+        var store1 = NewStore();
         store1.Set("Gateway Cleanup", "all traffic onto the tunnel", Now);
 
-        // A fresh store over the same file = a Gateway restart. The WHY must reload.
-        var store2 = new MissionNoteStore(Path_);
+        // A fresh store over the same database = a Gateway restart. The WHY must reload.
+        var store2 = new MissionNoteStore(_h.Open(), LegacyPath());
         var got = store2.Get("gateway cleanup");
         Assert.NotNull(got);
         Assert.Equal("all traffic onto the tunnel", got!.Why);
@@ -129,15 +130,54 @@ public sealed class MissionNoteStoreTests : IDisposable
     }
 
     [Fact]
+    public void LegacyJson_ImportedOnce_Lossless_ThenRenamedAside()
+    {
+        // A legacy mission-notes.json written by the old store (a document with a notes array, camelCase).
+        var legacy = LegacyPath();
+        WriteLegacyFile(legacy,
+            new MissionNoteStore.MissionNote("gateway cleanup", "Gateway Cleanup", "onto the tunnel", Now),
+            new MissionNoteStore.MissionNote("car mode", "Car Mode", "hands-free voice", Now.AddMinutes(5)));
+
+        var store = new MissionNoteStore(_h.Open(), legacy);
+
+        // Every field survived, keyed by the normalized name, ordered by key.
+        var all = store.All();
+        Assert.Equal(2, all.Count);
+        Assert.Equal(new[] { "car mode", "gateway cleanup" }, all.Select(n => n.Key).ToArray());
+        var gc = store.Get("Gateway Cleanup");
+        Assert.NotNull(gc);
+        Assert.Equal("Gateway Cleanup", gc!.Mission);
+        Assert.Equal("onto the tunnel", gc.Why);
+        Assert.Equal(Now, gc.UpdatedAtUtc);
+
+        // The legacy file is renamed aside (kept as a backup), never left to re-import.
+        Assert.False(File.Exists(legacy));
+        Assert.Single(Directory.GetFiles(Path.GetDirectoryName(legacy)!, Path.GetFileName(legacy) + ".migrated-*"));
+
+        // A fresh store over the same database does NOT re-import (the file is gone) and still has both.
+        Assert.Equal(2, new MissionNoteStore(_h.Open(), legacy).All().Count);
+    }
+
+    [Fact]
     public void A_corrupt_file_is_quarantined_and_the_store_starts_empty()
     {
-        Directory.CreateDirectory(_dir);
-        File.WriteAllText(Path_, "{ this is not valid json ");
+        var legacy = LegacyPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(legacy)!);
+        File.WriteAllText(legacy, "{ this is not valid json ");
 
-        var store = new MissionNoteStore(Path_);   // must not throw - the Gateway still boots
+        var store = new MissionNoteStore(_h.Open(), legacy);   // must not throw - the Gateway still boots
         Assert.Empty(store.All());
 
-        var quarantined = Directory.GetFiles(_dir, "mission-notes.json.corrupt-*");
-        Assert.Single(quarantined);                // the bad bytes were preserved, not overwritten
+        // The bad bytes were preserved (renamed aside as .corrupt-*), not overwritten, and NOT left in place
+        // to re-trip next boot.
+        Assert.False(File.Exists(legacy));
+        Assert.Single(Directory.GetFiles(Path.GetDirectoryName(legacy)!, Path.GetFileName(legacy) + ".corrupt-*"));
+    }
+
+    private static void WriteLegacyFile(string path, params MissionNoteStore.MissionNote[] notes)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
+        File.WriteAllText(path, JsonSerializer.Serialize(new { Notes = notes }, options));
     }
 }

--- a/src/CcDirector.Gateway/Data/Entities/MissionNoteEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/MissionNoteEntity.cs
@@ -1,0 +1,32 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// The persisted form of one mission's WHY (<see cref="MissionNotes.MissionNoteStore.MissionNote"/>) in the EF
+/// data layer: one row in the <c>mission_notes</c> table, keyed by the mission's NORMALIZED name.
+///
+/// <see cref="Key"/> is the PRIMARY KEY directly - it is the already-normalized grouping key (trimmed and
+/// lower-cased by <see cref="MissionNotes.MissionNoteStore.NormalizeKey"/>), the same key the old store used
+/// as its <c>Dictionary(StringComparer.Ordinal)</c> key. Because the store normalizes at the key boundary and
+/// then compares ordinally, storing the normalized key as an ordinally-compared primary key (SQLite's default
+/// BINARY collation) reproduces the lookup EXACTLY - there is no case-insensitive comparison at lookup time
+/// and no case-fold question (the U+017F problem the work-list name key has does not arise, because the value
+/// is already folded before it becomes the key).
+///
+/// <see cref="Mission"/> is the display name as last written (the original casing), kept alongside for
+/// reference. <see cref="UpdatedAtUtc"/> is UTC and round-trips through the backbone's UTC DateTime
+/// convention. <c>tenant_id</c> + the global query filter are inherited from the base.
+/// </summary>
+public sealed class MissionNoteEntity : TenantScopedEntity
+{
+    /// <summary>The normalized (trimmed, lower-cased) mission key. Primary key (ordinally compared).</summary>
+    public string Key { get; set; } = "";
+
+    /// <summary>The mission display name as last written (original casing).</summary>
+    public string Mission { get; set; } = "";
+
+    /// <summary>The mission's WHY text (trimmed). A row exists only for a set WHY - an empty WHY deletes it.</summary>
+    public string Why { get; set; } = "";
+
+    /// <summary>When the WHY was last set (UTC).</summary>
+    public DateTime UpdatedAtUtc { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -88,6 +88,9 @@ public sealed class GatewayDbContext : DbContext
     /// cloud credit-debit ledger - real metered dollars, never pinned to a session or run (issue #1771).</summary>
     public DbSet<AccountHostedAiSpendEntity> AccountHostedAiSpend => Set<AccountHostedAiSpendEntity>();
 
+    /// <summary>Mission WHY notes (<c>mission_notes</c>), keyed by the normalized mission name.</summary>
+    public DbSet<MissionNoteEntity> MissionNotes => Set<MissionNoteEntity>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -242,6 +245,17 @@ public sealed class GatewayDbContext : DbContext
             b.HasIndex(e => new { e.TenantId, e.TransactionCreatedUtc });
         });
 
+        modelBuilder.Entity<MissionNoteEntity>(b =>
+        {
+            b.ToTable("mission_notes");
+            // Key is the natural key - the already-normalized (trim + lower-cased) mission name - compared
+            // ordinally by SQLite's default BINARY collation, matching the legacy Dictionary(StringComparer.
+            // Ordinal) keyed by that same normalized value. It is the primary key directly, no surrogate. No
+            // case-fold question arises: the value is folded BEFORE it becomes the key, so lookup is a plain
+            // ordinal equality (unlike the work-list NAME key, which folds at comparison time).
+            b.HasKey(e => e.Key);
+        });
+
         // Tenant scoping - the tenant_id column plus the global query filter - applied uniformly to every
         // entity that derives from TenantScopedEntity, so future stores inherit it by deriving from the base.
         ApplyTenantScope<CronJobEntity>(modelBuilder);
@@ -258,6 +272,7 @@ public sealed class GatewayDbContext : DbContext
         ApplyTenantScope<WingmanInstructionEntity>(modelBuilder);
         ApplyTenantScope<SessionSpendEntity>(modelBuilder);
         ApplyTenantScope<AccountHostedAiSpendEntity>(modelBuilder);
+        ApplyTenantScope<MissionNoteEntity>(modelBuilder);
 
         ApplyCommonSubsetConventions(modelBuilder);
     }

--- a/src/CcDirector.Gateway/Data/LegacyJsonImport.cs
+++ b/src/CcDirector.Gateway/Data/LegacyJsonImport.cs
@@ -3,6 +3,44 @@ using CcDirector.Core.Utilities;
 namespace CcDirector.Gateway.Data;
 
 /// <summary>
+/// How <see cref="LegacyJsonImport.Recoverable"/> reacts to a CORRUPT legacy input file (one the store's
+/// import cannot parse). The choice is per-store BY CRITICALITY, and it is a deliberate contract, not a bug:
+/// <list type="bullet">
+/// <item><see cref="FailLoud"/> (the default) - an operationally-critical store (cron jobs, work-list claims,
+/// snooze/hold state, push subscriptions, wingman instructions) must NEVER silently lose data, so a corrupt
+/// file THROWS and is left in place for the operator; the Gateway does not boot half-blind. All five shipped
+/// stores use this and are byte-identical (they omit the parameter).</item>
+/// <item><see cref="Quarantine"/> - a COSMETIC store whose data must not block boot (the mission WHY notes)
+/// renames the corrupt file aside as <c>&lt;path&gt;.corrupt-&lt;stamp&gt;</c> (preserving the bytes for the
+/// operator) and boots EMPTY, reproducing that store's long-standing quarantine behaviour exactly.</item>
+/// </list>
+/// </summary>
+public enum CorruptFilePolicy
+{
+    /// <summary>A corrupt input file throws and is left in place (the default; operationally-critical stores).</summary>
+    FailLoud,
+
+    /// <summary>A corrupt input file is renamed aside as <c>.corrupt-&lt;stamp&gt;</c> and the store boots empty
+    /// (cosmetic stores that must not block boot).</summary>
+    Quarantine,
+}
+
+/// <summary>
+/// Thrown by a store's import when the legacy INPUT FILE cannot be parsed (a corrupt document) - as opposed
+/// to an infrastructure failure (a database or migration error). <see cref="LegacyJsonImport.Recoverable"/>
+/// distinguishes the two: under <see cref="CorruptFilePolicy.Quarantine"/> it catches ONLY this type (a bad
+/// input) and quarantines; every other exception - a DB/migrate failure - always propagates, even under
+/// Quarantine, so infrastructure problems still fail loud.
+///
+/// It derives from <see cref="InvalidOperationException"/> so the fail-loud stores' existing
+/// <c>Assert.Throws&lt;InvalidOperationException&gt;</c> corrupt-file tests stay green unchanged.
+/// </summary>
+public sealed class LegacyJsonImportCorruptException : InvalidOperationException
+{
+    public LegacyJsonImportCorruptException(string message, Exception? inner = null) : base(message, inner) { }
+}
+
+/// <summary>
 /// Shared helper for the one-time JSON-to-SQLite migration each structured store runs on first upgrade.
 /// After a store has imported a legacy JSON file into the EF database, it renames the file aside so the
 /// import never runs again and the original data stays on disk as a backup.
@@ -31,8 +69,17 @@ public static class LegacyJsonImport
     /// </list>
     /// The <paramref name="isPopulated"/> check and <paramref name="importCommitted"/> import are the store's
     /// own logic (they open their own scoped context); this helper only sequences them and owns the renames.
+    ///
+    /// <paramref name="corruptFilePolicy"/> selects what happens when <paramref name="importCommitted"/>
+    /// reports a corrupt INPUT file by throwing a <see cref="LegacyJsonImportCorruptException"/>. The default,
+    /// <see cref="CorruptFilePolicy.FailLoud"/>, does not catch it - so the five shipped stores are unchanged.
+    /// <see cref="CorruptFilePolicy.Quarantine"/> catches ONLY that type, renames the corrupt file aside as
+    /// <c>.corrupt-&lt;stamp&gt;</c>, and returns (boot empty). A DB/migrate failure is NOT a
+    /// <see cref="LegacyJsonImportCorruptException"/>, so it always propagates - infrastructure still fails
+    /// loud even under Quarantine.
     /// </summary>
-    public static void Recoverable(string path, string logPrefix, Func<bool> isPopulated, Action importCommitted)
+    public static void Recoverable(string path, string logPrefix, Func<bool> isPopulated, Action importCommitted,
+        CorruptFilePolicy corruptFilePolicy = CorruptFilePolicy.FailLoud)
     {
         if (!File.Exists(path))
             return;
@@ -45,10 +92,36 @@ public static class LegacyJsonImport
             return;
         }
 
-        // First upgrade: the store parses and inserts its rows (fail-loud on a parse error propagates and
-        // leaves the file in place), then the imported file is renamed aside best-effort.
-        importCommitted();
+        // First upgrade: the store parses and inserts its rows, then the imported file is renamed aside
+        // best-effort. A parse error surfaces as LegacyJsonImportCorruptException; under FailLoud it
+        // propagates and the file is left in place (fail-loud, all-or-nothing), under Quarantine it is
+        // renamed aside as .corrupt and the store boots empty. Any OTHER exception (a DB/migrate failure)
+        // always propagates - infrastructure is never quarantined.
+        try
+        {
+            importCommitted();
+        }
+        catch (LegacyJsonImportCorruptException) when (corruptFilePolicy == CorruptFilePolicy.Quarantine)
+        {
+            Quarantine(path, logPrefix);
+            return;
+        }
         TryRenameAside(path, logPrefix);
+    }
+
+    /// <summary>
+    /// Preserve an unreadable input file as <c>&lt;path&gt;.corrupt-&lt;stamp&gt;</c> and log loudly, then let
+    /// the store boot empty. Used only under <see cref="CorruptFilePolicy.Quarantine"/> for a COSMETIC store
+    /// whose corrupt data must not block Gateway boot; the bytes are preserved for the operator, never
+    /// silently overwritten. If even the quarantine rename fails, that exception propagates.
+    /// </summary>
+    private static void Quarantine(string path, string logPrefix)
+    {
+        var quarantinePath = $"{path}.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}";
+        File.Move(path, quarantinePath);
+        FileLog.Write($"{logPrefix} Import FAILED: legacy file {path} is corrupt; quarantined to {quarantinePath}; " +
+                      "starting empty (cosmetic store - a corrupt input must not block Gateway boot). Operator " +
+                      "action: inspect the quarantined file to recover the data.");
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Data/Migrations/20260718040528_AddMissionNotes.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718040528_AddMissionNotes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718040528_AddMissionNotes")]
+    partial class AddMissionNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260718040528_AddMissionNotes.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718040528_AddMissionNotes.cs
@@ -1,0 +1,42 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMissionNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "mission_notes",
+                columns: table => new
+                {
+                    Key = table.Column<string>(type: "TEXT", nullable: false),
+                    Mission = table.Column<string>(type: "TEXT", nullable: false),
+                    Why = table.Column<string>(type: "TEXT", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_mission_notes", x => x.Key);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_mission_notes_tenant_id",
+                table: "mission_notes",
+                column: "tenant_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "mission_notes");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -682,7 +682,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // Mission Screen mission (Phase 1b, issue #1405): the mission-WHY store, at a Gateway-side file
         // (CcStorage.Root(), the same location the snooze and cron stores use). Loaded here so a Gateway
         // restart re-serves every WHY. Tests MUST pass an isolated path so they never touch the real store.
-        _missionNotes = new MissionNotes.MissionNoteStore(missionNotesPath ?? Path.Combine(CcStorage.Root(), "mission-notes.json"));
+        // Mission WHY notes now persist in the mission_notes table of the EF data layer. The path argument is
+        // the LEGACY mission-notes.json, imported once on first upgrade (quarantine-on-corrupt, boot empty -
+        // a cosmetic store must not block boot) then renamed aside. Tests MUST pass an isolated path so they
+        // never touch the real legacy file.
+        _missionNotes = new MissionNotes.MissionNoteStore(_gatewayDb, missionNotesPath ?? Path.Combine(CcStorage.Root(), "mission-notes.json"));
         // Cron-job definitions persist across a Gateway restart (epic #479, #482) in the cron_jobs table
         // (next-run times recomputed on load). The path argument is the LEGACY cronjobs.json, imported once
         // on first upgrade then renamed aside. Tests MUST pass an isolated path so they never touch the real

--- a/src/CcDirector.Gateway/MissionNotes/MissionNoteStore.cs
+++ b/src/CcDirector.Gateway/MissionNotes/MissionNoteStore.cs
@@ -1,5 +1,8 @@
 using System.Text.Json;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
 
 namespace CcDirector.Gateway.MissionNotes;
 
@@ -22,22 +25,27 @@ namespace CcDirector.Gateway.MissionNotes;
 /// so the Mission Screen shows its "no why set" flag rather than a blank. A PUT with an empty why is the
 /// clear path.
 ///
-/// PERSISTENCE (SnoozeRegistry precedent): the whole store is ONE plain JSON file at the path the
-/// constructor receives (production: mission-notes.json in the Gateway data dir). Every mutation writes
-/// through immediately with an atomic temp-file + rename, so a crash mid-write can never half-truncate
-/// the store. On construction the file is loaded back so a Gateway restart re-serves every WHY. A corrupt
-/// file is quarantined (never silently overwritten) and the store starts empty so the Gateway still boots.
+/// PERSISTENCE (Hosted Gateway mission, Step 1b): notes live in the EF data layer's <c>mission_notes</c>
+/// table (SQLite locally), keyed by the normalized mission name, NOT the old hand-rolled
+/// <c>mission-notes.json</c>. The public API and observable behavior are unchanged. On first run after the
+/// upgrade a legacy <c>mission-notes.json</c> is imported once through the shared recoverable-import helper.
 ///
-/// NO FALLBACK (CLAUDE.md): a failed persist is a LOGGED error that PROPAGATES - a WHY that cannot be
-/// written to disk would silently vanish on the next restart, so the caller's request fails loudly.
+/// CORRUPT-FILE = QUARANTINE, deliberately (not fail-loud): this is a COSMETIC store, and a corrupt WHY file
+/// must NOT block Gateway boot. So the import uses <see cref="CorruptFilePolicy.Quarantine"/> - a corrupt
+/// legacy file is renamed aside as <c>.corrupt-&lt;stamp&gt;</c> (bytes preserved for the operator) and the
+/// store boots empty, reproducing the long-standing quarantine behaviour exactly. This is the per-store
+/// criticality contract: FAIL-LOUD for operationally-critical stores (never silently lose a scheduled job,
+/// claim, or hold), QUARANTINE-and-continue for cosmetic stores that must not block boot. A failed WRITE is
+/// still fail-loud (a WHY that cannot persist would vanish on restart, so the request fails loudly).
+///
+/// Threading: the Gateway is a single writer. Every operation runs under this store's write lock over a
+/// fresh pooled context.
 /// </summary>
 public sealed class MissionNoteStore
 {
     private readonly object _gate = new();
-    private readonly string _path;
-
-    // normalized mission key -> note. Ordinal keys: the key is already lower-cased by NormalizeKey.
-    private readonly Dictionary<string, MissionNote> _notes = new(StringComparer.Ordinal);
+    private readonly GatewayDatabase _db;
+    private readonly string _legacyJsonPath;
 
     private static readonly JsonSerializerOptions FileJsonOptions = new()
     {
@@ -46,18 +54,20 @@ public sealed class MissionNoteStore
         WriteIndented = true,
     };
 
-    /// <param name="path">
-    /// The JSON file the store persists to. REQUIRED so no caller can silently land on the real user's
-    /// file: production (<see cref="GatewayHost"/>) passes mission-notes.json in the Gateway data dir;
-    /// tests pass an isolated temp path.
-    /// </param>
-    /// <exception cref="ArgumentException">The path is null/empty/whitespace.</exception>
-    public MissionNoteStore(string path)
+    /// <param name="db">The Gateway EF database this store reads and writes through.</param>
+    /// <param name="legacyJsonPath">The legacy <c>mission-notes.json</c> path to import ONCE if it exists and
+    /// the table is empty. REQUIRED (no silent default).</param>
+    /// <exception cref="ArgumentNullException">The database is null.</exception>
+    /// <exception cref="ArgumentException">The legacy path is null/empty/whitespace.</exception>
+    public MissionNoteStore(GatewayDatabase db, string legacyJsonPath)
     {
-        if (string.IsNullOrWhiteSpace(path))
-            throw new ArgumentException("store path is required", nameof(path));
-        _path = path;
-        Load();
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        if (string.IsNullOrWhiteSpace(legacyJsonPath))
+            throw new ArgumentException("legacy json path is required", nameof(legacyJsonPath));
+        _legacyJsonPath = legacyJsonPath;
+
+        lock (_gate)
+            ImportLegacyJsonIfNeeded();
     }
 
     /// <summary>One mission's WHY: the normalized grouping key, the display name as last written, the
@@ -73,7 +83,7 @@ public sealed class MissionNoteStore
     /// <summary>
     /// Set (or clear) a mission's WHY. An empty or all-whitespace <paramref name="why"/> UNSETS the note
     /// (removes it) so the screen shows its flag; any other value stores the trimmed WHY. Returns the
-    /// resulting note, or null when the note was cleared/left unset. Written through to disk before
+    /// resulting note, or null when the note was cleared/left unset. Written through to the database before
     /// returning. <paramref name="nowUtc"/> is injected so tests are deterministic.
     /// </summary>
     /// <exception cref="ArgumentException">The mission name is null/empty/whitespace.</exception>
@@ -86,22 +96,42 @@ public sealed class MissionNoteStore
         var key = NormalizeKey(display);
         lock (_gate)
         {
+            using var ctx = _db.CreateContext();
+            var existing = ctx.MissionNotes.FirstOrDefault(e => e.Key == key);
+
             var trimmed = (why ?? "").Trim();
             if (trimmed.Length == 0)
             {
-                if (_notes.Remove(key))
+                if (existing is not null)
                 {
-                    Save();
+                    ctx.MissionNotes.Remove(existing);
+                    ctx.SaveChanges();
                     FileLog.Write($"[MissionNoteStore] Set: cleared why for mission='{display}' (key={key})");
                 }
                 return null;
             }
 
-            var note = new MissionNote(key, display, trimmed, nowUtc.ToUniversalTime());
-            _notes[key] = note;
-            Save();
+            var updatedAtUtc = nowUtc.ToUniversalTime();
+            if (existing is null)
+            {
+                ctx.MissionNotes.Add(new MissionNoteEntity
+                {
+                    Key = key,
+                    TenantId = ctx.ActiveTenant!,
+                    Mission = display,
+                    Why = trimmed,
+                    UpdatedAtUtc = updatedAtUtc,
+                });
+            }
+            else
+            {
+                existing.Mission = display;
+                existing.Why = trimmed;
+                existing.UpdatedAtUtc = updatedAtUtc;
+            }
+            ctx.SaveChanges();
             FileLog.Write($"[MissionNoteStore] Set: mission='{display}' (key={key}), why length={trimmed.Length}");
-            return note;
+            return new MissionNote(key, display, trimmed, updatedAtUtc);
         }
     }
 
@@ -111,7 +141,11 @@ public sealed class MissionNoteStore
         var key = NormalizeKey(mission);
         if (key.Length == 0) return null;
         lock (_gate)
-            return _notes.TryGetValue(key, out var n) ? n : null;
+        {
+            using var ctx = _db.CreateContext();
+            var e = ctx.MissionNotes.AsNoTracking().FirstOrDefault(x => x.Key == key);
+            return e is null ? null : ToRecord(e);
+        }
     }
 
     /// <summary>A snapshot of every set WHY, ordered by key so the read is stable. A copy, detached from
@@ -119,10 +153,22 @@ public sealed class MissionNoteStore
     public IReadOnlyList<MissionNote> All()
     {
         lock (_gate)
-            return _notes.Values.OrderBy(n => n.Key, StringComparer.Ordinal).ToList();
+        {
+            using var ctx = _db.CreateContext();
+            // Order by key in memory with StringComparer.Ordinal - matching the legacy OrderBy(Key, Ordinal)
+            // exactly. (SQLite's ORDER BY on a TEXT column also uses BINARY/ordinal, but sorting in memory
+            // keeps the ordinal guarantee independent of the provider's default collation.)
+            return ctx.MissionNotes.AsNoTracking().ToList()
+                .OrderBy(e => e.Key, StringComparer.Ordinal)
+                .Select(ToRecord)
+                .ToList();
+        }
     }
 
-    // ---- persistence (SnoozeRegistry precedent) ----------------------------------------------
+    private static MissionNote ToRecord(MissionNoteEntity e)
+        => new(e.Key, e.Mission, e.Why, e.UpdatedAtUtc);
+
+    // ---- one-time legacy JSON import --------------------------------------------------------------
 
     /// <summary>The on-disk shape: one document holding every mission WHY.</summary>
     private sealed class StoreFile
@@ -131,86 +177,71 @@ public sealed class MissionNoteStore
     }
 
     /// <summary>
-    /// Load the store file written by a previous Gateway run so a restart re-serves every WHY. A missing
-    /// file is the normal first boot (empty store, logged). A corrupt file is quarantined (renamed with a
-    /// timestamp suffix) so its bytes are preserved for the operator and never silently overwritten; the
-    /// store then starts empty so the Gateway still boots.
+    /// Import a legacy <c>mission-notes.json</c> exactly once, through the shared recoverable-import plumbing
+    /// (<see cref="LegacyJsonImport.Recoverable"/>): import only when the file exists AND the table is empty;
+    /// recover a lingering file idempotently; rename aside best-effort after a successful import. Uses
+    /// <see cref="CorruptFilePolicy.Quarantine"/> because this is a cosmetic store - a corrupt WHY file is
+    /// renamed aside as <c>.corrupt</c> and the store boots empty rather than blocking Gateway boot.
     /// </summary>
-    private void Load()
-    {
-        if (!File.Exists(_path))
-        {
-            FileLog.Write($"[MissionNoteStore] Load: no store file at {_path}; starting empty");
-            return;
-        }
+    private void ImportLegacyJsonIfNeeded()
+        => LegacyJsonImport.Recoverable(
+            _legacyJsonPath,
+            "[MissionNoteStore]",
+            isPopulated: () => { using var ctx = _db.CreateContext(); return ctx.MissionNotes.Any(); },
+            importCommitted: ImportRowsFromLegacyJson,
+            corruptFilePolicy: CorruptFilePolicy.Quarantine);
 
+    /// <summary>
+    /// Parse the legacy file and insert every note inside one transaction. Mirrors the old load exactly: skip
+    /// a row with an empty normalized key or an empty why, normalize the key, last-wins on a duplicate key,
+    /// and normalize the timestamp to UTC. A PARSE error (a corrupt input file) throws a
+    /// <see cref="LegacyJsonImportCorruptException"/> - the helper's Quarantine policy renames it aside as
+    /// <c>.corrupt</c> and boots empty (this cosmetic store must not block boot).
+    /// </summary>
+    private void ImportRowsFromLegacyJson()
+    {
         StoreFile? parsed;
         try
         {
-            parsed = JsonSerializer.Deserialize<StoreFile>(File.ReadAllText(_path), FileJsonOptions);
+            parsed = JsonSerializer.Deserialize<StoreFile>(File.ReadAllText(_legacyJsonPath), FileJsonOptions);
         }
         catch (JsonException ex)
         {
-            Quarantine(ex.Message);
-            return;
+            throw new LegacyJsonImportCorruptException(
+                $"The legacy mission-notes file '{_legacyJsonPath}' could not be parsed: {ex.Message}", ex);
         }
 
         if (parsed is null)
-        {
-            Quarantine("file deserialized to null (no store document)");
-            return;
-        }
+            throw new LegacyJsonImportCorruptException(
+                $"The legacy mission-notes file '{_legacyJsonPath}' deserialized to a null document.");
 
-        var loaded = 0;
+        // Reproduce the old load's row handling, INCLUDING last-wins on a duplicate normalized key (the old
+        // in-memory Dictionary keyed by the normalized key overwrote), so the imported set matches.
+        var toImport = new Dictionary<string, MissionNote>(StringComparer.Ordinal);
         foreach (var n in parsed.Notes)
         {
             var key = NormalizeKey(n.Mission);
             if (key.Length == 0 || string.IsNullOrWhiteSpace(n.Why))
                 continue; // skip a malformed/empty row rather than fail the whole boot
-            _notes[key] = n with { Key = key, UpdatedAtUtc = n.UpdatedAtUtc.ToUniversalTime() };
-            loaded++;
+            toImport[key] = n with { Key = key, UpdatedAtUtc = n.UpdatedAtUtc.ToUniversalTime() };
         }
 
-        FileLog.Write($"[MissionNoteStore] Load: loaded {loaded} mission why(s) from {_path}");
-    }
-
-    /// <summary>
-    /// Preserve an unreadable store file as "&lt;path&gt;.corrupt-&lt;stamp&gt;" and log loudly. The
-    /// original path is then free for the next write-through. If even the quarantine fails, the exception
-    /// propagates and the Gateway does not start half-blind.
-    /// </summary>
-    private void Quarantine(string reason)
-    {
-        var quarantinePath = $"{_path}.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}";
-        File.Move(_path, quarantinePath);
-        FileLog.Write($"[MissionNoteStore] Load FAILED: store file at {_path} is corrupt ({reason}); quarantined to {quarantinePath}; starting empty. Operator action: inspect the quarantined file to recover mission whys.");
-    }
-
-    /// <summary>
-    /// Write-through: serialize the whole store and atomically replace the file (temp + rename), so a
-    /// concurrent reader or a crash mid-write never sees a half-written store. Called inside the lock by
-    /// every mutation. A failed save is a LOGGED error that PROPAGATES (the caller's request fails
-    /// loudly) - never a silent skip, because a WHY that did not persist would vanish on the next restart.
-    /// </summary>
-    private void Save()
-    {
-        try
+        using var ctx = _db.CreateContext();
+        using var tx = ctx.Database.BeginTransaction();
+        foreach (var n in toImport.Values)
         {
-            var dir = Path.GetDirectoryName(_path);
-            if (!string.IsNullOrEmpty(dir))
-                Directory.CreateDirectory(dir);
-
-            var file = new StoreFile { Notes = _notes.Values.ToList() };
-            var json = JsonSerializer.Serialize(file, FileJsonOptions);
-
-            var tmp = _path + ".tmp";
-            File.WriteAllText(tmp, json);
-            File.Move(tmp, _path, overwrite: true);
+            ctx.MissionNotes.Add(new MissionNoteEntity
+            {
+                Key = n.Key,
+                TenantId = ctx.ActiveTenant!,
+                Mission = n.Mission,
+                Why = n.Why,
+                UpdatedAtUtc = n.UpdatedAtUtc,
+            });
         }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[MissionNoteStore] Save FAILED: path={_path}: {ex.Message}");
-            throw;
-        }
+        ctx.SaveChanges();
+        tx.Commit();
+
+        FileLog.Write($"[MissionNoteStore] Import: {toImport.Count} mission why(s) imported from {_legacyJsonPath}");
     }
 }


### PR DESCRIPTION
Migrate the mission-notes store off hand-rolled JSON onto the EF Core data layer
(SQLite locally), behind its unchanged public API, with a lossless one-time JSON
import.

Mission notes are keyed by the normalized mission name (trimmed and lower-cased),
so the normalized key is stored as the primary key with the original mission name
kept as a display column. Because the old store normalized at the key boundary and
compared ordinally, storing the normalized key as the primary key reproduces the
old dictionary exactly - there is no case-insensitive comparison at lookup and no
Unicode fold question. Setting an empty why deletes the row and returns null,
exactly as before. The tenant-id column and the global query filter apply.

Per-store corrupt-file contract: the other migrated stores fail loud on a corrupt
legacy file, because they hold operationally critical data (scheduled jobs, work
claims, hold state) that must never be lost silently. Mission notes are cosmetic,
and the store deliberately quarantines a corrupt file and boots empty rather than
blocking the Gateway on a bad annotations file. To keep that behavior faithfully,
the shared recoverable import gains a corrupt-file policy: fail-loud by default -
so the five already-migrated stores are byte-identical - and quarantine as an
opt-in for cosmetic stores. The quarantine path catches only the typed corrupt-file
exception, so a database or migration failure still fails loud even under
quarantine.

Evidence (a run, not only a build), recorded in the mission QA document:
- Full Windows solution test suite green across all seven projects, including the
  quarantine test (verified to fail under fail-loud and pass under quarantine) and
  a lossless import round-trip.
- A Linux container built from the repo Dockerfile applied the whole migration
  chain in order on a clean database as the non-root user, health returned 200,
  and the mission-notes table was present and writable.

The macOS native run is deferred - the Mac mini is offline.
