### PR TITLE
test(gateway): prove the Postgres provider on real Supabase (increment 2)

### DIFF
--- a/docs/architecture/hosted-gateway-qa.md
+++ b/docs/architecture/hosted-gateway-qa.md
@@ -209,3 +209,79 @@ Passed!  - Failed:     0, Passed:    35, Skipped:     5, Total:    40, Duration:
 
 The whole solution builds clean (Debug): 0 warnings, 0 errors, TreatWarningsAsErrors on. The container
 was removed after the run (`docker rm -f cc-pg-proof`).
+
+## Step 4a - increment 2: proof on the real Supabase Postgres
+
+Date: 2026-07-18
+
+Increment 1 proved the provider on a throwaway Docker Postgres. Increment 2 proves the SAME provider
+against the REAL hosted target - the Supabase Postgres project - through the actual Gateway startup path,
+in an isolated `gateway` schema, before any Azure deploy.
+
+### Target and constraints
+
+The connection points at the hosted Supabase project's SESSION POOLER
+(`Host=<...>.pooler.supabase.com;Port=5432;...;SSL Mode=Require`, password REDACTED - never committed or
+logged), authenticating as a dedicated role scoped to the `gateway` schema ONLY: it has no access to the
+website's accounts/auth/public tables, and it cannot create or drop databases. So the increment-1 harness
+that drops a throwaway database (the `ccpg`-prefixed `EnsureDeleted` path) does NOT apply here. This is a
+real integration run instead: it applies the migration into the existing `gateway` schema and leaves it in
+place (deploy-ready), and it cleans up its own test rows so the tables are left empty.
+
+The connection string lives ONLY in the machine-local credential file
+(`%LOCALAPPDATA%/cc-director/config/credentials.env`, key `DEVTHROTTLE_GATEWAY_DB_CONNECTION`), read at the
+point of use and exported into `CC_GATEWAY_DB_CONNECTION`. It is never echoed, committed, or written to a
+log - the Gateway's Postgres path logs only a redacted host+database target.
+
+### The proof (a real integration run)
+
+`GatewayDatabaseLivePostgresProofTests` (new) drives the REAL runtime path: each fact constructs a
+`GatewayDatabase` (the same class the running Gateway uses), whose constructor reads
+`CC_GATEWAY_DB_CONNECTION`, selects Npgsql, and runs `Database.Migrate()` - applying the Postgres migration
+set into the `gateway` schema on Supabase. It never calls `EnsureDeleted` and never drops anything.
+
+CI SAFETY: every fact is gated behind the PRESENCE of `CC_GATEWAY_DB_CONNECTION` (skips cleanly when
+unset, the same pattern as the increment-1 Postgres tests). Automated CI never sets it, so CI never
+connects to the hosted project and never needs the secret; the proof runs only locally/manually with the
+connection string exported.
+
+```
+CC_GATEWAY_DB_CONNECTION="<Supabase session-pooler string; password redacted>" \
+  dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj \
+  --filter "FullyQualifiedName~GatewayDatabaseLivePostgresProofTests"
+
+Passed!  - Failed:     0, Passed:     4, Skipped:     0, Total:     4, Duration: 6 s
+```
+
+The four facts that passed on real Supabase:
+
+- `Startup_AppliesGatewaySchemaAndTables_OnConfiguredPostgres` - constructing `GatewayDatabase` migrates
+  into the `gateway` schema; asserts the schema, all 16 mapped tables, and `__EFMigrationsHistory` exist
+  under `gateway` and NONE of the mapped tables exist under `public` (schema isolation holds on the real
+  project).
+- `JsonOwnedColumns_RoundTrip_OnConfiguredPostgres` - a WorkflowVersion's Steps + OutcomeCriteria written
+  and read back field-for-field through `jsonb`, then the row deleted.
+- `NaturalKeyByteOrdinalCollation_RoundTrip_OnConfiguredPostgres` - endpoints come back in byte order
+  (`..._B`, `..._C`, `..._a`; a locale collation would have put `..._a` first), a duplicate endpoint is
+  rejected, then the rows deleted.
+- `UtcTimestampRoundTrip_OnConfiguredPostgres` - a session_spend row's UTC timestamps come back equal with
+  `Kind == Utc`, then the row deleted.
+
+### Schema left clean and deploy-ready
+
+Every round-trip deletes its rows in a `finally`, so a failed assertion could not leave data behind.
+Verified independently after the run by counting rows directly on Supabase (via `psql` over the pooler),
+summing across ALL 16 application tables rather than only the three written:
+
+```
+app_table_rows_total=0        (sum of row counts across all 16 mapped tables)
+migrations_history_rows=1     (the one applied InitialPostgres record - expected)
+app_tables_in_gateway=16
+```
+
+So the `gateway` schema holds the 16 application tables, ALL empty (0 rows in total), plus the
+`__EFMigrationsHistory` table carrying exactly one row: the applied `InitialPostgres` migration. That one
+history row is not residue - it is the record that the migration ran, and it is precisely what makes the
+schema deploy-ready: the eventual hosted deploy's `Migrate()` reads it, sees the migration already applied,
+and is a no-op. This closes increment 2. The runtime host packaging that ships the migrations assembly (so
+the deployed Gateway can load it) remains the deploy increment's work.

--- a/src/CcDirector.Gateway.Tests/Data/GatewayDatabaseLivePostgresProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/GatewayDatabaseLivePostgresProofTests.cs
@@ -1,0 +1,320 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using CcDirector.Gateway.Contracts;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Data;
+
+/// <summary>
+/// Live integration proof for the Hosted Gateway data layer against a REAL, configured PostgreSQL server
+/// (the hosted Supabase target), driven through the SAME startup path the running Gateway uses:
+/// constructing a <see cref="GatewayDatabase"/> reads <c>CC_GATEWAY_DB_CONNECTION</c> and runs
+/// <c>Database.Migrate()</c>, applying the Postgres migration set into the <c>gateway</c> schema. Each fact
+/// then round-trips one of the shapes that could diverge between providers - a JSON-owned column, a
+/// natural-key column whose ordering depends on the collation, and a UTC timestamp - and DELETES the rows it
+/// wrote so the schema is left clean and deploy-ready (empty tables, migration applied).
+///
+/// Unlike the throwaway-container proof (<see cref="PostgresProviderProofTests"/>), this NEVER drops a
+/// database or a schema: the hosted role is scoped to the <c>gateway</c> schema and cannot create or drop
+/// databases, so the proof is a real integration run that leaves the applied schema in place.
+///
+/// GATING: every fact skips itself unless <c>CC_GATEWAY_DB_CONNECTION</c> is set to a non-blank value - the
+/// exact environment variable the runtime Gateway uses to select Postgres. With it UNSET (automated CI and
+/// the normal SQLite test run) nothing here connects to any server and no secret is needed; the facts report
+/// SKIPPED. It runs only locally/manually with the connection string exported.
+/// </summary>
+public sealed class GatewayDatabaseLivePostgresProofTests
+{
+    /// <summary>A Fact that skips itself unless the runtime Postgres selector <c>CC_GATEWAY_DB_CONNECTION</c>
+    /// is set to a non-blank value, so CI never reaches out to the hosted database and never needs the
+    /// secret.</summary>
+    private sealed class RequiresConfiguredPostgresFactAttribute : FactAttribute
+    {
+        public RequiresConfiguredPostgresFactAttribute()
+        {
+            if (string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar)))
+                Skip = $"Set {GatewayDatabase.PostgresConnectionEnvVar} to a real PostgreSQL connection " +
+                       "string to run the live hosted-Postgres integration proof.";
+        }
+    }
+
+    /// <summary>Open the Gateway database exactly as the runtime does: the constructor selects Postgres from
+    /// <c>CC_GATEWAY_DB_CONNECTION</c> and applies the migration set into the gateway schema. The caller
+    /// disposes it.
+    ///
+    /// A construction failure is re-thrown as a NEW, credential-free exception with NO inner exception
+    /// attached. GatewayDatabase's own failure path deliberately preserves the raw provider exception as the
+    /// InnerException (for a real host's diagnostics), and a provider exception can echo the connection
+    /// string; xUnit prints inner exceptions on a failed test. Stripping the chain here keeps any
+    /// connection-string material out of test output. Only the failing exception's TYPE name is surfaced,
+    /// never its message.</summary>
+    private static GatewayDatabase OpenGateway()
+    {
+        try
+        {
+            return new GatewayDatabase(new SingleTenantContext());
+        }
+        catch (Exception ex)
+        {
+            var kind = ex is InvalidOperationException && ex.InnerException is not null
+                ? ex.InnerException.GetType().Name
+                : ex.GetType().Name;
+            throw new InvalidOperationException(
+                "Opening the live Gateway database against the configured PostgreSQL server failed " +
+                $"({kind}). The original exception is intentionally not attached, so no connection-string " +
+                "material reaches test output. Check the server, the gateway schema, and the connection.");
+        }
+    }
+
+    /// <summary>
+    /// The real startup path: constructing GatewayDatabase runs Database.Migrate() against the configured
+    /// Postgres, which must create the gateway schema, all 16 mapped tables, and the migrations history table
+    /// under that schema (and nothing under public). This is read-only after the migrate, so it deliberately
+    /// leaves the applied - empty - schema in place, which is the desired deploy-ready state.
+    /// </summary>
+    [RequiresConfiguredPostgresFact]
+    public void Startup_AppliesGatewaySchemaAndTables_OnConfiguredPostgres()
+    {
+        using var db = OpenGateway();
+        using var ctx = db.CreateContext();
+
+        Assert.Equal(1, ScalarInt(ctx,
+            "SELECT count(*) FROM information_schema.schemata WHERE schema_name = 'gateway'"));
+
+        foreach (var table in MappedTables)
+        {
+            Assert.Equal(1, ScalarInt(ctx,
+                $"SELECT count(*) FROM information_schema.tables WHERE table_schema = 'gateway' AND table_name = '{table}'"));
+            // And NOT in public - the hosted schema is isolated from the website's tables.
+            Assert.Equal(0, ScalarInt(ctx,
+                $"SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = '{table}'"));
+        }
+
+        Assert.Equal(1, ScalarInt(ctx,
+            "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'gateway' AND table_name = '__EFMigrationsHistory'"));
+    }
+
+    /// <summary>
+    /// JSON-owned columns on real Postgres: a WorkflowVersion's Steps and OutcomeCriteria are owned
+    /// collections serialized to jsonb. Write, read back in a fresh context, assert field-for-field, then
+    /// delete the row so the table is left empty.
+    /// </summary>
+    [RequiresConfiguredPostgresFact]
+    public void JsonOwnedColumns_RoundTrip_OnConfiguredPostgres()
+    {
+        using var db = OpenGateway();
+        var id = Guid.NewGuid();
+        try
+        {
+            using (var ctx = db.CreateContext())
+            {
+                ctx.WorkflowVersions.Add(new WorkflowVersionEntity
+                {
+                    Id = id,
+                    TenantId = TenantId.Local.Value,
+                    WorkflowId = "wf-live-json-proof",
+                    Version = 1,
+                    Status = WorkflowVersionStatus.Published,
+                    Name = "live JSON proof",
+                    Summary = "owned collections to jsonb on Supabase",
+                    Steps = new List<WorkflowStepDto>
+                    {
+                        new() { Name = "Plan", Description = "d1", Doer = "architect", Reviewer = null, Done = "planned" },
+                        new() { Name = "Build", Description = "d2", Doer = "worker", Reviewer = "qa", Done = "merged" },
+                    },
+                    OutcomeCriteria = new List<WorkflowOutcomeCriterionDto>
+                    {
+                        new() { CriterionId = "merged-pr", Description = "the PR is merged", ProofHint = "the merged pull request URL" },
+                        new() { CriterionId = "green-ci", Description = "CI is green", ProofHint = null },
+                    },
+                    InstructionsMarkdown = "# conduct",
+                    ContentHash = "hash",
+                    AuthoredBy = "test",
+                    CreatedUtc = DateTime.UtcNow,
+                });
+                ctx.SaveChanges();
+            }
+
+            using (var ctx = db.CreateContext())
+            {
+                var read = ctx.WorkflowVersions.Single(v => v.Id == id);
+
+                // Every field of both owned Steps, in order.
+                Assert.Equal(2, read.Steps.Count);
+                Assert.Equal("Plan", read.Steps[0].Name);
+                Assert.Equal("d1", read.Steps[0].Description);
+                Assert.Equal("architect", read.Steps[0].Doer);
+                Assert.Null(read.Steps[0].Reviewer);
+                Assert.Equal("planned", read.Steps[0].Done);
+                Assert.Equal("Build", read.Steps[1].Name);
+                Assert.Equal("d2", read.Steps[1].Description);
+                Assert.Equal("worker", read.Steps[1].Doer);
+                Assert.Equal("qa", read.Steps[1].Reviewer);
+                Assert.Equal("merged", read.Steps[1].Done);
+
+                // Every field of both owned OutcomeCriteria, in order (including a null ProofHint).
+                Assert.Equal(2, read.OutcomeCriteria.Count);
+                Assert.Equal("merged-pr", read.OutcomeCriteria[0].CriterionId);
+                Assert.Equal("the PR is merged", read.OutcomeCriteria[0].Description);
+                Assert.Equal("the merged pull request URL", read.OutcomeCriteria[0].ProofHint);
+                Assert.Equal("green-ci", read.OutcomeCriteria[1].CriterionId);
+                Assert.Equal("CI is green", read.OutcomeCriteria[1].Description);
+                Assert.Null(read.OutcomeCriteria[1].ProofHint);
+            }
+        }
+        finally
+        {
+            using var ctx = db.CreateContext();
+            ctx.WorkflowVersions.Where(v => v.Id == id).ExecuteDelete();
+        }
+    }
+
+    /// <summary>
+    /// Natural-key byte-ordinal collation on real Postgres: the push_subscriptions Endpoint primary key
+    /// carries an explicit "C" collation, so keys differing by byte order come back in byte order (not a
+    /// locale grouping) and the primary key rejects a duplicate. Write, assert, then delete the rows.
+    /// </summary>
+    [RequiresConfiguredPostgresFact]
+    public void NaturalKeyByteOrdinalCollation_RoundTrip_OnConfiguredPostgres()
+    {
+        using var db = OpenGateway();
+        // A per-run GUID prefix scopes this test to exactly the three rows it writes: another live-proof run
+        // (or a pre-existing row) cannot be read, ordered, or deleted by this one. The three keys share the
+        // prefix and differ only in the final byte, so their relative order is decided by that byte:
+        // 'B'(66) < 'C'(67) < 'a'(97). A locale collation would group case-insensitively and put the "a" key
+        // first, so asserting [B, C, a] distinguishes the explicit "C" collation from a locale one.
+        var prefix = "live_" + Guid.NewGuid().ToString("N") + "_";
+        var endpoints = new[] { prefix + "a", prefix + "C", prefix + "B" };
+        try
+        {
+            using (var ctx = db.CreateContext())
+            {
+                foreach (var e in endpoints)
+                    ctx.PushSubscriptions.Add(new PushSubscriptionEntity
+                    {
+                        Endpoint = e,
+                        TenantId = TenantId.Local.Value,
+                        P256dh = "p",
+                        Auth = "a",
+                        CreatedAtUtc = DateTime.UtcNow,
+                    });
+                ctx.SaveChanges();
+            }
+
+            using (var ctx = db.CreateContext())
+            {
+                var ordered = ctx.PushSubscriptions
+                    .Where(p => p.Endpoint.StartsWith(prefix))
+                    .OrderBy(p => p.Endpoint)
+                    .Select(p => p.Endpoint)
+                    .ToList();
+                Assert.Equal(new[] { prefix + "B", prefix + "C", prefix + "a" }, ordered);
+            }
+
+            using (var ctx = db.CreateContext())
+            {
+                ctx.PushSubscriptions.Add(new PushSubscriptionEntity
+                {
+                    Endpoint = prefix + "B",
+                    TenantId = TenantId.Local.Value,
+                    P256dh = "p2",
+                    Auth = "a2",
+                    CreatedAtUtc = DateTime.UtcNow,
+                });
+                Assert.Throws<DbUpdateException>(() => ctx.SaveChanges());
+            }
+        }
+        finally
+        {
+            // Delete by the per-run GUID prefix: it matches exactly the three rows this run wrote and nothing
+            // else, so cleanup is as tightly scoped as an explicit key list, and StartsWith translates to a
+            // clean LIKE 'prefix%' in ExecuteDelete (an array .Contains() resolves to the ReadOnlySpan overload
+            // on this runtime and breaks EF's ExecuteDelete translation).
+            using var ctx = db.CreateContext();
+            ctx.PushSubscriptions.Where(p => p.Endpoint.StartsWith(prefix)).ExecuteDelete();
+        }
+    }
+
+    /// <summary>
+    /// UTC timestamp on real Postgres: a session_spend row written then read in a fresh context comes back
+    /// equal and with Kind == Utc (Npgsql maps a Kind=Utc DateTime to timestamp with time zone). Write,
+    /// assert, then delete the row.
+    /// </summary>
+    [RequiresConfiguredPostgresFact]
+    public void UtcTimestampRoundTrip_OnConfiguredPostgres()
+    {
+        using var db = OpenGateway();
+        var sessionId = "live-" + Guid.NewGuid().ToString();
+        var first = new DateTime(2026, 7, 18, 13, 45, 30, DateTimeKind.Utc);
+        var last = new DateTime(2026, 7, 18, 14, 05, 00, DateTimeKind.Utc);
+        try
+        {
+            using (var ctx = db.CreateContext())
+            {
+                ctx.SessionSpend.Add(new SessionSpendEntity
+                {
+                    SessionId = sessionId,
+                    TenantId = TenantId.Local.Value,
+                    AgentKind = "test-agent",
+                    TokensCaptured = true,
+                    InputTokens = 1000,
+                    OutputTokens = 200,
+                    BillingMode = "metered",
+                    MeteredCostMicros = 12345,
+                    FirstObservedUtc = first,
+                    LastObservedUtc = last,
+                });
+                ctx.SaveChanges();
+            }
+
+            using (var ctx = db.CreateContext())
+            {
+                var read = ctx.SessionSpend.Single(s => s.SessionId == sessionId);
+                Assert.Equal("test-agent", read.AgentKind);
+                Assert.Equal(12345, read.MeteredCostMicros);
+                Assert.Equal(DateTimeKind.Utc, read.FirstObservedUtc.Kind);
+                Assert.Equal(first, read.FirstObservedUtc);
+                Assert.Equal(DateTimeKind.Utc, read.LastObservedUtc.Kind);
+                Assert.Equal(last, read.LastObservedUtc);
+            }
+        }
+        finally
+        {
+            using var ctx = db.CreateContext();
+            ctx.SessionSpend.Where(s => s.SessionId == sessionId).ExecuteDelete();
+        }
+    }
+
+    /// <summary>The 16 mapped tables, for the schema-isolation assertion.</summary>
+    private static readonly string[] MappedTables =
+    {
+        "cron_jobs", "cron_runs", "worklists", "worklist_items", "workflows", "workflow_versions",
+        "workflow_files", "workflow_runs", "snoozes", "governance_events", "push_subscriptions",
+        "wingman_instructions", "session_spend", "account_hosted_ai_spend", "mission_notes",
+        "governance_audit_events",
+    };
+
+    private static int ScalarInt(GatewayDbContext ctx, string sql)
+    {
+        var conn = ctx.Database.GetDbConnection();
+        var opened = false;
+        if (conn.State != System.Data.ConnectionState.Open)
+        {
+            conn.Open();
+            opened = true;
+        }
+        try
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            return Convert.ToInt32(cmd.ExecuteScalar());
+        }
+        finally
+        {
+            if (opened) conn.Close();
+        }
+    }
+}


### PR DESCRIPTION
## What

Live integration proof that the (already-merged) Gateway PostgreSQL provider works against the **real hosted Supabase project**, in an isolated single-tenant `gateway` schema, driven through the actual `GatewayDatabase` startup path. Increment 2 of the hosted data-layer build (increment 1 = #1820 proved the provider on a throwaway Docker Postgres).

## How

`GatewayDatabaseLivePostgresProofTests` constructs a real `GatewayDatabase` (whose constructor selects Npgsql from `CC_GATEWAY_DB_CONNECTION` and runs `Database.Migrate()` into the `gateway` schema), then round-trips the shapes that could diverge between providers - `jsonb` owned columns, a byte-ordinal `C`-collation natural key, and a UTC `timestamptz` - and **deletes its own rows** so the schema is left empty and deploy-ready. It never drops a database or schema (the hosted role is scoped to the `gateway` schema and cannot), unlike the throwaway-container proof.

## CI safety

Every fact is gated behind the **presence of `CC_GATEWAY_DB_CONNECTION`** and skips cleanly when unset (same pattern as the increment-1 Postgres tests), so automated CI never connects to the hosted project and never needs a secret - it runs only locally with the connection string exported. A construction failure is re-thrown **credential-free** (no inner exception) so no connection-string material can reach test output.

## Proven on real Supabase

Migrations apply into the `gateway` schema (16 application tables + `__EFMigrationsHistory`, none under `public`); all three round-trips pass; and the schema is left with **zero rows across all 16 application tables** (independently verified via `psql` over the pooler), with the one expected applied-migration row in `__EFMigrationsHistory` - so the schema is deploy-ready and the eventual deploy's `Migrate()` is a no-op. Redacted transcript in `docs/architecture/hosted-gateway-qa.md`.

Reviewed adversarially; the connection string / password appears nowhere in the repo. Runtime host packaging (shipping the migrations assembly at deploy) remains the deploy increment's work.