### PR TITLE
Gateway: route a session past a silent voice provider to the backup (devthrottle_internal#405)

### DIFF
--- a/src/CcDirector.Gateway.Tests/WingmanVoiceFallbackTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceFallbackTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using CcDirector.AgentBrain;
 using CcDirector.Core;
+using CcDirector.Core.HostedAi;
 using CcDirector.Gateway.Wingman;
 using Xunit;
 
@@ -112,5 +113,74 @@ public sealed class WingmanVoiceFallbackTests
         var reloaded = ServiceWith(new SpeechStub(Array.Empty<byte>(), withFallbackHeader: false), persist);
         Assert.True(reloaded.HasVoice("sid-1"));
         Assert.True(reloaded.ServedViaFallbackFor("sid-1"));
+    }
+
+    /// <summary>A speech upstream that STALLS on its first call (the primary goes silent - a
+    /// TimeoutException, exactly what TtsSynthesis throws when its per-attempt deadline fires with no
+    /// answer), then on every later call returns 200 + audio with the fallback header, recording the
+    /// last request so a test can assert what headers the Gateway sent.</summary>
+    private sealed class HangThenBackupStub : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            LastRequest = request;
+            if (Calls == 1)
+                // A silent primary: the request never gets an answer, which TtsSynthesis surfaces as a
+                // TimeoutException. Returning a faulted task is how a stub reproduces that give-up.
+                return Task.FromException<HttpResponseMessage>(new TimeoutException("primary went silent"));
+            var resp = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(new byte[] { 1, 2, 3 }) };
+            resp.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("audio/mpeg");
+            resp.Headers.TryAddWithoutValidation("X-DevThrottle-TTS-Fallback", "1");   // the proxy served via the backup
+            return Task.FromResult(resp);
+        }
+    }
+
+    [Fact]
+    public async Task PrimaryHang_ArmsBackupRoute_SoTheNextCallAsksTheProxyForTheBackup_AndIsServedByIt()
+    {
+        // Issue devthrottle_internal#405 (Option B). The cloud proxy's failover only reacts to an ERROR the primary returns;
+        // a silent hang gives it nothing to react to, so the Gateway - which DID see the hang via its own
+        // deadline - must route the session's next narration past the stalling primary by asking the proxy
+        // for the backup (the X-DevThrottle-TTS-Prefer-Backup header).
+        var stub = new HangThenBackupStub();
+        var svc = ServiceWith(stub, TempPersist());
+
+        // First narration: the primary goes silent. No audio, Retrying, and the request did NOT yet ask
+        // for the backup (a fresh session has no reason to skip the primary).
+        await svc.StoreSpokenAsync("sid-1", "first summary", "reply one");
+        Assert.False(svc.HasVoice("sid-1"));
+        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-1"));
+        Assert.Equal(1, stub.Calls);
+        Assert.False(stub.LastRequest!.Headers.Contains("X-DevThrottle-TTS-Prefer-Backup"));
+
+        // Second narration (same session, inside the armed window): the Gateway routes past the hung
+        // primary - the request carries the prefer-backup header, the proxy serves the backup, and the
+        // session becomes playable with the backup-voice note.
+        await svc.StoreSpokenAsync("sid-1", "second summary", "reply two");
+        Assert.Equal(2, stub.Calls);
+        Assert.True(stub.LastRequest!.Headers.Contains("X-DevThrottle-TTS-Prefer-Backup"));
+        Assert.True(svc.HasVoice("sid-1"));
+        Assert.True(svc.ServedViaFallbackFor("sid-1"));
+        Assert.Null(svc.VoiceUnavailableFor("sid-1"));   // a served backup clears the Retrying state
+    }
+
+    [Fact]
+    public async Task PrimaryHang_OnOneSession_DoesNotRouteAnotherSessionToTheBackup()
+    {
+        // The backup-routing window is strictly per session (keyed by sid): one session's hang must never
+        // make a different, healthy session skip its primary.
+        var stub = new HangThenBackupStub();
+        var svc = ServiceWith(stub, TempPersist());
+
+        await svc.StoreSpokenAsync("sid-hang", "summary", "reply");   // sid-hang hits the silent primary
+        Assert.Equal(1, stub.Calls);
+
+        await svc.StoreSpokenAsync("sid-other", "summary", "reply");  // a DIFFERENT session
+        Assert.Equal(2, stub.Calls);
+        Assert.False(stub.LastRequest!.Headers.Contains("X-DevThrottle-TTS-Prefer-Backup"));   // not armed for sid-other
     }
 }

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -415,7 +415,10 @@ internal static class GatewayWingmanVoiceEndpoint
                 // stalled upstream voice worker fails fast and retries instead of freezing the caller,
                 // while a legitimately long read still gets the time it actually needs.
                 // The client is the shared static (see SharedTtsHttp) - never a per-call one.
-                using var resp = await TtsSynthesis.PostAsync(ttsHttp, url, key, new { model, voice, input, response_format = "mp3" }, input.Length, ct);
+                // preferBackup is false here: the silent-primary backup routing (issue devthrottle_internal#405) is driven by
+                // the per-session narration path (WingmanVoiceService), which owns the sticky state this
+                // interactive read-aloud endpoint does not carry. It still gets the proxy's own failover.
+                using var resp = await TtsSynthesis.PostAsync(ttsHttp, url, key, new { model, voice, input, response_format = "mp3" }, input.Length, preferBackup: false, ct);
                 if (!resp.IsSuccessStatusCode)
                 {
                     var status = (int)resp.StatusCode;

--- a/src/CcDirector.Gateway/HostedAi/TtsSynthesis.cs
+++ b/src/CcDirector.Gateway/HostedAi/TtsSynthesis.cs
@@ -181,9 +181,20 @@ internal static class TtsSynthesis
     /// <paramref name="ct"/>: caller cancellation propagates immediately and is never mistaken for a
     /// per-attempt timeout.
     /// </summary>
+    /// <summary>The out-of-band routing hint the Gateway sends the cloud speech proxy after it has
+    /// watched the primary voice provider go SILENT on a session (issue devthrottle_internal#405). A silent hang gives the
+    /// proxy's own failover no error to react to, so the Gateway - the layer that owns this deadline and
+    /// therefore actually observes the hang - asks the proxy to skip the stalling provider and serve
+    /// from the backup. It is a ROUTING hint, not a deadline: the proxy keys on the header's presence and
+    /// ignores its value. Kept as a stable literal so both repos agree without coordination.</summary>
+    public const string PreferBackupHeaderName = "X-DevThrottle-TTS-Prefer-Backup";
+
     /// <param name="inputChars">Length of the text being synthesised. The deadline is derived from
     /// it, so pass the length of the text actually in <paramref name="payload"/>.</param>
-    public static async Task<HttpResponseMessage> PostAsync(HttpClient http, string url, string key, object payload, int inputChars, CancellationToken ct)
+    /// <param name="preferBackup">When true, send <see cref="PreferBackupHeaderName"/> so the cloud
+    /// proxy routes straight to the backup provider (issue devthrottle_internal#405). The Gateway sets this after it has
+    /// seen the primary go silent on this session; it is a routing hint only and changes no deadline.</param>
+    public static async Task<HttpResponseMessage> PostAsync(HttpClient http, string url, string key, object payload, int inputChars, bool preferBackup, CancellationToken ct)
     {
         var deadline = DeadlineFor(inputChars);
         TimeoutException? lastTimeout = null;
@@ -196,6 +207,8 @@ internal static class TtsSynthesis
                 Content = JsonContent.Create(payload),
             };
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+            if (preferBackup)
+                req.Headers.TryAddWithoutValidation(PreferBackupHeaderName, "1");
             try
             {
                 return await http.SendAsync(req, perAttempt.Token);

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -43,6 +43,7 @@ public sealed class WingmanVoiceService
     private readonly ConcurrentDictionary<string, byte> _generating = new();       // sid -> wingman is running now
     private readonly ConcurrentDictionary<string, HostedAiState> _voiceUnavailable = new();  // sid -> why voice is off (issue #939)
     private readonly ConcurrentDictionary<string, byte> _nothingToNarrate = new();  // sid -> the last turn has no text reply to read aloud (waiting on a prompt)
+    private readonly ConcurrentDictionary<string, DateTime> _preferBackupUntil = new();  // sid -> UTC deadline while this session routes past a silent primary (issue devthrottle_internal#405)
     private readonly string _persistPath;
     private readonly string _audioDir;
     private readonly HttpClient? _ttsHttp;   // test seam for TtsAsync (issue #939); the shared static when null
@@ -332,6 +333,7 @@ public sealed class WingmanVoiceService
         _generating.TryRemove(sid, out _);
         _voiceUnavailable.TryRemove(sid, out _);   // voice is off, so its unavailable-state is moot (issue #939)
         _nothingToNarrate.TryRemove(sid, out _);   // voice is off, so "nothing to narrate" is moot too
+        _preferBackupUntil.TryRemove(sid, out _);  // voice is off, so the backup-routing window is moot too (issue devthrottle_internal#405)
         if (_ready.TryRemove(sid, out _))
             DeleteReadyAudio(sid);   // keep the durable cache in step so a stale tap can't 404
         if (wasVoice)
@@ -367,7 +369,7 @@ public sealed class WingmanVoiceService
     {
         Mark(sid);
         if (string.IsNullOrWhiteSpace(spoken)) return;
-        var tts = await TtsAsync(spoken, ct);
+        var tts = await TtsAsync(sid, spoken, ct);
         // The "if anything fails, remove the triangle" rule: when synthesis returns null/empty we
         // leave _ready WITHOUT this session, so HasVoice stays false and no triangle shows. Only a
         // real, playable summary becomes ready - and is persisted (issue #553) so it survives a restart.
@@ -553,6 +555,32 @@ public sealed class WingmanVoiceService
     }
 
     /// <summary>
+    /// How long a single observed primary hang keeps routing THIS session to the backup voice provider
+    /// (issue devthrottle_internal#405). The cloud proxy's failover only reacts to an ERROR the primary returns; a silent
+    /// hang gives it nothing to react to. The Gateway, which owns the only deadline on the speech path,
+    /// is the layer that actually sees the hang - so on a hang it arms this window and, while it lasts,
+    /// asks the proxy to skip the stalling primary and serve from the backup. Time-based with NO active
+    /// probing: once the window passes we call the primary again, and if it is still silent the next
+    /// hang re-arms it. Long enough to ride out a provider blip without re-eating the full per-attempt
+    /// deadline on every turn; short enough to return to the cheaper primary promptly once it recovers.
+    /// </summary>
+    private static readonly TimeSpan PreferBackupWindow = TimeSpan.FromMinutes(3);
+
+    /// <summary>True while this session should route past a silent primary straight to the backup
+    /// (the window armed by a recent hang has not yet expired).</summary>
+    private bool PrefersBackup(string sid)
+        => _preferBackupUntil.TryGetValue(sid, out var until) && until > DateTime.UtcNow;
+
+    /// <summary>Arm the "route to the backup" window for this session after the primary went silent.
+    /// Overwrites any existing deadline (a fresh hang restarts the full window).</summary>
+    private void ArmPreferBackup(string sid)
+    {
+        _preferBackupUntil[sid] = DateTime.UtcNow + PreferBackupWindow;
+        FileLog.Write($"[WingmanVoiceService] primary voice provider went silent on sid={sid}; " +
+                      $"routing this session to the backup provider for {PreferBackupWindow.TotalMinutes:0} min (issue devthrottle_internal#405)");
+    }
+
+    /// <summary>
     /// Synthesize the spoken summary to audio through the SAME provider seam the <c>/wingman/tts</c>
     /// endpoint uses (issue #939): the configured mode's base URL + key + model + the user's chosen
     /// voice (<see cref="TtsVoiceConfig"/> / <see cref="TtsModelConfig"/>). This replaced a hardcoded
@@ -561,7 +589,7 @@ public sealed class WingmanVoiceService
     /// condition is returned as a typed <see cref="HostedAiState"/> instead of a silent null, so the
     /// caller can surface the consistent unavailable state.
     /// </summary>
-    private async Task<TtsResult> TtsAsync(string text, CancellationToken ct)
+    private async Task<TtsResult> TtsAsync(string sid, string text, CancellationToken ct)
     {
         var mode = TranscriptionModeConfig.Get();
         var tts = TranscriptionEndpointResolver.ResolveTts(mode);
@@ -592,9 +620,13 @@ public sealed class WingmanVoiceService
         // connection to the proxy. The narration leg fires on a sweep, so that was the hottest speech
         // path in the product paying the reconnect cost every time.
         var http = _ttsHttp ?? SharedTtsHttp;
+        // If this session recently saw the primary go silent, ask the proxy to skip it and serve from the
+        // backup (issue devthrottle_internal#405). A hang is invisible to the proxy's own failover, so this is how a hang
+        // becomes a failover: the Gateway saw it, the proxy did not. The window expires on its own.
+        var preferBackup = PrefersBackup(sid);
         try
         {
-            using var resp = await TtsSynthesis.PostAsync(http, url, key, new { model, voice, input, response_format = "mp3" }, input.Length, ct);
+            using var resp = await TtsSynthesis.PostAsync(http, url, key, new { model, voice, input, response_format = "mp3" }, input.Length, preferBackup, ct);
             if (!resp.IsSuccessStatusCode)
             {
                 var body = await resp.Content.ReadAsStringAsync(ct);
@@ -656,6 +688,13 @@ public sealed class WingmanVoiceService
             // This is per session and touches nothing else: there is no shared gate for a timeout to arm.
             FileLog.Write($"[WingmanVoiceService] tts did not answer for this narration: {ex.Message} - " +
                           "no answer from the service, so this is Retrying (not down); this session retries on its own");
+            // A TimeoutException specifically means the primary went SILENT (the per-attempt deadline
+            // fired, no answer). That silent hang is exactly what the cloud proxy's own failover cannot
+            // see, so arm this session to route past the primary to the backup on its next turn-end /
+            // idle-sweep retry (issue devthrottle_internal#405, Option B). A transport failure (HttpRequestException) is a
+            // DIFFERENT fault - the proxy itself was unreachable, which does not implicate the primary -
+            // so it does not arm the backup route.
+            if (ex is TimeoutException) ArmPreferBackup(sid);
             return new TtsResult(null, null, HostedAiState.Retrying);
         }
         // NOTE: no `finally { http.Dispose(); }`. `http` is now either the caller's injected client or


### PR DESCRIPTION
The Gateway half of the silent-hang voice fix (Option B). Pairs with thefrederiksen/devthrottle_internal#405 (branch `fix/speech-prefer-backup-header`).

## Problem
The cloud speech proxy's failover only reacts to an error the primary returns. A silent hang gives it nothing to fail over on, so a stalled provider leaves voice sessions with no audio - the fifth recurrence of "voice mode but no voice". Every past fix was on the error path; the live failure is the hang path.

## Fix
The Gateway owns the only deadline on the speech path, so it is the layer that actually observes the hang. On a `TtsSynthesis` timeout it arms a short (3 min) per-session window and, while it lasts, sends `X-DevThrottle-TTS-Prefer-Backup` so the proxy skips the stalling primary and serves from the backup. Time-based, no active probing; the primary is retried once the window passes and a fresh hang re-arms it. Per session (never reaches across sessions); a transport failure (proxy unreachable) does not arm it, only a genuine primary silence.

A routing hint, not a second deadline - it invents no time bound, it only tells the proxy which provider to call first. The interactive read-aloud endpoint is unchanged (no sticky state; still relies on the proxy's own error-based failover).

## Tests
`WingmanVoiceFallbackTests`: arm-on-hang then the next call carries the header and is served by the backup; the window is per session and does not route a healthy session to the backup. Full Tts/Wingman/Voice suite green (287).