### PR TITLE
feat(cockpit): the workflows register - ledger layout, switch on every row, lifecycle strip, on-page explainer (register redesign, slice 2)

### DIFF
--- a/apps/cockpit/src/workflows/WorkflowDetail.tsx
+++ b/apps/cockpit/src/workflows/WorkflowDetail.tsx
@@ -3,11 +3,13 @@ import { Link, useParams } from "react-router-dom";
 import {
   getWorkflow,
   getWorkflowInstructions,
+  resetWorkflow,
+  setWorkflowEnabled,
   type WorkflowDefinition,
 } from "@devthrottle/client-core/workflows/workflowsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 import { markdownToHtml } from "@devthrottle/client-core/history/historyMarkdown";
-import { ErrorBanner, LoadingState } from "../components";
+import { Button, ConfirmDialog, ErrorBanner, LoadingState } from "../components";
 
 // One workflow, in full (Workflows mission, phase 7). The list row answered "what exists"; this page
 // answers "what does it actually say": the metadata and step summary up top (the machine-readable
@@ -20,6 +22,8 @@ export function WorkflowDetail() {
   const [workflow, setWorkflow] = useState<WorkflowDefinition | null>(null);
   const [instructions, setInstructions] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [pendingOff, setPendingOff] = useState(false);
+  const [pendingReset, setPendingReset] = useState(false);
 
   const load = useCallback(
     async (signal?: AbortSignal) => {
@@ -47,6 +51,12 @@ export function WorkflowDetail() {
     return () => ctrl.abort();
   }, [load]);
 
+  const flip = async (enabled: boolean) => {
+    if (id === undefined) return;
+    await setWorkflowEnabled(id, enabled, "cockpit");
+    await load();
+  };
+
   return (
     <div className="page wf">
       <header className="ui-page-header">
@@ -66,12 +76,41 @@ export function WorkflowDetail() {
       ) : (
         <>
           <div className="wf-detail-facts">
-            <span className={workflow.isBuiltIn === true ? "wf-badge wf-badge-builtin" : "wf-badge wf-badge-custom"}>
-              {workflow.isBuiltIn === true ? "Built-in" : "Custom"}
-            </span>
+            {workflow.isBuiltIn === true ? <span className="wf-badge wf-badge-builtin">Built-in</span> : null}
+            {workflow.isBuiltIn === false ? <span className="wf-badge">Custom</span> : null}
             {typeof workflow.version === "number" ? <span className="wf-badge">v{workflow.version}</span> : null}
             {workflow.hasDraft === true ? <span className="wf-badge wf-badge-draft">Draft waiting</span> : null}
+            {/* The owner's switch, on the workflow's own page too - state named, flip confirmed
+                when turning off (the register's semantics, in one place per the shared client). */}
+            {workflow.enabled !== undefined ? (
+              <span className="wf-detail-switch">
+                <button
+                  className={workflow.enabled ? "wf-switch wf-switch-on" : "wf-switch"}
+                  role="switch"
+                  aria-checked={workflow.enabled}
+                  aria-label={workflow.enabled ? "in force - turn off" : "off - turn on"}
+                  onClick={() => {
+                    if (workflow.enabled) setPendingOff(true);
+                    else void flip(true);
+                  }}
+                ></button>
+                <span className={workflow.enabled ? "wf-state-label wf-state-on" : "wf-state-label wf-state-off"}>
+                  {workflow.enabled ? "In force" : "Off"}
+                </span>
+              </span>
+            ) : null}
+            {workflow.isBuiltIn === true ? (
+              <Button variant="secondary" onClick={() => setPendingReset(true)}>
+                Reset to shipped
+              </Button>
+            ) : null}
           </div>
+          {workflow.enabled === false ? (
+            <p className="wf-off-banner">
+              This workflow is OFF: agents will not see it in their briefings, and it cannot start
+              new runs or seat new sessions. Nothing is deleted - turn it back on anytime.
+            </p>
+          ) : null}
 
           <dl className="wf-facts">
             <dt>When to use it</dt>
@@ -104,6 +143,41 @@ export function WorkflowDetail() {
           </section>
         </>
       )}
+
+      <ConfirmDialog
+        open={pendingOff}
+        title={`Turn '${workflow?.name ?? id}' off?`}
+        message={
+          <>
+            Agents will no longer see this workflow in their briefings, and it cannot start new runs
+            or seat new sessions. Nothing is deleted - turn it back on anytime.
+          </>
+        }
+        confirmLabel="Turn off"
+        danger={false}
+        onConfirm={() => flip(false)}
+        onClose={() => setPendingOff(false)}
+      />
+
+      <ConfirmDialog
+        open={pendingReset}
+        title={`Reset '${workflow?.name ?? id}' to the shipped content?`}
+        message={
+          <>
+            The content DevThrottle ships becomes a NEW published version, in force immediately.
+            Your customized versions stay as history and remain readable by version number.
+          </>
+        }
+        confirmLabel="Reset to shipped"
+        danger={false}
+        onConfirm={async () => {
+          if (id !== undefined) {
+            await resetWorkflow(id);
+            await load();
+          }
+        }}
+        onClose={() => setPendingReset(false)}
+      />
     </div>
   );
 }

--- a/apps/cockpit/src/workflows/WorkflowDetail.tsx
+++ b/apps/cockpit/src/workflows/WorkflowDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import {
   getWorkflow,
@@ -24,21 +24,28 @@ export function WorkflowDetail() {
   const [error, setError] = useState<string | null>(null);
   const [pendingOff, setPendingOff] = useState(false);
   const [pendingReset, setPendingReset] = useState(false);
+  // Every load claims a generation; a load that finishes after a newer one started (a mutation
+  // refresh racing a route change to another workflow) drops its result instead of painting
+  // workflow A's state under workflow B's URL.
+  const loadGen = useRef(0);
 
   const load = useCallback(
     async (signal?: AbortSignal) => {
       if (id === undefined) return;
+      const gen = ++loadGen.current;
       try {
         // Sequential on purpose: the metadata names a version, and the conduct is fetched PINNED to
         // that exact version - two concurrent unpinned fetches can straddle a publish and render v1
-        // steps over v2 conduct (a torn read the inspection caught).
+        // steps over v2 conduct (a torn read the inspection caught). The pin also keeps this page
+        // working for an OFF workflow, whose unversioned conduct read the Gateway refuses.
         const wf = await getWorkflow(id, signal);
         const md = await getWorkflowInstructions(id, wf.version, signal);
+        if (gen !== loadGen.current) return;
         setWorkflow(wf);
         setInstructions(md);
         setError(null);
       } catch (err) {
-        if (signal?.aborted === true) return;
+        if (signal?.aborted === true || gen !== loadGen.current) return;
         setError(gatewayErrorMessage(err));
       }
     },
@@ -51,9 +58,15 @@ export function WorkflowDetail() {
     return () => ctrl.abort();
   }, [load]);
 
+  // A failed flip or reset is never silent: it lands in the page's error state (with Retry).
   const flip = async (enabled: boolean) => {
     if (id === undefined) return;
-    await setWorkflowEnabled(id, enabled, "cockpit");
+    try {
+      await setWorkflowEnabled(id, enabled, "cockpit");
+    } catch (err) {
+      setError(gatewayErrorMessage(err));
+      return;
+    }
     await load();
   };
 
@@ -171,10 +184,14 @@ export function WorkflowDetail() {
         confirmLabel="Reset to shipped"
         danger={false}
         onConfirm={async () => {
-          if (id !== undefined) {
+          if (id === undefined) return;
+          try {
             await resetWorkflow(id);
-            await load();
+          } catch (err) {
+            setError(gatewayErrorMessage(err));
+            return;
           }
+          await load();
         }}
         onClose={() => setPendingReset(false)}
       />

--- a/apps/cockpit/src/workflows/WorkflowsView.tsx
+++ b/apps/cockpit/src/workflows/WorkflowsView.tsx
@@ -68,8 +68,15 @@ export function WorkflowsView() {
     return byWorkflow;
   }, [runs]);
 
+  // A failed flip is never silent: the error lands in the page's error state (with Retry), and the
+  // register re-renders from the Gateway's truth rather than an optimistic guess.
   const flip = async (workflow: WorkflowDefinition, enabled: boolean) => {
-    await setWorkflowEnabled(workflow.id, enabled, "cockpit");
+    try {
+      await setWorkflowEnabled(workflow.id, enabled, "cockpit");
+    } catch (err) {
+      setError(gatewayErrorMessage(err));
+      return;
+    }
     await load();
   };
 
@@ -111,7 +118,7 @@ export function WorkflowsView() {
             <div>Workflow</div>
             <div>State</div>
             <div>Provenance</div>
-            <div>Activity</div>
+            <div>Recent activity</div>
           </div>
           {workflows.map((wf) => (
             <RegisterRow
@@ -129,7 +136,12 @@ export function WorkflowsView() {
             <span>
               Agents read and author these with <code>cc-devthrottle workflow ...</code>
             </span>
-            <button className="wf-linklike" onClick={() => setExplainerOpen((open) => !open)}>
+            <button
+              className="wf-linklike"
+              aria-expanded={explainerOpen}
+              aria-controls="wf-explainer-panel"
+              onClick={() => setExplainerOpen((open) => !open)}
+            >
               How workflows reach your agents
             </button>
           </div>
@@ -192,13 +204,17 @@ function RegisterRow({
         <div className="wf-reg-sum">{workflow.summary}</div>
       </div>
       <div className="wf-cell-state">
-        <button
-          className={off ? "wf-switch" : "wf-switch wf-switch-on"}
-          role="switch"
-          aria-checked={!off}
-          aria-label={`${workflow.name}: ${off ? "off - turn on" : "in force - turn off"}`}
-          onClick={() => onFlip(off)}
-        ></button>
+        {/* The switch renders only when the Gateway reported the enabled flag: an older Gateway
+            without the switch routes must not show a control that can only fail. */}
+        {workflow.enabled !== undefined ? (
+          <button
+            className={off ? "wf-switch" : "wf-switch wf-switch-on"}
+            role="switch"
+            aria-checked={!off}
+            aria-label={`${workflow.name}: ${off ? "off - turn on" : "in force - turn off"}`}
+            onClick={() => onFlip(off)}
+          ></button>
+        ) : null}
         <span className={`wf-state-label ${stateClass}`}>{stateLabel}</span>
       </div>
       <div className="wf-cell-prov">
@@ -220,7 +236,7 @@ function RegisterRow({
             last: {activity.newestUtc.slice(0, 10)}
           </>
         ) : runsLoaded ? (
-          <span>no runs yet</span>
+          <span>no recent runs</span>
         ) : (
           <span className="wf-off-note">activity unavailable</span>
         )}
@@ -233,7 +249,7 @@ function RegisterRow({
 // where the question gets asked.
 function Explainer() {
   return (
-    <section className="wf-explainer">
+    <section className="wf-explainer" id="wf-explainer-panel">
       <h2>How workflows reach your agents</h2>
       <dl>
         <dt>out of the box</dt>

--- a/apps/cockpit/src/workflows/WorkflowsView.tsx
+++ b/apps/cockpit/src/workflows/WorkflowsView.tsx
@@ -1,41 +1,49 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   createWorkflow,
+  getWorkflowRuns,
   getWorkflows,
+  setWorkflowEnabled,
   suggestWorkflowId,
   type WorkflowDefinition,
+  type WorkflowRunSummary,
 } from "@devthrottle/client-core/workflows/workflowsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
-import { Button, ErrorBanner, LoadingState } from "../components";
+import { Button, ConfirmDialog, ErrorBanner, LoadingState } from "../components";
 
-// The Workflows page (issue #1617; rebuilt by the Workflows mission, phase 7): the named ways of
-// working this fleet defines - Mission and its siblings, plus every workflow the user's agents author.
+// The Workflows REGISTER (register redesign, approved mockup direction A). Workflows are the rules
+// this fleet works by, and the page reads with that weight: a ledger, not cards. One row per
+// workflow with a colored state spine (in force / draft waiting / off), the owner's switch on every
+// row - built-ins included - provenance and activity columns, and the standing lifecycle strip that
+// answers "how does this reach my agents" as page furniture rather than a buried help link.
 //
-// The page's job is to LIST and BROWSE. One compact row per workflow; the conduct itself lives on the
-// detail page. Authoring is AGENT-driven by design - workflows are markdown + optional helper files
-// that agents pull, edit, and push through the cc-devthrottle workflow commands - so "Add workflow"
-// deliberately asks only for a name and a summary, creates a DRAFT, and hands you the exact prompt to
-// give an agent. No markdown box, no step builder: a form that pretended to be the authoring surface
-// would be worse than the one that already exists in every agent.
-//
-// The definitions come from the GATEWAY, not this bundle: the Gateway is the home, every Director and
-// every agent asks it, and the catalog this page shows is the same catalog every session's preamble
-// indexes.
+// The switch is the owner ruling verbatim: off removes the workflow from every agent's briefing and
+// refuses new runs and seats - and deletes nothing. Turning something off is consequential enough
+// to confirm; turning it back on is not.
 export function WorkflowsView() {
   const [workflows, setWorkflows] = useState<WorkflowDefinition[] | null>(null);
+  const [runs, setRuns] = useState<WorkflowRunSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [adding, setAdding] = useState(false);
+  const [pendingOff, setPendingOff] = useState<WorkflowDefinition | null>(null);
+  const [explainerOpen, setExplainerOpen] = useState(false);
 
   const load = useCallback(async (signal?: AbortSignal) => {
     try {
+      // The catalog IS the page (no fallback to an empty register); the runs read only feeds the
+      // activity column, so its failure costs the numbers and says so in place - an older Gateway
+      // without the run routes must not blank the whole register.
       const fresh = await getWorkflows(signal);
       setWorkflows(fresh);
       setError(null);
+      try {
+        setRuns(await getWorkflowRuns(200, signal));
+      } catch {
+        if (signal?.aborted !== true) setRuns(null);
+      }
     } catch (err) {
       if (signal?.aborted === true) return;
-      // No fallback to an empty list: an unreadable catalog says so, it does not render as "you have
-      // no workflows".
       setError(gatewayErrorMessage(err));
     }
   }, []);
@@ -46,65 +54,216 @@ export function WorkflowsView() {
     return () => ctrl.abort();
   }, [load]);
 
+  const activity = useMemo(() => {
+    const byWorkflow = new Map<string, { count: number; newestUtc: string }>();
+    for (const run of runs ?? []) {
+      const entry = byWorkflow.get(run.workflowId);
+      if (entry === undefined) {
+        byWorkflow.set(run.workflowId, { count: 1, newestUtc: run.createdUtc });
+      } else {
+        entry.count += 1;
+        if (run.createdUtc > entry.newestUtc) entry.newestUtc = run.createdUtc;
+      }
+    }
+    return byWorkflow;
+  }, [runs]);
+
+  const flip = async (workflow: WorkflowDefinition, enabled: boolean) => {
+    await setWorkflowEnabled(workflow.id, enabled, "cockpit");
+    await load();
+  };
+
   return (
     <div className="page wf">
       <header className="ui-page-header">
         <div className="ui-page-header-text">
+          <p className="wf-eyebrow">Fleet governance</p>
           <h1 className="ui-page-title">Workflows</h1>
           <p className="ui-page-subtitle">
-            Named ways of working, stored on the Gateway and usable by every agent on every machine.
+            The rules your fleet works by. Every agent on every machine reads these from the Gateway
+            - the same catalog every session is briefed with at launch.
           </p>
         </div>
         <Button variant="primary" onClick={() => setAdding(true)}>Add workflow</Button>
       </header>
 
+      <div className="wf-lifecycle">
+        <span className="wf-lc-step"><span className="wf-lc-who">any agent</span> authors</span>
+        <span className="wf-lc-arrow">-&gt;</span>
+        <span className="wf-lc-step">draft</span>
+        <span className="wf-lc-arrow">-&gt;</span>
+        <span className="wf-lc-step">publish</span>
+        <span className="wf-lc-arrow">-&gt;</span>
+        <span className="wf-lc-step wf-lc-live">in force everywhere, instantly</span>
+        <span className="wf-lc-tail">
+          nothing to deploy - no restart - running missions keep their pinned version
+        </span>
+      </div>
+
       {error !== null ? (
         <ErrorBanner message={error} onRetry={() => void load()} />
       ) : workflows === null ? (
-        <LoadingState message="Loading workflows..." />
+        <LoadingState message="Loading the register..." />
       ) : (
-        <div className="wf-rows">
+        <div className="wf-register">
+          <div className="wf-reg-head" aria-hidden="true">
+            <div className="wf-spine"></div>
+            <div>Workflow</div>
+            <div>State</div>
+            <div>Provenance</div>
+            <div>Activity</div>
+          </div>
           {workflows.map((wf) => (
-            <WorkflowRow key={wf.id} workflow={wf} />
+            <RegisterRow
+              key={wf.id}
+              workflow={wf}
+              activity={activity.get(wf.id)}
+              runsLoaded={runs !== null}
+              onFlip={(enabled) => {
+                if (!enabled) setPendingOff(wf);
+                else void flip(wf, true);
+              }}
+            />
           ))}
+          <div className="wf-reg-foot">
+            <span>
+              Agents read and author these with <code>cc-devthrottle workflow ...</code>
+            </span>
+            <button className="wf-linklike" onClick={() => setExplainerOpen((open) => !open)}>
+              How workflows reach your agents
+            </button>
+          </div>
         </div>
       )}
 
+      {explainerOpen ? <Explainer /> : null}
+
       {adding ? (
-        <AddWorkflowDialog
-          onClose={() => setAdding(false)}
-          onCreated={() => void load()}
-        />
+        <AddWorkflowDialog onClose={() => setAdding(false)} onCreated={() => void load()} />
       ) : null}
+
+      <ConfirmDialog
+        open={pendingOff !== null}
+        title={`Turn '${pendingOff?.name ?? ""}' off?`}
+        message={
+          <>
+            Agents will no longer see this workflow in their briefings, and it cannot start new runs
+            or seat new sessions. Nothing is deleted - history and versions stay, and you can turn
+            it back on anytime.
+          </>
+        }
+        confirmLabel="Turn off"
+        danger={false}
+        onConfirm={async () => {
+          if (pendingOff !== null) await flip(pendingOff, false);
+        }}
+        onClose={() => setPendingOff(null)}
+      />
     </div>
   );
 }
 
-function WorkflowRow({ workflow }: { workflow: WorkflowDefinition }) {
+function RegisterRow({
+  workflow,
+  activity,
+  runsLoaded,
+  onFlip,
+}: {
+  workflow: WorkflowDefinition;
+  activity: { count: number; newestUtc: string } | undefined;
+  runsLoaded: boolean;
+  onFlip: (enabled: boolean) => void;
+}) {
+  const off = workflow.enabled === false;
+  const spine = off ? "wf-spine-off" : workflow.hasDraft === true ? "wf-spine-draft" : "wf-spine-on";
+  const stateLabel = off ? "Off" : workflow.hasDraft === true ? "Draft waiting" : "In force";
+  const stateClass = off ? "wf-state-off" : workflow.hasDraft === true ? "wf-state-draft" : "wf-state-on";
+
   return (
-    <Link className="wf-row" to={`/workflows/${encodeURIComponent(workflow.id)}`}>
-      <div className="wf-row-main">
-        <span className="wf-row-name">{workflow.name}</span>
-        {/* The kind badge renders only when the Gateway REPORTS the field - an older Gateway that
-            omits it must not see every built-in mislabeled "Custom". Absent field, absent badge. */}
+    <div className={off ? "wf-reg-row wf-reg-row-off" : "wf-reg-row"}>
+      <div className={`wf-spine ${spine}`}></div>
+      <div className="wf-cell-main">
+        <Link className="wf-reg-id" to={`/workflows/${encodeURIComponent(workflow.id)}`}>
+          {workflow.id}
+        </Link>
         {workflow.isBuiltIn === true ? <span className="wf-badge wf-badge-builtin">Built-in</span> : null}
-        {workflow.isBuiltIn === false ? <span className="wf-badge wf-badge-custom">Custom</span> : null}
-        {workflow.hasDraft === true ? <span className="wf-badge wf-badge-draft">Draft waiting</span> : null}
+        {workflow.isBuiltIn === false ? <span className="wf-badge">Custom</span> : null}
+        <div className="wf-reg-name">{workflow.name}</div>
+        <div className="wf-reg-sum">{workflow.summary}</div>
       </div>
-      <p className="wf-row-summary">{workflow.summary}</p>
-      <div className="wf-row-facts">
-        {typeof workflow.version === "number" ? <span>v{workflow.version}</span> : null}
-        <span>
-          {workflow.steps.length} {workflow.steps.length === 1 ? "step" : "steps"}
-        </span>
+      <div className="wf-cell-state">
+        <button
+          className={off ? "wf-switch" : "wf-switch wf-switch-on"}
+          role="switch"
+          aria-checked={!off}
+          aria-label={`${workflow.name}: ${off ? "off - turn on" : "in force - turn off"}`}
+          onClick={() => onFlip(off)}
+        ></button>
+        <span className={`wf-state-label ${stateClass}`}>{stateLabel}</span>
       </div>
-    </Link>
+      <div className="wf-cell-prov">
+        {typeof workflow.version === "number" ? (
+          <>
+            <b>v{workflow.version}</b> in force
+            <br />
+          </>
+        ) : null}
+        {workflow.updatedUtc !== undefined ? <>updated {workflow.updatedUtc.slice(0, 10)}</> : null}
+      </div>
+      <div className="wf-cell-activity">
+        {off ? (
+          <span className="wf-off-note">agents will not see or run this</span>
+        ) : activity !== undefined ? (
+          <>
+            <b>{activity.count}</b> {activity.count === 1 ? "run" : "runs"}
+            <br />
+            last: {activity.newestUtc.slice(0, 10)}
+          </>
+        ) : runsLoaded ? (
+          <span>no runs yet</span>
+        ) : (
+          <span className="wf-off-note">activity unavailable</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// The standing answers to "how and when do these apply" - kept on the page because the register is
+// where the question gets asked.
+function Explainer() {
+  return (
+    <section className="wf-explainer">
+      <h2>How workflows reach your agents</h2>
+      <dl>
+        <dt>out of the box</dt>
+        <dd>
+          A fresh Gateway ships Mission, Standalone, and Standalone with review - working from the
+          first minute on every connected machine.
+        </dd>
+        <dt>no restart</dt>
+        <dd>
+          Agents fetch the conduct from the Gateway at the moment they use it. Publishing is the
+          deployment: every next read, on every machine, gets the new version.
+        </dd>
+        <dt>pinned runs</dt>
+        <dd>
+          A session seated on a mission keeps the version it started under. Publishing mid-run never
+          changes the rules under a running mission.
+        </dd>
+        <dt>off</dt>
+        <dd>
+          A workflow you turn off disappears from agents&apos; briefings and cannot start runs or
+          seat sessions. Nothing is deleted, and the flip is instant both ways.
+        </dd>
+      </dl>
+    </section>
   );
 }
 
 // The add dialog: name + one-line summary, nothing else. Submitting creates a DRAFT on the Gateway
-// (invisible to the fleet until an agent fleshes it out and publishes) and shows the copyable handoff
-// prompt. Errors surface inline and the dialog stays open - the failure is never swallowed.
+// (invisible to the fleet until an agent fleshes it out and publishes) and shows the copyable
+// handoff prompt. Errors surface inline and the dialog stays open - the failure is never swallowed.
 function AddWorkflowDialog({ onClose, onCreated }: { onClose: () => void; onCreated: () => void }) {
   const [name, setName] = useState("");
   const [summary, setSummary] = useState("");
@@ -133,9 +292,8 @@ function AddWorkflowDialog({ onClose, onCreated }: { onClose: () => void; onCrea
   };
 
   // The backdrop dismisses only while the form is idle: dismissing DURING the create leaves the
-  // draft half-born on the Gateway with its handoff prompt never shown (and a retry then hits an
-  // id conflict), and dismissing the success state would lose the prompt - both are click-through
-  // traps the inspection caught.
+  // draft half-born with its handoff prompt never shown, and dismissing the success state would
+  // lose the prompt.
   return (
     <div
       className="wf-dialog-backdrop"
@@ -200,9 +358,6 @@ function AddWorkflowDialog({ onClose, onCreated }: { onClose: () => void; onCrea
               <Button
                 variant="secondary"
                 onClick={() => {
-                  // Clipboard access can be absent (insecure remote origin) or denied. The prompt is
-                  // fully visible in the box above, so the honest degrade is to SAY the copy failed
-                  // and let the person select the text - never an unhandled rejection.
                   navigator.clipboard?.writeText(handoff).then(
                     () => setCopied(true),
                     () => setError("Copy failed - select the text above and copy it manually."),

--- a/apps/cockpit/src/workflows/workflows.css
+++ b/apps/cockpit/src/workflows/workflows.css
@@ -1,221 +1,152 @@
-/* The Workflows page (issue #1617). Rendered as normal scrolling content inside the padded main pane,
-   on the shell theme tokens (src/styles.css :root) so it reads as one product with the rest.
+/* The Workflows REGISTER (register redesign, approved mockup direction A), on the shell theme
+   tokens (src/styles.css :root) so it reads as one product with the rest.
 
-   The layout answers one question per card: what shape of work is this, and who sits in which seat.
-   The steps are a numbered spine so the order is readable at a glance, and each step states its seats
-   on one row - who does it, who reviews it, what done means - because those three are the whole reason
-   the feature exists. */
+   Workflows are the rules the fleet works by, and the page is styled with that weight: a ledger,
+   not cards. One row per workflow, a colored state spine on the left edge (in force / draft
+   waiting / off), the owner's switch in the State column, provenance and activity in tabular
+   figures - and the lifecycle strip up top as page furniture, because "how does this reach my
+   agents" is the standing question this page gets asked. */
 
 .wf {
-  max-width: 880px;
+  max-width: 1020px;
 }
 
-.wf-intro {
-  margin: 0 0 20px;
-  max-width: 68ch;
+.wf-eyebrow {
+  margin: 0 0 2px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--text-dim);
-  font-size: 13px;
-  line-height: 1.55;
 }
 
-.wf-list {
+/* The lifecycle strip: authors -> draft -> publish -> in force, with the no-deploy fact as the
+   tail. It states the delivery model once, above the register, instead of hiding it in help. */
+.wf-lifecycle {
   display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.wf-card {
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 10px;
+  margin: 0 0 18px;
+  padding: 10px 14px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 18px 20px;
-}
-
-.wf-card-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.wf-name {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text);
-}
-
-.wf-steps-count {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--text-dim);
+}
+
+.wf-lc-step {
+  color: var(--text);
   white-space: nowrap;
 }
 
-.wf-summary {
-  margin: 6px 0 0;
-  max-width: 68ch;
-  color: var(--text);
-  font-size: 13px;
-  line-height: 1.55;
+.wf-lc-who {
+  font-weight: 600;
 }
 
-/* The two standing facts about a workflow, as a label/value grid rather than prose: they are the
-   things you compare ACROSS workflows when choosing one, so they need to sit in the same place on
-   every card. */
-.wf-facts {
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  gap: 4px 14px;
-  margin: 14px 0 0;
-  padding: 12px 0 0;
-  border-top: 1px solid var(--border);
+.wf-lc-arrow {
+  color: var(--text-dim);
+  font-family: var(--mono, monospace);
 }
 
-.wf-facts dt {
+.wf-lc-live {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.wf-lc-tail {
+  flex: 1 1 100%;
   font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--text-dim);
-  padding-top: 1px;
-}
-
-.wf-facts dd {
-  margin: 0;
-  font-size: 13px;
-  line-height: 1.5;
-  color: var(--text);
-}
-
-.wf-steps {
-  list-style: none;
-  margin: 16px 0 0;
-  padding: 14px 0 0;
-  border-top: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.wf-step {
-  display: grid;
-  grid-template-columns: 24px 1fr;
-  gap: 12px;
-  align-items: start;
-}
-
-.wf-step-num {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-size: 12px;
-  font-weight: 600;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.wf-step-name {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-}
-
-.wf-step-desc {
-  margin: 3px 0 0;
-  max-width: 62ch;
-  color: var(--text-dim);
-  font-size: 13px;
-  line-height: 1.5;
-}
-
-/* The seats row. Wraps rather than scrolls: on a narrow pane the seats stack instead of clipping the
-   "Done when" value, which is the longest of the three. */
-.wf-seats {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 20px;
-  margin-top: 8px;
-}
-
-.wf-seat {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-}
-
-/* "Done when" carries a sentence, not a name - let it take the remaining width instead of squeezing
-   into a name-sized column. */
-.wf-seat-done {
-  flex: 1 1 22ch;
-}
-
-.wf-seat-label {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
   color: var(--text-dim);
 }
 
-.wf-seat-who {
-  font-size: 13px;
-  color: var(--text);
-  line-height: 1.45;
-}
+/* ---- The register itself. ---- */
 
-/* A step with no review seat states that plainly, dimmed - it is a real answer, not missing data. */
-.wf-seat-none {
-  color: var(--text-dim);
-  font-style: italic;
-}
-
-/* ---- Workflows mission, phase 7: the compact list, the add dialog, and the detail page. The list
-   answers "what exists" in one row per workflow; the conduct lives on the detail page; the dialog
-   asks only what a DRAFT needs, because authoring is agent-driven by design. ---- */
-
-.wf-rows {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.wf-row {
-  display: block;
+.wf-register {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 12px 16px;
-  color: inherit;
-  text-decoration: none;
+  overflow: hidden;
 }
 
-.wf-row:hover {
-  border-color: var(--accent);
+.wf-reg-head,
+.wf-reg-row {
+  display: grid;
+  grid-template-columns: 5px minmax(230px, 1.5fr) 160px minmax(150px, 1fr) 170px;
+  gap: 0 16px;
+  align-items: start;
 }
 
-.wf-row-main {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-}
-
-.wf-row-name {
-  font-size: 15px;
+.wf-reg-head {
+  padding: 8px 16px 8px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 10px;
   font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.wf-reg-row {
+  padding: 13px 16px 13px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.wf-reg-row:last-of-type {
+  border-bottom: none;
+}
+
+/* An OFF row stays fully readable - the register must show it to flip it back - just visibly
+   stood down. */
+.wf-reg-row-off .wf-cell-main,
+.wf-reg-row-off .wf-cell-prov {
+  opacity: 0.55;
+}
+
+/* The state spine: the row's left edge IS its state, readable before any label. */
+.wf-spine {
+  width: 5px;
+  align-self: stretch;
+}
+
+.wf-spine-on {
+  background: var(--ok, #3fb970);
+}
+
+.wf-spine-draft {
+  background: var(--warn);
+}
+
+.wf-spine-off {
+  background: var(--border);
+}
+
+.wf-cell-main {
+  min-width: 0;
+}
+
+.wf-reg-id {
+  font-family: var(--mono, monospace);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+  margin-right: 8px;
+}
+
+.wf-reg-id:hover {
+  text-decoration: underline;
 }
 
 .wf-badge {
-  font-size: 11px;
-  padding: 1px 8px;
+  font-size: 10px;
+  padding: 1px 7px;
   border-radius: 10px;
   border: 1px solid var(--border);
   color: var(--text-dim);
   white-space: nowrap;
+  vertical-align: 1px;
 }
 
 .wf-badge-builtin {
@@ -228,21 +159,195 @@
   border-color: var(--warn);
 }
 
-.wf-row-summary {
-  margin: 6px 0 4px;
+.wf-reg-name {
+  margin-top: 3px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.wf-reg-sum {
+  margin-top: 2px;
+  font-size: 12px;
+  line-height: 1.45;
   color: var(--text-dim);
+  max-width: 52ch;
+}
+
+.wf-cell-state {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* The owner's switch: a plain two-state pill, no text inside - the label beside it names the
+   state. Focus is visible because this is the most consequential control on the page. */
+.wf-switch {
+  position: relative;
+  width: 34px;
+  height: 19px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  cursor: pointer;
+  padding: 0;
+  flex: 0 0 auto;
+}
+
+.wf-switch::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: var(--text-dim);
+}
+
+.wf-switch-on {
+  background: var(--ok, #3fb970);
+  border-color: var(--ok, #3fb970);
+}
+
+.wf-switch-on::after {
+  left: auto;
+  right: 2px;
+  background: #fff;
+}
+
+.wf-switch:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.wf-state-label {
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.wf-state-on {
+  color: var(--ok, #3fb970);
+}
+
+.wf-state-draft {
+  color: var(--warn);
+}
+
+.wf-state-off {
+  color: var(--text-dim);
+}
+
+.wf-cell-prov,
+.wf-cell-activity {
+  font-family: var(--mono, monospace);
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  line-height: 1.6;
+  color: var(--text-dim);
+}
+
+.wf-cell-prov b,
+.wf-cell-activity b {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.wf-off-note {
+  font-family: inherit;
+  font-style: italic;
+}
+
+.wf-reg-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  padding: 9px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--surface-2);
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.wf-reg-foot code {
+  font-family: var(--mono, monospace);
+}
+
+.wf-linklike {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--accent);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.wf-linklike:hover {
+  text-decoration: underline;
+}
+
+/* On a narrow pane the grid collapses to a stacked row: spine on the left, cells flowing under
+   each other; the head row (pure labels) disappears because each cell is self-describing. */
+@media (max-width: 900px) {
+  .wf-reg-head {
+    display: none;
+  }
+
+  .wf-reg-row {
+    grid-template-columns: 5px 1fr;
+    gap: 6px 14px;
+  }
+
+  .wf-spine {
+    grid-row: 1 / span 4;
+  }
+}
+
+/* ---- The explainer: the standing answers, revealed under the register on demand. ---- */
+
+.wf-explainer {
+  margin-top: 18px;
+  padding: 16px 18px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.wf-explainer h2 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.wf-explainer dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 8px 16px;
+  margin: 0;
+}
+
+.wf-explainer dt {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  padding-top: 2px;
+  white-space: nowrap;
+}
+
+.wf-explainer dd {
+  margin: 0;
   font-size: 13px;
   line-height: 1.5;
+  color: var(--text);
+  max-width: 72ch;
 }
 
-.wf-row-facts {
-  display: flex;
-  gap: 14px;
-  font-size: 12px;
-  color: var(--text-dim);
-}
+/* ---- The add dialog (phase 7): name + one-line summary only, then the copyable handoff. ---- */
 
-/* The add dialog. */
 .wf-dialog-backdrop {
   position: fixed;
   inset: 0;
@@ -322,7 +427,8 @@
   overflow-y: scroll;
 }
 
-/* The detail page. */
+/* ---- The detail page (phase 7 + the switch and off banner from the register redesign). ---- */
+
 .wf-crumb {
   margin: 0 0 2px;
   font-size: 12px;
@@ -339,8 +445,56 @@
 
 .wf-detail-facts {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin: 0 0 14px;
+}
+
+.wf-detail-switch {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: 4px;
+}
+
+.wf-off-banner {
+  margin: 0 0 14px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--warn);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.5;
+  max-width: 72ch;
+}
+
+/* The two standing facts about a workflow, as a label/value grid: they are the things you compare
+   ACROSS workflows when choosing one, so they sit in the same place on every detail page. */
+.wf-facts {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 14px;
+  margin: 0 0 16px;
+}
+
+.wf-facts dt {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  padding-top: 1px;
+}
+
+.wf-facts dd {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text);
+  max-width: 72ch;
 }
 
 .wf-detail-steps {

--- a/apps/cockpit/src/workflows/workflows.css
+++ b/apps/cockpit/src/workflows/workflows.css
@@ -9,6 +9,9 @@
 
 .wf {
   max-width: 1020px;
+  /* The register collapses on the width of THIS pane, not the viewport: with the session rail
+     open, a wide window can still leave the main pane too narrow for the full grid. */
+  container-type: inline-size;
 }
 
 .wf-eyebrow {
@@ -291,7 +294,7 @@
 
 /* On a narrow pane the grid collapses to a stacked row: spine on the left, cells flowing under
    each other; the head row (pure labels) disappears because each cell is self-describing. */
-@media (max-width: 900px) {
+@container (max-width: 900px) {
   .wf-reg-head {
     display: none;
   }

--- a/packages/client-core/src/workflows/workflowsClient.ts
+++ b/packages/client-core/src/workflows/workflowsClient.ts
@@ -43,6 +43,9 @@ export interface WorkflowDefinition {
   contentHash?: string;
   /** When the workflow head last changed (UTC, ISO). */
   updatedUtc?: string;
+  /** The owner's switch: false = OFF (hidden from agents' briefings, no new runs or seats).
+   *  Absent on an older Gateway, which means enabled. */
+  enabled?: boolean;
 }
 
 /** The response of creating a workflow: the new draft's snapshot (subset this client reads). */
@@ -131,6 +134,57 @@ export async function createWorkflow(
   });
   if (!res.ok) throw await gatewayErrorFrom(res, "POST /gateway/workflows");
   return (await res.json()) as WorkflowDraft;
+}
+
+/** One workflow run (the slice this page reads: activity rollups per workflow). */
+export interface WorkflowRunSummary {
+  id: string;
+  workflowId: string;
+  workflowVersion: number;
+  status: string;
+  acceptanceStatus: string;
+  createdUtc: string;
+}
+
+// GET /gateway/workflow-runs - newest first, bounded server-side. The register groups these
+// client-side into per-workflow activity (count + newest); a dedicated rollup endpoint can replace
+// this read if catalogs ever outgrow it.
+export async function getWorkflowRuns(limit = 200, signal?: AbortSignal): Promise<WorkflowRunSummary[]> {
+  const res = await fetch(`/gateway/workflow-runs?limit=${limit}`, {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) throw await gatewayErrorFrom(res, "GET /gateway/workflow-runs");
+  const body = (await res.json()) as { runs?: WorkflowRunSummary[] } | null;
+  return body?.runs ?? [];
+}
+
+// POST /gateway/workflows/{id}/enable | /disable - the owner's switch. The Gateway REQUIRES the
+// actor: a governance change is never anonymous.
+export async function setWorkflowEnabled(
+  id: string,
+  enabled: boolean,
+  by: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const verb = enabled ? "enable" : "disable";
+  const res = await fetch(
+    `/gateway/workflows/${encodeURIComponent(id)}/${verb}?by=${encodeURIComponent(by)}`,
+    { method: "POST", headers: { Accept: "application/json", ...authHeaders() }, signal },
+  );
+  if (!res.ok) throw await gatewayErrorFrom(res, `POST /gateway/workflows/${id}/${verb}`);
+}
+
+// POST /gateway/workflows/{id}/reset - built-ins only: republish the shipped content as a new
+// version. The customized versions stay as history.
+export async function resetWorkflow(id: string, signal?: AbortSignal): Promise<void> {
+  const res = await fetch(`/gateway/workflows/${encodeURIComponent(id)}/reset`, {
+    method: "POST",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) throw await gatewayErrorFrom(res, `POST /gateway/workflows/${id}/reset`);
 }
 
 /** A workflow id slug from a display name: "Release Train" -> "release-train". The Gateway enforces


### PR DESCRIPTION
Slice 2 of the register redesign (the layout the owner approved from the mockups). Slice 1 (#1817) shipped the switch end to end on the Gateway, Director, and CLI; this slice gives the cockpit the register that presents it.

## What changes

**The list becomes a register** (`WorkflowsView.tsx` rewritten):
- One row per workflow with a 5px state spine on the left edge: green = in force, amber = draft waiting, gray = off. The row reads as a ledger entry, not a card.
- The owner's switch on every row, built-ins included. Turning OFF asks for confirmation (it removes the workflow from every agent's briefing and refuses new runs and seats); turning ON is direct. Nothing is deleted either way.
- Provenance column: published version + last update date. Activity column: run counts rolled up client-side from the run spine; an off workflow states "agents will not see or run this"; if the runs read fails (an older Gateway), the column says "activity unavailable" instead of blanking the register.
- The lifecycle strip above the register states the delivery model as page furniture: any agent authors -> draft -> publish -> in force everywhere, instantly; nothing to deploy, no restart, running missions keep their pinned version.
- A collapsible explainer under the register answers the standing questions (out of the box, no restart, pinned runs, off) on the page itself.
- The add dialog is unchanged in behavior (draft + copyable agent handoff prompt).

**The detail page** (`WorkflowDetail.tsx`):
- The same switch and state label in the facts row, with the same confirm-on-off semantics.
- An off banner when the workflow is off. The conduct still renders, because the detail read is pinned to the workflow's published version and pinned reads bypass the off refusal by design.
- Built-ins gain a "Reset to shipped" action (confirmed): the shipped content becomes a new published version; customized history stays readable by version number.

**Client** (`workflowsClient.ts`): `WorkflowRunSummary` + `getWorkflowRuns`, `setWorkflowEnabled` (actor required, per the Gateway contract), `resetWorkflow`, and the additive `enabled` flag on `WorkflowDefinition` (absent on an older Gateway means enabled).

**Styles** (`workflows.css`): rewritten for the register on the shell theme tokens; the dead card and compact-row styles from the two earlier layouts are removed. Scrollable panes use always-visible scrollbars per the house rule.

## Verification

- `npm run typecheck --workspaces --if-present`: client-core, cockpit, mobile all clean.
- `npm run test --workspace @devthrottle/client-core`: 544 passed (50 files).
- `npm run test --workspace @devthrottle/cockpit`: 145 passed (14 files).
- `npm run build --workspace @devthrottle/cockpit`: production build clean.
- No C#/Python changes in this slice; the seven-project suite ran green on slice 1 (#1817), which this branch is cut on top of.
