### PR TITLE
fix(setup): make the Gateway update path releasable to existing Gateway machines (D2)

### DIFF
--- a/tools/cc-director-setup-cli.Tests/GatewayInstallPreflightTests.cs
+++ b/tools/cc-director-setup-cli.Tests/GatewayInstallPreflightTests.cs
@@ -1,0 +1,40 @@
+using CcDirector.Setup.Cli;
+using Xunit;
+
+namespace CcDirector.Setup.Cli.Tests;
+
+/// <summary>
+/// Guards the managed Gateway install/update pre-flight (D2a). The ONLY hard requirement is the
+/// platform: there is NO OPENAI_API_KEY demand, because inference routes through the account-minted
+/// dt_live_ key the managed Gateway runtime mints itself. Demanding an OpenAI key here used to block a
+/// Gateway refresh on machines that never had one.
+/// </summary>
+public class GatewayInstallPreflightTests
+{
+    // The headline D2a guard: on Windows the pre-flight passes with NO OPENAI_API_KEY anywhere -
+    // Check takes no key and reads no environment, so it CANNOT demand one.
+    // Revert-proof: re-add an OpenAI-key demand (an openAiKey parameter that fails when blank, the
+    // shape this slice deleted) and this no-key call goes red - Check returns the key-demand error
+    // instead of null.
+    [Fact]
+    public void Check_Windows_NoOpenAiKeyDemanded_ReturnsNull()
+    {
+        Assert.Null(GatewayInstallPreflight.Check(isWindows: true));
+    }
+
+    [Fact]
+    public void Check_NonWindows_FailsWindowsOnly()
+    {
+        var result = GatewayInstallPreflight.Check(isWindows: false);
+        Assert.NotNull(result);
+        Assert.Contains("Windows-only", result);
+    }
+
+    // The pre-flight decision is a pure function of the platform - nothing about a key, so nothing an
+    // ambient environment variable can change. This locks that no key concept leaked back in.
+    [Fact]
+    public void Check_MentionsNoOpenAiKey()
+    {
+        Assert.DoesNotContain("OPENAI", GatewayInstallPreflight.Check(isWindows: false), System.StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tools/cc-director-setup-cli.Tests/GatewayInstallPreflightTests.cs
+++ b/tools/cc-director-setup-cli.Tests/GatewayInstallPreflightTests.cs
@@ -1,40 +1,69 @@
 using CcDirector.Setup.Cli;
+using CcDirector.Setup.Engine;
 using Xunit;
 
 namespace CcDirector.Setup.Cli.Tests;
 
 /// <summary>
-/// Guards the managed Gateway install/update pre-flight (D2a). The ONLY hard requirement is the
-/// platform: there is NO OPENAI_API_KEY demand, because inference routes through the account-minted
-/// dt_live_ key the managed Gateway runtime mints itself. Demanding an OpenAI key here used to block a
-/// Gateway refresh on machines that never had one.
+/// Guards the managed Gateway install/update path (D2a) at the PRODUCTION SEAM: the real
+/// <see cref="Commands.UpdateAsync"/> gateway branch, not the extracted helper. There is NO
+/// OPENAI_API_KEY demand - inference routes through the account-minted dt_live_ key the managed
+/// Gateway runtime mints itself. Demanding an OpenAI key here used to block a Gateway refresh on
+/// machines that never had one.
 /// </summary>
 public class GatewayInstallPreflightTests
 {
-    // The headline D2a guard: on Windows the pre-flight passes with NO OPENAI_API_KEY anywhere -
-    // Check takes no key and reads no environment, so it CANNOT demand one.
-    // Revert-proof: re-add an OpenAI-key demand (an openAiKey parameter that fails when blank, the
-    // shape this slice deleted) and this no-key call goes red - Check returns the key-demand error
-    // instead of null.
+    /// <summary>
+    /// The headline D2a guard, driven through the ACTUAL <c>install --role gateway</c> dispatch. With
+    /// no OPENAI_API_KEY in the environment, the real gateway branch runs its pre-flight and then
+    /// proceeds to release resolution - it does NOT demand a key. We point it at an empty offline
+    /// release dir so resolution fails fast (no network, no install work): reaching that failure proves
+    /// the branch got PAST pre-flight without a key demand.
+    ///
+    /// Revert-proof: re-insert an executable OPENAI_API_KEY demand in the REAL Commands gateway branch
+    /// (Commands.cs, the `if (isGatewayInstall)` block ~:276-285) - e.g. reject when
+    /// Environment.GetEnvironmentVariable("OPENAI_API_KEY") is blank -> UpdateAsync returns Error
+    /// instead of reaching release resolution, so this test's ThrowsAny (FileNotFoundException) goes red.
+    /// </summary>
     [Fact]
-    public void Check_Windows_NoOpenAiKeyDemanded_ReturnsNull()
+    public async Task InstallRoleGateway_NoOpenAiKey_ReachesReleaseResolution_NoKeyDemand()
     {
-        Assert.Null(GatewayInstallPreflight.Check(isWindows: true));
+        if (!OperatingSystem.IsWindows())
+            return; // the managed Gateway is Windows-only; the no-key assertion applies where it installs.
+
+        var root = Directory.CreateTempSubdirectory("d2a-cli-").FullName;
+        var emptyReleaseDir = Path.Combine(root, "release");
+        Directory.CreateDirectory(emptyReleaseDir); // no release-manifest.json -> offline resolution fails fast
+
+        // Run the real branch with NO OpenAI key in the process environment (User-scope is left untouched;
+        // the fixed pre-flight never reads either, so this only matters for a reverted key demand).
+        var savedProcessKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY", EnvironmentVariableTarget.Process);
+        Environment.SetEnvironmentVariable("OPENAI_API_KEY", null, EnvironmentVariableTarget.Process);
+        try
+        {
+            var args = CliArgs.Parse(new[] { "install", "--role", "gateway", "--release-dir", emptyReleaseDir });
+            var layout = new InstallLayout(Path.Combine(root, "local"));
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(
+                () => Commands.UpdateAsync(args, layout, json: false, installMode: true));
+
+            // It failed resolving the offline release (past pre-flight), NOT on a key demand.
+            Assert.IsType<FileNotFoundException>(ex);
+            Assert.DoesNotContain("OPENAI", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OPENAI_API_KEY", savedProcessKey, EnvironmentVariableTarget.Process);
+            Directory.Delete(root, recursive: true);
+        }
     }
 
+    // The pre-flight's only hard requirement is the platform (the managed Gateway is Windows-only).
     [Fact]
     public void Check_NonWindows_FailsWindowsOnly()
     {
         var result = GatewayInstallPreflight.Check(isWindows: false);
         Assert.NotNull(result);
         Assert.Contains("Windows-only", result);
-    }
-
-    // The pre-flight decision is a pure function of the platform - nothing about a key, so nothing an
-    // ambient environment variable can change. This locks that no key concept leaked back in.
-    [Fact]
-    public void Check_MentionsNoOpenAiKey()
-    {
-        Assert.DoesNotContain("OPENAI", GatewayInstallPreflight.Check(isWindows: false), System.StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tools/cc-director-setup-cli/CcDirector.Setup.Cli.csproj
+++ b/tools/cc-director-setup-cli/CcDirector.Setup.Cli.csproj
@@ -12,6 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- The test project drives the internal Commands entry points (the managed Gateway install
+         branch) at the production seam. -->
+    <InternalsVisibleTo Include="CcDirector.Setup.Cli.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\cc-director-setup-engine\CcDirector.Setup.Engine.csproj" />
     <!-- signin/enroll drive account sign-in + gateway enrollment: GatewayConfig + OperationResult live in
          Core, and the /m/enroll response type lives in Gateway.Contracts. Both also flow transitively

--- a/tools/cc-director-setup-cli/Commands.cs
+++ b/tools/cc-director-setup-cli/Commands.cs
@@ -271,11 +271,12 @@ internal static class Commands
         var role = Role(args);
         var isGatewayInstall = installMode && role == InstallRole.Gateway && !args.HasFlag("dry-run");
 
-        // Gateway installs are per-user (tray app, %LOCALAPPDATA%) - NO elevation. Still verify the
-        // key the Gateway needs, and fail loudly (no silent degrade) before doing any work.
+        // Gateway installs are per-user (tray app, %LOCALAPPDATA%) - NO elevation. Verify the platform
+        // (the managed Gateway is Windows-only) and fail loudly before doing any work. No OPENAI_API_KEY
+        // is required: inference routes through the account-minted dt_live_ key the runtime auto-mints.
         if (isGatewayInstall)
         {
-            var preflight = GatewayPreflight();
+            var preflight = GatewayInstallPreflight.Check(OperatingSystem.IsWindows());
             if (preflight is not null)
             {
                 if (json) Program.WriteJson(new { mode = "install", role = "gateway", failed = preflight });
@@ -359,10 +360,8 @@ internal static class Commands
         // served in-process by the Gateway now (issue #979), so there is no Cockpit zip to extract.
         if (isGatewayInstall && result.Failed == 0 && OperatingSystem.IsWindows())
         {
-            var key = OpenAiKey()
-                ?? throw new InvalidOperationException("OPENAI_API_KEY missing after Gateway pre-flight passed.");
             var installer = new GatewayTrayInstaller(layout);
-            var tray = await installer.InstallAsync(release, source, key);
+            var tray = await installer.InstallAsync(release, source);
             if (json)
                 Program.WriteJson(new { gatewayTray = new { success = tray.Success, message = tray.Message, steps = tray.Steps } });
             else
@@ -471,30 +470,6 @@ internal static class Commands
         if (!json) Console.WriteLine("Placing CC Director.app:");
         return await MacAppPlacer.PlaceAsync(layout, release, source,
             log: m => { if (!json) Console.WriteLine($"  {m}"); });
-    }
-
-    /// <summary>
-    /// Pre-flight checks for a Gateway install. Returns an error message to print, or null if OK.
-    /// Not a fallback: it stops the install with an exact fix rather than half-installing.
-    /// </summary>
-    private static string? GatewayPreflight()
-    {
-        if (!OperatingSystem.IsWindows())
-            return "ERROR: The Gateway role is Windows-only.";
-        if (string.IsNullOrWhiteSpace(OpenAiKey()))
-            return "ERROR: OPENAI_API_KEY is not set in your environment; the Gateway needs it to start.\n" +
-                   "       Set it (User scope) and re-run, e.g.:\n" +
-                   "         setx OPENAI_API_KEY \"sk-...\"";
-        return null;
-    }
-
-    /// <summary>The OpenAI key from the process env, falling back to the User-scope env on Windows.</summary>
-    private static string? OpenAiKey()
-    {
-        var key = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
-        if (string.IsNullOrWhiteSpace(key) && OperatingSystem.IsWindows())
-            key = Environment.GetEnvironmentVariable("OPENAI_API_KEY", EnvironmentVariableTarget.User);
-        return string.IsNullOrWhiteSpace(key) ? null : key;
     }
 
     public static int Rollback(CliArgs args, InstallLayout layout, bool json)

--- a/tools/cc-director-setup-cli/GatewayInstallPreflight.cs
+++ b/tools/cc-director-setup-cli/GatewayInstallPreflight.cs
@@ -1,0 +1,25 @@
+namespace CcDirector.Setup.Cli;
+
+/// <summary>
+/// Pure pre-flight decision for a managed Gateway install/update pass. Factored out of
+/// <see cref="Commands"/> so the rule can be unit-tested without touching the environment.
+///
+/// The ONLY hard requirement is the platform: the managed Gateway is a Windows-only tray app. There
+/// is deliberately NO OPENAI_API_KEY requirement - there is no bring-your-own-key anywhere; inference
+/// routes through DevThrottle's account-minted <c>dt_live_</c> key, which the managed Gateway runtime
+/// auto-mints and stores itself after account sign-in. Demanding an OpenAI key here would block a
+/// Gateway refresh on machines that never needed one.
+/// </summary>
+public static class GatewayInstallPreflight
+{
+    /// <summary>
+    /// Returns an error message to print, or null if the pass may proceed. Takes the platform as a
+    /// parameter (not read from the environment) so the decision is pure and testable.
+    /// </summary>
+    public static string? Check(bool isWindows)
+    {
+        if (!isWindows)
+            return "ERROR: The Gateway role is Windows-only.";
+        return null;
+    }
+}

--- a/tools/cc-director-setup-engine.Tests/GatewayAndPinsTests.cs
+++ b/tools/cc-director-setup-engine.Tests/GatewayAndPinsTests.cs
@@ -55,21 +55,56 @@ public class GatewayTrayInstallerTests
         Assert.Equal(7878, GatewayTrayInstaller.GatewayDefaultPort);
     }
 
-    // D2a: the Gateway install contract no longer carries an OPENAI_API_KEY. Inference routes through
-    // the account-minted dt_live_ key the managed Gateway runtime mints itself, so InstallAsync neither
-    // asks for nor writes an OpenAI key. Revert-proof: re-add the `string? openAiKey` parameter (and the
-    // env-write block this slice deleted) and this test goes red - the parameter reappears.
+    // D2a at the PRODUCTION SEAM: run the real GatewayTrayInstaller.InstallAsync in a no-key
+    // environment and prove it neither demands nor writes an OPENAI_API_KEY. With the Gateway exe
+    // present, control runs PAST the point where the old key demand/write lived and fails later (here,
+    // at sidecar extraction because the offline release carries no download URL) - NOT with a key
+    // demand, and without touching the User-scope OPENAI_API_KEY.
+    //
+    // Revert-proof: re-insert an executable OPENAI_API_KEY demand in the REAL
+    // GatewayTrayInstaller.InstallAsync (right after the exe-present check, GatewayTrayInstaller.cs ~:56)
+    // - e.g. Fail(...) when the key is blank -> the failure message becomes the key demand, so the
+    // "does not contain OPENAI" assertion goes red.
     [Fact]
-    public void InstallAsync_HasNoOpenAiKeyParameter()
+    [SupportedOSPlatform("windows")]
+    public async Task InstallAsync_NoOpenAiKey_RunsPastKeyRegion_NoDemandNoWrite()
     {
-        var method = typeof(GatewayTrayInstaller).GetMethod(nameof(GatewayTrayInstaller.InstallAsync));
-        Assert.NotNull(method);
-        Assert.DoesNotContain(
-            method!.GetParameters(),
-            p => p.Name is not null && p.Name.Contains("openai", StringComparison.OrdinalIgnoreCase));
-        Assert.DoesNotContain(
-            method.GetParameters(),
-            p => p.Name is not null && p.Name.Equals("key", StringComparison.OrdinalIgnoreCase));
+        if (!OperatingSystem.IsWindows()) return;
+
+        var root = Directory.CreateTempSubdirectory("d2a-eng-").FullName;
+        var savedProcessKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY", EnvironmentVariableTarget.Process);
+        var userKeyBefore = Environment.GetEnvironmentVariable("OPENAI_API_KEY", EnvironmentVariableTarget.User);
+        Environment.SetEnvironmentVariable("OPENAI_API_KEY", null, EnvironmentVariableTarget.Process);
+        try
+        {
+            var layout = new InstallLayout(Path.Combine(root, "local"));
+            Directory.CreateDirectory(layout.GatewayDir);
+            // A file that exists (so the exe-present check passes) but is not a valid executable.
+            File.WriteAllBytes(layout.PathFor(ComponentRegistry.Gateway), new byte[] { 0x00, 0x01, 0x02 });
+
+            // Offline release: the mobile sidecar is in the manifest but has NO download URL, so
+            // extraction fails fast with "No source for asset" - no network, and BEFORE any process
+            // launch. The point is only that the failure is not a key demand.
+            var assets = new Dictionary<string, ManifestAsset>
+            {
+                [MobilePackage.AssetName] = new ManifestAsset(MobilePackage.AssetName, "0.0.0-test", "", "windows", 0),
+            };
+            var release = new ResolvedRelease(
+                new ReleaseManifest { Version = "0.0.0-test", Assets = assets },
+                new Dictionary<string, string>());
+
+            var result = await new GatewayTrayInstaller(layout).InstallAsync(release, new ReleaseSource());
+
+            Assert.False(result.Success);
+            Assert.DoesNotContain("OPENAI", result.Message, StringComparison.OrdinalIgnoreCase);
+            // The installer never writes the User-scope OPENAI_API_KEY.
+            Assert.Equal(userKeyBefore, Environment.GetEnvironmentVariable("OPENAI_API_KEY", EnvironmentVariableTarget.User));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OPENAI_API_KEY", savedProcessKey, EnvironmentVariableTarget.Process);
+            Directory.Delete(root, recursive: true);
+        }
     }
 
     // --- Issue #175: the tray launch must NOT inherit the caller's stdio ---------------------------

--- a/tools/cc-director-setup-engine.Tests/GatewayAndPinsTests.cs
+++ b/tools/cc-director-setup-engine.Tests/GatewayAndPinsTests.cs
@@ -55,6 +55,23 @@ public class GatewayTrayInstallerTests
         Assert.Equal(7878, GatewayTrayInstaller.GatewayDefaultPort);
     }
 
+    // D2a: the Gateway install contract no longer carries an OPENAI_API_KEY. Inference routes through
+    // the account-minted dt_live_ key the managed Gateway runtime mints itself, so InstallAsync neither
+    // asks for nor writes an OpenAI key. Revert-proof: re-add the `string? openAiKey` parameter (and the
+    // env-write block this slice deleted) and this test goes red - the parameter reappears.
+    [Fact]
+    public void InstallAsync_HasNoOpenAiKeyParameter()
+    {
+        var method = typeof(GatewayTrayInstaller).GetMethod(nameof(GatewayTrayInstaller.InstallAsync));
+        Assert.NotNull(method);
+        Assert.DoesNotContain(
+            method!.GetParameters(),
+            p => p.Name is not null && p.Name.Contains("openai", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(
+            method.GetParameters(),
+            p => p.Name is not null && p.Name.Equals("key", StringComparison.OrdinalIgnoreCase));
+    }
+
     // --- Issue #175: the tray launch must NOT inherit the caller's stdio ---------------------------
     // When step 4 launched the long-lived tray Gateway with UseShellExecute=false, the Gateway
     // inherited the setup CLI's stdout handle and held it open for its whole lifetime, so any caller

--- a/tools/cc-director-setup-engine/GatewayTrayInstaller.cs
+++ b/tools/cc-director-setup-engine/GatewayTrayInstaller.cs
@@ -10,11 +10,13 @@ public sealed record GatewayInstallResult(bool Success, string Message, IReadOnl
 /// <summary>
 /// Performs the Gateway-role first install that the generic <see cref="UpdateRunner"/> cannot:
 ///   1. extract the Cockpit .zip (the runner skips archive assets) into the per-user Cockpit dir,
-///   2. ensure OPENAI_API_KEY is available to the user environment (the Gateway needs it),
-///   3. start the Gateway tray app with <c>--managed</c> (it supervises the Cockpit and registers
+///   2. start the Gateway tray app with <c>--managed</c> (it supervises the Cockpit and registers
 ///      its own HKCU Run-key autostart on startup),
-///   4. wait for the Gateway (7878) and the supervised Cockpit (7470) to answer.
+///   3. wait for the Gateway (7878) and the supervised Cockpit (7470) to answer.
 ///
+/// The install path does NOT ask for or write an OPENAI_API_KEY: inference routes through
+/// DevThrottle's account-minted <c>dt_live_</c> key, which the managed Gateway runtime auto-mints and
+/// stores itself after account sign-in (AccountInferenceKeyProvisioner / TranscriptionKeyAutoProvisioner).
 /// The Gateway exe itself is already placed by the UpdateRunner at the Gateway component path before
 /// this runs. Everything is per-user (%LOCALAPPDATA%): NO elevation, NO Windows service
 /// (docs/plans/gateway-tray-app.md). Windows-only.
@@ -39,12 +41,12 @@ public sealed class GatewayTrayInstaller
     /// <summary>
     /// Install + start the Gateway tray app from an already-resolved release. The Gateway exe must
     /// already be placed (by the UpdateRunner) at <see cref="InstallLayout.PathFor"/> for the Gateway
-    /// component. <paramref name="openAiKey"/> is written to the user environment when provided;
-    /// otherwise it must already be present there.
+    /// component. No OPENAI_API_KEY is asked for or written: the managed Gateway runtime auto-mints and
+    /// stores the account <c>dt_live_</c> inference key itself after sign-in.
     /// </summary>
     [SupportedOSPlatform("windows")]
     public async Task<GatewayInstallResult> InstallAsync(
-        ResolvedRelease release, ReleaseSource source, string? openAiKey = null, CancellationToken ct = default)
+        ResolvedRelease release, ReleaseSource source, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(release);
         ArgumentNullException.ThrowIfNull(source);
@@ -56,31 +58,12 @@ public sealed class GatewayTrayInstaller
         if (!File.Exists(gatewayExe))
             return Fail(steps, $"Gateway exe not present at {gatewayExe}; the file swap must run first.");
 
-        // 1. OPENAI_API_KEY: the Gateway process needs it (dictation cleanup, recap). Write it to the
-        // user environment when provided; otherwise require it to already be there. No silent degrade.
-        var keyInUserEnv = Environment.GetEnvironmentVariable("OPENAI_API_KEY", EnvironmentVariableTarget.User);
-        if (!string.IsNullOrWhiteSpace(openAiKey))
-        {
-            Environment.SetEnvironmentVariable("OPENAI_API_KEY", openAiKey, EnvironmentVariableTarget.User);
-            steps.Add("wrote OPENAI_API_KEY to the user environment");
-        }
-        else if (string.IsNullOrWhiteSpace(keyInUserEnv))
-        {
-            return Fail(steps,
-                "OPENAI_API_KEY is not set in the user environment and was not provided. " +
-                "Set it (setx OPENAI_API_KEY <key>) and re-run the Gateway install.");
-        }
-        else
-        {
-            steps.Add("OPENAI_API_KEY already present in the user environment");
-        }
-
-        // 2. Stop any already-running installed Gateway (and a legacy Cockpit child from a
+        // 1. Stop any already-running installed Gateway (and a legacy Cockpit child from a
         // pre-cutover install) so their files unlock before extraction (re-install / repair path).
         // Scoped to processes under the install dirs only.
         StopInstalledProcesses(steps);
 
-        // 3. Extract the mobile app (issue #809) into wwwroot/m beside the Gateway exe so /m serves on
+        // 2. Extract the mobile app (issue #809) into wwwroot/m beside the Gateway exe so /m serves on
         // a clean install with no manual copy. The single-file exe carries no loose content, so this
         // side-car zip is the delivery. A release that predates the mobile app (#806) has no such asset
         // and simply serves no /m (ExtractAsync returns null).
@@ -97,7 +80,7 @@ public sealed class GatewayTrayInstaller
             return Fail(steps, $"Mobile app extraction failed: {ex.Message}");
         }
 
-        // 3b. Extract the React Cockpit (epic #967 cutover, issue #979) into wwwroot/c beside the exe so
+        // 2b. Extract the React Cockpit (epic #967 cutover, issue #979) into wwwroot/c beside the exe so
         // the Gateway serves the Cockpit at the site root on a clean install. Same side-car delivery as
         // the mobile app above (the single-file exe carries no loose content). A release that predates
         // the cutover has no such asset and serves no Cockpit (ExtractAsync returns null).
@@ -114,7 +97,7 @@ public sealed class GatewayTrayInstaller
             return Fail(steps, $"Cockpit extraction failed: {ex.Message}");
         }
 
-        // 3c. Extract the bundled ffmpeg (issue #1186) beside the Gateway exe so the long-clip WebM/Opus
+        // 2c. Extract the bundled ffmpeg (issue #1186) beside the Gateway exe so the long-clip WebM/Opus
         // -> PCM WAV transcode (issue #1139) works on a clean install with no manual copy. Same side-car
         // delivery as the mobile app / Cockpit above (the single-file exe carries no loose content), but
         // ffmpeg.exe lands in the Gateway dir root where FfmpegAudioTranscoder resolves it. A release that
@@ -133,7 +116,7 @@ public sealed class GatewayTrayInstaller
             return Fail(steps, $"ffmpeg extraction failed: {ex.Message}");
         }
 
-        // 4. Start the tray app. It registers its own HKCU Run-key autostart (pointing at itself with
+        // 3. Start the tray app. It registers its own HKCU Run-key autostart (pointing at itself with
         // the same arguments) on startup, so install-time registration and app self-registration can
         // never disagree.
         try
@@ -148,7 +131,7 @@ public sealed class GatewayTrayInstaller
             return Fail(steps, $"Failed to start the Gateway tray app: {ex.Message}");
         }
 
-        // 5. Wait for health: the Gateway itself. It serves the React Cockpit in-process (issue #979),
+        // 4. Wait for health: the Gateway itself. It serves the React Cockpit in-process (issue #979),
         // so a healthy Gateway IS a live Cockpit - there is no separate Cockpit process to health-check.
         var gatewayUp = await WaitForHttpAsync($"http://127.0.0.1:{GatewayDefaultPort}/healthz", TimeSpan.FromSeconds(20), ct);
         steps.Add($"gateway healthz on {GatewayDefaultPort}: {(gatewayUp ? "OK" : "no response")}");

--- a/tools/cc-director-setup.Tests/InstallCompletionTests.cs
+++ b/tools/cc-director-setup.Tests/InstallCompletionTests.cs
@@ -4,61 +4,94 @@ using Xunit;
 namespace CcDirectorSetup.Tests;
 
 /// <summary>
-/// Guards the honest completion reporting (D2b). A failed Gateway refresh on an existing Gateway
-/// machine must feed the "skipped" (failed) count so the Complete step reads as a failure instead of
-/// "Everything went perfectly." Before this, RunGatewayTrayInstallAsync painted the row failed but
-/// never counted it, so CompleteStep reported a clean success while the Gateway never updated.
+/// Guards the honest completion reporting (D2b) at the PRODUCTION SEAM: <see cref="GatewayRefresh"/>,
+/// the exact gateway-outcome -> completion-state transition that <c>MainWindow.RunGatewayTrayInstallAsync</c>
+/// runs (MainWindow has no other path). A returned failure AND a thrown failure both add one to the
+/// skipped (failed) count, so the resulting completion model reads as Problems - it CANNOT render
+/// "Everything went perfectly" or "Already Up to Date." Before this, a failed refresh was painted on
+/// the row but never counted, so the wizard reported a clean success while the Gateway never updated.
 /// </summary>
+public sealed class GatewayRefreshTests
+{
+    // A returned Gateway failure counts one skip and forces Problems - not Success, not AlreadyUpToDate -
+    // even when the Director itself was already up to date.
+    // Revert-proof: in GatewayRefresh.RunAsync, stop counting the failure (return `skippedBefore` on a
+    // failed result) -> Skipped stays 0, Classify yields AlreadyUpToDate/Success, and this goes red.
+    [Fact]
+    public async Task RunAsync_ReturnedFailure_CountsSkip_CannotRenderSuccess()
+    {
+        var outcome = await GatewayRefresh.RunAsync(
+            () => Task.FromResult(new GatewayTrayLauncher.Result(false, 3, "Gateway install failed (exit 3).")),
+            skippedBefore: 0);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(1, outcome.Skipped);
+
+        var kind = InstallCompletion.Classify(outcome.Skipped, alreadyUpToDate: true);
+        Assert.Equal(InstallCompletionKind.Problems, kind);
+        Assert.NotEqual(InstallCompletionKind.AlreadyUpToDate, kind);
+        Assert.NotEqual(InstallCompletionKind.Success, kind);
+    }
+
+    // A thrown Gateway failure travels the same production catch: it counts one skip, forces Problems,
+    // and carries the reason (for the Complete screen, R2).
+    // Revert-proof: in GatewayRefresh.RunAsync, return `skippedBefore` in the catch instead of
+    // `skippedBefore + 1` -> Skipped stays 0 and Classify yields Success, so this goes red.
+    [Fact]
+    public async Task RunAsync_ThrownFailure_CountsSkip_CarriesReason_CannotRenderSuccess()
+    {
+        var outcome = await GatewayRefresh.RunAsync(
+            () => throw new InvalidOperationException("cli vanished"),
+            skippedBefore: 0);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(1, outcome.Skipped);
+        Assert.Contains("cli vanished", outcome.Message);
+
+        var kind = InstallCompletion.Classify(outcome.Skipped, alreadyUpToDate: true);
+        Assert.Equal(InstallCompletionKind.Problems, kind);
+        Assert.NotEqual(InstallCompletionKind.Success, kind);
+    }
+
+    // A successful refresh leaves the count untouched, so a clean update still renders success.
+    [Fact]
+    public async Task RunAsync_Success_KeepsCleanCompletion()
+    {
+        var outcome = await GatewayRefresh.RunAsync(
+            () => Task.FromResult(new GatewayTrayLauncher.Result(true, 0, "Gateway tray app installed.")),
+            skippedBefore: 0);
+
+        Assert.True(outcome.Success);
+        Assert.Equal(0, outcome.Skipped);
+        Assert.Equal(InstallCompletionKind.AlreadyUpToDate, InstallCompletion.Classify(outcome.Skipped, alreadyUpToDate: true));
+        Assert.Equal(InstallCompletionKind.Success, InstallCompletion.Classify(outcome.Skipped, alreadyUpToDate: false));
+    }
+
+    // A Gateway failure on top of existing engine skips accumulates (never overwrites the earlier count).
+    [Fact]
+    public async Task RunAsync_ReturnedFailure_AddsToExistingSkips()
+    {
+        var outcome = await GatewayRefresh.RunAsync(
+            () => Task.FromResult(new GatewayTrayLauncher.Result(false, 1, "boom")),
+            skippedBefore: 2);
+        Assert.Equal(3, outcome.Skipped);
+    }
+}
+
+/// <summary>The pure completion classification the Complete step renders (single-sourced verdict).</summary>
 public sealed class InstallCompletionTests
 {
-    // The headline D2b guard: a failed Gateway refresh increments the skipped (failed) count.
-    // Revert-proof: swallow the failure again (return skippedBefore on a failed refresh) and this goes
-    // red - the count stays 0, which is exactly the false-success symptom.
-    [Fact]
-    public void SkippedAfterGateway_FailedRefresh_CountsOne()
-    {
-        Assert.Equal(1, InstallCompletion.SkippedAfterGateway(skippedBefore: 0, gatewaySuccess: false));
-    }
-
-    [Fact]
-    public void SkippedAfterGateway_SuccessfulRefresh_LeavesCountUnchanged()
-    {
-        Assert.Equal(0, InstallCompletion.SkippedAfterGateway(skippedBefore: 0, gatewaySuccess: true));
-        Assert.Equal(2, InstallCompletion.SkippedAfterGateway(skippedBefore: 2, gatewaySuccess: true));
-    }
-
-    [Fact]
-    public void SkippedAfterGateway_FailedRefresh_AddsToExistingFailures()
-    {
-        Assert.Equal(3, InstallCompletion.SkippedAfterGateway(skippedBefore: 2, gatewaySuccess: false));
-    }
-
-    // The other half of the false-success symptom: any skipped component reads as Problems - never
-    // the "Everything went perfectly" (Success) or "Already Up to Date" state. So once a failed
-    // Gateway refresh has bumped the count to >= 1, the Complete step cannot report success.
     [Fact]
     public void Classify_AnySkipped_IsProblems()
     {
-        Assert.Equal(InstallCompletionKind.Problems, InstallCompletion.Classify(installed: 5, skipped: 1, isUpdate: true, alreadyUpToDate: false));
-        Assert.Equal(InstallCompletionKind.Problems, InstallCompletion.Classify(installed: 0, skipped: 1, isUpdate: true, alreadyUpToDate: true));
+        Assert.Equal(InstallCompletionKind.Problems, InstallCompletion.Classify(skipped: 1, alreadyUpToDate: false));
+        Assert.Equal(InstallCompletionKind.Problems, InstallCompletion.Classify(skipped: 1, alreadyUpToDate: true));
     }
 
     [Fact]
     public void Classify_NoSkipped_UpToDateOrSuccess()
     {
-        Assert.Equal(InstallCompletionKind.AlreadyUpToDate, InstallCompletion.Classify(installed: 0, skipped: 0, isUpdate: true, alreadyUpToDate: true));
-        Assert.Equal(InstallCompletionKind.Success, InstallCompletion.Classify(installed: 3, skipped: 0, isUpdate: true, alreadyUpToDate: false));
-        Assert.Equal(InstallCompletionKind.Success, InstallCompletion.Classify(installed: 3, skipped: 0, isUpdate: false, alreadyUpToDate: false));
-    }
-
-    // End-to-end reasoning: an update that found the Director already current (alreadyUpToDate) but
-    // whose Gateway refresh then FAILED must not report "Already Up to Date" - the failed refresh
-    // bumps the count and the verdict flips to Problems.
-    [Fact]
-    public void FailedGatewayRefresh_FlipsAlreadyUpToDate_ToProblems()
-    {
-        var skipped = InstallCompletion.SkippedAfterGateway(skippedBefore: 0, gatewaySuccess: false);
-        var kind = InstallCompletion.Classify(installed: 0, skipped: skipped, isUpdate: true, alreadyUpToDate: true);
-        Assert.Equal(InstallCompletionKind.Problems, kind);
+        Assert.Equal(InstallCompletionKind.AlreadyUpToDate, InstallCompletion.Classify(skipped: 0, alreadyUpToDate: true));
+        Assert.Equal(InstallCompletionKind.Success, InstallCompletion.Classify(skipped: 0, alreadyUpToDate: false));
     }
 }

--- a/tools/cc-director-setup.Tests/InstallCompletionTests.cs
+++ b/tools/cc-director-setup.Tests/InstallCompletionTests.cs
@@ -1,0 +1,64 @@
+using CcDirectorSetup.Services;
+using Xunit;
+
+namespace CcDirectorSetup.Tests;
+
+/// <summary>
+/// Guards the honest completion reporting (D2b). A failed Gateway refresh on an existing Gateway
+/// machine must feed the "skipped" (failed) count so the Complete step reads as a failure instead of
+/// "Everything went perfectly." Before this, RunGatewayTrayInstallAsync painted the row failed but
+/// never counted it, so CompleteStep reported a clean success while the Gateway never updated.
+/// </summary>
+public sealed class InstallCompletionTests
+{
+    // The headline D2b guard: a failed Gateway refresh increments the skipped (failed) count.
+    // Revert-proof: swallow the failure again (return skippedBefore on a failed refresh) and this goes
+    // red - the count stays 0, which is exactly the false-success symptom.
+    [Fact]
+    public void SkippedAfterGateway_FailedRefresh_CountsOne()
+    {
+        Assert.Equal(1, InstallCompletion.SkippedAfterGateway(skippedBefore: 0, gatewaySuccess: false));
+    }
+
+    [Fact]
+    public void SkippedAfterGateway_SuccessfulRefresh_LeavesCountUnchanged()
+    {
+        Assert.Equal(0, InstallCompletion.SkippedAfterGateway(skippedBefore: 0, gatewaySuccess: true));
+        Assert.Equal(2, InstallCompletion.SkippedAfterGateway(skippedBefore: 2, gatewaySuccess: true));
+    }
+
+    [Fact]
+    public void SkippedAfterGateway_FailedRefresh_AddsToExistingFailures()
+    {
+        Assert.Equal(3, InstallCompletion.SkippedAfterGateway(skippedBefore: 2, gatewaySuccess: false));
+    }
+
+    // The other half of the false-success symptom: any skipped component reads as Problems - never
+    // the "Everything went perfectly" (Success) or "Already Up to Date" state. So once a failed
+    // Gateway refresh has bumped the count to >= 1, the Complete step cannot report success.
+    [Fact]
+    public void Classify_AnySkipped_IsProblems()
+    {
+        Assert.Equal(InstallCompletionKind.Problems, InstallCompletion.Classify(installed: 5, skipped: 1, isUpdate: true, alreadyUpToDate: false));
+        Assert.Equal(InstallCompletionKind.Problems, InstallCompletion.Classify(installed: 0, skipped: 1, isUpdate: true, alreadyUpToDate: true));
+    }
+
+    [Fact]
+    public void Classify_NoSkipped_UpToDateOrSuccess()
+    {
+        Assert.Equal(InstallCompletionKind.AlreadyUpToDate, InstallCompletion.Classify(installed: 0, skipped: 0, isUpdate: true, alreadyUpToDate: true));
+        Assert.Equal(InstallCompletionKind.Success, InstallCompletion.Classify(installed: 3, skipped: 0, isUpdate: true, alreadyUpToDate: false));
+        Assert.Equal(InstallCompletionKind.Success, InstallCompletion.Classify(installed: 3, skipped: 0, isUpdate: false, alreadyUpToDate: false));
+    }
+
+    // End-to-end reasoning: an update that found the Director already current (alreadyUpToDate) but
+    // whose Gateway refresh then FAILED must not report "Already Up to Date" - the failed refresh
+    // bumps the count and the verdict flips to Problems.
+    [Fact]
+    public void FailedGatewayRefresh_FlipsAlreadyUpToDate_ToProblems()
+    {
+        var skipped = InstallCompletion.SkippedAfterGateway(skippedBefore: 0, gatewaySuccess: false);
+        var kind = InstallCompletion.Classify(installed: 0, skipped: skipped, isUpdate: true, alreadyUpToDate: true);
+        Assert.Equal(InstallCompletionKind.Problems, kind);
+    }
+}

--- a/tools/cc-director-setup/MainWindow.xaml.cs
+++ b/tools/cc-director-setup/MainWindow.xaml.cs
@@ -22,6 +22,9 @@ public partial class MainWindow : Window
     // disk in the constructor via InstalledRoleDetector so an existing Gateway host stays a Gateway host.
     private InstallRole _role = InstallRole.Workstation;
     private string? _gatewayResultMessage;
+    // The Gateway refresh failure reason (null when it succeeded), carried onto the Complete screen so
+    // a failed Gateway update tells the user WHY, not just that a component did not install.
+    private string? _gatewayFailureReason;
 
     private readonly bool _isUpdate;
     private readonly string? _installedVersion;
@@ -191,7 +194,7 @@ public partial class MainWindow : Window
             StepPrivacy => _privacyStep ??= BuildPrivacyStep(),
             6 => _skillsStep ??= new SkillsStep(_isUpdate),
             StepInstall => _installStep ??= new InstallStep(),
-            StepComplete => _completeStep ??= new CompleteStep(_installedCount, _skippedCount, _installPath, _directorExePath, _isUpdate, _alreadyUpToDate, _cachedPrep?.Version),
+            StepComplete => _completeStep ??= new CompleteStep(_installedCount, _skippedCount, _installPath, _directorExePath, _isUpdate, _alreadyUpToDate, _cachedPrep?.Version, _gatewayFailureReason),
             _ => null
         };
 
@@ -483,32 +486,25 @@ public partial class MainWindow : Window
         _installStep?.SetStatus("Installing the Gateway tray app...");
         _installStep?.SetGatewayInstalling();
 
-        try
-        {
-            var launcher = new GatewayTrayLauncher(new ReleaseSource());
-            var result = await launcher.RunAsync(
+        // The gateway-outcome -> completion-state transition lives in GatewayRefresh (UI-free, tested):
+        // a returned failure AND a thrown failure both add one to the skipped count so the Complete step
+        // reports the honest failure instead of "Everything went perfectly." This is the ONLY place the
+        // wizard folds the Gateway refresh into its counts.
+        var launcher = new GatewayTrayLauncher(new ReleaseSource());
+        var outcome = await GatewayRefresh.RunAsync(
+            () => launcher.RunAsync(
                 prep.Release,
-                line => Dispatcher.BeginInvoke(() => _installStep?.SetStatus($"Gateway: {line}")));
+                line => Dispatcher.BeginInvoke(() => _installStep?.SetStatus($"Gateway: {line}"))),
+            _skippedCount);
 
-            _gatewayResultMessage = result.Message;
-            // result.Message already carries the tailnet Cockpit URL (never localhost).
-            _installStep?.SetStatus(result.Message);
-            if (result.Success) _installStep?.SetGatewayDone();
-            else _installStep?.SetGatewayFailed();
-            // A failed Gateway refresh is a component that did NOT install: count it so the Complete
-            // step reports the honest failure instead of "Everything went perfectly." Painting the row
-            // failed without this let the wizard report a clean success while the Gateway never updated.
-            _skippedCount = InstallCompletion.SkippedAfterGateway(_skippedCount, result.Success);
-            SetupLog.Write($"[MainWindow] Gateway install success={result.Success}: {result.Message} (skipped now {_skippedCount})");
-        }
-        catch (Exception ex)
-        {
-            _gatewayResultMessage = $"Gateway install error: {ex.Message}";
-            _installStep?.SetStatus(_gatewayResultMessage);
-            _installStep?.SetGatewayFailed();
-            _skippedCount = InstallCompletion.SkippedAfterGateway(_skippedCount, gatewaySuccess: false);
-            SetupLog.Write($"[MainWindow] RunGatewayTrayInstallAsync FAILED: {ex.Message} (skipped now {_skippedCount})");
-        }
+        _skippedCount = outcome.Skipped;
+        _gatewayResultMessage = outcome.Message;
+        // outcome.Message carries the tailnet Cockpit URL on success, the failure reason on failure.
+        _gatewayFailureReason = outcome.Success ? null : outcome.Message;
+        _installStep?.SetStatus(outcome.Message);
+        if (outcome.Success) _installStep?.SetGatewayDone();
+        else _installStep?.SetGatewayFailed();
+        SetupLog.Write($"[MainWindow] Gateway install success={outcome.Success}: {outcome.Message} (skipped now {_skippedCount})");
     }
 
     private Task<bool> OnProcessBlockingAsync(string processName)

--- a/tools/cc-director-setup/MainWindow.xaml.cs
+++ b/tools/cc-director-setup/MainWindow.xaml.cs
@@ -495,14 +495,19 @@ public partial class MainWindow : Window
             _installStep?.SetStatus(result.Message);
             if (result.Success) _installStep?.SetGatewayDone();
             else _installStep?.SetGatewayFailed();
-            SetupLog.Write($"[MainWindow] Gateway install success={result.Success}: {result.Message}");
+            // A failed Gateway refresh is a component that did NOT install: count it so the Complete
+            // step reports the honest failure instead of "Everything went perfectly." Painting the row
+            // failed without this let the wizard report a clean success while the Gateway never updated.
+            _skippedCount = InstallCompletion.SkippedAfterGateway(_skippedCount, result.Success);
+            SetupLog.Write($"[MainWindow] Gateway install success={result.Success}: {result.Message} (skipped now {_skippedCount})");
         }
         catch (Exception ex)
         {
             _gatewayResultMessage = $"Gateway install error: {ex.Message}";
             _installStep?.SetStatus(_gatewayResultMessage);
             _installStep?.SetGatewayFailed();
-            SetupLog.Write($"[MainWindow] RunGatewayTrayInstallAsync FAILED: {ex.Message}");
+            _skippedCount = InstallCompletion.SkippedAfterGateway(_skippedCount, gatewaySuccess: false);
+            SetupLog.Write($"[MainWindow] RunGatewayTrayInstallAsync FAILED: {ex.Message} (skipped now {_skippedCount})");
         }
     }
 

--- a/tools/cc-director-setup/Services/GatewayRefresh.cs
+++ b/tools/cc-director-setup/Services/GatewayRefresh.cs
@@ -1,0 +1,41 @@
+namespace CcDirectorSetup.Services;
+
+/// <summary>
+/// The managed Gateway refresh folded into the wizard's completion state: the new skipped (failed)
+/// count, whether the refresh succeeded, and the message to surface (the failure reason on failure).
+/// </summary>
+public readonly record struct GatewayRefreshOutcome(int Skipped, bool Success, string Message);
+
+/// <summary>
+/// The gateway-outcome -> completion-state transition that <c>MainWindow.RunGatewayTrayInstallAsync</c>
+/// runs. Extracted UI-free so it is testable off the WPF thread, and it is the ONE path MainWindow
+/// uses: a returned failure OR a thrown failure both add one to the skipped (failed) count, so the
+/// Complete step reports the honest failure instead of "Everything went perfectly." Swallowing the
+/// failure (leaving the count unchanged) is exactly the false-success bug this guards against.
+/// </summary>
+public static class GatewayRefresh
+{
+    /// <summary>
+    /// Run the Gateway refresh <paramref name="run"/> and fold its result into the completion state.
+    /// A returned failure and a thrown failure both count as one skipped component. The try/catch is
+    /// the boundary for the external Gateway subprocess launch, which can either return a nonzero
+    /// result or throw.
+    /// </summary>
+    public static async Task<GatewayRefreshOutcome> RunAsync(
+        Func<Task<GatewayTrayLauncher.Result>> run, int skippedBefore)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        try
+        {
+            var result = await run();
+            // A failed refresh is a component that did NOT install: count it so the Complete step
+            // cannot render success. This is the production line the D2b guard reverts.
+            var skipped = result.Success ? skippedBefore : skippedBefore + 1;
+            return new GatewayRefreshOutcome(skipped, result.Success, result.Message);
+        }
+        catch (Exception ex)
+        {
+            return new GatewayRefreshOutcome(skippedBefore + 1, false, $"Gateway install error: {ex.Message}");
+        }
+    }
+}

--- a/tools/cc-director-setup/Services/InstallCompletion.cs
+++ b/tools/cc-director-setup/Services/InstallCompletion.cs
@@ -14,35 +14,22 @@ public enum InstallCompletionKind
 }
 
 /// <summary>
-/// Pure completion-state decisions for the setup wizard, factored out of the WPF
-/// <c>CompleteStep</c>/<c>MainWindow</c> so the honesty rules can be unit-tested without a UI thread.
-///
-/// The verdict is computed in ONE place and rendered verbatim: a pass with ANY skipped (failed)
-/// component reads as <see cref="InstallCompletionKind.Problems"/>, and a "skipped" count is the only
-/// signal that separates an honest failure from "Everything went perfectly." A failed Gateway refresh
-/// on an existing Gateway machine MUST feed that count (<see cref="SkippedAfterGateway"/>) or the
-/// wizard would report success while the Gateway component did not actually update.
+/// Pure completion-state classification for the setup wizard, factored out of the WPF
+/// <c>CompleteStep</c> so the rule is single-sourced and unit-testable. Any skipped (failed) component
+/// reads as <see cref="InstallCompletionKind.Problems"/> - the "finished with problems" state - so a
+/// failure can never be rendered as "Everything went perfectly" or "Already Up to Date." The skipped
+/// count is fed by <see cref="GatewayRefresh"/> so a failed Gateway refresh lands here as Problems.
 /// </summary>
 public static class InstallCompletion
 {
     /// <summary>
-    /// The skipped (failed) component count AFTER accounting for the Gateway tray refresh. A failed
-    /// refresh is a component that did NOT install, so it adds one to the count; a successful refresh
-    /// leaves it unchanged. Swallowing the failure (returning <paramref name="skippedBefore"/> on a
-    /// failed refresh) is exactly the false-success bug this guards against.
-    /// </summary>
-    public static int SkippedAfterGateway(int skippedBefore, bool gatewaySuccess)
-        => gatewaySuccess ? skippedBefore : skippedBefore + 1;
-
-    /// <summary>
     /// Classify a finished pass. Any skipped component wins and reads as
-    /// <see cref="InstallCompletionKind.Problems"/> - the "finished with problems" state - so a
-    /// failure can never be rendered as "Everything went perfectly" or "Already Up to Date".
+    /// <see cref="InstallCompletionKind.Problems"/>; otherwise an update that found nothing to do is
+    /// <see cref="InstallCompletionKind.AlreadyUpToDate"/> and everything else is
+    /// <see cref="InstallCompletionKind.Success"/>.
     /// </summary>
-    public static InstallCompletionKind Classify(int installed, int skipped, bool isUpdate, bool alreadyUpToDate)
+    public static InstallCompletionKind Classify(int skipped, bool alreadyUpToDate)
     {
-        _ = installed;
-        _ = isUpdate;
         if (skipped > 0)
             return InstallCompletionKind.Problems;
         return alreadyUpToDate ? InstallCompletionKind.AlreadyUpToDate : InstallCompletionKind.Success;

--- a/tools/cc-director-setup/Services/InstallCompletion.cs
+++ b/tools/cc-director-setup/Services/InstallCompletion.cs
@@ -1,0 +1,50 @@
+namespace CcDirectorSetup.Services;
+
+/// <summary>How the Complete step should read an install/update pass.</summary>
+public enum InstallCompletionKind
+{
+    /// <summary>An update pass that found nothing to do (Director already current).</summary>
+    AlreadyUpToDate,
+
+    /// <summary>Every component that was meant to install/update did so.</summary>
+    Success,
+
+    /// <summary>At least one component did not install - the pass finished with problems.</summary>
+    Problems,
+}
+
+/// <summary>
+/// Pure completion-state decisions for the setup wizard, factored out of the WPF
+/// <c>CompleteStep</c>/<c>MainWindow</c> so the honesty rules can be unit-tested without a UI thread.
+///
+/// The verdict is computed in ONE place and rendered verbatim: a pass with ANY skipped (failed)
+/// component reads as <see cref="InstallCompletionKind.Problems"/>, and a "skipped" count is the only
+/// signal that separates an honest failure from "Everything went perfectly." A failed Gateway refresh
+/// on an existing Gateway machine MUST feed that count (<see cref="SkippedAfterGateway"/>) or the
+/// wizard would report success while the Gateway component did not actually update.
+/// </summary>
+public static class InstallCompletion
+{
+    /// <summary>
+    /// The skipped (failed) component count AFTER accounting for the Gateway tray refresh. A failed
+    /// refresh is a component that did NOT install, so it adds one to the count; a successful refresh
+    /// leaves it unchanged. Swallowing the failure (returning <paramref name="skippedBefore"/> on a
+    /// failed refresh) is exactly the false-success bug this guards against.
+    /// </summary>
+    public static int SkippedAfterGateway(int skippedBefore, bool gatewaySuccess)
+        => gatewaySuccess ? skippedBefore : skippedBefore + 1;
+
+    /// <summary>
+    /// Classify a finished pass. Any skipped component wins and reads as
+    /// <see cref="InstallCompletionKind.Problems"/> - the "finished with problems" state - so a
+    /// failure can never be rendered as "Everything went perfectly" or "Already Up to Date".
+    /// </summary>
+    public static InstallCompletionKind Classify(int installed, int skipped, bool isUpdate, bool alreadyUpToDate)
+    {
+        _ = installed;
+        _ = isUpdate;
+        if (skipped > 0)
+            return InstallCompletionKind.Problems;
+        return alreadyUpToDate ? InstallCompletionKind.AlreadyUpToDate : InstallCompletionKind.Success;
+    }
+}

--- a/tools/cc-director-setup/Steps/CompleteStep.xaml.cs
+++ b/tools/cc-director-setup/Steps/CompleteStep.xaml.cs
@@ -32,39 +32,43 @@ public partial class CompleteStep : UserControl
 
         var versionSuffix = string.IsNullOrEmpty(version) ? "" : $" · v{version.TrimStart('v')}";
 
-        if (alreadyUpToDate)
+        // One place computes the verdict; this only renders it (any skipped component reads as
+        // Problems, so a failure can never render as "Everything went perfectly").
+        switch (InstallCompletion.Classify(installed, skipped, isUpdate, alreadyUpToDate))
         {
-            HeadingText.Text = "✓  Already Up to Date";
-            DescriptionText.Text = "DevThrottle is already running the latest version.";
-            SummaryLine.Text = $"Nothing to do{versionSuffix}";
-            PathNote.Visibility = Visibility.Collapsed;
-        }
-        else if (isUpdate)
-        {
-            HeadingText.Text = "✓  Update Complete";
-            DescriptionText.Text = "Everything went perfectly. You're up to date.";
-            SummaryLine.Text = $"{installed} components updated{versionSuffix}";
-            PathNote.Visibility = Visibility.Collapsed;
-        }
-        else
-        {
-            SummaryLine.Text = $"{installed} components installed{versionSuffix}";
-        }
+            case InstallCompletionKind.AlreadyUpToDate:
+                HeadingText.Text = "✓  Already Up to Date";
+                DescriptionText.Text = "DevThrottle is already running the latest version.";
+                SummaryLine.Text = $"Nothing to do{versionSuffix}";
+                PathNote.Visibility = Visibility.Collapsed;
+                break;
 
-        // Failure path: surface the problem loudly - amber heading, full summary box,
-        // and the details/report expander forced open. On success all of that stays
-        // out of the way behind the small collapsed expander at the bottom.
-        if (skipped > 0)
-        {
-            var amber = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xE0, 0xA0, 0x30));
-            HeadingText.Text = isUpdate ? "Update finished with problems" : "Setup finished with problems";
-            HeadingText.Foreground = amber;
-            DescriptionText.Text = $"{skipped} component(s) did not install. DevThrottle may still work, but please report this.";
-            SummaryLine.Visibility = Visibility.Collapsed;
-            FailurePanel.Visibility = Visibility.Visible;
-            DetailsHeader.Text = $"{skipped} component(s) did not install - please report this";
-            DetailsHeader.Foreground = amber;
-            DetailsExpander.IsExpanded = true;
+            case InstallCompletionKind.Success when isUpdate:
+                HeadingText.Text = "✓  Update Complete";
+                DescriptionText.Text = "Everything went perfectly. You're up to date.";
+                SummaryLine.Text = $"{installed} components updated{versionSuffix}";
+                PathNote.Visibility = Visibility.Collapsed;
+                break;
+
+            case InstallCompletionKind.Success:
+                // Fresh install: heading/description keep their XAML defaults ("...ready to go.").
+                SummaryLine.Text = $"{installed} components installed{versionSuffix}";
+                break;
+
+            case InstallCompletionKind.Problems:
+                // Failure path: surface the problem loudly - amber heading, full summary box,
+                // and the details/report expander forced open. On success all of that stays
+                // out of the way behind the small collapsed expander at the bottom.
+                var amber = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xE0, 0xA0, 0x30));
+                HeadingText.Text = isUpdate ? "Update finished with problems" : "Setup finished with problems";
+                HeadingText.Foreground = amber;
+                DescriptionText.Text = $"{skipped} component(s) did not install. DevThrottle may still work, but please report this.";
+                SummaryLine.Visibility = Visibility.Collapsed;
+                FailurePanel.Visibility = Visibility.Visible;
+                DetailsHeader.Text = $"{skipped} component(s) did not install - please report this";
+                DetailsHeader.Foreground = amber;
+                DetailsExpander.IsExpanded = true;
+                break;
         }
 
         SetupLog.Write($"[CompleteStep] Created: installed={installed}, skipped={skipped}, isUpdate={isUpdate}, alreadyUpToDate={alreadyUpToDate}, version={version}");

--- a/tools/cc-director-setup/Steps/CompleteStep.xaml.cs
+++ b/tools/cc-director-setup/Steps/CompleteStep.xaml.cs
@@ -17,7 +17,7 @@ public partial class CompleteStep : UserControl
     private readonly int _skipped;
     private readonly bool _isUpdate;
 
-    public CompleteStep(int installed, int skipped, string installPath, string directorExePath, bool isUpdate, bool alreadyUpToDate = false, string? version = null)
+    public CompleteStep(int installed, int skipped, string installPath, string directorExePath, bool isUpdate, bool alreadyUpToDate = false, string? version = null, string? gatewayFailureReason = null)
     {
         InitializeComponent();
         _installPath = installPath;
@@ -34,7 +34,7 @@ public partial class CompleteStep : UserControl
 
         // One place computes the verdict; this only renders it (any skipped component reads as
         // Problems, so a failure can never render as "Everything went perfectly").
-        switch (InstallCompletion.Classify(installed, skipped, isUpdate, alreadyUpToDate))
+        switch (InstallCompletion.Classify(skipped, alreadyUpToDate))
         {
             case InstallCompletionKind.AlreadyUpToDate:
                 HeadingText.Text = "✓  Already Up to Date";
@@ -62,7 +62,11 @@ public partial class CompleteStep : UserControl
                 var amber = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xE0, 0xA0, 0x30));
                 HeadingText.Text = isUpdate ? "Update finished with problems" : "Setup finished with problems";
                 HeadingText.Foreground = amber;
-                DescriptionText.Text = $"{skipped} component(s) did not install. DevThrottle may still work, but please report this.";
+                // Carry the specific Gateway failure reason onto the final screen when we have it, so a
+                // failed Gateway update tells the user WHY - not just that something did not install.
+                DescriptionText.Text = string.IsNullOrWhiteSpace(gatewayFailureReason)
+                    ? $"{skipped} component(s) did not install. DevThrottle may still work, but please report this."
+                    : $"{skipped} component(s) did not install. DevThrottle may still work, but please report this.\n{gatewayFailureReason}";
                 SummaryLine.Visibility = Visibility.Collapsed;
                 FailurePanel.Visibility = Visibility.Visible;
                 DetailsHeader.Text = $"{skipped} component(s) did not install - please report this";


### PR DESCRIPTION
Makes the Gateway UPDATE path safe to release to machines that already run a Gateway - part of the D2
release-gate (#1810 / thefrederiksen/devthrottle_internal#870). These are pre-existing hazards on the update path, not introduced by the
Director-only install (#1807).

**D2a - delete the obsolete OPENAI_API_KEY requirement.** The managed Gateway install/update no longer
asks for or writes a user OpenAI key (removed from the CLI Gateway preflight and from
`GatewayTrayInstaller`). Inference routes through the account-minted `dt_live_` key that the managed
Gateway runtime auto-mints and stores itself after sign-in. Unrelated tools that still use the key are
untouched.

**D2b - a failed Gateway refresh reports an honest failure**, instead of "Everything went perfectly."
The gateway-outcome to completion-state transition is extracted into `GatewayRefresh` (UI-free, and the
one path `MainWindow.RunGatewayTrayInstallAsync` uses); a returned OR thrown failure counts as a skipped
component, so the Complete step cannot render success, and the failure reason is now carried onto the
completion screen.

## Verification
- Builds clean (0 warnings). Suites green: setup 30, cli 19, engine 318.
- Independent adversarial review, plus revert-proofs reproduced at the PRODUCTION line: swallowing the
  failure in `GatewayRefresh.RunAsync` reds the completion guards; re-inserting a key demand in the real
  `GatewayTrayInstaller.InstallAsync` reds the no-key guard.

Pairs with the D1 legacy-name detection fix; together they let the next release reach existing Gateway
machines without orphaning them.
