### PR TITLE
fix(setup): detect a legacy-named Gateway host on update so it is not orphaned (D1, #1821)

### DIFF
--- a/tools/cc-director-setup-engine.Tests/InstalledRoleDetectorTests.cs
+++ b/tools/cc-director-setup-engine.Tests/InstalledRoleDetectorTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using CcDirector.Setup.Engine;
 using Xunit;
 
@@ -8,9 +10,19 @@ public class InstalledRoleDetectorTests
     private static readonly InstallLayout Layout = new(@"C:\root");
     private static readonly string GatewayExe = Layout.PathFor(ComponentRegistry.Gateway);
 
-    /// <summary>Build a reader whose file-existence answer we control, with no disk access.</summary>
+    // The pre-rename Gateway name, asserted as a LITERAL to PIN the historical spelling. Deriving it
+    // from LegacyAliasesFor (the very method under guard) would let a wrong alias spelling still pass:
+    // production and the expectation would drift together. Spelled out here, a misspelled alias in
+    // LegacyAliasesFor makes Detect_OnlyLegacyGatewayExePresent_IsGateway go red.
+    private static readonly string LegacyGatewayExe = Path.Combine(Layout.GatewayDir, "cc-director-gateway.exe");
+
+    /// <summary>
+    /// Build a reader whose file-existence answers we control, with no disk access. The same predicate
+    /// drives the current-name probe and the legacy-alias probe, so a test simply names which paths exist.
+    /// </summary>
     private static InstalledStateReader ReaderWith(Func<string, bool> fileExists) =>
-        new(Layout, fileExists: fileExists, readVersion: _ => null, installed: InstalledManifest.Empty());
+        new(Layout, fileExists: fileExists, aliasFileExists: fileExists, readVersion: _ => null,
+            installed: InstalledManifest.Empty());
 
     [Fact]
     public void Detect_GatewayExePresent_IsGateway()
@@ -20,10 +32,49 @@ public class InstalledRoleDetectorTests
     }
 
     [Fact]
+    public void Detect_OnlyLegacyGatewayExePresent_IsGateway()
+    {
+        // An existing host whose Gateway is still the pre-rename cc-director-gateway.exe (the current
+        // devthrottle-gateway.exe absent) must be recognised as a Gateway so the update refreshes it
+        // instead of misclassifying it as a Workstation and orphaning its Gateway (issue #1821).
+        var role = InstalledRoleDetector.Detect(Layout, ReaderWith(path => path == LegacyGatewayExe));
+        Assert.Equal(InstallRole.Gateway, role);
+    }
+
+    [Fact]
+    public void Detect_LegacyGatewayNameIsADirectory_IsWorkstation()
+    {
+        // Issue #1821 false-positive: the legacy alias is probed FILE-only (File.Exists), so a
+        // Workstation that merely has a DIRECTORY named gateway\cc-director-gateway.exe is NOT misread
+        // as a Gateway host. The renamed Gateway is only ever a file; the one component that is a
+        // directory (the macOS .app bundle) is the Director, never the Gateway. Real filesystem, default
+        // reader - this exercises the actual File.Exists vs Directory.Exists distinction. Windows-only:
+        // the pre-rename name only ever existed on Windows.
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), "cc-d1-" + Guid.NewGuid().ToString("N"));
+        var layout = new InstallLayout(root);
+        var legacyDir = Path.Combine(layout.GatewayDir, "cc-director-gateway.exe");
+        try
+        {
+            Directory.CreateDirectory(legacyDir); // a DIRECTORY sharing the legacy exe's name
+            var role = InstalledRoleDetector.Detect(layout); // default reader = real File/Directory probes
+            Assert.Equal(InstallRole.Workstation, role);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Detect_GatewayExeAbsent_IsWorkstation()
     {
-        // Director present, Gateway absent: a plain Workstation install.
-        var role = InstalledRoleDetector.Detect(Layout, ReaderWith(path => path != GatewayExe));
+        // Director present, no Gateway of any name (neither the current nor the legacy exe): a plain
+        // Workstation install.
+        var role = InstalledRoleDetector.Detect(
+            Layout, ReaderWith(path => path != GatewayExe && path != LegacyGatewayExe));
         Assert.Equal(InstallRole.Workstation, role);
     }
 

--- a/tools/cc-director-setup-engine/InstallLayout.cs
+++ b/tools/cc-director-setup-engine/InstallLayout.cs
@@ -146,4 +146,22 @@ public sealed class InstallLayout
             _ => throw new ArgumentOutOfRangeException(nameof(component), component.Kind, "Unknown component kind."),
         };
     }
+
+    /// <summary>
+    /// Pre-rename on-disk names a component may still occupy on an existing host, besides its current
+    /// canonical <see cref="PathFor"/> location. Presence detection accepts these so an update
+    /// recognises a legacy host and refreshes it instead of silently orphaning it (issue #1821). Only
+    /// the Gateway was renamed (cc-director-gateway.exe -> devthrottle-gateway.exe); every other
+    /// component has no legacy alias. The CURRENT name stays canonical/target - these are read-only
+    /// aliases for detection, never a place we write to.
+    /// </summary>
+    public IReadOnlyList<string> LegacyAliasesFor(Component component)
+    {
+        ArgumentNullException.ThrowIfNull(component);
+        if (component.Kind != ComponentKind.Gateway)
+            return Array.Empty<string>();
+
+        var legacyName = OperatingSystem.IsWindows() ? "cc-director-gateway.exe" : "cc-director-gateway";
+        return new[] { Path.Combine(GatewayDir, legacyName) };
+    }
 }

--- a/tools/cc-director-setup-engine/InstalledStateReader.cs
+++ b/tools/cc-director-setup-engine/InstalledStateReader.cs
@@ -11,17 +11,20 @@ public sealed class InstalledStateReader
 {
     private readonly InstallLayout _layout;
     private readonly Func<string, bool> _fileExists;
+    private readonly Func<string, bool> _aliasFileExists;
     private readonly Func<string, string?> _readVersion;
     private readonly InstalledManifest _installed;
 
     public InstalledStateReader(
         InstallLayout layout,
         Func<string, bool>? fileExists = null,
+        Func<string, bool>? aliasFileExists = null,
         Func<string, string?>? readVersion = null,
         InstalledManifest? installed = null)
     {
         _layout = layout ?? throw new ArgumentNullException(nameof(layout));
         _fileExists = fileExists ?? DefaultExists;
+        _aliasFileExists = aliasFileExists ?? DefaultAliasExists;
         _readVersion = readVersion ?? DefaultReadVersion;
         _installed = installed ?? InstalledManifest.Load(layout);
     }
@@ -33,17 +36,34 @@ public sealed class InstalledStateReader
     /// </summary>
     internal static bool DefaultExists(string path) => File.Exists(path) || Directory.Exists(path);
 
+    /// <summary>
+    /// Default presence check for a legacy alias (issue #1821). A pre-rename alias is only ever a
+    /// FILE - the renamed component is a Windows exe, never a bundle - so this probes File.Exists
+    /// only. It deliberately does NOT accept a directory (unlike <see cref="DefaultExists"/>), or a
+    /// Workstation that merely happened to have a DIRECTORY named gateway\cc-director-gateway.exe
+    /// would falsely read as a Gateway host.
+    /// </summary>
+    internal static bool DefaultAliasExists(string path) => File.Exists(path);
+
     /// <summary>Inspect one component.</summary>
     public InstalledComponent Read(Component component)
     {
         ArgumentNullException.ThrowIfNull(component);
         var path = _layout.PathFor(component);
-        if (!_fileExists(path))
+
+        // Presence accepts a pre-rename alias (issue #1821): an existing Gateway host whose exe is the
+        // legacy cc-director-gateway.exe must still read as present, or the update misclassifies it as a
+        // Workstation and orphans its Gateway. The canonical path stays the target we report; the
+        // version is read from whichever file is actually on disk.
+        var onDisk = _fileExists(path)
+            ? path
+            : _layout.LegacyAliasesFor(component).FirstOrDefault(_aliasFileExists);
+        if (onDisk is null)
             return new InstalledComponent(component.Id, Present: false, Version: null, Path: path);
 
         // The on-disk file-version stamp is the ground truth for what the exe actually IS. Read it
         // separately so the planner can cross-check the recorded version against it (issue #176).
-        var fileVersion = _readVersion(path);
+        var fileVersion = _readVersion(onDisk);
 
         // Prefer the version we recorded when we placed it (reliable for every component, incl. tools
         // that carry no file-version stamp); fall back to the on-disk file version for installs that


### PR DESCRIPTION
Detects a legacy-named Gateway host on update so it is not orphaned - the D1 release-gate (#1821).

An existing host whose Gateway is the pre-rename `gateway\cc-director-gateway.exe` (not the current
`gateway\devthrottle-gateway.exe`) was misclassified as a Workstation on update, so its Gateway was
never refreshed - silently orphaned / left to version-drift. Gateway-component PRESENCE detection now
also accepts the legacy name, so such a host is recognised as a Gateway and enters the update refresh.

Detection-only: the current name stays the canonical install/update TARGET; the legacy name is a
read-only presence/version probe, never a place anything is written. Scoped narrowly - the broader
migration/uninstall work (and the uninstall retain/remove decision) stays in thefrederiksen/devthrottle_internal#871.

False-positive guarded: the alias is Gateway-only (no other component gets one), and it is probed
FILE-only, so a plain Workstation that merely has a *directory* named `gateway\cc-director-gateway.exe`
is not misread as a Gateway.

## Verification
- Builds clean (0 warnings, warnings-as-errors). Engine suite 320 green.
- Independent adversarial review, plus revert-proofs reproduced at the PRODUCTION line: nulling the
  alias-consumption line in `InstalledStateReader` reds the legacy-detection test; making the alias
  probe accept directories again reds the directory false-positive test; the controls stay green.

Pairs with the D2 fix; together they make the Director-only install (#1807) releasable to machines that
already run a Gateway.
