### PR TITLE
Make session dot colours come from one Gateway source

### DIFF
--- a/apps/cockpit/src/fleet/DirectorDetailView.tsx
+++ b/apps/cockpit/src/fleet/DirectorDetailView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { gatewayErrorMessage, getRepos, type RepoInfo, type SessionDto } from "@devthrottle/client-core/api/client";
-import { dotColor, effectiveColor, inDesktopOrder, stateLabel } from "@devthrottle/client-core/sessions/ordering";
+import { dotHex, inDesktopOrder, stateLabel } from "@devthrottle/client-core/sessions/ordering";
 import {
   getDirectorSettings,
   getFleetDirectors,
@@ -43,7 +43,7 @@ export function directorSessionRow(s: SessionDto): {
 } {
   const label = stateLabel(s);
   return {
-    dot: dotColor(effectiveColor(s)),
+    dot: dotHex(s),
     state: label,
     // "Snoozed" and "Wingman reading" are the fold's OWN words (SessionOrdering.StateLabel), so asking
     // the label is asking the fold. Never re-read s.onHold here: that is a raw sensor fact the fold

--- a/apps/cockpit/src/fleet/FleetMapView.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { type SessionDto } from "@devthrottle/client-core/api/client";
-import { dotColor, effectiveColor, stateLabel } from "@devthrottle/client-core/sessions/ordering";
+import { dotColor, dotHex, effectiveColor, stateLabel } from "@devthrottle/client-core/sessions/ordering";
 import {
   reachabilityFor,
   reachabilityLastSeen,
@@ -534,7 +534,7 @@ function NodeCard({
       <div className="fmap-card-top">
         <span
           className={color === "blue" ? "fmap-dot working" : "fmap-dot"}
-          style={{ backgroundColor: dotColor(color) }}
+          style={{ backgroundColor: dotHex(s) }}
           title={s.lastStatusReason ?? undefined}
         />
         {hasNum && <span className="num-badge">{num}</span>}
@@ -556,7 +556,7 @@ function NodeCard({
         </div>
       )}
 
-      <div className="fmap-card-state" style={{ color: dotColor(color) }}>
+      <div className="fmap-card-state" style={{ color: dotHex(s) }}>
         {stateLabel(s)}
         <span className="fmap-card-idle">{relativeTime(s.lastActivityAt)}</span>
       </div>

--- a/apps/cockpit/src/fleet/directorSessionRow.test.ts
+++ b/apps/cockpit/src/fleet/directorSessionRow.test.ts
@@ -1,16 +1,24 @@
 import { describe, expect, it } from "vitest";
 import type { SessionDto } from "@devthrottle/client-core/api/client";
+import { dotColor } from "@devthrottle/client-core/sessions/ordering";
 import { directorSessionRow } from "./DirectorDetailView";
 
 // Defect 7: the Director-detail Sessions table carried THREE authorities in ONE row - a Gateway-stamped
 // dot, a State cell re-derived from raw activity fields, and a SNOOZED tag read off the raw onHold
 // boolean. These tests pin the row to the single fold. Each one was watched failing against the old
 // code with the reported symptom before this file was kept; see the report for the evidence.
+//
+// The row dot reads the Gateway-stamped effectiveColorHex, so a fixture must model the REAL /sessions
+// payload: name AND its canonical hex. This helper stamps the hex from the colour name (the same value
+// the Gateway stamps), unless a test overrides effectiveColorHex explicitly to model a missing/malformed
+// stamp.
 function session(fields: Partial<SessionDto> = {}): SessionDto {
+  const name = (fields as { effectiveColor?: string }).effectiveColor;
   return {
     sessionId: "s1",
     createdAt: "2026-07-08T00:00:00Z",
     sortOrder: 0,
+    ...(name ? { effectiveColorHex: dotColor(name) } : {}),
     ...fields,
   } as unknown as SessionDto;
 }

--- a/apps/cockpit/src/missions/MissionsBoard.tsx
+++ b/apps/cockpit/src/missions/MissionsBoard.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { type SessionDto } from "@devthrottle/client-core/api/client";
-import { dotColor, effectiveColor, stateLabel } from "@devthrottle/client-core/sessions/ordering";
+import { dotColor, dotHex, effectiveColor, stateLabel } from "@devthrottle/client-core/sessions/ordering";
 import { getMissionNotes, setMissionNote } from "@devthrottle/client-core/missions/missionNotes";
 import { repoBasename, relativeTime } from "../fleet/format";
 import { groupByMission, type MissionGroup } from "./missionGrouping";
@@ -303,8 +303,9 @@ interface SessionRowProps {
 // live state label - all colored by the ONE shared effective-color rule so the row agrees with the rail
 // and the Fleet Map. Clicking (or Enter/Space) opens the session.
 function SessionRow({ session: s, label, onOpenSession }: SessionRowProps) {
-  const color = effectiveColor(s);
-  const hex = dotColor(color);
+  // A real session row paints the Gateway-stamped dot hex, not the local COLORS table (which is only for
+  // the mission-card accent and the priority-legend swatches below, none of which have a session).
+  const hex = dotHex(s);
   const sid = s.sessionId ?? "";
   const num = s.number;
   const hasNum = num !== null && num !== undefined && String(num).trim().length > 0;

--- a/apps/cockpit/src/schedule/ScheduleView.tsx
+++ b/apps/cockpit/src/schedule/ScheduleView.tsx
@@ -18,7 +18,7 @@ import {
 } from "@devthrottle/client-core/fleet/fleetClient";
 import type { SessionDto } from "@devthrottle/client-core/api/client";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
-import { classify, dotColor, effectiveColor, stateLabel } from "@devthrottle/client-core/sessions/ordering";
+import { classify, dotHex, stateLabel } from "@devthrottle/client-core/sessions/ordering";
 import { useVisiblePolling } from "@devthrottle/client-core/polling/useVisiblePolling";
 import { clockLabel, relativeTime, repoBasename } from "../fleet/format";
 import { Button, ConfirmDialog, DataTable, PageHeader, type DataTableColumn } from "../components";
@@ -1140,7 +1140,7 @@ function sessName(s: SessionDto): string {
 // The picker reads the same /sessions envelope that stamps every other screen (getSessionsEnvelope),
 // so the fold's answers were available here all along. The client renders; it does not decide.
 export function pickerSession(s: SessionDto): { dot: string; state: string } {
-  return { dot: dotColor(effectiveColor(s)), state: stateLabel(s) };
+  return { dot: dotHex(s), state: stateLabel(s) };
 }
 
 // How many of a machine's sessions actually need you: the Gateway's stamped bucket, never a count of

--- a/apps/cockpit/src/schedule/pickerSession.test.ts
+++ b/apps/cockpit/src/schedule/pickerSession.test.ts
@@ -1,15 +1,22 @@
 import { describe, expect, it } from "vitest";
 import type { SessionDto } from "@devthrottle/client-core/api/client";
+import { dotColor } from "@devthrottle/client-core/sessions/ordering";
 import { needsYouCount, pickerSession } from "./ScheduleView";
 
 // Defect 9: the schedule page's Director picker ran an entire parallel triage fold (sessState /
 // sessClass), deriving "needs you" from the needsYouSince timestamp instead of the Gateway's stamped
 // bucket, and painting a working session GREEN. These tests pin the picker to the one fold.
+//
+// The picker dot reads the Gateway-stamped effectiveColorHex, so a fixture models the REAL /sessions
+// payload: name AND its canonical hex. This helper stamps the hex from the colour name (the same value
+// the Gateway stamps), unless a test overrides effectiveColorHex explicitly.
 function session(fields: Partial<SessionDto> = {}): SessionDto {
+  const name = (fields as { effectiveColor?: string }).effectiveColor;
   return {
     sessionId: "s1",
     createdAt: "2026-07-08T00:00:00Z",
     sortOrder: 0,
+    ...(name ? { effectiveColorHex: dotColor(name) } : {}),
     ...fields,
   } as unknown as SessionDto;
 }

--- a/apps/cockpit/src/schedule/schedule.css
+++ b/apps/cockpit/src/schedule/schedule.css
@@ -875,10 +875,10 @@
   color: var(--text-dim);
 }
 
-/* The dot's colour is applied inline from the shared palette (dotColor), like every other session dot
-   in the Cockpit. There are deliberately no .run / .needs / .idle modifiers: they were a local palette
-   fed by a local fold, and .run painted a WORKING session --sched-green when the law says working is
-   blue - with green already meaning "ready, parked at its prompt" everywhere else. */
+/* The dot's colour is the Gateway-stamped hex, applied inline (dotHex), like every other session dot in
+   the Cockpit. There are deliberately no .run / .needs / .idle modifiers: they were a local palette fed
+   by a local fold, and .run painted a WORKING session --sched-green when the law says working is blue -
+   with green already meaning "ready, parked at its prompt" everywhere else. */
 .sched-sdot {
   width: 7px;
   height: 7px;

--- a/apps/cockpit/src/sessions/SessionRoster.tsx
+++ b/apps/cockpit/src/sessions/SessionRoster.tsx
@@ -5,8 +5,7 @@ import {
   classify,
   contextLine,
   deletionReason,
-  dotColor,
-  effectiveColor,
+  dotHex,
   groupByDirector,
   inBucket,
   pendingDeletion,
@@ -276,7 +275,6 @@ function RosterRow({
   selectedId: string | undefined;
 }) {
   const sid = session.sessionId ?? "";
-  const color = effectiveColor(session);
   const selected = sid === selectedId;
   const attention = classify(session) === "needsYou";
   const name = session.name && session.name.trim().length > 0 ? session.name : session.repoPath || "(unnamed session)";
@@ -311,11 +309,11 @@ function RosterRow({
     <li className="roster-li">
       <Link
         className={`roster-row${selected ? " roster-row-selected" : ""}${attention ? " roster-row-attention" : ""}${wobbly ? " roster-row-wobbly" : ""}${offline ? " roster-row-offline" : ""}`}
-        style={{ borderLeftColor: dotColor(color) }}
+        style={{ borderLeftColor: dotHex(session) }}
         to={`/session/${encodeURIComponent(sid)}`}
         title={session.lastStatusReason ?? undefined}
       >
-        <span className="roster-dot" style={{ backgroundColor: dotColor(color) }} aria-hidden="true" />
+        <span className="roster-dot" style={{ backgroundColor: dotHex(session) }} aria-hidden="true" />
         <span className="roster-body">
           {/* Line 1: the session number badge + the full name (wraps freely, no clamp). */}
           <span className="roster-name">

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { setVoiceModeAllSessions, type SessionDto } from "@devthrottle/client-core/api/client";
 import { getSessionsEnvelope } from "@devthrottle/client-core/fleet/fleetClient";
 import { emptyRetentionCache, mergeRosterRetention, type RosterSessionMark } from "@devthrottle/client-core/fleet/rosterRetention";
-import { classify, contextLine, deletionReason, dotColor, dotHex, inBucket, inDesktopOrder, inWaitingOrder, isWorking, pendingDeletion, repoLeaf, snoozeCountdown, snoozeExpired } from "@devthrottle/client-core/sessions/ordering";
+import { classify, contextLine, deletionReason, dotHex, inBucket, inDesktopOrder, inWaitingOrder, isWorking, pendingDeletion, repoLeaf, snoozeCountdown, snoozeExpired } from "@devthrottle/client-core/sessions/ordering";
 import { applyFilter, filterIsActive, filterSummary, machineName, pruneFilter } from "@devthrottle/client-core/sessions/filter";
 import { useDictationStatusFor } from "@devthrottle/client-core/dictation/status";
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
@@ -421,7 +421,11 @@ function SessionRow({ session, mark }: { session: SessionDto; mark?: RosterSessi
       {/* Hand the known voice-mode state to the destination (issue #1015) so the Voice screen paints
           the right state on the first render instead of flashing OFF while its first poll resolves. */}
       <Link className="row-link" to={to} state={{ voiceMode: Boolean(session.voiceMode) }}>
-        <span className="dot" style={{ backgroundColor: unreachable ? dotColor("grey") : dotHex(session) }} aria-hidden="true" />
+        {/* The dot always paints the Gateway-stamped colour - even when the owning machine is unreachable,
+            the dot keeps telling the truth about the session's last-known state. Unreachability is shown by
+            the row treatment (the .row-unreachable dashed border + dimming opacity + the "Unreachable" note),
+            never by overriding the dot with a locally chosen grey. */}
+        <span className="dot" style={{ backgroundColor: dotHex(session) }} aria-hidden="true" />
         <span className="row-body">
           {/* The name uses the full card width and WRAPS (no truncation) - issue #838. A muted
               three-digit number prefix sits before the bold name, matching the desktop SessionRail

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { setVoiceModeAllSessions, type SessionDto } from "@devthrottle/client-core/api/client";
 import { getSessionsEnvelope } from "@devthrottle/client-core/fleet/fleetClient";
 import { emptyRetentionCache, mergeRosterRetention, type RosterSessionMark } from "@devthrottle/client-core/fleet/rosterRetention";
-import { classify, contextLine, deletionReason, dotColor, effectiveColor, inBucket, inDesktopOrder, inWaitingOrder, isWorking, pendingDeletion, repoLeaf, snoozeCountdown, snoozeExpired } from "@devthrottle/client-core/sessions/ordering";
+import { classify, contextLine, deletionReason, dotColor, dotHex, inBucket, inDesktopOrder, inWaitingOrder, isWorking, pendingDeletion, repoLeaf, snoozeCountdown, snoozeExpired } from "@devthrottle/client-core/sessions/ordering";
 import { applyFilter, filterIsActive, filterSummary, machineName, pruneFilter } from "@devthrottle/client-core/sessions/filter";
 import { useDictationStatusFor } from "@devthrottle/client-core/dictation/status";
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
@@ -396,7 +396,6 @@ function unreachableNote(mark: RosterSessionMark): string {
 }
 
 function SessionRow({ session, mark }: { session: SessionDto; mark?: RosterSessionMark }) {
-  const color = effectiveColor(session);
   const name = session.name && session.name.trim().length > 0 ? session.name : "(unnamed session)";
   const repo = repoLeaf(session);
   const machine = machineName(session);
@@ -422,7 +421,7 @@ function SessionRow({ session, mark }: { session: SessionDto; mark?: RosterSessi
       {/* Hand the known voice-mode state to the destination (issue #1015) so the Voice screen paints
           the right state on the first render instead of flashing OFF while its first poll resolves. */}
       <Link className="row-link" to={to} state={{ voiceMode: Boolean(session.voiceMode) }}>
-        <span className="dot" style={{ backgroundColor: dotColor(unreachable ? "grey" : color) }} aria-hidden="true" />
+        <span className="dot" style={{ backgroundColor: unreachable ? dotColor("grey") : dotHex(session) }} aria-hidden="true" />
         <span className="row-body">
           {/* The name uses the full card width and WRAPS (no truncation) - issue #838. A muted
               three-digit number prefix sits before the bold name, matching the desktop SessionRail

--- a/packages/client-core/src/api/schema.ts
+++ b/packages/client-core/src/api/schema.ts
@@ -7638,6 +7638,7 @@ export interface components {
             /** Format: date-time */
             needsYouSince?: null | string;
             effectiveColor?: null | string;
+            effectiveColorHex?: null | string;
             triageBucket?: null | string;
             stateLabel?: null | string;
             backendType?: string;

--- a/packages/client-core/src/sessions/ordering.test.ts
+++ b/packages/client-core/src/sessions/ordering.test.ts
@@ -167,6 +167,21 @@ describe("dotHex - the session dot renders the Gateway-stamped pixel", () => {
       spy.mockRestore();
     }
   });
+
+  it("contains a bad row instead of crashing when the stamp is a non-string JSON value", () => {
+    // Optional chaining does NOT guard a number/object/array - .trim would throw a TypeError from the
+    // render path and take down the whole roster. dotHex must type-guard and paint the sentinel instead.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(() => dotHex(session({ effectiveColor: "red", effectiveColorHex: 16711680 } as unknown as Partial<SessionDto>))).not.toThrow();
+      expect(dotHex(session({ effectiveColor: "red", effectiveColorHex: 16711680 } as unknown as Partial<SessionDto>))).toBe("#FF00FF");
+      expect(dotHex(session({ effectiveColor: "red", effectiveColorHex: { r: 255 } } as unknown as Partial<SessionDto>))).toBe("#FF00FF");
+      expect(dotHex(session({ effectiveColor: "red", effectiveColorHex: ["#EF4444"] } as unknown as Partial<SessionDto>))).toBe("#FF00FF");
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });
 
 describe("needs-you waiting-line order", () => {

--- a/packages/client-core/src/sessions/ordering.test.ts
+++ b/packages/client-core/src/sessions/ordering.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { SessionDto } from "../api/client";
-import { classify, contextLine, deletionReason, dotColor, effectiveColor, groupByDirector, inBucket, inWaitingOrder, isWorking, pendingDeletion, snoozeCountdown, stateLabel } from "./ordering";
+import { classify, contextLine, deletionReason, dotColor, dotHex, effectiveColor, groupByDirector, inBucket, inWaitingOrder, isWorking, pendingDeletion, snoozeCountdown, stateLabel } from "./ordering";
 
 function session(fields: Partial<SessionDto> & { sessionId?: string } = {}): SessionDto {
   return {
@@ -133,6 +133,39 @@ describe("Gateway-stamped session presentation state", () => {
     // ladder that produced a blue dot beside the word "Snoozed" is gone.
     expect(contextLine(session({ effectiveColor: "blue", stateLabel: "Working", transcribing: true } as Partial<SessionDto>)))
       .toBe("Working");
+  });
+});
+
+describe("dotHex - the session dot renders the Gateway-stamped pixel", () => {
+  it("paints the stamped effectiveColorHex verbatim", () => {
+    // The Gateway resolves the name through the ONE canonical map and stamps the hex; the dot paints it.
+    expect(dotHex(session({ effectiveColor: "red", effectiveColorHex: "#EF4444" } as Partial<SessionDto>))).toBe("#EF4444");
+    expect(dotHex(session({ effectiveColor: "blue", effectiveColorHex: "#3B82F6" } as Partial<SessionDto>))).toBe("#3B82F6");
+  });
+
+  it("paints the magenta sentinel and logs when the stamp is missing (an old Gateway, mixed-version deploy)", () => {
+    // FAIL LOUD, NEVER GUESS: no hex on the wire must NOT fall back to the local COLORS table. Magenta is
+    // not a state and cannot be mistaken for one; grey would read as "parked", which would be a quiet lie.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(dotHex(session({ effectiveColor: "red" }))).toBe("#FF00FF");
+      expect(spy).toHaveBeenCalledOnce();
+      // It must NOT paint the real red the name would have mapped to - that is the guessed colour we refuse.
+      expect(dotHex(session({ effectiveColor: "red" }))).not.toBe(dotColor("red"));
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("paints the magenta sentinel and logs when the stamp is not a hex", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(dotHex(session({ effectiveColor: "red", effectiveColorHex: "reddish" } as Partial<SessionDto>))).toBe("#FF00FF");
+      expect(dotHex(session({ effectiveColor: "red", effectiveColorHex: "" } as Partial<SessionDto>))).toBe("#FF00FF");
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 

--- a/packages/client-core/src/sessions/ordering.ts
+++ b/packages/client-core/src/sessions/ordering.ts
@@ -6,10 +6,6 @@ import type { SessionDto } from "../api/client";
 export type TriageBucket = "needsYou" | "active" | "onHold";
 type GatewayStampedSession = SessionDto & {
   effectiveColor?: string | null;
-  // The Gateway-stamped pixel hex for the dot (SessionColorPalette.HexFor of effectiveColor). The session
-  // dot renders this verbatim via dotHex(); the generated schema does not carry it, so it is augmented here
-  // like effectiveColor. Absent from an old Gateway - dotHex() then paints the magenta sentinel.
-  effectiveColorHex?: string | null;
   stateLabel?: string | null;
   triageBucket?: TriageBucket | string | null;
   // Snooze Length mission: display-only marker that this session just returned from an EXPIRED snooze
@@ -276,10 +272,18 @@ const HEX_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 // so it would not degrade gracefully, it would lie quietly. Magenta plus a console error is the honest
 // answer - loud on the dot, diagnosable in the log.
 export function dotHex(s: SessionDto): string {
-  const raw = (s as GatewayStampedSession).effectiveColorHex?.trim();
+  // Read the generated-contract property directly (schema.ts carries effectiveColorHex). Typed as
+  // string | null, but a mixed-version or malformed wire can still deliver anything, so guard the runtime
+  // type below rather than trusting the annotation.
+  const value: unknown = s.effectiveColorHex;
+  // Type-guard BEFORE trim. Optional chaining only guards null/undefined; a malformed but possible JSON
+  // value (a number, object, or array) would make .trim non-callable and throw a TypeError from the React
+  // render path - one bad row taking down the whole roster. A non-string stamp is a protocol error exactly
+  // like a missing one: log and paint the magenta sentinel, never crash and never guess a colour.
+  const raw = typeof value === "string" ? value.trim() : "";
   if (raw && HEX_RE.test(raw)) return raw;
   console.error(
-    `Gateway /sessions missing or unparseable effectiveColorHex ('${raw ?? ""}') for session ` +
+    `Gateway /sessions missing or unparseable effectiveColorHex (${JSON.stringify(value)}) for session ` +
       `${s.sessionId ?? "(unknown)"}. Rendering the magenta protocol-error sentinel. Redeploy Gateway and clients together.`,
   );
   return BROKEN_HEX;

--- a/packages/client-core/src/sessions/ordering.ts
+++ b/packages/client-core/src/sessions/ordering.ts
@@ -6,6 +6,10 @@ import type { SessionDto } from "../api/client";
 export type TriageBucket = "needsYou" | "active" | "onHold";
 type GatewayStampedSession = SessionDto & {
   effectiveColor?: string | null;
+  // The Gateway-stamped pixel hex for the dot (SessionColorPalette.HexFor of effectiveColor). The session
+  // dot renders this verbatim via dotHex(); the generated schema does not carry it, so it is augmented here
+  // like effectiveColor. Absent from an old Gateway - dotHex() then paints the magenta sentinel.
+  effectiveColorHex?: string | null;
   stateLabel?: string | null;
   triageBucket?: TriageBucket | string | null;
   // Snooze Length mission: display-only marker that this session just returned from an EXPIRED snooze
@@ -215,20 +219,20 @@ function waitingSinceMs(s: SessionDto): number {
   return Number.isNaN(parsed) ? Number.POSITIVE_INFINITY : parsed;
 }
 
-// Map an effective Gateway colour name to its dot hex. THE CANONICAL PALETTE: one name, one hex,
-// every surface. These exact values are also the desktop rail's brushes (SessionViewModel.cs), so a
-// session renders the same pixel on the phone, the Cockpit and the rail - which is the whole point of
-// law 7 ("every device shows the same thing, always"). A name that resolves to two hexes, or two
-// surfaces that resolve one name differently, IS the violation - comparing fold answers ("red" ===
-// "red") cannot see it, so keep this table and the rail's in step by hand when either moves.
+// Map a Gateway colour NAME to its dot hex, for the LEGEND / AGGREGATE swatches that have no session
+// behind them (the fleet-map legend, the lane aggregate dots, the missions-board priority key). A real
+// SESSION dot no longer reads this table - it renders the Gateway-stamped hex via dotHex() below, so the
+// name->hex step is done ONCE on the Gateway and every device paints the identical pixel. This table
+// survives only for the decorative swatches, which have no stamped session to read.
 //
-// This comment used to say the table "mirrors the m.js palette so the mobile roster's dots match the
-// existing prototype and the desktop rail". Both halves were false: m.js does not exist anywhere in
-// the repository, and the table disagreed with the rail on red (#F14C4C here vs #EF4444 there) and
-// yellow (#F59E0B, which is amber-500, vs #EAB308). It named a deleted file as the source of truth
-// for a claim that was not true. Every name below is now Tailwind-500 for its own ramp - the two
-// strays were the two that disagreed - except `error`, which is deliberately red-700 so a crashed
-// session reads darker than a needs-you red.
+// THE DRIFT GUARD: these values must equal the canonical Gateway map (SessionColorPalette.HexFor in
+// CcDirector.Gateway.Contracts). Comparing fold answers ("red" === "red") cannot see a table that paints
+// "red" a different hex, so the StateAgreementCheck asserts canonical == this table == the desktop
+// StatusPalette on every run. Change a value here and that check goes red until the canonical map and the
+// desktop agree - which is how a legend swatch is kept from drifting from the session dot beside it.
+//
+// Every name below is Tailwind-500 for its own ramp, except `error`, which is deliberately red-700 so a
+// crashed session reads darker than a needs-you red.
 const COLORS: Record<string, string> = {
   red: "#EF4444", // needs you
   yellow: "#EAB308", // wingman narrating / preparing voice
@@ -251,6 +255,34 @@ export function dotColor(color: string): string {
   const value = COLORS[color];
   if (!value) throw new Error(`Unknown Gateway effectiveColor '${color}'.`);
   return value;
+}
+
+// The magenta protocol-error sentinel - matches SessionColorPalette.Broken and the desktop rail's
+// StatusPalette.Broken. NOT a state: it is what a session dot paints when the Gateway did not stamp a
+// usable hex, and it is deliberately unmissable and impossible to mistake for a real colour (grey MEANS
+// snoozed/exited, so a fallback to grey would be an affirmative lie that the session is parked).
+const BROKEN_HEX = "#FF00FF";
+// A #RGB or #RRGGBB hex, the only shapes the canonical palette emits.
+const HEX_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+// THE session dot's colour: the Gateway-stamped pixel hex (effectiveColorHex), resolved once on the
+// Gateway through the canonical name->hex map and painted here verbatim. A session dot renders THIS, not
+// the COLORS table above, so the phone, the Cockpit and the desktop rail all paint the identical pixel
+// and no client carries a name->hex table that can drift from the others.
+//
+// FAIL LOUD, NEVER GUESS. A missing or unparseable stamp - an old Gateway that sends the colour NAME but
+// not the hex, i.e. a mixed-version deploy - renders the magenta sentinel and logs it. It does NOT fall
+// back to dotColor(effectiveColor(s)): a guessed colour is indistinguishable from a real one on screen,
+// so it would not degrade gracefully, it would lie quietly. Magenta plus a console error is the honest
+// answer - loud on the dot, diagnosable in the log.
+export function dotHex(s: SessionDto): string {
+  const raw = (s as GatewayStampedSession).effectiveColorHex?.trim();
+  if (raw && HEX_RE.test(raw)) return raw;
+  console.error(
+    `Gateway /sessions missing or unparseable effectiveColorHex ('${raw ?? ""}') for session ` +
+      `${s.sessionId ?? "(unknown)"}. Rendering the magenta protocol-error sentinel. Redeploy Gateway and clients together.`,
+  );
+  return BROKEN_HEX;
 }
 
 // One short context line per row: the Gateway's stamped label, else the latest status reason.

--- a/src/CcDirector.Avalonia.Tests/AgreementCheckFaultInjectionTests.cs
+++ b/src/CcDirector.Avalonia.Tests/AgreementCheckFaultInjectionTests.cs
@@ -47,6 +47,9 @@ public sealed class AgreementCheckFaultInjectionTests
     private static SessionDto AsGatewayServesIt(SessionDto s)
     {
         s.EffectiveColor = SessionOrdering.EffectiveColor(s);
+        // The Gateway stamps the hex beside the name in the same fold (StampFleetRolesAndFold), so a row
+        // built here carries it too - the web session dot paints this verbatim.
+        s.EffectiveColorHex = SessionColorPalette.HexFor(s.EffectiveColor);
         s.StateLabel = SessionOrdering.StateLabel(s);
         s.TriageBucket = SessionOrdering.Classify(s) switch
         {

--- a/src/CcDirector.Avalonia.Tests/PaletteAgreementTests.cs
+++ b/src/CcDirector.Avalonia.Tests/PaletteAgreementTests.cs
@@ -1,0 +1,58 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.StateAgreementCheck;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The "Dumb Clients" palette guard: ONE canonical name-&gt;hex map, every surface sourced from it, and a
+/// machine-checked assertion that the three can never drift.
+///
+/// <see cref="SessionColorPalette"/> (CcDirector.Gateway.Contracts) is the single source. The Gateway
+/// stamps it onto <see cref="SessionDto.EffectiveColorHex"/> - the pixel the web session dot paints
+/// verbatim - and the desktop <see cref="StatusPalette"/> references it compile-time. The web client
+/// cannot reference C#, so it ships its own COLORS table (packages/client-core/src/sessions/ordering.ts)
+/// for its legend swatches. This test reads that SHIPPING table - never a copy typed here, which would be
+/// a fourteenth private palette that agrees with itself and proves nothing - and asserts
+/// canonical == desktop == web COLORS for every colour name. Change one and this goes red and names it.
+///
+/// This is the exhaustive companion to the live per-row check in <c>AgreementCheck.Compare</c> section 5:
+/// that one only sees colours a live fleet is currently showing, this one covers the whole vocabulary,
+/// always, in CI.
+/// </summary>
+public sealed class PaletteAgreementTests
+{
+    // The canonical vocabulary, spelled out literally rather than read from the palette under test - a test
+    // that iterates the values it is checking proves nothing. "unknown" is a real fold colour (grey), so it
+    // is in the list; both "grey" and "unknown" map to the one grey on every surface.
+    private static readonly string[] Names =
+        { "red", "yellow", "orange", "green", "blue", "purple", "supporting", "error", "grey", "unknown" };
+
+    [Fact]
+    public void Canonical_Desktop_AndWebColors_AgreeOnEveryName()
+    {
+        var web = ClientPalette.Read(RepoRoot());
+
+        foreach (var name in Names)
+        {
+            var canonical = SessionColorPalette.HexFor(name).ToUpperInvariant();
+
+            Assert.Equal(canonical, StatusPalette.HexFor(name).ToUpperInvariant());
+
+            Assert.True(web.TryGetValue(name, out var webHex),
+                $"the web COLORS table ({ClientPalette.RelativePath}) has no entry for '{name}' - the legend " +
+                "swatch cannot paint it.");
+            Assert.Equal(canonical, webHex!.ToUpperInvariant());
+        }
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "packages")))
+            dir = dir.Parent;
+        return dir?.FullName
+               ?? throw new InvalidOperationException(
+                   "Could not locate the repository root (no 'packages' directory above the test binary).");
+    }
+}

--- a/src/CcDirector.Avalonia.Tests/StatusPaletteTests.cs
+++ b/src/CcDirector.Avalonia.Tests/StatusPaletteTests.cs
@@ -86,6 +86,43 @@ public sealed class StatusPaletteTests
     [Fact]
     public void EveryColourTheRealFoldCanEmit_IsKnownToThePalette()
     {
+        var emitted = EveryColourTheRealFoldCanEmit();
+
+        Assert.NotEmpty(emitted);
+        foreach (var color in emitted)
+            Assert.True(StatusPalette.Knows(color),
+                $"The fold can emit '{color}' and the desktop palette does not know it, so the rail would " +
+                $"render the BROKEN magenta sentinel. Add it to StatusPalette AND to the palette table in " +
+                $"docs/new_architecture/session-state.html AND to the client's ordering.ts, in one pull request.");
+    }
+
+    /// <summary>
+    /// The CANONICAL half of the exhaustiveness proof. The desktop palette test above
+    /// asserts StatusPalette.Knows, but the Gateway stamps EffectiveColorHex from the CANONICAL map
+    /// (SessionColorPalette), and an unknown name there stamps the magenta sentinel. So a future fold colour
+    /// could escape if the desktop table were taught it while the canonical map was not. Drive the SAME real
+    /// fold and assert SessionColorPalette knows every colour it can emit, so the canonical map is provably
+    /// exhaustive over the fold - not just the desktop table.
+    /// </summary>
+    [Fact]
+    public void EveryColourTheRealFoldCanEmit_IsKnownToTheCanonicalMap()
+    {
+        var emitted = EveryColourTheRealFoldCanEmit();
+
+        Assert.NotEmpty(emitted);
+        foreach (var color in emitted)
+            Assert.True(SessionColorPalette.Knows(color),
+                $"The fold can emit '{color}' and the canonical SessionColorPalette does not know it, so the " +
+                "Gateway would stamp the magenta BROKEN sentinel for it. Add it to SessionColorPalette AND to " +
+                "docs/new_architecture/session-state.html AND to the client's ordering.ts, in one pull request.");
+    }
+
+    /// <summary>Every colour the REAL fold (<see cref="SessionOrdering.EffectiveColor"/>) can emit across
+    /// every activity state crossed with every overlay it folds. Deliberately NOT a hand-copied list of
+    /// names: a list would rot the moment the fold learned a tenth colour, which is how the desktop came to
+    /// have five palettes in the first place.</summary>
+    private static HashSet<string> EveryColourTheRealFoldCanEmit()
+    {
         var states = new[] { "Starting", "Working", "WaitingForInput", "WaitingForPerm", "Idle", "Exited", "NonsenseState" };
         var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -117,12 +154,7 @@ public sealed class StatusPaletteTests
                                             emitted.Add(SessionOrdering.EffectiveColor(dto));
                                         }
 
-        Assert.NotEmpty(emitted);
-        foreach (var color in emitted)
-            Assert.True(StatusPalette.Knows(color),
-                $"The fold can emit '{color}' and the desktop palette does not know it, so the rail would " +
-                $"render the BROKEN magenta sentinel. Add it to StatusPalette AND to the palette table in " +
-                $"docs/new_architecture/session-state.html AND to the client's ordering.ts, in one pull request.");
+        return emitted;
     }
 
     [Fact]

--- a/src/CcDirector.Avalonia.Tests/StatusPaletteTests.cs
+++ b/src/CcDirector.Avalonia.Tests/StatusPaletteTests.cs
@@ -12,8 +12,9 @@ namespace CcDirector.Avalonia.Tests;
 /// #F44747 in the FIFO window and the (dead) Director view, and #F14C4C on the phone. This file is
 /// the C# half of the pin; the web/mobile client carries the same table in
 /// packages/client-core/src/sessions/ordering.ts, and docs/new_architecture/session-state.html is
-/// the single written source both sides cite. A C# test cannot assert the TypeScript, so the spec's
-/// table is what keeps them honest - change it and both sides in the same pull request.
+/// the single written source both sides cite. PaletteAgreementTests now READS that shipping TypeScript
+/// table and asserts it equals the canonical map and this one, so the two sides are machine-checked to
+/// agree instead of relying on a human to change both in the same pull request.
 /// </summary>
 public sealed class StatusPaletteTests
 {

--- a/src/CcDirector.Avalonia/StatusPalette.cs
+++ b/src/CcDirector.Avalonia/StatusPalette.cs
@@ -1,16 +1,26 @@
 using Avalonia.Media;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
 
 namespace CcDirector.Avalonia;
 
 /// <summary>
-/// THE desktop palette: one fold-colour NAME, one hex, everywhere. This is the whole of defect 18.
+/// The desktop's Avalonia-brush adapter over the ONE canonical palette. This is the whole of defect 18.
 ///
-/// The colour NAMES are the shared fold's (SessionOrdering.EffectiveColor). The hexes are the
-/// Tailwind 500 ramp, and they are written down in docs/new_architecture/session-state.html, which
-/// is the single source both this table and the web/mobile client
-/// (packages/client-core/src/sessions/ordering.ts) cite. Change the spec's table and both sides in
-/// the same pull request, or they drift - which is exactly how this defect happened.
+/// The colour NAMES are the shared fold's (SessionOrdering.EffectiveColor). The hexes are NO LONGER
+/// hand-written here: every value below references <see cref="SessionColorPalette"/> in
+/// CcDirector.Gateway.Contracts - the single source the Gateway also stamps from onto
+/// <see cref="SessionDto.EffectiveColorHex"/>. The desktop is the same C# solution as the Gateway, so
+/// referencing that canonical map compile-time IS sharing the Gateway's own source of truth, not a
+/// second copy that can drift. (A change to the canonical hex therefore needs a desktop rebuild; the
+/// two ship together as one solution, so a colour never lands on one and not the other.) This class
+/// stays because the rail, the fleet map, the FIFO window and the turn review still need Avalonia
+/// brushes and the magenta sentinel; only its VALUES moved to the canonical map.
+///
+/// The web/mobile client (packages/client-core/src/sessions/ordering.ts) cannot reference C#, so it
+/// carries its own COLORS table for legend swatches AND renders the Gateway-stamped hex for a real
+/// session dot. The StateAgreementCheck asserts canonical == this table == that COLORS table every run,
+/// so the three can never drift - which is the guard that ends this defect for good.
 ///
 /// There used to be FIVE private palettes for the same colour names: the rail said red was #EF4444,
 /// the turn review said #E5484D, the (dead) Director view said #F44747 - and there it meant EXITED,
@@ -28,15 +38,15 @@ namespace CcDirector.Avalonia;
 /// </summary>
 public static class StatusPalette
 {
-    public const string Red        = "#EF4444";  // red-500      - needs you
-    public const string Blue       = "#3B82F6";  // blue-500     - working
-    public const string Green      = "#22C55E";  // green-500    - ready (brand new)
-    public const string Yellow     = "#EAB308";  // yellow-500   - wingman reading / preparing voice
-    public const string Orange     = "#F97316";  // orange-500   - dictation in flight / deep dive
-    public const string Purple     = "#A855F7";  // purple-500   - parked on its own background task
-    public const string Supporting = "#64748B";  // slate-500    - a live Worker's suppressed red
-    public const string Error      = "#B91C1C";  // red-700      - crashed, NOT finished (issue #959)
-    public const string Grey       = "#6B7280";  // gray-500     - snoozed, exited, or indeterminate
+    public const string Red        = SessionColorPalette.Red;         // red-500      - needs you
+    public const string Blue       = SessionColorPalette.Blue;        // blue-500     - working
+    public const string Green      = SessionColorPalette.Green;       // green-500    - ready (brand new)
+    public const string Yellow     = SessionColorPalette.Yellow;      // yellow-500   - wingman reading / preparing voice
+    public const string Orange     = SessionColorPalette.Orange;      // orange-500   - dictation in flight / deep dive
+    public const string Purple     = SessionColorPalette.Purple;      // purple-500   - parked on its own background task
+    public const string Supporting = SessionColorPalette.Supporting;  // slate-500    - a live Worker's suppressed red
+    public const string Error      = SessionColorPalette.Error;       // red-700      - crashed, NOT finished (issue #959)
+    public const string Grey       = SessionColorPalette.Grey;        // gray-500     - snoozed, exited, or indeterminate
 
     /// <summary>
     /// The BROKEN sentinel - magenta. Not a state. It means "the Gateway sent this desktop a colour
@@ -57,7 +67,7 @@ public static class StatusPalette
     /// across every state it can emit and proves this branch cannot fire. The sentinel is a tripwire
     /// a test guarantees is unreachable, not a guess that fires silently in production.
     /// </summary>
-    public const string Broken     = "#FF00FF";  // magenta - NOT a state; "this desktop does not know that colour"
+    public const string Broken     = SessionColorPalette.Broken;  // magenta - NOT a state; "this desktop does not know that colour"
 
     private static readonly ISolidColorBrush RedBrush        = new SolidColorBrush(Color.Parse(Red));
     private static readonly ISolidColorBrush BlueBrush       = new SolidColorBrush(Color.Parse(Blue));

--- a/src/CcDirector.Gateway.Contracts/SessionColorPalette.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionColorPalette.cs
@@ -1,0 +1,72 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// THE ONE canonical map from a fold colour NAME (<see cref="SessionOrdering.EffectiveColor"/>) to its
+/// pixel HEX. This is the single source of truth for the dot colour every surface paints.
+///
+/// The mission "Dumb Clients" exists because the NAME-&gt;hex step was hand-maintained in three separate
+/// places - the web client table, the desktop palette, and the state-agreement check's own copy - and
+/// they DRIFTED: red and yellow rendered as different shades on different screens even though all three
+/// folded to the same name. The fix is this one map. The Gateway stamps the resolved hex onto
+/// <see cref="SessionDto.EffectiveColorHex"/> from HERE, so a browser paints exactly the pixel the
+/// Gateway chose; the desktop palette (<c>StatusPalette</c>) sources its values from these same
+/// constants so a C# client cannot drift from the wire either.
+///
+/// The values are the Tailwind-500 ramp, written down in docs/new_architecture/session-state.html - the
+/// single spec both this map and the web client (packages/client-core/src/sessions/ordering.ts) cite.
+/// TWO deliberate departures from the 500 ramp, both load-bearing:
+///   - <see cref="Error"/> is red-700, not red-500. A session that DIED must never read as one that
+///     merely finished (issue #959).
+///   - <see cref="Grey"/> is ONE grey. Snoozed, exited, and indeterminate all fold to the "grey" name on
+///     purpose, so every client renders them identically.
+/// </summary>
+public static class SessionColorPalette
+{
+    public const string Red        = "#EF4444";  // red-500      - needs you
+    public const string Yellow     = "#EAB308";  // yellow-500   - wingman reading / preparing voice
+    public const string Orange     = "#F97316";  // orange-500   - dictation in flight / deep dive
+    public const string Green      = "#22C55E";  // green-500    - ready (brand new)
+    public const string Blue       = "#3B82F6";  // blue-500     - working
+    public const string Purple     = "#A855F7";  // purple-500   - parked on its own background task
+    public const string Supporting = "#64748B";  // slate-500    - a live Worker's suppressed red
+    public const string Error      = "#B91C1C";  // red-700      - crashed, NOT finished (issue #959)
+    public const string Grey       = "#6B7280";  // gray-500     - snoozed, exited, or indeterminate
+
+    /// <summary>
+    /// The PROTOCOL-ERROR sentinel - magenta. Not a state. It is what a client paints when the Gateway
+    /// sends it a colour name (or a stamped hex) it does not understand - a mixed-version deploy, or a
+    /// fold that learned a name nobody taught the palette. It exists to be impossible to misread: it is
+    /// not grey (which MEANS snoozed/exited), so it can never be mistaken for a real state, and it comes
+    /// with a logged error so it is diagnosable rather than a silent guess.
+    /// </summary>
+    public const string Broken     = "#FF00FF";  // magenta - NOT a state; "this colour name is not in the palette"
+
+    /// <summary>
+    /// The canonical hex for a fold colour name. Case-insensitive, because the names cross the wire.
+    ///
+    /// "unknown" is a REAL fold colour - <see cref="SessionOrdering.EffectiveColor"/> emits it for an
+    /// activity state it does not recognise - and it maps to <see cref="Grey"/> legitimately: an
+    /// indeterminate session is not asking for anything. That is a mapping, not a fallback. Anything
+    /// OUTSIDE the fold's vocabulary is a bug and gets the <see cref="Broken"/> sentinel, never a colour
+    /// that means something else.
+    /// </summary>
+    public static string HexFor(string? foldColor) => foldColor?.ToLowerInvariant() switch
+    {
+        "red"        => Red,
+        "yellow"     => Yellow,
+        "orange"     => Orange,
+        "green"      => Green,
+        "blue"       => Blue,
+        "purple"     => Purple,
+        "supporting" => Supporting,
+        "error"      => Error,
+        "grey"       => Grey,
+        "unknown"    => Grey,
+        _            => Broken,
+    };
+
+    /// <summary>True when <paramref name="foldColor"/> is a name this palette knows. A name it does not
+    /// know is a bug (it renders the <see cref="Broken"/> sentinel), never a state.</summary>
+    public static bool Knows(string? foldColor) => foldColor?.ToLowerInvariant() is
+        "red" or "yellow" or "orange" or "green" or "blue" or "purple" or "supporting" or "error" or "grey" or "unknown";
+}

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -217,6 +217,17 @@ public sealed class SessionDto
     public string? EffectiveColor { get; set; }
 
     /// <summary>
+    /// The pixel HEX for <see cref="EffectiveColor"/>, resolved through the ONE canonical map
+    /// (<see cref="SessionColorPalette.HexFor"/>) and stamped beside the name at the same fold point.
+    /// This is the whole of the "Dumb Clients" palette slice: a client paints THIS verbatim instead of
+    /// carrying its own name-&gt;hex table that can drift from the others. A missing/unparseable value on
+    /// a client (an old Gateway that stamps the name but not the hex) renders the loud magenta sentinel
+    /// (<see cref="SessionColorPalette.Broken"/>) plus a log - never a guessed colour. Required on Gateway
+    /// /sessions responses; Director-local responses may leave it null.
+    /// </summary>
+    public string? EffectiveColorHex { get; set; }
+
+    /// <summary>
     /// Gateway-owned triage bucket after the same effective-color fold:
     /// "needsYou" | "active" | "onHold". Stamped by the Gateway aggregator as the
     /// authoritative grouping value for mobile/Cockpit rosters. Required on Gateway /sessions

--- a/src/CcDirector.Gateway.Tests/EffectiveColorHexStampTests.cs
+++ b/src/CcDirector.Gateway.Tests/EffectiveColorHexStampTests.cs
@@ -1,0 +1,62 @@
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The "Dumb Clients" palette slice: the Gateway stamps the dot's pixel HEX beside the colour NAME in the
+/// same fold, resolved through the ONE canonical map (<see cref="SessionColorPalette"/>). Every client
+/// paints that stamp; none keeps its own name-&gt;hex table that can drift.
+///
+/// These drive the REAL fold (<c>StampFleetRolesAndFold</c> - the same method the /sessions roster and the
+/// desktop display-state push both fold through), not a hand-stamped DTO, so they cannot pass on a value
+/// production never puts there. Revert the stamp line in StampFleetRolesAndFold and
+/// <see cref="TheFoldStampsTheCanonicalHexForTheFoldedColour"/> goes red with a null hex - which is the web
+/// session dot painting the magenta sentinel instead of the real colour.
+/// </summary>
+public sealed class EffectiveColorHexStampTests
+{
+    private static SessionDto Fold(SessionDto s)
+    {
+        var list = new List<SessionDto> { s };
+        GatewayEndpoints.StampFleetRolesAndFold(list, list);
+        return s;
+    }
+
+    [Theory]
+    [InlineData("Working", "blue", "#3B82F6")]
+    [InlineData("Starting", "blue", "#3B82F6")]
+    [InlineData("WaitingForInput", "red", "#EF4444")]
+    [InlineData("Idle", "red", "#EF4444")]
+    public void TheFoldStampsTheCanonicalHexForTheFoldedColour(string activityState, string expectedColor, string expectedHex)
+    {
+        var s = Fold(new SessionDto { SessionId = "s", ActivityState = activityState });
+
+        Assert.Equal(expectedColor, s.EffectiveColor);
+        Assert.Equal(expectedHex, s.EffectiveColorHex);
+        // The hex is exactly the canonical map's answer for whatever colour the fold chose, so the stamped
+        // hex and the stamped name can never disagree.
+        Assert.Equal(SessionColorPalette.HexFor(s.EffectiveColor), s.EffectiveColorHex);
+    }
+
+    [Fact]
+    public void ASnoozedSession_StampsTheOneGrey()
+    {
+        var s = Fold(new SessionDto { SessionId = "s", ActivityState = "WaitingForInput", OnHold = true });
+
+        Assert.Equal("grey", s.EffectiveColor);
+        Assert.Equal(SessionColorPalette.Grey, s.EffectiveColorHex);
+    }
+
+    [Fact]
+    public void ACrashedSession_StampsTheDeepRed_NotNeedsYouRed()
+    {
+        var s = Fold(new SessionDto { SessionId = "s", ActivityState = "Exited", Crashed = true });
+
+        Assert.Equal("error", s.EffectiveColor);
+        Assert.Equal(SessionColorPalette.Error, s.EffectiveColorHex);
+        // Issue #959: a session that DIED must never paint the bright needs-you red.
+        Assert.NotEqual(SessionColorPalette.Red, s.EffectiveColorHex);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/EffectiveColorHexStampTests.cs
+++ b/src/CcDirector.Gateway.Tests/EffectiveColorHexStampTests.cs
@@ -6,14 +6,16 @@ namespace CcDirector.Gateway.Tests;
 
 /// <summary>
 /// The "Dumb Clients" palette slice: the Gateway stamps the dot's pixel HEX beside the colour NAME in the
-/// same fold, resolved through the ONE canonical map (<see cref="SessionColorPalette"/>). Every client
-/// paints that stamp; none keeps its own name-&gt;hex table that can drift.
+/// same fold, resolved through the ONE canonical map (<see cref="SessionColorPalette"/>). The /sessions
+/// consumers (the web phone and Cockpit) paint that stamp; the DESKTOP does NOT receive the hex - it
+/// resolves the same canonical values at compile time (StatusPalette references SessionColorPalette). No
+/// client keeps its own name-&gt;hex table that can drift from that one map.
 ///
-/// These drive the REAL fold (<c>StampFleetRolesAndFold</c> - the same method the /sessions roster and the
-/// desktop display-state push both fold through), not a hand-stamped DTO, so they cannot pass on a value
-/// production never puts there. Revert the stamp line in StampFleetRolesAndFold and
-/// <see cref="TheFoldStampsTheCanonicalHexForTheFoldedColour"/> goes red with a null hex - which is the web
-/// session dot painting the magenta sentinel instead of the real colour.
+/// These drive the REAL fold (<c>StampFleetRolesAndFold</c> - the method that stamps the /sessions roster
+/// and the display-state push, though the push carries the NAME and not this hex), not a hand-stamped DTO,
+/// so they cannot pass on a value production never puts there. Revert the stamp line in
+/// StampFleetRolesAndFold and <see cref="TheFoldStampsTheCanonicalHexForTheFoldedColour"/> goes red with a
+/// null hex - which is the web session dot painting the magenta sentinel instead of the real colour.
 /// </summary>
 public sealed class EffectiveColorHexStampTests
 {

--- a/src/CcDirector.Gateway.Tests/EffectiveColorHexStampTests.cs
+++ b/src/CcDirector.Gateway.Tests/EffectiveColorHexStampTests.cs
@@ -59,4 +59,21 @@ public sealed class EffectiveColorHexStampTests
         // Issue #959: a session that DIED must never paint the bright needs-you red.
         Assert.NotEqual(SessionColorPalette.Red, s.EffectiveColorHex);
     }
+
+    /// <summary>
+    /// Prove the stamped hex is on the served /sessions WIRE, not just the C# object. The
+    /// web reads the camel-cased JSON property, so serialize the folded DTO with the SAME Web JSON defaults
+    /// the Gateway serves with and assert the property is present, camel-cased, and carries the stamped
+    /// value. Revert the stamp and this goes red (the field serializes null, not "#EF4444").
+    /// </summary>
+    [Fact]
+    public void TheStampedHex_IsOnTheServedSessionsJson_CamelCased()
+    {
+        var s = Fold(new SessionDto { SessionId = "s", ActivityState = "WaitingForInput" });
+
+        var json = System.Text.Json.JsonSerializer.Serialize(
+            s, new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+
+        Assert.Contains("\"effectiveColorHex\":\"#EF4444\"", json);
+    }
 }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -2700,11 +2700,22 @@ internal static class GatewayEndpoints
         {
             var effectiveColor = SessionOrdering.EffectiveColor(s);
             s.EffectiveColor = effectiveColor;
-            // The "Dumb Clients" palette slice: resolve the name to its pixel HEX through the ONE canonical
-            // map, right here beside the name, so every client paints the same hex and none carries its own
-            // name->hex table that can drift. This one fold feeds BOTH the /sessions HTTP roster (the web
-            // reads EffectiveColorHex) and the desktop display-state push (FleetDisplayStateObserver reads it
-            // off the stamped session), so a single line covers every surface.
+            // The "Dumb Clients" palette slice: resolve the colour NAME to its pixel HEX through the ONE
+            // canonical map, right here beside the name, so the /sessions consumers (the web phone and the
+            // Cockpit) paint that hex verbatim and carry no name->hex table that can drift. The DESKTOP does
+            // NOT receive this hex - it is held to the SAME canonical values at compile time (StatusPalette
+            // references SessionColorPalette) and by the agreement tests (approved Fork B: no pushed hex).
+            // So this stamp is for the /sessions wire only; the display-state push still carries the name.
+            //
+            // FAIL LOUD on a name the canonical map does not know. HexFor returns the magenta sentinel for an
+            // unknown name, and a valid-looking #FF00FF would otherwise sail through the web unlogged - a
+            // silent magenta, the exact class of quiet failure this mission ends. A fold colour the palette
+            // does not know is a bug (the fold learned a name nobody taught the palette), so say so here.
+            if (!SessionColorPalette.Knows(effectiveColor))
+                FileLog.Write($"[GatewayEndpoints] UNKNOWN FOLD COLOUR '{effectiveColor}' for session " +
+                              $"{s.SessionId} - not in SessionColorPalette; stamping the magenta BROKEN sentinel. " +
+                              "The fold emitted a colour name the canonical palette does not know; see " +
+                              "docs/new_architecture/session-state.html.");
             s.EffectiveColorHex = SessionColorPalette.HexFor(effectiveColor);
             s.StateLabel = SessionOrdering.StateLabel(s);
             s.TriageBucket = SessionOrdering.Classify(s) switch

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -2700,6 +2700,12 @@ internal static class GatewayEndpoints
         {
             var effectiveColor = SessionOrdering.EffectiveColor(s);
             s.EffectiveColor = effectiveColor;
+            // The "Dumb Clients" palette slice: resolve the name to its pixel HEX through the ONE canonical
+            // map, right here beside the name, so every client paints the same hex and none carries its own
+            // name->hex table that can drift. This one fold feeds BOTH the /sessions HTTP roster (the web
+            // reads EffectiveColorHex) and the desktop display-state push (FleetDisplayStateObserver reads it
+            // off the stamped session), so a single line covers every surface.
+            s.EffectiveColorHex = SessionColorPalette.HexFor(effectiveColor);
             s.StateLabel = SessionOrdering.StateLabel(s);
             s.TriageBucket = SessionOrdering.Classify(s) switch
             {

--- a/src/CcDirector.StateAgreementCheck/AgreementCheck.cs
+++ b/src/CcDirector.StateAgreementCheck/AgreementCheck.cs
@@ -373,31 +373,48 @@ public static class AgreementCheck
                         $"'{desktopLabel}'. {WhyDesktopDiffers(row)}");
             }
 
-            // ---- 5. THE RENDERED PIXEL. The hole the Phase 4 Manager found, and it would have made this
-            // whole measurement worthless: comparing the fold's ANSWER reports ZERO while two screens paint
-            // different colours. Before Phase 4 the rail's red was #EF4444 and the client's #F14C4C, and the
-            // rail's yellow #EAB308 against #F59E0B - both surfaces folded to "red", agreed perfectly, and
-            // painted different pixels. Law 7 is "every device shows the same thing, always", and the thing
-            // the owner sees is a pixel, not a string. So resolve each surface's answer THROUGH ITS OWN
-            // PALETTE and compare the hex.
+            // ---- 5. THE RENDERED PIXEL, MEASURED AGAINST THE ONE CANONICAL MAP. Comparing the fold's
+            // ANSWER (the colour NAME) reports agreement while two screens paint different hexes - the exact
+            // hole the Phase 4 Manager found (the rail's red #EF4444 against the client's #F14C4C, the rail's
+            // yellow #EAB308 against #F59E0B). Law 7 is "every device shows the same thing, always", and the
+            // thing the owner sees is a pixel, not a string.
+            //
+            // The "Dumb Clients" palette slice made ONE map the source: SessionColorPalette
+            // (CcDirector.Gateway.Contracts). The Gateway stamps it onto SessionDto.EffectiveColorHex (what
+            // the web session dot paints), and the desktop StatusPalette now REFERENCES it compile-time. So
+            // this check resolves the name through canonical and asserts each client table matches it - the
+            // guard that keeps the web's over-the-wire values from ever drifting from the canonical source.
+            var canonicalHex = SessionColorPalette.HexFor(row.EffectiveColor).ToUpperInvariant();
             var desktopHex = StatusPalette.HexFor(row.EffectiveColor).ToUpperInvariant();
+
+            // The desktop table must equal canonical. It does so BY CONSTRUCTION today (StatusPalette's
+            // constants reference SessionColorPalette), so this arm is the tripwire that fires the instant a
+            // future edit hardcodes a desktop hex again - the very drift this mission exists to end.
+            if (!string.Equals(desktopHex, canonicalHex, StringComparison.OrdinalIgnoreCase))
+                yield return new Finding(row.SessionId, name, "two-different-pixels",
+                    $"the desktop StatusPalette paints '{row.EffectiveColor}' {desktopHex}, the canonical map " +
+                    $"{canonicalHex} - both fold the same name and paint different colours. The desktop palette " +
+                    "has drifted from SessionColorPalette. Law 7 is 'every device shows the same thing, always'.");
+
+            // The web client's COLORS table must equal canonical too - read from the file the phone and the
+            // Cockpit actually ship, so a drift here is a real different pixel on those screens.
             if (!clientPalette.TryGetValue(row.EffectiveColor, out var clientHex))
             {
                 yield return new Finding(row.SessionId, name, "palette-missing",
                     $"the Gateway emitted colour '{row.EffectiveColor}' and the client palette " +
                     $"({ClientPalette.RelativePath}) has no entry for it - the phone cannot paint it.");
             }
-            else if (!string.Equals(desktopHex, clientHex, StringComparison.OrdinalIgnoreCase))
+            else if (!string.Equals(clientHex.ToUpperInvariant(), canonicalHex, StringComparison.OrdinalIgnoreCase))
             {
                 yield return new Finding(row.SessionId, name, "two-different-pixels",
                     $"both surfaces fold to '{row.EffectiveColor}' and AGREE - and then paint different colours: " +
-                    $"the desktop rail {desktopHex}, the phone and Cockpit {clientHex}. Law 7 is 'every device " +
-                    "shows the same thing, always'.");
+                    $"the canonical map {canonicalHex}, the web client table {clientHex.ToUpperInvariant()}. Law 7 is " +
+                    "'every device shows the same thing, always'.");
             }
-            else if (!StatusPalette.Knows(row.EffectiveColor))
+            else if (!SessionColorPalette.Knows(row.EffectiveColor))
             {
                 yield return new Finding(row.SessionId, name, "palette-missing",
-                    $"the desktop palette does not know '{row.EffectiveColor}' - the rail renders the magenta " +
+                    $"the palette does not know '{row.EffectiveColor}' - every surface renders the magenta " +
                     "BROKEN sentinel for this session.");
             }
         }


### PR DESCRIPTION
# One source for session dot colours

## What this does
The Gateway already decides each session's dot colour NAME (red/blue/yellow/...). But the NAME -> hex
(the actual pixel) was hand-maintained in three separate places - the web client table, the desktop
palette, and the state-agreement check's own copy - and they had drifted (red and yellow rendered as
different shades on different screens). This makes ONE canonical name->hex map the source, so the phone,
the Cockpit and the desktop show the identical colour, always.

## The change (small, one coherent slice)
- New `SessionColorPalette` (CcDirector.Gateway.Contracts): the ONE canonical name->hex map (Tailwind-500,
  error deliberately red-700, one grey).
- The Gateway stamps `SessionDto.EffectiveColorHex` from that map, right beside the colour name in the same
  fold (`StampFleetRolesAndFold`). The web reads this hex off the /sessions roster; the desktop does NOT
  receive it - the display-state push still carries only the colour name, and the desktop resolves that name
  through the same canonical map at compile time (`StatusPalette` references `SessionColorPalette`).
- Web session dots render the stamped hex (`dotHex`). A missing/unparseable stamp renders a loud magenta
  sentinel plus a console error - never a guessed colour. The web `COLORS` table stays only for the legend
  and aggregate swatches that have no session behind them.
- Desktop `StatusPalette`'s hex values now REFERENCE `SessionColorPalette` (compile-time), so the rail and
  fleet map paint canonical pixels without any second table. (Colour-name logic is unchanged; the rail's
  render path and its 25 existing tests are untouched.)
- `StateAgreementCheck` section 5 now asserts canonical == desktop StatusPalette == web COLORS, so the
  three can never drift again. A new exhaustive unit test pins the same across the whole colour vocabulary,
  reading the SHIPPING web table (never a copy).

## Deploy note (honest)
This is a contract change: Gateway and clients ship together. A colour change updates the web on a Gateway
deploy but needs a desktop rebuild - the desktop is the same solution as the Gateway and ships with it, so
a colour never lands on one and not the other. During a mixed-version window (old Gateway, new web) the web
paints the magenta sentinel and logs, rather than guessing.

## Proof each fix can fail (revert -> red with the real symptom -> restore)
- Gateway stamp: EffectiveColorHexStampTests go red with a null hex when the stamp line is removed.
- Web dotHex: the sentinel tests go red (painting the guessed #EF4444 instead of #FF00FF) when dotHex is
  reverted to the forbidden name-fallback. VERIFIED.
- Desktop/web drift guard: PaletteAgreementTests go red when a canonical value and a client table disagree.

## Not in scope (unchanged)
Which colour a state gets; background/border tints; other verdicts (labels, triage, voice). The general
broken-presentation system is a separate slice. The desktop is not live-served: it renders canonical
pixels from the shared compile-time map, not a pushed hex string (a redundant field through the name-only
display-state push, avoided to keep this small).
