### PR TITLE
feat(gateway): structured intervention + permission audit trail (governance spine item 4, #1771)

### DIFF
--- a/src/CcDirector.Gateway.Contracts/GovernanceAuditEventDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/GovernanceAuditEventDtos.cs
@@ -1,0 +1,101 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>The two categories of governance audit event (issue #1771, spine item 4).</summary>
+public static class GovernanceAuditCategory
+{
+    /// <summary>The agent needed a human, and what the human did about it.</summary>
+    public const string Intervention = "intervention";
+
+    /// <summary>Permission/sandbox posture: requests, decisions, effective mode, elevated-run brackets.</summary>
+    public const string Permission = "permission";
+
+    public static readonly string[] All = { Intervention, Permission };
+}
+
+/// <summary>
+/// The specific audit event types, grouped by category. Each is an explicitly-recorded event, never inferred
+/// from a transcript (issue #1771). <see cref="ForCategory"/> gives the legal types for a category, so an
+/// event's type is validated against its category.
+/// </summary>
+public static class GovernanceAuditEventType
+{
+    // Intervention category.
+    /// <summary>The agent stopped and needs a human (the need/ask).</summary>
+    public const string Needed = "needed";
+    /// <summary>A human stepped in to unblock the agent.</summary>
+    public const string HumanRescued = "human-rescued";
+    /// <summary>A human changed the agent's direction.</summary>
+    public const string HumanRedirected = "human-redirected";
+    /// <summary>A human cancelled the work.</summary>
+    public const string HumanCancelled = "human-cancelled";
+    /// <summary>The intervention resolved and the agent resumed (the response closed out).</summary>
+    public const string Resolved = "resolved";
+
+    // Permission category.
+    /// <summary>The agent requested a permission or approval (Detail = what: e.g. "bash", "write path").</summary>
+    public const string PermissionRequested = "permission-requested";
+    /// <summary>A permission request was granted (Actor = who granted).</summary>
+    public const string PermissionGranted = "permission-granted";
+    /// <summary>A permission request was denied (Actor = who denied).</summary>
+    public const string PermissionDenied = "permission-denied";
+    /// <summary>The effective sandbox/approval mode observed (Detail = the mode).</summary>
+    public const string ModeObserved = "mode-observed";
+    /// <summary>An elevated (dangerous-permission) run began. Its end pairs with this to give the duration.</summary>
+    public const string ElevatedRunStarted = "elevated-run-started";
+    /// <summary>An elevated run ended - the close of the elevated-run bracket.</summary>
+    public const string ElevatedRunEnded = "elevated-run-ended";
+
+    private static readonly string[] Intervention =
+        { Needed, HumanRescued, HumanRedirected, HumanCancelled, Resolved };
+
+    private static readonly string[] Permission =
+        { PermissionRequested, PermissionGranted, PermissionDenied, ModeObserved, ElevatedRunStarted, ElevatedRunEnded };
+
+    /// <summary>The legal event types for a category, or empty for an unknown category.</summary>
+    public static IReadOnlyList<string> ForCategory(string category) => category switch
+    {
+        GovernanceAuditCategory.Intervention => Intervention,
+        GovernanceAuditCategory.Permission => Permission,
+        _ => System.Array.Empty<string>(),
+    };
+}
+
+/// <summary>
+/// One structured governance audit event - an intervention (the agent needed a human, and what the human did)
+/// or a permission/sandbox decision. Append-only: this DTO is both the write acknowledgement and the read row.
+/// </summary>
+public sealed class GovernanceAuditEventDto
+{
+    public Guid Id { get; set; }
+    public string SessionId { get; set; } = "";
+    public Guid? RunId { get; set; }
+    public string Category { get; set; } = "";
+    public string EventType { get; set; } = "";
+    public string? Actor { get; set; }
+    public string? Detail { get; set; }
+    public DateTime OccurredUtc { get; set; }
+    public DateTime RecordedUtc { get; set; }
+}
+
+/// <summary>
+/// Body of an append to the audit trail. One request records one event. <see cref="OccurredUtc"/> is optional
+/// (the Gateway stamps the append time when omitted); the recorded time is always server-stamped.
+/// A permission decision (granted/denied) and a human intervention require <see cref="Actor"/> - "who decided"
+/// is an audit fact that is never null there.
+/// </summary>
+public sealed class AppendGovernanceAuditEventRequest
+{
+    public string? SessionId { get; set; }
+    public Guid? RunId { get; set; }
+    public string? Category { get; set; }
+    public string? EventType { get; set; }
+    public string? Actor { get; set; }
+    public string? Detail { get; set; }
+    public DateTime? OccurredUtc { get; set; }
+}
+
+/// <summary>Body of a batched append: many audit events in one call, landed all-or-nothing.</summary>
+public sealed class AppendGovernanceAuditEventsBatchRequest
+{
+    public List<AppendGovernanceAuditEventRequest> Events { get; set; } = new();
+}

--- a/src/CcDirector.Gateway.Tests/GovernanceAuditLogTests.cs
+++ b/src/CcDirector.Gateway.Tests/GovernanceAuditLogTests.cs
@@ -1,0 +1,214 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Governance;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Store tests for the append-only governance audit trail (issue #1771, spine item 4). The claims that
+/// matter: category and event-type are validated together (a type must belong to its category); a human or
+/// permission decision requires an actor; detail is capped; the trail reads newest-first with working
+/// session/category/time filters; the batch lands all-or-nothing; and every row is tenant-scoped.
+/// </summary>
+public sealed class GovernanceAuditLogTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    private GovernanceAuditLog NewLog() => new(_h.Open());
+
+    private const string Session = "sess-audit-1";
+    private static readonly Guid Run = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private static AppendGovernanceAuditEventRequest Intervention(
+        string type, string? actor = null, string session = Session) => new()
+    {
+        SessionId = session,
+        RunId = Run,
+        Category = GovernanceAuditCategory.Intervention,
+        EventType = type,
+        Actor = actor,
+    };
+
+    private static AppendGovernanceAuditEventRequest Permission(
+        string type, string? actor = null, string? detail = null) => new()
+    {
+        SessionId = Session,
+        Category = GovernanceAuditCategory.Permission,
+        EventType = type,
+        Actor = actor,
+        Detail = detail,
+    };
+
+    [Fact]
+    public void Append_records_a_permission_request_and_server_stamps_it()
+    {
+        var log = NewLog();
+        var before = DateTime.UtcNow;
+        var dto = log.Append(Permission(GovernanceAuditEventType.PermissionRequested, detail: "bash"));
+
+        Assert.NotEqual(Guid.Empty, dto.Id);
+        Assert.Equal(GovernanceAuditCategory.Permission, dto.Category);
+        Assert.Equal(GovernanceAuditEventType.PermissionRequested, dto.EventType);
+        Assert.Equal("bash", dto.Detail);
+        Assert.True(dto.RecordedUtc >= before);
+        Assert.True(dto.OccurredUtc >= before);
+    }
+
+    [Fact]
+    public void An_event_type_must_belong_to_its_category()
+    {
+        var log = NewLog();
+        // "permission-granted" is a permission type, not an intervention type.
+        var ex = Assert.Throws<GovernanceValidationException>(() => log.Append(new AppendGovernanceAuditEventRequest
+        {
+            SessionId = Session,
+            Category = GovernanceAuditCategory.Intervention,
+            EventType = GovernanceAuditEventType.PermissionGranted,
+        }));
+        Assert.Contains("not a legal event type for category", ex.Message);
+    }
+
+    [Fact]
+    public void An_unknown_category_is_rejected()
+    {
+        var log = NewLog();
+        var ex = Assert.Throws<GovernanceValidationException>(() => log.Append(new AppendGovernanceAuditEventRequest
+        {
+            SessionId = Session, Category = "escalation", EventType = "x",
+        }));
+        Assert.Contains("audit category", ex.Message);
+    }
+
+    [Fact]
+    public void A_human_or_permission_decision_requires_an_actor()
+    {
+        var log = NewLog();
+        Assert.Throws<GovernanceValidationException>(
+            () => log.Append(Intervention(GovernanceAuditEventType.HumanCancelled)));         // no actor
+        Assert.Throws<GovernanceValidationException>(
+            () => log.Append(Permission(GovernanceAuditEventType.PermissionDenied)));         // no actor
+
+        // An agent-side event does NOT require an actor.
+        var needed = log.Append(Intervention(GovernanceAuditEventType.Needed));
+        Assert.Null(needed.Actor);
+        // With an actor, the human decision is accepted and the actor is recorded.
+        var cancelled = log.Append(Intervention(GovernanceAuditEventType.HumanCancelled, actor: "human:soren"));
+        Assert.Equal("human:soren", cancelled.Actor);
+    }
+
+    [Fact]
+    public void An_event_needs_a_session()
+    {
+        var log = NewLog();
+        Assert.Throws<GovernanceValidationException>(() => log.Append(new AppendGovernanceAuditEventRequest
+        {
+            Category = GovernanceAuditCategory.Permission, EventType = GovernanceAuditEventType.ModeObserved,
+        }));
+    }
+
+    [Fact]
+    public void An_oversize_detail_is_rejected()
+    {
+        var log = NewLog();
+        var ex = Assert.Throws<GovernanceValidationException>(() => log.Append(
+            Permission(GovernanceAuditEventType.ModeObserved,
+                detail: new string('x', GovernanceAuditLog.MaxDetailChars + 1))));
+        Assert.Contains("detail", ex.Message);
+    }
+
+    [Fact]
+    public void List_filters_by_session_run_category_and_window()
+    {
+        var log = NewLog();
+        var t0 = DateTime.UtcNow.AddHours(-1);
+        log.Append(new AppendGovernanceAuditEventRequest
+        {
+            SessionId = Session, RunId = Run, Category = GovernanceAuditCategory.Intervention,
+            EventType = GovernanceAuditEventType.Needed, OccurredUtc = t0,
+        });
+        log.Append(new AppendGovernanceAuditEventRequest
+        {
+            SessionId = Session, Category = GovernanceAuditCategory.Permission,
+            EventType = GovernanceAuditEventType.PermissionRequested, Detail = "write", OccurredUtc = t0.AddMinutes(20),
+        });
+        log.Append(new AppendGovernanceAuditEventRequest
+        {
+            SessionId = "other", Category = GovernanceAuditCategory.Permission,
+            EventType = GovernanceAuditEventType.ModeObserved, Detail = "acceptEdits", OccurredUtc = t0.AddMinutes(21),
+        });
+
+        Assert.Equal(2, log.List(sessionId: Session).Count);
+        Assert.Single(log.List(sessionId: Session, category: GovernanceAuditCategory.Permission));
+        Assert.Single(log.List(runId: Run));
+        Assert.Equal(GovernanceAuditEventType.Needed, log.List(runId: Run)[0].EventType);
+
+        var windowed = log.List(sessionId: Session, sinceUtc: t0.AddMinutes(10), untilUtc: t0.AddMinutes(30));
+        Assert.Single(windowed);
+        Assert.Equal(GovernanceAuditEventType.PermissionRequested, windowed[0].EventType);
+    }
+
+    [Fact]
+    public void List_returns_newest_first()
+    {
+        var log = NewLog();
+        var t0 = DateTime.UtcNow.AddMinutes(-10);
+        log.Append(new AppendGovernanceAuditEventRequest
+        {
+            SessionId = Session, Category = GovernanceAuditCategory.Permission,
+            EventType = GovernanceAuditEventType.ElevatedRunStarted, OccurredUtc = t0,
+        });
+        log.Append(new AppendGovernanceAuditEventRequest
+        {
+            SessionId = Session, Category = GovernanceAuditCategory.Permission,
+            EventType = GovernanceAuditEventType.ElevatedRunEnded, OccurredUtc = t0.AddMinutes(5),
+        });
+
+        var all = log.List(sessionId: Session);
+        Assert.Equal(GovernanceAuditEventType.ElevatedRunEnded, all[0].EventType);
+        Assert.Equal(GovernanceAuditEventType.ElevatedRunStarted, all[1].EventType);
+    }
+
+    [Fact]
+    public void AppendBatch_is_all_or_nothing_when_one_entry_is_invalid()
+    {
+        var log = NewLog();
+        Assert.Throws<GovernanceValidationException>(() => log.AppendBatch(new List<AppendGovernanceAuditEventRequest>
+        {
+            Permission(GovernanceAuditEventType.PermissionRequested, detail: "bash"),
+            Permission(GovernanceAuditEventType.PermissionGranted), // invalid - no actor - aborts the batch
+        }));
+        Assert.Empty(log.List(sessionId: Session));
+    }
+
+    [Fact]
+    public void AppendBatch_writes_every_valid_event()
+    {
+        var log = NewLog();
+        var written = log.AppendBatch(new List<AppendGovernanceAuditEventRequest>
+        {
+            Permission(GovernanceAuditEventType.PermissionRequested, detail: "bash"),
+            Permission(GovernanceAuditEventType.PermissionGranted, actor: "human:soren"),
+            Intervention(GovernanceAuditEventType.Needed),
+        });
+        Assert.Equal(3, written);
+        Assert.Equal(3, log.List(sessionId: Session).Count);
+    }
+
+    [Fact]
+    public void The_trail_is_tenant_scoped()
+    {
+        var alpha = new GovernanceAuditLog(_h.Open(new FixedTenantContext(new TenantId("alpha"))));
+        var beta = new GovernanceAuditLog(_h.Open(new FixedTenantContext(new TenantId("beta"))));
+
+        alpha.Append(Intervention(GovernanceAuditEventType.Needed, session: "alpha-sess"));
+        beta.Append(Intervention(GovernanceAuditEventType.Needed, session: "beta-sess"));
+
+        Assert.Single(alpha.List());
+        Assert.Single(beta.List());
+        Assert.Equal("alpha-sess", alpha.List()[0].SessionId);
+    }
+}

--- a/src/CcDirector.Gateway/Api/GovernanceAuditEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GovernanceAuditEndpoints.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Governance;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The governance audit surface (issue #1771, spine item 4) - structured intervention and permission/sandbox
+/// events. Append-only: an audit fact can be recorded and read, never edited or removed, so there is a POST
+/// and a GET and deliberately no PUT/PATCH/DELETE.
+///
+///   POST  /gateway/governance/audit-events        body AppendGovernanceAuditEventRequest       -> 201 | 400
+///   POST  /gateway/governance/audit-events/batch    body AppendGovernanceAuditEventsBatchRequest -> 200 { written } | 400
+///   GET   /gateway/governance/audit-events          ?sessionId=&amp;runId=&amp;category=&amp;eventType=&amp;since=&amp;until=&amp;limit=
+///                                                   -> { events: [...] }
+///
+/// Inherits the host-wide token middleware, like every other Gateway route.
+/// </summary>
+internal static class GovernanceAuditEndpoints
+{
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    public static void Map(IEndpointRouteBuilder app, GovernanceAuditLog log)
+    {
+        app.MapPost("/gateway/governance/audit-events", async (HttpContext ctx) =>
+        {
+            AppendGovernanceAuditEventRequest? req;
+            try
+            {
+                req = await JsonSerializer.DeserializeAsync<AppendGovernanceAuditEventRequest>(
+                    ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+            }
+            catch (JsonException ex)
+            {
+                FileLog.Write($"[GovernanceAuditEndpoints] POST bad JSON: {ex.Message}");
+                return Results.BadRequest(new { error = "invalid JSON" });
+            }
+            if (req is null)
+                return Results.BadRequest(new { error = "an audit event body is required" });
+
+            return Guard(() =>
+            {
+                var recorded = log.Append(req);
+                return Results.Json(recorded, statusCode: StatusCodes.Status201Created);
+            });
+        });
+
+        app.MapPost("/gateway/governance/audit-events/batch", async (HttpContext ctx) =>
+        {
+            AppendGovernanceAuditEventsBatchRequest? req;
+            try
+            {
+                req = await JsonSerializer.DeserializeAsync<AppendGovernanceAuditEventsBatchRequest>(
+                    ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+            }
+            catch (JsonException ex)
+            {
+                FileLog.Write($"[GovernanceAuditEndpoints] POST batch bad JSON: {ex.Message}");
+                return Results.BadRequest(new { error = "invalid JSON" });
+            }
+            if (req is null)
+                return Results.BadRequest(new { error = "a batch body is required" });
+
+            return Guard(() =>
+            {
+                var written = log.AppendBatch(req.Events ?? new List<AppendGovernanceAuditEventRequest>());
+                return Results.Json(new { written });
+            });
+        });
+
+        app.MapGet("/gateway/governance/audit-events",
+            (string? sessionId, Guid? runId, string? category, string? eventType,
+             DateTime? since, DateTime? until, int? limit) =>
+                Results.Json(new
+                {
+                    events = log.List(sessionId, runId, category, eventType, since, until, limit ?? 500),
+                }));
+
+        FileLog.Write("[GovernanceAuditEndpoints] mapped /gateway/governance/audit-events routes");
+    }
+
+    private static IResult Guard(Func<IResult> action)
+    {
+        try
+        {
+            return action();
+        }
+        catch (GovernanceValidationException ex)
+        {
+            FileLog.Write($"[GovernanceAuditEndpoints] rejected: {ex.Message}");
+            return Results.BadRequest(new { error = ex.Message });
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Data/Entities/GovernanceAuditEventEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/GovernanceAuditEventEntity.cs
@@ -1,0 +1,57 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// One structured governance audit event, in the <c>governance_audit_events</c> table - the intervention and
+/// permission/sandbox audit trail of the governance outcome spine (issue #1771, spine item 4). Append-only:
+/// a row is written once and never changed, because an audit trail you can rewrite is not an audit trail.
+///
+/// This is a DISTINCT ledger from <see cref="GovernanceEventEntity"/> (the activity/duration timeline). This
+/// one records DECISIONS and INTERVENTIONS, in two categories (<see cref="Category"/>):
+///  - "intervention" - the agent needed a human and what the human did: the need/ask, and a human rescue,
+///    redirect, or cancel, and the resolution.
+///  - "permission" - permission/sandbox posture: a permission request and its decision, the effective
+///    sandbox/approval mode observed, and the start/end brackets of an elevated (dangerous) run (its duration
+///    is derived from the pair, so the ledger stays purely event-based).
+///
+/// Everything here is an EXPLICITLY-RECORDED event, NEVER inferred from a prose transcript (issue #1771), and
+/// <see cref="Detail"/> is a short control-flow note (a permission name, a mode, a redirect reason) - NEVER
+/// prompt content. The <see cref="Actor"/> is the audit "who": the human identity on a human decision, the
+/// agent on an agent event.
+/// </summary>
+public sealed class GovernanceAuditEventEntity : TenantScopedEntity
+{
+    /// <summary>Primary key, minted in code - never a database default.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>The canonical fleet session GUID the event belongs to (audit events are session-scoped).
+    /// The same id run participants, the event ledger, and session spend key on.</summary>
+    public string SessionId { get; set; } = "";
+
+    /// <summary>The workflow run the session was working, when known (value reference to
+    /// <see cref="WorkflowRunEntity.Id"/>, never a foreign key - the audit trail outlives the run).</summary>
+    public Guid? RunId { get; set; }
+
+    /// <summary>"intervention" or "permission".</summary>
+    public string Category { get; set; } = "";
+
+    /// <summary>The specific event within the category (e.g. "needed", "human-rescued", "permission-requested",
+    /// "permission-granted", "mode-observed", "elevated-run-started"). Validated against the category.</summary>
+    public string EventType { get; set; } = "";
+
+    /// <summary>Who acted: a human identity ("human:&lt;user&gt;") on a human decision, or the agent seat on an
+    /// agent event. Required on human decisions and permission decisions - "who decided" is an audit fact that
+    /// must never be null there.</summary>
+    public string? Actor { get; set; }
+
+    /// <summary>A short control-flow note describing the specific subject: the permission requested, the
+    /// effective mode, the redirect reason. NEVER prompt content - the audit records what was decided, not
+    /// what anyone typed.</summary>
+    public string? Detail { get; set; }
+
+    /// <summary>When the event actually happened. Caller-supplied; defaults to the append time.</summary>
+    public DateTime OccurredUtc { get; set; }
+
+    /// <summary>When the Gateway appended the row (server-stamped) - the tie-breaker that orders two events
+    /// sharing an <see cref="OccurredUtc"/>, and the audit fact of when we learned.</summary>
+    public DateTime RecordedUtc { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -91,6 +91,10 @@ public sealed class GatewayDbContext : DbContext
     /// <summary>Mission WHY notes (<c>mission_notes</c>), keyed by the normalized mission name.</summary>
     public DbSet<MissionNoteEntity> MissionNotes => Set<MissionNoteEntity>();
 
+    /// <summary>The append-only governance audit trail (<c>governance_audit_events</c>) - structured
+    /// intervention and permission/sandbox decisions, never inferred from transcripts (issue #1771).</summary>
+    public DbSet<GovernanceAuditEventEntity> GovernanceAuditEvents => Set<GovernanceAuditEventEntity>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -256,6 +260,19 @@ public sealed class GatewayDbContext : DbContext
             b.HasKey(e => e.Key);
         });
 
+        modelBuilder.Entity<GovernanceAuditEventEntity>(b =>
+        {
+            b.ToTable("governance_audit_events");
+            b.HasKey(e => e.Id);
+            // The read paths: a session's audit trail over time, a run's, and a category scan (all the
+            // permission decisions, all the interventions) over a window - each tenant-leading for the
+            // global filter. SessionId/RunId are value references, never foreign keys - the trail outlives
+            // the session and run it records.
+            b.HasIndex(e => new { e.TenantId, e.SessionId, e.OccurredUtc });
+            b.HasIndex(e => new { e.TenantId, e.RunId, e.OccurredUtc });
+            b.HasIndex(e => new { e.TenantId, e.Category, e.OccurredUtc });
+        });
+
         // Tenant scoping - the tenant_id column plus the global query filter - applied uniformly to every
         // entity that derives from TenantScopedEntity, so future stores inherit it by deriving from the base.
         ApplyTenantScope<CronJobEntity>(modelBuilder);
@@ -273,6 +290,7 @@ public sealed class GatewayDbContext : DbContext
         ApplyTenantScope<SessionSpendEntity>(modelBuilder);
         ApplyTenantScope<AccountHostedAiSpendEntity>(modelBuilder);
         ApplyTenantScope<MissionNoteEntity>(modelBuilder);
+        ApplyTenantScope<GovernanceAuditEventEntity>(modelBuilder);
 
         ApplyCommonSubsetConventions(modelBuilder);
     }

--- a/src/CcDirector.Gateway/Data/Migrations/20260718044138_AddGovernanceAuditEvents.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718044138_AddGovernanceAuditEvents.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718044138_AddGovernanceAuditEvents")]
+    partial class AddGovernanceAuditEvents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260718044138_AddGovernanceAuditEvents.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718044138_AddGovernanceAuditEvents.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGovernanceAuditEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "governance_audit_events",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    SessionId = table.Column<string>(type: "TEXT", nullable: false),
+                    RunId = table.Column<Guid>(type: "TEXT", nullable: true),
+                    Category = table.Column<string>(type: "TEXT", nullable: false),
+                    EventType = table.Column<string>(type: "TEXT", nullable: false),
+                    Actor = table.Column<string>(type: "TEXT", nullable: true),
+                    Detail = table.Column<string>(type: "TEXT", nullable: true),
+                    OccurredUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    RecordedUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_governance_audit_events", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_governance_audit_events_tenant_id",
+                table: "governance_audit_events",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_governance_audit_events_tenant_id_Category_OccurredUtc",
+                table: "governance_audit_events",
+                columns: new[] { "tenant_id", "Category", "OccurredUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_governance_audit_events_tenant_id_RunId_OccurredUtc",
+                table: "governance_audit_events",
+                columns: new[] { "tenant_id", "RunId", "OccurredUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_governance_audit_events_tenant_id_SessionId_OccurredUtc",
+                table: "governance_audit_events",
+                columns: new[] { "tenant_id", "SessionId", "OccurredUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "governance_audit_events");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -342,6 +342,9 @@ public sealed class GatewayHost : IAsyncDisposable
     // label, and the account-level hosted-AI service dollars mirrored from the credit-debit ledger.
     private readonly Governance.SessionSpendStore _sessionSpend;
     private readonly Governance.AccountHostedAiSpendStore _hostedAiSpend;
+    // The append-only governance audit trail (issue #1771, spine item 4): structured intervention +
+    // permission/sandbox decisions, recorded as events, never inferred from transcripts.
+    private readonly Governance.GovernanceAuditLog _governanceAudit;
     private readonly CronJobStore _cronJobs;
     private readonly CronRunHistoryStore _cronRuns;
     private readonly Running.CronEngine _cronEngine;
@@ -618,6 +621,9 @@ public sealed class GatewayHost : IAsyncDisposable
         // account-level hosted-AI service dollars mirrored from the credit-debit ledger.
         _sessionSpend = new Governance.SessionSpendStore(_gatewayDb);
         _hostedAiSpend = new Governance.AccountHostedAiSpendStore(_gatewayDb);
+        // The governance audit trail (issue #1771, spine item 4): append-only intervention + permission/
+        // sandbox decisions on the EF data layer, so a Gateway restart never loses a recorded audit fact.
+        _governanceAudit = new Governance.GovernanceAuditLog(_gatewayDb);
         // Snooze Length mission: the persisted snooze registry (sessionId -> SnoozeUntilUtc), now in the
         // snoozes table of the EF data layer - a Gateway restart re-arms every pending snooze from the
         // database; an entry already past its time simply fires on the first sweep. The path argument is the
@@ -1653,6 +1659,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // Honest driver-normalized spend (issue #1771, spine item 3): per-session token effort + billing-mode
         // label, and the account-level hosted-AI service dollars read from the mirrored credit-debit ledger.
         Api.GovernanceSpendEndpoints.Map(_app, _sessionSpend, _hostedAiSpend);
+
+        // The governance audit trail (issue #1771, spine item 4): append-only intervention +
+        // permission/sandbox decisions - the safety and attention-burden audit. Append and read only.
+        Api.GovernanceAuditEndpoints.Map(_app, _governanceAudit);
 
         // Gateway Centralization Phase 1 (issue #628): the inbound login-telemetry RELAY. The Director
         // POSTs its login-telemetry event here (instead of the cloud) and the Gateway forwards it on,

--- a/src/CcDirector.Gateway/Governance/GovernanceAuditLog.cs
+++ b/src/CcDirector.Gateway/Governance/GovernanceAuditLog.cs
@@ -1,0 +1,233 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Governance;
+
+/// <summary>
+/// The Gateway's append-only governance audit log (issue #1771, spine item 4) over the
+/// <c>governance_audit_events</c> table. Every row is one explicitly-recorded intervention or permission/
+/// sandbox decision - the agent needing a human and what the human did, a permission request and its ruling,
+/// the effective mode, the brackets of an elevated run. It is the audit trail the safety and attention-burden
+/// reports read.
+///
+/// Append-only by contract: no update, no delete. Everything recorded here is an EVENT the caller observed,
+/// never something inferred from a prose transcript, and the detail field is a short control-flow note, never
+/// prompt content.
+///
+/// Two write shapes, mirroring the event ledger: <see cref="Append"/> for one event, <see cref="AppendBatch"/>
+/// for many in one unit of work (change-detection disabled for the insert, tenant_id still set per row).
+/// Threading matches the rest of the data layer: single writer, write lock, fresh pooled context per operation.
+/// </summary>
+public sealed class GovernanceAuditLog
+{
+    private readonly object _gate = new();
+    private readonly GatewayDatabase _db;
+
+    /// <summary>A detail is a short control-flow note (a permission name, a mode, a reason); cap it.</summary>
+    public const int MaxDetailChars = 500;
+
+    /// <summary>The hard ceiling on one batched append.</summary>
+    public const int MaxBatchSize = 1000;
+
+    /// <summary>The hard ceiling on one list read; the default page is 500.</summary>
+    public const int MaxListLimit = 5000;
+
+    /// <summary>The event types that REQUIRE an actor - a human decision or a permission ruling: "who decided"
+    /// is an audit fact that must never be null on these.</summary>
+    private static readonly HashSet<string> ActorRequired = new(StringComparer.Ordinal)
+    {
+        GovernanceAuditEventType.HumanRescued,
+        GovernanceAuditEventType.HumanRedirected,
+        GovernanceAuditEventType.HumanCancelled,
+        GovernanceAuditEventType.PermissionGranted,
+        GovernanceAuditEventType.PermissionDenied,
+    };
+
+    public GovernanceAuditLog(GatewayDatabase db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    /// <summary>Append one audit event. Returns the recorded row.</summary>
+    public GovernanceAuditEventDto Append(AppendGovernanceAuditEventRequest request)
+    {
+        if (request is null)
+            throw new GovernanceValidationException("An audit event body is required.");
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var now = DateTime.UtcNow;
+            var entity = BuildEntity(request, ctx.ActiveTenant!, now);
+            ctx.GovernanceAuditEvents.Add(entity);
+            ctx.SaveChanges();
+
+            FileLog.Write($"[GovernanceAuditLog] Append: id={entity.Id}, session={entity.SessionId}, " +
+                          $"category={entity.Category}, type={entity.EventType}, actor={entity.Actor ?? "-"}");
+            return ToDto(entity);
+        }
+    }
+
+    /// <summary>
+    /// Append many audit events in one unit of work, validated first: one invalid entry rejects the whole
+    /// batch (the trail never lands a half-batch). Returns the number of rows written.
+    /// </summary>
+    public int AppendBatch(IReadOnlyList<AppendGovernanceAuditEventRequest> requests)
+    {
+        if (requests is null)
+            throw new GovernanceValidationException("An events list is required.");
+        if (requests.Count == 0)
+            return 0;
+        if (requests.Count > MaxBatchSize)
+            throw new GovernanceValidationException(
+                $"A batch carries at most {MaxBatchSize} events (got {requests.Count}).");
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var now = DateTime.UtcNow;
+            var tenant = ctx.ActiveTenant!;
+
+            var entities = new List<GovernanceAuditEventEntity>(requests.Count);
+            foreach (var request in requests)
+            {
+                if (request is null)
+                    throw new GovernanceValidationException("The events list contains a null entry.");
+                entities.Add(BuildEntity(request, tenant, now));
+            }
+
+            var previousAutoDetect = ctx.ChangeTracker.AutoDetectChangesEnabled;
+            ctx.ChangeTracker.AutoDetectChangesEnabled = false;
+            try
+            {
+                ctx.GovernanceAuditEvents.AddRange(entities);
+                ctx.SaveChanges();
+            }
+            finally
+            {
+                ctx.ChangeTracker.AutoDetectChangesEnabled = previousAutoDetect;
+            }
+
+            FileLog.Write($"[GovernanceAuditLog] AppendBatch: wrote {entities.Count} events");
+            return entities.Count;
+        }
+    }
+
+    /// <summary>
+    /// Audit events, newest first, optionally filtered by session, run, category, event type, and time window
+    /// (<paramref name="sinceUtc"/> inclusive, <paramref name="untilUtc"/> exclusive on OccurredUtc).
+    /// </summary>
+    public IReadOnlyList<GovernanceAuditEventDto> List(
+        string? sessionId = null, Guid? runId = null, string? category = null, string? eventType = null,
+        DateTime? sinceUtc = null, DateTime? untilUtc = null, int limit = 500)
+    {
+        var take = Math.Clamp(limit, 1, MaxListLimit);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            IQueryable<GovernanceAuditEventEntity> query = ctx.GovernanceAuditEvents.AsNoTracking();
+
+            if (!string.IsNullOrWhiteSpace(sessionId))
+            {
+                var id = sessionId.Trim();
+                query = query.Where(e => e.SessionId == id);
+            }
+            if (runId.HasValue)
+                query = query.Where(e => e.RunId == runId.Value);
+            if (!string.IsNullOrWhiteSpace(category))
+            {
+                var cat = category.Trim().ToLowerInvariant();
+                query = query.Where(e => e.Category == cat);
+            }
+            if (!string.IsNullOrWhiteSpace(eventType))
+            {
+                var type = eventType.Trim().ToLowerInvariant();
+                query = query.Where(e => e.EventType == type);
+            }
+            if (sinceUtc.HasValue)
+            {
+                var since = DateTime.SpecifyKind(sinceUtc.Value, DateTimeKind.Utc);
+                query = query.Where(e => e.OccurredUtc >= since);
+            }
+            if (untilUtc.HasValue)
+            {
+                var until = DateTime.SpecifyKind(untilUtc.Value, DateTimeKind.Utc);
+                query = query.Where(e => e.OccurredUtc < until);
+            }
+
+            return query
+                .OrderByDescending(e => e.OccurredUtc)
+                .ThenByDescending(e => e.RecordedUtc)
+                .Take(take)
+                .ToList()
+                .Select(ToDto)
+                .ToList();
+        }
+    }
+
+    /// <summary>Validate one request and build the immutable row (tenant + timestamps stamped here).</summary>
+    private static GovernanceAuditEventEntity BuildEntity(
+        AppendGovernanceAuditEventRequest request, string tenant, DateTime now)
+    {
+        if (string.IsNullOrWhiteSpace(request.SessionId))
+            throw new GovernanceValidationException("An audit event needs a sessionId.");
+
+        var category = (request.Category ?? "").Trim().ToLowerInvariant();
+        if (!GovernanceAuditCategory.All.Contains(category, StringComparer.Ordinal))
+            throw new GovernanceValidationException(
+                $"'{request.Category}' is not an audit category. Legal values: " +
+                string.Join(", ", GovernanceAuditCategory.All) + ".");
+
+        var eventType = (request.EventType ?? "").Trim().ToLowerInvariant();
+        var legalTypes = GovernanceAuditEventType.ForCategory(category);
+        if (!legalTypes.Contains(eventType, StringComparer.Ordinal))
+            throw new GovernanceValidationException(
+                $"'{request.EventType}' is not a legal event type for category '{category}'. Legal values: " +
+                string.Join(", ", legalTypes) + ".");
+
+        var actor = string.IsNullOrWhiteSpace(request.Actor) ? null : request.Actor.Trim();
+        if (actor is null && ActorRequired.Contains(eventType))
+            throw new GovernanceValidationException(
+                $"Event '{eventType}' requires an actor - who made the call is an audit fact.");
+
+        if (request.Detail is not null && request.Detail.Length > MaxDetailChars)
+            throw new GovernanceValidationException(
+                $"The detail is too long (limit {MaxDetailChars} characters).");
+
+        var occurred = request.OccurredUtc.HasValue
+            ? DateTime.SpecifyKind(request.OccurredUtc.Value, DateTimeKind.Utc)
+            : now;
+        if (occurred > now)
+            occurred = now;
+
+        return new GovernanceAuditEventEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenant,
+            SessionId = request.SessionId.Trim(),
+            RunId = request.RunId,
+            Category = category,
+            EventType = eventType,
+            Actor = actor,
+            Detail = request.Detail,
+            OccurredUtc = occurred,
+            RecordedUtc = now,
+        };
+    }
+
+    private static GovernanceAuditEventDto ToDto(GovernanceAuditEventEntity e) => new()
+    {
+        Id = e.Id,
+        SessionId = e.SessionId,
+        RunId = e.RunId,
+        Category = e.Category,
+        EventType = e.EventType,
+        Actor = e.Actor,
+        Detail = e.Detail,
+        OccurredUtc = e.OccurredUtc,
+        RecordedUtc = e.RecordedUtc,
+    };
+}


### PR DESCRIPTION
## Structured intervention + permission/sandbox audit trail (governance spine item 4, thefrederiksen/devthrottle_internal#856)

Spine item 4 of the governance outcome-spine: a durable, structured audit trail of the decisions the fleet makes under supervision — the agent needing a human, and the permission/sandbox posture it ran under. Everything here is an **explicitly-recorded event, never inferred from a prose transcript** (the thefrederiksen/devthrottle_internal#856 principle), and no field ever carries prompt content.

Distinct from the phase-1 event ledger (which records *activity/duration* transitions), this table records *decisions and interventions*.

### `governance_audit_events` — append-only, two categories
- **intervention** — the agent needed a human and what the human did: `needed` (the need/ask), `human-rescued`, `human-redirected`, `human-cancelled`, `resolved`.
- **permission** — permission/sandbox posture: `permission-requested`, `permission-granted`, `permission-denied`, `mode-observed` (the effective sandbox/approval mode), and `elevated-run-started` / `elevated-run-ended` bracketing an elevated run (its duration derived from the pair, so the trail stays purely event-based).

### Integrity
- **Append-only by contract** — no update, no delete. An audit trail you can rewrite is not an audit trail.
- **Event type is validated against its category** — a permission type cannot be logged as an intervention.
- **A human or permission decision requires an actor** — "who decided" is an audit fact that is never null on `human-rescued`/`redirected`/`cancelled` and `permission-granted`/`denied`.
- `detail` is a short control-flow note (a permission name, a mode, a reason), capped, **never prompt content**.
- `SessionId` / `RunId` are value references, never foreign keys — the trail outlives the session and run it records.

### Conventions & coordination
- Derives from `TenantScopedEntity`; composite indexes lead with `tenant_id` (session, run, and category read paths) for the Phase B multi-tenant filter. Append + batched append (change-detection off, `tenant_id` per row) + read, mirroring the event ledger. Provider-agnostic.
- Migration `AddGovernanceAuditEvents` — additive `CreateTable` only, generated as the chain tail after `AddMissionNotes`, serialized through the single fleet migration slot with the Hosted Gateway Architect. The clean-DB migrate applies all nine migrations in order.

### Scope boundary
This PR is the persistence spine + store + REST + tests. The live capture wiring (emitting these events from the Director's permission/intervention seams) is owned by the parallel capture-wiring workstream, deliberately separate.

Third of the four spine phases. Next: the weekly Outcome Ledger report (reads the run tables + the event ledger + the spend layer + this audit trail).
