### PR TITLE
test(core): allowlist the EF design-time factory in the loopback guard

### DIFF
--- a/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
+++ b/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
@@ -44,6 +44,7 @@ public sealed class NoCrossMachineLoopbackGuardTests
         ["src/CcDirector.Gateway/Api/RecordingEndpoints.cs"] = "Local recording paths.",
         ["src/CcDirector.Gateway/Api/MachineEndpoints.cs"] = "Same-machine relay/launcher wiring.",
         ["src/CcDirector.Gateway/Running/IDirectorLauncher.cs"] = "RelayDirectorLauncher posts to the local Gateway's own loopback port to relay a Director start request (same-machine self-call to the Gateway's own /machines/{machine}/director/start endpoint).",
+        ["src/CcDirector.Gateway/Data/GatewayDbContextDesignTimeFactory.cs"] = "Design-time-only EF tooling factory (dotnet ef migrations): the localhost Postgres connection string is a THROWAWAY design value - migrations add builds the model and writes source without ever opening the connection, and the running Gateway wires its context through GatewayDatabase instead.",
         ["src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs"] = "The Car Mode brain's fleet tools call THIS Gateway's own endpoints over http://127.0.0.1:{port} (same-machine self-call), the same pattern the Web Push needs-you notifier uses to read its own /sessions - so the brain sees the identical aggregated roster every client sees with no re-implementation.",
         ["src/CcDirector.GatewayApp/Program.cs"] = "Local Gateway bootstrap.",
         ["src/CcDirector.Launcher/DirectorSupervisor.cs"] = "Supervises a local Director over loopback.",


### PR DESCRIPTION
Pull request #1820 added GatewayDbContextDesignTimeFactory.cs, whose Postgres
branch carries a localhost connection string, and the no-cross-machine-loopback
fitness function has been failing on main since. The literal is a legitimate
design-time-only value: dotnet ef migrations add builds the model and writes
source without ever opening the connection, and the running Gateway wires its
context through GatewayDatabase. Allowlisted with that reason.
