### PR TITLE
Gateway: TTS fallback signal keyed on header presence, not the provider value

### DIFF
--- a/src/CcDirector.Gateway.Tests/WingmanVoiceFallbackTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceFallbackTests.cs
@@ -16,15 +16,17 @@ namespace CcDirector.Gateway.Tests;
 /// </summary>
 public sealed class WingmanVoiceFallbackTests
 {
-    /// <summary>A speech upstream that returns 200 + audio bytes, optionally with the fallback header.</summary>
-    private sealed class SpeechStub(byte[] audio, bool withFallbackHeader) : HttpMessageHandler
+    /// <summary>A speech upstream that returns 200 + audio bytes, optionally with the fallback header.
+    /// The header VALUE is configurable so a test can prove the Gateway keys on the header's presence,
+    /// never on its value (the cloud proxy sends a generic "1", never the provider name).</summary>
+    private sealed class SpeechStub(byte[] audio, bool withFallbackHeader, string headerValue = "1") : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
         {
             var resp = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(audio) };
             resp.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("audio/mpeg");
             if (withFallbackHeader)
-                resp.Headers.TryAddWithoutValidation("X-DevThrottle-TTS-Fallback", "openai");
+                resp.Headers.TryAddWithoutValidation("X-DevThrottle-TTS-Fallback", headerValue);
             return Task.FromResult(resp);
         }
     }
@@ -55,13 +57,34 @@ public sealed class WingmanVoiceFallbackTests
     [Fact]
     public async Task Synthesis_WithFallbackHeader_MarksTheClipServedViaFallback_AndIsNotAnOutage()
     {
-        var svc = ServiceWith(new SpeechStub(new byte[] { 1, 2, 3 }, withFallbackHeader: true), TempPersist());
+        // The generic marker "1" is what the cloud proxy now sends (never the provider name).
+        var svc = ServiceWith(new SpeechStub(new byte[] { 1, 2, 3 }, withFallbackHeader: true, headerValue: "1"), TempPersist());
 
         await svc.StoreSpokenAsync("sid-1", "a spoken summary", "the reply");
 
         Assert.True(svc.HasVoice("sid-1"));                       // a fallback is a real, playable clip
         Assert.True(svc.ServedViaFallbackFor("sid-1"));           // ...noted as backup-served
         Assert.Null(svc.VoiceUnavailableFor("sid-1"));            // ...and NEVER an outage/unavailable state
+    }
+
+    // The Gateway must detect the fallback by the header's PRESENCE alone, never by its value. This
+    // locks that contract: the notice fires for the generic marker the cloud sends today ("1"), for the
+    // legacy value from before the value was scrubbed ("openai" - proving backward-compatibility across
+    // the deploy window), and for any other opaque value. A regression that starts comparing the value
+    // against a provider name would break exactly one of these and be caught.
+    [Theory]
+    [InlineData("1")]         // the generic marker the cloud sends now
+    [InlineData("backup")]    // any other opaque value must work identically
+    [InlineData("openai")]    // the legacy value: old cloud + new Gateway stays compatible
+    public async Task Synthesis_FallbackDetection_IsByHeaderPresence_NotValue(string headerValue)
+    {
+        var svc = ServiceWith(new SpeechStub(new byte[] { 1, 2, 3 }, withFallbackHeader: true, headerValue), TempPersist());
+
+        await svc.StoreSpokenAsync("sid-1", "a spoken summary", "the reply");
+
+        Assert.True(svc.HasVoice("sid-1"));
+        Assert.True(svc.ServedViaFallbackFor("sid-1"));           // fires regardless of the header value
+        Assert.Null(svc.VoiceUnavailableFor("sid-1"));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -197,9 +197,11 @@ public sealed class WingmanVoiceService
     public bool HasVoice(string sid) => _ready.ContainsKey(sid);
 
     /// <summary>The response header the cloud speech proxy sets when it quietly failed the primary
-    /// provider over to the backup (Phase 1). Its mere PRESENCE means "served via backup"; the value is
-    /// never surfaced to a user. Reading it is how the Gateway learns to show the generic backup-voice
-    /// notice (a success-with-a-note), and it is deliberately out-of-band so it never touches the audio.</summary>
+    /// provider over to the backup (Phase 1). Its mere PRESENCE means "served via backup". We key on
+    /// presence ONLY and never read the value: the cloud sends a generic opaque marker ("1"), NOT the
+    /// provider name, so which provider served stays invisible even to a direct API caller who inspects
+    /// headers. Reading presence is how the Gateway learns to show the generic backup-voice notice (a
+    /// success-with-a-note), and it is deliberately out-of-band so it never touches the audio.</summary>
     private const string FallbackHeaderName = "X-DevThrottle-TTS-Fallback";
 
     /// <summary>True when this session's current ready clip was made by the BACKUP voice provider (the
@@ -628,9 +630,10 @@ public sealed class WingmanVoiceService
             }
             var contentType = resp.Content.Headers.ContentType?.MediaType;
             // The cloud proxy sets this out-of-band header when it quietly failed the primary voice
-            // provider over to the backup (Phase 1). Its mere presence is the signal - the value is never
-            // shown to a user. A fallback is a SUCCESS: the audio is real and playable; we only note it so
-            // the Voice screen can add the generic backup-voice line.
+            // provider over to the backup (Phase 1). Its mere PRESENCE is the whole signal - we never read
+            // the value (a generic opaque marker, not the provider name). A fallback is a SUCCESS: the
+            // audio is real and playable; we only note it so the Voice screen can add the generic
+            // backup-voice line.
             var servedViaFallback = resp.Headers.Contains(FallbackHeaderName);
             if (servedViaFallback)
                 FileLog.Write($"[WingmanVoiceService] tts served via backup voice provider (fallback) - {mode.ToConfigString()}");


### PR DESCRIPTION
Companion to the provider-agnostic audio work in devthrottle_internal. The cloud speech proxy now sends a generic opaque marker (1) in the X-DevThrottle-TTS-Fallback header instead of the provider name.

The Gateway already detects a fallback by the header's mere presence (resp.Headers.Contains), never by its value, so this is backward-compatible across the deploy window in either order. This PR:
- updates the reader comments to state the value is a generic marker and the detection is presence-only;
- updates the test fixture to the generic value;
- adds a value-independence Theory asserting the backup-voice notice fires for 1 (today), backup (any opaque value), and legacy openai (old cloud + new Gateway) - locking that a regression which starts comparing the value against a provider name would be caught.

Production code change is comment-only.

## Tests
WingmanVoiceFallbackTests 6 pass; voice/wingman subset 284 pass; solution builds clean.