### PR TITLE
feat(gateway): the weekly Outcome Ledger report (governance spine item 4, #1771)

### DIFF
--- a/src/CcDirector.Gateway.Contracts/OutcomeLedgerDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/OutcomeLedgerDtos.cs
@@ -1,0 +1,99 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// The hero metric of the weekly Outcome Ledger (issue #1771): verified yield. Deliberately NOT a bare
+/// percent - a headline metric is never shown without its denominator, so this carries the numerator and
+/// denominator ("6 of 8 delivered") and the excused count, and a client renders the ratio from them.
+///
+/// Numerator = runs accepted (an evidenced, accepted outcome). Denominator = runs that reached a terminal
+/// outcome in the window and were NOT waived. Waived runs are EXCLUDED from the denominator (a run we
+/// explicitly decided need not count - e.g. exploratory) and disclosed separately, so a waiver neither helps
+/// nor hurts the yield.
+/// </summary>
+public sealed class VerifiedYieldDto
+{
+    /// <summary>Numerator: runs with an accepted outcome in the window.</summary>
+    public int AcceptedRuns { get; set; }
+
+    /// <summary>Denominator: runs that reached a terminal outcome in the window, excluding waived.</summary>
+    public int EffortRuns { get; set; }
+
+    /// <summary>Runs waived in the window - excluded from the denominator, disclosed so the number is honest.</summary>
+    public int WaivedRuns { get; set; }
+
+    /// <summary>Runs rejected in the window - these stay in the denominator as "did not deliver".</summary>
+    public int RejectedRuns { get; set; }
+}
+
+/// <summary>
+/// One run's line in the Outcome Ledger, carrying its cost (token effort) and its attention-burden beside it.
+/// Aggregated per RUN - never per person (issue #1771 principle). Cost is expressed in tokens with a coverage
+/// flag, not dollars: per-session dollars wait on the #1608 rate card, and subscription traffic has no
+/// marginal dollar. The account-level hosted-AI dollars are a separate report line, never pinned to a run.
+/// </summary>
+public sealed class OutcomeLedgerRowDto
+{
+    public Guid RunId { get; set; }
+    public string RunName { get; set; } = "";
+    public string WorkflowId { get; set; } = "";
+    public string? RepoPath { get; set; }
+    public string Status { get; set; } = "";
+    public string AcceptanceStatus { get; set; } = "";
+    public DateTime? CompletedUtc { get; set; }
+
+    /// <summary>How many sessions joined this run (the effort join, from the run's participants).</summary>
+    public int ParticipantSessions { get; set; }
+
+    /// <summary>Cumulative output tokens across the run's participant sessions (0 when none captured).</summary>
+    public long OutputTokens { get; set; }
+
+    /// <summary>Cumulative input tokens across the run's participant sessions.</summary>
+    public long InputTokens { get; set; }
+
+    /// <summary>False when any participant session's additive token spend was NOT captured (a context-gauge-only
+    /// driver): the token cost is then a floor, not a total, and the report discloses it rather than read it as
+    /// complete.</summary>
+    public bool TokenCoverageComplete { get; set; }
+
+    /// <summary>Count of intervention audit events for this run's sessions in the window (the agent needed a
+    /// human) - an attention-burden signal.</summary>
+    public int InterventionCount { get; set; }
+
+    /// <summary>Total seconds this run's sessions spent waiting on a human in the window (from the event
+    /// ledger) - the attention-burden duration a manager actually feels.</summary>
+    public long WaitingOnHumanSeconds { get; set; }
+}
+
+/// <summary>
+/// The weekly Outcome Ledger (issue #1771, spine item 4) - the first report that pays rent. It answers both
+/// "where did my week go" and "where did value leak" by putting accepted runs, aging work-in-progress, and
+/// high-effort/no-outcome runs side by side, each with its cost and attention-burden, under the verified-yield
+/// headline. Aggregated by run/repo/workflow, NEVER by person, and it discloses its own coverage so a low
+/// number is never mistaken for a good one.
+/// </summary>
+public sealed class OutcomeLedgerReportDto
+{
+    public DateTime SinceUtc { get; set; }
+    public DateTime UntilUtc { get; set; }
+
+    /// <summary>The hero metric: verified yield, as numerator + denominator (never a bare percent).</summary>
+    public VerifiedYieldDto VerifiedYield { get; set; } = new();
+
+    /// <summary>Delivered: runs accepted in the window.</summary>
+    public List<OutcomeLedgerRowDto> Delivered { get; set; } = new();
+
+    /// <summary>Aging work-in-progress: runs that succeeded but are still not accepted - the acceptance backlog.</summary>
+    public List<OutcomeLedgerRowDto> AgingWip { get; set; } = new();
+
+    /// <summary>High-effort / no-outcome: runs that consumed effort in the window and ended without an accepted
+    /// outcome (failed, abandoned, or rejected) - the value leak.</summary>
+    public List<OutcomeLedgerRowDto> HighEffortNoOutcome { get; set; } = new();
+
+    /// <summary>The account-level hosted-AI service dollars for the window - a real, separate line, never
+    /// blended into per-run cost.</summary>
+    public AccountHostedAiSpendSummaryDto HostedAiServices { get; set; } = new();
+
+    /// <summary>Spend coverage disclosure over the window's sessions - how much of the effort is captured in
+    /// tokens vs not captured at all, so the cost figures are read honestly.</summary>
+    public SpendCoverageDto SpendCoverage { get; set; } = new();
+}

--- a/src/CcDirector.Gateway.Tests/OutcomeLedgerReporterTests.cs
+++ b/src/CcDirector.Gateway.Tests/OutcomeLedgerReporterTests.cs
@@ -1,0 +1,184 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Governance;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Workflows;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tests for the weekly Outcome Ledger reporter (issue #1771, spine item 4). The claims that matter: verified
+/// yield reads acceptance (accepted / terminal-not-waived), a waiver is excluded from the denominator, runs
+/// bucket into delivered / aging-WIP / high-effort-no-outcome, and each row carries the token cost and
+/// attention-burden (interventions + waiting-on-human seconds) joined from the spend, audit, and event tables
+/// via the run's participants. Aggregated by run, never by person.
+/// </summary>
+public sealed class OutcomeLedgerReporterTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+    private readonly GatewayDatabase _db;
+    private readonly WorkflowStore _workflows;
+    private readonly WorkflowRunStore _runs;
+    private readonly SessionSpendStore _spend;
+    private readonly GovernanceEventLedger _events;
+    private readonly GovernanceAuditLog _audit;
+    private readonly AccountHostedAiSpendStore _hostedAi;
+    private readonly OutcomeLedgerReporter _reporter;
+
+    public OutcomeLedgerReporterTests()
+    {
+        _db = _h.Open();
+        _workflows = new WorkflowStore(_db);
+        _runs = new WorkflowRunStore(_db);
+        _spend = new SessionSpendStore(_db);
+        _events = new GovernanceEventLedger(_db);
+        _audit = new GovernanceAuditLog(_db);
+        _hostedAi = new AccountHostedAiSpendStore(_db);
+        _reporter = new OutcomeLedgerReporter(_db);
+
+        _workflows.CreateDraft(new WorkflowContentRequest
+        {
+            Id = "test-flow",
+            Name = "Mission",
+            Summary = "Run a mission.",
+            Steps = new List<WorkflowStepDto> { new() { Name = "Do", Doer = "Worker", Done = "Merged." } },
+            InstructionsMarkdown = "# Mission",
+            OutcomeCriteria = new List<WorkflowOutcomeCriterionDto>
+            {
+                new() { CriterionId = "merged", Description = "A pull request merged." },
+            },
+            AuthoredBy = "test",
+        });
+        _workflows.Publish("test-flow");
+    }
+
+    public void Dispose() => _h.Dispose();
+
+    /// <summary>Create a run, attach a session, drive it to succeeded, and set its acceptance.</summary>
+    private WorkflowRunDto SeedRun(string name, string sessionId, string acceptance, bool succeed = true)
+    {
+        var run = _runs.Create("test-flow", name);
+        _runs.Patch(run.Id, new PatchWorkflowRunRequest
+        {
+            Status = WorkflowRunStatus.Active,
+            AddParticipants = new List<WorkflowRunParticipantDto> { new() { SessionId = sessionId } },
+        });
+        _runs.Patch(run.Id, new PatchWorkflowRunRequest
+        {
+            Status = succeed ? WorkflowRunStatus.Succeeded : WorkflowRunStatus.Failed,
+        });
+        if (acceptance != WorkflowRunAcceptance.Pending)
+            _runs.Patch(run.Id, new PatchWorkflowRunRequest
+            {
+                AcceptanceStatus = acceptance,
+                AcceptedBy = "human:soren",
+            });
+        return run;
+    }
+
+    private void SeedSpend(string sessionId, long output, bool captured = true) =>
+        _spend.Record(new RecordSessionSpendRequest
+        {
+            SessionId = sessionId,
+            AgentKind = "claude",
+            TokensCaptured = captured,
+            OutputTokens = output,
+            InputTokens = 10,
+            BillingMode = SessionBillingMode.SubscriptionIncluded,
+        });
+
+    [Fact]
+    public void A_delivered_run_carries_its_yield_cost_and_attention()
+    {
+        const string session = "sess-deliver";
+        var run = SeedRun("Ship it", session, WorkflowRunAcceptance.Accepted);
+        SeedSpend(session, output: 5000);
+
+        // One intervention and a 60-second wait on a human.
+        _audit.Append(new AppendGovernanceAuditEventRequest
+        {
+            SessionId = session, RunId = run.Id,
+            Category = GovernanceAuditCategory.Intervention, EventType = GovernanceAuditEventType.Needed,
+        });
+        var t = DateTime.UtcNow.AddMinutes(-30);
+        _events.Append(new AppendGovernanceEventRequest
+        {
+            SubjectKind = GovernanceEventSubject.Session, SessionId = session,
+            State = GovernanceEventState.WaitingOnHuman, OccurredUtc = t,
+        });
+        _events.Append(new AppendGovernanceEventRequest
+        {
+            SubjectKind = GovernanceEventSubject.Session, SessionId = session,
+            State = GovernanceEventState.Active, OccurredUtc = t.AddSeconds(60),
+        });
+        _hostedAi.RecordObservedDebits(new List<ObservedAccountDebit>
+        {
+            new() { Kind = "debit", AmountMicros = 1234, TransactionCreatedUtc = DateTime.UtcNow.AddMinutes(-10) },
+        });
+
+        var report = _reporter.Build(DateTime.UtcNow.AddHours(-1), DateTime.UtcNow.AddHours(1));
+
+        Assert.Equal(1, report.VerifiedYield.AcceptedRuns);
+        Assert.Equal(1, report.VerifiedYield.EffortRuns);
+        var row = Assert.Single(report.Delivered);
+        Assert.Equal(run.Id, row.RunId);
+        Assert.Equal(5000, row.OutputTokens);
+        Assert.True(row.TokenCoverageComplete);
+        Assert.Equal(1, row.InterventionCount);
+        Assert.Equal(60, row.WaitingOnHumanSeconds);
+        Assert.Equal(1234, report.HostedAiServices.TotalMicros);
+        Assert.Equal(1, report.SpendCoverage.SessionsWithTokens);
+    }
+
+    [Fact]
+    public void Runs_bucket_by_outcome_and_a_waiver_leaves_the_denominator()
+    {
+        SeedRun("Delivered", "s-accepted", WorkflowRunAcceptance.Accepted);
+        SeedRun("Rejected", "s-rejected", WorkflowRunAcceptance.Rejected);
+        SeedRun("Blew up", "s-failed", WorkflowRunAcceptance.Pending, succeed: false);
+        SeedRun("Excused", "s-waived", WorkflowRunAcceptance.Waived);
+        SeedRun("Awaiting", "s-pending", WorkflowRunAcceptance.Pending); // succeeded, pending -> aging WIP
+
+        var report = _reporter.Build(DateTime.UtcNow.AddHours(-1), DateTime.UtcNow.AddHours(1));
+
+        // Yield: accepted=1; denominator excludes the waiver -> 4 (accepted, rejected, failed, pending).
+        Assert.Equal(1, report.VerifiedYield.AcceptedRuns);
+        Assert.Equal(4, report.VerifiedYield.EffortRuns);
+        Assert.Equal(1, report.VerifiedYield.WaivedRuns);
+        Assert.Equal(1, report.VerifiedYield.RejectedRuns);
+
+        Assert.Single(report.Delivered);
+        Assert.Contains(report.Delivered, r => r.RunName == "Delivered");
+
+        // High-effort/no-outcome: the rejected and the failed run.
+        Assert.Equal(2, report.HighEffortNoOutcome.Count);
+        Assert.Contains(report.HighEffortNoOutcome, r => r.RunName == "Rejected");
+        Assert.Contains(report.HighEffortNoOutcome, r => r.RunName == "Blew up");
+
+        // Aging WIP: the succeeded-but-pending run.
+        Assert.Single(report.AgingWip);
+        Assert.Equal("Awaiting", report.AgingWip[0].RunName);
+    }
+
+    [Fact]
+    public void A_context_gauge_only_participant_marks_coverage_incomplete()
+    {
+        const string session = "sess-codex";
+        SeedRun("Codex run", session, WorkflowRunAcceptance.Accepted);
+        SeedSpend(session, output: 0, captured: false); // Codex: no additive token capture
+
+        var report = _reporter.Build(DateTime.UtcNow.AddHours(-1), DateTime.UtcNow.AddHours(1));
+
+        var row = Assert.Single(report.Delivered);
+        Assert.False(row.TokenCoverageComplete);
+        Assert.Equal(1, report.SpendCoverage.SessionsWithoutTokenCapture);
+    }
+
+    [Fact]
+    public void An_inverted_window_is_rejected()
+    {
+        Assert.Throws<GovernanceValidationException>(
+            () => _reporter.Build(DateTime.UtcNow, DateTime.UtcNow.AddHours(-1)));
+    }
+}

--- a/src/CcDirector.Gateway/Api/GovernanceReportEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GovernanceReportEndpoints.cs
@@ -1,0 +1,38 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Governance;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The governance report surface (issue #1771, spine item 4) - the weekly Outcome Ledger. Read-only: it
+/// assembles the run tables, event ledger, spend, and audit trail into one report; it writes nothing.
+///
+///   GET /gateway/governance/outcome-ledger  ?since=&amp;until=  -> OutcomeLedgerReportDto
+///
+/// The window defaults to the trailing seven days when omitted. Inherits the host-wide token middleware.
+/// </summary>
+internal static class GovernanceReportEndpoints
+{
+    public static void Map(IEndpointRouteBuilder app, OutcomeLedgerReporter reporter)
+    {
+        app.MapGet("/gateway/governance/outcome-ledger", (DateTime? since, DateTime? until) =>
+        {
+            var untilUtc = until ?? DateTime.UtcNow;
+            var sinceUtc = since ?? untilUtc.AddDays(-7);
+            try
+            {
+                return Results.Json(reporter.Build(sinceUtc, untilUtc));
+            }
+            catch (GovernanceValidationException ex)
+            {
+                FileLog.Write($"[GovernanceReportEndpoints] rejected: {ex.Message}");
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        });
+
+        FileLog.Write("[GovernanceReportEndpoints] mapped /gateway/governance/outcome-ledger route");
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -347,6 +347,9 @@ public sealed class GatewayHost : IAsyncDisposable
     private readonly Governance.GovernanceAuditLog _governanceAudit;
     // Fills session_spend at each turn-end from the pushed roster snapshot (issue #1771, spine item 3).
     private readonly Governance.SessionSpendEmitter _sessionSpendEmitter;
+    // The weekly Outcome Ledger reporter (issue #1771, spine item 4): a read-only assembly over the run
+    // tables, event ledger, spend, and audit trail - the first governance report that pays rent.
+    private readonly Governance.OutcomeLedgerReporter _outcomeLedger;
     private readonly CronJobStore _cronJobs;
     private readonly CronRunHistoryStore _cronRuns;
     private readonly Running.CronEngine _cronEngine;
@@ -627,6 +630,9 @@ public sealed class GatewayHost : IAsyncDisposable
         // sandbox decisions on the EF data layer, so a Gateway restart never loses a recorded audit fact.
         _governanceAudit = new Governance.GovernanceAuditLog(_gatewayDb);
         _sessionSpendEmitter = new Governance.SessionSpendEmitter(_sessionSpend);
+        // The weekly Outcome Ledger reporter (issue #1771, spine item 4): read-only over the run tables +
+        // event ledger + spend + audit trail. No store of its own.
+        _outcomeLedger = new Governance.OutcomeLedgerReporter(_gatewayDb);
         // Snooze Length mission: the persisted snooze registry (sessionId -> SnoozeUntilUtc), now in the
         // snoozes table of the EF data layer - a Gateway restart re-arms every pending snooze from the
         // database; an entry already past its time simply fires on the first sweep. The path argument is the
@@ -1684,6 +1690,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // The governance audit trail (issue #1771, spine item 4): append-only intervention +
         // permission/sandbox decisions - the safety and attention-burden audit. Append and read only.
         Api.GovernanceAuditEndpoints.Map(_app, _governanceAudit);
+
+        // The weekly Outcome Ledger (issue #1771, spine item 4): the first report that pays rent - verified
+        // yield, aging WIP, and high-effort/no-outcome runs with cost + attention-burden. Read-only.
+        Api.GovernanceReportEndpoints.Map(_app, _outcomeLedger);
 
         // Gateway Centralization Phase 1 (issue #628): the inbound login-telemetry RELAY. The Director
         // POSTs its login-telemetry event here (instead of the cloud) and the Gateway forwards it on,

--- a/src/CcDirector.Gateway/Governance/OutcomeLedgerReporter.cs
+++ b/src/CcDirector.Gateway/Governance/OutcomeLedgerReporter.cs
@@ -1,0 +1,254 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Governance;
+
+/// <summary>
+/// The weekly Outcome Ledger reporter (issue #1771, spine item 4) - the first report that pays rent. It is a
+/// READ-ONLY assembly over the governance spine already on the data layer: the workflow-run rows (#1779), the
+/// event ledger (#1782), the session/account spend (#1789), and the audit trail (#1794). It writes nothing
+/// and needs no table of its own.
+///
+/// It answers, for a window, the hero question - verified yield (accepted runs over runs that reached a
+/// terminal outcome and were not waived) - and lays three buckets side by side, each row carrying its token
+/// cost and its attention-burden: DELIVERED (accepted), AGING WIP (succeeded but still unaccepted), and
+/// HIGH-EFFORT / NO-OUTCOME (failed, abandoned, or rejected). It aggregates by RUN, never by person, and
+/// discloses its own coverage (token-capture gaps, account-level dollars kept separate) so a low number is
+/// never mistaken for a good one.
+/// </summary>
+public sealed class OutcomeLedgerReporter
+{
+    private readonly GatewayDatabase _db;
+
+    /// <summary>The per-bucket row cap, so one call cannot materialize an unbounded history.</summary>
+    public const int MaxRowsPerBucket = 500;
+
+    public OutcomeLedgerReporter(GatewayDatabase db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    /// <summary>Assemble the Outcome Ledger for the window [<paramref name="sinceUtc"/>, <paramref name="untilUtc"/>).</summary>
+    public OutcomeLedgerReportDto Build(DateTime sinceUtc, DateTime untilUtc)
+    {
+        var since = DateTime.SpecifyKind(sinceUtc, DateTimeKind.Utc);
+        var until = DateTime.SpecifyKind(untilUtc, DateTimeKind.Utc);
+        if (until <= since)
+            throw new GovernanceValidationException("The report window's end must be after its start.");
+
+        using var ctx = _db.CreateContext();
+
+        // The window population: runs that reached a terminal outcome in the window. This is the denominator's
+        // universe and the source of Delivered + High-effort/no-outcome.
+        var completedInWindow = ctx.WorkflowRuns.AsNoTracking()
+            .Where(r => r.CompletedUtc != null && r.CompletedUtc >= since && r.CompletedUtc < until)
+            .ToList();
+
+        // Aging WIP is NOT window-bounded on completion: it is the acceptance backlog - succeeded runs still
+        // pending acceptance as of the window end, oldest first.
+        var agingWip = ctx.WorkflowRuns.AsNoTracking()
+            .Where(r => r.Status == WorkflowRunStatus.Succeeded &&
+                        r.AcceptanceStatus == WorkflowRunAcceptance.Pending &&
+                        r.CompletedUtc != null && r.CompletedUtc < until)
+            .OrderBy(r => r.CompletedUtc)
+            .Take(MaxRowsPerBucket)
+            .ToList();
+
+        // Every session that did work for any run in scope - the join key set for the cost/attention lookups.
+        var runsInScope = completedInWindow.Concat(agingWip).ToList();
+        var sessionIds = runsInScope
+            .SelectMany(r => r.Participants.Select(p => p.SessionId))
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        // Load the cost and attention facts for those sessions in ONE query each (an IN list), then join in
+        // memory - a weekly window is bounded, so this stays cheap and avoids an N+1 per run.
+        var spendBySession = sessionIds.Count == 0
+            ? new Dictionary<string, SessionSpendEntity>(StringComparer.Ordinal)
+            : ctx.SessionSpend.AsNoTracking()
+                .Where(s => sessionIds.Contains(s.SessionId))
+                .ToList()
+                .ToDictionary(s => s.SessionId, StringComparer.Ordinal);
+
+        var interventionsBySession = sessionIds.Count == 0
+            ? new Dictionary<string, int>(StringComparer.Ordinal)
+            : ctx.GovernanceAuditEvents.AsNoTracking()
+                .Where(e => sessionIds.Contains(e.SessionId) &&
+                            e.Category == GovernanceAuditCategory.Intervention &&
+                            e.OccurredUtc >= since && e.OccurredUtc < until)
+                .ToList()
+                .GroupBy(e => e.SessionId, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+
+        var waitingEvents = sessionIds.Count == 0
+            ? new List<GovernanceEventEntity>()
+            : ctx.GovernanceEvents.AsNoTracking()
+                .Where(e => sessionIds.Contains(e.SessionId!) &&
+                            e.SubjectKind == GovernanceEventSubject.Session &&
+                            e.OccurredUtc >= since && e.OccurredUtc < until)
+                .OrderBy(e => e.OccurredUtc)
+                .ToList();
+        var waitingSecondsBySession = WaitingOnHumanSecondsBySession(waitingEvents, until);
+
+        var report = new OutcomeLedgerReportDto
+        {
+            SinceUtc = since,
+            UntilUtc = until,
+            VerifiedYield = Yield(completedInWindow),
+            Delivered = completedInWindow
+                .Where(r => r.AcceptanceStatus == WorkflowRunAcceptance.Accepted)
+                .OrderByDescending(r => r.CompletedUtc)
+                .Take(MaxRowsPerBucket)
+                .Select(r => Row(r, spendBySession, interventionsBySession, waitingSecondsBySession))
+                .ToList(),
+            HighEffortNoOutcome = completedInWindow
+                .Where(IsNoOutcome)
+                .OrderByDescending(r => r.CompletedUtc)
+                .Take(MaxRowsPerBucket)
+                .Select(r => Row(r, spendBySession, interventionsBySession, waitingSecondsBySession))
+                .ToList(),
+            AgingWip = agingWip
+                .Select(r => Row(r, spendBySession, interventionsBySession, waitingSecondsBySession))
+                .ToList(),
+            HostedAiServices = HostedAiSummary(ctx, since, until),
+            SpendCoverage = Coverage(ctx, since, until),
+        };
+
+        FileLog.Write($"[OutcomeLedgerReporter] Build: window={since:o}..{until:o}, " +
+                      $"yield={report.VerifiedYield.AcceptedRuns}/{report.VerifiedYield.EffortRuns}, " +
+                      $"delivered={report.Delivered.Count}, agingWip={report.AgingWip.Count}, " +
+                      $"noOutcome={report.HighEffortNoOutcome.Count}");
+        return report;
+    }
+
+    /// <summary>A run ended without an accepted outcome: it failed or was abandoned, or its outcome was
+    /// rejected. A succeeded-but-pending run is NOT here - that is aging WIP, not a value leak.</summary>
+    private static bool IsNoOutcome(WorkflowRunEntity r) =>
+        r.Status == WorkflowRunStatus.Failed ||
+        r.Status == WorkflowRunStatus.Abandoned ||
+        r.AcceptanceStatus == WorkflowRunAcceptance.Rejected;
+
+    private static VerifiedYieldDto Yield(List<WorkflowRunEntity> completedInWindow) => new()
+    {
+        AcceptedRuns = completedInWindow.Count(r => r.AcceptanceStatus == WorkflowRunAcceptance.Accepted),
+        // Denominator excludes waived (excused runs), so a waiver neither helps nor hurts the yield.
+        EffortRuns = completedInWindow.Count(r => r.AcceptanceStatus != WorkflowRunAcceptance.Waived),
+        WaivedRuns = completedInWindow.Count(r => r.AcceptanceStatus == WorkflowRunAcceptance.Waived),
+        RejectedRuns = completedInWindow.Count(r => r.AcceptanceStatus == WorkflowRunAcceptance.Rejected),
+    };
+
+    private static OutcomeLedgerRowDto Row(
+        WorkflowRunEntity run,
+        IReadOnlyDictionary<string, SessionSpendEntity> spendBySession,
+        IReadOnlyDictionary<string, int> interventionsBySession,
+        IReadOnlyDictionary<string, long> waitingSecondsBySession)
+    {
+        var sessions = run.Participants
+            .Select(p => p.SessionId)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        long output = 0, input = 0, interventions = 0, waiting = 0;
+        // Coverage is complete only when EVERY participant session has a spend row that captured tokens; a
+        // participant with no spend row, or a context-gauge-only driver, makes the token cost a floor.
+        var coverageComplete = sessions.Count > 0;
+        foreach (var sessionId in sessions)
+        {
+            if (spendBySession.TryGetValue(sessionId, out var spend) && spend.TokensCaptured)
+            {
+                output += spend.OutputTokens;
+                input += spend.InputTokens;
+            }
+            else
+            {
+                coverageComplete = false;
+            }
+            if (interventionsBySession.TryGetValue(sessionId, out var count))
+                interventions += count;
+            if (waitingSecondsBySession.TryGetValue(sessionId, out var secs))
+                waiting += secs;
+        }
+
+        return new OutcomeLedgerRowDto
+        {
+            RunId = run.Id,
+            RunName = run.Name,
+            WorkflowId = run.WorkflowId,
+            RepoPath = run.RepoPath,
+            Status = run.Status,
+            AcceptanceStatus = run.AcceptanceStatus,
+            CompletedUtc = run.CompletedUtc,
+            ParticipantSessions = sessions.Count,
+            OutputTokens = output,
+            InputTokens = input,
+            TokenCoverageComplete = coverageComplete,
+            InterventionCount = (int)interventions,
+            WaitingOnHumanSeconds = waiting,
+        };
+    }
+
+    /// <summary>
+    /// Sum the seconds each session spent in "waiting-on-human" over the window. For a session's ordered
+    /// events, a waiting-on-human state runs until the next event (or the window end if it is the last), so
+    /// the ledger's transitions give a real duration - the attention-burden a manager actually feels.
+    /// </summary>
+    private static Dictionary<string, long> WaitingOnHumanSecondsBySession(
+        List<GovernanceEventEntity> orderedEvents, DateTime until)
+    {
+        var result = new Dictionary<string, long>(StringComparer.Ordinal);
+        foreach (var group in orderedEvents.Where(e => e.SessionId is not null)
+                     .GroupBy(e => e.SessionId!, StringComparer.Ordinal))
+        {
+            var events = group.OrderBy(e => e.OccurredUtc).ToList();
+            long seconds = 0;
+            for (var i = 0; i < events.Count; i++)
+            {
+                if (events[i].State != GovernanceEventState.WaitingOnHuman)
+                    continue;
+                var end = i + 1 < events.Count ? events[i + 1].OccurredUtc : until;
+                var span = end - events[i].OccurredUtc;
+                if (span > TimeSpan.Zero)
+                    seconds += (long)span.TotalSeconds;
+            }
+            if (seconds > 0)
+                result[group.Key] = seconds;
+        }
+        return result;
+    }
+
+    private static AccountHostedAiSpendSummaryDto HostedAiSummary(
+        GatewayDbContext ctx, DateTime since, DateTime until)
+    {
+        var rows = ctx.AccountHostedAiSpend.AsNoTracking()
+            .Where(e => e.TransactionCreatedUtc >= since && e.TransactionCreatedUtc < until)
+            .ToList();
+        return new AccountHostedAiSpendSummaryDto
+        {
+            TotalMicros = rows.Sum(e => e.AmountMicros),
+            DebitCount = rows.Count,
+            SinceUtc = since,
+            UntilUtc = until,
+        };
+    }
+
+    private static SpendCoverageDto Coverage(GatewayDbContext ctx, DateTime since, DateTime until)
+    {
+        var rows = ctx.SessionSpend.AsNoTracking()
+            .Where(s => s.LastObservedUtc >= since && s.LastObservedUtc < until)
+            .ToList();
+        return new SpendCoverageDto
+        {
+            Sessions = rows.Count,
+            SessionsWithTokens = rows.Count(s => s.TokensCaptured),
+            SessionsWithMeteredDollars = rows.Count(s => s.MeteredCostMicros.HasValue),
+            SessionsSubscriptionIncluded =
+                rows.Count(s => s.BillingMode == SessionBillingMode.SubscriptionIncluded),
+            SessionsWithoutTokenCapture = rows.Count(s => !s.TokensCaptured),
+        };
+    }
+}


### PR DESCRIPTION
## The weekly Outcome Ledger report (governance spine item 4, thefrederiksen/devthrottle_internal#856)

The first governance report that pays rent — and the completion of the thefrederiksen/devthrottle_internal#856 outcome-spine. It is a **read-only assembly** over the spine already on the data layer: the workflow-run rows (#1779), the event ledger (#1782), the session/account spend (#1789), and the audit trail (#1794). It has no table of its own and needs no migration.

### What it answers
For a window it puts the hero metric over three buckets, each row carrying its cost and its attention-burden:

- **Verified yield** — accepted runs over runs that reached a terminal outcome and were not waived. Carried as **numerator + denominator** ("6 of 8"), never a bare percent — a headline is never shown without its denominator. A **waiver is excluded from the denominator** and disclosed, so it neither helps nor hurts the yield; a rejection stays in as "did not deliver".
- **Delivered** — runs accepted in the window.
- **Aging WIP** — runs that succeeded but are still not accepted (the acceptance backlog, oldest first).
- **High-effort / no-outcome** — runs that ended without an accepted outcome (failed, abandoned, or rejected): the value leak.

Each row carries **cost** (output/input tokens summed across the run's participant sessions, with a `TokenCoverageComplete` flag) and **attention-burden** (`InterventionCount` from the audit trail + `WaitingOnHumanSeconds` computed from the event ledger's transitions), joined to the run via `workflow_runs.Participants[].SessionId`.

### Governance principles, enforced
- **Aggregated by run, never by person** — no user dimension anywhere in the report.
- **No prompt content** — it reads structured facts only.
- **Every headline has its denominator and a drill-down** — the yield carries numerator/denominator/waived/rejected, and each bucket lists the actual runs.
- **Discloses its own coverage** — `SpendCoverage` reports token-capture gaps (a context-gauge-only participant marks a row's cost a floor, not a total), and account-level hosted-AI dollars are a **separate line, never blended into per-run cost**. A low number is never mistaken for a good one.

### Surface & scope
- `GET /gateway/governance/outcome-ledger?since=&until=` (defaults to the trailing seven days). This is the view the already-tracked weekly email (#1761) summarizes.
- Read-only — no migration, no schema change. The report reflects whatever the capture-wiring workstream fills the spine tables with.

Fourth and final phase of the thefrederiksen/devthrottle_internal#856 governance outcome-spine (event ledger thefrederiksen/devthrottle#1782, spend thefrederiksen/devthrottle#1789, audit trail thefrederiksen/devthrottle#1794, and this).
