### PR TITLE
feat(gateway): emit session state transitions into the event ledger (governance capture, #1771)

### DIFF
--- a/src/CcDirector.Gateway.Tests/SessionStateEventEmitterTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionStateEventEmitterTests.cs
@@ -1,0 +1,110 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Governance;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tests for the session state-transition emitter (issue #1771, spine item 2). The claims that matter: the
+/// four activity states map to ledger states and Starting/Exited do not; an event lands only on a real change
+/// (a heartbeat repeat is skipped); a session that exits mid-wait gets one closing event so its wait is not
+/// overcounted; a session that exits while active needs no closer; and a restarted session re-emits.
+/// </summary>
+public sealed class SessionStateEventEmitterTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    private (SessionStateEventEmitter Emitter, GovernanceEventLedger Ledger) New()
+    {
+        var ledger = new GovernanceEventLedger(_h.Open());
+        return (new SessionStateEventEmitter(ledger), ledger);
+    }
+
+    private List<string> StatesFor(GovernanceEventLedger ledger, string sessionId) =>
+        ledger.List(sessionId: sessionId).Select(e => e.State).ToList();
+
+    [Theory]
+    [InlineData("Working", "active")]
+    [InlineData("Idle", "idle")]
+    [InlineData("WaitingForInput", "waiting-on-human")]
+    [InlineData("WaitingForPerm", "waiting-on-permission")]
+    [InlineData("waitingforinput", "waiting-on-human")] // case-insensitive
+    public void MapState_maps_the_four_activity_states(string activity, string expected)
+    {
+        Assert.Equal(expected, SessionStateEventEmitter.MapState(activity));
+    }
+
+    [Theory]
+    [InlineData("Starting")]
+    [InlineData("Exited")]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("nonsense")]
+    public void MapState_returns_null_for_non_ledger_states(string? activity)
+    {
+        Assert.Null(SessionStateEventEmitter.MapState(activity));
+    }
+
+    [Fact]
+    public void Observe_emits_only_on_a_real_transition()
+    {
+        var (emitter, ledger) = New();
+        emitter.Observe("s1", "Working");
+        emitter.Observe("s1", "Working");          // heartbeat repeat - no new event
+        emitter.Observe("s1", "WaitingForInput");
+        emitter.Observe("s1", "WaitingForInput");  // repeat - no new event
+
+        var states = StatesFor(ledger, "s1");
+        Assert.Equal(2, states.Count);
+        Assert.Contains(GovernanceEventState.Active, states);
+        Assert.Contains(GovernanceEventState.WaitingOnHuman, states);
+    }
+
+    [Fact]
+    public void Observe_skips_starting_and_emits_nothing()
+    {
+        var (emitter, ledger) = New();
+        emitter.Observe("s1", "Starting");
+        Assert.Empty(ledger.List(sessionId: "s1"));
+    }
+
+    [Fact]
+    public void Exit_while_waiting_emits_one_closing_event()
+    {
+        var (emitter, ledger) = New();
+        emitter.Observe("s1", "WaitingForInput"); // open wait
+        emitter.Observe("s1", "Exited");          // exits mid-wait -> close the interval honestly
+
+        var states = StatesFor(ledger, "s1");
+        Assert.Equal(2, states.Count);
+        Assert.Contains(GovernanceEventState.WaitingOnHuman, states);
+        Assert.Contains(GovernanceEventState.Recovered, states); // the close-on-exit
+    }
+
+    [Fact]
+    public void Exit_while_active_emits_no_closing_event()
+    {
+        var (emitter, ledger) = New();
+        emitter.Observe("s1", "Working"); // active, no open wait
+        emitter.Observe("s1", "Exited");  // no closer needed
+
+        var states = StatesFor(ledger, "s1");
+        Assert.Single(states);
+        Assert.Equal(GovernanceEventState.Active, states[0]);
+    }
+
+    [Fact]
+    public void A_restarted_session_after_exit_re_emits_its_first_state()
+    {
+        var (emitter, ledger) = New();
+        emitter.Observe("s1", "Working");
+        emitter.Observe("s1", "Exited");  // forgets s1 (no open wait, no closer)
+        emitter.Observe("s1", "Working"); // a fresh transition after the guard was cleared
+
+        var active = ledger.List(sessionId: "s1", state: GovernanceEventState.Active);
+        Assert.Equal(2, active.Count);
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -352,6 +352,8 @@ public sealed class GatewayHost : IAsyncDisposable
     private readonly Governance.GovernanceAuditLog _governanceAudit;
     // Fills session_spend at each turn-end from the pushed roster snapshot (issue #1771, spine item 3).
     private readonly Governance.SessionSpendEmitter _sessionSpendEmitter;
+    // Fills the governance event ledger with session state transitions (issue #1771, spine item 2).
+    private readonly Governance.SessionStateEventEmitter _sessionStateEmitter;
     // The weekly Outcome Ledger reporter (issue #1771, spine item 4): a read-only assembly over the run
     // tables, event ledger, spend, and audit trail - the first governance report that pays rent.
     private readonly Governance.OutcomeLedgerReporter _outcomeLedger;
@@ -635,6 +637,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // sandbox decisions on the EF data layer, so a Gateway restart never loses a recorded audit fact.
         _governanceAudit = new Governance.GovernanceAuditLog(_gatewayDb);
         _sessionSpendEmitter = new Governance.SessionSpendEmitter(_sessionSpend);
+        _sessionStateEmitter = new Governance.SessionStateEventEmitter(_governanceEvents);
         // The weekly Outcome Ledger reporter (issue #1771, spine item 4): read-only over the run tables +
         // event ledger + spend + audit trail. No store of its own.
         _outcomeLedger = new Governance.OutcomeLedgerReporter(_gatewayDb);
@@ -1447,6 +1450,18 @@ public sealed class GatewayHost : IAsyncDisposable
                 // directorId, so feed THAT to the watcher (the voice-refresh path reaches the Director
                 // through the tunnel by id) instead of converting it to a dialable control URL.
                 _turnEndWatcher.Observe(sessionId, newState, directorId);
+
+                // Governance capture (issue #1771, spine item 2): record this session's state transition on
+                // the append-only ledger (emits only on a real change; isolated so a ledger hiccup never
+                // breaks the turn tracking above).
+                try
+                {
+                    _sessionStateEmitter.Observe(sessionId, newState);
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[GatewayHost] session-state event emit FAILED: sid={sessionId}: {ex.Message}");
+                }
             },
             // Issue #549: the assessed-state refutation (issue #186) is dropped with the pipeline
             // (Option A) - "needs you" reverts to the Director's raw mechanical signal. The

--- a/src/CcDirector.Gateway/Governance/SessionStateEventEmitter.cs
+++ b/src/CcDirector.Gateway/Governance/SessionStateEventEmitter.cs
@@ -1,0 +1,103 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Governance;
+
+/// <summary>
+/// Fills the append-only governance event ledger (issue #1771, spine item 2) with session state transitions,
+/// so a duration report can measure active / idle / waiting time. It observes the Gateway's single
+/// session-state funnel (which fires on every doorbell ping and heartbeat) and appends a ledger event ONLY on
+/// a real transition - a repeat of the current state is skipped, so a heartbeat storm never floods the ledger.
+///
+/// The six ledger states are entered; the reader closes each interval at the NEXT event of any state, so a
+/// normal came-back needs no synthetic event. The one exception, for honesty: a session that EXITS while in an
+/// open wait/block interval would otherwise have its wait counted to the report window's end, so on exit from
+/// waiting-on-human / waiting-on-permission / blocked this emits one closing event at the true exit time.
+/// <see cref="ActivityState"/>'s Starting and Exited are lifecycle, not activity states, so they are not
+/// emitted as-is (and the ledger would reject them anyway).
+/// </summary>
+public sealed class SessionStateEventEmitter
+{
+    private readonly GovernanceEventLedger _ledger;
+
+    // The last ledger state emitted per session, so an event lands only on a real change. Cleared on exit so
+    // the map does not grow without bound. Per-session observations are ordered by the funnel, so the
+    // read-then-write is effectively serial per session; a rare race would at worst emit a duplicate the
+    // reader tolerates.
+    private readonly ConcurrentDictionary<string, string> _lastState = new(StringComparer.Ordinal);
+
+    public SessionStateEventEmitter(GovernanceEventLedger ledger)
+    {
+        _ledger = ledger ?? throw new ArgumentNullException(nameof(ledger));
+    }
+
+    /// <summary>
+    /// Observe a session's reported activity state. Appends a ledger event on a real transition; on exit,
+    /// closes an open wait/block interval at the true exit time and forgets the session.
+    /// </summary>
+    public void Observe(string sessionId, string? activityState)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            return;
+
+        var mapped = MapState(activityState);
+        if (mapped is null)
+        {
+            // Not one of the six ledger states. On exit, close any open wait/block interval at the true exit
+            // (so a mid-wait exit is not overcounted to the window end), then forget the session.
+            if (IsExit(activityState) &&
+                _lastState.TryRemove(sessionId, out var lastOnExit) &&
+                IsOpenInterval(lastOnExit))
+            {
+                Append(sessionId, GovernanceEventState.Recovered);
+            }
+            return;
+        }
+
+        // A real transition only - a heartbeat re-reporting the current state must not append a duplicate.
+        var previous = _lastState.GetValueOrDefault(sessionId);
+        if (string.Equals(previous, mapped, StringComparison.Ordinal))
+            return;
+
+        _lastState[sessionId] = mapped;
+        Append(sessionId, mapped);
+    }
+
+    private void Append(string sessionId, string state)
+    {
+        _ledger.Append(new AppendGovernanceEventRequest
+        {
+            SubjectKind = GovernanceEventSubject.Session,
+            SessionId = sessionId,
+            State = state,
+            OccurredUtc = null, // the Gateway stamps the append time
+        });
+        FileLog.Write($"[SessionStateEventEmitter] Append: session={sessionId}, state={state}");
+    }
+
+    /// <summary>
+    /// Map a Director <see cref="ActivityState"/> name to a ledger state, or null when it is not one of the
+    /// six (Starting and Exited are lifecycle, not activity states). Case-insensitive.
+    /// </summary>
+    public static string? MapState(string? activityState) => Normalize(activityState) switch
+    {
+        "working" => GovernanceEventState.Active,
+        "idle" => GovernanceEventState.Idle,
+        "waitingforinput" => GovernanceEventState.WaitingOnHuman,
+        "waitingforperm" => GovernanceEventState.WaitingOnPermission,
+        _ => null,
+    };
+
+    private static bool IsExit(string? activityState) =>
+        string.Equals(Normalize(activityState), "exited", StringComparison.Ordinal);
+
+    /// <summary>An open wait/block interval whose duration a report measures - it must be closed on exit so it
+    /// is not counted to the report window's end.</summary>
+    private static bool IsOpenInterval(string state) =>
+        state == GovernanceEventState.WaitingOnHuman ||
+        state == GovernanceEventState.WaitingOnPermission ||
+        state == GovernanceEventState.Blocked;
+
+    private static string Normalize(string? s) => (s ?? "").Trim().ToLowerInvariant();
+}


### PR DESCRIPTION
## What

The append-only governance event ledger (spine item 2, thefrederiksen/devthrottle_internal#856) shipped empty. This wires the emitter that fills it - the last of the three capture-wiring emitters.

Observing the Gateway's single session-state funnel, it appends a ledger event on each **real transition**:
- `Working -> active`, `Idle -> idle`, `WaitingForInput -> waiting-on-human`, `WaitingForPerm -> waiting-on-permission`.
- A heartbeat that re-reports the current state is **skipped** (per-session guard), so the ledger is not flooded.

Honesty on exit (confirmed against `OutcomeLedgerReporter`'s duration math):
- The reader closes each interval at the **next event of any state**, so a normal came-back needs no synthetic event.
- But a session that **exits while in an open wait/block** (`waiting-on-human` / `waiting-on-permission` / `blocked`) would otherwise have its wait counted to the report window's end. So on that exit it emits **one closing event at the true exit time**, keeping `WaitingOnHumanSeconds` honest. `Starting`/`Exited` are lifecycle, not ledger states, and are never emitted as-is (the ledger validates against the six).

The emit is isolated so a ledger hiccup never breaks the turn tracking.

## Scope

Write-only to the existing `governance_events` ledger - **no EF migration**.

## Tests

New `SessionStateEventEmitterTests` (15 cases): the four state mappings + case-insensitivity, non-ledger states return null, emit-only-on-change, Starting skipped, exit-while-waiting closes the interval, exit-while-active emits no closer, restarted session re-emits. Full Gateway suite run before merge.

## Completes the capture wiring

With this, all three governance tables have their fillers: `session_spend` (#1796), `account_hosted_ai_spend` (#1801), and now the `governance_events` ledger - so the weekly Outcome Ledger's attention-burden and duration columns light up on real data.
