### PR TITLE
Wingman reads the live screen for menus and fails closed on voice turns (#1777)

### DIFF
--- a/src/CcDirector.ControlApi/SessionReadExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionReadExecutor.cs
@@ -274,15 +274,17 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
         if (session is null)
             return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
 
-        // Rows + cursor + alternate-screen flag from ONE coherent snapshot (issue #1777, finding 8): the menu
-        // classifier relies on the alternate-screen flag describing the same frame as the rows.
-        var (rows, cursorRow, cursorCol, isAlternateScreen) = session.SnapshotLiveScreen();
+        // Rows + cursor + cursor VISIBILITY + alternate-screen flag from ONE coherent snapshot (issue #1777,
+        // finding 8): the classifier relies on the flags describing the same frame as the rows. Cursor
+        // visibility is the discriminator between a composer (visible) and a drawn Ink menu (hidden).
+        var (rows, cursorRow, cursorCol, cursorVisible, isAlternateScreen) = session.SnapshotLiveScreen();
         return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new ScreenGridResponse
         {
             SessionId = command.SessionId,
             Rows = rows.ToList(),
             CursorRow = cursorRow,
             CursorCol = cursorCol,
+            CursorVisible = cursorVisible,
             IsAlternateScreen = isAlternateScreen,
             // A session with a real terminal parser yields a fixed-height grid (rows.Length > 0) even when the
             // screen is blank; only an Embedded session (no parser) yields an empty array - that is unreadable.

--- a/src/CcDirector.ControlApi/SessionReadExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionReadExecutor.cs
@@ -274,14 +274,16 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
         if (session is null)
             return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
 
-        var (rows, cursorRow, cursorCol) = session.SnapshotScreenRowsWithCursor();
+        // Rows + cursor + alternate-screen flag from ONE coherent snapshot (issue #1777, finding 8): the menu
+        // classifier relies on the alternate-screen flag describing the same frame as the rows.
+        var (rows, cursorRow, cursorCol, isAlternateScreen) = session.SnapshotLiveScreen();
         return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new ScreenGridResponse
         {
             SessionId = command.SessionId,
             Rows = rows.ToList(),
             CursorRow = cursorRow,
             CursorCol = cursorCol,
-            IsAlternateScreen = session.IsAlternateScreen,
+            IsAlternateScreen = isAlternateScreen,
             // A session with a real terminal parser yields a fixed-height grid (rows.Length > 0) even when the
             // screen is blank; only an Embedded session (no parser) yields an empty array - that is unreadable.
             HasGrid = rows.Length > 0,

--- a/src/CcDirector.ControlApi/SessionReadExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionReadExecutor.cs
@@ -34,6 +34,7 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
         "snapshot",
         "buffer",
         "buffer-html",
+        "screen-grid",
         "summary",
         "recap",
         "turn-summaries",
@@ -56,6 +57,7 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
             "snapshot" => Snapshot(sessionManager, context.DirectorId, command),
             "buffer" => Buffer(sessionManager, command),
             "buffer-html" => BufferHtml(sessionManager, command),
+            "screen-grid" => ScreenGrid(sessionManager, command),
             "summary" => Summary(sessionManager, context.DirectorId, command),
             "recap" => Recap(sessionManager, command),
             "turn-summaries" => TurnSummaries(context, command),
@@ -250,6 +252,39 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
             ScrollbackCount = scrollbackCount,
             // Backward-compat: existing callers read .html as the concatenated stream.
             Html = scrollbackHtml + gridHtml,
+        }));
+    }
+
+    /// <summary>
+    /// The <c>screen-grid</c> verb (issue #1777): the RESOLVED live terminal screen grid for a session -
+    /// the on-screen rows exactly as the emulator resolves them right now, the live cursor cell, and whether
+    /// the agent has the terminal in the alternate screen buffer. Invalid id -&gt; BadRequest, missing session
+    /// -&gt; NotFound. Additive (it does not touch the existing <c>buffer</c> verb); backed by
+    /// <see cref="Session.SnapshotScreenRowsWithCursor"/>, which reads the parser's ACTIVE grid, so it is
+    /// alternate-screen-correct - it sees a full-screen picker the scrollback-based <c>buffer</c> verb cannot.
+    /// An Embedded session with no server-side parser returns an empty grid with <c>HasGrid = false</c>, which
+    /// tells the caller the screen is unreadable (fail closed) rather than "not a menu".
+    /// </summary>
+    internal static DirectorCommandResult ScreenGrid(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var (rows, cursorRow, cursorCol) = session.SnapshotScreenRowsWithCursor();
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new ScreenGridResponse
+        {
+            SessionId = command.SessionId,
+            Rows = rows.ToList(),
+            CursorRow = cursorRow,
+            CursorCol = cursorCol,
+            IsAlternateScreen = session.IsAlternateScreen,
+            // A session with a real terminal parser yields a fixed-height grid (rows.Length > 0) even when the
+            // screen is blank; only an Embedded session (no parser) yields an empty array - that is unreadable.
+            HasGrid = rows.Length > 0,
         }));
     }
 

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -1857,6 +1857,26 @@ public sealed class Session : IDisposable
     }
 
     /// <summary>
+    /// The resolved live screen grid, the live cursor cell, and the alternate-screen flag captured from
+    /// ONE coherent read (issue #1777). Reading the rows/cursor with <see cref="SnapshotScreenRowsWithCursor"/>
+    /// and the alternate-screen state with <see cref="IsAlternateScreen"/> as two separate locked reads lets a
+    /// buffer switch land between them and report main-screen rows with <c>IsAlternateScreen=true</c> (or the
+    /// reverse). A caller that classifies a waiting screen from the alternate-screen flag needs the flag to
+    /// describe the SAME frame as the rows, so this takes both under a single lock. Returns empty rows and
+    /// (-1,-1) with the flag false when there is no grid (an Embedded session with no server-side parser).
+    /// </summary>
+    public (string[] Rows, int CursorRow, int CursorCol, bool IsAlternateScreen) SnapshotLiveScreen()
+    {
+        if (_htmlCells is null || _htmlParser is null)
+            return (System.Array.Empty<string>(), -1, -1, false);
+        lock (_htmlParserLock)
+        {
+            var (rows, cursorRow, cursorCol) = _htmlParser.SnapshotActiveRows();
+            return (rows, cursorRow, cursorCol, _htmlParser.IsAlternateScreen);
+        }
+    }
+
+    /// <summary>
     /// Snapshot the CURRENT visible terminal grid as rows of styled <see cref="ScreenSegment"/>
     /// runs, preserving the foreground/background colours and bold weight that
     /// <see cref="SnapshotScreenRows"/> throws away. Adjacent cells sharing a style are coalesced

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -1857,22 +1857,24 @@ public sealed class Session : IDisposable
     }
 
     /// <summary>
-    /// The resolved live screen grid, the live cursor cell, and the alternate-screen flag captured from
-    /// ONE coherent read (issue #1777). Reading the rows/cursor with <see cref="SnapshotScreenRowsWithCursor"/>
-    /// and the alternate-screen state with <see cref="IsAlternateScreen"/> as two separate locked reads lets a
-    /// buffer switch land between them and report main-screen rows with <c>IsAlternateScreen=true</c> (or the
-    /// reverse). A caller that classifies a waiting screen from the alternate-screen flag needs the flag to
-    /// describe the SAME frame as the rows, so this takes both under a single lock. Returns empty rows and
-    /// (-1,-1) with the flag false when there is no grid (an Embedded session with no server-side parser).
+    /// The resolved live screen grid, the live cursor cell, the cursor VISIBILITY, and the alternate-screen
+    /// flag captured from ONE coherent read (issue #1777). Reading these as separate locked reads lets a buffer
+    /// switch land between them and report main-screen rows with a mismatched flag. A caller that classifies a
+    /// waiting screen needs the flags to describe the SAME frame as the rows, so this takes them all under a
+    /// single lock. Returns empty rows and (-1,-1) with the flags false when there is no grid (an Embedded
+    /// session with no server-side parser).
     /// </summary>
-    public (string[] Rows, int CursorRow, int CursorCol, bool IsAlternateScreen) SnapshotLiveScreen()
+    public (string[] Rows, int CursorRow, int CursorCol, bool CursorVisible, bool IsAlternateScreen) SnapshotLiveScreen()
     {
         if (_htmlCells is null || _htmlParser is null)
-            return (System.Array.Empty<string>(), -1, -1, false);
+            return (System.Array.Empty<string>(), -1, -1, false, false);
         lock (_htmlParserLock)
         {
             var (rows, cursorRow, cursorCol) = _htmlParser.SnapshotActiveRows();
-            return (rows, cursorRow, cursorCol, _htmlParser.IsAlternateScreen);
+            // Cursor VISIBILITY is captured in the SAME locked frame as the rows/cursor/alt-screen: it is the
+            // discriminator between a text composer (cursor visible) and a drawn Ink menu (cursor hidden, a
+            // stale cursor cell), so it must describe the same frame the rows do (issue #1777).
+            return (rows, cursorRow, cursorCol, _htmlParser.IsCursorVisible, _htmlParser.IsAlternateScreen);
         }
     }
 

--- a/src/CcDirector.Gateway.Contracts/ScreenGridResponse.cs
+++ b/src/CcDirector.Gateway.Contracts/ScreenGridResponse.cs
@@ -29,6 +29,16 @@ public sealed class ScreenGridResponse
     public int CursorCol { get; set; } = -1;
 
     /// <summary>
+    /// True when the terminal hardware cursor is VISIBLE (DECTCEM ?25h). The discriminator between a text
+    /// composer (cursor visible in its input box) and a drawn full-screen menu (Claude Code's Ink picker HIDES
+    /// the cursor and draws its own selection marker). <see cref="CursorRow"/> / <see cref="CursorCol"/> carry a
+    /// position even when the cursor is hidden - a STALE value - so a consumer must check this before trusting
+    /// the cursor cell. A menu is owned by its drawn marker, not the hardware cursor; typing requires a VISIBLE
+    /// cursor inside the composer.
+    /// </summary>
+    public bool CursorVisible { get; set; }
+
+    /// <summary>
     /// True when the agent currently has the terminal in the alternate screen buffer (a full-screen picker,
     /// <c>ESC[?1049h</c>). While true the scrollback is intentionally empty, so a menu is visible only on
     /// <see cref="Rows"/>.

--- a/src/CcDirector.Gateway.Contracts/ScreenGridResponse.cs
+++ b/src/CcDirector.Gateway.Contracts/ScreenGridResponse.cs
@@ -1,0 +1,44 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// The resolved LIVE terminal screen grid for a session (issue #1777): the on-screen rows exactly as the
+/// emulator resolves them right now, the live cursor cell, and whether the agent has the terminal in the
+/// alternate screen buffer. This is the alternate-screen-correct read the wingman menu detector needs: when
+/// an agent draws a full-screen picker it switches to the alternate screen, where the scrollback (the
+/// <c>buffer</c> verb) is empty by design, so the menu is only visible on this grid.
+///
+/// Deliberately NOT the styled HTML snapshot (<c>buffer-html</c>): that is a presentation format. This
+/// carries the grid as plain, trailing-trimmed rows plus the cursor cell and the active-buffer identity, so a
+/// consumer reasons about the live screen without parsing HTML. The grid is a Session concern (the emulator
+/// resolves it the same way for every agent CLI), so it is agent-uniform - no per-agent data source.
+/// </summary>
+public sealed class ScreenGridResponse
+{
+    public string SessionId { get; set; } = "";
+
+    /// <summary>
+    /// The current visible grid as plain-text rows, top to bottom, each trailing-trimmed. Empty when the
+    /// session has no server-side grid parser (an Embedded session) - see <see cref="HasGrid"/>.
+    /// </summary>
+    public List<string> Rows { get; set; } = new();
+
+    /// <summary>0-based grid row of the live cursor, or -1 when there is no grid.</summary>
+    public int CursorRow { get; set; } = -1;
+
+    /// <summary>0-based grid column of the live cursor, or -1 when there is no grid.</summary>
+    public int CursorCol { get; set; } = -1;
+
+    /// <summary>
+    /// True when the agent currently has the terminal in the alternate screen buffer (a full-screen picker,
+    /// <c>ESC[?1049h</c>). While true the scrollback is intentionally empty, so a menu is visible only on
+    /// <see cref="Rows"/>.
+    /// </summary>
+    public bool IsAlternateScreen { get; set; }
+
+    /// <summary>
+    /// True when the session actually has a resolved live grid to read (a real agent terminal). False for an
+    /// Embedded session with no server-side parser - the screen is UNREADABLE and a caller must fail closed
+    /// rather than treat an empty grid as "not a menu".
+    /// </summary>
+    public bool HasGrid { get; set; }
+}

--- a/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
@@ -198,12 +198,13 @@ public sealed class SessionReadExecutorTests
             backend.Buffer!.Write(System.Text.Encoding.UTF8.GetBytes("normal shell output before the app started\r\n"));
             var draw = new System.Text.StringBuilder();
             draw.Append("\x1b[?1049h");                                  // enter the alternate screen
+            draw.Append("\x1b[?25l");                                     // HIDE the cursor (like the Ink picker)
             draw.Append("\x1b[2J");                                       // clear
             draw.Append("\x1b[1;1HPick an environment to deploy");
             draw.Append("\x1b[2;1H > 1. staging");
             draw.Append("\x1b[3;1H   2. production");
             draw.Append("\x1b[4;1H   3. cancel");
-            draw.Append("\x1b[2;3H");                                     // park the cursor on the selected option
+            draw.Append("\x1b[2;3H");                                     // park the (hidden) cursor on the option
             backend.Buffer!.Write(System.Text.Encoding.UTF8.GetBytes(draw.ToString()));
 
             var gridResult = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("screen-grid", session.Id.ToString()));
@@ -214,6 +215,9 @@ public sealed class SessionReadExecutorTests
             // Alternate-screen correct: the ACTIVE grid holds the menu (not the frozen pre-alt primary content).
             Assert.True(grid!.HasGrid);
             Assert.True(grid.IsAlternateScreen);
+            // The cursor visibility flows through the atomic snapshot (issue #1777, round-4): the Ink picker
+            // hid it, so the verb reports it hidden - the classifier must not trust the (stale) cursor cell.
+            Assert.False(grid.CursorVisible);
             Assert.Equal("Pick an environment to deploy", grid.Rows[0]);
             Assert.Equal(" > 1. staging", grid.Rows[1]);
             Assert.Equal("   2. production", grid.Rows[2]);

--- a/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
@@ -150,6 +150,54 @@ public sealed class SessionReadExecutorTests
         finally { sm.Dispose(); }
     }
 
+    // ---------- screen-grid (issue #1777) ----------
+
+    [Fact]
+    public async Task DispatchAsync_ScreenGrid_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("screen-grid", "not-a-guid"));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ScreenGrid_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("screen-grid", Guid.NewGuid().ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ScreenGrid_ExistingSession_ReturnsTheLiveGrid()
+    {
+        // The verb reads the session's RESOLVED live screen grid: a session with a terminal parser reports a
+        // grid (HasGrid=true) plus the live cursor cell and the alternate-screen flag - the alternate-screen-
+        // correct read the wingman menu detector uses. (Only a parser-less session yields HasGrid=false, which
+        // the detector treats as an unreadable screen and fails closed - exercised at the Gateway.)
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("screen-grid", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var resp = JsonSerializer.Deserialize<ScreenGridResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.Equal(session.Id.ToString(), resp.SessionId);
+            Assert.True(resp.HasGrid);
+            Assert.NotEmpty(resp.Rows);
+        }
+        finally { sm.Dispose(); }
+    }
+
     // ---------- summary ----------
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
@@ -238,6 +238,47 @@ public sealed class SessionReadExecutorTests
         finally { sm.Dispose(); }
     }
 
+    [Fact]
+    public async Task DispatchAsync_ScreenGrid_EmptyFooterComposer_TrimsTrailingSpace_ClassifiesPlainText()
+    {
+        // The REAL trailing-trimmed representation (issue #1777, final fix): Claude's empty "> " composer is
+        // drawn on the primary screen with a visible cursor right after "> " and a mode-status footer below.
+        // The parser trailing-trims each row, so the "> " row arrives as ">" (the space is gone) while the
+        // visible cursor stays at its true column. The classifier must still read this as a plain-text composer
+        // and allow typing - not over-block a normal empty composer.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        var backend = new ScreenGridBufferBackend();
+        try
+        {
+            var session = sm.CreateEmbeddedSession(Path.GetTempPath(), null, backend);
+            session.Resize(40, 6);
+
+            var draw = new System.Text.StringBuilder();
+            draw.Append("\x1b[?25h");                         // cursor visible (a composer keeps it visible)
+            draw.Append("\x1b[2J");
+            draw.Append("\x1b[1;1H> ");                        // the empty composer prompt: marker + a space
+            draw.Append("\x1b[2;1H? for shortcuts");          // the mode-status footer below it
+            draw.Append("\x1b[1;3H");                          // park the cursor right after "> " (row 1, col 3)
+            backend.Buffer!.Write(System.Text.Encoding.UTF8.GetBytes(draw.ToString()));
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("screen-grid", session.Id.ToString()));
+            var grid = JsonSerializer.Deserialize<ScreenGridResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(grid);
+
+            // The trailing space really is trimmed off the composer row, and the cursor really is at col 2.
+            Assert.Equal(">", grid!.Rows[0]);
+            Assert.True(grid.CursorVisible);
+            Assert.Equal(0, grid.CursorRow);
+            Assert.Equal(2, grid.CursorCol);
+
+            // The classifier reads THIS real representation as a plain-text composer (types), not a blocked screen.
+            var kind = CcDirector.Gateway.Wingman.WaitingScreenClassifier.Classify(
+                grid.Rows, grid.CursorRow, grid.CursorCol, grid.CursorVisible, grid.IsAlternateScreen, grid.HasGrid);
+            Assert.Equal(CcDirector.Gateway.Wingman.WaitingScreenKind.PlainText, kind);
+        }
+        finally { sm.Dispose(); }
+    }
+
     /// <summary>A minimal backend with a real terminal buffer, so a session's server-side parser is created
     /// and fed via the buffer's OnBytesWritten event - the same path the real backend uses.</summary>
     private sealed class ScreenGridBufferBackend : Core.Backends.ISessionBackend

--- a/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
@@ -177,25 +177,83 @@ public sealed class SessionReadExecutorTests
     }
 
     [Fact]
-    public async Task DispatchAsync_ScreenGrid_ExistingSession_ReturnsTheLiveGrid()
+    public async Task DispatchAsync_ScreenGrid_AlternateScreenMenu_ReadsTheLiveGrid_WhileScrollbackMissesIt()
     {
-        // The verb reads the session's RESOLVED live screen grid: a session with a terminal parser reports a
-        // grid (HasGrid=true) plus the live cursor cell and the alternate-screen flag - the alternate-screen-
-        // correct read the wingman menu detector uses. (Only a parser-less session yields HasGrid=false, which
-        // the detector treats as an unreadable screen and fails closed - exercised at the Gateway.)
-        var (sm, session, _) = NewSession();
+        // The REAL Director-layer bug (issue #1777, finding 7): drive a session ONTO the alternate screen and
+        // draw a menu the way a production TUI does - absolute cursor positioning, no line feeds - whose text
+        // does not contain a stock fingerprint phrase. The screen-grid verb reads the ACTIVE (alternate) grid,
+        // so it returns the exact menu rows, the cursor cell parked on the selected option, and
+        // IsAlternateScreen=true. The scrollback (the buffer verb) keeps only the raw byte stream: with no line
+        // feeds it has no line structure, so the OLD line-based gate MISSES the menu on it - which is exactly
+        // why the detector had to move to the live grid.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        var backend = new ScreenGridBufferBackend();
         try
         {
-            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("screen-grid", session.Id.ToString()));
+            var session = sm.CreateEmbeddedSession(Path.GetTempPath(), null, backend);
+            session.Resize(50, 14);
 
-            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
-            var resp = JsonSerializer.Deserialize<ScreenGridResponse>(result.BodyJson ?? "", Json);
-            Assert.NotNull(resp);
-            Assert.Equal(session.Id.ToString(), resp.SessionId);
-            Assert.True(resp.HasGrid);
-            Assert.NotEmpty(resp.Rows);
+            // Some ordinary primary-screen scrollback first, then enter the alternate screen and paint a menu
+            // with absolute positioning (\x1b[row;colH) and NO \r\n - the way a full-screen picker repaints.
+            backend.Buffer!.Write(System.Text.Encoding.UTF8.GetBytes("normal shell output before the app started\r\n"));
+            var draw = new System.Text.StringBuilder();
+            draw.Append("\x1b[?1049h");                                  // enter the alternate screen
+            draw.Append("\x1b[2J");                                       // clear
+            draw.Append("\x1b[1;1HPick an environment to deploy");
+            draw.Append("\x1b[2;1H > 1. staging");
+            draw.Append("\x1b[3;1H   2. production");
+            draw.Append("\x1b[4;1H   3. cancel");
+            draw.Append("\x1b[2;3H");                                     // park the cursor on the selected option
+            backend.Buffer!.Write(System.Text.Encoding.UTF8.GetBytes(draw.ToString()));
+
+            var gridResult = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("screen-grid", session.Id.ToString()));
+            Assert.Equal(DirectorCommandStatus.Ok, gridResult.Status);
+            var grid = JsonSerializer.Deserialize<ScreenGridResponse>(gridResult.BodyJson ?? "", Json);
+            Assert.NotNull(grid);
+
+            // Alternate-screen correct: the ACTIVE grid holds the menu (not the frozen pre-alt primary content).
+            Assert.True(grid!.HasGrid);
+            Assert.True(grid.IsAlternateScreen);
+            Assert.Equal("Pick an environment to deploy", grid.Rows[0]);
+            Assert.Equal(" > 1. staging", grid.Rows[1]);
+            Assert.Equal("   2. production", grid.Rows[2]);
+            Assert.Equal("   3. cancel", grid.Rows[3]);
+            // The cursor is parked on the selected option row (row index 1, "\x1b[2;3H" -> 0-based (1,2)).
+            Assert.Equal(1, grid.CursorRow);
+            Assert.Equal(2, grid.CursorCol);
+
+            // The OPERATIVE bug predicate at the Director layer: the live grid IS a menu, but the scrollback
+            // (buffer verb) - the old source - does NOT look like one, so detecting off it would have missed
+            // the menu and typed the spoken words in. (The buffer is not literally empty - it keeps the raw
+            // bytes - but with no line feeds the line-based gate finds no menu on it.)
+            var bufResult = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("buffer", session.Id.ToString()));
+            var buf = JsonSerializer.Deserialize<BufferResponse>(bufResult.BodyJson ?? "", Json);
+            Assert.False(CcDirector.Gateway.Wingman.WingmanMenuLogic.LooksLikeMenu(buf!.Text));
+            Assert.True(CcDirector.Gateway.Wingman.WingmanMenuLogic.LiveScreenLooksLikeMenu(grid.Rows));
         }
         finally { sm.Dispose(); }
+    }
+
+    /// <summary>A minimal backend with a real terminal buffer, so a session's server-side parser is created
+    /// and fed via the buffer's OnBytesWritten event - the same path the real backend uses.</summary>
+    private sealed class ScreenGridBufferBackend : Core.Backends.ISessionBackend
+    {
+        public Core.Memory.CircularTerminalBuffer? Buffer { get; } = new Core.Memory.CircularTerminalBuffer(256 * 1024);
+        public int ProcessId => 1234;
+        public string Status => "Buffered";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+#pragma warning disable CS0067
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() => Buffer?.Dispose();
     }
 
     // ---------- summary ----------

--- a/src/CcDirector.Gateway.Tests/TunnelWingmanVoiceProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelWingmanVoiceProofTests.cs
@@ -87,15 +87,24 @@ public sealed class TunnelWingmanVoiceProofTests : IAsyncLifetime
 
     private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
 
-    // Answer the session "buffer" verb with plain (non-menu) terminal text, so the wingman menu endpoint
+    // Answer the session "screen-grid" verb with a plain (non-menu) live grid, so the wingman menu endpoint
     // returns {isMenu:false} WITHOUT calling the wingman brain - the tunnel read is the whole point here.
+    // Since #1777 the LIVE screen grid is the authoritative read (the scrollback "buffer" verb is only read to
+    // supplement extraction once the live screen already looks like a menu), so a plain grid short-circuits
+    // before any buffer read.
     private DirectorCommandResult Dispatch(DirectorCommand cmd)
     {
         _lastCommand = cmd;
         return cmd.Verb switch
         {
-            "buffer" => DirectorCommandResult.Success(JsonSerializer.Serialize(
-                new BufferResponse { Text = "just some plain terminal output, no menu here\n" }, Web)),
+            "screen-grid" => DirectorCommandResult.Success(JsonSerializer.Serialize(
+                new ScreenGridResponse
+                {
+                    Rows = new List<string> { "just some plain terminal output, no menu here" },
+                    HasGrid = true,
+                    CursorRow = 0,
+                    CursorCol = 0,
+                }, Web)),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
         };
     }
@@ -117,13 +126,13 @@ public sealed class TunnelWingmanVoiceProofTests : IAsyncLifetime
         });
 
         var resp = await _http.GetAsync($"sessions/{sid}/wingman/menu");
-        // An HTTP dial to the unreachable Director would have failed to resolve the owner and read the buffer.
+        // An HTTP dial to the unreachable Director would have failed to resolve the owner and read the screen.
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
         Assert.False(node?["isMenu"]?.GetValue<bool>());
 
-        // The owner resolved from the push store and the terminal was read via the tunnel "buffer" verb.
-        Assert.Equal("buffer", _lastCommand!.Verb);
+        // The owner resolved from the push store and the LIVE screen was read via the tunnel "screen-grid" verb.
+        Assert.Equal("screen-grid", _lastCommand!.Verb);
         Assert.Equal(sid, _lastCommand.SessionId);
     }
 

--- a/src/CcDirector.Gateway.Tests/WaitingScreenClassifierTests.cs
+++ b/src/CcDirector.Gateway.Tests/WaitingScreenClassifierTests.cs
@@ -4,14 +4,15 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// The cursor-anchored fail-closed classifier (issue #1777, round-3): the spoken words may be typed ONLY when
-/// the cursor is positively inside the agent's framed composer input box. A bare "&gt;" row is not a composer,
-/// menu-like text elsewhere while the cursor is in the composer is stale, and a menu owns the turn only when
-/// the cursor is on a menu option. Everything the cursor does not positively resolve fails closed.
+/// The two-anchor fail-closed classifier (issue #1777, round-4). Cursor VISIBILITY is the discriminator: a
+/// text composer keeps the hardware cursor visible in its input box, while Claude Code's Ink permission menu
+/// HIDES the cursor and draws its own selection marker. So typing requires a VISIBLE cursor positively inside a
+/// framed composer with no menu on the grid; a menu is owned by its drawn marker (cursor-independent); and
+/// everything else - including a menu with a hidden cursor being typed into - fails closed.
 /// </summary>
 public sealed class WaitingScreenClassifierTests
 {
-    // A Claude permission menu on screen, cursor parked on the selected option (row 3, the "❯ 1. Yes" line).
+    // A Claude permission menu drawn with its selection marker. On a real menu the hardware cursor is HIDDEN.
     private static readonly string[] MenuRows =
     {
         "╭──────────────────────────────────────────────╮",
@@ -23,7 +24,7 @@ public sealed class WaitingScreenClassifierTests
         "╰──────────────────────────────────────────────╯",
     };
 
-    // A Claude composer, cursor in the empty input box (row 2), framed by box borders and a mode-status footer.
+    // A Claude composer, VISIBLE cursor in the empty input box (row 2), framed by box borders and a footer.
     private static readonly string[] ComposerRows =
     {
         "I finished the last change. What next?",
@@ -35,50 +36,37 @@ public sealed class WaitingScreenClassifierTests
 
     [Fact]
     public void Classify_NoGrid_IsBlocked()
-        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(new[] { "x" }, 0, 0, hasGrid: false));
-
-    [Fact]
-    public void Classify_EmptyRows_IsBlocked()
-        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(System.Array.Empty<string>(), -1, -1, hasGrid: true));
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(new[] { "x" }, 0, 0, true, false, hasGrid: false));
 
     [Fact]
     public void Classify_AllBlankGrid_IsBlocked()
-        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(new[] { "", "   ", "\t" }, 0, 0, hasGrid: true));
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(new[] { "", "   ", "\t" }, 0, 0, true, false, hasGrid: true));
 
     [Fact]
-    public void Classify_CursorOutOfRange_IsBlocked()
-        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 99, cursorCol: 4, hasGrid: true));
+    public void Classify_MenuWithHiddenCursor_IsMenu()
+        // The real-Claude case: the menu is drawn with its marker, the hardware cursor is HIDDEN and its cell
+        // is stale. The menu must still be recognized (via the marker) and answered.
+        => Assert.Equal(WaitingScreenKind.Menu, WaitingScreenClassifier.Classify(MenuRows, cursorRow: 0, cursorCol: -1, cursorVisible: false, isAlternateScreen: true, hasGrid: true));
 
     [Fact]
-    public void Classify_CursorOnMenuOption_IsMenu()
-        => Assert.Equal(WaitingScreenKind.Menu, WaitingScreenClassifier.Classify(MenuRows, cursorRow: 3, cursorCol: 5, hasGrid: true));
+    public void Classify_VisibleCursorInFramedComposer_IsPlainText()
+        => Assert.Equal(WaitingScreenKind.PlainText, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 2, cursorCol: 4, cursorVisible: true, isAlternateScreen: false, hasGrid: true));
 
     [Fact]
-    public void Classify_CursorOnMenuQuestionLine_NotAnOption_IsBlocked()
-        // The screen is a menu, but the cursor is on the question line, not on an option - fail closed.
-        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(MenuRows, cursorRow: 2, cursorCol: 5, hasGrid: true));
+    public void Classify_ComposerButCursorHidden_IsBlocked()
+        // Typing needs a VISIBLE cursor - a hidden cursor cell is stale and cannot be trusted.
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 2, cursorCol: 4, cursorVisible: false, isAlternateScreen: false, hasGrid: true));
 
     [Fact]
-    public void Classify_CursorInFramedComposer_IsPlainText()
-        => Assert.Equal(WaitingScreenKind.PlainText, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 2, cursorCol: 4, hasGrid: true));
+    public void Classify_ComposerButAlternateScreen_IsBlocked()
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 2, cursorCol: 4, cursorVisible: true, isAlternateScreen: true, hasGrid: true));
 
     [Fact]
-    public void Classify_BareSelectorRow_NoInputBoxFrame_IsBlocked()
+    public void Classify_MenuMarkerAndLiveComposerBothPresent_IsBlocked()
     {
-        // B1: "> production" under "Choose a deployment:" with the cursor on the selector is NOT a composer -
-        // there is no input-box frame - so it must fail closed, not be typed into.
-        var rows = new[] { "Choose a deployment:", "> production" };
-        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(rows, cursorRow: 1, cursorCol: 5, hasGrid: true));
-    }
-
-    [Fact]
-    public void Classify_StaleMenuAboveLiveComposer_CursorInComposer_IsPlainText()
-    {
-        // B2-new: an answered menu is still visible ABOVE the live composer. The cursor is in the composer, so
-        // this is plain text - the stale menu is ignored, the words go in the composer.
+        // Ambiguous: a drawn menu marker AND a live composer on the same grid. When in doubt, block.
         var rows = new[]
         {
-            "Do you want to proceed?",
             "❯ 1. Yes",
             "  2. No",
             "╭──────────────────────────────────────╮",
@@ -86,27 +74,57 @@ public sealed class WaitingScreenClassifierTests
             "╰──────────────────────────────────────╯",
             "  ? for shortcuts",
         };
-        Assert.Equal(WaitingScreenKind.PlainText, WaitingScreenClassifier.Classify(rows, cursorRow: 4, cursorCol: 4, hasGrid: true));
+        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(rows, cursorRow: 3, cursorCol: 4, cursorVisible: true, isAlternateScreen: false, hasGrid: true));
     }
 
     [Fact]
-    public void Classify_ComposerPromptButCursorBeforeThePrompt_IsBlocked()
+    public void Classify_BorderedSelectorHiddenCursor_IsBlocked()
     {
-        // The cursor is to the LEFT of the input start (not inside the editable input) - not a positive signal.
-        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 2, cursorCol: 1, hasGrid: true));
+        // B1: a bordered "> production" selector (a menu selection, hidden cursor) is NOT a composer. It has no
+        // numbered option after the marker, so it is not a recognized menu either -> Blocked.
+        var rows = new[] { "Choose a deployment:", "╭──────────────╮", "│ > production │", "╰──────────────╯" };
+        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(rows, cursorRow: 2, cursorCol: 4, cursorVisible: false, isAlternateScreen: false, hasGrid: true));
     }
 
+    // A small composer with a known geometry: row 2 = "│ >   │" -> prompt '>' at col 2, input starts col 4,
+    // closing border '│' at col 6.
+    private static readonly string[] TinyComposer = { "output", "╭─────╮", "│ >   │", "╰─────╯", "  ? for shortcuts" };
+
     [Fact]
-    public void Classify_ModeCycleArrow_IsNotAComposer_IsBlocked()
+    public void Classify_TinyComposer_CursorInInput_IsPlainText()
+        => Assert.Equal(WaitingScreenKind.PlainText, WaitingScreenClassifier.Classify(TinyComposer, cursorRow: 2, cursorCol: 4, cursorVisible: true, isAlternateScreen: false, hasGrid: true));
+
+    [Fact]
+    public void Classify_CursorColMinusOne_IsBlocked()
+        // finding 2: a stale/hidden CursorCol=-1 is not inside any input span.
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(TinyComposer, cursorRow: 2, cursorCol: -1, cursorVisible: true, isAlternateScreen: false, hasGrid: true));
+
+    [Fact]
+    public void Classify_CursorOnRightBorder_IsBlocked()
+        // finding 2: the cursor is on the closing box border (col 6), not inside the editable input span.
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(TinyComposer, cursorRow: 2, cursorCol: 6, cursorVisible: true, isAlternateScreen: false, hasGrid: true));
+
+    [Fact]
+    public void Classify_CursorBeforeThePrompt_IsBlocked()
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(TinyComposer, cursorRow: 2, cursorCol: 1, cursorVisible: true, isAlternateScreen: false, hasGrid: true));
+
+    [Fact]
+    public void Classify_ModeCycleArrow_IsBlocked()
     {
         var rows = new[] { "output", ">> bypass permissions on (shift+tab to cycle)" };
-        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(rows, cursorRow: 1, cursorCol: 5, hasGrid: true));
+        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(rows, cursorRow: 1, cursorCol: 5, cursorVisible: true, isAlternateScreen: false, hasGrid: true));
+    }
+
+    [Fact]
+    public void Classify_AlternateScreenNotAMenu_IsBlocked()
+    {
+        var rows = new[] { "a full screen viewer", "line of content", "status: reading" };
+        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(rows, cursorRow: 2, cursorCol: 8, cursorVisible: false, isAlternateScreen: true, hasGrid: true));
     }
 
     [Fact]
     public void LooksLikePlainTextPrompt_FramedByModeStatusFooterAlone_IsTrue()
     {
-        // No box border, but the mode-status footer just below anchors the composer positively.
         var rows = new[] { "some output", "> ", "  bypass permissions on (shift+tab to cycle)" };
         Assert.True(WaitingScreenClassifier.LooksLikePlainTextPrompt(rows, cursorRow: 1, cursorCol: 2));
     }

--- a/src/CcDirector.Gateway.Tests/WaitingScreenClassifierTests.cs
+++ b/src/CcDirector.Gateway.Tests/WaitingScreenClassifierTests.cs
@@ -4,15 +4,15 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// The fail-closed classifier (issue #1777, finding 1): the spoken words may be typed ONLY on a positive
-/// plain-text signal (a primary-screen composer input line with the cursor on it). Everything else - a blank
-/// grid, an unrecognized alternate-screen app, a primary screen with no composer, an unreadable session - is
-/// Blocked. "Not a recognized menu" must never collapse into "confident plain text".
+/// The cursor-anchored fail-closed classifier (issue #1777, round-3): the spoken words may be typed ONLY when
+/// the cursor is positively inside the agent's framed composer input box. A bare "&gt;" row is not a composer,
+/// menu-like text elsewhere while the cursor is in the composer is stale, and a menu owns the turn only when
+/// the cursor is on a menu option. Everything the cursor does not positively resolve fails closed.
 /// </summary>
 public sealed class WaitingScreenClassifierTests
 {
-    // A real Claude permission menu, drawn on the alternate screen (full-screen picker).
-    private static readonly string[] AltScreenMenuRows =
+    // A Claude permission menu on screen, cursor parked on the selected option (row 3, the "❯ 1. Yes" line).
+    private static readonly string[] MenuRows =
     {
         "╭──────────────────────────────────────────────╮",
         "│ Bash command                                 │",
@@ -23,7 +23,7 @@ public sealed class WaitingScreenClassifierTests
         "╰──────────────────────────────────────────────╯",
     };
 
-    // A Claude composer at the bottom of the PRIMARY screen, cursor sitting in the empty input box (row 1).
+    // A Claude composer, cursor in the empty input box (row 2), framed by box borders and a mode-status footer.
     private static readonly string[] ComposerRows =
     {
         "I finished the last change. What next?",
@@ -35,57 +35,79 @@ public sealed class WaitingScreenClassifierTests
 
     [Fact]
     public void Classify_NoGrid_IsBlocked()
-        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(new[] { "anything" }, 0, 0, false, hasGrid: false));
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(new[] { "x" }, 0, 0, hasGrid: false));
 
     [Fact]
     public void Classify_EmptyRows_IsBlocked()
-        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(System.Array.Empty<string>(), -1, -1, false, hasGrid: true));
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(System.Array.Empty<string>(), -1, -1, hasGrid: true));
 
     [Fact]
     public void Classify_AllBlankGrid_IsBlocked()
-        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(new[] { "", "   ", "\t" }, 0, 0, false, hasGrid: true));
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(new[] { "", "   ", "\t" }, 0, 0, hasGrid: true));
 
     [Fact]
-    public void Classify_MenuFingerprint_IsMenu_EvenOnAlternateScreen()
-        => Assert.Equal(WaitingScreenKind.Menu, WaitingScreenClassifier.Classify(AltScreenMenuRows, 3, 3, isAlternateScreen: true, hasGrid: true));
+    public void Classify_CursorOutOfRange_IsBlocked()
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 99, cursorCol: 4, hasGrid: true));
 
     [Fact]
-    public void Classify_AlternateScreen_Unrecognized_IsBlocked()
+    public void Classify_CursorOnMenuOption_IsMenu()
+        => Assert.Equal(WaitingScreenKind.Menu, WaitingScreenClassifier.Classify(MenuRows, cursorRow: 3, cursorCol: 5, hasGrid: true));
+
+    [Fact]
+    public void Classify_CursorOnMenuQuestionLine_NotAnOption_IsBlocked()
+        // The screen is a menu, but the cursor is on the question line, not on an option - fail closed.
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(MenuRows, cursorRow: 2, cursorCol: 5, hasGrid: true));
+
+    [Fact]
+    public void Classify_CursorInFramedComposer_IsPlainText()
+        => Assert.Equal(WaitingScreenKind.PlainText, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 2, cursorCol: 4, hasGrid: true));
+
+    [Fact]
+    public void Classify_BareSelectorRow_NoInputBoxFrame_IsBlocked()
     {
-        // A full-screen app (alternate screen) we did NOT recognize as a menu - never type into it. This is
-        // the inversion the original bug had: it is NOT a plain-text prompt just because no menu was matched.
-        var appRows = new[] { "some full screen TUI", "with content we cannot parse", "and a cursor somewhere" };
-        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(appRows, 2, 5, isAlternateScreen: true, hasGrid: true));
+        // B1: "> production" under "Choose a deployment:" with the cursor on the selector is NOT a composer -
+        // there is no input-box frame - so it must fail closed, not be typed into.
+        var rows = new[] { "Choose a deployment:", "> production" };
+        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(rows, cursorRow: 1, cursorCol: 5, hasGrid: true));
     }
 
     [Fact]
-    public void Classify_PrimaryComposer_CursorOnPromptLine_IsPlainText()
-        => Assert.Equal(WaitingScreenKind.PlainText, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 2, cursorCol: 4, isAlternateScreen: false, hasGrid: true));
-
-    [Fact]
-    public void Classify_PrimaryComposer_CursorNotOnPromptLine_IsBlocked()
-        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 0, cursorCol: 4, isAlternateScreen: false, hasGrid: true));
-
-    [Fact]
-    public void Classify_PrimaryScreen_NoComposer_IsBlocked()
+    public void Classify_StaleMenuAboveLiveComposer_CursorInComposer_IsPlainText()
     {
-        // Primary screen, non-blank, not a menu, but no recognizable composer - unsure, so fail closed.
-        var rows = new[] { "the agent printed some output", "and then more output", "but no input prompt is visible" };
-        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(rows, cursorRow: 2, cursorCol: 5, isAlternateScreen: false, hasGrid: true));
+        // B2-new: an answered menu is still visible ABOVE the live composer. The cursor is in the composer, so
+        // this is plain text - the stale menu is ignored, the words go in the composer.
+        var rows = new[]
+        {
+            "Do you want to proceed?",
+            "❯ 1. Yes",
+            "  2. No",
+            "╭──────────────────────────────────────╮",
+            "│ >                                     │",
+            "╰──────────────────────────────────────╯",
+            "  ? for shortcuts",
+        };
+        Assert.Equal(WaitingScreenKind.PlainText, WaitingScreenClassifier.Classify(rows, cursorRow: 4, cursorCol: 4, hasGrid: true));
     }
 
     [Fact]
-    public void Classify_ComposerButOnAlternateScreen_IsBlocked()
+    public void Classify_ComposerPromptButCursorBeforeThePrompt_IsBlocked()
     {
-        // Even a ">"-looking line on the alternate screen is not typed into: full-screen apps own their input.
-        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 2, cursorCol: 4, isAlternateScreen: true, hasGrid: true));
+        // The cursor is to the LEFT of the input start (not inside the editable input) - not a positive signal.
+        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 2, cursorCol: 1, hasGrid: true));
     }
 
     [Fact]
-    public void LooksLikePlainTextPrompt_ModeArrowIsNotAPrompt()
+    public void Classify_ModeCycleArrow_IsNotAComposer_IsBlocked()
     {
-        // ">> bypass permissions on" is the mode-cycle arrow, NOT the input prompt.
         var rows = new[] { "output", ">> bypass permissions on (shift+tab to cycle)" };
-        Assert.False(WaitingScreenClassifier.LooksLikePlainTextPrompt(rows, cursorRow: 1, cursorCol: 3));
+        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(rows, cursorRow: 1, cursorCol: 5, hasGrid: true));
+    }
+
+    [Fact]
+    public void LooksLikePlainTextPrompt_FramedByModeStatusFooterAlone_IsTrue()
+    {
+        // No box border, but the mode-status footer just below anchors the composer positively.
+        var rows = new[] { "some output", "> ", "  bypass permissions on (shift+tab to cycle)" };
+        Assert.True(WaitingScreenClassifier.LooksLikePlainTextPrompt(rows, cursorRow: 1, cursorCol: 2));
     }
 }

--- a/src/CcDirector.Gateway.Tests/WaitingScreenClassifierTests.cs
+++ b/src/CcDirector.Gateway.Tests/WaitingScreenClassifierTests.cs
@@ -123,10 +123,48 @@ public sealed class WaitingScreenClassifierTests
     }
 
     [Fact]
-    public void LooksLikePlainTextPrompt_FramedByModeStatusFooterAlone_IsTrue()
+    public void LooksLikePlainTextPrompt_FooterOnly_CursorAtTrailingEdge_IsTrue()
     {
+        // Footer-only composer (no right border), empty input: the trailing edge is right after "> " (col 2).
         var rows = new[] { "some output", "> ", "  bypass permissions on (shift+tab to cycle)" };
         Assert.True(WaitingScreenClassifier.LooksLikePlainTextPrompt(rows, cursorRow: 1, cursorCol: 2));
+    }
+
+    [Fact]
+    public void LooksLikePlainTextPrompt_FooterOnly_CursorPastTheInput_IsFalse()
+    {
+        // Blocker B: with no right border, the cursor is bounded by the END of the input content. A cursor far
+        // past the input (col 10 over an empty "> ") is NOT the trailing insertion point -> not a composer.
+        var rows = new[] { "some output", "> ", "  bypass permissions on (shift+tab to cycle)" };
+        Assert.False(WaitingScreenClassifier.LooksLikePlainTextPrompt(rows, cursorRow: 1, cursorCol: 10));
+    }
+
+    [Fact]
+    public void Classify_BorderedSelectorVisibleCursorAtMarker_IsBlocked()
+    {
+        // Blocker A: "Pick environment:" over a framed "> production" with a VISIBLE cursor at the marker
+        // (col 4, the start of "production"). The cursor is NOT trailing typed text, so it is a selector, not a
+        // composer -> fail closed.
+        var rows = new[] { "Pick environment:", "╭──────────────╮", "│ > production │", "╰──────────────╯" };
+        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(rows, cursorRow: 2, cursorCol: 4, cursorVisible: true, isAlternateScreen: false, hasGrid: true));
+    }
+
+    [Fact]
+    public void Classify_ComposerWithTypedWord_CursorTrailing_IsPlainText()
+    {
+        // The same "> production" text, but the cursor TRAILS the typed word (col 14, right after "production")
+        // and there is no menu prompt above - this is a real composer the user typed a word into -> PlainText.
+        var rows = new[] { "do the thing", "╭──────────────╮", "│ > production │", "╰──────────────╯", "  ? for shortcuts" };
+        Assert.Equal(WaitingScreenKind.PlainText, WaitingScreenClassifier.Classify(rows, cursorRow: 2, cursorCol: 14, cursorVisible: true, isAlternateScreen: false, hasGrid: true));
+    }
+
+    [Fact]
+    public void Classify_ComposerCursorMidLabel_IsBlocked()
+    {
+        // The cursor sits in the MIDDLE of the label (col 8 of "> production"), not at the trailing edge -> not
+        // a confident composer.
+        var rows = new[] { "do the thing", "╭──────────────╮", "│ > production │", "╰──────────────╯", "  ? for shortcuts" };
+        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(rows, cursorRow: 2, cursorCol: 8, cursorVisible: true, isAlternateScreen: false, hasGrid: true));
     }
 
     // ===== HasMenuishStructure (floor rescope, finding 3: any menu structure blocks typing) =====
@@ -152,9 +190,13 @@ public sealed class WaitingScreenClassifierTests
     [Theory]
     [InlineData(new[] { "some prose", "1. first", "2. second" }, true)]     // a numbered/lettered option line
     [InlineData(new[] { "prose", "❯ 1. Yes" }, true)]                        // a drawn selection marker
-    [InlineData(new[] { "Choose a deployment:", "the rest" }, true)]         // a menu-prompt phrase
-    [InlineData(new[] { "Do you want to proceed?", "..." }, true)]
-    [InlineData(new[] { "I finished the change.", "> ", "  ? for shortcuts" }, false)] // a plain composer
+    [InlineData(new[] { "Choose a deployment:", "the rest" }, true)]         // a ':'-terminated pick prompt
+    [InlineData(new[] { "Pick environment:", "..." }, true)]
+    [InlineData(new[] { "Do you want to proceed?", "..." }, true)]           // '?'-terminated proceed prompt
+    [InlineData(new[] { "prose", "> production" }, true)]                    // a bare-marker selector label
+    [InlineData(new[] { "prose", "❯ deploy to prod" }, true)]
+    [InlineData(new[] { "I'll select the rows for you.", "more" }, false)]   // 'select' mid-sentence, not a prompt
+    [InlineData(new[] { "I finished the change.", "> ", "  ? for shortcuts" }, false)] // a plain empty composer
     [InlineData(new[] { "just some prose output", "and more" }, false)]
     public void HasMenuishStructure_DetectsMenuStructure(string[] rows, bool expected)
         => Assert.Equal(expected, WaitingScreenClassifier.HasMenuishStructure(rows));

--- a/src/CcDirector.Gateway.Tests/WaitingScreenClassifierTests.cs
+++ b/src/CcDirector.Gateway.Tests/WaitingScreenClassifierTests.cs
@@ -1,0 +1,91 @@
+using CcDirector.Gateway.Wingman;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The fail-closed classifier (issue #1777, finding 1): the spoken words may be typed ONLY on a positive
+/// plain-text signal (a primary-screen composer input line with the cursor on it). Everything else - a blank
+/// grid, an unrecognized alternate-screen app, a primary screen with no composer, an unreadable session - is
+/// Blocked. "Not a recognized menu" must never collapse into "confident plain text".
+/// </summary>
+public sealed class WaitingScreenClassifierTests
+{
+    // A real Claude permission menu, drawn on the alternate screen (full-screen picker).
+    private static readonly string[] AltScreenMenuRows =
+    {
+        "╭──────────────────────────────────────────────╮",
+        "│ Bash command                                 │",
+        "│ Do you want to proceed?                      │",
+        "│ ❯ 1. Yes                                     │",
+        "│   2. Yes, and don't ask again this session   │",
+        "│   3. No, and tell Claude what to do          │",
+        "╰──────────────────────────────────────────────╯",
+    };
+
+    // A Claude composer at the bottom of the PRIMARY screen, cursor sitting in the empty input box (row 1).
+    private static readonly string[] ComposerRows =
+    {
+        "I finished the last change. What next?",
+        "╭──────────────────────────────────────╮",
+        "│ >                                     │",
+        "╰──────────────────────────────────────╯",
+        "  ? for shortcuts",
+    };
+
+    [Fact]
+    public void Classify_NoGrid_IsBlocked()
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(new[] { "anything" }, 0, 0, false, hasGrid: false));
+
+    [Fact]
+    public void Classify_EmptyRows_IsBlocked()
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(System.Array.Empty<string>(), -1, -1, false, hasGrid: true));
+
+    [Fact]
+    public void Classify_AllBlankGrid_IsBlocked()
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(new[] { "", "   ", "\t" }, 0, 0, false, hasGrid: true));
+
+    [Fact]
+    public void Classify_MenuFingerprint_IsMenu_EvenOnAlternateScreen()
+        => Assert.Equal(WaitingScreenKind.Menu, WaitingScreenClassifier.Classify(AltScreenMenuRows, 3, 3, isAlternateScreen: true, hasGrid: true));
+
+    [Fact]
+    public void Classify_AlternateScreen_Unrecognized_IsBlocked()
+    {
+        // A full-screen app (alternate screen) we did NOT recognize as a menu - never type into it. This is
+        // the inversion the original bug had: it is NOT a plain-text prompt just because no menu was matched.
+        var appRows = new[] { "some full screen TUI", "with content we cannot parse", "and a cursor somewhere" };
+        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(appRows, 2, 5, isAlternateScreen: true, hasGrid: true));
+    }
+
+    [Fact]
+    public void Classify_PrimaryComposer_CursorOnPromptLine_IsPlainText()
+        => Assert.Equal(WaitingScreenKind.PlainText, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 2, cursorCol: 4, isAlternateScreen: false, hasGrid: true));
+
+    [Fact]
+    public void Classify_PrimaryComposer_CursorNotOnPromptLine_IsBlocked()
+        => Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 0, cursorCol: 4, isAlternateScreen: false, hasGrid: true));
+
+    [Fact]
+    public void Classify_PrimaryScreen_NoComposer_IsBlocked()
+    {
+        // Primary screen, non-blank, not a menu, but no recognizable composer - unsure, so fail closed.
+        var rows = new[] { "the agent printed some output", "and then more output", "but no input prompt is visible" };
+        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(rows, cursorRow: 2, cursorCol: 5, isAlternateScreen: false, hasGrid: true));
+    }
+
+    [Fact]
+    public void Classify_ComposerButOnAlternateScreen_IsBlocked()
+    {
+        // Even a ">"-looking line on the alternate screen is not typed into: full-screen apps own their input.
+        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(ComposerRows, cursorRow: 2, cursorCol: 4, isAlternateScreen: true, hasGrid: true));
+    }
+
+    [Fact]
+    public void LooksLikePlainTextPrompt_ModeArrowIsNotAPrompt()
+    {
+        // ">> bypass permissions on" is the mode-cycle arrow, NOT the input prompt.
+        var rows = new[] { "output", ">> bypass permissions on (shift+tab to cycle)" };
+        Assert.False(WaitingScreenClassifier.LooksLikePlainTextPrompt(rows, cursorRow: 1, cursorCol: 3));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WaitingScreenClassifierTests.cs
+++ b/src/CcDirector.Gateway.Tests/WaitingScreenClassifierTests.cs
@@ -128,4 +128,34 @@ public sealed class WaitingScreenClassifierTests
         var rows = new[] { "some output", "> ", "  bypass permissions on (shift+tab to cycle)" };
         Assert.True(WaitingScreenClassifier.LooksLikePlainTextPrompt(rows, cursorRow: 1, cursorCol: 2));
     }
+
+    // ===== HasMenuishStructure (floor rescope, finding 3: any menu structure blocks typing) =====
+
+    [Fact]
+    public void Classify_ComposerWithNumberedListPresent_IsBlocked()
+    {
+        // Even a valid visible-cursor composer is not typed into when a numbered (menu-ish) list is anywhere on
+        // the grid. When in doubt, block.
+        var rows = new[]
+        {
+            "Here are the choices:",
+            "1. staging",
+            "2. production",
+            "╭──────────────────────────────────────╮",
+            "│ >                                     │",
+            "╰──────────────────────────────────────╯",
+            "  ? for shortcuts",
+        };
+        Assert.Equal(WaitingScreenKind.Blocked, WaitingScreenClassifier.Classify(rows, cursorRow: 4, cursorCol: 4, cursorVisible: true, isAlternateScreen: false, hasGrid: true));
+    }
+
+    [Theory]
+    [InlineData(new[] { "some prose", "1. first", "2. second" }, true)]     // a numbered/lettered option line
+    [InlineData(new[] { "prose", "❯ 1. Yes" }, true)]                        // a drawn selection marker
+    [InlineData(new[] { "Choose a deployment:", "the rest" }, true)]         // a menu-prompt phrase
+    [InlineData(new[] { "Do you want to proceed?", "..." }, true)]
+    [InlineData(new[] { "I finished the change.", "> ", "  ? for shortcuts" }, false)] // a plain composer
+    [InlineData(new[] { "just some prose output", "and more" }, false)]
+    public void HasMenuishStructure_DetectsMenuStructure(string[] rows, bool expected)
+        => Assert.Equal(expected, WaitingScreenClassifier.HasMenuishStructure(rows));
 }

--- a/src/CcDirector.Gateway.Tests/WaitingScreenClassifierTests.cs
+++ b/src/CcDirector.Gateway.Tests/WaitingScreenClassifierTests.cs
@@ -123,19 +123,21 @@ public sealed class WaitingScreenClassifierTests
     }
 
     [Fact]
-    public void LooksLikePlainTextPrompt_FooterOnly_CursorAtTrailingEdge_IsTrue()
+    public void LooksLikePlainTextPrompt_FooterOnly_EmptyTrimmedComposer_CursorAtInput_IsTrue()
     {
-        // Footer-only composer (no right border), empty input: the trailing edge is right after "> " (col 2).
-        var rows = new[] { "some output", "> ", "  bypass permissions on (shift+tab to cycle)" };
+        // The REAL trailing-trimmed representation: a footer-only empty "> " composer arrives as ">" (the space
+        // is trimmed). The visible cursor is at col 2 (the true input column, one past the trimmed marker). This
+        // is a normal empty composer and MUST type - a hand-supplied "> " row would mask the trimming.
+        var rows = new[] { "some output", ">", "  bypass permissions on (shift+tab to cycle)" };
         Assert.True(WaitingScreenClassifier.LooksLikePlainTextPrompt(rows, cursorRow: 1, cursorCol: 2));
     }
 
     [Fact]
     public void LooksLikePlainTextPrompt_FooterOnly_CursorPastTheInput_IsFalse()
     {
-        // Blocker B: with no right border, the cursor is bounded by the END of the input content. A cursor far
-        // past the input (col 10 over an empty "> ") is NOT the trailing insertion point -> not a composer.
-        var rows = new[] { "some output", "> ", "  bypass permissions on (shift+tab to cycle)" };
+        // Blocker B: with no right border, the cursor is still bounded. A cursor far past the input (col 10 over
+        // a trimmed ">") is neither the insertion point nor the trimmed-space column -> not a composer.
+        var rows = new[] { "some output", ">", "  bypass permissions on (shift+tab to cycle)" };
         Assert.False(WaitingScreenClassifier.LooksLikePlainTextPrompt(rows, cursorRow: 1, cursorCol: 10));
     }
 

--- a/src/CcDirector.Gateway.Tests/WingmanMenuTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanMenuTests.cs
@@ -72,6 +72,57 @@ public sealed class WingmanMenuTests
         Assert.False(WingmanMenuLogic.LooksLikeMenu(""));
     }
 
+    // ===== LiveScreenLooksLikeMenu (issue #1777: the live grid rules the verdict) =====
+
+    /// <summary>
+    /// The exact defect (issue #1777): a full-screen Claude picker draws on the ALTERNATE screen, where the
+    /// scrollback is empty by design. The old scrollback-only gate saw "" and returned false, so voice-turn
+    /// typed the spoken words into the picker. The live-grid gate reads the resolved on-screen rows and sees
+    /// the menu - this pins the fix: empty scrollback is NOT a menu, but the SAME menu on the live grid IS.
+    /// </summary>
+    private static readonly string[] AltScreenClaudeMenuRows =
+    {
+        "> run the tests",
+        "",
+        "╭──────────────────────────────────────────────╮",
+        "│ Bash command                                 │",
+        "│ dotnet test                                  │",
+        "│                                              │",
+        "│ Do you want to proceed?                      │",
+        "│ ❯ 1. Yes                                     │",
+        "│   2. Yes, and don't ask again this session   │",
+        "│   3. No, and tell Claude what to do          │",
+        "╰──────────────────────────────────────────────╯",
+    };
+
+    [Fact]
+    public void LiveScreenLooksLikeMenu_AltScreenClaudeMenu_IsTrue_EvenThoughScrollbackIsEmpty()
+    {
+        // The scrollback (what the old gate read) is EMPTY on the alternate screen - so the old path misses.
+        Assert.False(WingmanMenuLogic.LooksLikeMenu(""));
+        // The live grid holds the menu - the new gate catches it. This is the whole fix.
+        Assert.True(WingmanMenuLogic.LiveScreenLooksLikeMenu(AltScreenClaudeMenuRows));
+    }
+
+    [Fact]
+    public void LiveScreenLooksLikeMenu_PlainPrompt_IsFalse()
+    {
+        var rows = new[]
+        {
+            "I finished editing the file and ran the tests. Everything passes.",
+            "",
+            "> ",
+        };
+        Assert.False(WingmanMenuLogic.LiveScreenLooksLikeMenu(rows));
+    }
+
+    [Fact]
+    public void LiveScreenLooksLikeMenu_EmptyOrNull_IsFalse()
+    {
+        Assert.False(WingmanMenuLogic.LiveScreenLooksLikeMenu(null));
+        Assert.False(WingmanMenuLogic.LiveScreenLooksLikeMenu(System.Array.Empty<string>()));
+    }
+
     // ===== MatchOption (local spoken-answer mapping) =====
 
     [Theory]

--- a/src/CcDirector.Gateway.Tests/WingmanMenuTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanMenuTests.cs
@@ -172,6 +172,76 @@ public sealed class WingmanMenuTests
         Assert.False(WingmanMenuLogic.SameMenuStillOnScreen(new[] { "just prose", "more prose" }, new[] { "just prose", "more prose" }));
     }
 
+    [Fact]
+    public void SameMenuStillOnScreen_BlankLineSeparatedQuestionChanges_IsFalse()
+    {
+        // B3 (round-4): the question is separated from the options by a BLANK line. A changed question must
+        // still fail the re-verify - the signature has to reach across the blank line to the question.
+        var captured = new[] { "Delete production?", "", "❯ 1. Yes", "  2. No" };
+        var fresh = new[] { "Deploy production?", "", "❯ 1. Yes", "  2. No" };
+        Assert.False(WingmanMenuLogic.SameMenuStillOnScreen(captured, fresh));
+    }
+
+    // ===== IsSelectedOptionLine / LiveScreenHasMenuSelection (round-4: menu owned by its DRAWN marker) =====
+
+    [Theory]
+    [InlineData("❯ 1. Yes", true)]
+    [InlineData("│ ❯ 1. Yes │", true)]
+    [InlineData("> 1. Yes", true)]
+    [InlineData("  2. No", false)]          // an option, but not the SELECTED one (no marker)
+    [InlineData("> production", false)]     // a bare selector, no numbered option after the marker
+    [InlineData("Do you want to proceed?", false)]
+    public void IsSelectedOptionLine_DetectsTheDrawnMarker(string row, bool expected)
+        => Assert.Equal(expected, WingmanMenuLogic.IsSelectedOptionLine(row));
+
+    [Fact]
+    public void LiveScreenHasMenuSelection_MarkerPlusOptions_IsTrue()
+    {
+        var rows = new[] { "Do you want to proceed?", "❯ 1. Yes", "  2. No" };
+        Assert.True(WingmanMenuLogic.LiveScreenHasMenuSelection(rows));
+    }
+
+    [Fact]
+    public void LiveScreenHasMenuSelection_BareSelectorNoNumberedOptions_IsFalse()
+        => Assert.False(WingmanMenuLogic.LiveScreenHasMenuSelection(new[] { "Choose a deployment:", "> production" }));
+
+    [Fact]
+    public void LiveScreenHasMenuSelection_OptionsButNoDrawnMarker_IsFalse()
+        // A styled/reverse-video picker with no textual ❯/> marker is not recognized (fail closed, deferred).
+        => Assert.False(WingmanMenuLogic.LiveScreenHasMenuSelection(new[] { "  1. Yes", "  2. No" }));
+
+    // ===== MenuHasAnswerableOptions (finding 4: reject empty/invented labels) =====
+
+    [Fact]
+    public void MenuHasAnswerableOptions_RealLabelsOnScreen_IsTrue()
+    {
+        var rows = new[] { "Do you want to proceed?", "❯ 1. Yes", "  2. Yes, and don't ask again", "  3. No" };
+        Assert.True(WingmanMenuLogic.MenuHasAnswerableOptions(PermissionMenu(), rows));
+    }
+
+    [Fact]
+    public void MenuHasAnswerableOptions_BareNumberLabels_IsFalse()
+    {
+        var menu = new WingmanMenu
+        {
+            IsMenu = true,
+            Options = new() { new() { Key = "1.", Send = "1\r" }, new() { Key = "2.", Send = "2\r" } },
+        };
+        Assert.False(WingmanMenuLogic.MenuHasAnswerableOptions(menu, new[] { "❯ 1.", "  2." }));
+    }
+
+    [Fact]
+    public void MenuHasAnswerableOptions_LabelNotOnScreen_IsFalse()
+    {
+        // The model invented an option that is not actually on the live grid.
+        var menu = new WingmanMenu
+        {
+            IsMenu = true,
+            Options = new() { new() { Key = "1. Yes", Send = "1\r" }, new() { Key = "2. Delete everything", Send = "2\r" } },
+        };
+        Assert.False(WingmanMenuLogic.MenuHasAnswerableOptions(menu, new[] { "Proceed?", "❯ 1. Yes", "  2. No" }));
+    }
+
     // ===== MatchOption (local spoken-answer mapping) =====
 
     [Theory]

--- a/src/CcDirector.Gateway.Tests/WingmanMenuTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanMenuTests.cs
@@ -137,51 +137,6 @@ public sealed class WingmanMenuTests
     public void IsOptionLine_ClassifiesRows(string row, bool expected)
         => Assert.Equal(expected, WingmanMenuLogic.IsOptionLine(row));
 
-    // ===== SameMenuStillOnScreen (issue #1777, B3: re-verify against the CAPTURED menu block) =====
-
-    [Fact]
-    public void SameMenuStillOnScreen_IdenticalMenu_IsTrue()
-    {
-        var captured = new[] { "Do you want to proceed?", "❯ 1. Yes", "  2. No" };
-        var fresh = new[] { "Do you want to proceed?", "❯ 1. Yes", "  2. No" };
-        Assert.True(WingmanMenuLogic.SameMenuStillOnScreen(captured, fresh));
-    }
-
-    [Fact]
-    public void SameMenuStillOnScreen_SameLabelsDifferentQuestion_IsFalse()
-    {
-        // The exact B3 hole: a replacement menu with the SAME option labels but a different question. Comparing
-        // only labels would pass and press the old answer into the new menu; comparing the block catches it.
-        var captured = new[] { "Delete production?", "❯ 1. Yes", "  2. No" };
-        var fresh = new[] { "Deploy production?", "❯ 1. Yes", "  2. No" };
-        Assert.False(WingmanMenuLogic.SameMenuStillOnScreen(captured, fresh));
-    }
-
-    [Fact]
-    public void SameMenuStillOnScreen_MenuClosed_IsFalse()
-    {
-        var captured = new[] { "Do you want to proceed?", "❯ 1. Yes", "  2. No" };
-        var fresh = new[] { "user@host:~/repo$ ", "" };
-        Assert.False(WingmanMenuLogic.SameMenuStillOnScreen(captured, fresh));
-    }
-
-    [Fact]
-    public void SameMenuStillOnScreen_NoOptions_IsFalse()
-    {
-        // No option lines -> no signature -> never "the same menu" (nothing to verify against).
-        Assert.False(WingmanMenuLogic.SameMenuStillOnScreen(new[] { "just prose", "more prose" }, new[] { "just prose", "more prose" }));
-    }
-
-    [Fact]
-    public void SameMenuStillOnScreen_BlankLineSeparatedQuestionChanges_IsFalse()
-    {
-        // B3 (round-4): the question is separated from the options by a BLANK line. A changed question must
-        // still fail the re-verify - the signature has to reach across the blank line to the question.
-        var captured = new[] { "Delete production?", "", "❯ 1. Yes", "  2. No" };
-        var fresh = new[] { "Deploy production?", "", "❯ 1. Yes", "  2. No" };
-        Assert.False(WingmanMenuLogic.SameMenuStillOnScreen(captured, fresh));
-    }
-
     // ===== IsSelectedOptionLine / LiveScreenHasMenuSelection (round-4: menu owned by its DRAWN marker) =====
 
     [Theory]

--- a/src/CcDirector.Gateway.Tests/WingmanMenuTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanMenuTests.cs
@@ -123,29 +123,53 @@ public sealed class WingmanMenuTests
         Assert.False(WingmanMenuLogic.LiveScreenLooksLikeMenu(System.Array.Empty<string>()));
     }
 
-    // ===== MenuOptionsPresentOnScreen (issue #1777, finding 3: the re-verify before pressing) =====
+    // ===== IsOptionLine (issue #1777, round-3: is the CURSOR on a menu option?) =====
+
+    [Theory]
+    [InlineData("❯ 1. Yes", true)]
+    [InlineData("  2. No", true)]
+    [InlineData("│ 3. Cancel │", true)]
+    [InlineData("a) Apply", true)]
+    [InlineData("Do you want to proceed?", false)]
+    [InlineData("> production", false)]        // a bare selector, not a numbered/lettered option line
+    [InlineData("│ >  │", false)]              // a composer input line
+    [InlineData("", false)]
+    public void IsOptionLine_ClassifiesRows(string row, bool expected)
+        => Assert.Equal(expected, WingmanMenuLogic.IsOptionLine(row));
+
+    // ===== SameMenuStillOnScreen (issue #1777, B3: re-verify against the CAPTURED menu block) =====
 
     [Fact]
-    public void MenuOptionsPresentOnScreen_AllLabelsStillOnScreen_IsTrue()
+    public void SameMenuStillOnScreen_IdenticalMenu_IsTrue()
     {
-        var rows = new[] { "Do you want to proceed?", "❯ 1. Yes", "  2. Yes, and don't ask again", "  3. No" };
-        Assert.True(WingmanMenuLogic.MenuOptionsPresentOnScreen(PermissionMenu(), rows));
+        var captured = new[] { "Do you want to proceed?", "❯ 1. Yes", "  2. No" };
+        var fresh = new[] { "Do you want to proceed?", "❯ 1. Yes", "  2. No" };
+        Assert.True(WingmanMenuLogic.SameMenuStillOnScreen(captured, fresh));
     }
 
     [Fact]
-    public void MenuOptionsPresentOnScreen_MenuClosed_IsFalse()
+    public void SameMenuStillOnScreen_SameLabelsDifferentQuestion_IsFalse()
     {
-        // The menu closed and a shell prompt replaced it - the option labels are gone, so pressing would be
-        // dangerous. This is the TOCTOU guard: press NOTHING.
-        var rows = new[] { "user@host:~/repo$ ", "" };
-        Assert.False(WingmanMenuLogic.MenuOptionsPresentOnScreen(PermissionMenu(), rows));
+        // The exact B3 hole: a replacement menu with the SAME option labels but a different question. Comparing
+        // only labels would pass and press the old answer into the new menu; comparing the block catches it.
+        var captured = new[] { "Delete production?", "❯ 1. Yes", "  2. No" };
+        var fresh = new[] { "Deploy production?", "❯ 1. Yes", "  2. No" };
+        Assert.False(WingmanMenuLogic.SameMenuStillOnScreen(captured, fresh));
     }
 
     [Fact]
-    public void MenuOptionsPresentOnScreen_EmptyOrNull_IsFalse()
+    public void SameMenuStillOnScreen_MenuClosed_IsFalse()
     {
-        Assert.False(WingmanMenuLogic.MenuOptionsPresentOnScreen(PermissionMenu(), System.Array.Empty<string>()));
-        Assert.False(WingmanMenuLogic.MenuOptionsPresentOnScreen(new WingmanMenu { IsMenu = true }, new[] { "1. Yes" }));
+        var captured = new[] { "Do you want to proceed?", "❯ 1. Yes", "  2. No" };
+        var fresh = new[] { "user@host:~/repo$ ", "" };
+        Assert.False(WingmanMenuLogic.SameMenuStillOnScreen(captured, fresh));
+    }
+
+    [Fact]
+    public void SameMenuStillOnScreen_NoOptions_IsFalse()
+    {
+        // No option lines -> no signature -> never "the same menu" (nothing to verify against).
+        Assert.False(WingmanMenuLogic.SameMenuStillOnScreen(new[] { "just prose", "more prose" }, new[] { "just prose", "more prose" }));
     }
 
     // ===== MatchOption (local spoken-answer mapping) =====

--- a/src/CcDirector.Gateway.Tests/WingmanMenuTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanMenuTests.cs
@@ -123,6 +123,31 @@ public sealed class WingmanMenuTests
         Assert.False(WingmanMenuLogic.LiveScreenLooksLikeMenu(System.Array.Empty<string>()));
     }
 
+    // ===== MenuOptionsPresentOnScreen (issue #1777, finding 3: the re-verify before pressing) =====
+
+    [Fact]
+    public void MenuOptionsPresentOnScreen_AllLabelsStillOnScreen_IsTrue()
+    {
+        var rows = new[] { "Do you want to proceed?", "❯ 1. Yes", "  2. Yes, and don't ask again", "  3. No" };
+        Assert.True(WingmanMenuLogic.MenuOptionsPresentOnScreen(PermissionMenu(), rows));
+    }
+
+    [Fact]
+    public void MenuOptionsPresentOnScreen_MenuClosed_IsFalse()
+    {
+        // The menu closed and a shell prompt replaced it - the option labels are gone, so pressing would be
+        // dangerous. This is the TOCTOU guard: press NOTHING.
+        var rows = new[] { "user@host:~/repo$ ", "" };
+        Assert.False(WingmanMenuLogic.MenuOptionsPresentOnScreen(PermissionMenu(), rows));
+    }
+
+    [Fact]
+    public void MenuOptionsPresentOnScreen_EmptyOrNull_IsFalse()
+    {
+        Assert.False(WingmanMenuLogic.MenuOptionsPresentOnScreen(PermissionMenu(), System.Array.Empty<string>()));
+        Assert.False(WingmanMenuLogic.MenuOptionsPresentOnScreen(new WingmanMenu { IsMenu = true }, new[] { "1. Yes" }));
+    }
+
     // ===== MatchOption (local spoken-answer mapping) =====
 
     [Theory]

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
@@ -214,6 +214,44 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task VoiceTurn_EmptyFooterComposer_TrimmedRow_TypesTheSpokenAnswer()
+    {
+        // Regression (final fix): a NORMAL empty footer-only composer, in the REAL trailing-trimmed
+        // representation ("> " arrives as ">"), with the visible cursor at the true input column (2). A normal
+        // voice answer MUST be typed here - the trailing-edge rule must not over-block the empty composer.
+        var sid = await PushSessionAsync();
+        var spoken = "run the tests";
+        var promptSent = false;
+
+        _dispatch = cmd => cmd.Verb switch
+        {
+            "screen-grid" => Ok(new ScreenGridResponse
+            {
+                SessionId = sid,
+                Rows = new List<string> { ">", "  ? for shortcuts" },   // the trimmed "> " row
+                CursorRow = 0,
+                CursorCol = 2,
+                CursorVisible = true,
+                IsAlternateScreen = false,
+                HasGrid = true,
+            }),
+            "turns" => Ok(new TurnsResponse
+            {
+                SessionId = sid,
+                Status = "ok",
+                Widgets = promptSent
+                    ? new List<TurnWidgetDto> { new() { Kind = "Text", Content = "Running." } }
+                    : new List<TurnWidgetDto>(),
+            }),
+            "prompt" => Mark(ref promptSent, Ok(new PromptResponse { Accepted = true })),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
+        };
+
+        await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = spoken });
+        Assert.Contains(DispatchedPrompts(), p => p.Text == spoken && p.AppendEnter);
+    }
+
+    [Fact]
     public async Task VoiceTurn_PlainTextThenBecomesMenuBeforeSend_TypesNothing()
     {
         // Finding 2 (snapshot-to-send race): the screen is a plain-text composer when classified, but a menu by

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
@@ -262,6 +262,28 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task VoiceTurn_PickPromptSelectorVisibleCursorAtMarker_TypesNothing()
+    {
+        // Blocker A: "Pick environment:" over a framed "> production" selector, with a VISIBLE cursor at the
+        // marker (col 4). It looks composer-like, but the cursor is at the selection marker, not trailing typed
+        // text - so it is a selector, not a composer. Type NOTHING.
+        var sid = await PushSessionAsync();
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? Ok(new ScreenGridResponse
+            {
+                SessionId = sid,
+                Rows = new List<string> { "Pick environment:", "╭──────────────╮", "│ > production │", "╰──────────────╯" },
+                CursorRow = 2,
+                CursorCol = 4,
+                CursorVisible = true,
+                IsAlternateScreen = false,
+                HasGrid = true,
+            })
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
+        await AssertTypesNothing(sid, "production");
+    }
+
+    [Fact]
     public async Task VoiceTurn_ComposerWithANumberedListPresent_TypesNothing()
     {
         // Finding 3, conservative floor: even a VISIBLE-cursor composer is not typed into when a numbered

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
@@ -5,9 +5,6 @@ using System.Net.Http.Json;
 using System.Net.Sockets;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using CcDirector.AgentBrain;
-using CcDirector.Core.Configuration;
-using CcDirector.Core.Drivers;
 using CcDirector.Gateway.Contracts;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection; // AddMessagePackProtocol (client)
@@ -16,16 +13,16 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// The fail-closed floor of the menu-handling mission (issue #1777), proven end-to-end against a REAL
-/// streamMode <see cref="GatewayHost"/> over the tunnel. Every session verb (<c>screen-grid</c> /
-/// <c>turns</c> / <c>prompt</c>) is answered per scenario and every dispatched command is recorded, so a test
-/// proves exactly what did - and did NOT - reach the terminal. A STUB warm brain is injected so the menu
-/// detector can be exercised WITH a working model (proving detection off the live grid and the menu-press
-/// path), while the fail-closed tests leave the brain throwing (no reply set) to prove that a menu the brain
-/// cannot read still types nothing.
+/// The FLOOR of the menu-handling mission (issue #1777), proven end-to-end against a REAL streamMode
+/// <see cref="GatewayHost"/> over the tunnel. THE INVARIANT this pins: voice-turn NEVER presses a key into a
+/// session, and it types the spoken words as a prompt ONLY on a confident plain-text composer (not the
+/// alternate screen, cursor VISIBLE, cursor within the composer's input span, no menu-ish structure anywhere,
+/// and re-confirmed plain-text immediately before the send). Every menu, and every uncertain / unreadable /
+/// alternate-screen / hidden-cursor screen, types NOTHING and presses NOTHING.
 ///
-/// The classification is decided ONLY from the live screen grid: the <c>buffer</c> (scrollback) verb is never
-/// read on this path, which these tests assert.
+/// Every dispatched command is recorded, so a test proves exactly what did - and did not - reach the terminal.
+/// No wingman brain is configured (the send path never calls one); the translate step after a successful type
+/// then fails, which is irrelevant - the claim is that the prompt WAS (or was NOT) dispatched.
 /// </summary>
 [Collection("DirectorRoot")]
 public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
@@ -50,44 +47,19 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
     private Func<DirectorCommand, DirectorCommandResult> _dispatch =
         cmd => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
 
-    // ---- Stub warm brain (issue #1777, finding 4) ----
-    // Every prompt the brain received (so a test can assert the LIVE grid text reached menu detection).
-    private readonly ConcurrentQueue<string> _brainPrompts = new();
-    // What the brain replies. Null => AskAsync throws (the real no-key brain behavior) => fail-closed path.
-    private Func<string, string>? _brainReply;
-
-    private sealed class StubBrain : IAgentBrain
+    public WingmanVoiceTurnLiveScreenProofTests()
     {
-        private readonly WingmanVoiceTurnLiveScreenProofTests _owner;
-        public StubBrain(WingmanVoiceTurnLiveScreenProofTests owner) => _owner = owner;
-        public string? SessionId => "stub";
-        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
-        {
-            _owner._brainPrompts.Enqueue(prompt);
-            var reply = _owner._brainReply;
-            if (reply is null)
-                throw new InvalidOperationException("stub brain: no reply configured (fail-closed path)");
-            return Task.FromResult(new AskResult { Text = reply(prompt) });
-        }
-        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
-        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth());
-        public void Dispose() { }
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-vlsproof-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
     }
-
-    /// <summary>Wrap a spoken answer in the brain's answer markers, the way the model is told to.</summary>
-    private static string Wrapped(string body) =>
-        SessionAskRunner.AnswerBeginMarker + "\n" + body + "\n" + SessionAskRunner.AnswerEndMarker;
 
     public async Task InitializeAsync()
     {
         _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
-            streamMode: true,
-            brainProviderOverride: (_, _) => Task.FromResult<IAgentBrain>(new StubBrain(this)));
+            streamMode: true);
         await _gateway.StartAsync();
         _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
         _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
@@ -113,13 +85,6 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         });
         await _conn.StartAsync();
         await _conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = DirectorId, Version = "test" });
-    }
-
-    public WingmanVoiceTurnLiveScreenProofTests()
-    {
-        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
-        _root = Path.Combine(Path.GetTempPath(), "ccd-vlsproof-" + Guid.NewGuid().ToString("N"));
-        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
     }
 
     public async Task DisposeAsync()
@@ -165,8 +130,8 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
     }
 
     // A real Claude permission menu drawn with its selection marker. Like the real Ink picker, the hardware
-    // cursor is HIDDEN (CursorVisible=false) and its cell is stale - the menu is owned by the drawn marker.
-    private static ScreenGridResponse PrimaryMenuGrid(string sid) => new()
+    // cursor is HIDDEN and its cell is stale - the menu is owned by the drawn marker.
+    private static ScreenGridResponse MenuGrid(string sid) => new()
     {
         SessionId = sid,
         Rows = new List<string> { "Do you want to proceed?", "❯ 1. Yes", "  2. No" },
@@ -196,122 +161,32 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         HasGrid = true,
     };
 
-    // ===================== Finding 4: detection off the LIVE grid, menu-press path =====================
+    // ===================== The floor: a menu types nothing AND presses nothing =====================
 
     [Fact]
-    public async Task VoiceTurn_LiveGridMenu_StubBrainRecognizesIt_PressesTheOptionOffTheLiveGrid()
+    public async Task VoiceTurn_MenuOnScreen_TypesNothingAndPressesNothing()
     {
+        // The invariant: a drawn menu (hidden cursor, real Claude case) is detected and the turn fails closed.
+        // NOTHING is sent into the session - not the spoken words, not any menu keystroke.
         var sid = await PushSessionAsync();
-        var promptSent = false;
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? Ok(MenuGrid(sid))
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
 
-        // The brain SUCCEEDS: it returns the menu it read from the live grid.
-        _brainReply = _ => Wrapped(
-            "{\"isMenu\":true,\"question\":\"Proceed?\",\"selectionMode\":\"single\",\"submit\":\"\"," +
-            "\"options\":[{\"key\":\"1. Yes\",\"send\":\"1\\r\"},{\"key\":\"2. No\",\"send\":\"2\\r\"}]}");
-
-        _dispatch = cmd => cmd.Verb switch
-        {
-            "screen-grid" => Ok(PrimaryMenuGrid(sid)),
-            "turns" => Ok(new TurnsResponse
-            {
-                SessionId = sid,
-                Status = "ok",
-                Widgets = promptSent
-                    ? new List<TurnWidgetDto> { new() { Kind = "Text", Content = "Ran the tests, all green." } }
-                    : new List<TurnWidgetDto>(),
-            }),
-            "prompt" => Mark(ref promptSent, Ok(new PromptResponse { Accepted = true })),
-            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
-        };
-
-        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = "option one" });
-        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-
-        // The menu-press path was taken with the cursor HIDDEN (the real Ink-picker case, PrimaryMenuGrid has
-        // CursorVisible=false): the menu was recognized via its DRAWN marker and answered. The option's
-        // keystroke reached the terminal (NOT the spoken words).
-        var prompts = DispatchedPrompts();
-        Assert.Contains(prompts, p => p.Text == "1\r");
-        Assert.DoesNotContain(prompts, p => p.Text == "option one");
-
-        // Detection ran off the LIVE grid text - the brain's first prompt carried the live menu content.
-        Assert.True(_brainPrompts.TryPeek(out var firstPrompt));
-        Assert.Contains("Do you want to proceed?", firstPrompt);
-
-        // The scrollback (buffer) verb was never read - the live grid is the only detection source (finding 2).
-        Assert.DoesNotContain(_commands, c => c.Verb == "buffer");
-    }
-
-    // ===================== Finding 3: re-verify the menu is still on screen before pressing =====================
-
-    [Fact]
-    public async Task VoiceTurn_MenuClosedBetweenReadAndPress_PressesNothing()
-    {
-        var sid = await PushSessionAsync();
-        var gridCall = 0;
-
-        // The brain recognizes the menu on the FIRST read. But by the time we go to press, the menu has closed
-        // and a shell prompt is on screen - the re-verify must catch that and press NOTHING (no selection bytes
-        // into the shell).
-        _brainReply = _ => Wrapped(
-            "{\"isMenu\":true,\"question\":\"Proceed?\",\"selectionMode\":\"single\",\"submit\":\"\"," +
-            "\"options\":[{\"key\":\"1. Yes\",\"send\":\"1\\r\"},{\"key\":\"2. No\",\"send\":\"2\\r\"}]}");
-
-        _dispatch = cmd =>
-        {
-            if (cmd.Verb == "screen-grid")
-            {
-                // First read: the menu. Re-verify read (and after): the menu is gone, a shell prompt is up.
-                var call = System.Threading.Interlocked.Increment(ref gridCall);
-                return call == 1
-                    ? Ok(PrimaryMenuGrid(sid))
-                    : Ok(new ScreenGridResponse
-                    {
-                        SessionId = sid,
-                        Rows = new List<string> { "user@host:~/repo$ ", "" },
-                        CursorRow = 0,
-                        CursorCol = 18,
-                        IsAlternateScreen = false,
-                        HasGrid = true,
-                    });
-            }
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
-        };
-
-        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = "option one" });
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = "yes go ahead" });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
         Assert.True(node?["cannotType"]?.GetValue<bool>());
-        // No keystrokes reached the terminal - not the option, not the spoken words.
-        Assert.Empty(DispatchedPrompts());
-    }
 
-    // ===================== Fail-closed: a menu the brain cannot read types nothing =====================
-
-    [Fact]
-    public async Task VoiceTurn_LiveGridMenu_BrainCannotRead_TypesNothing()
-    {
-        var sid = await PushSessionAsync();
-        _brainReply = null; // brain throws => detection fails => fail closed
-
-        _dispatch = cmd => cmd.Verb switch
-        {
-            "screen-grid" => Ok(PrimaryMenuGrid(sid)),
-            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
-        };
-
-        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = "yeah go ahead" });
-        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
-        Assert.True(node?["cannotType"]?.GetValue<bool>());
+        // The absolute floor invariant: NO prompt of ANY kind reached the terminal on this branch.
         Assert.Empty(DispatchedPrompts());
         Assert.Contains(_commands, c => c.Verb == "screen-grid");
     }
 
-    // ===================== Finding 5: plain text types ONLY on a positive composer signal =====================
+    // ===================== The one thing allowed: type on a confident plain-text composer ===============
 
     [Fact]
-    public async Task VoiceTurn_PrimaryComposerWithCursor_TypesTheSpokenAnswer()
+    public async Task VoiceTurn_ConfidentPlainTextComposer_TypesTheSpokenAnswer()
     {
         var sid = await PushSessionAsync();
         var spoken = "add a retry to the upload path";
@@ -319,7 +194,7 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
 
         _dispatch = cmd => cmd.Verb switch
         {
-            "screen-grid" => Ok(ComposerGrid(sid)),
+            "screen-grid" => Ok(ComposerGrid(sid)),   // both the classify and the pre-send re-confirm see it
             "turns" => Ok(new TurnsResponse
             {
                 SessionId = sid,
@@ -332,20 +207,44 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
         };
 
-        // It types only because the LIVE screen was POSITIVELY classified plain text (primary composer, cursor
-        // on the prompt line). The translate step then fails (stub brain has no reply set), which is
-        // irrelevant to the claim: the answer WAS typed.
+        // The translate step fails (no brain configured), which is irrelevant: the claim is the words WERE
+        // typed as an ordinary prompt onto the composer.
         await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = spoken });
-
         Assert.Contains(DispatchedPrompts(), p => p.Text == spoken && p.AppendEnter);
     }
 
     [Fact]
+    public async Task VoiceTurn_PlainTextThenBecomesMenuBeforeSend_TypesNothing()
+    {
+        // Finding 2 (snapshot-to-send race): the screen is a plain-text composer when classified, but a menu by
+        // the time we re-confirm immediately before the send. The re-confirm must catch it and type nothing.
+        var sid = await PushSessionAsync();
+        var gridCall = 0;
+        _dispatch = cmd =>
+        {
+            if (cmd.Verb == "screen-grid")
+            {
+                var call = System.Threading.Interlocked.Increment(ref gridCall);
+                return call == 1 ? Ok(ComposerGrid(sid)) : Ok(MenuGrid(sid));
+            }
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+        };
+
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = "do it" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.True(node?["cannotType"]?.GetValue<bool>());
+        Assert.Empty(DispatchedPrompts());
+    }
+
+    // ===================== Finding 3: menu-ish structure blocks typing =====================
+
+    [Fact]
     public async Task VoiceTurn_BorderedSelectorHiddenCursor_TypesNothing()
     {
-        // Named test / B1: a BORDERED "> production" selector - the exact thing that used to read as a composer
-        // because of the box frame. The hardware cursor is HIDDEN (a menu selection), so typing is refused; and
-        // it is not a recognized menu (no numbered option after the marker), so nothing is pressed either.
+        // A BORDERED "> production" selector - the thing that used to read as a composer because of the box
+        // frame. The hardware cursor is HIDDEN (a menu selection), and "Choose a deployment:" is a menu prompt,
+        // so typing is refused.
         var sid = await PushSessionAsync();
         _dispatch = cmd => cmd.Verb == "screen-grid"
             ? Ok(new ScreenGridResponse
@@ -363,31 +262,10 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task VoiceTurn_SelectorAboveFooterHiddenCursor_TypesNothing()
+    public async Task VoiceTurn_ComposerWithANumberedListPresent_TypesNothing()
     {
-        // Named test / B1: a ">"-row directly above the mode-status footer, cursor HIDDEN. The footer used to
-        // be read as composer framing; with a hidden cursor it fails closed.
-        var sid = await PushSessionAsync();
-        _dispatch = cmd => cmd.Verb == "screen-grid"
-            ? Ok(new ScreenGridResponse
-            {
-                SessionId = sid,
-                Rows = new List<string> { "> production", "  ? for shortcuts" },
-                CursorRow = 0,
-                CursorCol = 5,
-                CursorVisible = false,
-                IsAlternateScreen = false,
-                HasGrid = true,
-            })
-            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
-        await AssertTypesNothing(sid, "production");
-    }
-
-    [Fact]
-    public async Task VoiceTurn_MenuMarkerAndLiveComposerBothPresent_TypesNothing()
-    {
-        // Named test B (round-4 correction): a drawn menu marker AND a live composer on the same grid is
-        // AMBIGUOUS. When in doubt, block - neither type the words nor press the (possibly stale) menu.
+        // Finding 3, conservative floor: even a VISIBLE-cursor composer is not typed into when a numbered
+        // (menu-ish) list is anywhere on the grid. When in doubt, block.
         var sid = await PushSessionAsync();
         _dispatch = cmd => cmd.Verb == "screen-grid"
             ? Ok(new ScreenGridResponse
@@ -395,9 +273,9 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
                 SessionId = sid,
                 Rows = new List<string>
                 {
-                    "Do you want to proceed?",
-                    "❯ 1. Yes",
-                    "  2. No",
+                    "Here are the choices:",
+                    "1. staging",
+                    "2. production",
                     "╭──────────────────────────────────────╮",
                     "│ >                                     │",
                     "╰──────────────────────────────────────╯",
@@ -410,81 +288,10 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
                 HasGrid = true,
             })
             : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
-        await AssertTypesNothing(sid, "now run the integration tests");
+        await AssertTypesNothing(sid, "staging");
     }
 
-    [Fact]
-    public async Task VoiceTurn_ReplacementMenuSameLabels_ReVerifyFailsClosed_PressesNothing()
-    {
-        // Named test C: the menu is REPLACED between classification and press by a different menu with the SAME
-        // option labels (Delete production? -> Deploy production?, both 1.Yes / 2.No). The re-verify compares
-        // the captured menu BLOCK (question + options), so it catches the change and presses nothing.
-        var sid = await PushSessionAsync();
-        var gridCall = 0;
-
-        _brainReply = _ => Wrapped(
-            "{\"isMenu\":true,\"question\":\"Delete production?\",\"selectionMode\":\"single\",\"submit\":\"\"," +
-            "\"options\":[{\"key\":\"1. Yes\",\"send\":\"1\\r\"},{\"key\":\"2. No\",\"send\":\"2\\r\"}]}");
-
-        _dispatch = cmd =>
-        {
-            if (cmd.Verb == "screen-grid")
-            {
-                var call = System.Threading.Interlocked.Increment(ref gridCall);
-                var question = call == 1 ? "Delete production?" : "Deploy production?";
-                // The question is separated from the options by a BLANK line - the signature must still catch
-                // the change (finding B3, round-4). Cursor hidden, like a real menu.
-                return Ok(new ScreenGridResponse
-                {
-                    SessionId = sid,
-                    Rows = new List<string> { question, "", "❯ 1. Yes", "  2. No" },
-                    CursorRow = 0,
-                    CursorCol = -1,
-                    CursorVisible = false,
-                    IsAlternateScreen = true,
-                    HasGrid = true,
-                });
-            }
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
-        };
-
-        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = "yes" });
-        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
-        Assert.True(node?["cannotType"]?.GetValue<bool>());
-        Assert.Empty(DispatchedPrompts());
-    }
-
-    [Fact]
-    public async Task VoiceTurn_MenuLookingScreen_DetectorReturnsNotAMenu_TypesNothing()
-    {
-        // Named test D: the live screen looks like a menu and the brain is reached, but it returns isMenu:false
-        // (no pressable options). This must fail closed - never fall through to typing.
-        var sid = await PushSessionAsync();
-        _brainReply = _ => Wrapped("{\"isMenu\":false}");
-        _dispatch = cmd => cmd.Verb == "screen-grid"
-            ? Ok(PrimaryMenuGrid(sid))
-            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
-        await AssertTypesNothing(sid, "yes go ahead");
-    }
-
-    [Fact]
-    public async Task VoiceTurn_MenuWithBareNumberLabels_TypesNothing()
-    {
-        // Finding 4: the detector returns isMenu:true but the options are bare "1."/"2." with no words - not
-        // answerable. Block it rather than pressing a meaningless choice.
-        var sid = await PushSessionAsync();
-        // The grid IS a real drawn menu (so the classifier says Menu), but the detector extracts bare labels.
-        _brainReply = _ => Wrapped(
-            "{\"isMenu\":true,\"question\":\"Pick\",\"selectionMode\":\"single\",\"submit\":\"\"," +
-            "\"options\":[{\"key\":\"1.\",\"send\":\"1\\r\"},{\"key\":\"2.\",\"send\":\"2\\r\"}]}");
-        _dispatch = cmd => cmd.Verb == "screen-grid"
-            ? Ok(PrimaryMenuGrid(sid))
-            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
-        await AssertTypesNothing(sid, "one");
-    }
-
-    // ===================== Finding 6: cover the fail-closed edges - each types NOTHING =====================
+    // ===================== Finding 6-style fail-closed edges - each types NOTHING =====================
 
     [Fact]
     public async Task VoiceTurn_ScreenGridVerbFails_TypesNothing()
@@ -527,8 +334,6 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
     [Fact]
     public async Task VoiceTurn_AlternateScreenUnrecognized_TypesNothing()
     {
-        // A full-screen app on the alternate screen we did NOT recognize as a menu (no fingerprint). The old
-        // inversion would have called this plain text and typed into it.
         var sid = await PushSessionAsync();
         _dispatch = cmd => cmd.Verb == "screen-grid"
             ? Ok(new ScreenGridResponse
@@ -537,6 +342,7 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
                 Rows = new List<string> { "a full screen viewer", "line of content", "another line", "status: reading" },
                 CursorRow = 3,
                 CursorCol = 8,
+                CursorVisible = false,
                 IsAlternateScreen = true,
                 HasGrid = true,
             })

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
@@ -164,19 +164,20 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         return prompts;
     }
 
-    // A real Claude permission menu on the PRIMARY screen (the "do you want to proceed" / "❯ 1" fingerprint),
-    // whose option labels are on the grid so the re-verify before pressing passes.
+    // A real Claude permission menu drawn with its selection marker. Like the real Ink picker, the hardware
+    // cursor is HIDDEN (CursorVisible=false) and its cell is stale - the menu is owned by the drawn marker.
     private static ScreenGridResponse PrimaryMenuGrid(string sid) => new()
     {
         SessionId = sid,
         Rows = new List<string> { "Do you want to proceed?", "❯ 1. Yes", "  2. No" },
-        CursorRow = 1,
-        CursorCol = 2,
-        IsAlternateScreen = false,
+        CursorRow = 0,
+        CursorCol = -1,
+        CursorVisible = false,
+        IsAlternateScreen = true,
         HasGrid = true,
     };
 
-    // A Claude composer, cursor in the empty input box (row 2), framed by box borders and a mode-status footer.
+    // A Claude composer, VISIBLE cursor in the empty input box (row 2), framed by box borders and a footer.
     private static ScreenGridResponse ComposerGrid(string sid) => new()
     {
         SessionId = sid,
@@ -190,6 +191,7 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         },
         CursorRow = 2,
         CursorCol = 4,
+        CursorVisible = true,
         IsAlternateScreen = false,
         HasGrid = true,
     };
@@ -225,7 +227,9 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = "option one" });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
 
-        // The menu-press path was taken: the option's keystroke reached the terminal (NOT the spoken words).
+        // The menu-press path was taken with the cursor HIDDEN (the real Ink-picker case, PrimaryMenuGrid has
+        // CursorVisible=false): the menu was recognized via its DRAWN marker and answered. The option's
+        // keystroke reached the terminal (NOT the spoken words).
         var prompts = DispatchedPrompts();
         Assert.Contains(prompts, p => p.Text == "1\r");
         Assert.DoesNotContain(prompts, p => p.Text == "option one");
@@ -337,18 +341,20 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task VoiceTurn_BareSelectorRow_NoComposerFrame_TypesNothing()
+    public async Task VoiceTurn_BorderedSelectorHiddenCursor_TypesNothing()
     {
-        // Named test A / B1: "Choose a deployment:" / "> production" with the cursor on the selector is NOT a
-        // composer (no input-box frame). Typing + Enter would select "production" - so type NOTHING.
+        // Named test / B1: a BORDERED "> production" selector - the exact thing that used to read as a composer
+        // because of the box frame. The hardware cursor is HIDDEN (a menu selection), so typing is refused; and
+        // it is not a recognized menu (no numbered option after the marker), so nothing is pressed either.
         var sid = await PushSessionAsync();
         _dispatch = cmd => cmd.Verb == "screen-grid"
             ? Ok(new ScreenGridResponse
             {
                 SessionId = sid,
-                Rows = new List<string> { "Choose a deployment:", "> production" },
-                CursorRow = 1,
-                CursorCol = 5,
+                Rows = new List<string> { "Choose a deployment:", "╭──────────────╮", "│ > production │", "╰──────────────╯" },
+                CursorRow = 2,
+                CursorCol = 4,
+                CursorVisible = false,
                 IsAlternateScreen = false,
                 HasGrid = true,
             })
@@ -357,52 +363,54 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task VoiceTurn_StaleMenuAboveLiveComposer_TypesIntoTheComposer()
+    public async Task VoiceTurn_SelectorAboveFooterHiddenCursor_TypesNothing()
     {
-        // Named test B: an answered menu is still visible ABOVE the live composer, but the cursor is IN the
-        // composer. The words must be TYPED into the composer as plain text, NOT pressed as a menu choice.
+        // Named test / B1: a ">"-row directly above the mode-status footer, cursor HIDDEN. The footer used to
+        // be read as composer framing; with a hidden cursor it fails closed.
         var sid = await PushSessionAsync();
-        var spoken = "now run the integration tests";
-        var promptSent = false;
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? Ok(new ScreenGridResponse
+            {
+                SessionId = sid,
+                Rows = new List<string> { "> production", "  ? for shortcuts" },
+                CursorRow = 0,
+                CursorCol = 5,
+                CursorVisible = false,
+                IsAlternateScreen = false,
+                HasGrid = true,
+            })
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
+        await AssertTypesNothing(sid, "production");
+    }
 
-        _dispatch = cmd => cmd.Verb switch
-        {
-            "screen-grid" => Ok(new ScreenGridResponse
+    [Fact]
+    public async Task VoiceTurn_MenuMarkerAndLiveComposerBothPresent_TypesNothing()
+    {
+        // Named test B (round-4 correction): a drawn menu marker AND a live composer on the same grid is
+        // AMBIGUOUS. When in doubt, block - neither type the words nor press the (possibly stale) menu.
+        var sid = await PushSessionAsync();
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? Ok(new ScreenGridResponse
             {
                 SessionId = sid,
                 Rows = new List<string>
                 {
-                    "Do you want to proceed?",     // <- stale, already-answered menu still visible above
+                    "Do you want to proceed?",
                     "❯ 1. Yes",
                     "  2. No",
                     "╭──────────────────────────────────────╮",
-                    "│ >                                     │",   // <- the LIVE composer, cursor here
+                    "│ >                                     │",
                     "╰──────────────────────────────────────╯",
                     "  ? for shortcuts",
                 },
                 CursorRow = 4,
                 CursorCol = 4,
+                CursorVisible = true,
                 IsAlternateScreen = false,
                 HasGrid = true,
-            }),
-            "turns" => Ok(new TurnsResponse
-            {
-                SessionId = sid,
-                Status = "ok",
-                Widgets = promptSent
-                    ? new List<TurnWidgetDto> { new() { Kind = "Text", Content = "Ran them." } }
-                    : new List<TurnWidgetDto>(),
-            }),
-            "prompt" => Mark(ref promptSent, Ok(new PromptResponse { Accepted = true })),
-            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
-        };
-
-        await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = spoken });
-
-        var prompts = DispatchedPrompts();
-        // The spoken words were typed into the composer with Enter - NOT a menu keystroke like "1\r".
-        Assert.Contains(prompts, p => p.Text == spoken && p.AppendEnter);
-        Assert.DoesNotContain(prompts, p => p.Text == "1\r" || p.Text == "2\r");
+            })
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
+        await AssertTypesNothing(sid, "now run the integration tests");
     }
 
     [Fact]
@@ -424,13 +432,16 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
             {
                 var call = System.Threading.Interlocked.Increment(ref gridCall);
                 var question = call == 1 ? "Delete production?" : "Deploy production?";
+                // The question is separated from the options by a BLANK line - the signature must still catch
+                // the change (finding B3, round-4). Cursor hidden, like a real menu.
                 return Ok(new ScreenGridResponse
                 {
                     SessionId = sid,
-                    Rows = new List<string> { question, "❯ 1. Yes", "  2. No" },
-                    CursorRow = 1,
-                    CursorCol = 2,
-                    IsAlternateScreen = false,
+                    Rows = new List<string> { question, "", "❯ 1. Yes", "  2. No" },
+                    CursorRow = 0,
+                    CursorCol = -1,
+                    CursorVisible = false,
+                    IsAlternateScreen = true,
                     HasGrid = true,
                 });
             }
@@ -455,6 +466,22 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
             ? Ok(PrimaryMenuGrid(sid))
             : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
         await AssertTypesNothing(sid, "yes go ahead");
+    }
+
+    [Fact]
+    public async Task VoiceTurn_MenuWithBareNumberLabels_TypesNothing()
+    {
+        // Finding 4: the detector returns isMenu:true but the options are bare "1."/"2." with no words - not
+        // answerable. Block it rather than pressing a meaningless choice.
+        var sid = await PushSessionAsync();
+        // The grid IS a real drawn menu (so the classifier says Menu), but the detector extracts bare labels.
+        _brainReply = _ => Wrapped(
+            "{\"isMenu\":true,\"question\":\"Pick\",\"selectionMode\":\"single\",\"submit\":\"\"," +
+            "\"options\":[{\"key\":\"1.\",\"send\":\"1\\r\"},{\"key\":\"2.\",\"send\":\"2\\r\"}]}");
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? Ok(PrimaryMenuGrid(sid))
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
+        await AssertTypesNothing(sid, "one");
     }
 
     // ===================== Finding 6: cover the fail-closed edges - each types NOTHING =====================

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
@@ -1,0 +1,271 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection; // AddMessagePackProtocol (client)
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The floor of the menu-handling mission (issue #1777): the wingman voice-turn must READ THE LIVE SCREEN and
+/// FAIL CLOSED. It boots a REAL streamMode <see cref="GatewayHost"/>, dials the REAL DirectorHub over the
+/// tunnel, and answers the session verbs (<c>screen-grid</c> / <c>buffer</c> / <c>turns</c> / <c>prompt</c>)
+/// per scenario, recording every command the Gateway dispatches so a test can prove exactly what was - and
+/// was NOT - sent into the session.
+///
+/// The three cases the brief demands:
+///   1. Alternate-screen Claude menu, empty scrollback -> the menu is detected off the LIVE grid and NEITHER
+///      the spoken words NOR any selection bytes reach the terminal (no <c>prompt</c> verb at all).
+///   2. Confident plain-text prompt -> the spoken answer IS typed (a <c>prompt</c> verb carrying the words).
+///   3. Unreadable screen -> nothing is typed (no <c>prompt</c> verb).
+///
+/// TUNNEL-BY-CONSTRUCTION (as in <see cref="TunnelWingmanVoiceProofTests"/>): the Director is registered
+/// unreachable and the session arrives only via PushSnapshot, so any answered read rode the tunnel. No live
+/// wingman brain is configured, so the brain call throws immediately on the empty key - which is precisely the
+/// fail-closed path case 1 exercises (a menu on screen the brain could not read must still type nothing).
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
+{
+    private const string Token = "test-token-voice-liveScreen-proof";
+    private const string DirectorId = "dir-voice-liveScreen";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-vlsproof-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private HubConnection _conn = null!;
+
+    private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+    /// <summary>Every command the Gateway dispatched over the tunnel, in order (thread-safe).</summary>
+    private readonly ConcurrentQueue<DirectorCommand> _commands = new();
+
+    /// <summary>The per-test verb dispatcher; set by each test before it drives the endpoint.</summary>
+    private Func<DirectorCommand, DirectorCommandResult> _dispatch =
+        cmd => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+
+    public WingmanVoiceTurnLiveScreenProofTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-vlsproof-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        _gateway.Registry.Upsert(new DirectorRegistrationRequest
+        {
+            DirectorId = DirectorId,
+            TailnetEndpoint = "http://127.0.0.1:59923/", // nothing listens here
+            MachineName = Environment.MachineName,
+            Pid = 1,
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        });
+
+        _conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/director-stream", o => o.AccessTokenProvider = () => Task.FromResult<string?>(Token))
+            .AddMessagePackProtocol()
+            .Build();
+        _conn.On<DirectorCommand, DirectorCommandResult>("Command", cmd =>
+        {
+            _commands.Enqueue(cmd);
+            return _dispatch(cmd);
+        });
+        await _conn.StartAsync();
+        await _conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = DirectorId, Version = "test" });
+    }
+
+    public async Task DisposeAsync()
+    {
+        try { await _conn.DisposeAsync(); } catch { /* best effort */ }
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        foreach (var dir in new[] { _instancesDir, _root })
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { /* best effort */ }
+    }
+
+    private Task PushAsync(long sequence, params SessionDto[] sessions) =>
+        _conn.InvokeAsync("PushSnapshot", sequence, sessions);
+
+    private static DirectorCommandResult Ok(object body) =>
+        DirectorCommandResult.Success(JsonSerializer.Serialize(body, Web));
+
+    /// <summary>Push a voice session and return its id.</summary>
+    private async Task<string> PushSessionAsync()
+    {
+        var sid = Guid.NewGuid().ToString();
+        await PushAsync(1L, new SessionDto
+        {
+            SessionId = sid,
+            Name = "a voice session",
+            Status = "WaitingForInput",
+            ActivityState = "WaitingForInput",
+            RepoPath = @"D:\repo",
+        });
+        return sid;
+    }
+
+    /// <summary>Every prompt the Gateway dispatched into the session (the bytes that would reach the terminal).</summary>
+    private List<PromptRequest> DispatchedPrompts()
+    {
+        var prompts = new List<PromptRequest>();
+        foreach (var cmd in _commands)
+            if (cmd.Verb == "prompt")
+            {
+                var req = JsonSerializer.Deserialize<PromptRequest>(cmd.PayloadJson ?? "{}", Web);
+                if (req is not null) prompts.Add(req);
+            }
+        return prompts;
+    }
+
+    // A real Claude Code permission menu, as it renders on the ALTERNATE screen (full-screen picker). The
+    // scrollback is empty on the alternate screen by design, so this menu is visible ONLY on the live grid.
+    private static readonly List<string> AltScreenClaudeMenuRows = new()
+    {
+        "╭──────────────────────────────────────────────╮",
+        "│ Bash command                                 │",
+        "│ dotnet test                                  │",
+        "│                                              │",
+        "│ Do you want to proceed?                      │",
+        "│ ❯ 1. Yes                                     │",
+        "│   2. Yes, and don't ask again this session   │",
+        "│   3. No, and tell Claude what to do          │",
+        "╰──────────────────────────────────────────────╯",
+    };
+
+    [Fact]
+    public async Task VoiceTurn_AltScreenClaudeMenu_EmptyScrollback_DetectsMenuOffLiveGridAndTypesNothing()
+    {
+        var sid = await PushSessionAsync();
+
+        // The alternate-screen menu is on the LIVE grid; the scrollback (buffer) is empty, as it is on the
+        // alternate screen. A "prompt" answer would be the exact defect - so any prompt dispatch fails loud.
+        _dispatch = cmd => cmd.Verb switch
+        {
+            "screen-grid" => Ok(new ScreenGridResponse
+            {
+                SessionId = sid,
+                Rows = AltScreenClaudeMenuRows,
+                CursorRow = 5,
+                CursorCol = 3,
+                IsAlternateScreen = true,
+                HasGrid = true,
+            }),
+            "buffer" => Ok(new BufferResponse { SessionId = sid, Text = "" }),   // empty scrollback (alt screen)
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
+        };
+
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn",
+            new { text = "yeah go ahead and run them" });
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        // Fail closed: the client is told it cannot type here and to look at the terminal.
+        Assert.True(node?["cannotType"]?.GetValue<bool>());
+
+        // The whole point: the spoken words - and any selection bytes - NEVER reached the terminal.
+        Assert.Empty(DispatchedPrompts());
+
+        // And the menu situation was detected off the LIVE screen grid (the authoritative read), not scrollback.
+        Assert.Contains(_commands, c => c.Verb == "screen-grid" && c.SessionId == sid);
+    }
+
+    [Fact]
+    public async Task VoiceTurn_ConfidentPlainTextPrompt_TypesTheSpokenAnswer()
+    {
+        var sid = await PushSessionAsync();
+        var spoken = "add a retry to the upload path";
+        var promptSent = false;
+
+        // A readable, plain-text prompt (no menu) is the one case where typing is safe. "turns" returns no
+        // widgets before the prompt and one Text widget after, so WaitForReplyAsync converges quickly.
+        _dispatch = cmd => cmd.Verb switch
+        {
+            "screen-grid" => Ok(new ScreenGridResponse
+            {
+                SessionId = sid,
+                Rows = new List<string> { "I finished the last change. What next?", "", "> " },
+                CursorRow = 2,
+                CursorCol = 2,
+                IsAlternateScreen = false,
+                HasGrid = true,
+            }),
+            "turns" => Ok(new TurnsResponse
+            {
+                SessionId = sid,
+                Status = "ok",
+                Widgets = promptSent
+                    ? new List<TurnWidgetDto> { new() { Kind = "Text", Content = "Added the retry." } }
+                    : new List<TurnWidgetDto>(),
+            }),
+            "prompt" => Mark(ref promptSent, Ok(new PromptResponse { Accepted = true })),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
+        };
+
+        // The translate step needs a wingman brain, which this test does not configure, so the final response
+        // is a 502 - irrelevant to the claim. What matters is that the spoken answer WAS typed into the
+        // session as an ordinary prompt (a "prompt" verb carrying the words).
+        await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = spoken });
+
+        var prompts = DispatchedPrompts();
+        Assert.Contains(prompts, p => p.Text == spoken && p.AppendEnter);
+    }
+
+    [Fact]
+    public async Task VoiceTurn_UnreadableScreen_TypesNothing()
+    {
+        var sid = await PushSessionAsync();
+
+        // The session has no resolved live grid (HasGrid=false) - the screen is unreadable. A "prompt" answer
+        // would be typing blind, so it must not happen.
+        _dispatch = cmd => cmd.Verb switch
+        {
+            "screen-grid" => Ok(new ScreenGridResponse { SessionId = sid, Rows = new List<string>(), HasGrid = false }),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
+        };
+
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn",
+            new { text = "option two please" });
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.True(node?["cannotType"]?.GetValue<bool>());
+        Assert.Empty(DispatchedPrompts());
+    }
+
+    /// <summary>Set a flag as a side effect while returning a dispatcher result (used to flip "turns" output
+    /// once the prompt has been sent, so the reply-wait converges without a real running session).</summary>
+    private static DirectorCommandResult Mark(ref bool flag, DirectorCommandResult result)
+    {
+        flag = true;
+        return result;
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
@@ -5,6 +5,9 @@ using System.Net.Http.Json;
 using System.Net.Sockets;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using CcDirector.AgentBrain;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Drivers;
 using CcDirector.Gateway.Contracts;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection; // AddMessagePackProtocol (client)
@@ -13,22 +16,16 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// The floor of the menu-handling mission (issue #1777): the wingman voice-turn must READ THE LIVE SCREEN and
-/// FAIL CLOSED. It boots a REAL streamMode <see cref="GatewayHost"/>, dials the REAL DirectorHub over the
-/// tunnel, and answers the session verbs (<c>screen-grid</c> / <c>buffer</c> / <c>turns</c> / <c>prompt</c>)
-/// per scenario, recording every command the Gateway dispatches so a test can prove exactly what was - and
-/// was NOT - sent into the session.
+/// The fail-closed floor of the menu-handling mission (issue #1777), proven end-to-end against a REAL
+/// streamMode <see cref="GatewayHost"/> over the tunnel. Every session verb (<c>screen-grid</c> /
+/// <c>turns</c> / <c>prompt</c>) is answered per scenario and every dispatched command is recorded, so a test
+/// proves exactly what did - and did NOT - reach the terminal. A STUB warm brain is injected so the menu
+/// detector can be exercised WITH a working model (proving detection off the live grid and the menu-press
+/// path), while the fail-closed tests leave the brain throwing (no reply set) to prove that a menu the brain
+/// cannot read still types nothing.
 ///
-/// The three cases the brief demands:
-///   1. Alternate-screen Claude menu, empty scrollback -> the menu is detected off the LIVE grid and NEITHER
-///      the spoken words NOR any selection bytes reach the terminal (no <c>prompt</c> verb at all).
-///   2. Confident plain-text prompt -> the spoken answer IS typed (a <c>prompt</c> verb carrying the words).
-///   3. Unreadable screen -> nothing is typed (no <c>prompt</c> verb).
-///
-/// TUNNEL-BY-CONSTRUCTION (as in <see cref="TunnelWingmanVoiceProofTests"/>): the Director is registered
-/// unreachable and the session arrives only via PushSnapshot, so any answered read rode the tunnel. No live
-/// wingman brain is configured, so the brain call throws immediately on the empty key - which is precisely the
-/// fail-closed path case 1 exercises (a menu on screen the brain could not read must still type nothing).
+/// The classification is decided ONLY from the live screen grid: the <c>buffer</c> (scrollback) verb is never
+/// read on this path, which these tests assert.
 /// </summary>
 [Collection("DirectorRoot")]
 public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
@@ -53,19 +50,44 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
     private Func<DirectorCommand, DirectorCommandResult> _dispatch =
         cmd => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
 
-    public WingmanVoiceTurnLiveScreenProofTests()
+    // ---- Stub warm brain (issue #1777, finding 4) ----
+    // Every prompt the brain received (so a test can assert the LIVE grid text reached menu detection).
+    private readonly ConcurrentQueue<string> _brainPrompts = new();
+    // What the brain replies. Null => AskAsync throws (the real no-key brain behavior) => fail-closed path.
+    private Func<string, string>? _brainReply;
+
+    private sealed class StubBrain : IAgentBrain
     {
-        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
-        _root = Path.Combine(Path.GetTempPath(), "ccd-vlsproof-" + Guid.NewGuid().ToString("N"));
-        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        private readonly WingmanVoiceTurnLiveScreenProofTests _owner;
+        public StubBrain(WingmanVoiceTurnLiveScreenProofTests owner) => _owner = owner;
+        public string? SessionId => "stub";
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            _owner._brainPrompts.Enqueue(prompt);
+            var reply = _owner._brainReply;
+            if (reply is null)
+                throw new InvalidOperationException("stub brain: no reply configured (fail-closed path)");
+            return Task.FromResult(new AskResult { Text = reply(prompt) });
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth());
+        public void Dispose() { }
     }
+
+    /// <summary>Wrap a spoken answer in the brain's answer markers, the way the model is told to.</summary>
+    private static string Wrapped(string body) =>
+        SessionAskRunner.AnswerBeginMarker + "\n" + body + "\n" + SessionAskRunner.AnswerEndMarker;
 
     public async Task InitializeAsync()
     {
         _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
-            streamMode: true);
+            streamMode: true,
+            brainProviderOverride: (_, _) => Task.FromResult<IAgentBrain>(new StubBrain(this)));
         await _gateway.StartAsync();
         _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
         _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
@@ -73,7 +95,7 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         _gateway.Registry.Upsert(new DirectorRegistrationRequest
         {
             DirectorId = DirectorId,
-            TailnetEndpoint = "http://127.0.0.1:59923/", // nothing listens here
+            TailnetEndpoint = "http://127.0.0.1:59924/", // nothing listens here
             MachineName = Environment.MachineName,
             Pid = 1,
             Version = "test",
@@ -93,6 +115,13 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         await _conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = DirectorId, Version = "test" });
     }
 
+    public WingmanVoiceTurnLiveScreenProofTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-vlsproof-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
     public async Task DisposeAsync()
     {
         try { await _conn.DisposeAsync(); } catch { /* best effort */ }
@@ -109,7 +138,6 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
     private static DirectorCommandResult Ok(object body) =>
         DirectorCommandResult.Success(JsonSerializer.Serialize(body, Web));
 
-    /// <summary>Push a voice session and return its id.</summary>
     private async Task<string> PushSessionAsync()
     {
         var sid = Guid.NewGuid().ToString();
@@ -124,7 +152,6 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         return sid;
     }
 
-    /// <summary>Every prompt the Gateway dispatched into the session (the bytes that would reach the terminal).</summary>
     private List<PromptRequest> DispatchedPrompts()
     {
         var prompts = new List<PromptRequest>();
@@ -137,78 +164,158 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         return prompts;
     }
 
-    // A real Claude Code permission menu, as it renders on the ALTERNATE screen (full-screen picker). The
-    // scrollback is empty on the alternate screen by design, so this menu is visible ONLY on the live grid.
-    private static readonly List<string> AltScreenClaudeMenuRows = new()
+    // A real Claude permission menu on the PRIMARY screen (the "do you want to proceed" / "❯ 1" fingerprint),
+    // whose option labels are on the grid so the re-verify before pressing passes.
+    private static ScreenGridResponse PrimaryMenuGrid(string sid) => new()
     {
-        "╭──────────────────────────────────────────────╮",
-        "│ Bash command                                 │",
-        "│ dotnet test                                  │",
-        "│                                              │",
-        "│ Do you want to proceed?                      │",
-        "│ ❯ 1. Yes                                     │",
-        "│   2. Yes, and don't ask again this session   │",
-        "│   3. No, and tell Claude what to do          │",
-        "╰──────────────────────────────────────────────╯",
+        SessionId = sid,
+        Rows = new List<string> { "Do you want to proceed?", "❯ 1. Yes", "  2. No" },
+        CursorRow = 1,
+        CursorCol = 2,
+        IsAlternateScreen = false,
+        HasGrid = true,
     };
 
+    // A Claude composer at the bottom of the PRIMARY screen, cursor in the empty input box (row 2).
+    private static ScreenGridResponse ComposerGrid(string sid, bool alternateScreen = false) => new()
+    {
+        SessionId = sid,
+        Rows = new List<string>
+        {
+            "I finished the change. What next?",
+            "╭──────────────────────────────────────╮",
+            "│ >                                     │",
+            "╰──────────────────────────────────────╯",
+            "  ? for shortcuts",
+        },
+        CursorRow = 2,
+        CursorCol = 4,
+        IsAlternateScreen = alternateScreen,
+        HasGrid = true,
+    };
+
+    // ===================== Finding 4: detection off the LIVE grid, menu-press path =====================
+
     [Fact]
-    public async Task VoiceTurn_AltScreenClaudeMenu_EmptyScrollback_DetectsMenuOffLiveGridAndTypesNothing()
+    public async Task VoiceTurn_LiveGridMenu_StubBrainRecognizesIt_PressesTheOptionOffTheLiveGrid()
     {
         var sid = await PushSessionAsync();
+        var promptSent = false;
 
-        // The alternate-screen menu is on the LIVE grid; the scrollback (buffer) is empty, as it is on the
-        // alternate screen. A "prompt" answer would be the exact defect - so any prompt dispatch fails loud.
+        // The brain SUCCEEDS: it returns the menu it read from the live grid.
+        _brainReply = _ => Wrapped(
+            "{\"isMenu\":true,\"question\":\"Proceed?\",\"selectionMode\":\"single\",\"submit\":\"\"," +
+            "\"options\":[{\"key\":\"1. Yes\",\"send\":\"1\\r\"},{\"key\":\"2. No\",\"send\":\"2\\r\"}]}");
+
         _dispatch = cmd => cmd.Verb switch
         {
-            "screen-grid" => Ok(new ScreenGridResponse
+            "screen-grid" => Ok(PrimaryMenuGrid(sid)),
+            "turns" => Ok(new TurnsResponse
             {
                 SessionId = sid,
-                Rows = AltScreenClaudeMenuRows,
-                CursorRow = 5,
-                CursorCol = 3,
-                IsAlternateScreen = true,
-                HasGrid = true,
+                Status = "ok",
+                Widgets = promptSent
+                    ? new List<TurnWidgetDto> { new() { Kind = "Text", Content = "Ran the tests, all green." } }
+                    : new List<TurnWidgetDto>(),
             }),
-            "buffer" => Ok(new BufferResponse { SessionId = sid, Text = "" }),   // empty scrollback (alt screen)
+            "prompt" => Mark(ref promptSent, Ok(new PromptResponse { Accepted = true })),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
         };
 
-        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn",
-            new { text = "yeah go ahead and run them" });
-
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = "option one" });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
-        // Fail closed: the client is told it cannot type here and to look at the terminal.
-        Assert.True(node?["cannotType"]?.GetValue<bool>());
 
-        // The whole point: the spoken words - and any selection bytes - NEVER reached the terminal.
-        Assert.Empty(DispatchedPrompts());
+        // The menu-press path was taken: the option's keystroke reached the terminal (NOT the spoken words).
+        var prompts = DispatchedPrompts();
+        Assert.Contains(prompts, p => p.Text == "1\r");
+        Assert.DoesNotContain(prompts, p => p.Text == "option one");
 
-        // And the menu situation was detected off the LIVE screen grid (the authoritative read), not scrollback.
-        Assert.Contains(_commands, c => c.Verb == "screen-grid" && c.SessionId == sid);
+        // Detection ran off the LIVE grid text - the brain's first prompt carried the live menu content.
+        Assert.True(_brainPrompts.TryPeek(out var firstPrompt));
+        Assert.Contains("Do you want to proceed?", firstPrompt);
+
+        // The scrollback (buffer) verb was never read - the live grid is the only detection source (finding 2).
+        Assert.DoesNotContain(_commands, c => c.Verb == "buffer");
     }
 
+    // ===================== Finding 3: re-verify the menu is still on screen before pressing =====================
+
     [Fact]
-    public async Task VoiceTurn_ConfidentPlainTextPrompt_TypesTheSpokenAnswer()
+    public async Task VoiceTurn_MenuClosedBetweenReadAndPress_PressesNothing()
+    {
+        var sid = await PushSessionAsync();
+        var gridCall = 0;
+
+        // The brain recognizes the menu on the FIRST read. But by the time we go to press, the menu has closed
+        // and a shell prompt is on screen - the re-verify must catch that and press NOTHING (no selection bytes
+        // into the shell).
+        _brainReply = _ => Wrapped(
+            "{\"isMenu\":true,\"question\":\"Proceed?\",\"selectionMode\":\"single\",\"submit\":\"\"," +
+            "\"options\":[{\"key\":\"1. Yes\",\"send\":\"1\\r\"},{\"key\":\"2. No\",\"send\":\"2\\r\"}]}");
+
+        _dispatch = cmd =>
+        {
+            if (cmd.Verb == "screen-grid")
+            {
+                // First read: the menu. Re-verify read (and after): the menu is gone, a shell prompt is up.
+                var call = System.Threading.Interlocked.Increment(ref gridCall);
+                return call == 1
+                    ? Ok(PrimaryMenuGrid(sid))
+                    : Ok(new ScreenGridResponse
+                    {
+                        SessionId = sid,
+                        Rows = new List<string> { "user@host:~/repo$ ", "" },
+                        CursorRow = 0,
+                        CursorCol = 18,
+                        IsAlternateScreen = false,
+                        HasGrid = true,
+                    });
+            }
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+        };
+
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = "option one" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.True(node?["cannotType"]?.GetValue<bool>());
+        // No keystrokes reached the terminal - not the option, not the spoken words.
+        Assert.Empty(DispatchedPrompts());
+    }
+
+    // ===================== Fail-closed: a menu the brain cannot read types nothing =====================
+
+    [Fact]
+    public async Task VoiceTurn_LiveGridMenu_BrainCannotRead_TypesNothing()
+    {
+        var sid = await PushSessionAsync();
+        _brainReply = null; // brain throws => detection fails => fail closed
+
+        _dispatch = cmd => cmd.Verb switch
+        {
+            "screen-grid" => Ok(PrimaryMenuGrid(sid)),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
+        };
+
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = "yeah go ahead" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.True(node?["cannotType"]?.GetValue<bool>());
+        Assert.Empty(DispatchedPrompts());
+        Assert.Contains(_commands, c => c.Verb == "screen-grid");
+    }
+
+    // ===================== Finding 5: plain text types ONLY on a positive composer signal =====================
+
+    [Fact]
+    public async Task VoiceTurn_PrimaryComposerWithCursor_TypesTheSpokenAnswer()
     {
         var sid = await PushSessionAsync();
         var spoken = "add a retry to the upload path";
         var promptSent = false;
 
-        // A readable, plain-text prompt (no menu) is the one case where typing is safe. "turns" returns no
-        // widgets before the prompt and one Text widget after, so WaitForReplyAsync converges quickly.
         _dispatch = cmd => cmd.Verb switch
         {
-            "screen-grid" => Ok(new ScreenGridResponse
-            {
-                SessionId = sid,
-                Rows = new List<string> { "I finished the last change. What next?", "", "> " },
-                CursorRow = 2,
-                CursorCol = 2,
-                IsAlternateScreen = false,
-                HasGrid = true,
-            }),
+            "screen-grid" => Ok(ComposerGrid(sid)),
             "turns" => Ok(new TurnsResponse
             {
                 SessionId = sid,
@@ -221,39 +328,102 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
         };
 
-        // The translate step needs a wingman brain, which this test does not configure, so the final response
-        // is a 502 - irrelevant to the claim. What matters is that the spoken answer WAS typed into the
-        // session as an ordinary prompt (a "prompt" verb carrying the words).
+        // It types only because the LIVE screen was POSITIVELY classified plain text (primary composer, cursor
+        // on the prompt line). The translate step then fails (stub brain has no reply set), which is
+        // irrelevant to the claim: the answer WAS typed.
         await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = spoken });
 
-        var prompts = DispatchedPrompts();
-        Assert.Contains(prompts, p => p.Text == spoken && p.AppendEnter);
+        Assert.Contains(DispatchedPrompts(), p => p.Text == spoken && p.AppendEnter);
     }
 
     [Fact]
-    public async Task VoiceTurn_UnreadableScreen_TypesNothing()
+    public async Task VoiceTurn_SameComposerButOnAlternateScreen_TypesNothing()
     {
+        // Finding 5: the SAME composer content, but on the alternate screen, is NOT typed into. This is what
+        // distinguishes the new positive classifier from the old "anything that is not a menu is plain text".
         var sid = await PushSessionAsync();
-
-        // The session has no resolved live grid (HasGrid=false) - the screen is unreadable. A "prompt" answer
-        // would be typing blind, so it must not happen.
         _dispatch = cmd => cmd.Verb switch
         {
-            "screen-grid" => Ok(new ScreenGridResponse { SessionId = sid, Rows = new List<string>(), HasGrid = false }),
+            "screen-grid" => Ok(ComposerGrid(sid, alternateScreen: true)),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
         };
 
-        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn",
-            new { text = "option two please" });
-
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = "do the thing" });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
         Assert.True(node?["cannotType"]?.GetValue<bool>());
         Assert.Empty(DispatchedPrompts());
     }
 
-    /// <summary>Set a flag as a side effect while returning a dispatcher result (used to flip "turns" output
-    /// once the prompt has been sent, so the reply-wait converges without a real running session).</summary>
+    // ===================== Finding 6: cover the fail-closed edges - each types NOTHING =====================
+
+    [Fact]
+    public async Task VoiceTurn_ScreenGridVerbFails_TypesNothing()
+    {
+        var sid = await PushSessionAsync();
+        _dispatch = _ => DirectorCommandResult.Fail(DirectorCommandStatus.Timeout, "director did not answer");
+        await AssertTypesNothing(sid, "option two");
+    }
+
+    [Fact]
+    public async Task VoiceTurn_ScreenGridMalformedBody_TypesNothing()
+    {
+        var sid = await PushSessionAsync();
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? DirectorCommandResult.Success("this is not valid json for a ScreenGridResponse {{{")
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
+        await AssertTypesNothing(sid, "option two");
+    }
+
+    [Fact]
+    public async Task VoiceTurn_EmptyRowsWithHasGrid_TypesNothing()
+    {
+        var sid = await PushSessionAsync();
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? Ok(new ScreenGridResponse { SessionId = sid, Rows = new List<string>(), HasGrid = true })
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
+        await AssertTypesNothing(sid, "option two");
+    }
+
+    [Fact]
+    public async Task VoiceTurn_AllBlankRows_TypesNothing()
+    {
+        var sid = await PushSessionAsync();
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? Ok(new ScreenGridResponse { SessionId = sid, Rows = new List<string> { "", "   ", "\t" }, HasGrid = true, CursorRow = 0, CursorCol = 0 })
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
+        await AssertTypesNothing(sid, "option two");
+    }
+
+    [Fact]
+    public async Task VoiceTurn_AlternateScreenUnrecognized_TypesNothing()
+    {
+        // A full-screen app on the alternate screen we did NOT recognize as a menu (no fingerprint). The old
+        // inversion would have called this plain text and typed into it.
+        var sid = await PushSessionAsync();
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? Ok(new ScreenGridResponse
+            {
+                SessionId = sid,
+                Rows = new List<string> { "a full screen viewer", "line of content", "another line", "status: reading" },
+                CursorRow = 3,
+                CursorCol = 8,
+                IsAlternateScreen = true,
+                HasGrid = true,
+            })
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
+        await AssertTypesNothing(sid, "option two");
+    }
+
+    private async Task AssertTypesNothing(string sid, string spoken)
+    {
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = spoken });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.True(node?["cannotType"]?.GetValue<bool>());
+        Assert.Empty(DispatchedPrompts());
+    }
+
     private static DirectorCommandResult Mark(ref bool flag, DirectorCommandResult result)
     {
         flag = true;

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
@@ -176,8 +176,8 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         HasGrid = true,
     };
 
-    // A Claude composer at the bottom of the PRIMARY screen, cursor in the empty input box (row 2).
-    private static ScreenGridResponse ComposerGrid(string sid, bool alternateScreen = false) => new()
+    // A Claude composer, cursor in the empty input box (row 2), framed by box borders and a mode-status footer.
+    private static ScreenGridResponse ComposerGrid(string sid) => new()
     {
         SessionId = sid,
         Rows = new List<string>
@@ -190,7 +190,7 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         },
         CursorRow = 2,
         CursorCol = 4,
-        IsAlternateScreen = alternateScreen,
+        IsAlternateScreen = false,
         HasGrid = true,
     };
 
@@ -337,22 +337,124 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task VoiceTurn_SameComposerButOnAlternateScreen_TypesNothing()
+    public async Task VoiceTurn_BareSelectorRow_NoComposerFrame_TypesNothing()
     {
-        // Finding 5: the SAME composer content, but on the alternate screen, is NOT typed into. This is what
-        // distinguishes the new positive classifier from the old "anything that is not a menu is plain text".
+        // Named test A / B1: "Choose a deployment:" / "> production" with the cursor on the selector is NOT a
+        // composer (no input-box frame). Typing + Enter would select "production" - so type NOTHING.
         var sid = await PushSessionAsync();
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? Ok(new ScreenGridResponse
+            {
+                SessionId = sid,
+                Rows = new List<string> { "Choose a deployment:", "> production" },
+                CursorRow = 1,
+                CursorCol = 5,
+                IsAlternateScreen = false,
+                HasGrid = true,
+            })
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
+        await AssertTypesNothing(sid, "production");
+    }
+
+    [Fact]
+    public async Task VoiceTurn_StaleMenuAboveLiveComposer_TypesIntoTheComposer()
+    {
+        // Named test B: an answered menu is still visible ABOVE the live composer, but the cursor is IN the
+        // composer. The words must be TYPED into the composer as plain text, NOT pressed as a menu choice.
+        var sid = await PushSessionAsync();
+        var spoken = "now run the integration tests";
+        var promptSent = false;
+
         _dispatch = cmd => cmd.Verb switch
         {
-            "screen-grid" => Ok(ComposerGrid(sid, alternateScreen: true)),
+            "screen-grid" => Ok(new ScreenGridResponse
+            {
+                SessionId = sid,
+                Rows = new List<string>
+                {
+                    "Do you want to proceed?",     // <- stale, already-answered menu still visible above
+                    "❯ 1. Yes",
+                    "  2. No",
+                    "╭──────────────────────────────────────╮",
+                    "│ >                                     │",   // <- the LIVE composer, cursor here
+                    "╰──────────────────────────────────────╯",
+                    "  ? for shortcuts",
+                },
+                CursorRow = 4,
+                CursorCol = 4,
+                IsAlternateScreen = false,
+                HasGrid = true,
+            }),
+            "turns" => Ok(new TurnsResponse
+            {
+                SessionId = sid,
+                Status = "ok",
+                Widgets = promptSent
+                    ? new List<TurnWidgetDto> { new() { Kind = "Text", Content = "Ran them." } }
+                    : new List<TurnWidgetDto>(),
+            }),
+            "prompt" => Mark(ref promptSent, Ok(new PromptResponse { Accepted = true })),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
         };
 
-        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = "do the thing" });
+        await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = spoken });
+
+        var prompts = DispatchedPrompts();
+        // The spoken words were typed into the composer with Enter - NOT a menu keystroke like "1\r".
+        Assert.Contains(prompts, p => p.Text == spoken && p.AppendEnter);
+        Assert.DoesNotContain(prompts, p => p.Text == "1\r" || p.Text == "2\r");
+    }
+
+    [Fact]
+    public async Task VoiceTurn_ReplacementMenuSameLabels_ReVerifyFailsClosed_PressesNothing()
+    {
+        // Named test C: the menu is REPLACED between classification and press by a different menu with the SAME
+        // option labels (Delete production? -> Deploy production?, both 1.Yes / 2.No). The re-verify compares
+        // the captured menu BLOCK (question + options), so it catches the change and presses nothing.
+        var sid = await PushSessionAsync();
+        var gridCall = 0;
+
+        _brainReply = _ => Wrapped(
+            "{\"isMenu\":true,\"question\":\"Delete production?\",\"selectionMode\":\"single\",\"submit\":\"\"," +
+            "\"options\":[{\"key\":\"1. Yes\",\"send\":\"1\\r\"},{\"key\":\"2. No\",\"send\":\"2\\r\"}]}");
+
+        _dispatch = cmd =>
+        {
+            if (cmd.Verb == "screen-grid")
+            {
+                var call = System.Threading.Interlocked.Increment(ref gridCall);
+                var question = call == 1 ? "Delete production?" : "Deploy production?";
+                return Ok(new ScreenGridResponse
+                {
+                    SessionId = sid,
+                    Rows = new List<string> { question, "❯ 1. Yes", "  2. No" },
+                    CursorRow = 1,
+                    CursorCol = 2,
+                    IsAlternateScreen = false,
+                    HasGrid = true,
+                });
+            }
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+        };
+
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/wingman/voice-turn", new { text = "yes" });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
         Assert.True(node?["cannotType"]?.GetValue<bool>());
         Assert.Empty(DispatchedPrompts());
+    }
+
+    [Fact]
+    public async Task VoiceTurn_MenuLookingScreen_DetectorReturnsNotAMenu_TypesNothing()
+    {
+        // Named test D: the live screen looks like a menu and the brain is reached, but it returns isMenu:false
+        // (no pressable options). This must fail closed - never fall through to typing.
+        var sid = await PushSessionAsync();
+        _brainReply = _ => Wrapped("{\"isMenu\":false}");
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? Ok(PrimaryMenuGrid(sid))
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "x");
+        await AssertTypesNothing(sid, "yes go ahead");
     }
 
     // ===================== Finding 6: cover the fail-closed edges - each types NOTHING =====================

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -501,54 +501,30 @@ internal static class GatewayWingmanVoiceEndpoint
             if (route is null)
                 return Results.Json(new { error = "session not found on any director" }, statusCode: StatusCodes.Status404NotFound);
 
-            // Menu handling + FAIL CLOSED (issues #531 / #1777). Read the LIVE screen (authoritative) to
-            // classify what the session is waiting on: a menu, a confident plain-text prompt, or something we
-            // must NOT type into (a menu we could not read, an uncertain screen, or an unreadable one). The
-            // spoken words are only ever typed as an ordinary prompt when the screen is CONFIDENTLY plain text.
-            var screen = await DetectWaitingScreenAtAsync(route, translator, sid, ct);
-            if (screen.Kind == WaitingKind.Menu)
+            // THE FLOOR INVARIANT (issue #1777). This branch NEVER presses a key into a session. The spoken
+            // words are typed as an ordinary prompt ONLY when the live screen is a CONFIDENT plain-text
+            // composer: not the alternate screen, the hardware cursor VISIBLE, the cursor within the framed
+            // composer's input column span, and NO menu marker or menu-ish structure anywhere on the grid.
+            // Every menu, and every uncertain / unreadable / alternate-screen / hidden-cursor screen, types
+            // NOTHING and presses NOTHING. (Fully hands-free voice-ANSWERING - the wingman pressing menu keys -
+            // is its own later issue with per-agent picker profiles and a screen-version lock; it is not here.)
+            var (kind, blockedSpoken) = await ClassifyLiveScreenAtAsync(route, sid, ct);
+            if (kind != WaitingScreenKind.PlainText)
             {
-                // The agent is RIGHT NOW showing an on-screen menu, so the person's words are a CHOICE, not a
-                // new prompt. Map the words to an option and PRESS that option (raw keystrokes).
-                var menu = screen.Menu;
-                var idx = WingmanMenuLogic.MatchOption(menu, req.Text);
-                if (idx < 0) idx = await translator.MapChoiceAsync(menu, req.Text, ct);
-                if (idx >= 0 && idx < menu.Options.Count)
-                {
-                    // Finding 3: mapping the choice took one or two model calls; re-verify the SAME menu is
-                    // still on the live screen before pressing, so the selection bytes cannot land in a shell
-                    // or prompt if the menu closed in the meantime. If it changed, press NOTHING and fail closed.
-                    if (!await MenuStillOnScreenAsync(route, screen.MenuGridRows, sid, ct))
-                    {
-                        FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: menu changed before press - fail closed, not pressing");
-                        return Results.Json(new { reply = "", spoken = "The menu changed before I could answer, so I didn't press anything. Open the session to see what it's asking now.", cannotType = true, lookAtTerminal = true });
-                    }
-                    var opt = menu.Options[idx];
-                    var submit = string.Equals(menu.SelectionMode, "multiple", StringComparison.OrdinalIgnoreCase) ? menu.Submit : "";
-                    FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: menu choice -> option {idx + 1}");
-                    return await PressAndSummarizeAsync(route, translator, voice, sid, SessionTitle(sid), opt.Send, submit, $"Selecting option {idx + 1}. ", "voice-menu", ct);
-                }
-                // Heard them, but no confident option: re-read the menu and send NOTHING (don't burn the turn).
-                FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: menu present, choice unclear");
-                return Results.Json(new { reply = "", spoken = "I didn't catch which one. " + menu.Spoken, needsChoice = true, menu = MenuJson(menu) });
+                FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: FAIL CLOSED - not typing (screen is {kind})");
+                return Results.Json(new { reply = "", spoken = blockedSpoken, cannotType = true, lookAtTerminal = true });
             }
-            if (screen.Kind == WaitingKind.Blocked)
+
+            // Close the snapshot-to-send race (issue #1777, floor rescope, finding 2): RE-READ the live screen
+            // immediately before the send and re-confirm it is STILL a confident plain-text composer. If it
+            // changed in the meantime (now a menu / alternate screen / cursor hidden / gone), fail closed - the
+            // spoken words must never land on anything but the composer they were classified against.
+            var (kindNow, blockedNow) = await ClassifyLiveScreenAtAsync(route, sid, ct);
+            if (kindNow != WaitingScreenKind.PlainText)
             {
-                // FAIL CLOSED (issue #1777): the waiting screen is a menu we could not read, an uncertain
-                // screen, or an unreadable one. Typing the spoken words in blindly is the exact defect that
-                // leaves the person stuck (a wrong pick AND no escape), so send NOTHING - not the words, not
-                // any selection bytes - and tell them to look at the terminal.
-                FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: FAIL CLOSED - not typing ({screen.BlockedReason})");
-                return Results.Json(new { reply = "", spoken = screen.BlockedSpoken, cannotType = true, lookAtTerminal = true });
+                FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: screen changed before send (now {kindNow}) - fail closed, not typing");
+                return Results.Json(new { reply = "", spoken = blockedNow, cannotType = true, lookAtTerminal = true });
             }
-            // screen.Kind == WaitingKind.PlainText: a positive composer/input-prompt signal on the primary
-            // screen - typing the answer is safe.
-            //
-            // ACCEPTED, DOCUMENTED GAP (issue #1777, finding 3): there is a micro-race where a plain-text
-            // prompt turns into a menu between this classification and the PostPromptAsync below. We do NOT
-            // re-verify on this path (only the menu-press path re-verifies, where the cost of a wrong press is
-            // a bad selection). The full screen-revision-token precondition that would close this race is a
-            // later phase (issue #1786); it is not built here.
 
             // We are about to start a new turn, so the cached spoken summary + audio are now stale.
             // Clear them DETERMINISTICALLY here (do not rely on observing the Working state, which is
@@ -787,20 +763,36 @@ internal static class GatewayWingmanVoiceEndpoint
             return Results.Json(MenuJson(menu));
         });
 
-        // Press a specific menu option (the phone's option-button tap): send the exact keystrokes,
-        // then wait for the agent's result and translate it back. { send, submit? } -> { reply, spoken }.
-        app.MapPost("/sessions/{sid}/wingman/menu-press", async (string sid, WingmanMenuPressRequest? req, CancellationToken ct) =>
+        // NOTE (issue #1777, floor rescope): the raw POST /wingman/menu-press endpoint - which pressed menu
+        // keystrokes into a session - was REMOVED. Nothing on this branch ever presses a key into a session.
+        // Pressing menu options (fully hands-free voice-answering) is its own later issue, built with per-agent
+        // picker profiles and a screen-version lock on every keypress. The GET /wingman/menu detection above
+        // stays (read-only, for the announce step); it never leads to a keypress.
+    }
+
+    /// <summary>
+    /// Classify the live waiting screen for the FLOOR (issue #1777): read the grid over the tunnel and run the
+    /// pure, no-brain <see cref="WaitingScreenClassifier"/>. Returns the kind and, when it is not typeable, the
+    /// line to speak. This is all voice-turn needs - it types only on <see cref="WaitingScreenKind.PlainText"/>
+    /// and never presses - so no menu extraction (brain) happens on the send path.
+    /// </summary>
+    private static async Task<(WaitingScreenKind Kind, string BlockedSpoken)> ClassifyLiveScreenAtAsync(
+        SessionVerbClient route, string sid, CancellationToken ct)
+    {
+        Contracts.ScreenGridResponse? grid;
+        try { grid = await route.GetScreenGridAsync(sid, ct); }
+        catch (Exception ex)
         {
-            FileLog.Write($"[GatewayWingmanVoice] menu-press sid={sid}");
-            if (!Guid.TryParse(sid, out _))
-                return Results.Json(new { error = "invalid session id format" }, statusCode: StatusCodes.Status400BadRequest);
-            if (req is null || string.IsNullOrEmpty(req.Send))
-                return Results.Json(new { error = "send is required" }, statusCode: StatusCodes.Status400BadRequest);
-            var route = await ResolveRouteAsync(sid);
-            if (route is null)
-                return Results.Json(new { error = "session not found on any director" }, statusCode: StatusCodes.Status404NotFound);
-            return await PressAndSummarizeAsync(route, translator, voice, sid, SessionTitle(sid), req.Send, req.Submit, null, "menu-press", ct);
-        });
+            FileLog.Write($"[GatewayWingmanVoice] classify sid={sid}: screen-grid read threw ({ex.Message}) - fail closed");
+            return (WaitingScreenKind.Blocked, BlockedUnreadableSpoken);
+        }
+        if (grid is null)
+            return (WaitingScreenKind.Blocked, BlockedUnreadableSpoken);
+
+        var kind = WaitingScreenClassifier.Classify(grid.Rows, grid.CursorRow, grid.CursorCol, grid.CursorVisible, grid.IsAlternateScreen, grid.HasGrid);
+        // A menu says "look at the terminal"; everything else uncertain says the generic unreadable line.
+        var spoken = kind == WaitingScreenKind.Menu ? BlockedMenuSpoken : BlockedUnreadableSpoken;
+        return (kind, spoken);
     }
 
     /// <summary>What a session's live waiting screen turns out to be (issue #1777), so voice-turn can decide
@@ -817,14 +809,13 @@ internal static class GatewayWingmanVoiceEndpoint
         Blocked,
     }
 
-    /// <summary>The classified live waiting screen plus, for a menu, the extracted options and the live grid
-    /// rows the menu was read off (kept so the caller can re-verify the menu is STILL on screen right before
-    /// pressing keystrokes), and for a blocked screen, the plain-English reason and the line to speak.</summary>
+    /// <summary>The classified live waiting screen for the read-only <c>GET /wingman/menu</c> path: for a menu,
+    /// the extracted options; for a blocked screen, the plain-English reason and the line to speak. (The send
+    /// path does not use this - it classifies with the pure classifier and only ever types.)</summary>
     private sealed class WaitingScreen
     {
         public WaitingKind Kind { get; init; }
         public WingmanMenu Menu { get; init; } = new() { IsMenu = false };
-        public IReadOnlyList<string> MenuGridRows { get; init; } = System.Array.Empty<string>();
         public string BlockedReason { get; init; } = "";
         public string BlockedSpoken { get; init; } = "";
     }
@@ -904,7 +895,7 @@ internal static class GatewayWingmanVoiceEndpoint
         if (menu.IsMenu && WingmanMenuLogic.MenuHasAnswerableOptions(menu, liveRows))
         {
             FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: MENU with {menu.Options.Count} answerable option(s)");
-            return new WaitingScreen { Kind = WaitingKind.Menu, Menu = menu, MenuGridRows = liveRows };
+            return new WaitingScreen { Kind = WaitingKind.Menu, Menu = menu };
         }
 
         // Looks like a menu but no answerable options could be extracted. UNCERTAIN - the dangerous case the
@@ -913,85 +904,17 @@ internal static class GatewayWingmanVoiceEndpoint
         return Blocked("menu on screen, options not answerable", BlockedMenuSpoken);
     }
 
-    /// <summary>
-    /// TOCTOU re-verify before pressing (issue #1777, findings 3 / B3): between reading the grid and pressing
-    /// an option there are one or two model calls, in which the menu can close or be REPLACED, and the
-    /// selection bytes would land in a shell, a composer, or a different menu. Re-fetch the LIVE grid and
-    /// confirm it is STILL the SAME menu: the cursor is still on a menu option, and the captured menu block
-    /// (question + full option set) still matches - not merely that the same option labels appear somewhere
-    /// (a replacement menu "Delete production?" -> "Deploy production?" with the same Yes/No labels must fail
-    /// this). Returns false (do not press) on any doubt. The full screen-revision-token precondition is a later
-    /// phase; this is the floor.
-    /// </summary>
-    private static async Task<bool> MenuStillOnScreenAsync(
-        SessionVerbClient route, IReadOnlyList<string> capturedRows, string sid, CancellationToken ct)
-    {
-        Contracts.ScreenGridResponse? grid;
-        try { grid = await route.GetScreenGridAsync(sid, ct); }
-        catch { grid = null; }
-        if (grid is null || !grid.HasGrid || grid.Rows is null || grid.Rows.Count == 0) return false;
-        // Still a drawn menu on screen (its selection marker is present) - cursor-independent, since the Ink
-        // picker hides the hardware cursor.
-        if (!WingmanMenuLogic.LiveScreenHasMenuSelection(grid.Rows)) return false;
-        // And it is the SAME menu (question + options), not a same-labelled replacement.
-        return WingmanMenuLogic.SameMenuStillOnScreen(capturedRows, grid.Rows);
-    }
-
-    /// <summary>Fetch the session's live screen and, only when it looks like a menu, ask the warm brain to
-    /// extract it. Returns IsMenu=false on any miss - used by the read-only <c>wingman/menu</c> endpoint,
-    /// which only needs the menu shape (voice-turn uses <see cref="DetectWaitingScreenAtAsync"/> directly so
-    /// it can also fail closed).</summary>
+    /// <summary>Fetch the session's live screen and, only when it is a drawn menu, ask the warm brain to
+    /// extract it. Returns IsMenu=false on any miss. Used ONLY by the read-only <c>GET /wingman/menu</c>
+    /// endpoint (the phone's on-entry render / the later announce step) - it never leads to a keypress. The
+    /// send path (voice-turn) uses the pure <see cref="ClassifyLiveScreenAtAsync"/> instead and only ever
+    /// types on a plain-text composer.</summary>
     private static async Task<WingmanMenu> DetectMenuAtAsync(
         SessionVerbClient route, WingmanTranslator translator, string sid, CancellationToken ct)
     {
         var screen = await DetectWaitingScreenAtAsync(route, translator, sid, ct);
         return screen.Kind == WaitingKind.Menu ? screen.Menu : new WingmanMenu { IsMenu = false };
     }
-
-    /// <summary>Press an option's keystrokes (then the multi-select submit, if any), wait for the
-    /// agent's resulting turn, translate it, cache it, and return the spoken summary. Shared by the
-    /// option-button tap (menu-press) and the spoken-choice path (voice-turn).</summary>
-    private static async Task<IResult> PressAndSummarizeAsync(
-        SessionVerbClient route, WingmanTranslator translator, WingmanVoiceService voice,
-        string sid, string? sessionTitle, string send, string? submit, string? confirmPrefix, string source, CancellationToken ct)
-    {
-        voice.OnSessionWorking(sid);   // a new turn is coming; drop the stale cached summary
-        var before = await CountTextWidgetsAsync(route, sid, ct);
-
-        var (ok, _, err) = await route.PostPromptAsync(sid, new PromptRequest { Text = send, AppendEnter = false }, ct);
-        if (!ok)
-            return Results.Json(new { error = "press failed: " + err }, statusCode: StatusCodes.Status502BadGateway);
-        if (!string.IsNullOrEmpty(submit))
-        {
-            try { await Task.Delay(300, ct); } catch (OperationCanceledException) { }
-            await route.PostPromptAsync(sid, new PromptRequest { Text = submit, AppendEnter = false }, CancellationToken.None);
-        }
-        FileLog.Write($"[GatewayWingmanVoice] {source} sid={sid}: pressed send=\"{Escape(send)}\" submit=\"{Escape(submit)}\"");
-
-        var prefix = confirmPrefix ?? "";
-        var reply = await WaitForReplyAsync(route, sid, before, ct);
-        if (string.IsNullOrWhiteSpace(reply))
-            return Results.Json(new { reply = "", spoken = prefix + "Done. The agent is working - I'll have the result shortly.", pressed = true });
-
-        voice.BeginGenerating(sid);
-        try
-        {
-            var t = await translator.TranslateAsync("(you picked a menu option)", reply, sessionTitle, CancellationToken.None);
-            var spoken = prefix + t.Spoken;
-            await voice.StoreSpokenAsync(sid, spoken, reply, CancellationToken.None);
-            _ = voice.CaptureTrainingAsync(route, sid, source, reply, "(menu pick)", spoken, t.ReplySeconds, CancellationToken.None);
-            FileLog.Write($"[GatewayWingmanVoice] {source} sid={sid}: replyLen={reply.Length}, spokenLen={spoken.Length}");
-            return Results.Json(new { reply, spoken, replySeconds = t.ReplySeconds, pressed = true });
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[GatewayWingmanVoice] {source} sid={sid} translate FAILED: {ex.Message}");
-            return Results.Json(new { error = "wingman translation failed: " + ex.Message }, statusCode: StatusCodes.Status502BadGateway);
-        }
-        finally { voice.EndGenerating(sid); }
-    }
-
-    private static string Escape(string? s) => (s ?? "").Replace("\r", "\\r").Replace("\n", "\\n");
 
     /// <summary>
     /// Persist a mobile dictation capture-health record (issue #863) into the shared dictation
@@ -1106,13 +1029,6 @@ internal static class GatewayWingmanVoiceEndpoint
         var last = turns.Widgets.Skip(widgetsBefore).LastOrDefault(w => w.Kind == "Text");
         return last?.Content;
     }
-
-    private static async Task<int> CountTextWidgetsAsync(
-        SessionVerbClient route, string sid, CancellationToken ct)
-    {
-        var turns = await route.GetTurnsAsync(sid, ct);
-        return turns?.Widgets?.Count ?? 0;
-    }
 }
 
 /// <summary>Body of the wingman voice-turn and ask-direct routes: the person's message.</summary>
@@ -1126,14 +1042,6 @@ public sealed class WingmanVoiceTurnRequest
 public sealed class VoiceModeAllRequest
 {
     public bool Enabled { get; set; } = true;
-}
-
-/// <summary>Body of the menu-press route: the exact keystrokes that pick an option, and (for a
-/// multi-select menu) the completing submit keystroke.</summary>
-public sealed class WingmanMenuPressRequest
-{
-    public string Send { get; set; } = "";
-    public string? Submit { get; set; }
 }
 
 /// <summary>Body of the wingman text-to-speech route: the text to speak, and an optional voice + model

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -868,10 +868,11 @@ internal static class GatewayWingmanVoiceEndpoint
             return Blocked("no screen-grid answer", BlockedUnreadableSpoken);
         }
 
-        // The verdict is anchored to WHERE THE CURSOR IS (issue #1777, round-3), not to menu-like text anywhere
-        // on the grid. The alternate-screen flag is carried on the DTO for the fold phase but is not the
-        // discriminator here - the cursor's relationship to the composer / menu option is.
-        var kind = WaitingScreenClassifier.Classify(grid.Rows, grid.CursorRow, grid.CursorCol, grid.HasGrid);
+        // TWO anchors, fail-closed default (issue #1777, round-4): a MENU is owned by its drawn selection
+        // marker (cursor-independent - the Ink picker hides the cursor); TYPING requires the VISIBLE cursor
+        // inside a framed composer, on the primary screen, with no menu present. Cursor visibility is the
+        // discriminator, so it is passed in alongside the alternate-screen flag.
+        var kind = WaitingScreenClassifier.Classify(grid.Rows, grid.CursorRow, grid.CursorCol, grid.CursorVisible, grid.IsAlternateScreen, grid.HasGrid);
 
         if (kind == WaitingScreenKind.Blocked)
         {
@@ -885,7 +886,7 @@ internal static class GatewayWingmanVoiceEndpoint
             return new WaitingScreen { Kind = WaitingKind.PlainText };
         }
 
-        // kind == Menu: the LIVE grid carries a menu fingerprint. Extract it off the LIVE grid text ONLY.
+        // kind == Menu: the LIVE grid carries a drawn menu. Extract it off the LIVE grid text ONLY.
         var liveRows = grid.Rows ?? new List<string>();
         var liveText = string.Join("\n", liveRows);
         WingmanMenu menu;
@@ -897,16 +898,19 @@ internal static class GatewayWingmanVoiceEndpoint
             return Blocked("menu on screen, detection failed", BlockedMenuSpoken);
         }
 
-        if (menu.IsMenu && menu.Options.Count > 0)
+        // A menu is usable only when it has ANSWERABLE options (issue #1777, finding 4): options exist, every
+        // one has a real visible label (not a bare "1."/"2."), and every label actually appears on the live
+        // grid (the model did not invent options). Anything short of that fails closed.
+        if (menu.IsMenu && WingmanMenuLogic.MenuHasAnswerableOptions(menu, liveRows))
         {
-            FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: MENU with {menu.Options.Count} option(s)");
+            FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: MENU with {menu.Options.Count} answerable option(s)");
             return new WaitingScreen { Kind = WaitingKind.Menu, Menu = menu, MenuGridRows = liveRows };
         }
 
-        // Looks like a menu but no pressable options could be extracted. UNCERTAIN - the dangerous case the
+        // Looks like a menu but no answerable options could be extracted. UNCERTAIN - the dangerous case the
         // old code fell through on. Fail closed and point the person at the terminal.
-        FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: looks like a menu but no options extracted - fail closed");
-        return Blocked("menu on screen, options not extractable", BlockedMenuSpoken);
+        FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: looks like a menu but no answerable options - fail closed");
+        return Blocked("menu on screen, options not answerable", BlockedMenuSpoken);
     }
 
     /// <summary>
@@ -926,9 +930,9 @@ internal static class GatewayWingmanVoiceEndpoint
         try { grid = await route.GetScreenGridAsync(sid, ct); }
         catch { grid = null; }
         if (grid is null || !grid.HasGrid || grid.Rows is null || grid.Rows.Count == 0) return false;
-        // Still a live menu with the cursor on an option (same anchor the classifier used).
-        if (grid.CursorRow < 0 || grid.CursorRow >= grid.Rows.Count) return false;
-        if (!WingmanMenuLogic.IsOptionLine(grid.Rows[grid.CursorRow]) || !WingmanMenuLogic.LiveScreenLooksLikeMenu(grid.Rows)) return false;
+        // Still a drawn menu on screen (its selection marker is present) - cursor-independent, since the Ink
+        // picker hides the hardware cursor.
+        if (!WingmanMenuLogic.LiveScreenHasMenuSelection(grid.Rows)) return false;
         // And it is the SAME menu (question + options), not a same-labelled replacement.
         return WingmanMenuLogic.SameMenuStillOnScreen(capturedRows, grid.Rows);
     }

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -518,7 +518,7 @@ internal static class GatewayWingmanVoiceEndpoint
                     // Finding 3: mapping the choice took one or two model calls; re-verify the SAME menu is
                     // still on the live screen before pressing, so the selection bytes cannot land in a shell
                     // or prompt if the menu closed in the meantime. If it changed, press NOTHING and fail closed.
-                    if (!await MenuStillOnScreenAsync(route, menu, sid, ct))
+                    if (!await MenuStillOnScreenAsync(route, screen.MenuGridRows, sid, ct))
                     {
                         FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: menu changed before press - fail closed, not pressing");
                         return Results.Json(new { reply = "", spoken = "The menu changed before I could answer, so I didn't press anything. Open the session to see what it's asking now.", cannotType = true, lookAtTerminal = true });
@@ -868,7 +868,10 @@ internal static class GatewayWingmanVoiceEndpoint
             return Blocked("no screen-grid answer", BlockedUnreadableSpoken);
         }
 
-        var kind = WaitingScreenClassifier.Classify(grid.Rows, grid.CursorRow, grid.CursorCol, grid.IsAlternateScreen, grid.HasGrid);
+        // The verdict is anchored to WHERE THE CURSOR IS (issue #1777, round-3), not to menu-like text anywhere
+        // on the grid. The alternate-screen flag is carried on the DTO for the fold phase but is not the
+        // discriminator here - the cursor's relationship to the composer / menu option is.
+        var kind = WaitingScreenClassifier.Classify(grid.Rows, grid.CursorRow, grid.CursorCol, grid.HasGrid);
 
         if (kind == WaitingScreenKind.Blocked)
         {
@@ -907,21 +910,27 @@ internal static class GatewayWingmanVoiceEndpoint
     }
 
     /// <summary>
-    /// Cheap TOCTOU re-verify (issue #1777, finding 3): between reading the grid and pressing an option there
-    /// are one or two model calls, in which the menu can close and the selection bytes would land in a shell
-    /// or prompt. Re-fetch the LIVE grid and confirm the SAME menu is still on screen - every extracted option
-    /// label must still appear on the live rows. Returns false (do not press) if the grid could not be re-read
-    /// or the menu changed. The full screen-revision-token precondition is a later phase; this is the floor.
+    /// TOCTOU re-verify before pressing (issue #1777, findings 3 / B3): between reading the grid and pressing
+    /// an option there are one or two model calls, in which the menu can close or be REPLACED, and the
+    /// selection bytes would land in a shell, a composer, or a different menu. Re-fetch the LIVE grid and
+    /// confirm it is STILL the SAME menu: the cursor is still on a menu option, and the captured menu block
+    /// (question + full option set) still matches - not merely that the same option labels appear somewhere
+    /// (a replacement menu "Delete production?" -> "Deploy production?" with the same Yes/No labels must fail
+    /// this). Returns false (do not press) on any doubt. The full screen-revision-token precondition is a later
+    /// phase; this is the floor.
     /// </summary>
     private static async Task<bool> MenuStillOnScreenAsync(
-        SessionVerbClient route, WingmanMenu menu, string sid, CancellationToken ct)
+        SessionVerbClient route, IReadOnlyList<string> capturedRows, string sid, CancellationToken ct)
     {
         Contracts.ScreenGridResponse? grid;
         try { grid = await route.GetScreenGridAsync(sid, ct); }
         catch { grid = null; }
         if (grid is null || !grid.HasGrid || grid.Rows is null || grid.Rows.Count == 0) return false;
-        if (!WingmanMenuLogic.LiveScreenLooksLikeMenu(grid.Rows)) return false;
-        return WingmanMenuLogic.MenuOptionsPresentOnScreen(menu, grid.Rows);
+        // Still a live menu with the cursor on an option (same anchor the classifier used).
+        if (grid.CursorRow < 0 || grid.CursorRow >= grid.Rows.Count) return false;
+        if (!WingmanMenuLogic.IsOptionLine(grid.Rows[grid.CursorRow]) || !WingmanMenuLogic.LiveScreenLooksLikeMenu(grid.Rows)) return false;
+        // And it is the SAME menu (question + options), not a same-labelled replacement.
+        return WingmanMenuLogic.SameMenuStillOnScreen(capturedRows, grid.Rows);
     }
 
     /// <summary>Fetch the session's live screen and, only when it looks like a menu, ask the warm brain to

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -515,6 +515,14 @@ internal static class GatewayWingmanVoiceEndpoint
                 if (idx < 0) idx = await translator.MapChoiceAsync(menu, req.Text, ct);
                 if (idx >= 0 && idx < menu.Options.Count)
                 {
+                    // Finding 3: mapping the choice took one or two model calls; re-verify the SAME menu is
+                    // still on the live screen before pressing, so the selection bytes cannot land in a shell
+                    // or prompt if the menu closed in the meantime. If it changed, press NOTHING and fail closed.
+                    if (!await MenuStillOnScreenAsync(route, menu, sid, ct))
+                    {
+                        FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: menu changed before press - fail closed, not pressing");
+                        return Results.Json(new { reply = "", spoken = "The menu changed before I could answer, so I didn't press anything. Open the session to see what it's asking now.", cannotType = true, lookAtTerminal = true });
+                    }
                     var opt = menu.Options[idx];
                     var submit = string.Equals(menu.SelectionMode, "multiple", StringComparison.OrdinalIgnoreCase) ? menu.Submit : "";
                     FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: menu choice -> option {idx + 1}");
@@ -533,7 +541,14 @@ internal static class GatewayWingmanVoiceEndpoint
                 FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: FAIL CLOSED - not typing ({screen.BlockedReason})");
                 return Results.Json(new { reply = "", spoken = screen.BlockedSpoken, cannotType = true, lookAtTerminal = true });
             }
-            // screen.Kind == WaitingKind.PlainText: a confident plain-text prompt - typing the answer is safe.
+            // screen.Kind == WaitingKind.PlainText: a positive composer/input-prompt signal on the primary
+            // screen - typing the answer is safe.
+            //
+            // ACCEPTED, DOCUMENTED GAP (issue #1777, finding 3): there is a micro-race where a plain-text
+            // prompt turns into a menu between this classification and the PostPromptAsync below. We do NOT
+            // re-verify on this path (only the menu-press path re-verifies, where the cost of a wrong press is
+            // a bad selection). The full screen-revision-token precondition that would close this race is a
+            // later phase (issue #1786); it is not built here.
 
             // We are about to start a new turn, so the cached spoken summary + audio are now stale.
             // Clear them DETERMINISTICALLY here (do not rely on observing the Working state, which is
@@ -802,106 +817,111 @@ internal static class GatewayWingmanVoiceEndpoint
         Blocked,
     }
 
-    /// <summary>The classified live waiting screen plus, for a menu, the extracted options, and for a blocked
-    /// screen, the plain-English reason and the line to speak.</summary>
+    /// <summary>The classified live waiting screen plus, for a menu, the extracted options and the live grid
+    /// rows the menu was read off (kept so the caller can re-verify the menu is STILL on screen right before
+    /// pressing keystrokes), and for a blocked screen, the plain-English reason and the line to speak.</summary>
     private sealed class WaitingScreen
     {
         public WaitingKind Kind { get; init; }
         public WingmanMenu Menu { get; init; } = new() { IsMenu = false };
+        public IReadOnlyList<string> MenuGridRows { get; init; } = System.Array.Empty<string>();
         public string BlockedReason { get; init; } = "";
         public string BlockedSpoken { get; init; } = "";
     }
 
+    private static WaitingScreen Blocked(string reason, string spoken) =>
+        new() { Kind = WaitingKind.Blocked, BlockedReason = reason, BlockedSpoken = spoken };
+
+    private const string BlockedMenuSpoken =
+        "There's a menu on this session's screen that I couldn't read clearly, so I won't answer it blindly. Open the session to pick an option.";
+    private const string BlockedUnreadableSpoken =
+        "I can't read this session's screen right now, so I won't type your answer in blindly. Open the session to see what it's asking.";
+
     /// <summary>
-    /// Classify what a session is waiting on by reading the LIVE screen grid (issue #1777). The live grid is
-    /// the authority: it is alternate-screen-correct, so a full-screen picker the scrollback cannot see is
-    /// still classified as a menu. The scrollback (the <c>buffer</c> verb) is read ONLY to supplement the
-    /// brain's extraction text when the live screen already looks like a menu - it can never create a menu on
-    /// its own. Fails closed on every uncertainty: an unreadable screen, or a screen that looks like a menu
-    /// but whose options we could not extract, both return <see cref="WaitingKind.Blocked"/>.
+    /// Classify what a session is waiting on by reading the LIVE screen grid ONLY (issue #1777). The live grid
+    /// is the sole source of the verdict - the scrollback never gets a vote, so an already-answered menu buried
+    /// in history can never be extracted and pressed into whatever is actually on screen (the phantom-menu case
+    /// the owner ruled out). The classifier types ONLY on a positive plain-text signal; a blank grid, an
+    /// unrecognized alternate-screen app, or a menu whose options we cannot extract all fail closed. A brain
+    /// failure during extraction also fails closed - never guess into a picker.
+    ///
+    /// DEFERRED (next phase, issue #1786): a tall non-full-screen menu whose top scrolled above the visible
+    /// window needs the scrollback tail as a detection SUPPLEMENT - but only WITH validation that every
+    /// extracted option label appears on the live grid. That validation does not exist yet, so the scrollback
+    /// is not fed here at all.
     /// </summary>
     private static async Task<WaitingScreen> DetectWaitingScreenAtAsync(
         SessionVerbClient route, WingmanTranslator translator, string sid, CancellationToken ct)
     {
-        // The LIVE screen grid is the authoritative read.
+        // The LIVE screen grid is the ONLY read that decides the verdict (rows + cursor + alternate-screen
+        // flag come from one atomic Director snapshot).
         Contracts.ScreenGridResponse? grid;
         try { grid = await route.GetScreenGridAsync(sid, ct); }
-        catch { grid = null; }
-
-        // Unreadable: no answer from the owning Director, or a session with no resolved grid at all. We cannot
-        // see what is on screen, so we must not type the spoken words in blindly - fail closed.
-        if (grid is null || !grid.HasGrid || grid.Rows is null || grid.Rows.Count == 0)
+        catch (Exception ex)
         {
-            var why = grid is null ? "no grid answer" : grid.HasGrid ? "empty grid" : "no grid parser";
-            FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: UNREADABLE ({why}) - fail closed");
-            return new WaitingScreen
-            {
-                Kind = WaitingKind.Blocked,
-                BlockedReason = "unreadable screen (" + why + ")",
-                BlockedSpoken = "I can't read this session's screen right now, so I won't type your answer in blindly. Open the session to see what it's asking.",
-            };
+            FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: screen-grid read threw ({ex.Message}) - fail closed");
+            return Blocked("screen-grid read failed", BlockedUnreadableSpoken);
+        }
+        if (grid is null)
+        {
+            FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: no screen-grid answer - fail closed");
+            return Blocked("no screen-grid answer", BlockedUnreadableSpoken);
         }
 
-        // Does the LIVE screen look like a menu? This is the verdict, and the scrollback never gets a vote.
-        if (!WingmanMenuLogic.LiveScreenLooksLikeMenu(grid.Rows))
+        var kind = WaitingScreenClassifier.Classify(grid.Rows, grid.CursorRow, grid.CursorCol, grid.IsAlternateScreen, grid.HasGrid);
+
+        if (kind == WaitingScreenKind.Blocked)
         {
-            // A readable screen that is not a menu is a confident plain-text prompt - typing is safe.
-            FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: plain-text prompt (rows={grid.Rows.Count}, alt={grid.IsAlternateScreen})");
+            FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: BLOCKED (rows={grid.Rows?.Count ?? 0}, alt={grid.IsAlternateScreen}, hasGrid={grid.HasGrid}) - fail closed");
+            return Blocked("unrecognized / unreadable screen", BlockedUnreadableSpoken);
+        }
+
+        if (kind == WaitingScreenKind.PlainText)
+        {
+            FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: plain-text prompt (positive composer signal)");
             return new WaitingScreen { Kind = WaitingKind.PlainText };
         }
 
-        // The live screen IS a menu. Extract it with the brain, supplementing the live grid with the
-        // scrollback tail (text that scrolled above the visible window on a non-full-screen menu). The
-        // verdict already came from the live grid; the scrollback only enriches the extraction text.
-        var liveText = string.Join("\n", grid.Rows);
-        string scrollTail;
-        try
-        {
-            var buf = await route.GetBufferAsync(sid, lines: null, raw: false, since: null, ct);
-            scrollTail = buf?.Text ?? "";
-        }
-        catch { scrollTail = ""; }
-
+        // kind == Menu: the LIVE grid carries a menu fingerprint. Extract it off the LIVE grid text ONLY.
+        var liveRows = grid.Rows ?? new List<string>();
+        var liveText = string.Join("\n", liveRows);
         WingmanMenu menu;
-        try { menu = await translator.DetectMenuAsync(BuildMenuDetectionText(scrollTail, liveText), ct); }
+        try { menu = await translator.DetectMenuAsync(liveText, ct); }
         catch (Exception ex)
         {
-            // The screen looks like a menu but the brain could not read it (unreachable / no key / error).
-            // Never guess into a picker - fail closed.
+            // Looks like a menu but the brain could not read it (unreachable / no key / error). Fail closed.
             FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: menu on screen, detection FAILED ({ex.Message}) - fail closed");
-            menu = new WingmanMenu { IsMenu = false };
+            return Blocked("menu on screen, detection failed", BlockedMenuSpoken);
         }
 
         if (menu.IsMenu && menu.Options.Count > 0)
         {
             FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: MENU with {menu.Options.Count} option(s)");
-            return new WaitingScreen { Kind = WaitingKind.Menu, Menu = menu };
+            return new WaitingScreen { Kind = WaitingKind.Menu, Menu = menu, MenuGridRows = liveRows };
         }
 
-        // The live screen looks like a menu but we could not extract pressable options. UNCERTAIN - the
-        // dangerous case the old code fell through on. Fail closed and point the person at the terminal.
+        // Looks like a menu but no pressable options could be extracted. UNCERTAIN - the dangerous case the
+        // old code fell through on. Fail closed and point the person at the terminal.
         FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: looks like a menu but no options extracted - fail closed");
-        return new WaitingScreen
-        {
-            Kind = WaitingKind.Blocked,
-            BlockedReason = "menu on screen, options not extractable",
-            BlockedSpoken = "There's a menu on this session's screen that I couldn't read clearly, so I won't answer it blindly. Open the session to pick an option.",
-        };
+        return Blocked("menu on screen, options not extractable", BlockedMenuSpoken);
     }
 
     /// <summary>
-    /// Build the terminal text handed to the brain menu detector (issue #1777). The LIVE grid is the
-    /// authority and goes LAST so it is the "bottom of the screen" the detector prompt reads; the scrollback
-    /// tail is prepended ONLY to supply text that scrolled above the visible window on a non-full-screen menu.
-    /// The scrollback is capped to its tail so it enriches without dominating (and so it cannot re-introduce
-    /// an already-answered menu from far up the history).
+    /// Cheap TOCTOU re-verify (issue #1777, finding 3): between reading the grid and pressing an option there
+    /// are one or two model calls, in which the menu can close and the selection bytes would land in a shell
+    /// or prompt. Re-fetch the LIVE grid and confirm the SAME menu is still on screen - every extracted option
+    /// label must still appear on the live rows. Returns false (do not press) if the grid could not be re-read
+    /// or the menu changed. The full screen-revision-token precondition is a later phase; this is the floor.
     /// </summary>
-    private static string BuildMenuDetectionText(string scrollTail, string liveText)
+    private static async Task<bool> MenuStillOnScreenAsync(
+        SessionVerbClient route, WingmanMenu menu, string sid, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(scrollTail)) return liveText;
-        const int maxScroll = 2000;
-        var tail = scrollTail.Length > maxScroll ? scrollTail[^maxScroll..] : scrollTail;
-        return tail + "\n" + liveText;
+        Contracts.ScreenGridResponse? grid;
+        try { grid = await route.GetScreenGridAsync(sid, ct); }
+        catch { grid = null; }
+        if (grid is null || !grid.HasGrid || grid.Rows is null || grid.Rows.Count == 0) return false;
+        if (!WingmanMenuLogic.LiveScreenLooksLikeMenu(grid.Rows)) return false;
+        return WingmanMenuLogic.MenuOptionsPresentOnScreen(menu, grid.Rows);
     }
 
     /// <summary>Fetch the session's live screen and, only when it looks like a menu, ask the warm brain to

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -501,12 +501,16 @@ internal static class GatewayWingmanVoiceEndpoint
             if (route is null)
                 return Results.Json(new { error = "session not found on any director" }, statusCode: StatusCodes.Status404NotFound);
 
-            // Menu handling (issue #531): if the agent is RIGHT NOW showing an on-screen menu, the
-            // person's words are a CHOICE, not a new prompt. Detect it, map the words to an option,
-            // and PRESS that option (raw keystrokes) - never type the spoken words as a prompt.
-            var menu = await DetectMenuAtAsync(route, translator, sid, ct);
-            if (menu.IsMenu)
+            // Menu handling + FAIL CLOSED (issues #531 / #1777). Read the LIVE screen (authoritative) to
+            // classify what the session is waiting on: a menu, a confident plain-text prompt, or something we
+            // must NOT type into (a menu we could not read, an uncertain screen, or an unreadable one). The
+            // spoken words are only ever typed as an ordinary prompt when the screen is CONFIDENTLY plain text.
+            var screen = await DetectWaitingScreenAtAsync(route, translator, sid, ct);
+            if (screen.Kind == WaitingKind.Menu)
             {
+                // The agent is RIGHT NOW showing an on-screen menu, so the person's words are a CHOICE, not a
+                // new prompt. Map the words to an option and PRESS that option (raw keystrokes).
+                var menu = screen.Menu;
                 var idx = WingmanMenuLogic.MatchOption(menu, req.Text);
                 if (idx < 0) idx = await translator.MapChoiceAsync(menu, req.Text, ct);
                 if (idx >= 0 && idx < menu.Options.Count)
@@ -520,6 +524,16 @@ internal static class GatewayWingmanVoiceEndpoint
                 FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: menu present, choice unclear");
                 return Results.Json(new { reply = "", spoken = "I didn't catch which one. " + menu.Spoken, needsChoice = true, menu = MenuJson(menu) });
             }
+            if (screen.Kind == WaitingKind.Blocked)
+            {
+                // FAIL CLOSED (issue #1777): the waiting screen is a menu we could not read, an uncertain
+                // screen, or an unreadable one. Typing the spoken words in blindly is the exact defect that
+                // leaves the person stuck (a wrong pick AND no escape), so send NOTHING - not the words, not
+                // any selection bytes - and tell them to look at the terminal.
+                FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: FAIL CLOSED - not typing ({screen.BlockedReason})");
+                return Results.Json(new { reply = "", spoken = screen.BlockedSpoken, cannotType = true, lookAtTerminal = true });
+            }
+            // screen.Kind == WaitingKind.PlainText: a confident plain-text prompt - typing the answer is safe.
 
             // We are about to start a new turn, so the cached spoken summary + audio are now stale.
             // Clear them DETERMINISTICALLY here (do not rely on observing the Working state, which is
@@ -774,17 +788,131 @@ internal static class GatewayWingmanVoiceEndpoint
         });
     }
 
-    /// <summary>Fetch the session terminal and, only when it cheaply looks like a menu, ask the warm
-    /// brain to extract it. Returns IsMenu=false on any miss - the caller treats input as a prompt.</summary>
+    /// <summary>What a session's live waiting screen turns out to be (issue #1777), so voice-turn can decide
+    /// whether the person's spoken words may be typed. Only <see cref="PlainText"/> may be typed.</summary>
+    private enum WaitingKind
+    {
+        /// <summary>A readable on-screen menu with pressable options - map the words to a choice and press.</summary>
+        Menu,
+
+        /// <summary>A confident plain-text prompt (a readable screen that is not a menu) - typing is safe.</summary>
+        PlainText,
+
+        /// <summary>A menu we could not read, an uncertain screen, or an unreadable one - NEVER type; fail closed.</summary>
+        Blocked,
+    }
+
+    /// <summary>The classified live waiting screen plus, for a menu, the extracted options, and for a blocked
+    /// screen, the plain-English reason and the line to speak.</summary>
+    private sealed class WaitingScreen
+    {
+        public WaitingKind Kind { get; init; }
+        public WingmanMenu Menu { get; init; } = new() { IsMenu = false };
+        public string BlockedReason { get; init; } = "";
+        public string BlockedSpoken { get; init; } = "";
+    }
+
+    /// <summary>
+    /// Classify what a session is waiting on by reading the LIVE screen grid (issue #1777). The live grid is
+    /// the authority: it is alternate-screen-correct, so a full-screen picker the scrollback cannot see is
+    /// still classified as a menu. The scrollback (the <c>buffer</c> verb) is read ONLY to supplement the
+    /// brain's extraction text when the live screen already looks like a menu - it can never create a menu on
+    /// its own. Fails closed on every uncertainty: an unreadable screen, or a screen that looks like a menu
+    /// but whose options we could not extract, both return <see cref="WaitingKind.Blocked"/>.
+    /// </summary>
+    private static async Task<WaitingScreen> DetectWaitingScreenAtAsync(
+        SessionVerbClient route, WingmanTranslator translator, string sid, CancellationToken ct)
+    {
+        // The LIVE screen grid is the authoritative read.
+        Contracts.ScreenGridResponse? grid;
+        try { grid = await route.GetScreenGridAsync(sid, ct); }
+        catch { grid = null; }
+
+        // Unreadable: no answer from the owning Director, or a session with no resolved grid at all. We cannot
+        // see what is on screen, so we must not type the spoken words in blindly - fail closed.
+        if (grid is null || !grid.HasGrid || grid.Rows is null || grid.Rows.Count == 0)
+        {
+            var why = grid is null ? "no grid answer" : grid.HasGrid ? "empty grid" : "no grid parser";
+            FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: UNREADABLE ({why}) - fail closed");
+            return new WaitingScreen
+            {
+                Kind = WaitingKind.Blocked,
+                BlockedReason = "unreadable screen (" + why + ")",
+                BlockedSpoken = "I can't read this session's screen right now, so I won't type your answer in blindly. Open the session to see what it's asking.",
+            };
+        }
+
+        // Does the LIVE screen look like a menu? This is the verdict, and the scrollback never gets a vote.
+        if (!WingmanMenuLogic.LiveScreenLooksLikeMenu(grid.Rows))
+        {
+            // A readable screen that is not a menu is a confident plain-text prompt - typing is safe.
+            FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: plain-text prompt (rows={grid.Rows.Count}, alt={grid.IsAlternateScreen})");
+            return new WaitingScreen { Kind = WaitingKind.PlainText };
+        }
+
+        // The live screen IS a menu. Extract it with the brain, supplementing the live grid with the
+        // scrollback tail (text that scrolled above the visible window on a non-full-screen menu). The
+        // verdict already came from the live grid; the scrollback only enriches the extraction text.
+        var liveText = string.Join("\n", grid.Rows);
+        string scrollTail;
+        try
+        {
+            var buf = await route.GetBufferAsync(sid, lines: null, raw: false, since: null, ct);
+            scrollTail = buf?.Text ?? "";
+        }
+        catch { scrollTail = ""; }
+
+        WingmanMenu menu;
+        try { menu = await translator.DetectMenuAsync(BuildMenuDetectionText(scrollTail, liveText), ct); }
+        catch (Exception ex)
+        {
+            // The screen looks like a menu but the brain could not read it (unreachable / no key / error).
+            // Never guess into a picker - fail closed.
+            FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: menu on screen, detection FAILED ({ex.Message}) - fail closed");
+            menu = new WingmanMenu { IsMenu = false };
+        }
+
+        if (menu.IsMenu && menu.Options.Count > 0)
+        {
+            FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: MENU with {menu.Options.Count} option(s)");
+            return new WaitingScreen { Kind = WaitingKind.Menu, Menu = menu };
+        }
+
+        // The live screen looks like a menu but we could not extract pressable options. UNCERTAIN - the
+        // dangerous case the old code fell through on. Fail closed and point the person at the terminal.
+        FileLog.Write($"[GatewayWingmanVoice] waiting-screen sid={sid}: looks like a menu but no options extracted - fail closed");
+        return new WaitingScreen
+        {
+            Kind = WaitingKind.Blocked,
+            BlockedReason = "menu on screen, options not extractable",
+            BlockedSpoken = "There's a menu on this session's screen that I couldn't read clearly, so I won't answer it blindly. Open the session to pick an option.",
+        };
+    }
+
+    /// <summary>
+    /// Build the terminal text handed to the brain menu detector (issue #1777). The LIVE grid is the
+    /// authority and goes LAST so it is the "bottom of the screen" the detector prompt reads; the scrollback
+    /// tail is prepended ONLY to supply text that scrolled above the visible window on a non-full-screen menu.
+    /// The scrollback is capped to its tail so it enriches without dominating (and so it cannot re-introduce
+    /// an already-answered menu from far up the history).
+    /// </summary>
+    private static string BuildMenuDetectionText(string scrollTail, string liveText)
+    {
+        if (string.IsNullOrWhiteSpace(scrollTail)) return liveText;
+        const int maxScroll = 2000;
+        var tail = scrollTail.Length > maxScroll ? scrollTail[^maxScroll..] : scrollTail;
+        return tail + "\n" + liveText;
+    }
+
+    /// <summary>Fetch the session's live screen and, only when it looks like a menu, ask the warm brain to
+    /// extract it. Returns IsMenu=false on any miss - used by the read-only <c>wingman/menu</c> endpoint,
+    /// which only needs the menu shape (voice-turn uses <see cref="DetectWaitingScreenAtAsync"/> directly so
+    /// it can also fail closed).</summary>
     private static async Task<WingmanMenu> DetectMenuAtAsync(
         SessionVerbClient route, WingmanTranslator translator, string sid, CancellationToken ct)
     {
-        Contracts.BufferResponse? buf;
-        try { buf = await route.GetBufferAsync(sid, lines: null, raw: false, since: null, ct); }
-        catch { buf = null; }
-        var terminal = buf?.Text ?? "";
-        if (!WingmanMenuLogic.LooksLikeMenu(terminal)) return new WingmanMenu { IsMenu = false };
-        return await translator.DetectMenuAsync(terminal, ct);
+        var screen = await DetectWaitingScreenAtAsync(route, translator, sid, ct);
+        return screen.Kind == WaitingKind.Menu ? screen.Menu : new WingmanMenu { IsMenu = false };
     }
 
     /// <summary>Press an option's keystrokes (then the multi-select submit, if any), wait for the

--- a/src/CcDirector.Gateway/Api/SessionVerbClient.cs
+++ b/src/CcDirector.Gateway/Api/SessionVerbClient.cs
@@ -80,6 +80,18 @@ internal sealed class SessionVerbClient
         return result is not null && result.Ok ? DirectorCommandRouter.ReadBody<BufferResponse>(result) : null;
     }
 
+    /// <summary>Read the session's RESOLVED live screen grid (issue #1777). Tunnel-only ("screen-grid" verb
+    /// -> <see cref="ScreenGridResponse"/>); a failed or absent tunnel result maps to null (owning Director not
+    /// connected = unreachable, which the caller treats as an unreadable screen and fails closed). This is the
+    /// alternate-screen-correct read the menu detector uses - it sees a full-screen picker the scrollback-based
+    /// <see cref="GetBufferAsync"/> cannot.</summary>
+    public async Task<ScreenGridResponse?> GetScreenGridAsync(string sid, CancellationToken ct = default)
+    {
+        var result = await DirectorCommandRouter.TrySendAsync(_sendCommand, _director.DirectorId, "screen-grid", sid, null, ct,
+            machineName: _director.MachineName);
+        return result is not null && result.Ok ? DirectorCommandRouter.ReadBody<ScreenGridResponse>(result) : null;
+    }
+
     /// <summary>Send a prompt into the session. Tunnel-only ("prompt" verb, the <see cref="PromptRequest"/>
     /// as payload -> <see cref="PromptResponse"/>); a failed or absent tunnel result maps to the same
     /// (false, null, error) tuple. This is the UserInput send the voice cluster needs.</summary>

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -386,6 +386,9 @@ public sealed class GatewayHost : IAsyncDisposable
     // the Working transition. The wingman brain (BrainSupervisor) is kept; voice mode uses it.
     private TurnEndWatcher? _turnEndWatcher;
     private Wingman.WingmanVoiceService? _voiceService;
+
+    /// <summary>Test-only warm-brain provider override (issue #1777); null in production.</summary>
+    private readonly Func<Core.Configuration.WingmanModelRole, CancellationToken, Task<CcDirector.AgentBrain.IAgentBrain>>? _brainProviderOverride;
     // Editable/versioned wingman instructions (issue #537); the voice translator reads the active set.
     private readonly Wingman.WingmanInstructionsStore _instructionsStore = new();
     // Shared training-data store: the voice service WRITES captures, the instructions A/B test READS them.
@@ -516,8 +519,12 @@ public sealed class GatewayHost : IAsyncDisposable
     /// Shared instances that write to the real user's directories). Production omits it and the host builds
     /// the service over its own key vault, exactly as before.
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null, Core.Agents.AgentKind? brainTool = null)
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null, Core.Agents.AgentKind? brainTool = null,
+        Func<Core.Configuration.WingmanModelRole, CancellationToken, Task<CcDirector.AgentBrain.IAgentBrain>>? brainProviderOverride = null)
     {
+        // Test seam (issue #1777): a test passes a stub warm-brain provider so the wingman menu detector can be
+        // exercised end-to-end without a live model. Null in production - the real WingmanBrainAsync is used.
+        _brainProviderOverride = brainProviderOverride;
         // Resolve and VALIDATE the warm-brain tool up front, before any resource is opened: a brain tool
         // that cannot be hosted is a configuration error that must fail loudly at construction, not
         // silently later at the brain's first spawn. BrainToolConfig.Get reads config.json; a test passes
@@ -1530,7 +1537,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // listener with the phone in a pocket knows WHICH session is talking before anything else
         // (WingmanTranslator.FidelityPrompt v5.2). Push-store read - no dial. See ResolveSessionTitle.
         _voiceService ??= new Wingman.WingmanVoiceService(WingmanBrainAsync, _keyVault, training: _trainingStore, instructionsProvider: () => _instructionsStore.ActiveContent, sessionTitleResolver: ResolveSessionTitle);
-        GatewayWingmanVoiceEndpoint.Map(_app, Registry, WingmanBrainAsync, _keyVault, _voiceService,
+        GatewayWingmanVoiceEndpoint.Map(_app, Registry, _brainProviderOverride ?? WingmanBrainAsync, _keyVault, _voiceService,
             pushedSessions: PushedSessions,
             sendCommand: SendCommandAsync,
             owners: SessionOwners,

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -386,9 +386,6 @@ public sealed class GatewayHost : IAsyncDisposable
     // the Working transition. The wingman brain (BrainSupervisor) is kept; voice mode uses it.
     private TurnEndWatcher? _turnEndWatcher;
     private Wingman.WingmanVoiceService? _voiceService;
-
-    /// <summary>Test-only warm-brain provider override (issue #1777); null in production.</summary>
-    private readonly Func<Core.Configuration.WingmanModelRole, CancellationToken, Task<CcDirector.AgentBrain.IAgentBrain>>? _brainProviderOverride;
     // Editable/versioned wingman instructions (issue #537); the voice translator reads the active set.
     private readonly Wingman.WingmanInstructionsStore _instructionsStore = new();
     // Shared training-data store: the voice service WRITES captures, the instructions A/B test READS them.
@@ -519,12 +516,8 @@ public sealed class GatewayHost : IAsyncDisposable
     /// Shared instances that write to the real user's directories). Production omits it and the host builds
     /// the service over its own key vault, exactly as before.
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null, Core.Agents.AgentKind? brainTool = null,
-        Func<Core.Configuration.WingmanModelRole, CancellationToken, Task<CcDirector.AgentBrain.IAgentBrain>>? brainProviderOverride = null)
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null, Core.Agents.AgentKind? brainTool = null)
     {
-        // Test seam (issue #1777): a test passes a stub warm-brain provider so the wingman menu detector can be
-        // exercised end-to-end without a live model. Null in production - the real WingmanBrainAsync is used.
-        _brainProviderOverride = brainProviderOverride;
         // Resolve and VALIDATE the warm-brain tool up front, before any resource is opened: a brain tool
         // that cannot be hosted is a configuration error that must fail loudly at construction, not
         // silently later at the brain's first spawn. BrainToolConfig.Get reads config.json; a test passes
@@ -1537,7 +1530,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // listener with the phone in a pocket knows WHICH session is talking before anything else
         // (WingmanTranslator.FidelityPrompt v5.2). Push-store read - no dial. See ResolveSessionTitle.
         _voiceService ??= new Wingman.WingmanVoiceService(WingmanBrainAsync, _keyVault, training: _trainingStore, instructionsProvider: () => _instructionsStore.ActiveContent, sessionTitleResolver: ResolveSessionTitle);
-        GatewayWingmanVoiceEndpoint.Map(_app, Registry, _brainProviderOverride ?? WingmanBrainAsync, _keyVault, _voiceService,
+        GatewayWingmanVoiceEndpoint.Map(_app, Registry, WingmanBrainAsync, _keyVault, _voiceService,
             pushedSessions: PushedSessions,
             sendCommand: SendCommandAsync,
             owners: SessionOwners,

--- a/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
+++ b/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
@@ -1,82 +1,77 @@
 namespace CcDirector.Gateway.Wingman;
 
 /// <summary>
-/// What a session's live waiting screen is, decided from WHERE THE CURSOR IS (issue #1777). This is the
-/// fail-closed floor: the spoken words may be typed as an ordinary prompt ONLY when the cursor is positively
-/// inside the agent's composer input box. Everything the classifier is not sure about is
-/// <see cref="Blocked"/> - "not a recognized menu" must never collapse into "confident plain text".
+/// What a session's live waiting screen is (issue #1777). This is the fail-closed floor, and fail closed is
+/// the DEFAULT - anything the grid does not POSITIVELY resolve to a composer or a menu is <see cref="Blocked"/>.
 /// </summary>
 public enum WaitingScreenKind
 {
-    /// <summary>The selection cursor sits on a menu option. The caller extracts the menu (brain) off the LIVE grid.</summary>
+    /// <summary>A menu, owned by its DRAWN selection marker on the grid (not the hardware cursor, which the Ink
+    /// picker hides). The caller extracts and presses off the LIVE grid.</summary>
     Menu,
 
-    /// <summary>The cursor is positively inside the agent's composer input box - the spoken words go there.</summary>
+    /// <summary>The VISIBLE hardware cursor is positively inside the agent's composer input box and no menu is
+    /// on the grid - the spoken words go there.</summary>
     PlainText,
 
-    /// <summary>Unreadable, blank, an ambiguous input, or anything the cursor does not positively resolve: never type.</summary>
+    /// <summary>Unreadable, blank, alternate-screen non-menu, ambiguous, hidden/off-target cursor with no menu
+    /// marker: never type, never press. The default.</summary>
     Blocked,
 }
 
 /// <summary>
-/// The pure (no-brain) waiting-screen classifier, ANCHORED TO THE CURSOR (issue #1777, round-3). Text
-/// fingerprints alone cannot tell a live composer from a menu selection marker (both can read "&gt; x"), nor a
-/// live composer from an already-answered menu still visible above it - the cursor can. So the verdict is:
-///   - the cursor is positively inside the agent's composer input box  -> PlainText (type there; any menu-like
-///     text elsewhere on the grid is stale and ignored);
-///   - the cursor is on a menu option of a live menu                   -> Menu (the caller extracts + presses);
-///   - anything else (a bare "&gt;" row with no input-box frame, an ambiguous picker, an unreadable or blank
-///     grid, a cursor resolving to neither)                            -> Blocked.
-/// A bare row starting with "&gt;" is NOT a composer: the composer is positively identified as a framed input
-/// box (box border or the agent's mode-status footer) with the cursor sitting after the prompt inside it. This
-/// is what makes it agent-uniform: an unrecognized picker fails closed instead of being typed into.
+/// The pure (no-brain) waiting-screen classifier, using TWO DIFFERENT ANCHORS with fail-closed as the default
+/// (issue #1777, round-4). A text composer and an Ink menu cannot be told apart by the hardware cursor: Claude
+/// Code HIDES the cursor on its permission menu and draws its own selection marker, and the parser still
+/// reports a (stale) cursor cell. So:
+///   - TYPING is allowed only when ALL hold: NOT the alternate screen; the cursor is VISIBLE; the cursor is
+///     positively inside the agent's framed composer input box (row and column); and NO menu is on the grid.
+///   - A MENU is owned by its DRAWN selection marker (<c>❯</c>/<c>&gt;</c> on an option row) plus the option
+///     lines - cursor-independent, so menu-answering works with the cursor hidden.
+///   - EVERYTHING ELSE is Blocked. When in doubt, block.
+/// A grid carrying BOTH a menu marker and a live composer is ambiguous (a stale menu above a fresh composer, or
+/// the reverse) and is Blocked rather than guessed.
 /// </summary>
 public static class WaitingScreenClassifier
 {
-    /// <summary>Classify the live waiting screen from the grid and the cursor cell. <paramref name="hasGrid"/>
-    /// is false for an Embedded session with no server-side parser (unreadable). A <see cref="WaitingScreenKind.Menu"/>
-    /// result means the cursor is on an option of a live menu - the caller still has to extract pressable
-    /// options off the LIVE grid and must fail closed if it cannot.</summary>
+    /// <summary>Classify the live waiting screen. <paramref name="cursorVisible"/> is the DECTCEM hardware-cursor
+    /// visibility (a hidden cursor means the cursor cell is stale). <paramref name="hasGrid"/> is false for an
+    /// Embedded session with no parser (unreadable). A <see cref="WaitingScreenKind.Menu"/> result means a
+    /// drawn menu is present - the caller still extracts pressable, answerable options and fails closed if it
+    /// cannot.</summary>
     public static WaitingScreenKind Classify(
-        IReadOnlyList<string>? rows, int cursorRow, int cursorCol, bool hasGrid)
+        IReadOnlyList<string>? rows, int cursorRow, int cursorCol, bool cursorVisible, bool isAlternateScreen, bool hasGrid)
     {
-        // Unreadable: no resolved grid, or nothing on it.
+        // Unreadable / blank -> never type.
         if (!hasGrid || rows is null || rows.Count == 0) return WaitingScreenKind.Blocked;
-
-        // A blank / all-whitespace grid tells us nothing - never type into it.
         if (rows.All(string.IsNullOrWhiteSpace)) return WaitingScreenKind.Blocked;
 
-        // No usable cursor anchor -> we cannot say WHERE the interaction is, so fail closed.
-        if (cursorRow < 0 || cursorRow >= rows.Count) return WaitingScreenKind.Blocked;
+        // A menu is owned by its DRAWN marker, independent of the hardware cursor (the Ink picker hides it).
+        var hasMenu = WingmanMenuLogic.LiveScreenHasMenuSelection(rows);
 
-        // 1) The cursor positively inside the agent's composer input box -> the spoken words go THERE. A stale
-        //    menu still visible elsewhere on the grid does not matter: the cursor is in the composer.
-        if (CursorInComposer(rows, cursorRow, cursorCol)) return WaitingScreenKind.PlainText;
+        // A composer requires the VISIBLE cursor positively inside a framed input box, on the primary screen.
+        var hasComposer = !isAlternateScreen
+            && cursorVisible
+            && cursorRow >= 0 && cursorRow < rows.Count
+            && CursorInComposer(rows, cursorRow, cursorCol);
 
-        // 2) A menu owns the turn ONLY when the selection cursor is on a menu option AND the screen is a menu.
-        if (WingmanMenuLogic.IsOptionLine(rows[cursorRow]) && WingmanMenuLogic.LiveScreenLooksLikeMenu(rows))
-            return WaitingScreenKind.Menu;
-
-        // 3) The cursor resolves to neither a composer nor a menu option - ambiguous interactive UI. Fail closed.
+        // Both present is ambiguous (a stale menu above a live composer, or vice versa) - fail closed.
+        if (hasMenu && hasComposer) return WaitingScreenKind.Blocked;
+        if (hasMenu) return WaitingScreenKind.Menu;
+        if (hasComposer) return WaitingScreenKind.PlainText;
         return WaitingScreenKind.Blocked;
     }
 
     /// <summary>
-    /// POSITIVE composer identification (issue #1777, round-3): the cursor is inside the agent's composer input
-    /// box. That means the cursor's row is the agent's input-prompt line - after stripping the box edge it
-    /// begins with a single "&gt;" prompt marker (not "&gt;&gt;", the mode-cycle arrow) - the cursor is sitting
-    /// AT OR AFTER the prompt (inside the editable input, using <paramref name="cursorCol"/>), AND the line is
-    /// FRAMED as an input box: an adjacent box-border row, or the agent's mode-status footer just below it.
-    ///
-    /// The framing requirement is what closes the "bare &gt; row" hole (B1): a menu selection like
-    /// "&gt; production" under "Choose a deployment:" has no input-box frame, so it is NOT a composer and the
-    /// classifier falls through to Blocked. Public so a test can assert both the positive and the blocked edges.
+    /// POSITIVE composer identification (issue #1777): the cursor's row is the agent's input-prompt line -
+    /// after stripping the box edge it begins with a single "&gt;" prompt marker (not "&gt;&gt;", the mode-cycle
+    /// arrow) - the cursor column is WITHIN the editable input span (at or after the prompt, and left of the
+    /// closing box border), AND the line is FRAMED as an input box (an adjacent box-border row, or the agent's
+    /// mode-status footer just below). Note: this alone is NOT enough to type - the classifier also requires the
+    /// cursor to be VISIBLE and no menu on the grid. Public so a test can assert the input-span edges directly.
     /// </summary>
     public static bool LooksLikePlainTextPrompt(IReadOnlyList<string> rows, int cursorRow, int cursorCol)
-    {
-        if (rows is null || cursorRow < 0 || cursorRow >= rows.Count) return false;
-        return CursorInComposer(rows, cursorRow, cursorCol);
-    }
+        => rows is not null && cursorRow >= 0 && cursorRow < rows.Count && CursorInComposer(rows, cursorRow, cursorCol);
 
     private static bool CursorInComposer(IReadOnlyList<string> rows, int cursorRow, int cursorCol)
     {
@@ -89,13 +84,26 @@ public static class WaitingScreenClassifier
         if (first >= line.Length || line[first] != '>') return false;
         if (first + 1 < line.Length && line[first + 1] == '>') return false; // ">>" is the mode-cycle arrow
 
-        // The editable input begins just after "> " (or after a bare ">"). The cursor must sit at or after it -
-        // "the cursor sitting after the prompt inside it".
+        // The editable input begins just after "> " (or after a bare ">"). The cursor must sit within the input
+        // span: at or after the input start (so a hidden/stale CursorCol=-1 fails), and strictly left of the
+        // closing box border if there is one (so a right-border / off-target cursor fails). Both bounds matter
+        // (issue #1777, finding 2).
         var inputStart = (first + 1 < line.Length && line[first + 1] == ' ') ? first + 2 : first + 1;
         if (cursorCol < inputStart) return false;
+        var rightBorder = RightBorderColumn(line);
+        if (rightBorder >= 0 && cursorCol >= rightBorder) return false;
 
         // Positively framed as an input box: a box-border row adjacent, or the mode-status footer just below.
         return HasAdjacentBorder(rows, cursorRow) || HasModeStatusBelow(rows, cursorRow);
+    }
+
+    /// <summary>The column of the closing box border on a row (the trailing <c>│</c>), or -1 when the row has
+    /// no right border. Used as the upper bound of the composer input span.</summary>
+    private static int RightBorderColumn(string line)
+    {
+        var c = line.Length - 1;
+        while (c >= 0 && (line[c] == ' ' || line[c] == '\t' || line[c] == '\r')) c--;
+        return c >= 0 && System.Array.IndexOf(VerticalBorder, line[c]) >= 0 ? c : -1;
     }
 
     private static bool HasAdjacentBorder(IReadOnlyList<string> rows, int row)
@@ -109,14 +117,13 @@ public static class WaitingScreenClassifier
         foreach (var c in row)
         {
             if (c == ' ' || c == '\t' || c == '\r') continue;
-            if (System.Array.IndexOf(BoxEdge, c) < 0) return false; // a non-edge glyph -> this is content, not a border
+            if (System.Array.IndexOf(BoxEdge, c) < 0) return false; // a non-edge glyph -> content, not a border
             sawEdge = true;
         }
         return sawEdge;
     }
 
-    /// <summary>The agent's mode-status footer (Claude Code renders it directly below the composer box).
-    /// Its presence just below the cursor line is a strong positive "this is the bottom composer" signal.</summary>
+    /// <summary>The agent's mode-status footer (Claude Code renders it directly below the composer box).</summary>
     private static bool HasModeStatusBelow(IReadOnlyList<string> rows, int row)
     {
         var end = Math.Min(rows.Count - 1, row + 3);
@@ -134,8 +141,6 @@ public static class WaitingScreenClassifier
         "bypass permissions", "plan mode", "accept edits", "shift+tab to cycle", "? for shortcuts",
     };
 
-    /// <summary>Box-drawing glyphs and pipes framing the input box, plus whitespace, stripped from a line's
-    /// leading edge before looking for the prompt marker.</summary>
     private static readonly char[] BorderOrSpace =
     {
         '│','┃','┆','┇','┊','┋','╎','╏','║',
@@ -148,4 +153,7 @@ public static class WaitingScreenClassifier
     {
         '─','━','═','┄','┅','┈','┉','╭','╮','╰','╯','┌','┐','└','┘','╔','╗','╚','╝','│','║','|',
     };
+
+    /// <summary>Vertical box borders that frame the right edge of an input box.</summary>
+    private static readonly char[] VerticalBorder = { '│','┃','║','|' };
 }

--- a/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
+++ b/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
@@ -1,110 +1,151 @@
 namespace CcDirector.Gateway.Wingman;
 
 /// <summary>
-/// What a session's live waiting screen is, decided PURELY from the resolved grid (issue #1777). This is
-/// the fail-closed floor: the spoken words may be typed as an ordinary prompt ONLY when the screen is
-/// positively a plain-text composer. Everything the classifier is not sure about is <see cref="Blocked"/> -
-/// "not a recognized menu" must never collapse into "confident plain text", which was the original defect.
+/// What a session's live waiting screen is, decided from WHERE THE CURSOR IS (issue #1777). This is the
+/// fail-closed floor: the spoken words may be typed as an ordinary prompt ONLY when the cursor is positively
+/// inside the agent's composer input box. Everything the classifier is not sure about is
+/// <see cref="Blocked"/> - "not a recognized menu" must never collapse into "confident plain text".
 /// </summary>
 public enum WaitingScreenKind
 {
-    /// <summary>The live grid carries a menu fingerprint. The caller extracts it (brain) off the LIVE grid.</summary>
+    /// <summary>The selection cursor sits on a menu option. The caller extracts the menu (brain) off the LIVE grid.</summary>
     Menu,
 
-    /// <summary>The primary screen positively shows the agent's composer/input line with the cursor at it.</summary>
+    /// <summary>The cursor is positively inside the agent's composer input box - the spoken words go there.</summary>
     PlainText,
 
-    /// <summary>Unreadable, blank, an unrecognized alternate-screen app, or anything uncertain: never type.</summary>
+    /// <summary>Unreadable, blank, an ambiguous input, or anything the cursor does not positively resolve: never type.</summary>
     Blocked,
 }
 
 /// <summary>
-/// The pure (no-brain) waiting-screen classifier. It reads ONLY the live grid rows, the live cursor cell,
-/// and the alternate-screen flag - never the scrollback - and decides whether the caller may type. It is
-/// deliberately conservative: it emits <see cref="WaitingScreenKind.PlainText"/> only on a POSITIVE signal
-/// (a primary-screen composer input line with the cursor sitting on it) and everything else - a blank grid,
-/// an alternate-screen app we did not recognize as a menu, a primary screen with no composer - is
-/// <see cref="WaitingScreenKind.Blocked"/>. That is what makes it agent-uniform: an unrecognized menu (a
-/// styled picker, a non-Claude TUI) fails closed instead of being typed into.
+/// The pure (no-brain) waiting-screen classifier, ANCHORED TO THE CURSOR (issue #1777, round-3). Text
+/// fingerprints alone cannot tell a live composer from a menu selection marker (both can read "&gt; x"), nor a
+/// live composer from an already-answered menu still visible above it - the cursor can. So the verdict is:
+///   - the cursor is positively inside the agent's composer input box  -> PlainText (type there; any menu-like
+///     text elsewhere on the grid is stale and ignored);
+///   - the cursor is on a menu option of a live menu                   -> Menu (the caller extracts + presses);
+///   - anything else (a bare "&gt;" row with no input-box frame, an ambiguous picker, an unreadable or blank
+///     grid, a cursor resolving to neither)                            -> Blocked.
+/// A bare row starting with "&gt;" is NOT a composer: the composer is positively identified as a framed input
+/// box (box border or the agent's mode-status footer) with the cursor sitting after the prompt inside it. This
+/// is what makes it agent-uniform: an unrecognized picker fails closed instead of being typed into.
 /// </summary>
 public static class WaitingScreenClassifier
 {
-    /// <summary>Classify the live waiting screen. <paramref name="hasGrid"/> is false for an Embedded session
-    /// with no server-side parser (unreadable). A <see cref="WaitingScreenKind.Menu"/> result means the grid
-    /// carries a menu fingerprint - the caller still has to extract pressable options off the LIVE grid and
-    /// must fail closed if it cannot.</summary>
+    /// <summary>Classify the live waiting screen from the grid and the cursor cell. <paramref name="hasGrid"/>
+    /// is false for an Embedded session with no server-side parser (unreadable). A <see cref="WaitingScreenKind.Menu"/>
+    /// result means the cursor is on an option of a live menu - the caller still has to extract pressable
+    /// options off the LIVE grid and must fail closed if it cannot.</summary>
     public static WaitingScreenKind Classify(
-        IReadOnlyList<string>? rows, int cursorRow, int cursorCol, bool isAlternateScreen, bool hasGrid)
+        IReadOnlyList<string>? rows, int cursorRow, int cursorCol, bool hasGrid)
     {
         // Unreadable: no resolved grid, or nothing on it.
         if (!hasGrid || rows is null || rows.Count == 0) return WaitingScreenKind.Blocked;
 
-        // A blank / all-whitespace grid tells us nothing - never type into it (finding 1).
+        // A blank / all-whitespace grid tells us nothing - never type into it.
         if (rows.All(string.IsNullOrWhiteSpace)) return WaitingScreenKind.Blocked;
 
-        // A menu fingerprint on the LIVE grid is authoritative - the caller extracts it (off the live grid).
-        if (WingmanMenuLogic.LiveScreenLooksLikeMenu(rows)) return WaitingScreenKind.Menu;
+        // No usable cursor anchor -> we cannot say WHERE the interaction is, so fail closed.
+        if (cursorRow < 0 || cursorRow >= rows.Count) return WaitingScreenKind.Blocked;
 
-        // On the alternate screen and NOT recognized as a menu: a full-screen app is showing something we
-        // cannot parse. Never type into it (finding 1). This is the agent-uniform fail-closed case.
-        if (isAlternateScreen) return WaitingScreenKind.Blocked;
+        // 1) The cursor positively inside the agent's composer input box -> the spoken words go THERE. A stale
+        //    menu still visible elsewhere on the grid does not matter: the cursor is in the composer.
+        if (CursorInComposer(rows, cursorRow, cursorCol)) return WaitingScreenKind.PlainText;
 
-        // Primary screen: type ONLY on a positive plain-text signal - the agent's composer input line with
-        // the cursor sitting on it. When that is absent we are unsure, so we block.
-        return LooksLikePlainTextPrompt(rows, cursorRow, cursorCol)
-            ? WaitingScreenKind.PlainText
-            : WaitingScreenKind.Blocked;
+        // 2) A menu owns the turn ONLY when the selection cursor is on a menu option AND the screen is a menu.
+        if (WingmanMenuLogic.IsOptionLine(rows[cursorRow]) && WingmanMenuLogic.LiveScreenLooksLikeMenu(rows))
+            return WaitingScreenKind.Menu;
+
+        // 3) The cursor resolves to neither a composer nor a menu option - ambiguous interactive UI. Fail closed.
+        return WaitingScreenKind.Blocked;
     }
 
     /// <summary>
-    /// The POSITIVE plain-text signal (finding 1): the grid shows an agent composer/input-prompt line - a
-    /// line whose first non-border, non-space character is a single "&gt;" prompt marker (not "&gt;&gt;", the
-    /// mode-cycle arrow) - AND the live cursor is sitting on that line. Requiring the cursor ON the composer
-    /// line is what distinguishes "waiting for me to type" from a stray "&gt;" somewhere on screen, and it is
-    /// the agent-uniform reading of "the composer with the cursor at it".
+    /// POSITIVE composer identification (issue #1777, round-3): the cursor is inside the agent's composer input
+    /// box. That means the cursor's row is the agent's input-prompt line - after stripping the box edge it
+    /// begins with a single "&gt;" prompt marker (not "&gt;&gt;", the mode-cycle arrow) - the cursor is sitting
+    /// AT OR AFTER the prompt (inside the editable input, using <paramref name="cursorCol"/>), AND the line is
+    /// FRAMED as an input box: an adjacent box-border row, or the agent's mode-status footer just below it.
     ///
-    /// Conservative on purpose: a wrapped multi-line entry parks the cursor on a continuation row, not the
-    /// "&gt;" row, so this returns false and the caller fails closed (tells the person to look at the
-    /// terminal) rather than typing into an ambiguous state. That is the safe direction for this phase.
-    /// Public so a test can assert both the positive and the blocked edges directly.
+    /// The framing requirement is what closes the "bare &gt; row" hole (B1): a menu selection like
+    /// "&gt; production" under "Choose a deployment:" has no input-box frame, so it is NOT a composer and the
+    /// classifier falls through to Blocked. Public so a test can assert both the positive and the blocked edges.
     /// </summary>
     public static bool LooksLikePlainTextPrompt(IReadOnlyList<string> rows, int cursorRow, int cursorCol)
     {
-        if (rows is null || rows.Count == 0) return false;
-        // The composer sits at the bottom of the frame; only look there.
-        var start = Math.Max(0, rows.Count - 15);
-        for (var i = rows.Count - 1; i >= start; i--)
+        if (rows is null || cursorRow < 0 || cursorRow >= rows.Count) return false;
+        return CursorInComposer(rows, cursorRow, cursorCol);
+    }
+
+    private static bool CursorInComposer(IReadOnlyList<string> rows, int cursorRow, int cursorCol)
+    {
+        var line = rows[cursorRow];
+        if (string.IsNullOrWhiteSpace(line)) return false;
+
+        // The first non-border, non-space column is the prompt marker.
+        var first = 0;
+        while (first < line.Length && System.Array.IndexOf(BorderOrSpace, line[first]) >= 0) first++;
+        if (first >= line.Length || line[first] != '>') return false;
+        if (first + 1 < line.Length && line[first + 1] == '>') return false; // ">>" is the mode-cycle arrow
+
+        // The editable input begins just after "> " (or after a bare ">"). The cursor must sit at or after it -
+        // "the cursor sitting after the prompt inside it".
+        var inputStart = (first + 1 < line.Length && line[first + 1] == ' ') ? first + 2 : first + 1;
+        if (cursorCol < inputStart) return false;
+
+        // Positively framed as an input box: a box-border row adjacent, or the mode-status footer just below.
+        return HasAdjacentBorder(rows, cursorRow) || HasModeStatusBelow(rows, cursorRow);
+    }
+
+    private static bool HasAdjacentBorder(IReadOnlyList<string> rows, int row)
+        => (row - 1 >= 0 && IsBoxBorderRow(rows[row - 1])) || (row + 1 < rows.Count && IsBoxBorderRow(rows[row + 1]));
+
+    /// <summary>A row that is only box-drawing horizontal edge (a top/bottom border of the input box).</summary>
+    private static bool IsBoxBorderRow(string? row)
+    {
+        if (string.IsNullOrWhiteSpace(row)) return false;
+        var sawEdge = false;
+        foreach (var c in row)
         {
-            if (!IsComposerPromptLine(rows[i])) continue;
-            // The cursor must be on the composer line - the positive "with the cursor at it" signal.
-            return cursorRow == i;
+            if (c == ' ' || c == '\t' || c == '\r') continue;
+            if (System.Array.IndexOf(BoxEdge, c) < 0) return false; // a non-edge glyph -> this is content, not a border
+            sawEdge = true;
+        }
+        return sawEdge;
+    }
+
+    /// <summary>The agent's mode-status footer (Claude Code renders it directly below the composer box).
+    /// Its presence just below the cursor line is a strong positive "this is the bottom composer" signal.</summary>
+    private static bool HasModeStatusBelow(IReadOnlyList<string> rows, int row)
+    {
+        var end = Math.Min(rows.Count - 1, row + 3);
+        for (var i = row + 1; i <= end; i++)
+        {
+            var lower = (rows[i] ?? "").ToLowerInvariant();
+            foreach (var anchor in ModeStatusAnchors)
+                if (lower.Contains(anchor)) return true;
         }
         return false;
     }
 
-    /// <summary>Box-drawing glyphs and pipes an agent uses to frame its input box, plus whitespace, stripped
-    /// from the line edges before looking for the prompt marker (so "│ &gt; text │" reads as "&gt; text").</summary>
+    private static readonly string[] ModeStatusAnchors =
+    {
+        "bypass permissions", "plan mode", "accept edits", "shift+tab to cycle", "? for shortcuts",
+    };
+
+    /// <summary>Box-drawing glyphs and pipes framing the input box, plus whitespace, stripped from a line's
+    /// leading edge before looking for the prompt marker.</summary>
     private static readonly char[] BorderOrSpace =
     {
         '│','┃','┆','┇','┊','┋','╎','╏','║',
         '╭','╮','╰','╯','┌','┐','└','┘','╔','╗','╚','╝',
-        '─','━','═','┄','┅','┈','┉',
-        '|',
-        ' ','\t','\r',
+        '─','━','═','┄','┅','┈','┉','|',' ','\t','\r',
     };
 
-    /// <summary>True when the row is an agent composer input-prompt line: after stripping leading border and
-    /// whitespace, the first character is a single "&gt;" prompt marker (a bare "&gt;" empty box, or "&gt; "
-    /// followed by text), but NOT "&gt;&gt;" (the mode-cycle arrow Claude Code renders below the box).</summary>
-    private static bool IsComposerPromptLine(string? row)
+    /// <summary>Glyphs that may appear in a pure box-border row (a top/bottom edge of the input box).</summary>
+    private static readonly char[] BoxEdge =
     {
-        if (string.IsNullOrWhiteSpace(row)) return false;
-        var first = 0;
-        while (first < row.Length && System.Array.IndexOf(BorderOrSpace, row[first]) >= 0) first++;
-        if (first >= row.Length || row[first] != '>') return false;
-        // ">> ..." is the mode-cycle arrow, not the input prompt.
-        if (first + 1 < row.Length && row[first + 1] == '>') return false;
-        // A bare ">" (empty box) or "> " (a space, then optional text) is the composer prompt.
-        return first + 1 == row.Length || row[first + 1] == ' ';
-    }
+        '─','━','═','┄','┅','┈','┉','╭','╮','╰','╯','┌','┐','└','┘','╔','╗','╚','╝','│','║','|',
+    };
 }

--- a/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
+++ b/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
@@ -58,7 +58,10 @@ public static class WaitingScreenClassifier
         // Both present is ambiguous (a stale menu above a live composer, or vice versa) - fail closed.
         if (hasMenu && hasComposer) return WaitingScreenKind.Blocked;
         if (hasMenu) return WaitingScreenKind.Menu;
-        if (hasComposer) return WaitingScreenKind.PlainText;
+        // TYPING is allowed only on a composer with NO menu-ish structure ANYWHERE on the grid (issue #1777,
+        // floor rescope, finding 3): a numbered/lettered option line, a drawn selection marker, or a
+        // choose/select/proceed/pick prompt all block typing, even next to a live composer. When in doubt, block.
+        if (hasComposer && !HasMenuishStructure(rows)) return WaitingScreenKind.PlainText;
         return WaitingScreenKind.Blocked;
     }
 
@@ -72,6 +75,35 @@ public static class WaitingScreenClassifier
     /// </summary>
     public static bool LooksLikePlainTextPrompt(IReadOnlyList<string> rows, int cursorRow, int cursorCol)
         => rows is not null && cursorRow >= 0 && cursorRow < rows.Count && CursorInComposer(rows, cursorRow, cursorCol);
+
+    /// <summary>
+    /// Any menu-ish structure ANYWHERE on the grid (issue #1777, floor rescope): a numbered/lettered option
+    /// line, a drawn <c>❯</c>/<c>&gt;</c> selection marker on an option, or a menu-prompt phrase
+    /// ("choose", "select", "do you want to proceed", "pick one/a", "which option/one"). Typing is refused when
+    /// any of these is present - a bordered "&gt; production" under "Choose a deployment:" must block, not type.
+    /// This is deliberately conservative (an ordinary numbered list in the reply also blocks); on this floor
+    /// branch the spoken words are only ever typed onto an unambiguous plain-text composer. Public so a test
+    /// can assert it directly.
+    /// </summary>
+    public static bool HasMenuishStructure(IReadOnlyList<string>? rows)
+    {
+        if (rows is null) return false;
+        foreach (var row in rows)
+        {
+            if (string.IsNullOrWhiteSpace(row)) continue;
+            if (WingmanMenuLogic.IsOptionLine(row)) return true;
+            if (WingmanMenuLogic.IsSelectedOptionLine(row)) return true;
+            var lower = row.ToLowerInvariant();
+            foreach (var phrase in MenuPromptPhrases)
+                if (lower.Contains(phrase)) return true;
+        }
+        return false;
+    }
+
+    private static readonly string[] MenuPromptPhrases =
+    {
+        "do you want to proceed", "choose", "select ", "pick one", "pick a ", "which option", "which one",
+    };
 
     private static bool CursorInComposer(IReadOnlyList<string> rows, int cursorRow, int cursorCol)
     {

--- a/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
+++ b/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
@@ -58,10 +58,12 @@ public static class WaitingScreenClassifier
         // Both present is ambiguous (a stale menu above a live composer, or vice versa) - fail closed.
         if (hasMenu && hasComposer) return WaitingScreenKind.Blocked;
         if (hasMenu) return WaitingScreenKind.Menu;
-        // TYPING is allowed only on a composer with NO menu-ish structure ANYWHERE on the grid (issue #1777,
-        // floor rescope, finding 3): a numbered/lettered option line, a drawn selection marker, or a
-        // choose/select/proceed/pick prompt all block typing, even next to a live composer. When in doubt, block.
-        if (hasComposer && !HasMenuishStructure(rows)) return WaitingScreenKind.PlainText;
+        // TYPING is allowed only on a composer with NO menu-ish structure ANYWHERE ELSE on the grid (issue
+        // #1777): a numbered/lettered option line, a drawn selection marker, a bare-marker selector label, or a
+        // pick/choose/select/proceed prompt all block typing. The confident composer line itself is excluded
+        // from this scan (it is a "> <typed text>" line and would otherwise trip the bare-marker rule); a stale
+        // selector on any OTHER row still blocks. When in doubt, block.
+        if (hasComposer && !HasMenuishStructure(rows, excludeRow: cursorRow)) return WaitingScreenKind.PlainText;
         return WaitingScreenKind.Blocked;
     }
 
@@ -77,33 +79,60 @@ public static class WaitingScreenClassifier
         => rows is not null && cursorRow >= 0 && cursorRow < rows.Count && CursorInComposer(rows, cursorRow, cursorCol);
 
     /// <summary>
-    /// Any menu-ish structure ANYWHERE on the grid (issue #1777, floor rescope): a numbered/lettered option
-    /// line, a drawn <c>❯</c>/<c>&gt;</c> selection marker on an option, or a menu-prompt phrase
-    /// ("choose", "select", "do you want to proceed", "pick one/a", "which option/one"). Typing is refused when
-    /// any of these is present - a bordered "&gt; production" under "Choose a deployment:" must block, not type.
-    /// This is deliberately conservative (an ordinary numbered list in the reply also blocks); on this floor
-    /// branch the spoken words are only ever typed onto an unambiguous plain-text composer. Public so a test
-    /// can assert it directly.
+    /// Any menu-ish structure on the grid (issue #1777): a numbered/lettered option line, a drawn selection
+    /// marker on an option, a bare <c>❯</c>/<c>&gt;</c> selector label (a marker followed by a non-numbered
+    /// label - "&gt; production"), or a pick/choose/select/proceed prompt (a line ending in ':' or '?' naming
+    /// one of those). Typing is refused when any is present. <paramref name="excludeRow"/> is the confident
+    /// composer's own row, skipped so a legitimate "&gt; typed text" composer line does not trip the
+    /// bare-marker rule; a stale selector on any OTHER row still blocks. Deliberately conservative (an ordinary
+    /// numbered list also blocks) - the floor types only onto an unambiguous composer. Public so a test can
+    /// assert it directly.
     /// </summary>
-    public static bool HasMenuishStructure(IReadOnlyList<string>? rows)
+    public static bool HasMenuishStructure(IReadOnlyList<string>? rows, int excludeRow = -1)
     {
         if (rows is null) return false;
-        foreach (var row in rows)
+        for (var i = 0; i < rows.Count; i++)
         {
+            if (i == excludeRow) continue;
+            var row = rows[i];
             if (string.IsNullOrWhiteSpace(row)) continue;
             if (WingmanMenuLogic.IsOptionLine(row)) return true;
             if (WingmanMenuLogic.IsSelectedOptionLine(row)) return true;
-            var lower = row.ToLowerInvariant();
-            foreach (var phrase in MenuPromptPhrases)
-                if (lower.Contains(phrase)) return true;
+            if (IsBareMarkerLabel(row)) return true;
+            if (IsPickPrompt(row)) return true;
         }
         return false;
     }
 
-    private static readonly string[] MenuPromptPhrases =
+    /// <summary>A bare selector label: after the box edge, a single <c>&gt;</c>/<c>❯</c> marker then a space
+    /// then a NON-numbered label ("&gt; production", "❯ deploy to prod") - a drawn selection, not a composer.
+    /// A bare "&gt;" with no label (an empty composer) and a numbered option ("&gt; 1. Yes", caught elsewhere)
+    /// are not this.</summary>
+    private static bool IsBareMarkerLabel(string row)
     {
-        "do you want to proceed", "choose", "select ", "pick one", "pick a ", "which option", "which one",
-    };
+        var t = row.TrimStart(BorderOrSpace);
+        if (t.Length == 0) return false;
+        if (t[0] != '>' && t[0] != '❯') return false;
+        if (t.Length >= 2 && t[1] == '>') return false;                 // ">>" mode arrow
+        var rest = t[1..].TrimStart();
+        if (rest.Length == 0) return false;                             // bare marker, empty input -> composer
+        if (WingmanMenuLogic.IsOptionLine(rest)) return false;          // "> 1. Yes" is a numbered option, handled elsewhere
+        return true;                                                    // a marker with a non-numbered label
+    }
+
+    /// <summary>A menu prompt line: it ends in ':' or '?' and names a pick/choose/select/proceed action
+    /// ("Pick environment:", "Choose a deployment:", "Select an option:", "Proceed?"). The terminator keeps an
+    /// ordinary sentence that merely uses the word ("I'll select the rows.") from tripping it.</summary>
+    private static bool IsPickPrompt(string row)
+    {
+        var trimmed = row.TrimEnd();
+        if (trimmed.Length == 0) return false;
+        var last = trimmed[^1];
+        if (last != ':' && last != '?') return false;
+        var lower = trimmed.ToLowerInvariant();
+        return lower.Contains("pick") || lower.Contains("choose") || lower.Contains("select")
+            || lower.Contains("proceed") || lower.Contains("which option") || lower.Contains("which one");
+    }
 
     private static bool CursorInComposer(IReadOnlyList<string> rows, int cursorRow, int cursorCol)
     {
@@ -116,14 +145,24 @@ public static class WaitingScreenClassifier
         if (first >= line.Length || line[first] != '>') return false;
         if (first + 1 < line.Length && line[first + 1] == '>') return false; // ">>" is the mode-cycle arrow
 
-        // The editable input begins just after "> " (or after a bare ">"). The cursor must sit within the input
-        // span: at or after the input start (so a hidden/stale CursorCol=-1 fails), and strictly left of the
-        // closing box border if there is one (so a right-border / off-target cursor fails). Both bounds matter
-        // (issue #1777, finding 2).
+        // THE COMPOSER INVARIANT (issue #1777, final tighten): a real text composer has the visible cursor at
+        // the INSERTION POINT - it TRAILS the input, right after the last non-space character the user typed, or
+        // right after "> " when the input is empty. A "> production" SELECTION line instead has its marker at
+        // the start and a drawn label after it, with the cursor at the marker, NOT trailing typed text. So the
+        // cursor must sit EXACTLY at the trailing edge of the input content; anything else (a hidden/stale -1, a
+        // cursor at the marker or mid-label, a cursor past the input or on the border) is not a composer. This
+        // is one bound that closes BOTH the "> label selector" hole and the "no right border, cursor unbounded"
+        // hole - the column is bounded on both sides, always.
         var inputStart = (first + 1 < line.Length && line[first + 1] == ' ') ? first + 2 : first + 1;
-        if (cursorCol < inputStart) return false;
         var rightBorder = RightBorderColumn(line);
-        if (rightBorder >= 0 && cursorCol >= rightBorder) return false;
+        var scanEnd = rightBorder >= 0 ? rightBorder : line.Length;   // the input span is [inputStart, scanEnd)
+        var lastContent = inputStart - 1;
+        for (var c = Math.Min(scanEnd, line.Length) - 1; c >= inputStart; c--)
+        {
+            if (line[c] != ' ' && line[c] != '\t' && line[c] != '\r') { lastContent = c; break; }
+        }
+        var insertionPoint = lastContent + 1;   // right after the last typed char, or == inputStart when empty
+        if (cursorCol != insertionPoint) return false;
 
         // Positively framed as an input box: a box-border row adjacent, or the mode-status footer just below.
         return HasAdjacentBorder(rows, cursorRow) || HasModeStatusBelow(rows, cursorRow);

--- a/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
+++ b/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
@@ -161,8 +161,16 @@ public static class WaitingScreenClassifier
         {
             if (line[c] != ' ' && line[c] != '\t' && line[c] != '\r') { lastContent = c; break; }
         }
+        var emptyInput = lastContent < inputStart;
         var insertionPoint = lastContent + 1;   // right after the last typed char, or == inputStart when empty
-        if (cursorCol != insertionPoint) return false;
+        if (cursorCol == insertionPoint) { /* the trailing insertion point - a confident composer */ }
+        // Account for TRAILING-TRIMMED rows (issue #1777): ScreenGridResponse rows are trailing-trimmed, so a
+        // footer-only EMPTY "> " composer arrives as ">" - the trimmed space is gone, so the visible cursor sits
+        // one column PAST the marker, at the true input column. Accept that only for an empty composer with no
+        // right border. A "> label" selector keeps its non-space label (never empty here), so this never
+        // loosens the selector rejection - a cursor not at the trailing edge of a labelled line still fails.
+        else if (emptyInput && rightBorder < 0 && cursorCol == insertionPoint + 1) { /* trimmed "> " space */ }
+        else return false;
 
         // Positively framed as an input box: a box-border row adjacent, or the mode-status footer just below.
         return HasAdjacentBorder(rows, cursorRow) || HasModeStatusBelow(rows, cursorRow);

--- a/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
+++ b/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
@@ -1,0 +1,110 @@
+namespace CcDirector.Gateway.Wingman;
+
+/// <summary>
+/// What a session's live waiting screen is, decided PURELY from the resolved grid (issue #1777). This is
+/// the fail-closed floor: the spoken words may be typed as an ordinary prompt ONLY when the screen is
+/// positively a plain-text composer. Everything the classifier is not sure about is <see cref="Blocked"/> -
+/// "not a recognized menu" must never collapse into "confident plain text", which was the original defect.
+/// </summary>
+public enum WaitingScreenKind
+{
+    /// <summary>The live grid carries a menu fingerprint. The caller extracts it (brain) off the LIVE grid.</summary>
+    Menu,
+
+    /// <summary>The primary screen positively shows the agent's composer/input line with the cursor at it.</summary>
+    PlainText,
+
+    /// <summary>Unreadable, blank, an unrecognized alternate-screen app, or anything uncertain: never type.</summary>
+    Blocked,
+}
+
+/// <summary>
+/// The pure (no-brain) waiting-screen classifier. It reads ONLY the live grid rows, the live cursor cell,
+/// and the alternate-screen flag - never the scrollback - and decides whether the caller may type. It is
+/// deliberately conservative: it emits <see cref="WaitingScreenKind.PlainText"/> only on a POSITIVE signal
+/// (a primary-screen composer input line with the cursor sitting on it) and everything else - a blank grid,
+/// an alternate-screen app we did not recognize as a menu, a primary screen with no composer - is
+/// <see cref="WaitingScreenKind.Blocked"/>. That is what makes it agent-uniform: an unrecognized menu (a
+/// styled picker, a non-Claude TUI) fails closed instead of being typed into.
+/// </summary>
+public static class WaitingScreenClassifier
+{
+    /// <summary>Classify the live waiting screen. <paramref name="hasGrid"/> is false for an Embedded session
+    /// with no server-side parser (unreadable). A <see cref="WaitingScreenKind.Menu"/> result means the grid
+    /// carries a menu fingerprint - the caller still has to extract pressable options off the LIVE grid and
+    /// must fail closed if it cannot.</summary>
+    public static WaitingScreenKind Classify(
+        IReadOnlyList<string>? rows, int cursorRow, int cursorCol, bool isAlternateScreen, bool hasGrid)
+    {
+        // Unreadable: no resolved grid, or nothing on it.
+        if (!hasGrid || rows is null || rows.Count == 0) return WaitingScreenKind.Blocked;
+
+        // A blank / all-whitespace grid tells us nothing - never type into it (finding 1).
+        if (rows.All(string.IsNullOrWhiteSpace)) return WaitingScreenKind.Blocked;
+
+        // A menu fingerprint on the LIVE grid is authoritative - the caller extracts it (off the live grid).
+        if (WingmanMenuLogic.LiveScreenLooksLikeMenu(rows)) return WaitingScreenKind.Menu;
+
+        // On the alternate screen and NOT recognized as a menu: a full-screen app is showing something we
+        // cannot parse. Never type into it (finding 1). This is the agent-uniform fail-closed case.
+        if (isAlternateScreen) return WaitingScreenKind.Blocked;
+
+        // Primary screen: type ONLY on a positive plain-text signal - the agent's composer input line with
+        // the cursor sitting on it. When that is absent we are unsure, so we block.
+        return LooksLikePlainTextPrompt(rows, cursorRow, cursorCol)
+            ? WaitingScreenKind.PlainText
+            : WaitingScreenKind.Blocked;
+    }
+
+    /// <summary>
+    /// The POSITIVE plain-text signal (finding 1): the grid shows an agent composer/input-prompt line - a
+    /// line whose first non-border, non-space character is a single "&gt;" prompt marker (not "&gt;&gt;", the
+    /// mode-cycle arrow) - AND the live cursor is sitting on that line. Requiring the cursor ON the composer
+    /// line is what distinguishes "waiting for me to type" from a stray "&gt;" somewhere on screen, and it is
+    /// the agent-uniform reading of "the composer with the cursor at it".
+    ///
+    /// Conservative on purpose: a wrapped multi-line entry parks the cursor on a continuation row, not the
+    /// "&gt;" row, so this returns false and the caller fails closed (tells the person to look at the
+    /// terminal) rather than typing into an ambiguous state. That is the safe direction for this phase.
+    /// Public so a test can assert both the positive and the blocked edges directly.
+    /// </summary>
+    public static bool LooksLikePlainTextPrompt(IReadOnlyList<string> rows, int cursorRow, int cursorCol)
+    {
+        if (rows is null || rows.Count == 0) return false;
+        // The composer sits at the bottom of the frame; only look there.
+        var start = Math.Max(0, rows.Count - 15);
+        for (var i = rows.Count - 1; i >= start; i--)
+        {
+            if (!IsComposerPromptLine(rows[i])) continue;
+            // The cursor must be on the composer line - the positive "with the cursor at it" signal.
+            return cursorRow == i;
+        }
+        return false;
+    }
+
+    /// <summary>Box-drawing glyphs and pipes an agent uses to frame its input box, plus whitespace, stripped
+    /// from the line edges before looking for the prompt marker (so "│ &gt; text │" reads as "&gt; text").</summary>
+    private static readonly char[] BorderOrSpace =
+    {
+        '│','┃','┆','┇','┊','┋','╎','╏','║',
+        '╭','╮','╰','╯','┌','┐','└','┘','╔','╗','╚','╝',
+        '─','━','═','┄','┅','┈','┉',
+        '|',
+        ' ','\t','\r',
+    };
+
+    /// <summary>True when the row is an agent composer input-prompt line: after stripping leading border and
+    /// whitespace, the first character is a single "&gt;" prompt marker (a bare "&gt;" empty box, or "&gt; "
+    /// followed by text), but NOT "&gt;&gt;" (the mode-cycle arrow Claude Code renders below the box).</summary>
+    private static bool IsComposerPromptLine(string? row)
+    {
+        if (string.IsNullOrWhiteSpace(row)) return false;
+        var first = 0;
+        while (first < row.Length && System.Array.IndexOf(BorderOrSpace, row[first]) >= 0) first++;
+        if (first >= row.Length || row[first] != '>') return false;
+        // ">> ..." is the mode-cycle arrow, not the input prompt.
+        if (first + 1 < row.Length && row[first + 1] == '>') return false;
+        // A bare ">" (empty box) or "> " (a space, then optional text) is the composer prompt.
+        return first + 1 == row.Length || row[first + 1] == ' ';
+    }
+}

--- a/src/CcDirector.Gateway/Wingman/WingmanMenu.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanMenu.cs
@@ -104,26 +104,73 @@ public static class WingmanMenuLogic
         return LooksLikeMenu(string.Join("\n", rows));
     }
 
+    /// <summary>True when a row is a menu option / selection line (a leading marker run - a box edge, a
+    /// selection arrow like <c>❯</c> or <c>&gt;</c>, whitespace - then a number or letter, a <c>.</c> or
+    /// <c>)</c>, a space, and content). This is the same shape <see cref="LooksLikeMenu"/> counts; exposed so
+    /// the cursor-anchored classifier can ask "is the CURSOR sitting on an option row?" rather than deciding
+    /// from menu-like text anywhere on the grid.</summary>
+    public static bool IsOptionLine(string? row)
+        => !string.IsNullOrWhiteSpace(row) && OptionLine.IsMatch(row.Trim());
+
     /// <summary>
-    /// Re-verify a menu is STILL on the live screen (issue #1777, finding 3): every extracted option's visible
-    /// label must still appear on the given live grid rows. Used as the cheap TOCTOU guard right before
-    /// pressing an option's keystrokes - if the menu has closed or changed, the labels are gone and this
-    /// returns false so the caller does not press selection bytes into whatever replaced it. A menu with no
-    /// options is not "present". Normalizes both sides (lowercase, punctuation to spaces) so box padding and
-    /// spacing differences do not cause a false miss.
+    /// Re-verify the SAME menu is still on the live screen (issue #1777, finding B3), by comparing the CAPTURED
+    /// menu block (the question line plus the full option set, as they were when the menu was read) to the menu
+    /// block on the freshly re-read grid. Substring-of-labels is NOT enough: a replacement menu with the same
+    /// option labels but a different question ("Delete production?" -> "Deploy production?") must fail this, so
+    /// the whole block is compared, not just the labels. Returns false if either block is empty or they differ,
+    /// so the caller presses nothing when the menu changed or closed.
     /// </summary>
-    public static bool MenuOptionsPresentOnScreen(WingmanMenu? menu, IReadOnlyList<string>? rows)
+    public static bool SameMenuStillOnScreen(IReadOnlyList<string>? capturedRows, IReadOnlyList<string>? freshRows)
     {
-        if (menu?.Options is null || menu.Options.Count == 0 || rows is null || rows.Count == 0) return false;
-        var screen = Norm(string.Join("\n", rows));
-        foreach (var o in menu.Options)
-        {
-            var label = Norm(StripLeadingKey(o.Key));
-            if (label.Length == 0) continue;               // nothing to match on (a bare "1." key)
-            if (!screen.Contains(label)) return false;      // this option's label is gone -> not the same menu
-        }
-        return true;
+        var a = MenuSignature(capturedRows);
+        var b = MenuSignature(freshRows);
+        return a.Count > 0 && a.SequenceEqual(b);
     }
+
+    /// <summary>
+    /// The identity of the menu currently on a grid: the normalized menu block - the contiguous run from the
+    /// first non-blank line above the first option (the question / prompt) through the last option line. Box
+    /// borders and padding are normalized away so re-reads of the SAME static menu compare equal, while any
+    /// change to the question wording or the option set changes the signature. Empty when the grid holds no
+    /// option lines. Internal so a test can assert it directly.
+    /// </summary>
+    internal static List<string> MenuSignature(IReadOnlyList<string>? rows)
+    {
+        var result = new List<string>();
+        if (rows is null || rows.Count == 0) return result;
+
+        // The option lines bound the block; a menu with no options has no signature.
+        var firstOption = -1;
+        var lastOption = -1;
+        for (var i = 0; i < rows.Count; i++)
+        {
+            if (!IsOptionLine(rows[i])) continue;
+            if (firstOption < 0) firstOption = i;
+            lastOption = i;
+        }
+        if (firstOption < 0) return result;
+
+        // Walk up from the first option across any contiguous non-blank lines (the question / prompt) so a
+        // changed question is part of the identity. Stop at the first blank line.
+        var start = firstOption;
+        while (start - 1 >= 0 && !string.IsNullOrWhiteSpace(rows[start - 1])) start--;
+
+        for (var i = start; i <= lastOption; i++)
+        {
+            var norm = Norm(rows[i].Trim(BorderPadding));
+            if (norm.Length > 0) result.Add(norm);
+        }
+        return result;
+    }
+
+    /// <summary>Box-drawing glyphs and pipes stripped from a row's edges before normalizing, so a bordered
+    /// "│ 1. Yes │" compares equal to an unbordered "1. Yes".</summary>
+    private static readonly char[] BorderPadding =
+    {
+        '│','┃','┆','┇','┊','┋','╎','╏','║',
+        '╭','╮','╰','╯','┌','┐','└','┘','╔','╗','╚','╝',
+        '─','━','═','┄','┅','┈','┉','|',' ','\t','\r',
+    };
 
     private static readonly Dictionary<string, int> NumberWords = new()
     {

--- a/src/CcDirector.Gateway/Wingman/WingmanMenu.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanMenu.cs
@@ -87,6 +87,23 @@ public static class WingmanMenuLogic
             || tail.Contains("yes, and");
     }
 
+    /// <summary>
+    /// The AUTHORITATIVE menu gate (issue #1777), applied to the RESOLVED live screen grid rows rather than
+    /// the scrollback text. The live grid is alternate-screen-correct, so this sees the menu a full-screen
+    /// picker draws even though the scrollback is empty by design - which is exactly the case where the old
+    /// scrollback-only <see cref="LooksLikeMenu"/> returned false and the spoken words got typed into the
+    /// picker. Same fingerprint heuristic as <see cref="LooksLikeMenu"/> (2+ option lines, or a Claude-Code
+    /// permission-prompt fingerprint), but the LIVE screen rules the verdict: a menu counts only when its
+    /// choices and selection cursor are on screen NOW. The scrollback may only SUPPLEMENT extraction text
+    /// later; it can never create a menu on its own (it is full of already-answered menus). Empty/no grid is
+    /// not a menu here - an unreadable screen is handled by the caller, which fails closed.
+    /// </summary>
+    public static bool LiveScreenLooksLikeMenu(IReadOnlyList<string>? rows)
+    {
+        if (rows is null || rows.Count == 0) return false;
+        return LooksLikeMenu(string.Join("\n", rows));
+    }
+
     private static readonly Dictionary<string, int> NumberWords = new()
     {
         ["one"] = 1, ["two"] = 2, ["three"] = 3, ["four"] = 4, ["five"] = 5,

--- a/src/CcDirector.Gateway/Wingman/WingmanMenu.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanMenu.cs
@@ -129,6 +129,15 @@ public static class WingmanMenuLogic
         return SelectedOption.IsMatch(stripped);
     }
 
+    /// <summary>Box-drawing glyphs and pipes stripped from a row's leading edge before looking for a selection
+    /// marker, so a bordered "│ ❯ 1. Yes │" reads as "❯ 1. Yes".</summary>
+    private static readonly char[] BorderPadding =
+    {
+        '│','┃','┆','┇','┊','┋','╎','╏','║',
+        '╭','╮','╰','╯','┌','┐','└','┘','╔','╗','╚','╝',
+        '─','━','═','┄','┅','┈','┉','|',' ','\t','\r',
+    };
+
     /// <summary>
     /// True when the LIVE grid carries a menu OWNED BY ITS DRAWN SELECTION MARKER (issue #1777, round-4): a row
     /// with the drawn <c>❯</c>/<c>&gt;</c> marker on a numbered/lettered option, plus two or more option lines.
@@ -167,76 +176,6 @@ public static class WingmanMenuLogic
         }
         return true;
     }
-
-    /// <summary>
-    /// Re-verify the SAME menu is still on the live screen (issue #1777, finding B3), by comparing the CAPTURED
-    /// menu block (the question line plus the full option set, as they were when the menu was read) to the menu
-    /// block on the freshly re-read grid. Substring-of-labels is NOT enough: a replacement menu with the same
-    /// option labels but a different question ("Delete production?" -> "Deploy production?") must fail this, so
-    /// the whole block is compared, not just the labels. Returns false if either block is empty or they differ,
-    /// so the caller presses nothing when the menu changed or closed.
-    /// </summary>
-    public static bool SameMenuStillOnScreen(IReadOnlyList<string>? capturedRows, IReadOnlyList<string>? freshRows)
-    {
-        var a = MenuSignature(capturedRows);
-        var b = MenuSignature(freshRows);
-        return a.Count > 0 && a.SequenceEqual(b);
-    }
-
-    /// <summary>
-    /// The identity of the menu currently on a grid: the normalized menu block - the contiguous run from the
-    /// first non-blank line above the first option (the question / prompt) through the last option line. Box
-    /// borders and padding are normalized away so re-reads of the SAME static menu compare equal, while any
-    /// change to the question wording or the option set changes the signature. Empty when the grid holds no
-    /// option lines. Internal so a test can assert it directly.
-    /// </summary>
-    internal static List<string> MenuSignature(IReadOnlyList<string>? rows)
-    {
-        var result = new List<string>();
-        if (rows is null || rows.Count == 0) return result;
-
-        // The option lines bound the block; a menu with no options has no signature.
-        var firstOption = -1;
-        var lastOption = -1;
-        for (var i = 0; i < rows.Count; i++)
-        {
-            if (!IsOptionLine(rows[i])) continue;
-            if (firstOption < 0) firstOption = i;
-            lastOption = i;
-        }
-        if (firstOption < 0) return result;
-
-        // Capture the QUESTION block above the options, EVEN when a blank line separates it from them
-        // (issue #1777, finding B3: "Delete production?" and "Deploy production?" separated from the options by
-        // a blank line must NOT produce identical signatures). Skip the blank separator, then take the
-        // contiguous non-blank block (the question and any wrapped continuation), stopping at the blank above it.
-        var q0 = firstOption - 1;
-        while (q0 >= 0 && string.IsNullOrWhiteSpace(rows[q0])) q0--;   // skip the blank separator(s)
-        var questionEnd = q0;
-        while (q0 >= 0 && !string.IsNullOrWhiteSpace(rows[q0])) q0--;  // top of the question block
-        var questionStart = q0 + 1;
-
-        for (var q = questionStart; q <= questionEnd; q++)
-        {
-            var norm = Norm(rows[q].Trim(BorderPadding));
-            if (norm.Length > 0) result.Add(norm);
-        }
-        for (var o = firstOption; o <= lastOption; o++)
-        {
-            var norm = Norm(rows[o].Trim(BorderPadding));
-            if (norm.Length > 0) result.Add(norm);
-        }
-        return result;
-    }
-
-    /// <summary>Box-drawing glyphs and pipes stripped from a row's edges before normalizing, so a bordered
-    /// "│ 1. Yes │" compares equal to an unbordered "1. Yes".</summary>
-    private static readonly char[] BorderPadding =
-    {
-        '│','┃','┆','┇','┊','┋','╎','╏','║',
-        '╭','╮','╰','╯','┌','┐','└','┘','╔','╗','╚','╝',
-        '─','━','═','┄','┅','┈','┉','|',' ','\t','\r',
-    };
 
     private static readonly Dictionary<string, int> NumberWords = new()
     {

--- a/src/CcDirector.Gateway/Wingman/WingmanMenu.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanMenu.cs
@@ -104,6 +104,27 @@ public static class WingmanMenuLogic
         return LooksLikeMenu(string.Join("\n", rows));
     }
 
+    /// <summary>
+    /// Re-verify a menu is STILL on the live screen (issue #1777, finding 3): every extracted option's visible
+    /// label must still appear on the given live grid rows. Used as the cheap TOCTOU guard right before
+    /// pressing an option's keystrokes - if the menu has closed or changed, the labels are gone and this
+    /// returns false so the caller does not press selection bytes into whatever replaced it. A menu with no
+    /// options is not "present". Normalizes both sides (lowercase, punctuation to spaces) so box padding and
+    /// spacing differences do not cause a false miss.
+    /// </summary>
+    public static bool MenuOptionsPresentOnScreen(WingmanMenu? menu, IReadOnlyList<string>? rows)
+    {
+        if (menu?.Options is null || menu.Options.Count == 0 || rows is null || rows.Count == 0) return false;
+        var screen = Norm(string.Join("\n", rows));
+        foreach (var o in menu.Options)
+        {
+            var label = Norm(StripLeadingKey(o.Key));
+            if (label.Length == 0) continue;               // nothing to match on (a bare "1." key)
+            if (!screen.Contains(label)) return false;      // this option's label is gone -> not the same menu
+        }
+        return true;
+    }
+
     private static readonly Dictionary<string, int> NumberWords = new()
     {
         ["one"] = 1, ["two"] = 2, ["three"] = 3, ["four"] = 4, ["five"] = 5,

--- a/src/CcDirector.Gateway/Wingman/WingmanMenu.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanMenu.cs
@@ -104,13 +104,69 @@ public static class WingmanMenuLogic
         return LooksLikeMenu(string.Join("\n", rows));
     }
 
-    /// <summary>True when a row is a menu option / selection line (a leading marker run - a box edge, a
-    /// selection arrow like <c>❯</c> or <c>&gt;</c>, whitespace - then a number or letter, a <c>.</c> or
-    /// <c>)</c>, a space, and content). This is the same shape <see cref="LooksLikeMenu"/> counts; exposed so
-    /// the cursor-anchored classifier can ask "is the CURSOR sitting on an option row?" rather than deciding
-    /// from menu-like text anywhere on the grid.</summary>
+    /// <summary>True when a row is a menu option line (a leading marker run - a box edge, a selection arrow
+    /// like <c>❯</c> or <c>&gt;</c>, whitespace - then a number or letter, a <c>.</c> or <c>)</c>, a space, and
+    /// content). This is the same shape <see cref="LooksLikeMenu"/> counts.</summary>
     public static bool IsOptionLine(string? row)
         => !string.IsNullOrWhiteSpace(row) && OptionLine.IsMatch(row.Trim());
+
+    /// <summary>The DRAWN selection marker at the start of an option row: <c>❯</c> (Claude Code's Ink picker)
+    /// or a plain <c>&gt;</c>, then a space or the option content.</summary>
+    private static readonly Regex SelectedOption =
+        new(@"^(?:❯|>)\s*(?:\d{1,2}|[A-Za-z])[.)]\s+\S", RegexOptions.Compiled);
+
+    /// <summary>
+    /// True when a row is the SELECTED option of a menu - it carries the drawn selection marker (<c>❯</c> or
+    /// <c>&gt;</c>) directly before a numbered/lettered option (issue #1777, round-4). The Ink picker HIDES the
+    /// hardware cursor and draws this marker instead, so this - not the cursor cell - is how the live grid says
+    /// "a menu owns the turn". A bare <c>&gt; production</c> selector (no numbered option after the marker) is
+    /// deliberately NOT a selected option line.
+    /// </summary>
+    public static bool IsSelectedOptionLine(string? row)
+    {
+        if (string.IsNullOrWhiteSpace(row)) return false;
+        var stripped = row!.TrimStart(BorderPadding);
+        return SelectedOption.IsMatch(stripped);
+    }
+
+    /// <summary>
+    /// True when the LIVE grid carries a menu OWNED BY ITS DRAWN SELECTION MARKER (issue #1777, round-4): a row
+    /// with the drawn <c>❯</c>/<c>&gt;</c> marker on a numbered/lettered option, plus two or more option lines.
+    /// This is cursor-INDEPENDENT on purpose - a full-screen Ink menu hides the hardware cursor - so
+    /// menu-answering works with a hidden cursor. A menu with no recognizable textual marker (reverse-video
+    /// only) is NOT recognized here and the caller fails closed (styled-picker parsing is deferred).
+    /// </summary>
+    public static bool LiveScreenHasMenuSelection(IReadOnlyList<string>? rows)
+    {
+        if (rows is null || rows.Count == 0) return false;
+        var options = 0;
+        var hasMarker = false;
+        foreach (var r in rows)
+        {
+            if (IsOptionLine(r)) options++;
+            if (!hasMarker && IsSelectedOptionLine(r)) hasMarker = true;
+        }
+        return hasMarker && options >= 2;
+    }
+
+    /// <summary>
+    /// True when an extracted menu is actually ANSWERABLE (issue #1777, finding 4): it has options, every
+    /// option has a non-empty visible label (a bare <c>1.</c> / <c>2.</c> with no words is not answerable), and
+    /// every label actually appears on the live grid rows (the model did not invent options that are not on
+    /// screen). Fail closed when any of these does not hold.
+    /// </summary>
+    public static bool MenuHasAnswerableOptions(WingmanMenu? menu, IReadOnlyList<string>? liveRows)
+    {
+        if (menu?.Options is null || menu.Options.Count == 0 || liveRows is null || liveRows.Count == 0) return false;
+        var screen = Norm(string.Join("\n", liveRows));
+        foreach (var o in menu.Options)
+        {
+            var label = Norm(StripLeadingKey(o.Key));
+            if (label.Length == 0) return false;         // a bare "1." with no words - not answerable
+            if (!screen.Contains(label)) return false;    // an option the model invented, not on the live grid
+        }
+        return true;
+    }
 
     /// <summary>
     /// Re-verify the SAME menu is still on the live screen (issue #1777, finding B3), by comparing the CAPTURED
@@ -150,14 +206,24 @@ public static class WingmanMenuLogic
         }
         if (firstOption < 0) return result;
 
-        // Walk up from the first option across any contiguous non-blank lines (the question / prompt) so a
-        // changed question is part of the identity. Stop at the first blank line.
-        var start = firstOption;
-        while (start - 1 >= 0 && !string.IsNullOrWhiteSpace(rows[start - 1])) start--;
+        // Capture the QUESTION block above the options, EVEN when a blank line separates it from them
+        // (issue #1777, finding B3: "Delete production?" and "Deploy production?" separated from the options by
+        // a blank line must NOT produce identical signatures). Skip the blank separator, then take the
+        // contiguous non-blank block (the question and any wrapped continuation), stopping at the blank above it.
+        var q0 = firstOption - 1;
+        while (q0 >= 0 && string.IsNullOrWhiteSpace(rows[q0])) q0--;   // skip the blank separator(s)
+        var questionEnd = q0;
+        while (q0 >= 0 && !string.IsNullOrWhiteSpace(rows[q0])) q0--;  // top of the question block
+        var questionStart = q0 + 1;
 
-        for (var i = start; i <= lastOption; i++)
+        for (var q = questionStart; q <= questionEnd; q++)
         {
-            var norm = Norm(rows[i].Trim(BorderPadding));
+            var norm = Norm(rows[q].Trim(BorderPadding));
+            if (norm.Length > 0) result.Add(norm);
+        }
+        for (var o = firstOption; o <= lastOption; o++)
+        {
+            var norm = Norm(rows[o].Trim(BorderPadding));
             if (norm.Length > 0) result.Add(norm);
         }
         return result;


### PR DESCRIPTION
Closes thefrederiksen/devthrottle#1777.

## What this does

In voice mode, when a coding agent parks on an interactive menu, the Wingman used to go blind and type the person's spoken words straight into the picker (it read the terminal scrollback, which is empty while a full-screen picker is drawn). This makes the Wingman read the **live resolved screen grid** instead, and **fail closed**: the spoken words are typed as an ordinary prompt ONLY when the screen is confidently a plain-text composer; every menu, uncertain, unreadable, alternate-screen, or hidden-cursor screen types nothing.

## How the floor holds

- New Director `screen-grid` read verb returns the resolved live grid, the cursor cell, cursor visibility, and the alternate-screen flag as one atomic snapshot (alternate-screen-correct, agent-uniform - no per-agent data source, no agent SDK).
- Two anchors: **typing** requires a VISIBLE cursor sitting at the trailing edge of a framed composer's input, with the column bounded on both sides and NO menu-ish structure anywhere on the grid; **menus** are recognized by their drawn selection marker in the grid text (so detection works even when the CLI hides the hardware cursor).
- The screen is re-read and re-confirmed plain-text in the instant before the send, so a screen that changes underneath aborts.

## Scope

This is the safety floor only. It **detects** a menu and blocks; it does not press keys. Two follow-ups build on it:
- thefrederiksen/devthrottle_internal#857 - announce a waiting menu proactively (the phone speaks the question + a recommended pick).
- thefrederiksen/devthrottle_internal#861 - fully hands-free voice-answering (per-agent picker profiles + a screen-version lock on every keypress).

## Verification

Full test suite green across all seven projects. New proofs drive a real terminal onto the alternate screen and through the `screen-grid` verb; each safety guard was reverted and watched fail with its symptom before being restored. The change was independently reviewed for any path that could type into a picker; none remain.
