### PR TITLE
feat(gateway): account-to-tenant mapping foundation for hosted multi-tenancy

### DIFF
--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260718220815_AddTenants.Designer.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260718220815_AddTenants.Designer.cs
@@ -3,42 +3,51 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace CcDirector.Gateway.Data.Migrations
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718220815_AddTenants")]
+    partial class AddTenants
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "9.0.2");
+            modelBuilder
+                .HasDefaultSchema("gateway")
+                .HasAnnotation("ProductVersion", "9.0.2")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountHostedAiSpendEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<long>("AmountMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Kind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("TransactionCreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -48,109 +57,109 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "Kind", "AmountMicros", "TransactionCreatedUtc");
 
-                    b.ToTable("account_hosted_ai_spend", (string)null);
+                    b.ToTable("account_hosted_ai_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CronExpression")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("LastFiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LastStatus")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("NextRunUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("NotifyOn")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("NotifyWebhookUrl")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("PreventOverlap")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("RunAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ScheduleKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("TimeZoneId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("cron_jobs", (string)null);
+                    b.ToTable("cron_jobs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("FiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("InfraStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("JobId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Machine")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ScheduledUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("Sequence")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TargetDirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TaskStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -159,44 +168,44 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("JobId", "Sequence");
 
-                    b.ToTable("cron_runs", (string)null);
+                    b.ToTable("cron_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceAuditEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Actor")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Category")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -209,40 +218,40 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_audit_events", (string)null);
+                    b.ToTable("governance_audit_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Reason")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("State")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SubjectKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -255,112 +264,115 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_events", (string)null);
+                    b.ToTable("governance_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.MissionNoteEntity", b =>
                 {
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Mission")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Why")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("mission_notes", (string)null);
+                    b.ToTable("mission_notes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.PushSubscriptionEntity", b =>
                 {
                     b.Property<string>("Endpoint")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Auth")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("P256dh")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Endpoint");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("push_subscriptions", (string)null);
+                    b.ToTable("push_subscriptions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionSpendEntity", b =>
                 {
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AgentKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BillingMode")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("CacheCreationTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<long>("CacheReadTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("FirstObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("InputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("LastObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long?>("MeteredCostMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Model")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("OutputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<bool>("TokensCaptured")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.HasKey("SessionId");
 
@@ -368,139 +380,142 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "LastObservedUtc");
 
-                    b.ToTable("session_spend", (string)null);
+                    b.ToTable("session_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SnoozeEntity", b =>
                 {
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("OwnerTurnBaselineUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int?>("PendingMinutes")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime?>("SnoozeUntilUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("SessionId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("snoozes", (string)null);
+                    b.ToTable("snoozes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AccountSubject")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Email")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
                     b.HasIndex("AccountSubject")
                         .IsUnique();
 
-                    b.ToTable("tenants", (string)null);
+                    b.ToTable("tenants", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WingmanInstructionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AckDefaultContent")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AckDefaultVersion")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActiveVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("wingman_instructions", (string)null);
+                    b.ToTable("wingman_instructions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Consumer")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("worklists", (string)null);
+                    b.ToTable("worklists", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListItemEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Area")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ItemId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("Position")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("WorkListId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -508,76 +523,76 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkListId", "Position");
 
-                    b.ToTable("worklist_items", (string)null);
+                    b.ToTable("worklist_items", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Archived")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("Enabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("boolean")
                         .HasDefaultValue(true);
 
                     b.Property<bool>("IsBuiltIn")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<int>("LatestVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("PublishedVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ShippedContentHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("UpdatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflows", (string)null);
+                    b.ToTable("workflows", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowFileEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("VersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -585,71 +600,71 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("VersionId");
 
-                    b.ToTable("workflow_files", (string)null);
+                    b.ToTable("workflow_files", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AcceptanceStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AcceptedBy")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("AcceptedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("CompletedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("MissionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Outcome")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Guid?>("ParentRunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("StartedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("WorkflowVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<Guid>("WorkflowVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -659,66 +674,66 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkflowId");
 
-                    b.ToTable("workflow_runs", (string)null);
+                    b.ToTable("workflow_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowVersionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AuthoredBy")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ChangeNote")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("HumanCheckpoint")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("InstructionsMarkdown")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("PublishedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Summary")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<int>("Version")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("WhenToUse")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -727,7 +742,7 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.HasIndex("WorkflowId", "Version")
                         .IsUnique();
 
-                    b.ToTable("workflow_versions", (string)null);
+                    b.ToTable("workflow_versions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
@@ -735,25 +750,25 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobAction", "Action", b1 =>
                         {
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<bool>("AutoDismiss")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("boolean");
 
                             b1.Property<string>("RepoPath")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Seed")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("WorkListName")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Action");
 
@@ -764,15 +779,15 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobTarget", "Target", b1 =>
                         {
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Target");
 
@@ -792,36 +807,36 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Data.Entities.WingmanInstructionVersionOwned", "Versions", b1 =>
                         {
                             b1.Property<Guid>("WingmanInstructionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Content")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("CreatedAtUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Hash")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Id")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Label")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Source")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WingmanInstructionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("wingman_instructions");
+                            b1.ToTable("wingman_instructions", "gateway");
 
                             b1.ToJson("Versions");
 
@@ -846,35 +861,35 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunCriterionResultDto", "CriteriaResults", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime?>("EvaluatedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Evaluator")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Note")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofUrl")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Status")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("CriteriaResults");
 
@@ -885,37 +900,37 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunParticipantDto", "Participants", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("AgentKind")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("JoinedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<DateTime?>("LeftUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Role")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("SessionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("Participants");
 
@@ -926,23 +941,23 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunProofLinkDto", "ProofLinks", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Label")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Url")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("ProofLinks");
 
@@ -962,26 +977,26 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowOutcomeCriterionDto", "OutcomeCriteria", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofHint")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("OutcomeCriteria");
 
@@ -992,34 +1007,34 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowStepDto", "Steps", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Doer")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Done")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Name")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Reviewer")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("Steps");
 

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260718220815_AddTenants.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260718220815_AddTenants.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenants : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "tenants",
+                schema: "gateway",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false, collation: "C"),
+                    AccountSubject = table.Column<string>(type: "text", nullable: false, collation: "C"),
+                    Email = table.Column<string>(type: "text", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_tenants", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_tenants_AccountSubject",
+                schema: "gateway",
+                table: "tenants",
+                column: "AccountSubject",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "tenants",
+                schema: "gateway");
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
@@ -410,6 +410,31 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.ToTable("snoozes", "gateway");
                 });
 
+            modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantEntity", b =>
+                {
+                    b.Property<string>("Id")
+                        .HasColumnType("text")
+                        .UseCollation("C");
+
+                    b.Property<string>("AccountSubject")
+                        .IsRequired()
+                        .HasColumnType("text")
+                        .UseCollation("C");
+
+                    b.Property<DateTime>("CreatedAtUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Email")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AccountSubject")
+                        .IsUnique();
+
+                    b.ToTable("tenants", "gateway");
+                });
+
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WingmanInstructionEntity", b =>
                 {
                     b.Property<Guid>("Id")

--- a/src/CcDirector.Gateway.Tests/Data/GatewayDatabaseUnscopedContextTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/GatewayDatabaseUnscopedContextTests.cs
@@ -1,0 +1,68 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Data.Entities;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Data;
+
+/// <summary>
+/// The unscoped-context seam (Hosted Multi-Tenancy increment 1). <c>CreateUnscopedContext</c> exists for the
+/// global mapping tables, but it MUST leave <c>ActiveTenant</c> null so that a tenant-SCOPED read through it
+/// fails closed (returns nothing) rather than silently serving a leftover tenant's rows. Because the context
+/// factory is a POOL and pooling does not reset custom properties, a context previously stamped by
+/// <c>CreateContext</c> can be handed back here, so the null must be set explicitly - these tests pin that.
+/// </summary>
+public sealed class GatewayDatabaseUnscopedContextTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _harness = new();
+
+    public void Dispose() => _harness.Dispose();
+
+    [Fact]
+    public void CreateUnscopedContext_LeavesActiveTenantNull()
+    {
+        var db = _harness.Open(new FixedTenantContext(new TenantId("t-alice")));
+
+        // Hand out (and dispose) a SCOPED context first, so its tenant-stamped instance returns to the pool.
+        using (var scoped = db.CreateContext())
+        {
+            Assert.Equal("t-alice", scoped.ActiveTenant);
+        }
+
+        // A subsequent unscoped context must be null even if it reuses that pooled instance.
+        using var unscoped = db.CreateUnscopedContext();
+        Assert.Null(unscoped.ActiveTenant);
+    }
+
+    [Fact]
+    public void ScopedRead_ThroughUnscopedContext_FailsClosed()
+    {
+        var db = _harness.Open(new FixedTenantContext(new TenantId("t-alice")));
+
+        // Write a tenant-scoped row as t-alice.
+        using (var ctx = db.CreateContext())
+        {
+            ctx.MissionNotes.Add(new MissionNoteEntity
+            {
+                Key = "k1",
+                Mission = "m",
+                Why = "w",
+                UpdatedAtUtc = DateTime.UtcNow,
+                TenantId = "t-alice",
+            });
+            ctx.SaveChanges();
+        }
+
+        // The owning tenant sees its row (sanity - the write landed).
+        using (var scoped = db.CreateContext())
+        {
+            Assert.Single(scoped.MissionNotes.ToList());
+        }
+
+        // The unscoped context is null-tenant, so the global filter (tenant_id == null) matches nothing:
+        // a scoped table read through it returns EMPTY - fail closed, never the leftover tenant's rows.
+        using (var unscoped = db.CreateUnscopedContext())
+        {
+            Assert.Empty(unscoped.MissionNotes.ToList());
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Data/TenantScopeGuardTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/TenantScopeGuardTests.cs
@@ -68,4 +68,40 @@ public sealed class TenantScopeGuardTests : IDisposable
         Assert.Null(tenants.GetQueryFilter());
         Assert.False(typeof(TenantScopedEntity).IsAssignableFrom(tenants.ClrType));
     }
+
+    /// <summary>
+    /// The REVERSE invariant (deny-by-default for new tables). The forward test above only checks entities
+    /// that ALREADY derive from <see cref="TenantScopedEntity"/> - so an author who maps a brand-new table
+    /// and simply FORGETS to derive from the base would sail past it with no tenant_id and no filter, which is
+    /// exactly the cross-tenant leak this guard exists to prevent. This test flips it: EVERY mapped table must
+    /// be tenant-scoped, and the only tables allowed to be global are an explicit allowlist (today just the
+    /// <c>tenants</c> mapping table). Adding a new global table is therefore a CONSCIOUS act - a line added to
+    /// this allowlist with a reason - never a silent omission.
+    ///
+    /// Owned types are excluded: an owned type mapped to a JSON column (the cron/workflow "sub-doc -> JSON in
+    /// a column" pattern) is not its own table - it rides inside its owner's row and its owner's tenant_id, so
+    /// it neither needs nor has a tenant_id of its own.
+    /// </summary>
+    [Fact]
+    public void EveryMappedTable_IsTenantScopedOrAnExplicitlyAllowlistedGlobalTable()
+    {
+        // The ONLY tables permitted to be global (un-scoped). Growing this set must be deliberate: a new
+        // entry here is an author consciously declaring "this table is not tenant data".
+        var allowedGlobalTables = new HashSet<Type> { typeof(TenantEntity) };
+
+        var model = Model();
+        var offenders = model.GetEntityTypes()
+            // Owned types (JSON sub-documents) are part of their owner's table, not tables in their own right.
+            .Where(e => !e.IsOwned())
+            .Where(e => !typeof(TenantScopedEntity).IsAssignableFrom(e.ClrType))
+            .Where(e => !allowedGlobalTables.Contains(e.ClrType))
+            .Select(e => e.ClrType.Name)
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "These mapped tables are neither tenant-scoped nor an allowlisted global table, so a tenant " +
+            "could read another tenant's rows: " + string.Join(", ", offenders) +
+            ". Derive the entity from TenantScopedEntity, or - only if it is genuinely global mapping data - " +
+            "add it to allowedGlobalTables with a reason.");
+    }
 }

--- a/src/CcDirector.Gateway.Tests/Data/TenantScopeGuardTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/TenantScopeGuardTests.cs
@@ -1,0 +1,71 @@
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Data;
+
+/// <summary>
+/// The tenancy CI guard (Hosted Multi-Tenancy increment 1) - the check PostHog learned the hard way. It
+/// reflects the actual EF model and fails the build if ANY tenant-scoped table is missing its tenant key or
+/// its isolation filter. A future store that forgets to derive from <see cref="TenantScopedEntity"/>, or a
+/// change that drops the <c>tenant_id</c> column or the global query filter, turns red here instead of
+/// silently letting one tenant read another's rows.
+///
+/// The rule is exact and two-directional:
+///  - EVERY entity derived from <see cref="TenantScopedEntity"/> MUST map a <c>tenant_id</c> column AND carry
+///    a global query filter (deny-by-default isolation).
+///  - The GLOBAL mapping table <see cref="TenantEntity"/> MUST NOT be scoped: it is the table the filter's
+///    tenant values come from, so it carries no <c>tenant_id</c> column and no query filter.
+/// </summary>
+public sealed class TenantScopeGuardTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _harness = new();
+
+    public void Dispose() => _harness.Dispose();
+
+    private IModel Model()
+    {
+        using var ctx = _harness.Open().CreateContext();
+        return ctx.Model;
+    }
+
+    [Fact]
+    public void EveryTenantScopedEntity_HasTenantIdColumnAndQueryFilter()
+    {
+        var model = Model();
+        var scoped = model.GetEntityTypes()
+            .Where(e => typeof(TenantScopedEntity).IsAssignableFrom(e.ClrType))
+            .ToList();
+
+        // Sanity: the scan actually found the scoped stores (guard against a reflection no-op passing green).
+        Assert.NotEmpty(scoped);
+
+        foreach (var entity in scoped)
+        {
+            var tenantColumn = entity.GetProperties()
+                .FirstOrDefault(p => string.Equals(p.GetColumnName(), "tenant_id", StringComparison.Ordinal));
+            Assert.True(tenantColumn is not null,
+                $"{entity.ClrType.Name} derives from TenantScopedEntity but has no tenant_id column.");
+
+            Assert.True(entity.GetQueryFilter() is not null,
+                $"{entity.ClrType.Name} derives from TenantScopedEntity but has no global query filter " +
+                "(a tenant could read another tenant's rows).");
+        }
+    }
+
+    [Fact]
+    public void TheTenantMappingTable_IsNotItselfTenantScoped()
+    {
+        var model = Model();
+        var tenants = model.FindEntityType(typeof(TenantEntity));
+        Assert.NotNull(tenants);
+
+        // It is the global mapping table: no tenant_id column, no query filter.
+        Assert.DoesNotContain(tenants!.GetProperties(),
+            p => string.Equals(p.GetColumnName(), "tenant_id", StringComparison.Ordinal));
+        Assert.Null(tenants.GetQueryFilter());
+        Assert.False(typeof(TenantScopedEntity).IsAssignableFrom(tenants.ClrType));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DeviceRegistryAccountBindingTests.cs
+++ b/src/CcDirector.Gateway.Tests/DeviceRegistryAccountBindingTests.cs
@@ -1,0 +1,86 @@
+using CcDirector.Gateway.Pairing;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The per-device account/tenant binding (Hosted Multi-Tenancy increment 1). At hosted enrollment a device
+/// is bound to its verified account subject and the tenant it resolved to; the tunnel later reads that tenant
+/// back from the SAME per-device key that authenticated the connection (<see cref="DeviceRegistry.TenantForKey"/>),
+/// so the resolved tenant comes from the authenticated credential, never from client input. An unbound device
+/// (the single-tenant local install) resolves to no tenant - a deny on hosted, never a fall-back to local.
+/// </summary>
+public sealed class DeviceRegistryAccountBindingTests : IDisposable
+{
+    private readonly string _storePath =
+        Path.Combine(Path.GetTempPath(), $"devreg-bind-{Guid.NewGuid():N}.json");
+
+    public void Dispose()
+    {
+        if (File.Exists(_storePath)) File.Delete(_storePath);
+    }
+
+    [Fact]
+    public void TenantForKey_UnboundDevice_ReturnsNull()
+    {
+        var registry = new DeviceRegistry(_storePath);
+        var device = registry.Register("device-a", "MACHINE-A");
+
+        // A freshly registered device has no account binding yet (the local single-tenant shape).
+        Assert.Null(registry.TenantForKey(device.DeviceKey));
+    }
+
+    [Fact]
+    public void SetAccountBinding_ThenTenantForKey_ReturnsTheBoundTenant()
+    {
+        var registry = new DeviceRegistry(_storePath);
+        var device = registry.Register("device-a", "MACHINE-A");
+
+        var bound = registry.SetAccountBinding("device-a", "sub-alice", "tenant-alice");
+
+        Assert.True(bound);
+        Assert.Equal("tenant-alice", registry.TenantForKey(device.DeviceKey));
+    }
+
+    [Fact]
+    public void TenantForKey_WrongKey_ReturnsNull()
+    {
+        var registry = new DeviceRegistry(_storePath);
+        registry.Register("device-a", "MACHINE-A");
+        registry.SetAccountBinding("device-a", "sub-alice", "tenant-alice");
+
+        Assert.Null(registry.TenantForKey("not-a-real-device-key"));
+    }
+
+    [Fact]
+    public void TenantForKey_ResolvesEachDeviceToItsOwnTenant()
+    {
+        var registry = new DeviceRegistry(_storePath);
+        var a = registry.Register("device-a", "MACHINE-A");
+        var b = registry.Register("device-b", "MACHINE-B");
+        registry.SetAccountBinding("device-a", "sub-alice", "tenant-alice");
+        registry.SetAccountBinding("device-b", "sub-bob", "tenant-bob");
+
+        Assert.Equal("tenant-alice", registry.TenantForKey(a.DeviceKey));
+        Assert.Equal("tenant-bob", registry.TenantForKey(b.DeviceKey));
+    }
+
+    [Fact]
+    public void SetAccountBinding_PersistsAcrossReload()
+    {
+        var device = new DeviceRegistry(_storePath).Register("device-a", "MACHINE-A");
+        new DeviceRegistry(_storePath).SetAccountBinding("device-a", "sub-alice", "tenant-alice");
+
+        // A fresh registry over the same store file (a Gateway restart) still resolves the binding.
+        var reloaded = new DeviceRegistry(_storePath);
+        Assert.Equal("tenant-alice", reloaded.TenantForKey(device.DeviceKey));
+    }
+
+    [Fact]
+    public void SetAccountBinding_UnknownDevice_ReturnsFalse()
+    {
+        var registry = new DeviceRegistry(_storePath);
+
+        Assert.False(registry.SetAccountBinding("device-missing", "sub-alice", "tenant-alice"));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Tenancy/TenantRegistryTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/TenantRegistryTests.cs
@@ -1,0 +1,114 @@
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Tenancy;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Tenancy;
+
+/// <summary>
+/// The account-to-tenant resolver (Hosted Multi-Tenancy increment 1). These tests exercise the mint-or-lookup
+/// contract over a real (throwaway) EF database: a first-seen account subject mints a fresh tenant, the SAME
+/// subject resolves to the SAME tenant (so a second device of one account lands in one tenant), distinct
+/// subjects get distinct tenants, and the email is display metadata only - never the mapping key.
+/// </summary>
+public sealed class TenantRegistryTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _harness = new();
+
+    public void Dispose() => _harness.Dispose();
+
+    [Fact]
+    public void MintOrLookup_FirstSeenSubject_MintsAValidTenant()
+    {
+        var registry = new TenantRegistry(_harness.Open());
+
+        var tenant = registry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+
+        Assert.True(tenant.IsValid);
+        Assert.False(tenant.IsLocal);
+        // A code-generated GUID string, not the subject and not the email.
+        Assert.True(Guid.TryParse(tenant.Value, out _));
+    }
+
+    [Fact]
+    public void MintOrLookup_SameSubjectTwice_ResolvesToTheSameTenant()
+    {
+        var registry = new TenantRegistry(_harness.Open());
+
+        var first = registry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        var second = registry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+
+        Assert.Equal(first.Value, second.Value);
+    }
+
+    [Fact]
+    public void MintOrLookup_SameSubjectAfterRestart_StillResolvesToTheSameTenant()
+    {
+        var minted = new TenantRegistry(_harness.Open()).MintOrLookupBySubject("sub-alice", "alice@example.com");
+
+        // Re-open the SAME database file (a Gateway restart) and resolve again.
+        var afterRestart = new TenantRegistry(_harness.Open()).MintOrLookupBySubject("sub-alice", "alice@example.com");
+
+        Assert.Equal(minted.Value, afterRestart.Value);
+    }
+
+    [Fact]
+    public void MintOrLookup_DifferentSubjects_GetDifferentTenants()
+    {
+        var registry = new TenantRegistry(_harness.Open());
+
+        var alice = registry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        var bob = registry.MintOrLookupBySubject("sub-bob", "bob@example.com");
+
+        Assert.NotEqual(alice.Value, bob.Value);
+    }
+
+    [Fact]
+    public void MintOrLookup_EmailIsNotTheKey_TwoSubjectsSharingAnEmailGetTwoTenants()
+    {
+        var registry = new TenantRegistry(_harness.Open());
+
+        // The stable subject is the key; a shared (or reused) email must NEVER collapse two accounts.
+        var first = registry.MintOrLookupBySubject("sub-one", "shared@example.com");
+        var second = registry.MintOrLookupBySubject("sub-two", "shared@example.com");
+
+        Assert.NotEqual(first.Value, second.Value);
+    }
+
+    [Fact]
+    public void MintOrLookup_NullOrBlankEmail_StillMints()
+    {
+        var registry = new TenantRegistry(_harness.Open());
+
+        var tenant = registry.MintOrLookupBySubject("sub-no-email", null);
+
+        Assert.True(tenant.IsValid);
+    }
+
+    [Fact]
+    public void MintOrLookup_BlankSubject_Throws()
+    {
+        var registry = new TenantRegistry(_harness.Open());
+
+        Assert.Throws<ArgumentException>(() => registry.MintOrLookupBySubject("   ", "x@example.com"));
+    }
+
+    [Fact]
+    public void Lookup_UnknownSubject_ReturnsNull()
+    {
+        var registry = new TenantRegistry(_harness.Open());
+
+        Assert.Null(registry.LookupBySubject("sub-never-seen"));
+    }
+
+    [Fact]
+    public void Lookup_KnownSubject_ReturnsTheMintedTenant()
+    {
+        var registry = new TenantRegistry(_harness.Open());
+        var minted = registry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+
+        var looked = registry.LookupBySubject("sub-alice");
+
+        Assert.NotNull(looked);
+        Assert.Equal(minted.Value, looked!.Value.Value);
+    }
+}

--- a/src/CcDirector.Gateway/Data/Entities/TenantEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/TenantEntity.cs
@@ -1,0 +1,38 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// The account-to-tenant mapping (Hosted Multi-Tenancy mission, increment 1): one row per tenant in the
+/// <c>tenants</c> table. This is the GLOBAL mapping table - the one place that answers "which tenant does
+/// this verified account belong to?" - so it deliberately does NOT derive from
+/// <see cref="TenantScopedEntity"/>: it carries no <c>tenant_id</c> column and no global query filter,
+/// because it is the table the filter's tenant values COME FROM. It is read by the account subject, before
+/// any tenant is resolved, so scoping it to a tenant would be circular.
+///
+/// The mapping key is the STABLE Supabase subject (<see cref="AccountSubject"/>, the token's <c>sub</c>
+/// claim), never the email - an email can change over an account's life, so it is stored only as display
+/// metadata (<see cref="Email"/>) and is NEVER used to look a tenant up. The relationship is 1:1 now (one
+/// account subject -> one tenant), structured so many subjects can map to one tenant later (enterprise):
+/// the mint path looks up by subject first and reuses an existing tenant, minting a new
+/// <see cref="Id"/> only for a subject that has none - so a second device of the same account resolves to
+/// the SAME tenant.
+///
+/// On the single-tenant local install this table is unused: everything resolves to
+/// <see cref="Core.Tenancy.TenantId.Local"/> ("local") without a lookup.
+/// </summary>
+public sealed class TenantEntity
+{
+    /// <summary>The tenant's own id - the value carried in every tenant-scoped row's <c>tenant_id</c> column.
+    /// A GUID string generated in code on mint (never a database default). Primary key (ordinally compared).</summary>
+    public string Id { get; set; } = "";
+
+    /// <summary>The verified Supabase subject (<c>sub</c>) this tenant maps from - the STABLE mapping key.
+    /// Unique across the table. Never logged (personally identifying).</summary>
+    public string AccountSubject { get; set; } = "";
+
+    /// <summary>The account email as last seen at mint time - DISPLAY METADATA ONLY, never the mapping key
+    /// (an email can change). Null when not supplied. Never logged.</summary>
+    public string? Email { get; set; }
+
+    /// <summary>When this tenant was minted (UTC).</summary>
+    public DateTime CreatedAtUtc { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/GatewayDatabase.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDatabase.cs
@@ -202,6 +202,18 @@ public sealed class GatewayDatabase : IDisposable
         return ctx;
     }
 
+    /// <summary>
+    /// A fresh context that is NOT scoped to any tenant - for the GLOBAL mapping tables ONLY (the
+    /// <c>tenants</c> account-subject -> tenant-id table), which carry no <c>tenant_id</c> column and no
+    /// query filter. It leaves <see cref="GatewayDbContext.ActiveTenant"/> null, so any tenant-SCOPED entity
+    /// read through it fails CLOSED - the global filter compares <c>tenant_id == null</c> and matches no row -
+    /// which is exactly the deny-by-default we want if this context is ever misused on a scoped table. It
+    /// exists because the tenant registry must mint or look up a tenant BEFORE any tenant is resolved, so it
+    /// cannot go through <see cref="CreateContext"/> (which fails loud on an unresolved tenant). The caller
+    /// disposes it (it returns to the pool).
+    /// </summary>
+    public GatewayDbContext CreateUnscopedContext() => _factory.CreateDbContext();
+
     public void Dispose()
     {
         if (_disposed) return;

--- a/src/CcDirector.Gateway/Data/GatewayDatabase.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDatabase.cs
@@ -211,8 +211,20 @@ public sealed class GatewayDatabase : IDisposable
     /// exists because the tenant registry must mint or look up a tenant BEFORE any tenant is resolved, so it
     /// cannot go through <see cref="CreateContext"/> (which fails loud on an unresolved tenant). The caller
     /// disposes it (it returns to the pool).
+    ///
+    /// It EXPLICITLY sets <see cref="GatewayDbContext.ActiveTenant"/> to null. The factory is a POOL - a
+    /// returned context keeps its custom <c>ActiveTenant</c> (pooling resets EF's own state, not arbitrary
+    /// properties), so a context previously handed out by <see cref="CreateContext"/> could come back here
+    /// still stamped with that prior tenant. Without this reset a scoped-entity read through the "unscoped"
+    /// context would silently filter by a leftover tenant instead of failing closed - so the null is set here,
+    /// exactly as <see cref="CreateContext"/> always sets the real tenant.
     /// </summary>
-    public GatewayDbContext CreateUnscopedContext() => _factory.CreateDbContext();
+    public GatewayDbContext CreateUnscopedContext()
+    {
+        var ctx = _factory.CreateDbContext();
+        ctx.ActiveTenant = null;
+        return ctx;
+    }
 
     public void Dispose()
     {

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -95,6 +95,12 @@ public sealed class GatewayDbContext : DbContext
     /// intervention and permission/sandbox decisions, never inferred from transcripts (issue #1771).</summary>
     public DbSet<GovernanceAuditEventEntity> GovernanceAuditEvents => Set<GovernanceAuditEventEntity>();
 
+    /// <summary>The account-to-tenant mapping (<c>tenants</c>), keyed by the verified Supabase subject. This
+    /// is the GLOBAL mapping table (Hosted Multi-Tenancy increment 1) - deliberately NOT tenant-scoped, so it
+    /// has no <c>tenant_id</c> column and no query filter; it is the table the filter's tenant values come
+    /// from. Unused on the single-tenant local install.</summary>
+    public DbSet<TenantEntity> Tenants => Set<TenantEntity>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -277,6 +283,19 @@ public sealed class GatewayDbContext : DbContext
             b.HasIndex(e => new { e.TenantId, e.Category, e.OccurredUtc });
         });
 
+        modelBuilder.Entity<TenantEntity>(b =>
+        {
+            b.ToTable("tenants");
+            // Id is the tenant's own id value (a code-generated GUID string), the natural primary key -
+            // ordinally compared (SQLite's default BINARY collation), no surrogate. This table is the GLOBAL
+            // account->tenant mapping, so it is deliberately NOT passed to ApplyTenantScope below: it carries
+            // no tenant_id column and no query filter (it is the table the filter's tenant values come from).
+            b.HasKey(e => e.Id);
+            // The mapping is looked up by the verified Supabase subject; it is unique (1:1 account->tenant now,
+            // enforced at the database, so a duplicate mint can never split one account across two tenants).
+            b.HasIndex(e => e.AccountSubject).IsUnique();
+        });
+
         // Tenant scoping - the tenant_id column plus the global query filter - applied uniformly to every
         // entity that derives from TenantScopedEntity, so future stores inherit it by deriving from the base.
         ApplyTenantScope<CronJobEntity>(modelBuilder);
@@ -325,6 +344,11 @@ public sealed class GatewayDbContext : DbContext
             modelBuilder.Entity<PushSubscriptionEntity>().Property(e => e.Endpoint).UseCollation("C");
             modelBuilder.Entity<SessionSpendEntity>().Property(e => e.SessionId).UseCollation("C");
             modelBuilder.Entity<MissionNoteEntity>().Property(e => e.Key).UseCollation("C");
+            // The tenants mapping table's natural-key string columns (the tenant id primary key and the
+            // account_subject unique index) rely on byte-ordinal equality/uniqueness, same as the keys above,
+            // so pin them to "C" too - the account subject in particular must match EXACTLY on both providers.
+            modelBuilder.Entity<TenantEntity>().Property(e => e.Id).UseCollation("C");
+            modelBuilder.Entity<TenantEntity>().Property(e => e.AccountSubject).UseCollation("C");
         }
     }
 

--- a/src/CcDirector.Gateway/Data/Migrations/20260718220759_AddTenants.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718220759_AddTenants.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718220759_AddTenants")]
+    partial class AddTenants
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260718220759_AddTenants.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260718220759_AddTenants.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenants : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "tenants",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "TEXT", nullable: false),
+                    AccountSubject = table.Column<string>(type: "TEXT", nullable: false),
+                    Email = table.Column<string>(type: "TEXT", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_tenants", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_tenants_AccountSubject",
+                table: "tenants",
+                column: "AccountSubject",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "tenants");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -327,6 +327,15 @@ public sealed class GatewayHost : IAsyncDisposable
     // local install every row is the "local" tenant (SingleTenantContext), so behavior is unchanged.
     private readonly Core.Tenancy.SingleTenantContext _tenantContext = new();
     private readonly Data.GatewayDatabase _gatewayDb;
+
+    /// <summary>
+    /// The account-to-tenant resolver (Hosted Multi-Tenancy increment 1): owns the tenants mapping table and
+    /// mints or looks up a tenant from a verified account subject. Exposed so the hosted enrollment boundary
+    /// can resolve a tenant once, at the point the account token is validated. Unused on the single-tenant
+    /// local install (everything resolves to "local" without a lookup).
+    /// </summary>
+    public Tenancy.TenantRegistry TenantRegistry { get; }
+
     // The persisted workflow catalog (Workflows mission, phase 1): built-ins seeded at startup,
     // user-defined workflows beside them, served by Api.WorkflowEndpoints.
     private readonly Workflows.WorkflowStore _workflows;
@@ -608,6 +617,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // (work lists, cron) read/write through it, so it is built before them. Tests get an isolated
         // database via CC_DIRECTOR_ROOT, exactly as gateway-stats.db is isolated today.
         _gatewayDb = new Data.GatewayDatabase(_tenantContext);
+        // The account-to-tenant resolver (Hosted Multi-Tenancy increment 1): owns the tenants mapping table
+        // and mints/looks up a tenant from a verified account subject. Built over the EF database; wired into
+        // the hosted enrollment boundary (which validates the account token and stamps the resolved tenant on
+        // the device) in the follow-up increment. Unused on the single-tenant local install.
+        TenantRegistry = new Tenancy.TenantRegistry(_gatewayDb);
         // Named work lists persist across a Gateway restart (issue #301) in the worklists table (stale
         // claims released on load). The path argument is the LEGACY worklists.json, imported once on first
         // upgrade then renamed aside. Tests MUST pass an isolated path so they never touch the real legacy file.

--- a/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
+++ b/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
@@ -221,6 +221,58 @@ public sealed class DeviceRegistry
         return null;
     }
 
+    /// <summary>
+    /// The tenant id of the active device whose per-device key matches <paramref name="key"/>, or null when
+    /// no active device matches OR the matched device has no tenant binding (Hosted Multi-Tenancy increment
+    /// 1). The tunnel reads this at Hello from the SAME verified key that already authenticated the
+    /// connection, so the resolved tenant comes from the AUTHENTICATED credential, never from anything the
+    /// client sent in its Hello payload. The compare is constant-time, mirroring <see cref="IsValidDeviceKey"/>,
+    /// so a near-miss reveals nothing through timing. A null return on hosted is a DENY, never a fall-back to
+    /// the local tenant.
+    /// </summary>
+    public string? TenantForKey(string? key)
+    {
+        if (string.IsNullOrEmpty(key)) return null;
+        var supplied = System.Text.Encoding.ASCII.GetBytes(key);
+        foreach (var record in _byDeviceId.Values)
+        {
+            if (!string.Equals(record.Status, StatusActive, StringComparison.Ordinal)) continue;
+            var stored = System.Text.Encoding.ASCII.GetBytes(record.DeviceKey);
+            if (stored.Length == supplied.Length &&
+                CryptographicOperations.FixedTimeEquals(stored, supplied))
+                return string.IsNullOrEmpty(record.TenantId) ? null : record.TenantId;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Bind an enrolled device to its verified account and resolved tenant (Hosted Multi-Tenancy increment
+    /// 1). Called at hosted enrollment AFTER the account token has been validated and the tenant minted or
+    /// looked up. Idempotent for an unchanged binding. Returns false when the device id is unknown (nothing
+    /// to bind). The subject and tenant are personally identifying / security-relevant, so neither is logged.
+    /// </summary>
+    public bool SetAccountBinding(string deviceId, string accountSubject, string tenantId)
+    {
+        if (string.IsNullOrWhiteSpace(deviceId))
+            throw new ArgumentException("deviceId is required", nameof(deviceId));
+        if (string.IsNullOrWhiteSpace(accountSubject))
+            throw new ArgumentException("accountSubject is required", nameof(accountSubject));
+        if (string.IsNullOrWhiteSpace(tenantId))
+            throw new ArgumentException("tenantId is required", nameof(tenantId));
+
+        if (!_byDeviceId.TryGetValue(deviceId, out var record))
+        {
+            FileLog.Write($"[DeviceRegistry] SetAccountBinding: no local device id={deviceId} -> no-op");
+            return false;
+        }
+
+        record.AccountSubject = accountSubject.Trim();
+        record.TenantId = tenantId.Trim();
+        Save();
+        FileLog.Write($"[DeviceRegistry] SetAccountBinding: bound device id={deviceId} to its account tenant");
+        return true;
+    }
+
     /// <summary>The host-readable list of registered devices, newest first. Keys are never included.</summary>
     public IReadOnlyList<RegisteredDeviceDto> List()
     {
@@ -302,6 +354,16 @@ public sealed class DeviceRegistry
 
         /// <summary>The cloud roster id assigned when this child was mirrored up, or null until mirrored.</summary>
         public string? CloudDeviceId { get; set; }
+
+        /// <summary>The verified Supabase subject (<c>sub</c>) this device's account resolved to at hosted
+        /// enrollment (Hosted Multi-Tenancy increment 1), or null on the single-tenant local install (where a
+        /// device binds to no account). Personally identifying - never logged.</summary>
+        public string? AccountSubject { get; set; }
+
+        /// <summary>The tenant id this device resolved to at hosted enrollment - the value the tunnel binds at
+        /// Hello and every stored row is scoped to. Null on the single-tenant local install (which resolves to
+        /// "local" without a per-device binding).</summary>
+        public string? TenantId { get; set; }
     }
 }
 

--- a/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
+++ b/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
@@ -1,0 +1,95 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// The account-to-tenant resolver (Hosted Multi-Tenancy mission, increment 1). It owns the <c>tenants</c>
+/// mapping table and answers the one question the hosted enrollment boundary asks: "what tenant does this
+/// VERIFIED account belong to?" The mapping key is the STABLE Supabase subject (the token's <c>sub</c>),
+/// never the email.
+///
+/// Mint-or-lookup is idempotent by subject: an account that already has a tenant gets that SAME tenant back
+/// (so a second device of the same account resolves to the same tenant - the property that keeps 1:1-now /
+/// many-accounts-per-tenant-later working), and a brand-new subject mints a fresh tenant id (a GUID
+/// generated in code). Writes are serialized under a single write lock, preserving the Gateway's
+/// single-writer invariant; the unique index on <c>account_subject</c> is the database-level backstop so
+/// two racing mints can never split one account across two tenants.
+///
+/// Security: the account subject and email are personally identifying, so NEITHER is ever written to the
+/// log - only the accept/mint decision is logged.
+/// </summary>
+public sealed class TenantRegistry
+{
+    private readonly GatewayDatabase _db;
+    private readonly object _writeLock = new();
+
+    /// <param name="db">The Gateway EF database. The registry reads and writes the global <c>tenants</c>
+    /// table through its UNSCOPED context (the mapping table carries no tenant_id and no query filter).</param>
+    public TenantRegistry(GatewayDatabase db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    /// <summary>
+    /// Resolve the tenant for a verified account subject, minting one if the subject has none. Returns the
+    /// EXISTING tenant when the subject is already mapped (idempotent - a second device of the same account
+    /// resolves to the same tenant); mints a new tenant id (a code-generated GUID) only for a subject with no
+    /// mapping. The email is stored as display metadata on a fresh mint only and is never the lookup key.
+    /// </summary>
+    /// <param name="accountSubject">The verified Supabase subject (<c>sub</c>). The caller must have already
+    /// validated the token this came from; this method does not re-verify.</param>
+    /// <param name="email">The account email for display metadata, or null. Never used as a key.</param>
+    /// <returns>The resolved (existing or newly minted) tenant.</returns>
+    public TenantId MintOrLookupBySubject(string accountSubject, string? email)
+    {
+        if (string.IsNullOrWhiteSpace(accountSubject))
+            throw new ArgumentException("An account subject is required to resolve a tenant.", nameof(accountSubject));
+
+        var subject = accountSubject.Trim();
+
+        lock (_writeLock)
+        {
+            using var ctx = _db.CreateUnscopedContext();
+
+            var existing = ctx.Tenants.AsNoTracking().FirstOrDefault(t => t.AccountSubject == subject);
+            if (existing is not null)
+            {
+                FileLog.Write("[TenantRegistry] MintOrLookupBySubject: resolved an existing tenant for a known account");
+                return new TenantId(existing.Id);
+            }
+
+            var tenantId = Guid.NewGuid().ToString();
+            ctx.Tenants.Add(new TenantEntity
+            {
+                Id = tenantId,
+                AccountSubject = subject,
+                Email = string.IsNullOrWhiteSpace(email) ? null : email!.Trim(),
+                CreatedAtUtc = DateTime.UtcNow,
+            });
+            ctx.SaveChanges();
+
+            FileLog.Write("[TenantRegistry] MintOrLookupBySubject: minted a new tenant for a first-seen account");
+            return new TenantId(tenantId);
+        }
+    }
+
+    /// <summary>
+    /// Look a tenant up by verified account subject WITHOUT minting. Returns null when the subject has no
+    /// tenant. Used where a missing mapping must be a deny (never a mint) - the read-only counterpart to
+    /// <see cref="MintOrLookupBySubject"/>.
+    /// </summary>
+    public TenantId? LookupBySubject(string accountSubject)
+    {
+        if (string.IsNullOrWhiteSpace(accountSubject))
+            return null;
+
+        var subject = accountSubject.Trim();
+        using var ctx = _db.CreateUnscopedContext();
+        var existing = ctx.Tenants.AsNoTracking().FirstOrDefault(t => t.AccountSubject == subject);
+        return existing is null ? null : new TenantId(existing.Id);
+    }
+}

--- a/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
+++ b/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
@@ -70,7 +70,28 @@ public sealed class TenantRegistry
                 Email = string.IsNullOrWhiteSpace(email) ? null : email!.Trim(),
                 CreatedAtUtc = DateTime.UtcNow,
             });
-            ctx.SaveChanges();
+
+            try
+            {
+                ctx.SaveChanges();
+            }
+            catch (DbUpdateException)
+            {
+                // A competing mint for the SAME subject won the unique index on account_subject (a second
+                // instance/process, or a future non-single-writer deployment - the in-process write lock above
+                // does not cover those). The mapping is idempotent by subject, so the loser adopts the winner's
+                // tenant: re-read what the index committed and return it. This is NOT a fallback that hides a
+                // problem - the unique index is the source of truth and we are reading back the value it
+                // enforced. A still-absent row would be a genuine failure, so it re-throws rather than mint again.
+                using var reread = _db.CreateUnscopedContext();
+                var winner = reread.Tenants.AsNoTracking().FirstOrDefault(t => t.AccountSubject == subject);
+                if (winner is not null)
+                {
+                    FileLog.Write("[TenantRegistry] MintOrLookupBySubject: lost a mint race, adopting the winning tenant for the account");
+                    return new TenantId(winner.Id);
+                }
+                throw;
+            }
 
             FileLog.Write("[TenantRegistry] MintOrLookupBySubject: minted a new tenant for a first-seen account");
             return new TenantId(tenantId);


### PR DESCRIPTION
## What

Increment 1 of the Hosted Multi-Tenancy mission, sequenced as the FIRST of two green steps: the data foundation for per-account tenant isolation on the hosted Gateway. No behavior change - the single-tenant local install and the current hosted Gateway both still resolve every unit of work to the "local" tenant. The follow-up PR wires hosted enrollment and the tunnel-side resolution that make isolation live (with the two-account isolation test).

## Changes

- **`tenants` table + `TenantEntity`** - the global account-subject to tenant-id mapping. Deliberately NOT tenant-scoped (no `tenant_id` column, no query filter): it is the table the filter's tenant values come from.
- **`TenantRegistry`** - mint-or-lookup keyed by the STABLE Supabase subject (`sub`). An account that already has a tenant gets the SAME tenant back, so a second device of one account lands in one tenant. Email is display metadata only, never the mapping key. Subject and email are never logged.
- **Unscoped-context accessor** on `GatewayDatabase` for the global mapping table - a tenant is minted before any tenant is resolved, so it cannot go through the tenant-scoped context path (which fails loud on an unresolved tenant).
- **Per-device account binding** - `DeviceRecord` records the resolved account subject + tenant; `DeviceRegistry.TenantForKey` is a constant-time lookup so the tunnel can later resolve a tenant from the same per-device key that authenticated the connection.
- **Tenancy CI guard** (`TenantScopeGuardTests`) - reflects the EF model and fails the build if any tenant-scoped table is missing its `tenant_id` column or its global query filter; asserts the mapping table is NOT itself scoped.
- **Migration** generated for both providers (SQLite + Postgres), `tenants` table only.

## Proof

- New tests: `TenantRegistryTests` (mint idempotent by subject, distinct subjects -> distinct tenants, email-is-not-the-key, survives restart), `DeviceRegistryAccountBindingTests` (bind + resolve per device, persists across reload), `TenantScopeGuardTests`.
- Full `CcDirector.Gateway.Tests` suite: 1265 passed, 0 failed (the teardown "Test Run Aborted" is the known DirectorRegistry FileSystemWatcher dispose-race, exit code 0).
- Core tenancy-seam tests: 8 passed.
- **Tests-must-fail-on-purpose**: removed the global query filter and confirmed the CI guard turns RED ("no global query filter - a tenant could read another tenant's rows") while the mapping-table control test stays green; restored and re-confirmed green.
- Both providers report no pending model changes.