### PR TITLE
feat(gateway): fill session_spend at turn-end (governance capture, #1771)

### DIFF
--- a/src/CcDirector.Gateway.Tests/SessionSpendEmitterTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionSpendEmitterTests.cs
@@ -1,0 +1,105 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Governance;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tests for the turn-end spend emitter (issue #1771, spine item 3). The claims that matter: a Claude
+/// snapshot records real tokens labelled subscription-included; a snapshot with no token totals is still
+/// recorded but as UNKNOWN coverage (never a fabricated zero-with-captured); a non-Claude agent is labelled
+/// unknown (never a guessed "metered"); and the agent label is normalised to a lowercase family.
+/// </summary>
+public sealed class SessionSpendEmitterTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    private (SessionSpendEmitter Emitter, SessionSpendStore Store) NewEmitter()
+    {
+        var store = new SessionSpendStore(_h.Open());
+        return (new SessionSpendEmitter(store), store);
+    }
+
+    private static SessionDto Session(
+        string id = "sess-1", string agent = "ClaudeCode", TokenTotalsDto? totals = null) => new()
+    {
+        SessionId = id,
+        Agent = agent,
+        RepoPath = "D:/repo",
+        CurrentModel = "claude-opus-4-8",
+        TokenTotals = totals,
+    };
+
+    [Theory]
+    [InlineData("ClaudeCode", "claude")]
+    [InlineData("claude", "claude")]
+    [InlineData("Codex", "codex")]
+    [InlineData("Pi", "pi")]
+    [InlineData("", "unknown")]
+    [InlineData(null, "unknown")]
+    public void ResolveAgentKind_normalises_to_a_lowercase_family(string? agent, string expected)
+    {
+        Assert.Equal(expected, SessionSpendEmitter.ResolveAgentKind(agent));
+    }
+
+    [Fact]
+    public void ResolveBillingMode_labels_claude_subscription_and_others_unknown()
+    {
+        Assert.Equal(SessionBillingMode.SubscriptionIncluded, SessionSpendEmitter.ResolveBillingMode("claude"));
+        Assert.Equal(SessionBillingMode.Unknown, SessionSpendEmitter.ResolveBillingMode("codex"));
+        Assert.Equal(SessionBillingMode.Unknown, SessionSpendEmitter.ResolveBillingMode("pi"));
+    }
+
+    [Fact]
+    public void Emit_records_real_tokens_as_subscription_included_for_claude()
+    {
+        var (emitter, store) = NewEmitter();
+        emitter.Emit(Session(totals: new TokenTotalsDto
+        {
+            InputTokens = 10,
+            OutputTokens = 100,
+            CacheReadTokens = 5,
+            CacheCreationTokens = 3,
+        }));
+
+        var dto = store.Get("sess-1");
+        Assert.NotNull(dto);
+        Assert.Equal("claude", dto!.AgentKind);
+        Assert.True(dto.TokensCaptured);
+        Assert.Equal(100, dto.OutputTokens);
+        Assert.Equal(SessionBillingMode.SubscriptionIncluded, dto.BillingMode);
+        // Subscription traffic never carries a fabricated dollar figure.
+        Assert.Null(dto.MeteredCostMicros);
+    }
+
+    [Fact]
+    public void Emit_records_a_gauge_only_session_as_uncaptured_not_zero()
+    {
+        var (emitter, store) = NewEmitter();
+        // A driver that reports no additive totals (context gauge only) still gets a row, disclosed as
+        // uncaptured so the coverage summary counts the gap rather than reading it as a real zero.
+        emitter.Emit(Session(id: "sess-2", agent: "Codex", totals: null));
+
+        var dto = store.Get("sess-2");
+        Assert.NotNull(dto);
+        Assert.Equal("codex", dto!.AgentKind);
+        Assert.False(dto.TokensCaptured);
+        Assert.Equal(0, dto.OutputTokens);
+        Assert.Equal(SessionBillingMode.Unknown, dto.BillingMode);
+    }
+
+    [Fact]
+    public void Emit_upserts_cumulative_totals_by_overwrite()
+    {
+        var (emitter, store) = NewEmitter();
+        emitter.Emit(Session(totals: new TokenTotalsDto { OutputTokens = 100 }));
+        emitter.Emit(Session(totals: new TokenTotalsDto { OutputTokens = 250 })); // a later cumulative read
+
+        var dto = store.Get("sess-1");
+        Assert.Equal(250, dto!.OutputTokens); // overwrite, not add
+        Assert.Single(store.List());
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -345,6 +345,8 @@ public sealed class GatewayHost : IAsyncDisposable
     // The append-only governance audit trail (issue #1771, spine item 4): structured intervention +
     // permission/sandbox decisions, recorded as events, never inferred from transcripts.
     private readonly Governance.GovernanceAuditLog _governanceAudit;
+    // Fills session_spend at each turn-end from the pushed roster snapshot (issue #1771, spine item 3).
+    private readonly Governance.SessionSpendEmitter _sessionSpendEmitter;
     private readonly CronJobStore _cronJobs;
     private readonly CronRunHistoryStore _cronRuns;
     private readonly Running.CronEngine _cronEngine;
@@ -624,6 +626,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // The governance audit trail (issue #1771, spine item 4): append-only intervention + permission/
         // sandbox decisions on the EF data layer, so a Gateway restart never loses a recorded audit fact.
         _governanceAudit = new Governance.GovernanceAuditLog(_gatewayDb);
+        _sessionSpendEmitter = new Governance.SessionSpendEmitter(_sessionSpend);
         // Snooze Length mission: the persisted snooze registry (sessionId -> SnoozeUntilUtc), now in the
         // snoozes table of the EF data layer - a Gateway restart re-arms every pending snooze from the
         // database; an entry already past its time simply fires on the first sweep. The path argument is the
@@ -1162,6 +1165,20 @@ public sealed class GatewayHost : IAsyncDisposable
         _turnEndWatcher = new TurnEndWatcher(
             onTurnEnd: signal =>
             {
+                // Governance capture (issue #1771, spine item 3): record this session's cumulative spend at
+                // turn-end from the pushed roster snapshot. Runs for EVERY session (not just voice), and is
+                // isolated so a spend hiccup never breaks the voice refresh below - the failure is logged loud,
+                // not swallowed into a fabricated value.
+                try
+                {
+                    if (PushedSessions.TryLocate(TenantId.Local, signal.SessionId, _streamStaleAfter) is { } spendLoc)
+                        _sessionSpendEmitter.Emit(spendLoc.Session);
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[GatewayHost] turn-end spend emit FAILED: sid={signal.SessionId}: {ex.Message}");
+                }
+
                 // Voice sessions (issue #531): the turn just finished on its own, so re-make the
                 // spoken summary + audio in the background. It is then "voice ready" in the session
                 // list with no wait. Non-voice sessions do nothing here - the watcher is voice-only.

--- a/src/CcDirector.Gateway/Governance/SessionSpendEmitter.cs
+++ b/src/CcDirector.Gateway/Governance/SessionSpendEmitter.cs
@@ -1,0 +1,88 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Governance;
+
+/// <summary>
+/// Fills the <c>session_spend</c> table (issue #1771, spine item 3) at each turn-end. The Director reads the
+/// driver's cumulative token usage locally and stamps it on the session; that snapshot rides the roster push
+/// up to the Gateway as <see cref="SessionDto.TokenTotals"/>. This emitter takes one located session snapshot
+/// at turn-end and upserts its cumulative spend through <see cref="SessionSpendStore"/> - the totals are
+/// running sums, so an overwrite is an idempotent upsert and calling it every turn-end is safe.
+///
+/// It keeps the honest split (never fabricates a dollar figure):
+///  - Raw tokens are recorded when the driver reports additive usage; a driver that reports only a context
+///    gauge (<see cref="SessionDto.TokenTotals"/> null) is recorded as <c>TokensCaptured=false</c> - UNKNOWN
+///    coverage, never a real zero.
+///  - The billing-mode label says which bucket the tokens fall in. A coding agent on the owner's Claude
+///    subscription is <see cref="SessionBillingMode.SubscriptionIncluded"/> (which is WHY it carries no
+///    per-session dollar); any other agent's mode is not determinable from the roster snapshot yet, so it is
+///    honestly <see cref="SessionBillingMode.Unknown"/> - never a guessed "metered".
+/// </summary>
+public sealed class SessionSpendEmitter
+{
+    private readonly SessionSpendStore _store;
+
+    public SessionSpendEmitter(SessionSpendStore store)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+    }
+
+    /// <summary>
+    /// Record one session's cumulative spend from a turn-end roster snapshot. A snapshot with no
+    /// <see cref="SessionDto.TokenTotals"/> is still recorded, with <c>TokensCaptured=false</c>, so the
+    /// coverage disclosure counts it as an unmeasured session rather than dropping it silently.
+    /// </summary>
+    public void Emit(SessionDto session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        var totals = session.TokenTotals;
+        var tokensCaptured = totals is not null;
+        var agentKind = ResolveAgentKind(session.Agent);
+
+        var request = new RecordSessionSpendRequest
+        {
+            SessionId = session.SessionId,
+            AgentKind = agentKind,
+            Model = session.CurrentModel,
+            RepoPath = string.IsNullOrWhiteSpace(session.RepoPath) ? null : session.RepoPath,
+            TokensCaptured = tokensCaptured,
+            InputTokens = totals?.InputTokens ?? 0,
+            OutputTokens = totals?.OutputTokens ?? 0,
+            CacheReadTokens = totals?.CacheReadTokens ?? 0,
+            CacheCreationTokens = totals?.CacheCreationTokens ?? 0,
+            BillingMode = ResolveBillingMode(agentKind),
+        };
+
+        _store.Record(request);
+        FileLog.Write($"[SessionSpendEmitter] Emit: session={session.SessionId}, agent={agentKind}, " +
+                      $"tokensCaptured={tokensCaptured}, billing={request.BillingMode}");
+    }
+
+    /// <summary>
+    /// Normalise the roster's agent label (<c>ClaudeCode</c>, <c>Codex</c>, ...) to a lowercase agent family
+    /// so a report groups a session by its agent consistently. An unrecognised or empty value is passed
+    /// through lowercased (never dropped), so a new agent kind still records rather than vanishing.
+    /// </summary>
+    public static string ResolveAgentKind(string? agent)
+    {
+        var a = (agent ?? "").Trim().ToLowerInvariant();
+        return a switch
+        {
+            "" => "unknown",
+            "claudecode" or "claude" => "claude",
+            _ => a,
+        };
+    }
+
+    /// <summary>
+    /// The honest billing-mode label. A Claude coding session runs on the owner's subscription, so it is
+    /// subscription-included (no marginal dollar cost, which is WHY there is no per-session dollar figure) -
+    /// never a fabricated "metered". Any other agent's mode is not yet determinable from the roster snapshot,
+    /// so it is "unknown" rather than a guess. A precise subscription-versus-API-key signal is a follow-on
+    /// that needs a Director-side flag on the pushed session.
+    /// </summary>
+    public static string ResolveBillingMode(string agentKind) =>
+        agentKind == "claude" ? SessionBillingMode.SubscriptionIncluded : SessionBillingMode.Unknown;
+}


### PR DESCRIPTION
## What

The `session_spend` table (governance spine item 3, thefrederiksen/devthrottle_internal#856) shipped empty. This wires the emitter that fills it.

At each turn-end the Gateway locates the pushed session snapshot and upserts its cumulative spend via `SessionSpendStore`:

- **Real tokens** for a token-reporting driver, labelled **subscription-included** for Claude (which is why it carries no per-session dollar figure).
- A **context-gauge-only driver** (Codex/Pi, no additive `TokenTotals`) is recorded as **uncaptured coverage**, never a fabricated zero.
- **No dollar figure is ever invented** - the metered-dollar column stays null pending the thefrederiksen/devthrottle_internal#812 rate card.

The emit runs for **every** session (not just voice) and is **isolated** so a spend hiccup can never break the turn-end voice refresh - the failure is logged loud, not swallowed into a fabricated value.

## Scope

Write-only to the existing `session_spend` table - **no EF migration**, so it does not contend for the single migration slot (held by the phase-3 build).

## Tests

New `SessionSpendEmitterTests` (10 cases): agent-family normalization, billing labels, real-token capture, gauge-only coverage, cumulative overwrite. Full Gateway suite green (2650) pre-rebase; rebuilt and emitter tests green post-rebase onto the phase-3 base.

Follow-on: the periodic credit-ledger snapshot writer (fills `account_hosted_ai_spend`) and the state-transition event emitter (fills the phase-1 event ledger).
