### PR TITLE
feat(gateway): add a hosted mode for running on Azure App Service

### DIFF
--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -26,7 +26,10 @@ using Microsoft.Extensions.Logging;
 namespace CcDirector.Gateway;
 
 /// <summary>
-/// The Gateway's Kestrel host. One process per machine. Binds to 127.0.0.1:7878.
+/// The Gateway's Kestrel host. One process per machine. Binds all interfaces (0.0.0.0:7878 by default) so a
+/// tailnet or hosted client can reach it; every route except /healthz, /login, /logout requires auth, so the
+/// bind is reachable-but-authenticated, not open. When CC_GATEWAY_HOSTED=1 the port follows the platform's
+/// WEBSITES_PORT/PORT (see <see cref="GatewayHostedMode"/>).
 /// </summary>
 public sealed class GatewayHost : IAsyncDisposable
 {
@@ -1133,8 +1136,11 @@ public sealed class GatewayHost : IAsyncDisposable
 
         // Subscribe the Tailscale provisioner BEFORE Registry.Start() so the initial
         // file-discovery load fires OnDirectorAdded into it and every Director port
-        // gets an HTTPS mapping without anyone re-running a script.
-        _serveProvisioner.Start();
+        // gets an HTTPS mapping without anyone re-running a script. Skipped when HOSTED: a
+        // hosted Gateway is reached by its public URL, not a tailnet, and the image bundles
+        // no tailscale binary, so provisioning would only produce noise.
+        if (!GatewayHostedMode.IsHosted)
+            _serveProvisioner.Start();
         Registry.Start();
 
         // Issue #331: start the stale-launcher sweep timer so launchers that crash
@@ -1145,7 +1151,9 @@ public sealed class GatewayHost : IAsyncDisposable
         // reconcile - re-assert the front door, drop serve mappings for Directors that died
         // while the Gateway was down (orphans -> 502 from a phone), and sweep any leaked
         // ephemeral-port mappings (issue #179). The provisioner repeats this on a timer.
-        _serveProvisioner.Reconcile();
+        // Skipped when HOSTED (no tailnet, no tailscale binary).
+        if (!GatewayHostedMode.IsHosted)
+            _serveProvisioner.Reconcile();
 
         // Gateway Cleanup mission (post-cut): the advertised-endpoint re-verification monitor (issue #325)
         // is DELETED. It HTTP-probed each Director's advertised /healthz; post-cut liveness is the tunnel
@@ -1908,7 +1916,7 @@ public sealed class GatewayHost : IAsyncDisposable
         Cockpit.CockpitReactApp.Map(_app);
 
         await _app.StartAsync();
-        FileLog.Write($"[GatewayHost] listening on http://127.0.0.1:{Port} (version {version})");
+        FileLog.Write($"[GatewayHost] listening on http://0.0.0.0:{Port} (all interfaces, auth-gated; version {version})");
 
         // Cron firing sweep (epic #479, #483): wake ~every minute and fire due jobs. The first tick
         // also catches up a fire that came due while the Gateway was down (at most once per job).
@@ -1980,23 +1988,29 @@ public sealed class GatewayHost : IAsyncDisposable
         // Network Diagnostics monitor (Network Diagnostics mission, Phase 1): on a timer, watch each
         // connected device's direct-vs-relay path and log persistent home-relay drift QUIETLY. Alert
         // channels (doorbell + owner email) are wired in P5 onto the same Decide-machine state.
-        var netDiagDeviceStore = new Api.NetDiagDeviceStore(Path.Combine(CcStorage.Root(), "netdiag-devices.json"));
-        // P5: deliver the monitor's drift/resolve to the doorbell + owner email. The alert service owns the
-        // 401-explicit "not signed in" path, the daily email cap, and one-email-per-episode; the monitor
-        // just hands it the device name on the machine's rising/falling edges.
-        var netDiagNotify = new Core.Account.AccountNotifyClient(new HttpClient { Timeout = TimeSpan.FromSeconds(30) });
-        var netDiagAlerts = new Api.NetDiagAlertService(
-            DirectorEvents,
-            () => Account?.GetAccessTokenForForwarding(),
-            async (token, subject, bodyText) =>
-            {
-                var r = await netDiagNotify.SendOwnerAsync(token, subject, bodyText, null, null, default).ConfigureAwait(false);
-                return r.Sent;
-            });
-        _netDiagMonitor = new Api.NetDiagMonitor(
-            Api.TailscaleDiagnostics.Collect, Api.LanPresenceProbe.TryResolveMac, netDiagDeviceStore, _netDiagRollup,
-            netDiagAlerts.OnDrift, netDiagAlerts.OnResolve);
-        _netDiagMonitor.Start();
+        //
+        // Skipped when HOSTED: the monitor's collector shells out to the tailscale CLI, which the container
+        // image does not bundle, so every poll would throw. A hosted Gateway has no tailnet to diagnose.
+        if (!GatewayHostedMode.IsHosted)
+        {
+            var netDiagDeviceStore = new Api.NetDiagDeviceStore(Path.Combine(CcStorage.Root(), "netdiag-devices.json"));
+            // P5: deliver the monitor's drift/resolve to the doorbell + owner email. The alert service owns the
+            // 401-explicit "not signed in" path, the daily email cap, and one-email-per-episode; the monitor
+            // just hands it the device name on the machine's rising/falling edges.
+            var netDiagNotify = new Core.Account.AccountNotifyClient(new HttpClient { Timeout = TimeSpan.FromSeconds(30) });
+            var netDiagAlerts = new Api.NetDiagAlertService(
+                DirectorEvents,
+                () => Account?.GetAccessTokenForForwarding(),
+                async (token, subject, bodyText) =>
+                {
+                    var r = await netDiagNotify.SendOwnerAsync(token, subject, bodyText, null, null, default).ConfigureAwait(false);
+                    return r.Sent;
+                });
+            _netDiagMonitor = new Api.NetDiagMonitor(
+                Api.TailscaleDiagnostics.Collect, Api.LanPresenceProbe.TryResolveMac, netDiagDeviceStore, _netDiagRollup,
+                netDiagAlerts.OnDrift, netDiagAlerts.OnResolve);
+            _netDiagMonitor.Start();
+        }
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/GatewayHostedMode.cs
+++ b/src/CcDirector.Gateway/GatewayHostedMode.cs
@@ -1,0 +1,41 @@
+namespace CcDirector.Gateway;
+
+/// <summary>
+/// The HOSTED-mode signal for a Gateway running as a hosted/container deployment (for example Azure App
+/// Service), reached by its PUBLIC URL rather than a tailnet. Set the environment variable
+/// <c>CC_GATEWAY_HOSTED=1</c> to enable it. Fail-safe: any missing or other value is NOT hosted, so the
+/// desktop/local behavior is byte-identical to today.
+///
+/// When hosted:
+///  - Tailscale Serve auto-provisioning (<see cref="Tailscale.TailscaleServeProvisioner"/>) and the
+///    tailscale-shelling network-diagnostics monitor (<see cref="Api.NetDiagMonitor"/>) are NOT started. A
+///    hosted Gateway is reached by its public URL, not a tailnet, and the container image bundles no tailscale
+///    binary, so starting them only produces noise and repeated errors.
+///  - The listener honors the App Service port convention (<c>WEBSITES_PORT</c>, else <c>PORT</c>, else the
+///    default), so the platform's front-end can route to the container's assigned port. The bind address is
+///    all-interfaces in BOTH modes (that is unchanged - it is how a tailnet client reaches a desktop Gateway),
+///    with the auth gate enforcing on every non-public route, so an all-interfaces bind is
+///    reachable-but-authenticated, not open.
+/// </summary>
+public static class GatewayHostedMode
+{
+    /// <summary>True when <c>CC_GATEWAY_HOSTED=1</c> - this Gateway is a hosted/container deployment.</summary>
+    public static bool IsHosted =>
+        string.Equals(Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED"), "1", StringComparison.Ordinal);
+
+    /// <summary>
+    /// The port a hosted Gateway should listen on: the App Service <c>WEBSITES_PORT</c>, else <c>PORT</c>, else
+    /// <paramref name="fallbackPort"/> (the port the process was started with). Only consulted in hosted mode;
+    /// a missing/blank/invalid value falls through to the fallback, so it never fails the listener.
+    /// </summary>
+    public static int ResolveHostedPort(int fallbackPort)
+    {
+        foreach (var name in new[] { "WEBSITES_PORT", "PORT" })
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            if (!string.IsNullOrWhiteSpace(value) && int.TryParse(value, out var p) && p is > 0 and <= 65535)
+                return p;
+        }
+        return fallbackPort;
+    }
+}

--- a/src/CcDirector.Gateway/Program.cs
+++ b/src/CcDirector.Gateway/Program.cs
@@ -42,6 +42,19 @@ for (int i = 0; i < args.Length; i++)
     }
 }
 
+// Hosted (Azure App Service): honor the platform's assigned port (WEBSITES_PORT, else PORT), so the
+// front-end can route to the container. Falls through to the --port value when unset. Applied HERE, before
+// the port flows into the Gateway, so the ONE port value is consistent everywhere - the all-interfaces
+// listener bind AND every loopback self-call the Gateway makes to itself. The bind is 0.0.0.0 in both modes;
+// only the port source differs when hosted.
+if (GatewayHostedMode.IsHosted)
+{
+    var hostedPort = GatewayHostedMode.ResolveHostedPort(port);
+    if (hostedPort != port)
+        FileLog.Write($"[Program] HOSTED mode: listening on the platform port {hostedPort} (was {port})");
+    port = hostedPort;
+}
+
 var builder = Host.CreateApplicationBuilder(args);
 builder.Services.AddSingleton(new GatewayWorker(port));
 builder.Services.AddHostedService(sp => sp.GetRequiredService<GatewayWorker>());


### PR DESCRIPTION
Add a hosted-mode flag, CC_GATEWAY_HOSTED=1, for running the Gateway on Azure App
Service. It does two things, and does nothing when the flag is unset - the
desktop and local behavior is byte-identical to today.

When hosted:
- The Tailscale-serve provisioning and the tailscale-dependent network-diagnostics
  collector are skipped. A hosted Gateway is reached over its public URL, not a
  tailnet, and the tailscale binary is not in the container, so leaving them on
  only threw harmless-but-noisy errors. This is the deliberate choice the mission
  called for - gate it off rather than bundle a tailnet binary the hosted service
  does not use.
- The listener honors the platform-assigned port (WEBSITES_PORT, else PORT, else
  the usual 7878), resolved once so the same port is used for the bind and for
  every loopback self-call. App Service assigns the port it routes the public URL
  to; the container must listen there.

The Gateway already binds all interfaces (0.0.0.0) unconditionally, which the
desktop tailnet dashboard and phone rely on, so external reachability was never a
gap - this change does not touch the bind. It also corrects a stale class comment
and a log line that printed 127.0.0.1 and wrongly implied a loopback bind.

The auth gate is unaffected - a token or per-device key is still required - so a
hosted Gateway is reachable but authenticated, not open.

Evidence: full Windows solution test suite green across all seven projects with
the flag unset (behavior unchanged). A Linux container run with CC_GATEWAY_HOSTED=1
and WEBSITES_PORT=8080 logged that it moved to the platform port and listened on
0.0.0.0:8080, threw zero tailscale or network-diagnostics errors, answered health
200 on the container's non-loopback address and on loopback, returned 401 without
a token (auth still enforced), and started the warm brain successfully - proving
gating the tailnet work off did not break the Gateway.
