### PR TITLE
feat(gateway,director,cli): the owner's switch - any workflow can be turned off, built-ins included (register redesign, slice 1)

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -685,6 +685,13 @@ internal static class ControlEndpoints
                             statusCode: StatusCodes.Status502BadGateway);
                     }
 
+                    if (seatRun is not null && !seatRun.WorkflowEnabled)
+                    {
+                        // The owner turned this workflow OFF: no new seats; spawn unseated, loudly.
+                        FileLog.Write($"[ControlEndpoints] POST /fleet/spawn: workflow " +
+                                      $"'{seatRun.WorkflowId}' is OFF - spawning UNSEATED");
+                        seatRun = null;
+                    }
                     if (seatRun is not null)
                     {
                         req.WorkflowRunId = seatRun.Id;

--- a/src/CcDirector.Core/Sessions/WorkflowIndexStore.cs
+++ b/src/CcDirector.Core/Sessions/WorkflowIndexStore.cs
@@ -153,18 +153,19 @@ public sealed class WorkflowIndexStore
     /// </summary>
     public static string BuildIndexText(IReadOnlyList<CatalogWorkflow> workflows)
     {
-        if (workflows.Count == 0)
+        var inForce = workflows.Where(w => w.Enabled != false).ToList();
+        if (inForce.Count == 0)
             return "";
 
         var text = new StringBuilder();
         text.Append("[Workflows] Named ways of working this fleet defines - usable by ANY agent. Before taking\n");
         text.Append("on work that matches one, fetch its conduct and FOLLOW it:  cc-devthrottle workflow instructions <id>\n");
         var rendered = 0;
-        foreach (var workflow in workflows)
+        foreach (var workflow in inForce)
         {
             if (rendered == MaxIndexEntries)
             {
-                text.Append($"  ...and {workflows.Count - MaxIndexEntries} more - list them all with: cc-devthrottle workflow list\n");
+                text.Append($"  ...and {inForce.Count - MaxIndexEntries} more - list them all with: cc-devthrottle workflow list\n");
                 break;
             }
             // ONE line per workflow is the index's structural promise, and the line is PRINTABLE text
@@ -242,7 +243,10 @@ public sealed class WorkflowIndexStore
     /// <summary>The slice of <c>GET /gateway/workflows</c> the index needs.</summary>
     public sealed record CatalogWorkflow(
         [property: JsonPropertyName("id")] string Id,
-        [property: JsonPropertyName("summary")] string? Summary);
+        [property: JsonPropertyName("summary")] string? Summary,
+        // Null (an older Gateway that omits the field) means enabled - only an explicit false, the
+        // owner's own switch, removes a workflow from every session's briefing.
+        [property: JsonPropertyName("enabled")] bool? Enabled = null);
 
     private sealed record CatalogResponse(
         [property: JsonPropertyName("workflows")] List<CatalogWorkflow>? Workflows);

--- a/src/CcDirector.Gateway.Contracts/WorkflowDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/WorkflowDtos.cs
@@ -63,6 +63,12 @@ public sealed class WorkflowDto
 
     /// <summary>The canonical content hash of the published version (the exact bundle a run pins).</summary>
     public string ContentHash { get; set; } = "";
+
+    /// <summary>The owner's switch (register redesign): false = OFF - hidden from agents' launch
+    /// briefings, default conduct reads refused, no new runs or seats; nothing deleted. The catalog
+    /// still LISTS off workflows so the register can show and flip them. Defaults true so a reader
+    /// of an older Gateway that omits the field treats everything as in force.</summary>
+    public bool Enabled { get; set; } = true;
 }
 
 /// <summary>A helper file carried by a workflow version, with full content (authoring payloads).</summary>

--- a/src/CcDirector.Gateway.Contracts/WorkflowRunDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/WorkflowRunDtos.cs
@@ -108,6 +108,12 @@ public sealed class WorkflowRunDto
     public List<WorkflowRunProofLinkDto> ProofLinks { get; set; } = new();
     public List<WorkflowRunParticipantDto> Participants { get; set; } = new();
 
+    /// <summary>Whether the run's WORKFLOW is currently in force (the owner's switch, register
+    /// redesign). False means the owner turned the workflow off: existing runs remain readable, but
+    /// spawn paths refuse NEW seats on them. Defaults true so a Director reading an older Gateway
+    /// that omits the field keeps seating normally.</summary>
+    public bool WorkflowEnabled { get; set; } = true;
+
     /// <summary>The Mission record this run is anchored to, when the run came from the mission path.
     /// A reference, not a merge - standalone runs have no Mission.</summary>
     public Guid? MissionId { get; set; }

--- a/src/CcDirector.Gateway.Tests/WorkflowEnableSwitchTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowEnableSwitchTests.cs
@@ -34,7 +34,7 @@ public sealed class WorkflowEnableSwitchTests : IDisposable
     {
         var (workflows, _) = NewStores();
 
-        Assert.True(workflows.SetEnabled("mission", false));
+        Assert.True(workflows.SetEnabled("mission", false, "test:owner"));
 
         // The catalog still lists it - the register must be able to SHOW an off workflow to flip
         // it back - and the state is reported honestly.
@@ -49,7 +49,7 @@ public sealed class WorkflowEnableSwitchTests : IDisposable
     public void Off_refuses_the_default_conduct_read_with_a_clear_message_but_pinned_reads_resolve()
     {
         var (workflows, _) = NewStores();
-        workflows.SetEnabled("mission", false);
+        workflows.SetEnabled("mission", false, "test:owner");
 
         var refusal = Assert.Throws<WorkflowValidationException>(
             () => workflows.GetInstructions("mission", version: null));
@@ -65,14 +65,14 @@ public sealed class WorkflowEnableSwitchTests : IDisposable
     {
         var (workflows, runs) = NewStores();
         var before = runs.Create("mission", "Governed while on");
-        workflows.SetEnabled("mission", false);
+        workflows.SetEnabled("mission", false, "test:owner");
 
         Assert.Throws<WorkflowValidationException>(() => runs.Create("mission", "Refused while off"));
         Assert.False(runs.IsWorkflowEnabled("mission"));
         // Past runs stay readable, and they report the workflow's current state.
         Assert.False(runs.Get(before.Id)!.WorkflowEnabled);
 
-        Assert.True(workflows.SetEnabled("mission", true));
+        Assert.True(workflows.SetEnabled("mission", true, "test:owner"));
         Assert.True(runs.IsWorkflowEnabled("mission"));
         Assert.Equal("mission", runs.Create("mission", "Governed again").WorkflowId);
         Assert.Contains("THE FOUR LAWS", workflows.GetInstructions("mission", version: null));
@@ -148,7 +148,7 @@ public sealed class WorkflowEnableSwitchEndpointTests : IAsyncLifetime
     [Fact]
     public async Task Disable_off_missions_run_ungoverned_then_enable_governs_again()
     {
-        var off = await _http.PostAsync("gateway/workflows/mission/disable", null);
+        var off = await _http.PostAsync("gateway/workflows/mission/disable?by=test-owner", null);
         Assert.Equal(HttpStatusCode.OK, off.StatusCode);
 
         // The default conduct read refuses with the clear message, as a 400 - never a 404.
@@ -162,7 +162,7 @@ public sealed class WorkflowEnableSwitchEndpointTests : IAsyncLifetime
         var ungovernedDto = await ungoverned.Content.ReadFromJsonAsync<JsonObject>();
         Assert.Null(ungovernedDto!["workflowRunId"]?.GetValue<string?>());
 
-        var on = await _http.PostAsync("gateway/workflows/mission/enable", null);
+        var on = await _http.PostAsync("gateway/workflows/mission/enable?by=test-owner", null);
         Assert.Equal(HttpStatusCode.OK, on.StatusCode);
 
         var governed = await _http.PostAsJsonAsync("missions", new { missionName = "After the flip" });
@@ -172,9 +172,19 @@ public sealed class WorkflowEnableSwitchEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task The_switch_requires_an_actor()
+    {
+        // A governance change has an actor, always - flipping the fleet's rules anonymously is
+        // refused, the same posture as run acceptance.
+        var resp = await _http.PostAsync("gateway/workflows/mission/disable", null);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("requires 'by'", await resp.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
     public async Task Unknown_workflow_switch_is_a_404()
     {
-        var resp = await _http.PostAsync("gateway/workflows/no-such/disable", null);
+        var resp = await _http.PostAsync("gateway/workflows/no-such/disable?by=test-owner", null);
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 

--- a/src/CcDirector.Gateway.Tests/WorkflowEnableSwitchTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowEnableSwitchTests.cs
@@ -1,0 +1,189 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Workflows;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The owner's switch (register redesign, owner ruling 2026-07-18): any workflow - built-ins
+/// included - can be turned off, because DevThrottle configures to what the USER wants. The
+/// semantics under test are the ruling verbatim: off hides the workflow from agents' briefings,
+/// refuses the default conduct read with a clear message, refuses new runs and seats - and deletes
+/// NOTHING: the catalog still lists it (so the register can show and flip it), pinned
+/// explicit-version reads keep resolving, past runs stay, and the flip is instant both ways.
+/// A mission whose workflow is off still gets created; it runs ungoverned until the flip back.
+/// </summary>
+public sealed class WorkflowEnableSwitchTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    private (WorkflowStore Workflows, WorkflowRunStore Runs) NewStores()
+    {
+        var db = _h.Open();
+        return (new WorkflowStore(db), new WorkflowRunStore(db));
+    }
+
+    [Fact]
+    public void Off_hides_from_nothing_in_the_catalog_but_marks_the_state()
+    {
+        var (workflows, _) = NewStores();
+
+        Assert.True(workflows.SetEnabled("mission", false));
+
+        // The catalog still lists it - the register must be able to SHOW an off workflow to flip
+        // it back - and the state is reported honestly.
+        var listed = workflows.ListPublished();
+        var mission = listed.Single(w => w.Id == "mission");
+        Assert.False(mission.Enabled);
+        Assert.True(listed.Single(w => w.Id == "standalone").Enabled);
+        Assert.False(workflows.GetPublished("mission")!.Enabled);
+    }
+
+    [Fact]
+    public void Off_refuses_the_default_conduct_read_with_a_clear_message_but_pinned_reads_resolve()
+    {
+        var (workflows, _) = NewStores();
+        workflows.SetEnabled("mission", false);
+
+        var refusal = Assert.Throws<WorkflowValidationException>(
+            () => workflows.GetInstructions("mission", version: null));
+        Assert.Contains("turned OFF", refusal.Message);
+        Assert.Contains("workflow enable mission", refusal.Message);
+
+        // Pinned history is untouchable: a seated run's conduct never disappears under it.
+        Assert.Contains("THE FOUR LAWS", workflows.GetInstructions("mission", version: 1));
+    }
+
+    [Fact]
+    public void Off_refuses_new_runs_and_the_flip_back_restores_everything()
+    {
+        var (workflows, runs) = NewStores();
+        var before = runs.Create("mission", "Governed while on");
+        workflows.SetEnabled("mission", false);
+
+        Assert.Throws<WorkflowValidationException>(() => runs.Create("mission", "Refused while off"));
+        Assert.False(runs.IsWorkflowEnabled("mission"));
+        // Past runs stay readable, and they report the workflow's current state.
+        Assert.False(runs.Get(before.Id)!.WorkflowEnabled);
+
+        Assert.True(workflows.SetEnabled("mission", true));
+        Assert.True(runs.IsWorkflowEnabled("mission"));
+        Assert.Equal("mission", runs.Create("mission", "Governed again").WorkflowId);
+        Assert.Contains("THE FOUR LAWS", workflows.GetInstructions("mission", version: null));
+    }
+
+    [Fact]
+    public void The_briefing_index_drops_off_workflows_and_counts_honestly()
+    {
+        // The Director-side index builder consumes the catalog wire shape; enabled=false is the
+        // owner's own switch and removes the workflow from every session's briefing. Absent
+        // (an older Gateway) means enabled.
+        var text = Core.Sessions.WorkflowIndexStore.BuildIndexText(new[]
+        {
+            new Core.Sessions.WorkflowIndexStore.CatalogWorkflow("mission", "The conduct.", Enabled: true),
+            new Core.Sessions.WorkflowIndexStore.CatalogWorkflow("standalone", "Off now.", Enabled: false),
+            new Core.Sessions.WorkflowIndexStore.CatalogWorkflow("legacy", "Old gateway.", Enabled: null),
+        });
+
+        Assert.Contains("  - mission:", text);
+        Assert.Contains("  - legacy:", text);
+        Assert.DoesNotContain("standalone", text);
+
+        Assert.Equal("", Core.Sessions.WorkflowIndexStore.BuildIndexText(new[]
+        {
+            new Core.Sessions.WorkflowIndexStore.CatalogWorkflow("only", "Everything off.", Enabled: false),
+        }));
+    }
+}
+
+/// <summary>
+/// The switch over real HTTP, including the ungoverned-mission ruling: turning the mission workflow
+/// off must never break mission creation - the mission is simply created without a governance run,
+/// and turning the switch back on governs the next one.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class WorkflowEnableSwitchEndpointTests : IAsyncLifetime
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-wf-switch-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    public WorkflowEnableSwitchEndpointTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-wf-switch-root-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: "test-token-12345", authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "test-token-12345");
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { }
+    }
+
+    [Fact]
+    public async Task Disable_off_missions_run_ungoverned_then_enable_governs_again()
+    {
+        var off = await _http.PostAsync("gateway/workflows/mission/disable", null);
+        Assert.Equal(HttpStatusCode.OK, off.StatusCode);
+
+        // The default conduct read refuses with the clear message, as a 400 - never a 404.
+        var read = await _http.GetAsync("gateway/workflows/mission/instructions");
+        Assert.Equal(HttpStatusCode.BadRequest, read.StatusCode);
+        Assert.Contains("turned OFF", await read.Content.ReadAsStringAsync());
+
+        // The owner ruling: mission creation still works - ungoverned, with no run id.
+        var ungoverned = await _http.PostAsJsonAsync("missions", new { missionName = "While off" });
+        Assert.Equal(HttpStatusCode.Created, ungoverned.StatusCode);
+        var ungovernedDto = await ungoverned.Content.ReadFromJsonAsync<JsonObject>();
+        Assert.Null(ungovernedDto!["workflowRunId"]?.GetValue<string?>());
+
+        var on = await _http.PostAsync("gateway/workflows/mission/enable", null);
+        Assert.Equal(HttpStatusCode.OK, on.StatusCode);
+
+        var governed = await _http.PostAsJsonAsync("missions", new { missionName = "After the flip" });
+        Assert.Equal(HttpStatusCode.Created, governed.StatusCode);
+        var governedDto = await governed.Content.ReadFromJsonAsync<JsonObject>();
+        Assert.False(string.IsNullOrWhiteSpace((string?)governedDto!["workflowRunId"]));
+    }
+
+    [Fact]
+    public async Task Unknown_workflow_switch_is_a_404()
+    {
+        var resp = await _http.PostAsync("gateway/workflows/no-such/disable", null);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -215,9 +215,22 @@ internal static class GatewayEndpoints
                 var dto = ToMissionDto(mission);
                 if (workflowRuns is not null && missionWorkflowEnabled != false)
                 {
-                    var run = workflowRuns.Create(
-                        "mission", mission.MissionName, missionId: mission.MissionId);
-                    dto.WorkflowRunId = run.Id;
+                    try
+                    {
+                        var run = workflowRuns.Create(
+                            "mission", mission.MissionName, missionId: mission.MissionId);
+                        dto.WorkflowRunId = run.Id;
+                    }
+                    catch (Workflows.WorkflowValidationException)
+                        when (workflowRuns.GetWorkflowEnabled("mission") == false)
+                    {
+                        // The owner flipped the switch between the pre-check and the run create.
+                        // The mission record already exists, and the ruling says an explicit OFF
+                        // makes an UNGOVERNED mission - so honor the flip instead of returning an
+                        // error for a mission that was in fact created.
+                        FileLog.Write($"[GatewayEndpoints] POST /missions: the mission workflow was " +
+                                      $"turned OFF mid-create - mission {mission.MissionId} is UNGOVERNED");
+                    }
                 }
                 else if (workflowRuns is not null)
                 {

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -191,7 +191,11 @@ internal static class GatewayEndpoints
                 // and EF), so a process death exactly between the two writes can still orphan a
                 // mission - a transition-era window that closes when the JSON mission store retires
                 // onto the EF layer; the pre-check removes every failure mode short of that.
-                if (workflowRuns is not null)
+                // The owner's switch (register redesign ruling): a mission whose workflow is
+                // turned OFF still gets created - it runs UNGOVERNED (no run record) until the
+                // switch flips back. Only an unrunnable-but-enabled workflow refuses the create.
+                var missionWorkflowEnabled = workflowRuns?.IsWorkflowEnabled("mission") ?? false;
+                if (workflowRuns is not null && missionWorkflowEnabled)
                 {
                     try
                     {
@@ -206,11 +210,16 @@ internal static class GatewayEndpoints
 
                 var mission = missions.Create(req.MissionName, req.ParentMissionId);
                 var dto = ToMissionDto(mission);
-                if (workflowRuns is not null)
+                if (workflowRuns is not null && missionWorkflowEnabled)
                 {
                     var run = workflowRuns.Create(
                         "mission", mission.MissionName, missionId: mission.MissionId);
                     dto.WorkflowRunId = run.Id;
+                }
+                else if (workflowRuns is not null)
+                {
+                    FileLog.Write($"[GatewayEndpoints] POST /missions: the mission workflow is OFF - " +
+                                  $"mission {mission.MissionId} created UNGOVERNED (no run record)");
                 }
                 return Results.Json(dto, statusCode: StatusCodes.Status201Created);
             });

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -191,11 +191,14 @@ internal static class GatewayEndpoints
                 // and EF), so a process death exactly between the two writes can still orphan a
                 // mission - a transition-era window that closes when the JSON mission store retires
                 // onto the EF layer; the pre-check removes every failure mode short of that.
-                // The owner's switch (register redesign ruling): a mission whose workflow is
-                // turned OFF still gets created - it runs UNGOVERNED (no run record) until the
-                // switch flips back. Only an unrunnable-but-enabled workflow refuses the create.
-                var missionWorkflowEnabled = workflowRuns?.IsWorkflowEnabled("mission") ?? false;
-                if (workflowRuns is not null && missionWorkflowEnabled)
+                // The owner's switch (register redesign ruling): a mission whose workflow the
+                // owner EXPLICITLY turned off still gets created - it runs UNGOVERNED (no run
+                // record) until the switch flips back. Three-valued on purpose: only an explicit
+                // FALSE is the owner's choice; a MISSING mission workflow (null - a broken or
+                // unseeded store) keeps the fail-loud path below, because silently ungoverned
+                // missions are exactly the gap the outcome spine exists to close.
+                var missionWorkflowEnabled = workflowRuns?.GetWorkflowEnabled("mission") ?? true;
+                if (workflowRuns is not null && missionWorkflowEnabled != false)
                 {
                     try
                     {
@@ -210,7 +213,7 @@ internal static class GatewayEndpoints
 
                 var mission = missions.Create(req.MissionName, req.ParentMissionId);
                 var dto = ToMissionDto(mission);
-                if (workflowRuns is not null && missionWorkflowEnabled)
+                if (workflowRuns is not null && missionWorkflowEnabled != false)
                 {
                     var run = workflowRuns.Create(
                         "mission", mission.MissionName, missionId: mission.MissionId);

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -180,6 +180,14 @@ internal static class MachineEndpoints
                     seatRun = workflowRuns.List(missionId: seatMissionId, limit: 1).FirstOrDefault();
                 }
 
+                if (seatRun is not null && !seatRun.WorkflowEnabled)
+                {
+                    // The owner turned this workflow OFF: no new seats. The spawn proceeds
+                    // unseated - the owner's switch, honestly applied and loudly logged.
+                    FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: workflow " +
+                                  $"'{seatRun.WorkflowId}' is OFF - spawning UNSEATED");
+                    seatRun = null;
+                }
                 if (seatRun is not null)
                 {
                     req.WorkflowRunId = seatRun.Id;

--- a/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
@@ -142,11 +142,26 @@ internal static class WorkflowEndpoints
 
         // The agent read path: raw markdown, no JSON envelope, so `cc-devthrottle workflow
         // instructions <id>` can print it verbatim into an agent's context.
-        app.MapGet("/gateway/workflows/{id}/instructions", (string id, int? version) =>
+        app.MapGet("/gateway/workflows/{id}/instructions", (string id, int? version) => Guard(() =>
         {
+            // Guard: a workflow the owner turned OFF refuses the default read with a clear 400
+            // message (never a misleading 404); pinned explicit-version reads keep serving.
             var markdown = store.GetInstructions(id, version);
             return markdown is null ? NotFound(id) : Results.Text(markdown, "text/markdown");
-        });
+        }));
+
+        // The owner's switch (register redesign): turn a workflow on or off - built-ins included.
+        // Off = hidden from agents' briefings, default reads refused, no new runs or seats; nothing
+        // deleted, instant both ways fleet-wide.
+        app.MapPost("/gateway/workflows/{id}/enable", (string id) =>
+            store.SetEnabled(id, true)
+                ? Results.Json(new { id, enabled = true })
+                : NotFound(id));
+
+        app.MapPost("/gateway/workflows/{id}/disable", (string id) =>
+            store.SetEnabled(id, false)
+                ? Results.Json(new { id, enabled = false })
+                : NotFound(id));
 
         app.MapGet("/gateway/workflows/{id}/files/{fileName}", (string id, string fileName, int? version) =>
         {

--- a/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
@@ -153,15 +153,17 @@ internal static class WorkflowEndpoints
         // The owner's switch (register redesign): turn a workflow on or off - built-ins included.
         // Off = hidden from agents' briefings, default reads refused, no new runs or seats; nothing
         // deleted, instant both ways fleet-wide.
-        app.MapPost("/gateway/workflows/{id}/enable", (string id) =>
-            store.SetEnabled(id, true)
+        // Both verbs REQUIRE ?by=<who> - a governance change has an actor, always (the run-
+        // acceptance posture). Attribution is log-based until governance's event ledger lands.
+        app.MapPost("/gateway/workflows/{id}/enable", (string id, string? by) => Guard(() =>
+            store.SetEnabled(id, true, by ?? "")
                 ? Results.Json(new { id, enabled = true })
-                : NotFound(id));
+                : NotFound(id)));
 
-        app.MapPost("/gateway/workflows/{id}/disable", (string id) =>
-            store.SetEnabled(id, false)
+        app.MapPost("/gateway/workflows/{id}/disable", (string id, string? by) => Guard(() =>
+            store.SetEnabled(id, false, by ?? "")
                 ? Results.Json(new { id, enabled = false })
-                : NotFound(id));
+                : NotFound(id)));
 
         app.MapGet("/gateway/workflows/{id}/files/{fileName}", (string id, string fileName, int? version) =>
         {

--- a/src/CcDirector.Gateway/Data/Entities/WorkflowEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/WorkflowEntity.cs
@@ -25,6 +25,17 @@ public sealed class WorkflowEntity : TenantScopedEntity
     /// versions remain - a run that pinned one must always be able to resolve it.</summary>
     public bool Archived { get; set; }
 
+    /// <summary>
+    /// The owner's switch (register redesign, owner ruling 2026-07-18): DevThrottle configures to
+    /// what the USER wants, so any workflow - built-ins included - can be turned off. Off means:
+    /// hidden from every agent's launch briefing, the default conduct read refused with a clear
+    /// message, and no new runs or seats - but NOTHING deleted: versions, history, and past runs
+    /// stay, pinned explicit-version reads keep resolving, and the switch is instant both ways
+    /// fleet-wide. Distinct from <see cref="Archived"/>: off is a standing choice shown in the
+    /// register; archived is removal from it.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
     /// <summary>The highest version number ever minted for this workflow (the draft counter).</summary>
     public int LatestVersion { get; set; }
 

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -145,6 +145,10 @@ public sealed class GatewayDbContext : DbContext
             b.ToTable("workflows");
             b.HasKey(e => e.Id);
             b.Property(e => e.Id);
+            // The owner's switch defaults ON at the DATABASE level too, so the migration that adds
+            // the column backfills every pre-existing workflow as in-force - upgrading must never
+            // silently switch a fleet's workflows off.
+            b.Property(e => e.Enabled).HasDefaultValue(true);
         });
 
         modelBuilder.Entity<WorkflowVersionEntity>(b =>

--- a/src/CcDirector.Gateway/Data/Migrations/20260718110722_AddWorkflowEnabled.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718110722_AddWorkflowEnabled.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718110722_AddWorkflowEnabled")]
+    partial class AddWorkflowEnabled
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260718110722_AddWorkflowEnabled.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718110722_AddWorkflowEnabled.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkflowEnabled : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Enabled",
+                table: "workflows",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Enabled",
+                table: "workflows");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
@@ -204,15 +204,26 @@ public sealed class WorkflowRunStore
     /// off still gets created - it simply runs ungoverned (no run record) until the switch flips
     /// back, which is a different answer than the hard refusal an unrunnable workflow gets.
     /// </summary>
-    public bool IsWorkflowEnabled(string workflowId)
+    public bool IsWorkflowEnabled(string workflowId) => GetWorkflowEnabled(workflowId) == true;
+
+    /// <summary>
+    /// Three-valued on purpose: TRUE = in force, FALSE = the owner explicitly turned it off, NULL =
+    /// the workflow does not exist (or is archived). The mission-create path needs the distinction,
+    /// because only the owner's explicit OFF may produce an ungoverned mission - a MISSING mission
+    /// workflow is a broken store and must keep failing loud, never be mistaken for a choice.
+    /// </summary>
+    public bool? GetWorkflowEnabled(string workflowId)
     {
         if (string.IsNullOrWhiteSpace(workflowId))
-            return false;
+            return null;
         var key = workflowId.Trim().ToLowerInvariant();
         lock (_gate)
         {
             using var ctx = _db.CreateContext();
-            return WorkflowEnabledFor(ctx, key);
+            return ctx.Workflows.AsNoTracking()
+                .Where(h => h.Id == key && !h.Archived)
+                .Select(h => (bool?)h.Enabled)
+                .FirstOrDefault();
         }
     }
 

--- a/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
@@ -85,6 +85,10 @@ public sealed class WorkflowRunStore
             if (head is null || head.Archived || head.PublishedVersion is null)
                 throw new WorkflowValidationException(
                     $"Workflow '{key}' has no published version to run.");
+            if (!head.Enabled)
+                throw new WorkflowValidationException(
+                    $"Workflow '{key}' is turned OFF on this fleet - no new runs while the owner has " +
+                    "it disabled. Re-enable it in the cockpit or with: cc-devthrottle workflow enable " + key);
             var version = ctx.WorkflowVersions.AsNoTracking().First(
                 v => v.WorkflowId == key && v.Status == WorkflowVersionStatus.Published);
 
@@ -115,7 +119,7 @@ public sealed class WorkflowRunStore
 
             FileLog.Write($"[WorkflowRunStore] Create: run={entity.Id}, workflow={key} v{version.Version}, " +
                           $"name=\"{entity.Name}\", mission={missionId?.ToString() ?? "-"}");
-            return ToDto(entity);
+            return ToDto(entity, workflowEnabled: true);
         }
     }
 
@@ -126,7 +130,7 @@ public sealed class WorkflowRunStore
         {
             using var ctx = _db.CreateContext();
             var entity = ctx.WorkflowRuns.AsNoTracking().FirstOrDefault(r => r.Id == id);
-            return entity is null ? null : ToDto(entity);
+            return entity is null ? null : ToDto(entity, WorkflowEnabledFor(ctx, entity.WorkflowId));
         }
     }
 
@@ -158,11 +162,13 @@ public sealed class WorkflowRunStore
             if (missionId.HasValue)
                 query = query.Where(r => r.MissionId == missionId.Value);
 
-            return query
+            var page = query
                 .OrderByDescending(r => r.CreatedUtc)
                 .Take(take)
-                .ToList()
-                .Select(ToDto)
+                .ToList();
+            var enabledByWorkflow = WorkflowEnabledMap(ctx, page.Select(r => r.WorkflowId));
+            return page
+                .Select(r => ToDto(r, enabledByWorkflow.GetValueOrDefault(r.WorkflowId, false)))
                 .ToList();
         }
     }
@@ -185,7 +191,46 @@ public sealed class WorkflowRunStore
             if (head is null || head.Archived || head.PublishedVersion is null)
                 throw new WorkflowValidationException(
                     $"Workflow '{key}' has no published version to run.");
+            if (!head.Enabled)
+                throw new WorkflowValidationException(
+                    $"Workflow '{key}' is turned OFF on this fleet - no new runs while the owner has " +
+                    "it disabled.");
         }
+    }
+
+    /// <summary>
+    /// Whether a workflow is currently in force (the owner's switch). The mission-create path asks
+    /// THIS before <see cref="EnsureRunnable"/>: per the owner ruling, a mission whose workflow is
+    /// off still gets created - it simply runs ungoverned (no run record) until the switch flips
+    /// back, which is a different answer than the hard refusal an unrunnable workflow gets.
+    /// </summary>
+    public bool IsWorkflowEnabled(string workflowId)
+    {
+        if (string.IsNullOrWhiteSpace(workflowId))
+            return false;
+        var key = workflowId.Trim().ToLowerInvariant();
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            return WorkflowEnabledFor(ctx, key);
+        }
+    }
+
+    private static bool WorkflowEnabledFor(GatewayDbContext ctx, string workflowId) =>
+        ctx.Workflows.AsNoTracking()
+            .Where(h => h.Id == workflowId && !h.Archived)
+            .Select(h => (bool?)h.Enabled)
+            .FirstOrDefault() ?? false;
+
+    private static Dictionary<string, bool> WorkflowEnabledMap(
+        GatewayDbContext ctx, IEnumerable<string> workflowIds)
+    {
+        var ids = workflowIds.Distinct(StringComparer.Ordinal).ToList();
+        return ctx.Workflows.AsNoTracking()
+            .Where(h => ids.Contains(h.Id) && !h.Archived)
+            .Select(h => new { h.Id, h.Enabled })
+            .ToList()
+            .ToDictionary(h => h.Id, h => h.Enabled, StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -251,7 +296,7 @@ public sealed class WorkflowRunStore
             ctx.SaveChanges();
             FileLog.Write($"[WorkflowRunStore] Patch: run={id}, status={entity.Status}, " +
                           $"acceptance={entity.AcceptanceStatus}");
-            return ToDto(entity);
+            return ToDto(entity, WorkflowEnabledFor(ctx, entity.WorkflowId));
         }
     }
 
@@ -363,8 +408,9 @@ public sealed class WorkflowRunStore
         }
     }
 
-    private static WorkflowRunDto ToDto(WorkflowRunEntity e) => new()
+    private static WorkflowRunDto ToDto(WorkflowRunEntity e, bool workflowEnabled) => new()
     {
+        WorkflowEnabled = workflowEnabled,
         Id = e.Id,
         WorkflowId = e.WorkflowId,
         WorkflowVersionId = e.WorkflowVersionId,

--- a/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
@@ -550,8 +550,13 @@ public sealed class WorkflowStore
     /// deletes NOTHING; the flip is instant both ways for every subsequent read fleet-wide. False
     /// when no such workflow exists (archived counts as gone).
     /// </summary>
-    public bool SetEnabled(string id, bool enabled)
+    public bool SetEnabled(string id, bool enabled, string by)
     {
+        // A governance change has an actor, always - the same posture as run acceptance (#1771):
+        // who flipped the fleet's rules is never allowed to be nobody.
+        if (string.IsNullOrWhiteSpace(by))
+            throw new WorkflowValidationException(
+                "Turning a workflow on or off requires 'by' - who is making the change.");
         var key = NormalizeId(id);
         lock (_gate)
         {
@@ -563,7 +568,9 @@ public sealed class WorkflowStore
             head.Enabled = enabled;
             head.UpdatedUtc = DateTime.UtcNow;
             ctx.SaveChanges();
-            FileLog.Write($"[WorkflowStore] SetEnabled: id={key}, enabled={enabled}");
+            // Attribution is log-based for now; the durable audit trail is governance's append-only
+            // event ledger (#1771), which will hang off these same ids.
+            FileLog.Write($"[WorkflowStore] SetEnabled: id={key}, enabled={enabled}, by={by.Trim()}");
             return true;
         }
     }

--- a/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
@@ -356,14 +356,28 @@ public sealed class WorkflowStore
     /// but never the draft: a draft is mutable, so serving it as pinned history would be a lie, and
     /// the publish boundary is exactly what makes content fleet-readable. (Authoring reads a draft
     /// through the versions/{n} detail route, which states the status.) Without a version, the
-    /// published version of a live workflow serves; a draft-only or archived workflow yields null.
+    /// published version of a live workflow serves; a draft-only or archived workflow yields null,
+    /// and a workflow the owner turned OFF refuses with a clear message - never a misleading 404.
     /// </summary>
+    /// <exception cref="WorkflowValidationException">The workflow exists but is OFF and no explicit
+    /// version was named. Pinned reads (explicit version) keep resolving - a seated run's conduct
+    /// never disappears under it - but the default head read is exactly the "use this workflow" path
+    /// the owner switched off.</exception>
     public string? GetInstructions(string id, int? version)
     {
         var key = NormalizeId(id);
         lock (_gate)
         {
             using var ctx = _db.CreateContext();
+            if (version is null)
+            {
+                var head = ctx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == key);
+                if (head is { Archived: false, Enabled: false })
+                    throw new WorkflowValidationException(
+                        $"Workflow '{key}' is turned OFF on this fleet. The owner disabled it; its " +
+                        "history remains readable by explicit version, and it can be re-enabled in " +
+                        "the cockpit or with: cc-devthrottle workflow enable " + key);
+            }
             var row = ResolveVersionRow(ctx, key, version);
             return row?.InstructionsMarkdown;
         }
@@ -526,5 +540,31 @@ public sealed class WorkflowStore
         UpdatedUtc = head.UpdatedUtc,
         HasDraft = hasDraft,
         ContentHash = version.ContentHash,
+        Enabled = head.Enabled,
     };
+
+    /// <summary>
+    /// The owner's switch (register redesign, owner ruling 2026-07-18): turn a workflow on or off -
+    /// built-ins included, because DevThrottle configures to what the USER wants. Off hides the
+    /// workflow from agents' launch briefings, refuses default conduct reads and new runs/seats, and
+    /// deletes NOTHING; the flip is instant both ways for every subsequent read fleet-wide. False
+    /// when no such workflow exists (archived counts as gone).
+    /// </summary>
+    public bool SetEnabled(string id, bool enabled)
+    {
+        var key = NormalizeId(id);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var head = ctx.Workflows.FirstOrDefault(h => h.Id == key);
+            if (head is null || head.Archived)
+                return false;
+
+            head.Enabled = enabled;
+            head.UpdatedUtc = DateTime.UtcNow;
+            ctx.SaveChanges();
+            FileLog.Write($"[WorkflowStore] SetEnabled: id={key}, enabled={enabled}");
+            return true;
+        }
+    }
 }

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -347,6 +347,20 @@ _ACTIONS = [
         "args": [{"name": "run_id", "required": True}],
     },
     {
+        "id": "workflow-enable",
+        "description": "Turn a Workflow back ON (returns to agents' briefings; runs and seats resume).",
+        "command": "cc-devthrottle workflow enable <id>",
+        "mutatesState": True,
+        "args": [{"name": "id", "required": True}],
+    },
+    {
+        "id": "workflow-disable",
+        "description": "Turn a Workflow OFF - hidden from agents' briefings, no new runs or seats; nothing deleted.",
+        "command": "cc-devthrottle workflow disable <id>",
+        "mutatesState": True,
+        "args": [{"name": "id", "required": True}],
+    },
+    {
         "id": "workflow-reset",
         "description": "Reset a built-in Workflow to the shipped content (published as a new version).",
         "command": "cc-devthrottle workflow reset <id>",
@@ -932,6 +946,22 @@ def workflow_run(
 ) -> None:
     """Show one workflow run: pinned version, lifecycle, acceptance, criteria, participants, proof."""
     workflow_ops.show_run(run_id, json_output)
+
+
+@workflow_app.command("enable")
+def workflow_enable(
+    workflow_id: str = typer.Argument(..., help="The workflow id."),
+) -> None:
+    """Turn a Workflow back ON - it returns to every agent's briefing; runs and seats resume."""
+    workflow_ops.set_workflow_enabled(workflow_id, True)
+
+
+@workflow_app.command("disable")
+def workflow_disable(
+    workflow_id: str = typer.Argument(..., help="The workflow id (built-ins included)."),
+) -> None:
+    """Turn a Workflow OFF - hidden from agents' briefings, no new runs or seats; nothing deleted."""
+    workflow_ops.set_workflow_enabled(workflow_id, False)
 
 
 @workflow_app.command("reset")

--- a/tools/cc-devthrottle/src/workflow_ops.py
+++ b/tools/cc-devthrottle/src/workflow_ops.py
@@ -213,6 +213,12 @@ class WorkflowClient:
             self._request("DELETE", f"/gateway/workflows/{workflow_id}")
         )
 
+    def set_enabled(self, workflow_id: str, enabled: bool) -> Dict[str, Any]:
+        verb = "enable" if enabled else "disable"
+        return self._json_or_raise(
+            self._request("POST", f"/gateway/workflows/{workflow_id}/{verb}")
+        )
+
     # ---- runs (the governance outcome spine, issue #1771) -------------------------------------
 
     def list_runs(
@@ -298,14 +304,18 @@ def list_workflows(json_output: bool) -> None:
     table.add_column("Name")
     table.add_column("Version", justify="right")
     table.add_column("Kind")
+    table.add_column("State")
     table.add_column("Draft?")
     table.add_column("Summary", overflow="fold")
     for wf in workflows:
+        # An older Gateway omits the enabled field; absent means in force.
+        state = "OFF" if wf.get("enabled") is False else "in force"
         table.add_row(
             wf.get("id", ""),
             wf.get("name", ""),
             str(wf.get("version", "")),
             "built-in" if wf.get("isBuiltIn") else "custom",
+            state,
             "yes" if wf.get("hasDraft") else "",
             wf.get("summary", ""),
         )
@@ -572,6 +582,24 @@ def reset_workflow(workflow_id: str) -> None:
         f"Reset '{workflow_id}' to the shipped content as v{result.get('version')}. "
         "Earlier versions remain as history."
     )
+
+
+def set_workflow_enabled(workflow_id: str, enabled: bool) -> None:
+    try:
+        _client().set_enabled(workflow_id, enabled)
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+    if enabled:
+        console.print(
+            f"'{workflow_id}' is IN FORCE again - back in every agent's briefing, runs and seats allowed."
+        )
+    else:
+        console.print(
+            f"'{workflow_id}' is OFF - hidden from agents' briefings, no new runs or seats. "
+            "Nothing was deleted; re-enable anytime with: "
+            f"cc-devthrottle workflow enable {workflow_id}"
+        )
 
 
 def delete_workflow(workflow_id: str, yes: bool) -> None:

--- a/tools/cc-devthrottle/src/workflow_ops.py
+++ b/tools/cc-devthrottle/src/workflow_ops.py
@@ -26,7 +26,7 @@ import typer
 from rich import box
 from rich.console import Console
 from rich.table import Table
-from urllib.parse import urlparse
+from urllib.parse import quote as urllib_quote, urlparse
 
 _tools_dir = str(Path(__file__).resolve().parent.parent.parent)
 if _tools_dir not in sys.path:
@@ -215,8 +215,10 @@ class WorkflowClient:
 
     def set_enabled(self, workflow_id: str, enabled: bool) -> Dict[str, Any]:
         verb = "enable" if enabled else "disable"
+        # A governance change has an actor: the session flipping the switch names itself.
+        actor = urllib_quote(default_authored_by())
         return self._json_or_raise(
-            self._request("POST", f"/gateway/workflows/{workflow_id}/{verb}")
+            self._request("POST", f"/gateway/workflows/{workflow_id}/{verb}?by={actor}")
         )
 
     # ---- runs (the governance outcome spine, issue #1771) -------------------------------------


### PR DESCRIPTION
Slice 1 of the register redesign (approved mockup direction A). The switch semantics are the owner ruling verbatim.

## What this does

- Every workflow head gains Enabled (default true; the migration backfills existing rows at the database level, so upgrading can never silently switch workflows off).
- OFF means: dropped from every agent's launch briefing (index builder filters; absent field from an older Gateway = enabled); the default conduct read refuses with a clear 400 naming the re-enable command (pinned explicit-version reads keep resolving - a seated run's conduct never vanishes under it); no new runs (store + EnsureRunnable) and no new seats on either spawn leg (run projections carry workflowEnabled, defaulting true for older Gateways so Director-ahead compatibility holds).
- The owner ruling on missions: a mission whose workflow is off still gets created - UNGOVERNED, loudly logged, no run record - and the next mission after re-enable is governed again. Never a 400.
- Nothing deleted, ever: catalog lists off workflows with honest state; history, versions, and past runs stay; the flip is instant both ways fleet-wide.
- Surface: POST /gateway/workflows/{id}/enable + /disable; cc-devthrottle workflow enable/disable (agent-discoverable); State column on workflow list.

## Proof

- Six new tests pin every semantic: catalog still lists with state; default read refused with the exact message while pinned reads resolve; new runs refused and restored by the flip; past runs report state; the briefing index drops off workflows and counts honestly (absent field = enabled); and over real HTTP: disable -> 400 conduct read -> UNGOVERNED mission created (no run id) -> enable -> governed mission again; unknown id 404s.
- Suites: Gateway standalone 2,797 passed 0 failed (full honest count - see the note), Core 3,272, CLI 86, all other projects green.
- Test-runner note: the intermittent silent-truncation defect (#1791) fired twice during this slice's gates, including on a standalone run (190 reported as everything while 2,773 were discoverable). Evidence added to the issue; every count above is from verified-complete runs.

## Next

Slice 2: the register layout itself (approved mockup direction A) - state spine, switch, provenance and activity columns, lifecycle strip, explainer/Help.