### PR TITLE
TTS fallback: generic backup-voice notice on the Gateway + clients (Phase 2)

### DIFF
--- a/apps/cockpit/src/sessions/VoiceTab.tsx
+++ b/apps/cockpit/src/sessions/VoiceTab.tsx
@@ -31,6 +31,13 @@ export function VoiceTab({ sessionId }: { sessionId: string | undefined }) {
           <div className="composer-error" role="alert">{v.error}</div>
         )}
 
+        {/* TTS fallback: the Gateway folded a generic "switched to a backup voice" notice onto this turn's
+            ready clip (the primary provider was temporarily overloaded). Rendered VERBATIM - never names a
+            provider. Shows above whichever voice card is up while the backup clip is the current one. */}
+        {v.voiceDisplay?.voiceFallbackNotice != null && v.voiceDisplay.voiceFallbackNotice !== "" && (
+          <div className="voice-fallback-note" role="status">{v.voiceDisplay.voiceFallbackNotice}</div>
+        )}
+
         {/* A. OFF - one clear "Switch to voice mode" button; only ever shown once a poll has confirmed
             the session is NOT in voice mode. */}
         {!v.voiceOn && v.pollDone && (

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -1848,6 +1848,18 @@ body {
   margin: 0 0 12px;
 }
 
+/* TTS fallback: the generic "switched to a backup voice" heads-up. A calm amber note - the voice is
+   working (a success), just via the backup provider. */
+.voice-fallback-note {
+  background: rgba(234, 179, 8, 0.12);
+  border: 1px solid rgba(234, 179, 8, 0.4);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin: 0 0 12px;
+  font-size: 13px;
+}
+
 .voice-narr-title {
   font-size: 14px;
   font-weight: 700;

--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -162,6 +162,14 @@ export function VoiceMode() {
           <div className="banner banner-error" role="alert">{error}</div>
         )}
 
+        {/* TTS fallback: the Gateway folded a generic "switched to a backup voice" notice onto this turn's
+            ready clip (the primary provider was temporarily overloaded). Rendered VERBATIM - the client
+            derives nothing and never names a provider. Shows above whichever voice card is up, for as long
+            as the backup clip is the current one (downloading, then speaking). */}
+        {vd?.voiceFallbackNotice != null && vd.voiceFallbackNotice !== "" && (
+          <div className="banner voice-fallback-note" role="status">{vd.voiceFallbackNotice}</div>
+        )}
+
         {/* A. OFF - one clear "Switch to voice mode" button. Only ever shown once a poll has confirmed
             the session is NOT in voice mode, so the screen never flashes OFF then flips (issue #1015). */}
         {!voiceOn && pollDone && (

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -117,6 +117,14 @@ body {
   color: var(--text);
 }
 
+/* TTS fallback: the generic "switched to a backup voice" heads-up. A calm, non-alarming amber note -
+   the voice is working (a success), just via the backup provider. */
+.voice-fallback-note {
+  background: rgba(234, 179, 8, 0.12);
+  border: 1px solid rgba(234, 179, 8, 0.4);
+  color: var(--text);
+}
+
 .banner-action {
   display: flex;
   align-items: center;

--- a/docs/cencon/proof/tts-fallback-phase2/qa-report.html
+++ b/docs/cencon/proof/tts-fallback-phase2/qa-report.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Mission QA Report - Text-to-Speech Fallback (Phase 2: Gateway notice)</title>
+<style>
+  body { font-family: Georgia, 'Times New Roman', serif; max-width: 1040px; margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; line-height: 1.5; }
+  h1 { border-bottom: 3px solid #1a1a1a; padding-bottom: .4rem; }
+  h2 { margin-top: 2.2rem; border-bottom: 1px solid #999; padding-bottom: .2rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: .92rem; }
+  th, td { border: 1px solid #bbb; padding: .45rem .6rem; text-align: left; vertical-align: top; }
+  th { background: #f0ede6; }
+  code, pre { font-family: Consolas, monospace; background: #f6f4ef; }
+  pre { padding: .6rem; overflow-x: auto; border: 1px solid #ddd; font-size: .85rem; }
+  .pass { color: #14601c; font-weight: bold; }
+  .verdict { background: #eaf4ea; border: 2px solid #14601c; padding: 1rem 1.2rem; margin: 1.5rem 0; font-size: 1.05rem; }
+  .decision { background: #eef3fb; border: 2px solid #2b5fa5; padding: 1rem 1.2rem; margin: 1.5rem 0; }
+  .note { background: #fdf6e3; border: 1px solid #c9b458; padding: .6rem .8rem; margin: .8rem 0; font-size: .92rem; }
+  /* Faithful mock of the mobile Voice card - the exact notice string + the exact CSS I added. */
+  .mock { max-width: 380px; margin: 1rem 0; background: #14161a; border-radius: 14px; padding: 16px; font-family: system-ui, sans-serif; color: #e8e8ea; }
+  .mock .fallback-note { background: rgba(234,179,8,0.12); border: 1px solid rgba(234,179,8,0.4); color: #e8e8ea; border-radius: 8px; padding: 10px 12px; margin: 0 0 12px; font-size: 13px; }
+  .mock .statusbar { margin-bottom: 10px; }
+  .mock .state-green { display: inline-block; background: rgba(34,197,94,0.15); border: 1px solid rgba(34,197,94,0.5); color: #86efac; border-radius: 999px; padding: 3px 12px; font-size: 13px; font-weight: 600; }
+  .mock .player { display: flex; align-items: center; gap: 12px; margin-top: 8px; }
+  .mock .tri { width: 44px; height: 44px; border-radius: 999px; background: #2b5fa5; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 18px; }
+  .mock .clock { font-size: 12px; color: #9aa0a6; }
+</style>
+</head>
+<body>
+<h1>Mission QA Report &mdash; Text-to-Speech Fallback (Phase 2)</h1>
+<p>
+<strong>Mission:</strong> Wingman voice fails over to a backup provider when the primary speech provider is down; the user is told, generically, and never charged extra.<br>
+<strong>Phase:</strong> 2 of 2 &mdash; the Gateway + clients transparency notice (repo <code>devthrottle</code>). Phase 1 (the cloud failover + billing, repo <code>devthrottle_internal</code>) is <strong>already merged</strong> (PR #403).<br>
+<strong>Branch:</strong> <code>mission/tts-fallback-notice</code> off <code>origin/main</code> (<code>3e789960</code>), commit <code>5c1cafdd</code><br>
+<strong>Date:</strong> 2026-07-18<br>
+<strong>Author of this report:</strong> Architect session, run autonomously to this report per the mission method.
+</p>
+
+<div class="verdict">
+<strong>VERDICT: <span class="pass">PASS</span> (Phase 2 ready to merge, pending owner acceptance).</strong><br>
+When the cloud proxy fails a synthesis over to the backup, it sets an out-of-band header on the success. The Gateway now reads it and folds ONE generic, provider-neutral notice onto the session's voice verdict, which every client renders verbatim. A fallback is treated as a SUCCESS-with-a-note &mdash; it never becomes an outage/red state and never names a provider. Verified by the canonical fold unit tests plus a new service-level header-read test (<strong>voice/wingman/turn-end suite: 263 passed, 0 failed</strong>), all three client packages typechecking clean, and the mobile app building.
+</div>
+
+<div class="decision">
+<strong>What I need from you (the one decision):</strong> approve the notice wording below and accept this report. On your &ldquo;accepted,&rdquo; I open the Phase 2 PR and squash-merge to <code>origin/main</code>. That completes the whole mission. Nothing merges before you accept.
+</div>
+
+<h2>The notice the user sees (owner-approved wording)</h2>
+<p>Single-source on the Gateway (<code>VoiceDisplayFold.BackupVoiceNotice</code>), rendered verbatim by every client. It names no provider (the host non-disclosure rule has no carve-out) and states there is no extra charge, which is true &mdash; Phase 1 bills the member the normal Kokoro rate on a fallback.</p>
+<blockquote style="border-left:4px solid #c9b458;padding-left:1rem;font-size:1.05rem;">
+&ldquo;Some voice providers are overloaded right now, so we switched you to a backup voice. No extra charge.&rdquo;
+</blockquote>
+
+<h3>How it renders (faithful mock of the mobile Voice card)</h3>
+<p>The exact notice string and the exact CSS I added, showing how the amber heads-up sits above the playable (green &ldquo;Voice ready&rdquo;) card. This is a faithful reproduction of the render; the real component (<code>apps/mobile/src/pages/VoiceMode.tsx</code>) prints <code>vd.voiceFallbackNotice</code> through the same <code>.voice-fallback-note</code> class.</p>
+<div class="mock">
+  <div class="fallback-note">Some voice providers are overloaded right now, so we switched you to a backup voice. No extra charge.</div>
+  <div class="statusbar"><span class="state-green">Voice ready</span></div>
+  <div class="player">
+    <span class="tri">&#9654;</span>
+    <span class="clock">0:00 / 0:12</span>
+  </div>
+</div>
+
+<h2>Brief adaptation (validate-against-current-product)</h2>
+<div class="note">
+The brief (written 2026-07-17) said the Gateway must read the header on success and record it &ldquo;without touching <code>_ttsGate</code>&rdquo; (the shared TTS cooldown). By 2026-07-18 that was stale: <strong>all shared cooldown gates were removed on 2026-07-17</strong> (<code>WingmanVoiceService</code> now has no fleet-wide gate at all). So there is no gate to avoid arming. The <em>intent</em> &mdash; a fallback is a success-with-a-note, never an outage state &mdash; is preserved and is simpler now: the note rides the normal ready path and the fold never converts it into a red/unavailable verdict (asserted by a test). No owner decision was needed; the intent was unambiguous.
+</div>
+
+<h2>Acceptance criteria &mdash; Expected vs Actual</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (evidence)</th><th>Result</th></tr>
+<tr><td>1</td><td>Gateway reads the fallback header on a success</td><td>Header present &rarr; the ready clip is marked served-via-fallback; header absent &rarr; normal clip</td><td><code>WingmanVoiceFallbackTests</code>: header present &rarr; <code>ServedViaFallbackFor</code> true; absent &rarr; false. Driven through the real <code>StoreSpokenAsync</code>/<code>TtsAsync</code> with a stub transport.</td><td class="pass">PASS</td></tr>
+<tr><td>2</td><td>A fallback is a success, never an outage</td><td>Header present &rarr; still HasVoice; <em>not</em> an unavailable/ServiceDown state</td><td><code>WingmanVoiceFallbackTests</code>: <code>HasVoice</code> true and <code>VoiceUnavailableFor</code> null. Fold test: a fallback flag with no audio never overrides a real ServiceDown.</td><td class="pass">PASS</td></tr>
+<tr><td>3</td><td>ONE generic notice, folded once on the Gateway</td><td>Ready + fallback &rarr; <code>VoiceFallbackNotice</code> = the single-source generic string; ready + no fallback &rarr; null</td><td><code>VoiceDisplayFoldTests</code>: notice equals <code>BackupVoiceNotice</code> on ready+fallback; null otherwise; the verdict stays green/ready/CanPlay.</td><td class="pass">PASS</td></tr>
+<tr><td>4</td><td>Names no provider (non-disclosure, no carve-out)</td><td>The notice never contains a provider name</td><td>Fold test asserts the notice does not contain &ldquo;openai&rdquo; (case-insensitive) and does say &ldquo;backup voice&rdquo;.</td><td class="pass">PASS</td></tr>
+<tr><td>5</td><td>Survives a gateway restart</td><td>The fallback fact persists with the clip</td><td><code>WingmanVoiceFallbackTests</code>: after a fresh service loads the durable cache, <code>ServedViaFallbackFor</code> is still true.</td><td class="pass">PASS</td></tr>
+<tr><td>6</td><td>Every client renders it verbatim</td><td>The mobile Voice screen and cockpit Voice tab show the notice; no client re-derives it</td><td>Both render <code>voiceFallbackNotice</code> through a one-line conditional (verbatim). All three client packages (<code>client-core</code>, <code>mobile</code>, <code>cockpit</code>) typecheck clean; the mobile app builds.</td><td class="pass">PASS</td></tr>
+<tr><td>7</td><td>No regression to the existing voice fold</td><td>All existing voice states unchanged</td><td>Full voice/wingman/turn-end suite 263 passed, 0 failed. The new fold param defaults to false, so every existing state is byte-identical.</td><td class="pass">PASS</td></tr>
+</table>
+
+<h2>A real test-isolation bug I found and fixed (in the test harness)</h2>
+<p>My first broad run showed two <em>existing</em> tests failing only when my new test class ran in parallel. Root cause: these tests place the persist file directly in <code>Path.GetTempPath()</code>, so they all share one <code>TEMP/voice-audio</code> durable cache dir &mdash; a session id one test writes is loaded by another test's fresh service constructor (<code>LoadReadyAudio</code>). My new tests write the same <code>sid-1</code> concurrently. Fix: my tests use a unique <em>subdirectory</em> per test, so the cache dir never collides. After the fix the full set is green (263/0). I did not alter the existing tests (their latent sharing is pre-existing and safe sequentially); I only kept my additions from contaminating them.</p>
+
+<h2>Files changed (Phase 2)</h2>
+<table>
+<tr><th>File</th><th>Change</th></tr>
+<tr><td><code>Gateway.Contracts/VoiceDisplay.cs</code></td><td>New <code>VoiceFallbackNotice</code> DTO field (the finished string clients render).</td></tr>
+<tr><td><code>Gateway/Wingman/VoiceDisplayFold.cs</code></td><td>Single-source <code>BackupVoiceNotice</code> const; new <code>servedViaFallback</code> param; set the notice ONLY on the green ready verdict.</td></tr>
+<tr><td><code>Gateway/Wingman/WingmanVoiceService.cs</code></td><td>Read the <code>X-DevThrottle-TTS-Fallback</code> header on a success; carry it through <code>TtsResult</code> &rarr; <code>VoiceReady.ServedViaFallback</code> (persisted); new <code>ServedViaFallbackFor</code> resolver.</td></tr>
+<tr><td><code>Gateway/Api/GatewayEndpoints.cs</code>, <code>Gateway/GatewayHost.cs</code></td><td>Thread a <code>servedViaFallbackFor</code> resolver into the fold.</td></tr>
+<tr><td><code>apps/mobile/.../VoiceMode.tsx</code> + <code>styles.css</code></td><td>Render the notice above the voice card; amber <code>.voice-fallback-note</code> style.</td></tr>
+<tr><td><code>apps/cockpit/.../VoiceTab.tsx</code> + <code>styles.css</code></td><td>Same, on the cockpit Voice tab.</td></tr>
+<tr><td><code>packages/client-core/.../schema.ts</code></td><td>Generated client type carries <code>voiceFallbackNotice</code>.</td></tr>
+<tr><td><code>Gateway.Tests/VoiceDisplayFoldTests.cs</code>, <code>WingmanVoiceFallbackTests.cs</code> (new)</td><td>The fold + service-level proof.</td></tr>
+</table>
+
+<h2>Build / verify result</h2>
+<table>
+<tr><th>Check</th><th>Result</th></tr>
+<tr><td>Gateway + tests build (<code>dotnet build</code>)</td><td class="pass">0 warnings, 0 errors</td></tr>
+<tr><td>Voice/Wingman/TurnEnd tests (<code>dotnet test</code>)</td><td class="pass">263 passed, 0 failed</td></tr>
+<tr><td>Client typecheck (<code>client-core</code>, <code>mobile</code>, <code>cockpit</code>)</td><td class="pass">clean</td></tr>
+<tr><td>Mobile app build (<code>tsc + vite build</code>)</td><td class="pass">built</td></tr>
+</table>
+
+<h2>Mission complete after this merges</h2>
+<p>Phase 1 (cloud failover + billing) is merged. Phase 2 (this) closes the loop: the user hears a backup voice instead of silence during a primary outage, learns generically what happened, and is charged nothing extra &mdash; with no provider ever named. The separate TTS-pileup root-cause work remains complementary: it reduces how often we need to fall over at all.</p>
+
+</body>
+</html>

--- a/packages/client-core/src/api/schema.ts
+++ b/packages/client-core/src/api/schema.ts
@@ -7461,6 +7461,7 @@ export interface components {
             canPlay?: boolean;
             canGenerate?: boolean;
             reason?: null | components["schemas"]["HostedAiMessageDto"];
+            voiceFallbackNotice?: string | null;
         };
         InputStatBucketDto: {
             modality?: string;

--- a/src/CcDirector.Gateway.Contracts/VoiceDisplay.cs
+++ b/src/CcDirector.Gateway.Contracts/VoiceDisplay.cs
@@ -54,4 +54,15 @@ public sealed class VoiceDisplay
     /// <c>blocked</c> - the same single-source <see cref="HostedAiMessageDto"/> the roster uses. Null
     /// otherwise.</summary>
     public HostedAiMessageDto? Reason { get; set; }
+
+    /// <summary>
+    /// The optional GENERIC heads-up shown when this turn's ready clip was made by the BACKUP voice
+    /// provider (the primary was temporarily overloaded and the cloud proxy quietly failed over - see the
+    /// TTS-fallback mission). Null in the normal case. It is the finished, verbatim string every client
+    /// shows AS-IS next to the voice card; the Gateway computes it once (VoiceDisplayFold) so no client
+    /// re-derives it. It NAMES NO PROVIDER and states there is no extra charge, because the member is
+    /// billed the normal rate on a fallback. A success-with-a-note, not a failure: it rides the green
+    /// <c>ready</c> verdict, never a red/unavailable one.
+    /// </summary>
+    public string? VoiceFallbackNotice { get; set; }
 }

--- a/src/CcDirector.Gateway.Tests/VoiceDisplayFoldTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceDisplayFoldTests.cs
@@ -128,4 +128,42 @@ public sealed class VoiceDisplayFoldTests
         Assert.Equal("notReady", d.Kind);
         Assert.True(d.CanGenerate);
     }
+
+    // --- TTS fallback: the generic backup-voice notice (mission Phase 2) ------------------------------
+
+    [Fact]
+    public void ServedViaFallback_IsStillReady_WithTheGenericNotice_NoProviderNamed()
+    {
+        // A backup-served clip is a SUCCESS-with-a-note: a normal green, playable "ready", plus the one
+        // generic notice line. It is NOT an outage state and names no provider.
+        var d = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: true, generating: false, unavailable: null, nothingToNarrate: false, servedViaFallback: true);
+        Assert.Equal("ready", d.Kind);
+        Assert.Equal("green", d.Tone);
+        Assert.True(d.CanPlay);
+        Assert.False(d.CanGenerate);
+        Assert.Equal(VoiceDisplayFold.BackupVoiceNotice, d.VoiceFallbackNotice);
+        // Host non-disclosure has no carve-out: the notice must never name the backup provider.
+        Assert.DoesNotContain("openai", d.VoiceFallbackNotice!, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("backup voice", d.VoiceFallbackNotice!, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void NotServedViaFallback_HasNoNotice()
+    {
+        // The normal case: a ready clip made by the primary provider carries no notice.
+        var d = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: true, generating: false, unavailable: null, nothingToNarrate: false, servedViaFallback: false);
+        Assert.Equal("ready", d.Kind);
+        Assert.Null(d.VoiceFallbackNotice);
+    }
+
+    [Fact]
+    public void ServedViaFallback_NeverRidesAnOutageState()
+    {
+        // Defensive: a fallback flag with no playable audio must NEVER turn a real outage into a
+        // "ready + notice". The notice only ever attaches to the green ready verdict; an answered
+        // ServiceDown stays ServiceDown with no notice (a fallback SUCCESS never becomes an outage).
+        var d = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false, unavailable: HostedAiState.ServiceDown, nothingToNarrate: false, servedViaFallback: true);
+        Assert.Equal("serviceDown", d.Kind);
+        Assert.Null(d.VoiceFallbackNotice);
+    }
 }

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceFallbackTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceFallbackTests.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using CcDirector.AgentBrain;
+using CcDirector.Core;
+using CcDirector.Gateway.Wingman;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// TTS fallback (mission Phase 2): when the cloud speech proxy quietly fails the primary voice provider
+/// over to the backup, it sets the out-of-band <c>X-DevThrottle-TTS-Fallback</c> response header on the
+/// SUCCESS. The Gateway must read that header, record it on the ready clip as a success-with-a-note, and
+/// surface it through <see cref="WingmanVoiceService.ServedViaFallbackFor"/> for the VoiceDisplay fold -
+/// WITHOUT ever treating it as an outage (no VoiceUnavailable state). The header's presence is the whole
+/// signal; its value is never shown to a user.
+/// </summary>
+public sealed class WingmanVoiceFallbackTests
+{
+    /// <summary>A speech upstream that returns 200 + audio bytes, optionally with the fallback header.</summary>
+    private sealed class SpeechStub(byte[] audio, bool withFallbackHeader) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var resp = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(audio) };
+            resp.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("audio/mpeg");
+            if (withFallbackHeader)
+                resp.Headers.TryAddWithoutValidation("X-DevThrottle-TTS-Fallback", "openai");
+            return Task.FromResult(resp);
+        }
+    }
+
+    private static WingmanVoiceService ServiceWith(HttpMessageHandler handler, string persistPath)
+    {
+        var vault = new KeyVault(Path.Combine(Path.GetTempPath(), "wmvfb-" + Guid.NewGuid().ToString("N") + ".vault"));
+        vault.Set("OPENAI_API_KEY", "sk-test");
+        vault.Set("DEVTHROTTLE_API_KEY", "dt_live_test");
+        // StoreSpokenAsync takes the spoken text directly, so the brain is never reached here.
+        Func<Core.Configuration.WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
+            (_, _) => throw new InvalidOperationException("the brain must not be reached by a fallback header test");
+        return new WingmanVoiceService(brain, vault, persistPath, ttsHttpClient: new HttpClient(handler));
+    }
+
+    // A unique SUBDIRECTORY per test, not a bare temp filename. The service derives its durable audio
+    // cache dir from the persist path's DIRECTORY (".../voice-audio"), so tests that drop the persist file
+    // straight in Path.GetTempPath() all share one TEMP/voice-audio - and a session id written by one test
+    // is then loaded by another test's fresh service (LoadReadyAudio runs in the constructor), which breaks
+    // them when classes run in parallel. An isolated directory keeps each test's cache to itself.
+    private static string TempPersist()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "wmvfb-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return Path.Combine(dir, "voice-sessions.json");
+    }
+
+    [Fact]
+    public async Task Synthesis_WithFallbackHeader_MarksTheClipServedViaFallback_AndIsNotAnOutage()
+    {
+        var svc = ServiceWith(new SpeechStub(new byte[] { 1, 2, 3 }, withFallbackHeader: true), TempPersist());
+
+        await svc.StoreSpokenAsync("sid-1", "a spoken summary", "the reply");
+
+        Assert.True(svc.HasVoice("sid-1"));                       // a fallback is a real, playable clip
+        Assert.True(svc.ServedViaFallbackFor("sid-1"));           // ...noted as backup-served
+        Assert.Null(svc.VoiceUnavailableFor("sid-1"));            // ...and NEVER an outage/unavailable state
+    }
+
+    [Fact]
+    public async Task Synthesis_WithoutFallbackHeader_IsANormalReadyClip_NoFallbackNote()
+    {
+        var svc = ServiceWith(new SpeechStub(new byte[] { 1, 2, 3 }, withFallbackHeader: false), TempPersist());
+
+        await svc.StoreSpokenAsync("sid-1", "a spoken summary", "the reply");
+
+        Assert.True(svc.HasVoice("sid-1"));
+        Assert.False(svc.ServedViaFallbackFor("sid-1"));
+    }
+
+    [Fact]
+    public void ServedViaFallback_SurvivesAGatewayRestart()
+    {
+        // The fallback fact is a property of the specific clip, persisted next to its audio so the notice
+        // does not vanish on a gateway restart while that clip is still the current one.
+        var persist = TempPersist();
+        var first = ServiceWith(new SpeechStub(Array.Empty<byte>(), withFallbackHeader: false), persist);
+        first.StoreReadyAudioForTest("sid-1", "spoken", "reply", new byte[] { 9, 9, 9 }, "audio/mpeg", servedViaFallback: true);
+        Assert.True(first.ServedViaFallbackFor("sid-1"));
+
+        // A fresh instance from the SAME persist path reloads the durable cache.
+        var reloaded = ServiceWith(new SpeechStub(Array.Empty<byte>(), withFallbackHeader: false), persist);
+        Assert.True(reloaded.HasVoice("sid-1"));
+        Assert.True(reloaded.ServedViaFallbackFor("sid-1"));
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -51,6 +51,7 @@ internal static class GatewayEndpoints
         Func<string, bool>? voiceAudioReadyFor = null,
         Func<string, Core.HostedAi.HostedAiState?>? voiceUnavailableFor = null,
         Func<string, bool>? nothingToNarrateFor = null,
+        Func<string, bool>? servedViaFallbackFor = null,
         Func<string, bool, DateTime?>? needsYouStampFor = null,
         Func<string, bool>? transcribingFor = null,
         Func<string, string?>? dictationStatusFor = null,
@@ -861,7 +862,8 @@ internal static class GatewayEndpoints
                         hasAudio: s.VoiceAudioReady,
                         generating: s.VoiceGenerating,
                         unavailable: voiceUnavailableFor?.Invoke(s.SessionId),
-                        nothingToNarrate: nothingToNarrateFor?.Invoke(s.SessionId) ?? false);
+                        nothingToNarrate: nothingToNarrateFor?.Invoke(s.SessionId) ?? false,
+                        servedViaFallback: servedViaFallbackFor?.Invoke(s.SessionId) ?? false);
                     // Orange "Transcribing..." while a dictated utterance is uploading/transcribing in
                     // the background for this session (mobile Speak -> Send released the screen). Stamped
                     // BEFORE the NeedsYouSince clock below so the EffectiveColor fold already sees orange

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1429,6 +1429,10 @@ public sealed class GatewayHost : IAsyncDisposable
             // VoiceDisplay so the screen shows an honest "nothing to read aloud" instead of a Generate
             // button that cannot work - the client no longer rules on this.
             nothingToNarrateFor: sid => _voiceService?.NothingToNarrateFor(sid) == true,
+            // TTS fallback: this session's ready clip was made by the backup voice provider (the primary
+            // was overloaded and the cloud proxy failed over). Feeds the folded VoiceDisplay so the screen
+            // shows the generic backup-voice notice. A success-with-a-note, never an outage state.
+            servedViaFallbackFor: sid => _voiceService?.ServedViaFallbackFor(sid) == true,
             // Issue #218: stamp the Gateway-owned NeedsYouSince entry clock onto each session.
             needsYouStampFor: (sid, isRed) => _needsYouClock.Stamp(sid, isRed),
             // Stamp the orange "Transcribing..." flag while a dictated utterance is being uploaded

--- a/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
+++ b/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
@@ -18,6 +18,15 @@ namespace CcDirector.Gateway.Wingman;
 /// </summary>
 public static class VoiceDisplayFold
 {
+    /// <summary>
+    /// The GENERIC, provider-neutral heads-up shown when a ready clip was served by the BACKUP voice
+    /// provider (the TTS-fallback mission). Single-source and rendered verbatim by every client. It
+    /// deliberately names NO provider (the host non-disclosure rule has no carve-out) and states there is
+    /// no extra charge, because the member is billed the normal rate on a fallback. Owner-approved wording.
+    /// </summary>
+    public const string BackupVoiceNotice =
+        "Some voice providers are overloaded right now, so we switched you to a backup voice. No extra charge.";
+
     /// <param name="voiceMode">The session is in voice mode (the Director's authoritative flag).</param>
     /// <param name="agentWorking">The agent is mid-turn (a blue / working activity state). The
     /// finished-turn narration is stale while it works, so this dominates: no play, no Generate button,
@@ -31,7 +40,11 @@ public static class VoiceDisplayFold
     /// waiting on a prompt / menu, so there is genuinely nothing to narrate (a NON-failure, distinct from
     /// "not made yet"). This is the fact that used to reach the client as a bare null and got rendered as
     /// a dead-end Generate button.</param>
-    public static VoiceDisplay Fold(bool voiceMode, bool agentWorking, bool hasAudio, bool generating, HostedAiState? unavailable, bool nothingToNarrate)
+    /// <param name="servedViaFallback">This turn's ready clip was made by the BACKUP voice provider (the
+    /// primary was overloaded and the cloud proxy quietly failed over). A SUCCESS-with-a-note: it only ever
+    /// rides the green <c>ready</c> verdict and adds the generic <see cref="BackupVoiceNotice"/> - it is not
+    /// an unavailable/outage state and changes nothing else. Ignored unless there is playable audio.</param>
+    public static VoiceDisplay Fold(bool voiceMode, bool agentWorking, bool hasAudio, bool generating, HostedAiState? unavailable, bool nothingToNarrate, bool servedViaFallback = false)
     {
         // Not a voice session: the screen shows its own "off" card; there is no verdict to render.
         if (!voiceMode)
@@ -51,7 +64,17 @@ public static class VoiceDisplayFold
         // Playable audio wins over everything below. Even mid-regeneration we keep offering the existing
         // clip (issue #1322: never pull the rug on a listener), so has-audio is checked before generating.
         if (hasAudio)
-            return new VoiceDisplay { Kind = "ready", Tone = "green", Label = "Voice ready", Message = "", CanPlay = true };
+            return new VoiceDisplay
+            {
+                Kind = "ready",
+                Tone = "green",
+                Label = "Voice ready",
+                Message = "",
+                CanPlay = true,
+                // A backup-served clip is still a normal, playable "ready" - just with a generic heads-up.
+                // The failover is never surfaced as an outage; it only adds this one verbatim line.
+                VoiceFallbackNotice = servedViaFallback ? BackupVoiceNotice : null,
+            };
 
         // Being made right now: a calm "on its way", no button (it is already happening).
         if (generating)

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -27,13 +27,13 @@ namespace CcDirector.Gateway.Wingman;
 /// </summary>
 public sealed class WingmanVoiceService
 {
-    public sealed record VoiceReady(string Spoken, string Reply, byte[] Audio, DateTime AtUtc, string ContentType = "audio/mpeg");
+    public sealed record VoiceReady(string Spoken, string Reply, byte[] Audio, DateTime AtUtc, string ContentType = "audio/mpeg", bool ServedViaFallback = false);
 
     /// <summary>The outcome of one text-to-speech synthesis (issue #939): the audio bytes on success,
     /// or the shared <see cref="HostedAiState"/> when hosted AI is unavailable (out of credits, cap
     /// reached, or account setup is incomplete) so the caller can surface it instead of a silent
     /// null. Both null means a generic provider error (logged, no shared state).</summary>
-    private sealed record TtsResult(byte[]? Audio, string? ContentType, HostedAiState? Unavailable);
+    private sealed record TtsResult(byte[]? Audio, string? ContentType, HostedAiState? Unavailable, bool ServedViaFallback = false);
 
     private readonly WingmanTranslator _translator;
     private readonly KeyVault _vault;
@@ -86,7 +86,7 @@ public sealed class WingmanVoiceService
 
     /// <summary>On-disk shape of one ready session's metadata (the audio bytes live next to it as
     /// an .mp3). Persisted so the play triangle / playability survives a gateway restart (issue #553).</summary>
-    private sealed record PersistedVoice(string Spoken, string Reply, DateTime AtUtc, string? ContentType = null);
+    private sealed record PersistedVoice(string Spoken, string Reply, DateTime AtUtc, string? ContentType = null, bool ServedViaFallback = false);
 
     /// <param name="ttsHttpClient">Optional HTTP client for the text-to-speech call (tests inject a stub
     /// over a fake handler, issue #939). A per-call 60-second client is created when null.</param>
@@ -153,7 +153,7 @@ public sealed class WingmanVoiceService
                 var meta = JsonSerializer.Deserialize<PersistedVoice>(File.ReadAllText(metaPath));
                 if (meta is null) continue;
                 var contentType = NormalizeContentType(meta.ContentType) ?? DetectAudioContentType(audio);
-                _ready[sid] = new VoiceReady(meta.Spoken, meta.Reply, audio, meta.AtUtc, contentType);
+                _ready[sid] = new VoiceReady(meta.Spoken, meta.Reply, audio, meta.AtUtc, contentType, meta.ServedViaFallback);
                 loaded++;
             }
             FileLog.Write($"[WingmanVoiceService] loaded {loaded} ready voice audio cache(s) from disk");
@@ -170,7 +170,7 @@ public sealed class WingmanVoiceService
             // .mp3 and the .json) never sees a session ready before its bytes are on disk.
             File.WriteAllBytes(Path.Combine(_audioDir, sid + ".mp3"), ready.Audio);
             File.WriteAllText(Path.Combine(_audioDir, sid + ".json"),
-                JsonSerializer.Serialize(new PersistedVoice(ready.Spoken, ready.Reply, ready.AtUtc, ready.ContentType)));
+                JsonSerializer.Serialize(new PersistedVoice(ready.Spoken, ready.Reply, ready.AtUtc, ready.ContentType, ready.ServedViaFallback)));
         }
         catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] save ready audio FAILED sid={sid}: {ex.Message}"); }
     }
@@ -195,6 +195,18 @@ public sealed class WingmanVoiceService
 
     /// <summary>True when this session currently has a fresh, playable cached summary.</summary>
     public bool HasVoice(string sid) => _ready.ContainsKey(sid);
+
+    /// <summary>The response header the cloud speech proxy sets when it quietly failed the primary
+    /// provider over to the backup (Phase 1). Its mere PRESENCE means "served via backup"; the value is
+    /// never surfaced to a user. Reading it is how the Gateway learns to show the generic backup-voice
+    /// notice (a success-with-a-note), and it is deliberately out-of-band so it never touches the audio.</summary>
+    private const string FallbackHeaderName = "X-DevThrottle-TTS-Fallback";
+
+    /// <summary>True when this session's current ready clip was made by the BACKUP voice provider (the
+    /// primary was overloaded and the cloud proxy failed over). Fed to <see cref="VoiceDisplayFold"/> so
+    /// the Voice screen shows the generic backup-voice notice. False when there is no ready clip, or the
+    /// ready clip was served normally. Never an outage signal - a fallback IS a successful narration.</summary>
+    public bool ServedViaFallbackFor(string sid) => _ready.TryGetValue(sid, out var v) && v.ServedViaFallback;
 
     /// <summary>
     /// Whether a turn-end should (re)generate the spoken narration for this session. True when there is
@@ -360,7 +372,7 @@ public sealed class WingmanVoiceService
         if (tts.Audio is { Length: > 0 })
         {
             _voiceUnavailable.TryRemove(sid, out _);   // success clears any prior unavailable-state (dismissible)
-            StoreReady(sid, spoken, reply ?? "", tts.Audio, tts.ContentType);
+            StoreReady(sid, spoken, reply ?? "", tts.Audio, tts.ContentType, tts.ServedViaFallback);
         }
         else if (tts.Unavailable is HostedAiState state)
         {
@@ -376,19 +388,20 @@ public sealed class WingmanVoiceService
     /// persist it to disk so it survives a gateway restart (issue #553). The single place the success
     /// branch lives - the test seam (<see cref="StoreReadyAudioForTest"/>) reuses it so persistence is
     /// exercised without a live provider call.</summary>
-    private void StoreReady(string sid, string spoken, string reply, byte[] audio, string? contentType)
+    private void StoreReady(string sid, string spoken, string reply, byte[] audio, string? contentType, bool servedViaFallback = false)
     {
         var ready = new VoiceReady(spoken, reply, audio, DateTime.UtcNow,
-            NormalizeContentType(contentType) ?? DetectAudioContentType(audio));
+            NormalizeContentType(contentType) ?? DetectAudioContentType(audio), servedViaFallback);
         _ready[sid] = ready;
         _nothingToNarrate.TryRemove(sid, out _);   // audio exists, so there was something to narrate after all
         SaveReadyAudio(sid, ready);
     }
 
     /// <summary>Test seam: store ready audio exactly as a successful synthesis would (in-memory +
-    /// durable), so the persistence round-trip can be tested without calling a provider.</summary>
-    internal void StoreReadyAudioForTest(string sid, string spoken, string reply, byte[] audio, string? contentType = null)
-        => StoreReady(sid, spoken, reply, audio, contentType);
+    /// durable), so the persistence round-trip can be tested without calling a provider. The optional
+    /// <paramref name="servedViaFallback"/> lets a test store a backup-served clip and assert the notice.</summary>
+    internal void StoreReadyAudioForTest(string sid, string spoken, string reply, byte[] audio, string? contentType = null, bool servedViaFallback = false)
+        => StoreReady(sid, spoken, reply, audio, contentType, servedViaFallback);
 
     /// <summary>
     /// Regenerate the voice for a session from its latest turn: read the last reply, translate it,
@@ -614,7 +627,14 @@ public sealed class WingmanVoiceService
                 return new TtsResult(null, null, HostedAiState.ServiceDown);
             }
             var contentType = resp.Content.Headers.ContentType?.MediaType;
-            return new TtsResult(await resp.Content.ReadAsByteArrayAsync(ct), contentType, null);
+            // The cloud proxy sets this out-of-band header when it quietly failed the primary voice
+            // provider over to the backup (Phase 1). Its mere presence is the signal - the value is never
+            // shown to a user. A fallback is a SUCCESS: the audio is real and playable; we only note it so
+            // the Voice screen can add the generic backup-voice line.
+            var servedViaFallback = resp.Headers.Contains(FallbackHeaderName);
+            if (servedViaFallback)
+                FileLog.Write($"[WingmanVoiceService] tts served via backup voice provider (fallback) - {mode.ToConfigString()}");
+            return new TtsResult(await resp.Content.ReadAsByteArrayAsync(ct), contentType, null, servedViaFallback);
         }
         // A timeout (TtsSynthesis exhausted its attempts) or a transport failure is the same story from
         // the user's side: the service did not answer. It is not their fault and there is nothing for


### PR DESCRIPTION
## Text-to-Speech Fallback — Phase 2 (Gateway + clients transparency notice)

Phase 2 of the TTS-fallback mission. Phase 1 (the cloud failover + billing) shipped in the website repo (devthrottle_internal #403); this is the Gateway + clients half.

When the cloud speech proxy quietly fails the primary voice provider over to the backup, it sets an out-of-band `X-DevThrottle-TTS-Fallback` header on the SUCCESS. The Gateway now reads it and, per the dumb-client law, folds ONE finished, generic notice onto the session's voice verdict for every client to render verbatim.

### Behavior
- `WingmanVoiceService.TtsAsync` reads the header on a success and records it on the ready clip (`VoiceReady.ServedViaFallback`), persisted so it survives a restart. A fallback is a **success-with-a-note**: it never sets an unavailable/outage state.
- `VoiceDisplayFold` adds `VoiceFallbackNotice` (a new DTO field), set to the single-source generic `BackupVoiceNotice` ONLY on the green `ready` verdict. It names no provider and states there is no extra charge (the member is billed the normal rate on a fallback).
- `GatewayEndpoints`/`GatewayHost` thread a `servedViaFallbackFor` resolver into the fold.
- The mobile Voice screen and cockpit Voice tab render the notice verbatim above the voice card; the generated `client-core` schema carries the new field.

### Note on the brief
The brief referenced avoiding the `_ttsGate` shared cooldown; that gate was removed on 2026-07-17, so there is nothing to avoid — the note simply rides the normal ready path, and a test pins that a fallback never becomes an outage verdict.

### Verification
- Voice/Wingman/TurnEnd suite: **263 passed, 0 failed** (new `VoiceDisplayFoldTests` + `WingmanVoiceFallbackTests`).
- All three client packages typecheck clean; the mobile app builds.
- A test-isolation bug (existing tests shared one `TEMP/voice-audio` cache dir) was found and fixed by isolating the new tests to a unique subdirectory; existing tests untouched.

QA report: `docs/cencon/proof/tts-fallback-phase2/qa-report.html`.
