### PR TITLE
feat(gateway): mirror hosted-AI debits into account_hosted_ai_spend (governance capture, #1771)

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedAiSpendSweepTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedAiSpendSweepTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using CcDirector.Core.Account;
+using CcDirector.Gateway.Governance;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tests for the periodic hosted-AI spend sweep (issue #1771, spine item 3). The claims that matter: only
+/// debits are mirrored, as a positive magnitude; a top-up or a zero is dropped; an unparseable transaction
+/// time is left null so the store skips it (a disclosed undercount over double-counting money); re-observing
+/// the rolling window mirrors nothing new; and a signed-out Gateway records nothing rather than fabricating.
+/// </summary>
+public sealed class HostedAiSpendSweepTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    private AccountHostedAiSpendStore NewStore() => new(_h.Open());
+
+    [Fact]
+    public void MapDebits_keeps_only_debits_as_positive_magnitude()
+    {
+        var recent = new List<CloudCreditTransaction>
+        {
+            new("debit", -1500, "2026-07-18T01:00:00Z"),
+            new("credit", 5000, "2026-07-18T02:00:00Z"), // a top-up: dropped
+            new("debit", -250, "2026-07-18T03:00:00Z"),
+            new("debit", 0, "2026-07-18T04:00:00Z"),      // not negative: dropped
+        };
+
+        var debits = HostedAiSpendSweep.MapDebits(recent);
+
+        Assert.Equal(2, debits.Count);
+        Assert.All(debits, d => Assert.Equal(AccountHostedAiSpendStore.DebitKind, d.Kind));
+        Assert.Equal(1500, debits[0].AmountMicros); // stored positive
+        Assert.Equal(250, debits[1].AmountMicros);
+    }
+
+    [Fact]
+    public void MapDebits_leaves_time_null_when_absent_or_unparseable()
+    {
+        var recent = new List<CloudCreditTransaction>
+        {
+            new("debit", -100, null),
+            new("debit", -200, "not-a-date"),
+        };
+
+        var debits = HostedAiSpendSweep.MapDebits(recent);
+
+        Assert.Equal(2, debits.Count);
+        Assert.All(debits, d => Assert.Null(d.TransactionCreatedUtc));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("garbage")]
+    public void ParseUtc_returns_null_for_absent_or_unparseable(string? s)
+    {
+        Assert.Null(HostedAiSpendSweep.ParseUtc(s));
+    }
+
+    [Fact]
+    public void ParseUtc_reads_an_iso_timestamp_as_utc()
+    {
+        var t = HostedAiSpendSweep.ParseUtc("2026-07-18T01:23:45Z");
+        Assert.NotNull(t);
+        Assert.Equal(DateTimeKind.Utc, t!.Value.Kind);
+        Assert.Equal(new DateTime(2026, 7, 18, 1, 23, 45, DateTimeKind.Utc), t.Value);
+    }
+
+    [Fact]
+    public void Mapped_debits_mirror_into_the_store_and_dedup_on_re_observe()
+    {
+        var store = NewStore();
+        var recent = new List<CloudCreditTransaction>
+        {
+            new("debit", -1500, "2026-07-18T01:00:00Z"),
+            new("debit", -250, "2026-07-18T03:00:00Z"),
+            new("debit", -99, null), // no time: the store skips it (cannot de-dup)
+        };
+
+        var first = store.RecordObservedDebits(HostedAiSpendSweep.MapDebits(recent));
+        Assert.Equal(2, first); // the null-time debit is skipped
+
+        // Re-observing the same rolling window mirrors nothing new.
+        var second = store.RecordObservedDebits(HostedAiSpendSweep.MapDebits(recent));
+        Assert.Equal(0, second);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_signed_out_records_nothing()
+    {
+        var store = NewStore();
+        var sweep = new HostedAiSpendSweep(
+            accessToken: () => null, // signed out - an expected state, never a fabricated figure
+            credits: new AccountCreditsClient(new HttpClient(new ThrowingHandler()), baseUrl: "http://stub"),
+            store: store);
+
+        await sweep.RunOnceAsync(CancellationToken.None);
+
+        Assert.Empty(store.List());
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_mirrors_debits_from_the_ledger()
+    {
+        var store = NewStore();
+        var body = "{\"data\":{\"balance_micros\":9000,\"transactions\":[" +
+                   "{\"kind\":\"debit\",\"amount_micros\":-1500,\"created_at\":\"2026-07-18T01:00:00Z\"}," +
+                   "{\"kind\":\"credit\",\"amount_micros\":5000,\"created_at\":\"2026-07-18T02:00:00Z\"}]}}";
+        var sweep = new HostedAiSpendSweep(
+            accessToken: () => "tok",
+            credits: new AccountCreditsClient(new HttpClient(new CannedHandler(body)), baseUrl: "http://stub"),
+            store: store);
+
+        await sweep.RunOnceAsync(CancellationToken.None);
+
+        var rows = store.List();
+        Assert.Single(rows); // only the debit, not the top-up
+        Assert.Equal(1500, rows[0].AmountMicros);
+    }
+
+    private sealed class CannedHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+        public CannedHandler(string body) { _body = body; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+            });
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            throw new HttpRequestException("must not be called when signed out");
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -322,6 +322,8 @@ public sealed class GatewayHost : IAsyncDisposable
     // built and started in StartAsync (it needs the live Director client) and disposed in StopAsync.
     private readonly Snooze.SnoozeRegistry _snoozeRegistry;
     private Snooze.SnoozeExpirySweep? _snoozeSweep;
+    // Fills account_hosted_ai_spend by periodically mirroring the cloud credit-debit ledger (issue #1771).
+    private Governance.HostedAiSpendSweep? _hostedAiSpendSweep;
     // Mission Screen mission (Phase 1b, issue #1405): the Gateway-owned, restart-surviving store of each
     // mission's WHY, keyed by the mission's normalized name. Durable + shared so every Cockpit, the phone,
     // and the future Mission-Control chat/API read the same WHY. Constructed here (load-on-construct
@@ -1986,6 +1988,16 @@ public sealed class GatewayHost : IAsyncDisposable
             utcNow: () => DateTime.UtcNow);
         _snoozeSweep.Start();
 
+        // Governance capture (issue #1771, spine item 3): periodically mirror the account's real hosted-AI
+        // service debits from the cloud credit-debit ledger into account_hosted_ai_spend, so the weekly
+        // report shows an honest account-level "Hosted-AI services: $X" figure. Signed out is an expected
+        // no-op (no fabricated spend); the store dedups the ledger's rolling window so over-polling is safe.
+        _hostedAiSpendSweep = new Governance.HostedAiSpendSweep(
+            accessToken: () => Account?.GetAccessTokenForForwarding(),
+            credits: new Core.Account.AccountCreditsClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) }),
+            store: _hostedAiSpend);
+        _hostedAiSpendSweep.Start();
+
         // Web Push (mobile app-icon "needs you" dot): start the background notifier now that this
         // Gateway's own /sessions endpoint is live on loopback. The notifier reads that endpoint (so its
         // "needs you" verdict is byte-identical to the roster's) and pushes the count to subscribed
@@ -2179,6 +2191,7 @@ public sealed class GatewayHost : IAsyncDisposable
         try { _pushNotifier?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] push notifier dispose error: {ex.Message}"); }
         try { _netDiagMonitor?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] netdiag monitor dispose error: {ex.Message}"); }
         try { _snoozeSweep?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] snooze sweep dispose error: {ex.Message}"); }
+        try { _hostedAiSpendSweep?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] hosted-ai spend sweep dispose error: {ex.Message}"); }
         _pushNotifier = null;
         try { _pushLoopbackHttp.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] push loopback client dispose error: {ex.Message}"); }
 

--- a/src/CcDirector.Gateway/Governance/HostedAiSpendSweep.cs
+++ b/src/CcDirector.Gateway/Governance/HostedAiSpendSweep.cs
@@ -1,0 +1,139 @@
+using System.Globalization;
+using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Governance;
+
+/// <summary>
+/// Fills the <c>account_hosted_ai_spend</c> table (issue #1771, spine item 3) by periodically mirroring the
+/// account's real hosted-AI service debits from the cloud credit-debit ledger. A background timer on the
+/// Gateway (the same shape as <see cref="Snooze.SnoozeExpirySweep"/>): every few minutes it reads the
+/// signed-in account's recent ledger entries and hands the debits to <see cref="AccountHostedAiSpendStore"/>,
+/// which de-duplicates the cloud's rolling window so over-polling is safe.
+///
+/// Honesty at the edges (no fabricated money):
+///  - Signed out (no account credential) is an expected state, not an error: nothing is mirrored, and no
+///    spend is invented.
+///  - The store keeps the amount ACCOUNT-LEVEL - never pinned to a session or run - because the ledger
+///    attributes a debit to neither.
+///  - A debit the cloud returns without a parseable transaction time is left with a null time so the store
+///    skips it: a disclosed undercount beats double-counting real dollars.
+/// </summary>
+public sealed class HostedAiSpendSweep : IDisposable
+{
+    /// <summary>How often the account ledger is re-read. The store dedups, so the exact cadence is not
+    /// correctness - it only bounds how soon a new hosted-AI debit shows up in the report.</summary>
+    public static readonly TimeSpan SweepInterval = TimeSpan.FromMinutes(5);
+
+    /// <summary>A short settling delay before the first read, so startup finishes first.</summary>
+    public static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(20);
+
+    private readonly Func<string?> _accessToken;
+    private readonly AccountCreditsClient _credits;
+    private readonly AccountHostedAiSpendStore _store;
+
+    private System.Threading.Timer? _timer;
+    private int _busy; // 0 = idle, 1 = a tick is running (reentrancy guard)
+
+    /// <param name="accessToken">Reads the Gateway-held account access token, or null/empty when signed out.
+    /// The token is passed straight to the credits client and never logged.</param>
+    /// <param name="credits">The cloud credits client (the injectable cloud egress seam).</param>
+    /// <param name="store">The account-level hosted-AI spend store the debits are mirrored into.</param>
+    public HostedAiSpendSweep(Func<string?> accessToken, AccountCreditsClient credits, AccountHostedAiSpendStore store)
+    {
+        _accessToken = accessToken ?? throw new ArgumentNullException(nameof(accessToken));
+        _credits = credits ?? throw new ArgumentNullException(nameof(credits));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+    }
+
+    /// <summary>Start the background sweep. Returns immediately; the first read runs after a short delay.</summary>
+    public void Start()
+    {
+        _timer = new System.Threading.Timer(_ => Tick(), null, StartupDelay, SweepInterval);
+        FileLog.Write($"[HostedAiSpendSweep] started: every {SweepInterval.TotalMinutes:0} min");
+    }
+
+    /// <summary>
+    /// One read-and-mirror pass. Public so a test can drive it directly. A signed-out Gateway returns without
+    /// mirroring (an expected state, never an error); a cloud failure throws (surfaced by the tick's log,
+    /// never a fabricated figure).
+    /// </summary>
+    public async Task RunOnceAsync(CancellationToken cancellationToken)
+    {
+        var token = _accessToken();
+        if (string.IsNullOrEmpty(token))
+        {
+            FileLog.Write("[HostedAiSpendSweep] no account credential -> skipping (signed out)");
+            return;
+        }
+
+        var credits = await _credits.GetCreditsAsync(token, cancellationToken).ConfigureAwait(false);
+        var debits = MapDebits(credits.Recent);
+        var mirrored = _store.RecordObservedDebits(debits);
+        FileLog.Write($"[HostedAiSpendSweep] observed {credits.Recent.Count} ledger entries, mirrored {mirrored} new debit(s)");
+    }
+
+    /// <summary>
+    /// Map the cloud's recent ledger to observed debits: a debit is a negative-amount entry, stored as its
+    /// positive magnitude. A top-up (positive) or a zero is not a hosted-AI cost and is dropped. The
+    /// transaction time is parsed to UTC; an absent or unparseable time is left null so the store skips it
+    /// (it cannot be de-duplicated) rather than risk double-counting real money.
+    /// </summary>
+    internal static IReadOnlyList<ObservedAccountDebit> MapDebits(IReadOnlyList<CloudCreditTransaction> recent)
+    {
+        var debits = new List<ObservedAccountDebit>();
+        foreach (var tx in recent)
+        {
+            if (tx.AmountMicros >= 0)
+                continue;
+            debits.Add(new ObservedAccountDebit
+            {
+                Kind = AccountHostedAiSpendStore.DebitKind,
+                AmountMicros = -tx.AmountMicros,
+                TransactionCreatedUtc = ParseUtc(tx.CreatedAt),
+            });
+        }
+        return debits;
+    }
+
+    /// <summary>Parse a cloud timestamp to UTC, or null when it is absent or unparseable.</summary>
+    internal static DateTime? ParseUtc(string? createdAt)
+    {
+        if (string.IsNullOrWhiteSpace(createdAt))
+            return null;
+        if (DateTime.TryParse(createdAt, CultureInfo.InvariantCulture,
+                DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var parsed))
+            return DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
+        return null;
+    }
+
+    private void Tick()
+    {
+        if (Interlocked.CompareExchange(ref _busy, 1, 0) != 0)
+            return; // a previous tick is still running - skip this one
+        _ = TickAsync();
+    }
+
+    private async Task TickAsync()
+    {
+        try
+        {
+            await RunOnceAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[HostedAiSpendSweep] tick FAILED: {ex.Message}");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _busy, 0);
+        }
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+        _timer = null;
+    }
+}


### PR DESCRIPTION
## What

The `account_hosted_ai_spend` table (governance spine item 3, thefrederiksen/devthrottle_internal#856) shipped empty. This wires the periodic sweep that fills it.

A background timer (same shape as `SnoozeExpirySweep`) reads the signed-in account's recent credit-ledger entries every few minutes and mirrors the **debits** - the real dollars the account spent on hosted AI services (text-to-speech, transcription, wingman) - into `AccountHostedAiSpendStore`, which de-duplicates the cloud's rolling window so over-polling is safe.

Honest at the edges:
- **Account-level by contract** - a mirrored debit is never pinned to a session or run (the ledger attributes it to neither).
- **Signed out is an expected no-op** - nothing mirrored, no spend fabricated.
- An **unparseable transaction time is left null** so the store skips it - a disclosed undercount over double-counting real money.
- Only **debits** are mirrored (a top-up / zero is dropped), stored as a positive magnitude.

## Scope

Write-only to the existing `account_hosted_ai_spend` table - **no EF migration**, so it does not contend for the migration slot.

## Tests

New `HostedAiSpendSweepTests` (10 cases): debit-only mapping and magnitude, credit/zero dropped, unparseable-time left null, map->store mirror + dedup on re-observe, signed-out no-op, and a stubbed-cloud happy path. Full Gateway suite run before merge.

Follow-on: PR3 - the state-transition event emitter that fills the phase-1 event ledger.
