### PR TITLE
feat(gateway): activate per-account tenant isolation on the hosted Gateway (increment 2a)

### DIFF
--- a/src/CcDirector.Core.Tests/Account/JwtAccessTokenValidatorAuthorizationTests.cs
+++ b/src/CcDirector.Core.Tests/Account/JwtAccessTokenValidatorAuthorizationTests.cs
@@ -27,6 +27,38 @@ public sealed class JwtAccessTokenValidatorAuthorizationTests : IDisposable
         new(TestJwt.SigningSecret, new FakeTimeProvider(Now), _key.PublicKeySetJson(),
             expectedAudience: ExpectedAudience, expectedIssuer: ExpectedIssuer);
 
+    private JwtAccessTokenValidator MakeEs256OnlyValidator() =>
+        new(TestJwt.SigningSecret, new FakeTimeProvider(Now), _key.PublicKeySetJson(),
+            expectedAudience: ExpectedAudience, expectedIssuer: ExpectedIssuer, allowSymmetricHs256: false);
+
+    [Fact]
+    public void ValidateForAuthorization_Hs256_WhenEs256Only_IsNotValid()
+    {
+        // Algorithm-confusion defense: an HS256 token signed with the (possibly public placeholder) secret
+        // must be REFUSED by an ES256-only validator, so a forged symmetric token cannot authorize as any
+        // subject. This is the validator-level fix every hosted account-token authorization path inherits.
+        var forged = TestJwt.CreateAuthorization(Now.AddHours(1), ExpectedAudience, ExpectedIssuer, "attacker",
+            TestJwt.SigningSecret);
+
+        var result = MakeEs256OnlyValidator().ValidateForAuthorization(forged);
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void ValidateForAuthorization_Hs256_WhenSymmetricAllowed_IsValid()
+    {
+        // Self-host / legacy is UNCHANGED: with HS256 allowed (the default), a properly-signed HS256 token
+        // still validates. Only the hosted authorization validators opt into ES256-only.
+        var token = TestJwt.CreateAuthorization(Now.AddHours(1), ExpectedAudience, ExpectedIssuer, "account-42",
+            TestJwt.SigningSecret);
+
+        var result = MakeValidator().ValidateForAuthorization(token);
+
+        Assert.True(result.IsValid);
+        Assert.Equal("account-42", result.Subject);
+    }
+
     [Fact]
     public void ValidateForAuthorization_FullyValidToken_IsValidAndExposesSubject()
     {

--- a/src/CcDirector.Core.Tests/Account/TestJwt.cs
+++ b/src/CcDirector.Core.Tests/Account/TestJwt.cs
@@ -67,6 +67,32 @@ internal static class TestJwt
         return $"{signingInput}.{signature}";
     }
 
+    /// <summary>Creates a valid HS256 token carrying authorization-mode claims (audience, issuer, subject,
+    /// exp), so an authorization validator that ACCEPTS HS256 would pass it - used to prove an ES256-only
+    /// validator refuses the same well-formed symmetric token.</summary>
+    public static string CreateAuthorization(DateTime expiresAtUtc, string audience, string issuer, string subject,
+        string secret = SigningSecret)
+    {
+        var header = Base64Url(JsonSerializer.SerializeToUtf8Bytes(new Dictionary<string, object>
+        {
+            ["alg"] = "HS256",
+            ["typ"] = "JWT",
+        }));
+
+        var payload = Base64Url(JsonSerializer.SerializeToUtf8Bytes(new Dictionary<string, object>
+        {
+            ["sub"] = subject,
+            ["aud"] = audience,
+            ["iss"] = issuer,
+            ["exp"] = new DateTimeOffset(expiresAtUtc, TimeSpan.Zero).ToUnixTimeSeconds(),
+        }));
+
+        var signingInput = $"{header}.{payload}";
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var signature = Base64Url(hmac.ComputeHash(Encoding.ASCII.GetBytes(signingInput)));
+        return $"{signingInput}.{signature}";
+    }
+
     /// <summary>Returns the token with its final signature byte flipped, so the signature no longer verifies.</summary>
     public static string Tamper(string token)
     {

--- a/src/CcDirector.Core.Tests/Tenancy/AsyncLocalTenantContextTests.cs
+++ b/src/CcDirector.Core.Tests/Tenancy/AsyncLocalTenantContextTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Tenancy;
+
+/// <summary>
+/// The hosted ambient tenant context (Hosted Multi-Tenancy increment 1). These pin the deny-by-default
+/// contract: no scope -> Current THROWS (never a default tenant), a scope resolves its tenant, scopes nest
+/// and restore, and the ambient value flows across async boundaries down to the code that reads it.
+/// </summary>
+public sealed class AsyncLocalTenantContextTests
+{
+    [Fact]
+    public void NoScope_Current_ThrowsFailClosed()
+    {
+        var ctx = new AsyncLocalTenantContext();
+
+        // Deny-by-default: reading the tenant with no scope in effect must fail loud, never default.
+        Assert.Throws<InvalidOperationException>(() => _ = ctx.Current);
+    }
+
+    [Fact]
+    public void NoScope_CurrentOrNull_IsNull()
+    {
+        var ctx = new AsyncLocalTenantContext();
+
+        Assert.Null(ctx.CurrentOrNull);
+    }
+
+    [Fact]
+    public void InsideScope_Current_ResolvesThatTenant()
+    {
+        var ctx = new AsyncLocalTenantContext();
+
+        using (ctx.Enter(new TenantId("t-alice")))
+        {
+            Assert.Equal("t-alice", ctx.Current.Value);
+            Assert.Equal("t-alice", ctx.CurrentOrNull!.Value.Value);
+        }
+    }
+
+    [Fact]
+    public void AfterScopeDisposed_Current_ThrowsAgain()
+    {
+        var ctx = new AsyncLocalTenantContext();
+
+        using (ctx.Enter(new TenantId("t-alice"))) { }
+
+        Assert.Throws<InvalidOperationException>(() => _ = ctx.Current);
+    }
+
+    [Fact]
+    public void NestedScopes_RestoreTheOuterTenantOnDispose()
+    {
+        var ctx = new AsyncLocalTenantContext();
+
+        using (ctx.Enter(new TenantId("t-outer")))
+        {
+            Assert.Equal("t-outer", ctx.Current.Value);
+            using (ctx.Enter(new TenantId("t-inner")))
+            {
+                Assert.Equal("t-inner", ctx.Current.Value);
+            }
+            Assert.Equal("t-outer", ctx.Current.Value);
+        }
+    }
+
+    [Fact]
+    public void SystemScope_ResolvesTheReservedSystemTenant()
+    {
+        var ctx = new AsyncLocalTenantContext();
+
+        using (ctx.Enter(TenantId.System))
+        {
+            Assert.True(ctx.Current.IsSystem);
+            Assert.Equal("system", ctx.Current.Value);
+        }
+    }
+
+    [Fact]
+    public void Enter_InvalidTenant_Throws()
+    {
+        var ctx = new AsyncLocalTenantContext();
+
+        Assert.Throws<ArgumentException>(() => ctx.Enter(default));
+    }
+
+    [Fact]
+    public async Task Scope_FlowsAcrossAnAwait()
+    {
+        var ctx = new AsyncLocalTenantContext();
+
+        using (ctx.Enter(new TenantId("t-alice")))
+        {
+            await Task.Yield();
+            // The ambient value flows across the await, so a store call after an await still resolves it.
+            Assert.Equal("t-alice", ctx.Current.Value);
+        }
+    }
+}

--- a/src/CcDirector.Core.Tests/Tenancy/TenantSeamTests.cs
+++ b/src/CcDirector.Core.Tests/Tenancy/TenantSeamTests.cs
@@ -35,6 +35,24 @@ public sealed class TenantSeamTests
     }
 
     [Fact]
+    public void ToLogString_RedactsRealTenants_ButKeepsLocalAndSystemReadable()
+    {
+        // The well-known non-sensitive identities stay readable in logs.
+        Assert.Equal("local", TenantId.Local.ToLogString());
+        Assert.Equal("system", TenantId.System.ToLogString());
+
+        // A real (account) tenant id is redacted to a short one-way tag - the raw id NEVER appears in the log
+        // rendering - and is deterministic so log lines for one tenant stay correlatable.
+        var account = new TenantId("11111111-2222-3333-4444-555555555555");
+        var rendered = account.ToLogString();
+        Assert.StartsWith("t#", rendered);
+        Assert.DoesNotContain(account.Value, rendered);
+        Assert.Equal(rendered, account.ToLogString());
+        // Distinct tenants render distinctly (isolation is still visible in logs).
+        Assert.NotEqual(rendered, new TenantId("99999999-8888-7777-6666-555555555555").ToLogString());
+    }
+
+    [Fact]
     public void Construct_TrimsAndKeepsValue()
     {
         var id = new TenantId("  acme  ");

--- a/src/CcDirector.Core.Tests/Tenancy/TenantSeamTests.cs
+++ b/src/CcDirector.Core.Tests/Tenancy/TenantSeamTests.cs
@@ -20,6 +20,21 @@ public sealed class TenantSeamTests
     }
 
     [Fact]
+    public void System_IsValidReservedAndDistinctFromLocalAndAccounts()
+    {
+        Assert.True(TenantId.System.IsValid);
+        Assert.True(TenantId.System.IsSystem);
+        Assert.Equal("system", TenantId.System.Value);
+        // Distinct from local (self-host) and never flagged as local.
+        Assert.False(TenantId.System.IsLocal);
+        Assert.NotEqual(TenantId.Local.Value, TenantId.System.Value);
+        // A real account tenant (a GUID) is neither system nor local.
+        var account = new TenantId(Guid.NewGuid().ToString());
+        Assert.False(account.IsSystem);
+        Assert.False(account.IsLocal);
+    }
+
+    [Fact]
     public void Construct_TrimsAndKeepsValue()
     {
         var id = new TenantId("  acme  ");

--- a/src/CcDirector.Core/Account/JwtAccessTokenValidator.cs
+++ b/src/CcDirector.Core/Account/JwtAccessTokenValidator.cs
@@ -47,6 +47,7 @@ public sealed class JwtAccessTokenValidator
     private readonly TimeProvider _timeProvider;
     private readonly string? _expectedAudience;
     private readonly string? _expectedIssuer;
+    private readonly bool _allowSymmetricHs256;
 
     /// <summary>One elliptic-curve P-256 public verification key from the configured key set.</summary>
     private sealed record VerificationKey(string? KeyId, ECParameters PublicKey);
@@ -75,12 +76,20 @@ public sealed class JwtAccessTokenValidator
     /// The issuer (<c>iss</c>) value a token must carry to pass authorization-mode validation. Supplied
     /// as configuration, not hard-coded at the call site. Null when only <see cref="Validate"/> is used.
     /// </param>
+    /// <param name="allowSymmetricHs256">
+    /// Whether a symmetric HS256 token is accepted. Defaults to true (the historic behavior). Set FALSE for a
+    /// validator that must ONLY trust asymmetric ES256 tokens - the hosted enrollment boundary does this,
+    /// because the account tokens are Supabase ES256 and the shared HS256 secret can be an unconfigured public
+    /// placeholder; accepting HS256 there would let anyone forge an arbitrary-subject token. When false, an
+    /// HS256 token is rejected regardless of the secret.
+    /// </param>
     public JwtAccessTokenValidator(
         string signingSecret,
         TimeProvider? timeProvider = null,
         string? publicKeySetJson = null,
         string? expectedAudience = null,
-        string? expectedIssuer = null)
+        string? expectedIssuer = null,
+        bool allowSymmetricHs256 = true)
     {
         if (string.IsNullOrEmpty(signingSecret))
             throw new ArgumentException("Signing secret is required", nameof(signingSecret));
@@ -90,6 +99,7 @@ public sealed class JwtAccessTokenValidator
         _timeProvider = timeProvider ?? TimeProvider.System;
         _expectedAudience = expectedAudience;
         _expectedIssuer = expectedIssuer;
+        _allowSymmetricHs256 = allowSymmetricHs256;
     }
 
     /// <summary>
@@ -147,7 +157,9 @@ public sealed class JwtAccessTokenValidator
         var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
 
         var expiresAtUtc = ReadUnixTimeClaim(root, "exp");
-        if (expiresAtUtc is not null && expiresAtUtc.Value <= nowUtc)
+        if (expiresAtUtc is null)
+            return Reject("token has no exp claim (a non-expiring token is not accepted for authorization)");
+        if (expiresAtUtc.Value <= nowUtc)
             return Reject("token has expired (exp is in the past)");
 
         var notBeforeUtc = ReadUnixTimeClaim(root, "nbf");
@@ -193,7 +205,9 @@ public sealed class JwtAccessTokenValidator
 
         var signatureVerifies = header.Value.Algorithm switch
         {
-            "HS256" => HmacSignatureVerifies(parts[0], parts[1], parts[2]),
+            "HS256" => _allowSymmetricHs256
+                ? HmacSignatureVerifies(parts[0], parts[1], parts[2])
+                : RejectSymmetricHs256(),
             "ES256" => EcdsaSignatureVerifies(header.Value.KeyId, parts[0], parts[1], parts[2]),
             _ => UnsupportedAlgorithm(header.Value.Algorithm),
         };
@@ -237,6 +251,14 @@ public sealed class JwtAccessTokenValidator
     private static bool UnsupportedAlgorithm(string? algorithm)
     {
         FileLog.Write($"[JwtAccessTokenValidator] Validate: unsupported signing algorithm '{algorithm}' (only ES256 and HS256 are supported)");
+        return false;
+    }
+
+    private static bool RejectSymmetricHs256()
+    {
+        // This validator is configured ES256-only (asymmetric): a symmetric HS256 token is refused regardless
+        // of the shared secret, so an unconfigured/public placeholder secret can never forge a valid token.
+        FileLog.Write("[JwtAccessTokenValidator] VerifySignature: HS256 refused - this validator accepts only asymmetric ES256 tokens");
         return false;
     }
 

--- a/src/CcDirector.Core/Tenancy/AsyncLocalTenantContext.cs
+++ b/src/CcDirector.Core/Tenancy/AsyncLocalTenantContext.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading;
+
+namespace CcDirector.Core.Tenancy;
+
+/// <summary>
+/// The hosted, multi-tenant implementation of <see cref="ITenantContext"/> (Hosted Multi-Tenancy increment
+/// 1). Unlike <see cref="SingleTenantContext"/> (which always answers <see cref="TenantId.Local"/>), this
+/// resolves the tenant of the CURRENT unit of work from an ambient, async-flowed scope that a boundary
+/// establishes with <see cref="Enter"/>.
+///
+/// DENY-BY-DEFAULT / FAIL-CLOSED: when no scope is in effect, <see cref="Current"/> THROWS - it never
+/// defaults to a tenant. A hosted operation that touches tenant data outside an explicit scope is a bug (a
+/// caller path that was not bound at its auth boundary), and failing closed turns that into a loud error
+/// rather than a silent cross-tenant read or a write into the wrong tenant. The per-account boundaries enter
+/// the resolved account tenant; the reserved <see cref="TenantId.System"/> scope is entered ONLY by
+/// explicitly-system code (startup/built-in seeding) - it is never the answer to "no tenant resolved".
+///
+/// The ambient value is an <see cref="AsyncLocal{T}"/>, so it flows down an async call chain (a SignalR hub
+/// method, an HTTP request, a background operation) to the store calls inside it, and nested scopes restore
+/// the previous value on dispose. The value is per-instance (the field is not static), so tests are isolated.
+/// </summary>
+public sealed class AsyncLocalTenantContext : ITenantContext
+{
+    private readonly AsyncLocal<TenantId?> _current = new();
+
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">No tenant scope is in effect (deny-by-default).</exception>
+    public TenantId Current =>
+        _current.Value is { IsValid: true } tenant
+            ? tenant
+            : throw new InvalidOperationException(
+                "No tenant is in scope for this hosted operation. A tenant-scoped read or write ran outside " +
+                "any resolved-tenant boundary. Hosted operations must run inside an explicit tenant scope - " +
+                "the per-account tenant bound at the auth boundary, or the reserved system scope for system " +
+                "operations. This fails closed rather than defaulting to a tenant (deny-by-default).");
+
+    /// <summary>The tenant currently in scope, or null when none is - for a boundary that must DECIDE whether a
+    /// scope is already active without triggering the fail-closed throw.</summary>
+    public TenantId? CurrentOrNull => _current.Value is { IsValid: true } tenant ? tenant : (TenantId?)null;
+
+    /// <summary>
+    /// Enter a tenant scope for the current async flow. Every tenant-scoped store operation inside the
+    /// returned scope resolves to <paramref name="tenant"/>. Dispose restores the previously-active scope (so
+    /// scopes nest correctly). Fails loud on an invalid tenant - a boundary must resolve a valid tenant before
+    /// entering, never enter <c>default</c>.
+    /// </summary>
+    public IDisposable Enter(TenantId tenant)
+    {
+        if (!tenant.IsValid)
+            throw new ArgumentException("Cannot enter a scope for an invalid tenant.", nameof(tenant));
+
+        var previous = _current.Value;
+        _current.Value = tenant;
+        return new Scope(this, previous);
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        private readonly AsyncLocalTenantContext _owner;
+        private readonly TenantId? _previous;
+        private bool _disposed;
+
+        public Scope(AsyncLocalTenantContext owner, TenantId? previous)
+        {
+            _owner = owner;
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _owner._current.Value = _previous;
+        }
+    }
+}

--- a/src/CcDirector.Core/Tenancy/TenantId.cs
+++ b/src/CcDirector.Core/Tenancy/TenantId.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace CcDirector.Core.Tenancy;
 
@@ -62,4 +64,19 @@ public readonly record struct TenantId
 
     /// <inheritdoc />
     public override string ToString() => IsValid ? Value : "<invalid-tenant>";
+
+    /// <summary>
+    /// A LOG-SAFE rendering of this tenant. The well-known, non-sensitive identities (<see cref="Local"/> and
+    /// <see cref="System"/>) render as themselves so logs stay readable; a real (account) tenant id renders as
+    /// a short ONE-WAY hash tag (<c>t#</c> + 8 hex) so the raw account tenant id NEVER reaches a log while log
+    /// lines stay correlatable. Use this - never the raw <see cref="Value"/> or <see cref="ToString"/> - when
+    /// writing a tenant to a log.
+    /// </summary>
+    public string ToLogString()
+    {
+        if (!IsValid) return "<invalid-tenant>";
+        if (IsLocal || IsSystem) return Value;
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(Value));
+        return "t#" + Convert.ToHexString(hash, 0, 4).ToLowerInvariant();
+    }
 }

--- a/src/CcDirector.Core/Tenancy/TenantId.cs
+++ b/src/CcDirector.Core/Tenancy/TenantId.cs
@@ -23,6 +23,17 @@ public readonly record struct TenantId
     /// <summary>The well-known single-tenant identity. Self-host and the open core resolve to this.</summary>
     public static readonly TenantId Local = new("local");
 
+    /// <summary>
+    /// The well-known RESERVED system identity (Hosted Multi-Tenancy increment 1). It scopes the hosted
+    /// Gateway's legitimate NON-account writes - startup/built-in seeding and other explicitly-system
+    /// operations - so those never fall back to a real account's tenant OR to <see cref="Local"/>. It is a
+    /// reserved value distinct from <see cref="Local"/> (self-host only) and from every real account tenant
+    /// (which are GUID strings), and its rows are isolated by the SAME global query filter, so a real tenant
+    /// never reads a system row. It is reached ONLY by code that explicitly enters the system scope - it is
+    /// NEVER the answer to "no tenant resolved" (that fails closed). Unused on the single-tenant local install.
+    /// </summary>
+    public static readonly TenantId System = new("system");
+
     /// <summary>The underlying identifier. Null only for an invalid <c>default(TenantId)</c>.</summary>
     public string Value { get; }
 
@@ -45,6 +56,9 @@ public readonly record struct TenantId
 
     /// <summary>True when this is the well-known single-tenant identity (the self-host / N=1 case).</summary>
     public bool IsLocal => IsValid && string.Equals(Value, Local.Value, StringComparison.Ordinal);
+
+    /// <summary>True when this is the reserved <see cref="System"/> identity (hosted non-account/system rows).</summary>
+    public bool IsSystem => IsValid && string.Equals(Value, System.Value, StringComparison.Ordinal);
 
     /// <inheritdoc />
     public override string ToString() => IsValid ? Value : "<invalid-tenant>";

--- a/src/CcDirector.Gateway.Tests/HostedEnrollmentEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedEnrollmentEndpointTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Account;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The hosted enrollment logic (Hosted Multi-Tenancy increment 1): validate a remote Director's OWN Supabase
+/// account token (signature + expiry + audience + issuer), map its subject to a tenant, and bind a per-device
+/// key to that tenant. Exercised through the endpoint's extracted <see cref="HostedEnrollmentEndpoint.Enroll"/>
+/// with a real ES256-signed token, so the audience/issuer enforcement is proven for real.
+/// </summary>
+public sealed class HostedEnrollmentEndpointTests : IDisposable
+{
+    private const string Audience = "authenticated";
+    private const string Issuer = "https://test.example.supabase.co/auth/v1";
+
+    private readonly GatewayDbTestHarness _harness = new();
+    private readonly string _devPath = Path.Combine(Path.GetTempPath(), $"henr-dev-{Guid.NewGuid():N}.json");
+    private readonly TestEs256Key _key = new();
+
+    public void Dispose()
+    {
+        _harness.Dispose();
+        _key.Dispose();
+        if (File.Exists(_devPath)) File.Delete(_devPath);
+    }
+
+    private (DeviceRegistry devices, TenantRegistry tenants, JwtAccessTokenValidator validator) Wire()
+    {
+        var db = _harness.Open();
+        var devices = new DeviceRegistry(_devPath);
+        var tenants = new TenantRegistry(db);
+        var validator = new JwtAccessTokenValidator(
+            "test-signing-secret", timeProvider: null, publicKeySetJson: _key.PublicKeySetJson(),
+            expectedAudience: Audience, expectedIssuer: Issuer);
+        return (devices, tenants, validator);
+    }
+
+    private static EnrollSignedInRequest Req(string deviceId) => new()
+    {
+        DeviceId = deviceId,
+        MachineName = "M",
+        Platform = "linux",
+        DeviceType = "workstation",
+    };
+
+    [Fact]
+    public void ValidToken_MintsADeviceKeyBoundToTheAccountTenant()
+    {
+        var (devices, tenants, validator) = Wire();
+        var token = _key.Token("sub-alice", "alice@example.com", Audience, Issuer);
+
+        var result = HostedEnrollmentEndpoint.Enroll(token, Req("dev-a"), devices, tenants, validator);
+
+        Assert.Equal(200, result.Status);
+        Assert.False(string.IsNullOrWhiteSpace(result.Response!.DeviceKey));
+        // The device is bound to the account's tenant, resolvable from the same key (what the tunnel does).
+        Assert.False(string.IsNullOrEmpty(devices.TenantForKey(result.Response.DeviceKey)));
+    }
+
+    [Fact]
+    public void TwoDistinctAccounts_GetTwoDistinctTenants_AndSameAccountReusesItsTenant()
+    {
+        var (devices, tenants, validator) = Wire();
+
+        var a = HostedEnrollmentEndpoint.Enroll(_key.Token("sub-alice", "a@x.com", Audience, Issuer), Req("dev-a"), devices, tenants, validator);
+        var b = HostedEnrollmentEndpoint.Enroll(_key.Token("sub-bob", "b@x.com", Audience, Issuer), Req("dev-b"), devices, tenants, validator);
+        // A SECOND device of the SAME account (alice) must land in alice's existing tenant.
+        var a2 = HostedEnrollmentEndpoint.Enroll(_key.Token("sub-alice", "a@x.com", Audience, Issuer), Req("dev-a2"), devices, tenants, validator);
+
+        var tenantA = devices.TenantForKey(a.Response!.DeviceKey);
+        var tenantB = devices.TenantForKey(b.Response!.DeviceKey);
+        var tenantA2 = devices.TenantForKey(a2.Response!.DeviceKey);
+
+        Assert.NotEqual(tenantA, tenantB);
+        Assert.Equal(tenantA, tenantA2);
+    }
+
+    [Fact]
+    public void MissingToken_Is401()
+    {
+        var (devices, tenants, validator) = Wire();
+        var result = HostedEnrollmentEndpoint.Enroll(bearer: null, Req("dev-a"), devices, tenants, validator);
+        Assert.Equal(401, result.Status);
+    }
+
+    [Fact]
+    public void WrongIssuer_Is401_NoBinding()
+    {
+        var (devices, tenants, validator) = Wire();
+        var token = _key.Token("sub-alice", "a@x.com", Audience, issuer: "https://attacker.example.com/auth/v1");
+
+        var result = HostedEnrollmentEndpoint.Enroll(token, Req("dev-a"), devices, tenants, validator);
+
+        Assert.Equal(401, result.Status);
+    }
+
+    [Fact]
+    public void WrongAudience_Is401()
+    {
+        var (devices, tenants, validator) = Wire();
+        var token = _key.Token("sub-alice", "a@x.com", audience: "some-other-audience", issuer: Issuer);
+
+        var result = HostedEnrollmentEndpoint.Enroll(token, Req("dev-a"), devices, tenants, validator);
+
+        Assert.Equal(401, result.Status);
+    }
+
+    [Fact]
+    public void MissingDeviceId_Is400()
+    {
+        var (devices, tenants, validator) = Wire();
+        var token = _key.Token("sub-alice", "a@x.com", Audience, Issuer);
+
+        var result = HostedEnrollmentEndpoint.Enroll(token, Req("   "), devices, tenants, validator);
+
+        Assert.Equal(400, result.Status);
+    }
+
+    /// <summary>The Supabase audience/issuer the production validator enforces are the project's real values.</summary>
+    [Fact]
+    public void BuildAuthorizationValidator_DefaultsToTheSupabaseAudienceAndIssuer()
+    {
+        Assert.Equal("authenticated", CcDirector.Gateway.Account.GatewayAccountFactory.DefaultSupabaseAudience);
+        Assert.Equal("https://ompujpfrglgqvqprilxa.supabase.co/auth/v1",
+            CcDirector.Gateway.Account.GatewayAccountFactory.DefaultSupabaseIssuer);
+    }
+
+    /// <summary>A compact ES256 (P-256) signer that mints Supabase-shaped tokens and exports its public JWKS.</summary>
+    private sealed class TestEs256Key : IDisposable
+    {
+        private readonly ECDsa _key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        private const string KeyId = "test-key";
+
+        public void Dispose() => _key.Dispose();
+
+        public string PublicKeySetJson()
+        {
+            var p = _key.ExportParameters(includePrivateParameters: false);
+            return JsonSerializer.Serialize(new
+            {
+                keys = new[]
+                {
+                    new { alg = "ES256", crv = "P-256", kid = KeyId, kty = "EC", use = "sig",
+                          x = B64(p.Q.X!), y = B64(p.Q.Y!) },
+                },
+            });
+        }
+
+        public string Token(string subject, string email, string audience, string issuer)
+        {
+            var header = B64(Encoding.UTF8.GetBytes(
+                JsonSerializer.Serialize(new { alg = "ES256", typ = "JWT", kid = KeyId })));
+            const long nowSeconds = 1_781_000_000L; // fixed instant; token is far from expiry at test time
+            var payload = B64(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
+            {
+                sub = subject,
+                email,
+                aud = audience,
+                iss = issuer,
+                iat = nowSeconds,
+                nbf = nowSeconds,
+                exp = 4_070_000_000L, // year ~2099
+            })));
+            var signingInput = header + "." + payload;
+            var sig = _key.SignData(Encoding.ASCII.GetBytes(signingInput), HashAlgorithmName.SHA256);
+            return signingInput + "." + B64(sig);
+        }
+
+        private static string B64(byte[] bytes) =>
+            Convert.ToBase64String(bytes).Replace('+', '-').Replace('/', '_').TrimEnd('=');
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedEnrollmentEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedEnrollmentEndpointTests.cs
@@ -39,9 +39,10 @@ public sealed class HostedEnrollmentEndpointTests : IDisposable
         var db = _harness.Open();
         var devices = new DeviceRegistry(_devPath);
         var tenants = new TenantRegistry(db);
+        // ES256-only, exactly as production BuildAuthorizationValidator configures it - HS256 is refused.
         var validator = new JwtAccessTokenValidator(
             "test-signing-secret", timeProvider: null, publicKeySetJson: _key.PublicKeySetJson(),
-            expectedAudience: Audience, expectedIssuer: Issuer);
+            expectedAudience: Audience, expectedIssuer: Issuer, allowSymmetricHs256: false);
         return (devices, tenants, validator);
     }
 
@@ -126,6 +127,54 @@ public sealed class HostedEnrollmentEndpointTests : IDisposable
         Assert.Equal(400, result.Status);
     }
 
+    [Fact]
+    public void DeviceIdCollisionAcrossAccounts_CannotHijackAnotherTenantsKey()
+    {
+        var (devices, tenants, validator) = Wire();
+
+        // Attacker pre-enrolls a client-chosen deviceId "shared" under its OWN account.
+        var attacker = HostedEnrollmentEndpoint.Enroll(
+            _key.Token("sub-attacker", "atk@x.com", Audience, Issuer), Req("shared"), devices, tenants, validator);
+        var attackerKey = attacker.Response!.DeviceKey;
+        var attackerTenant = devices.TenantForKey(attackerKey);
+
+        // Victim later enrolls the SAME deviceId "shared" under the victim account.
+        var victim = HostedEnrollmentEndpoint.Enroll(
+            _key.Token("sub-victim", "vic@x.com", Audience, Issuer), Req("shared"), devices, tenants, validator);
+        var victimKey = victim.Response!.DeviceKey;
+        var victimTenant = devices.TenantForKey(victimKey);
+
+        // The victim gets a DISTINCT key and tenant, and - the security property - the attacker's key was
+        // NEVER handed over or rebound: it still resolves to the attacker's OWN tenant, not the victim's.
+        Assert.NotEqual(attackerKey, victimKey);
+        Assert.NotEqual(attackerTenant, victimTenant);
+        Assert.Equal(attackerTenant, devices.TenantForKey(attackerKey));
+        Assert.NotEqual(victimTenant, devices.TenantForKey(attackerKey));
+    }
+
+    [Fact]
+    public void Hs256Token_IsRefused_EvenWithAKnownSecret()
+    {
+        var (devices, tenants, validator) = Wire();
+        // An attacker forges an HS256 token with an arbitrary subject, signed with a known/placeholder secret.
+        var forged = TestEs256Key.Hs256Token("test-signing-secret", "sub-attacker", Audience, Issuer);
+
+        var result = HostedEnrollmentEndpoint.Enroll(forged, Req("dev-a"), devices, tenants, validator);
+
+        Assert.Equal(401, result.Status);
+    }
+
+    [Fact]
+    public void TokenWithNoExpClaim_IsRefused()
+    {
+        var (devices, tenants, validator) = Wire();
+        var noExp = _key.Token("sub-alice", "a@x.com", Audience, Issuer, includeExp: false);
+
+        var result = HostedEnrollmentEndpoint.Enroll(noExp, Req("dev-a"), devices, tenants, validator);
+
+        Assert.Equal(401, result.Status);
+    }
+
     /// <summary>The Supabase audience/issuer the production validator enforces are the project's real values.</summary>
     [Fact]
     public void BuildAuthorizationValidator_DefaultsToTheSupabaseAudienceAndIssuer()
@@ -156,24 +205,42 @@ public sealed class HostedEnrollmentEndpointTests : IDisposable
             });
         }
 
-        public string Token(string subject, string email, string audience, string issuer)
+        public string Token(string subject, string email, string audience, string issuer, bool includeExp = true)
         {
             var header = B64(Encoding.UTF8.GetBytes(
                 JsonSerializer.Serialize(new { alg = "ES256", typ = "JWT", kid = KeyId })));
-            const long nowSeconds = 1_781_000_000L; // fixed instant; token is far from expiry at test time
-            var payload = B64(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
-            {
-                sub = subject,
-                email,
-                aud = audience,
-                iss = issuer,
-                iat = nowSeconds,
-                nbf = nowSeconds,
-                exp = 4_070_000_000L, // year ~2099
-            })));
-            var signingInput = header + "." + payload;
+            var signingInput = header + "." + PayloadSegment(subject, email, audience, issuer, includeExp);
             var sig = _key.SignData(Encoding.ASCII.GetBytes(signingInput), HashAlgorithmName.SHA256);
             return signingInput + "." + B64(sig);
+        }
+
+        /// <summary>A forged HS256 token signed with <paramref name="secret"/> - to prove an ES256-only
+        /// validator refuses symmetric tokens no matter the (possibly public/placeholder) secret.</summary>
+        public static string Hs256Token(string secret, string subject, string audience, string issuer)
+        {
+            var header = B64(Encoding.UTF8.GetBytes(
+                JsonSerializer.Serialize(new { alg = "HS256", typ = "JWT" })));
+            var signingInput = header + "." + PayloadSegment(subject, "x@x.com", audience, issuer, includeExp: true);
+            using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+            var sig = hmac.ComputeHash(Encoding.ASCII.GetBytes(signingInput));
+            return signingInput + "." + B64(sig);
+        }
+
+        private static string PayloadSegment(string subject, string email, string audience, string issuer, bool includeExp)
+        {
+            const long nowSeconds = 1_781_000_000L; // fixed instant; token is far from expiry at test time
+            var claims = new Dictionary<string, object>
+            {
+                ["sub"] = subject,
+                ["email"] = email,
+                ["aud"] = audience,
+                ["iss"] = issuer,
+                ["iat"] = nowSeconds,
+                ["nbf"] = nowSeconds,
+            };
+            if (includeExp)
+                claims["exp"] = 4_070_000_000L; // year ~2099
+            return B64(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(claims)));
         }
 
         private static string B64(byte[] bytes) =>

--- a/src/CcDirector.Gateway.Tests/HostedTenancyActivationTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedTenancyActivationTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Linq;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data.Entities;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Stats;
+using CcDirector.Gateway.Streaming;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The hosted per-account activation (Hosted Multi-Tenancy increment 1). These prove the isolation the whole
+/// increment exists for: two DIFFERENT accounts each resolve to their OWN tenant from their AUTHENTICATED
+/// device key, and neither can see the other's data - at the EF store level (the query filter) and at the
+/// tunnel level (the tenant-keyed pushed-session store). The revert-prove is explicit: reverting the
+/// resolution-from-the-authenticated-device-key makes two accounts share one tenant and the isolation
+/// assertions go RED.
+/// </summary>
+public sealed class HostedTenancyActivationTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _harness = new();
+    private readonly string _devPath = Path.Combine(Path.GetTempPath(), $"htact-dev-{Guid.NewGuid():N}.json");
+    private readonly string _tempDir = Path.Combine(Path.GetTempPath(), $"htact-{Guid.NewGuid():N}");
+
+    public HostedTenancyActivationTests() => Directory.CreateDirectory(_tempDir);
+
+    public void Dispose()
+    {
+        _harness.Dispose();
+        if (File.Exists(_devPath)) File.Delete(_devPath);
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    // ---- The boundary: resolve a tenant from the AUTHENTICATED device key -------------------------------
+
+    [Fact]
+    public void Boundary_Hosted_ResolvesEachDeviceKeyToItsBoundTenant()
+    {
+        var ambient = new AsyncLocalTenantContext();
+        var devices = new DeviceRegistry(_devPath);
+        var boundary = new HostedTenantBoundary(ambient, devices);
+        Assert.True(boundary.IsHosted);
+
+        var keyA = devices.Register("dev-a", "MA").DeviceKey;
+        devices.SetAccountBinding("dev-a", "sub-alice", "tenant-alice");
+
+        Assert.Equal("tenant-alice", boundary.ResolveForDeviceKey(keyA)!.Value.Value);
+    }
+
+    [Fact]
+    public void Boundary_Hosted_DeviceKeyWithNoBoundTenant_ResolvesNull_DenyByDefault()
+    {
+        var ambient = new AsyncLocalTenantContext();
+        var devices = new DeviceRegistry(_devPath);
+        var boundary = new HostedTenantBoundary(ambient, devices);
+
+        // A registered-but-unbound device (e.g. a self-host-shaped enrollment) has no tenant -> a DENY, never
+        // a fall-back to local or SYSTEM.
+        var key = devices.Register("dev-x", "MX").DeviceKey;
+        Assert.Null(boundary.ResolveForDeviceKey(key));
+        // An unknown / blank key likewise resolves to nothing.
+        Assert.Null(boundary.ResolveForDeviceKey("not-a-key"));
+        Assert.Null(boundary.ResolveForDeviceKey(null));
+    }
+
+    [Fact]
+    public void Boundary_SelfHost_EveryAuthenticatedCallerIsLocal()
+    {
+        // Self-host: the context is the SingleTenantContext, so the boundary is inert and resolves Local.
+        var devices = new DeviceRegistry(_devPath);
+        var boundary = new HostedTenantBoundary(new SingleTenantContext(), devices);
+
+        Assert.False(boundary.IsHosted);
+        Assert.True(boundary.ResolveForDeviceKey("anything")!.Value.IsLocal);
+    }
+
+    // ---- EF store isolation: two accounts, cross-read returns nothing -----------------------------------
+
+    [Fact]
+    public void TwoAccounts_WriteUnderTheirResolvedTenant_AndCannotSeeEachOther()
+    {
+        var ambient = new AsyncLocalTenantContext();
+        var db = _harness.Open(ambient);
+        var tenants = new TenantRegistry(db);
+        var devices = new DeviceRegistry(_devPath);
+        var boundary = new HostedTenantBoundary(ambient, devices);
+
+        // Two accounts enroll: two subjects -> two DISTINCT tenant ids -> two devices, each bound to its tenant.
+        var tenantA = tenants.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        var tenantB = tenants.MintOrLookupBySubject("sub-bob", "bob@example.com");
+        Assert.NotEqual(tenantA.Value, tenantB.Value);
+
+        var keyA = devices.Register("dev-a", "MA").DeviceKey;
+        var keyB = devices.Register("dev-b", "MB").DeviceKey;
+        devices.SetAccountBinding("dev-a", "sub-alice", tenantA.Value);
+        devices.SetAccountBinding("dev-b", "sub-bob", tenantB.Value);
+
+        // Each account writes a row under the tenant resolved from its AUTHENTICATED device key - the exact
+        // production resolution the tunnel Hello and the HTTP middleware use.
+        WriteNote(db, boundary, keyA, "mission-a", "alice's why");
+        WriteNote(db, boundary, keyB, "mission-b", "bob's why");
+
+        // Cross-read: under A's tenant, ONLY A's row is visible; under B's tenant, ONLY B's. This is the
+        // isolation the increment exists for - reverting HostedTenantBoundary.ResolveForDeviceKey to a fixed
+        // tenant makes both accounts share one tenant and these assertions fail.
+        Assert.Equal(new[] { "mission-a" }, ReadKeys(db, boundary, keyA));
+        Assert.Equal(new[] { "mission-b" }, ReadKeys(db, boundary, keyB));
+    }
+
+    private static void WriteNote(CcDirector.Gateway.Data.GatewayDatabase db, HostedTenantBoundary boundary, string deviceKey,
+        string key, string why)
+    {
+        var tenant = boundary.ResolveForDeviceKey(deviceKey);
+        Assert.NotNull(tenant);
+        using (boundary.EnterScope(tenant!.Value))
+        using (var ctx = db.CreateContext())
+        {
+            // Stamp the tenant exactly as the stores do (TenantId = ctx.ActiveTenant), driven by the scope.
+            ctx.MissionNotes.Add(new MissionNoteEntity
+            {
+                Key = key,
+                Mission = key,
+                Why = why,
+                UpdatedAtUtc = DateTime.UtcNow,
+                TenantId = ctx.ActiveTenant!,
+            });
+            ctx.SaveChanges();
+        }
+    }
+
+    private static string[] ReadKeys(CcDirector.Gateway.Data.GatewayDatabase db, HostedTenantBoundary boundary, string deviceKey)
+    {
+        var tenant = boundary.ResolveForDeviceKey(deviceKey);
+        using (boundary.EnterScope(tenant!.Value))
+        using (var ctx = db.CreateContext())
+        {
+            return ctx.MissionNotes.Select(n => n.Key).OrderBy(k => k).ToArray();
+        }
+    }
+
+    // ---- Tunnel isolation: Hello binds the tenant from the authenticated key ----------------------------
+
+    [Fact]
+    public void DirectorHub_Hello_BindsTheTenantFromTheAuthenticatedKey_AndPushesIsolate()
+    {
+        var ambient = new AsyncLocalTenantContext();
+        var devices = new DeviceRegistry(_devPath);
+        var boundary = new HostedTenantBoundary(ambient, devices);
+        var store = new PushedSessionStore(() => DateTime.UtcNow);
+
+        var tenantA = new TenantId(Guid.NewGuid().ToString());
+        var tenantB = new TenantId(Guid.NewGuid().ToString());
+        var keyA = devices.Register("dev-a", "MA").DeviceKey;
+        var keyB = devices.Register("dev-b", "MB").DeviceKey;
+        devices.SetAccountBinding("dev-a", "sub-alice", tenantA.Value);
+        devices.SetAccountBinding("dev-b", "sub-bob", tenantB.Value);
+
+        // Director A: authenticated with key A -> Hello binds tenant A -> its pushed session lands in tenant A.
+        var hubA = NewHub("conn-a", keyA, boundary, store);
+        hubA.Hello(new DirectorStreamHello { DirectorId = "dir-a", Version = "t" });
+        hubA.PushDelta(1, new SessionDto { SessionId = "sess-a" });
+
+        var hubB = NewHub("conn-b", keyB, boundary, store);
+        hubB.Hello(new DirectorStreamHello { DirectorId = "dir-b", Version = "t" });
+        hubB.PushDelta(1, new SessionDto { SessionId = "sess-b" });
+
+        // The tenant-keyed store isolates: tenant A sees only sess-a, tenant B only sess-b. Reverting the hub's
+        // ResolveConnectionTenant to a fixed tenant makes both bind the same tenant and this fails.
+        Assert.Equal(new[] { "sess-a" }, SessionIds(store, tenantA));
+        Assert.Equal(new[] { "sess-b" }, SessionIds(store, tenantB));
+    }
+
+    [Fact]
+    public void DirectorHub_Hello_Hosted_UnboundDeviceKey_IsDenied()
+    {
+        var ambient = new AsyncLocalTenantContext();
+        var devices = new DeviceRegistry(_devPath);
+        var boundary = new HostedTenantBoundary(ambient, devices);
+        var store = new PushedSessionStore(() => DateTime.UtcNow);
+
+        // An authenticated device key with NO tenant binding must be denied (deny-by-default), not defaulted.
+        var key = devices.Register("dev-x", "MX").DeviceKey;
+        var (hub, ctx) = NewHubWithContext("conn-x", key, boundary, store);
+
+        hub.Hello(new DirectorStreamHello { DirectorId = "dir-x", Version = "t" });
+
+        Assert.True(ctx.Aborted);
+    }
+
+    private DirectorHub NewHub(string connId, string deviceKey, HostedTenantBoundary boundary, PushedSessionStore store)
+        => NewHubWithContext(connId, deviceKey, boundary, store).hub;
+
+    private (DirectorHub hub, FakeHubCtx ctx) NewHubWithContext(
+        string connId, string deviceKey, HostedTenantBoundary boundary, PushedSessionStore store)
+    {
+        var http = new DefaultHttpContext();
+        http.Items[AuthMiddleware.DeviceKeyItemKey] = deviceKey;
+        var ctx = new FakeHubCtx(connId, http);
+        var registry = new DirectorRegistry(_tempDir);
+        var inputStats = new GatewayInputStatsAggregator(Path.Combine(_tempDir, $"stats-{Guid.NewGuid():N}.db"));
+        var hub = new DirectorHub(store, registry, inputStats, new GatewayStreamRegistry(), tenantBoundary: boundary)
+        {
+            Context = ctx,
+        };
+        return (hub, ctx);
+    }
+
+    private static string[] SessionIds(PushedSessionStore store, TenantId tenant)
+        => store.SnapshotFresh(tenant, TimeSpan.FromMinutes(5)).Select(x => x.Session.SessionId).OrderBy(s => s).ToArray();
+
+    private sealed class FakeHubCtx : HubCallerContext
+    {
+        public FakeHubCtx(string connectionId, HttpContext http)
+        {
+            ConnectionId = connectionId;
+            Features.Set<Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature>(new HttpContextFeatureImpl { HttpContext = http });
+        }
+
+        public override string ConnectionId { get; }
+        public override string? UserIdentifier => null;
+        public override System.Security.Claims.ClaimsPrincipal? User => null;
+        public override IDictionary<object, object?> Items { get; } = new Dictionary<object, object?>();
+        public override IFeatureCollection Features { get; } = new FeatureCollection();
+        public override System.Threading.CancellationToken ConnectionAborted => System.Threading.CancellationToken.None;
+
+        public bool Aborted { get; private set; }
+        public override void Abort() => Aborted = true;
+
+        private sealed class HttpContextFeatureImpl : Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature
+        {
+            public HttpContext? HttpContext { get; set; }
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Account/GatewayAccountFactory.cs
+++ b/src/CcDirector.Gateway/Account/GatewayAccountFactory.cs
@@ -78,7 +78,11 @@ public static class GatewayAccountFactory
             ResolveSigningSecret(),
             publicKeySetJson: DevThrottleSigningKeys.ResolvePublicKeySet(),
             expectedAudience: audience,
-            expectedIssuer: issuer);
+            expectedIssuer: issuer,
+            // ES256-ONLY: Supabase account tokens are asymmetric ES256, verified against the project's public
+            // key set. Refuse symmetric HS256, so the shared signing secret - which can be an unconfigured
+            // public placeholder - can never be used to forge an arbitrary-subject enrollment token.
+            allowSymmetricHs256: false);
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Account/GatewayAccountFactory.cs
+++ b/src/CcDirector.Gateway/Account/GatewayAccountFactory.cs
@@ -39,6 +39,48 @@ public static class GatewayAccountFactory
     /// </summary>
     public const string RefreshUrlEnvVar = GatewayHttpTokenRefresher.RefreshUrlEnvVar;
 
+    /// <summary>The environment variable overriding the expected account-token audience (Hosted Multi-Tenancy
+    /// increment 1). Unset in production; tests point it at their test audience.</summary>
+    public const string SupabaseAudienceEnvVar = "CC_GATEWAY_SUPABASE_AUDIENCE";
+
+    /// <summary>The environment variable overriding the expected account-token issuer. Unset in production;
+    /// tests point it at their test issuer.</summary>
+    public const string SupabaseIssuerEnvVar = "CC_GATEWAY_SUPABASE_ISSUER";
+
+    /// <summary>The Supabase audience (<c>aud</c>) a DevThrottle account token must carry to authorize hosted
+    /// enrollment. Supabase mints authenticated-user tokens with this audience.</summary>
+    public const string DefaultSupabaseAudience = "authenticated";
+
+    /// <summary>The Supabase issuer (<c>iss</c>) a DevThrottle account token must carry - the project's auth
+    /// endpoint (project ompujpfrglgqvqprilxa), the same project whose public key set verifies the signature.</summary>
+    public const string DefaultSupabaseIssuer = "https://ompujpfrglgqvqprilxa.supabase.co/auth/v1";
+
+    /// <summary>
+    /// Build the AUTHORIZATION-mode account-token validator used by the hosted enrollment boundary (Hosted
+    /// Multi-Tenancy increment 1). Unlike <see cref="Build"/>'s membership validator (which does not check
+    /// audience/issuer), this one is configured with the Supabase audience and issuer so
+    /// <see cref="JwtAccessTokenValidator.ValidateForAuthorization"/> enforces them and exposes the subject -
+    /// the verified account id the tenant maps from. The public key set and signing secret resolve exactly as
+    /// the membership validator's do; the audience and issuer are the Supabase defaults unless overridden for
+    /// tests. Cross-platform (no operating-system credential store involved).
+    /// </summary>
+    public static JwtAccessTokenValidator BuildAuthorizationValidator()
+    {
+        var audience = Environment.GetEnvironmentVariable(SupabaseAudienceEnvVar);
+        if (string.IsNullOrWhiteSpace(audience))
+            audience = DefaultSupabaseAudience;
+
+        var issuer = Environment.GetEnvironmentVariable(SupabaseIssuerEnvVar);
+        if (string.IsNullOrWhiteSpace(issuer))
+            issuer = DefaultSupabaseIssuer;
+
+        return new JwtAccessTokenValidator(
+            ResolveSigningSecret(),
+            publicKeySetJson: DevThrottleSigningKeys.ResolvePublicKeySet(),
+            expectedAudience: audience,
+            expectedIssuer: issuer);
+    }
+
     /// <summary>
     /// Creates the Gateway-hosted credential service on Windows, using Windows Data Protection as the
     /// credential store under the Gateway config directory. Honors the signing-secret and test-seed

--- a/src/CcDirector.Gateway/Account/GatewayAccountFactory.cs
+++ b/src/CcDirector.Gateway/Account/GatewayAccountFactory.cs
@@ -135,7 +135,14 @@ public static class GatewayAccountFactory
 
         var validator = new JwtAccessTokenValidator(
             ResolveSigningSecret(),
-            publicKeySetJson: DevThrottleSigningKeys.ResolvePublicKeySet());
+            publicKeySetJson: DevThrottleSigningKeys.ResolvePublicKeySet(),
+            // Defense in depth (Hosted Multi-Tenancy increment 2a): in HOSTED mode this account/membership
+            // validator is ES256-only too, so ANY hosted account-token authorization path - not just
+            // enrollment - refuses a symmetric HS256 token forged against the (possibly public placeholder)
+            // signing secret. Self-host is unaffected (HS256 stays allowed) so legacy non-hosted behavior does
+            // not change. The audience/issuer are unset here (this is the membership validator, not the
+            // authorization-mode enrollment validator), so this only hardens the signature-algorithm surface.
+            allowSymmetricHs256: !GatewayHostedMode.IsHosted);
         var eventLog = new AuthEventLog(authEventsLogPath);
         // Issue #640 / #876: the real Gateway-owned token refresher. It exchanges the cached refresh
         // token for a fresh pair against the embedded production backend (environment override for

--- a/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
@@ -87,18 +87,26 @@ internal static class HostedEnrollmentEndpoint
         // The device id is CLIENT-supplied, so it must NEVER be the registry key on its own: two different
         // accounts presenting the same deviceId would otherwise collide, and RegisterIfAbsent's idempotency
         // would hand one account the OTHER's key (which SetAccountBinding then rebinds to the new tenant) -
-        // letting a pre-enroller keep a key that becomes bound to the victim's tenant. Namespacing the
-        // registry id with the VERIFIED subject makes cross-account collision impossible: each account gets
-        // its own device space, so RegisterIfAbsent only ever returns THIS account's own key, and the binding
-        // is always to this account's tenant. The subject is a fixed Supabase id (prepended), so no
-        // client-supplied suffix can make one account's id collide with another's.
-        var scopedDeviceId = validation.Subject + "|" + req.DeviceId;
+        // letting a pre-enroller keep a key that becomes bound to the victim's tenant. Namespacing the registry
+        // id with a ONE-WAY HASH of the resolved tenant makes cross-account collision impossible (different
+        // accounts -> different tenants -> different hashes -> different device spaces) while staying
+        // idempotent for one account (same tenant -> same hash). The hash - not the subject and not the raw
+        // tenant id, both of which must never be logged - is what the device registry logs as the device id.
+        var scopedDeviceId = NamespaceHash(tenant.Value) + "|" + req.DeviceId;
         var response = devices.RegisterIfAbsent(scopedDeviceId, req.MachineName, req.Platform, req.DeviceType);
         devices.SetAccountBinding(scopedDeviceId, validation.Subject, tenant.Value);
 
         FileLog.Write($"[HostedEnrollment] enrolled deviceId={req.DeviceId}, machine={req.MachineName} " +
                       $"-> bound to its account tenant (no subject/email logged), deviceCount={response.DeviceCount}");
         return new EnrollResult(StatusCodes.Status200OK, response, "");
+    }
+
+    /// <summary>A one-way SHA-256 hex hash used to namespace the device registry id per tenant WITHOUT ever
+    /// putting the subject or the raw tenant id into a value the device registry logs.</summary>
+    private static string NamespaceHash(string value)
+    {
+        var bytes = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
     }
 
     private static string? ReadBearer(HttpContext ctx)

--- a/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
@@ -1,0 +1,106 @@
+using System;
+using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Pairing;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Hosted device enrollment (Hosted Multi-Tenancy increment 1): a REMOTE Director enrolls with the HOSTED
+/// Gateway by presenting its OWN verified DevThrottle (Supabase) account token, and receives a per-device
+/// key bound to that account's tenant. This is the hosted counterpart to the loopback-only, single-owner
+/// <see cref="SignedInEnrollmentEndpoint"/>: on the hosted Gateway there is NO single signed-in Gateway
+/// account, so the caller's OWN account token is the authorization, and each distinct account (subject) maps
+/// to its own tenant.
+///
+///   POST /devices/enroll-hosted
+///     Authorization: Bearer &lt;the caller's Supabase access token&gt;
+///     { deviceId, machineName, platform, deviceType }
+///   -&gt; 200 { deviceKey, ... }   mint (or return, if already present) this device's key, bound to the tenant
+///   -&gt; 400                       deviceId missing
+///   -&gt; 401                       missing / invalid / expired account token (no verified subject to bind)
+///
+/// The account token is validated (signature + expiry + audience + issuer) and its stable subject extracted;
+/// the subject maps (mint-or-lookup) to a tenant; the device is registered and bound to (subject, tenant), so
+/// the tunnel can later resolve the tenant from the SAME per-device key. The route is in the AuthMiddleware
+/// public set because it carries its OWN authorization (the account token) - a fresh remote Director has no
+/// Gateway device key yet. Security: the subject and email are personally identifying, so NEITHER is logged.
+/// </summary>
+internal static class HostedEnrollmentEndpoint
+{
+    public const string Path = "/devices/enroll-hosted";
+
+    /// <summary>The outcome of <see cref="Enroll"/>, extracted so the enrollment logic is unit-tested without a
+    /// web host. <see cref="Response"/> is set only on <see cref="Status"/> 200.</summary>
+    public sealed record EnrollResult(int Status, DeviceRegistrationResponse? Response, string Error);
+
+    public static void Map(IEndpointRouteBuilder app, DeviceRegistry devices,
+        Tenancy.TenantRegistry tenants, JwtAccessTokenValidator accountTokenValidator)
+    {
+        if (devices is null) throw new ArgumentNullException(nameof(devices));
+        if (tenants is null) throw new ArgumentNullException(nameof(tenants));
+        if (accountTokenValidator is null) throw new ArgumentNullException(nameof(accountTokenValidator));
+
+        app.MapPost(Path, (EnrollSignedInRequest req, HttpContext ctx) =>
+        {
+            var result = Enroll(ReadBearer(ctx), req, devices, tenants, accountTokenValidator);
+            return result.Status == StatusCodes.Status200OK
+                ? Results.Json(result.Response, statusCode: StatusCodes.Status200OK)
+                : Results.Json(new { error = result.Error }, statusCode: result.Status);
+        });
+    }
+
+    /// <summary>
+    /// The enrollment decision as a pure function (Hosted Multi-Tenancy increment 1), so the security-relevant
+    /// steps - validate the account token, extract the subject, map it to a tenant, bind the device - are
+    /// unit-tested without a web host. Validates the account token fully (signature + expiry + audience +
+    /// issuer); a token that is not authorization-valid or carries no subject is a 401 (no verified account to
+    /// bind). The email is display metadata only, never the mapping key. Nothing personally identifying is
+    /// logged.
+    /// </summary>
+    public static EnrollResult Enroll(string? bearer, EnrollSignedInRequest? req, DeviceRegistry devices,
+        Tenancy.TenantRegistry tenants, JwtAccessTokenValidator accountTokenValidator)
+    {
+        if (req is null || string.IsNullOrWhiteSpace(req.DeviceId))
+            return new EnrollResult(StatusCodes.Status400BadRequest, null, "deviceId is required");
+
+        if (bearer is null)
+            return new EnrollResult(StatusCodes.Status401Unauthorized, null, "an account access token is required");
+
+        var validation = accountTokenValidator.ValidateForAuthorization(bearer);
+        if (!validation.IsValid || string.IsNullOrEmpty(validation.Subject))
+        {
+            FileLog.Write("[HostedEnrollment] REJECTED: the account token is not authorization-valid (no subject to bind)");
+            return new EnrollResult(StatusCodes.Status401Unauthorized, null, "the account token is not valid");
+        }
+
+        // The email is DISPLAY METADATA only (never the mapping key). Read it from the same verified token.
+        var email = JwtIdentityReader.Read(bearer)?.Email;
+
+        // Mint-or-lookup the tenant for this verified subject (same account -> same tenant), then mint (or
+        // return) the device's per-device key and bind the device to (subject, tenant).
+        var tenant = tenants.MintOrLookupBySubject(validation.Subject, email);
+        var response = devices.RegisterIfAbsent(req.DeviceId, req.MachineName, req.Platform, req.DeviceType);
+        devices.SetAccountBinding(req.DeviceId, validation.Subject, tenant.Value);
+
+        FileLog.Write($"[HostedEnrollment] enrolled deviceId={req.DeviceId}, machine={req.MachineName} " +
+                      $"-> bound to its account tenant (no subject/email logged), deviceCount={response.DeviceCount}");
+        return new EnrollResult(StatusCodes.Status200OK, response, "");
+    }
+
+    private static string? ReadBearer(HttpContext ctx)
+    {
+        if (!ctx.Request.Headers.TryGetValue("Authorization", out var header))
+            return null;
+        var raw = header.ToString();
+        const string prefix = "Bearer ";
+        if (!raw.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return null;
+        var token = raw.Substring(prefix.Length).Trim();
+        return string.IsNullOrEmpty(token) ? null : token;
+    }
+}

--- a/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
@@ -81,11 +81,20 @@ internal static class HostedEnrollmentEndpoint
         // The email is DISPLAY METADATA only (never the mapping key). Read it from the same verified token.
         var email = JwtIdentityReader.Read(bearer)?.Email;
 
-        // Mint-or-lookup the tenant for this verified subject (same account -> same tenant), then mint (or
-        // return) the device's per-device key and bind the device to (subject, tenant).
+        // Mint-or-lookup the tenant for this verified subject (same account -> same tenant).
         var tenant = tenants.MintOrLookupBySubject(validation.Subject, email);
-        var response = devices.RegisterIfAbsent(req.DeviceId, req.MachineName, req.Platform, req.DeviceType);
-        devices.SetAccountBinding(req.DeviceId, validation.Subject, tenant.Value);
+
+        // The device id is CLIENT-supplied, so it must NEVER be the registry key on its own: two different
+        // accounts presenting the same deviceId would otherwise collide, and RegisterIfAbsent's idempotency
+        // would hand one account the OTHER's key (which SetAccountBinding then rebinds to the new tenant) -
+        // letting a pre-enroller keep a key that becomes bound to the victim's tenant. Namespacing the
+        // registry id with the VERIFIED subject makes cross-account collision impossible: each account gets
+        // its own device space, so RegisterIfAbsent only ever returns THIS account's own key, and the binding
+        // is always to this account's tenant. The subject is a fixed Supabase id (prepended), so no
+        // client-supplied suffix can make one account's id collide with another's.
+        var scopedDeviceId = validation.Subject + "|" + req.DeviceId;
+        var response = devices.RegisterIfAbsent(scopedDeviceId, req.MachineName, req.Platform, req.DeviceType);
+        devices.SetAccountBinding(scopedDeviceId, validation.Subject, tenant.Value);
 
         FileLog.Write($"[HostedEnrollment] enrolled deviceId={req.DeviceId}, machine={req.MachineName} " +
                       $"-> bound to its account tenant (no subject/email logged), deviceCount={response.DeviceCount}");

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -325,7 +325,19 @@ public sealed class GatewayHost : IAsyncDisposable
     // Hosted Gateway mission, Step 1b: the EF data layer (gateway.db). The host owns ONE instance and the
     // structured stores that have moved off hand-rolled JSON read/write through it. On the single-tenant
     // local install every row is the "local" tenant (SingleTenantContext), so behavior is unchanged.
-    private readonly Core.Tenancy.SingleTenantContext _tenantContext = new();
+    // Hosted Multi-Tenancy increment 1: the tenant context GatewayDatabase reads. On the hosted Gateway it is
+    // the AsyncLocalTenantContext (per-account, fail-closed, set at the auth boundary); on self-host it is the
+    // SingleTenantContext (always Local). Assigned in the constructor from GatewayHostedMode.IsHosted.
+    private readonly Core.Tenancy.ITenantContext _tenantContext;
+    // The concrete ambient context - non-null ONLY on the hosted Gateway - the object the auth boundaries
+    // enter per-account (and the reserved SYSTEM) scopes on. Null on self-host (Local is the ambient answer,
+    // nothing to enter). It is the SAME instance GatewayDatabase reads, so a boundary's scope is what the
+    // stores see.
+    private readonly Core.Tenancy.AsyncLocalTenantContext? _hostedTenant;
+    // The auth-boundary tenant binder (Hosted Multi-Tenancy increment 1): resolves an authenticated device
+    // key to its tenant and enters the scope. Used by the tunnel Hello and the device-key HTTP middleware.
+    // Inert on self-host (every authenticated caller is Local).
+    private readonly Tenancy.HostedTenantBoundary _tenantBoundary;
     private readonly Data.GatewayDatabase _gatewayDb;
 
     /// <summary>
@@ -616,12 +628,42 @@ public sealed class GatewayHost : IAsyncDisposable
         // migrated on open, fail-loud (no JSON fallback). The structured stores that have moved off JSON
         // (work lists, cron) read/write through it, so it is built before them. Tests get an isolated
         // database via CC_DIRECTOR_ROOT, exactly as gateway-stats.db is isolated today.
+        // Hosted Multi-Tenancy increment 1: choose the tenant context. Hosted -> the AsyncLocalTenantContext
+        // (per-account, fail-closed: a tenant-scoped op outside a resolved scope THROWS, never defaults to
+        // local); self-host -> the SingleTenantContext (always Local, unchanged). The same instance is handed
+        // to GatewayDatabase (below) and registered in DI, so a scope entered at an auth boundary is exactly
+        // what the stores read.
+        if (GatewayHostedMode.IsHosted)
+        {
+            _hostedTenant = new Core.Tenancy.AsyncLocalTenantContext();
+            _tenantContext = _hostedTenant;
+        }
+        else
+        {
+            _tenantContext = new Core.Tenancy.SingleTenantContext();
+        }
+
         _gatewayDb = new Data.GatewayDatabase(_tenantContext);
         // The account-to-tenant resolver (Hosted Multi-Tenancy increment 1): owns the tenants mapping table
         // and mints/looks up a tenant from a verified account subject. Built over the EF database; wired into
         // the hosted enrollment boundary (which validates the account token and stamps the resolved tenant on
         // the device) in the follow-up increment. Unused on the single-tenant local install.
         TenantRegistry = new Tenancy.TenantRegistry(_gatewayDb);
+        // The auth-boundary tenant binder (Hosted Multi-Tenancy increment 1): the tunnel Hello and the
+        // device-key HTTP middleware resolve a tenant from the AUTHENTICATED device key through this, and
+        // enter the scope the stores read. Inert on self-host. Built over the same _tenantContext instance
+        // the stores read (so a scope it enters is what they resolve) and the device registry.
+        _tenantBoundary = new Tenancy.HostedTenantBoundary(_tenantContext, Devices);
+        // Hosted Multi-Tenancy increment 1: the store constructors below seed built-ins and import/re-arm from
+        // the database at startup - legitimate SYSTEM operations with no per-account identity. On the hosted
+        // Gateway (fail-closed ambient tenant) they must run inside the reserved SYSTEM scope, or the very
+        // first construction-time read/write would fail closed at boot. On self-host _hostedTenant is null and
+        // this is a no-op (SingleTenantContext already answers Local). The scope is disposed in the finally so
+        // a construction fault cannot leak it, and so per-account and per-request scopes (never SYSTEM) govern
+        // everything after startup.
+        var startupSystemScope = _hostedTenant?.Enter(Core.Tenancy.TenantId.System);
+        try
+        {
         // Named work lists persist across a Gateway restart (issue #301) in the worklists table (stale
         // claims released on load). The path argument is the LEGACY worklists.json, imported once on first
         // upgrade then renamed aside. Tests MUST pass an isolated path so they never touch the real legacy file.
@@ -715,6 +757,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // path the work-list runner uses). The background sweep timer is started in StartAsync. The path
         // argument is the LEGACY cronruns.json, imported once then renamed aside.
         _cronRuns = new CronRunHistoryStore(_gatewayDb, cronRunsPath ?? Path.Combine(CcStorage.Root(), "cronruns.json"));
+        }
+        finally
+        {
+            startupSystemScope?.Dispose();
+        }
         // The Gateway-hosted DevThrottle credential service (issue #636, Gateway Centralization Phase 2
         // foundation). Tests inject their own service over an isolated store; production builds the
         // service over the operating system credential store rooted under the Gateway config directory:
@@ -1288,9 +1335,13 @@ public sealed class GatewayHost : IAsyncDisposable
         builder.Services.AddSingleton(SnoozeLandings);
         builder.Services.AddSingleton(FleetRoles);
         builder.Services.AddSingleton(FleetDisplayState);
-        // Register the tenancy seam. The core ships the single-tenant default (everything resolves to
-        // TenantId.Local), so behavior is unchanged; a resolver can replace this behind the same interface.
-        builder.Services.AddSingleton<CcDirector.Core.Tenancy.ITenantContext, CcDirector.Core.Tenancy.SingleTenantContext>();
+        // Register the tenancy seam as the SAME instance GatewayDatabase reads (Hosted Multi-Tenancy
+        // increment 1), so a scope a SignalR-hosted boundary enters is exactly what the stores resolve. On
+        // self-host this is the SingleTenantContext (always Local); on hosted it is the AsyncLocalTenantContext.
+        builder.Services.AddSingleton<CcDirector.Core.Tenancy.ITenantContext>(_tenantContext);
+        // The auth-boundary tenant binder, so the SignalR-constructed DirectorHub resolves a tenant from the
+        // authenticated device key at Hello and enters that scope on every push (Hosted Multi-Tenancy incr 1).
+        builder.Services.AddSingleton(_tenantBoundary);
         builder.Services.AddSingleton(SessionConcurrency);
         builder.Services.AddSingleton(Registry);
         // launcher-persistent-join: the LauncherHub (constructed per-invocation by SignalR) and
@@ -1372,6 +1423,31 @@ public sealed class GatewayHost : IAsyncDisposable
             // sign-in - see SignedInEnrollmentEndpoint).
             var requireToken = new AuthMiddleware.RequireToken { Token = Token, Devices = Devices };
             _app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, requireToken, next));
+        }
+
+        // Hosted Multi-Tenancy increment 1: the device-key HTTP boundary. After auth, resolve this request's
+        // tenant from the AUTHENTICATED device key the auth middleware stashed, and enter that scope for the
+        // rest of the pipeline, so tenant-scoped stores read the caller's tenant - derived from the verified
+        // credential, never from client input. Only device-key-authenticated requests carry a key; a
+        // shared-token or public request enters no scope, so any tenant-scoped store access it makes fails
+        // closed on hosted (deny-by-default), while non-tenant endpoints (enrollment, health) still work.
+        // Registered only on the hosted Gateway; on self-host Local is the ambient answer (nothing to enter).
+        if (_tenantBoundary.IsHosted)
+        {
+            _app.Use(async (ctx, next) =>
+            {
+                var key = ctx.Items.TryGetValue(AuthMiddleware.DeviceKeyItemKey, out var k) ? k as string : null;
+                var tenant = key is null ? (Core.Tenancy.TenantId?)null : _tenantBoundary.ResolveForDeviceKey(key);
+                if (tenant is { } resolved)
+                {
+                    using (_tenantBoundary.EnterScope(resolved))
+                        await next();
+                }
+                else
+                {
+                    await next();
+                }
+            });
         }
 
         // Mobile front door (issue #806, docs/architecture/mobile/): a phone browser-navigation
@@ -1616,6 +1692,16 @@ public sealed class GatewayHost : IAsyncDisposable
         // a co-located Director mints its own per-device key by having the Gateway signed in to
         // DevThrottle, gated on a loopback caller. Same-machine only; remote via tailnet is a follow-up.
         Api.SignedInEnrollmentEndpoint.Map(_app, Devices, SignIn, _childMirror);
+
+        // POST /devices/enroll-hosted (Hosted Multi-Tenancy increment 1): the HOSTED counterpart - a REMOTE
+        // Director enrolls by presenting its OWN verified Supabase account token; the Gateway validates it,
+        // resolves the account's tenant, and binds the minted device key to it. Only mapped on the hosted
+        // Gateway (self-host uses the loopback signed-in route above and stays single-tenant Local).
+        if (GatewayHostedMode.IsHosted)
+        {
+            Api.HostedEnrollmentEndpoint.Map(_app, Devices, TenantRegistry,
+                CcDirector.Gateway.Account.GatewayAccountFactory.BuildAuthorizationValidator());
+        }
 
         // Wingman-voice surface for the Cockpit's Voice tab (issue #531): drive one turn of a
         // session and have the persistent wingman brain translate the reply into speakable form,

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -3,6 +3,8 @@ using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
 using CcDirector.Gateway.Stats;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Util;
 using Microsoft.AspNetCore.SignalR;
 
 namespace CcDirector.Gateway.Streaming;
@@ -36,10 +38,15 @@ public sealed class DirectorHub : Hub
     private readonly Snooze.SnoozeLandingObserver? _snoozeLandings;
     private readonly Fleet.FleetRoleObserver? _fleetRoles;
     private readonly Fleet.FleetDisplayStateObserver? _fleetDisplayState;
+    // Hosted Multi-Tenancy increment 1: resolves THIS connection's tenant from the authenticated device key
+    // at Hello and enters that tenant's scope on every push (so the EF-writing observers stamp the right
+    // tenant). Null for older callers/tests -> the self-host Local behavior, unchanged.
+    private readonly HostedTenantBoundary? _tenantBoundary;
 
     public DirectorHub(PushedSessionStore store, DirectorRegistry registry, GatewayInputStatsAggregator inputStats,
         GatewayStreamRegistry streamRegistry, Snooze.SnoozeLandingObserver? snoozeLandings = null,
-        Fleet.FleetRoleObserver? fleetRoles = null, Fleet.FleetDisplayStateObserver? fleetDisplayState = null)
+        Fleet.FleetRoleObserver? fleetRoles = null, Fleet.FleetDisplayStateObserver? fleetDisplayState = null,
+        HostedTenantBoundary? tenantBoundary = null)
     {
         _store = store;
         _registry = registry;
@@ -48,6 +55,7 @@ public sealed class DirectorHub : Hub
         _snoozeLandings = snoozeLandings;
         _fleetRoles = fleetRoles;
         _fleetDisplayState = fleetDisplayState;
+        _tenantBoundary = tenantBoundary;
     }
 
     /// <summary>
@@ -84,11 +92,19 @@ public sealed class DirectorHub : Hub
             return;
         }
 
+        // Hosted Multi-Tenancy increment 1: resolve the tenant this connection belongs to ONCE, here at bind
+        // time, from the AUTHENTICATED device key the auth layer stashed on the negotiate request - NEVER from
+        // the Hello payload. On self-host (or no boundary) this is Local, unchanged. On hosted a device key
+        // with no bound tenant is a DENY: abort rather than bind a wrong or defaulted tenant (deny-by-default).
+        // THIS resolution is the isolation line - reverting it to a fixed tenant makes two accounts share one.
+        var resolved = ResolveConnectionTenant();
+        if (resolved is not { } tenant)
+        {
+            FileLog.Write($"[DirectorHub] Hello REJECTED (hosted: the authenticated device key resolves to no tenant): conn={Short(Context.ConnectionId)}");
+            Context.Abort();
+            return;
+        }
         Context.Items[DirectorIdItemKey] = directorId;
-        // Stage 3b: resolve the tenant this Director's connection belongs to, ONCE, here at bind time, and
-        // carry it on the connection like the directorId. The single-tenant core resolves to Local; the
-        // resolver (Stage 3c) supplies the real tenant from the Director's device key at exactly this point.
-        var tenant = TenantId.Local;
         Context.Items[TenantIdItemKey] = tenant;
         _store.RegisterConnection(tenant, directorId, Context.ConnectionId);
         // Gateway Cleanup mission (tunnel-only): the stream IS the registration now (HTTP register is gone).
@@ -102,6 +118,9 @@ public sealed class DirectorHub : Hub
     public void PushSnapshot(long sequence, SessionDto[] sessions)
     {
         var directorId = RequireBoundDirector();
+        // Hosted Multi-Tenancy increment 1: run the whole handler in the bound tenant's scope, so the
+        // EF-writing observers below (snooze landings, spend) stamp and filter by this connection's tenant.
+        using var tenantScope = EnterBoundTenantScope();
         var set = sessions ?? Array.Empty<SessionDto>();
         var accepted = _store.ApplySnapshot(RequireBoundTenant(), directorId, Context.ConnectionId, sequence, set);
         // DevThrottle Stats: fold each session's input tally into the always-available aggregate.
@@ -136,6 +155,9 @@ public sealed class DirectorHub : Hub
             FileLog.Write($"[DirectorHub] PushDelta ignored (no session id): director={directorId}, conn={Short(Context.ConnectionId)}");
             return;
         }
+        // Hosted Multi-Tenancy increment 1: run the handler in the bound tenant's scope (the landing seam
+        // below writes the snooze/spend EF stores, which must stamp and filter by this connection's tenant).
+        using var tenantScope = EnterBoundTenantScope();
         var accepted = _store.ApplyDelta(RequireBoundTenant(), directorId, Context.ConnectionId, sequence, session);
         // DevThrottle Stats: fold this session's tally into the always-available aggregate.
         _inputStats.Observe(session);
@@ -168,6 +190,9 @@ public sealed class DirectorHub : Hub
             FileLog.Write($"[DirectorHub] RemoveSession ignored (no session id): director={directorId}, conn={Short(Context.ConnectionId)}");
             return;
         }
+        // Hosted Multi-Tenancy increment 1: scope the handler to the bound tenant (the removal re-folds and
+        // can touch tenant-scoped state through the observers below).
+        using var tenantScope = EnterBoundTenantScope();
         _store.ApplyRemove(RequireBoundTenant(), directorId, Context.ConnectionId, sequence, sessionId);
         // DevThrottle Stats: its contribution stays in the totals; drop only its high-water entry.
         _inputStats.Forget(sessionId);
@@ -201,6 +226,34 @@ public sealed class DirectorHub : Hub
         }
         FileLog.Write($"[DirectorHub] disconnected: conn={Short(Context.ConnectionId)}, director={directorId ?? "(unbound)"} ({exception?.Message ?? "clean"})");
         return base.OnDisconnectedAsync(exception);
+    }
+
+    /// <summary>
+    /// Resolve this connection's tenant from the AUTHENTICATED device key the auth layer stashed on the
+    /// negotiate request, via the hosted tenant boundary - NEVER from the Hello payload. Self-host (or no
+    /// boundary) resolves to Local, unchanged. Hosted resolves to the key's bound tenant, or null (a DENY)
+    /// when the key has no binding. This is the isolation resolution the whole design rests on.
+    /// </summary>
+    private TenantId? ResolveConnectionTenant()
+    {
+        if (_tenantBoundary is null)
+            return TenantId.Local;
+
+        var key = Context.GetHttpContext()?.Items.TryGetValue(AuthMiddleware.DeviceKeyItemKey, out var value) == true
+            ? value as string
+            : null;
+        return _tenantBoundary.ResolveForDeviceKey(key);
+    }
+
+    /// <summary>Enter the bound tenant's scope for the duration of a push handler, so the EF-writing observers
+    /// stamp the right tenant. A no-op on self-host (Local is ambient) or when there is no boundary.</summary>
+    private IDisposable EnterBoundTenantScope() =>
+        _tenantBoundary is null ? NoScope.Instance : _tenantBoundary.EnterScope(RequireBoundTenant());
+
+    private sealed class NoScope : IDisposable
+    {
+        public static readonly NoScope Instance = new();
+        public void Dispose() { }
     }
 
     private string? BoundDirectorId() =>

--- a/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
+++ b/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
@@ -81,7 +81,7 @@ public sealed class PushedSessionStore
             entry.ActiveConnectionId = connectionId;
             entry.LastSequence = -1;
         }
-        FileLog.Write($"[PushedSessionStore] RegisterConnection: tenant={tenant}, director={directorId}, conn={Short(connectionId)} is now the active connection");
+        FileLog.Write($"[PushedSessionStore] RegisterConnection: tenant={tenant.ToLogString()}, director={directorId}, conn={Short(connectionId)} is now the active connection");
     }
 
     /// <summary>
@@ -105,12 +105,12 @@ public sealed class PushedSessionStore
         {
             if (!string.Equals(entry.ActiveConnectionId, connectionId, StringComparison.Ordinal))
             {
-                FileLog.Write($"[PushedSessionStore] UnregisterConnection IGNORED (not active): tenant={tenant}, director={directorId}, conn={Short(connectionId)}, active={Short(entry.ActiveConnectionId)}");
+                FileLog.Write($"[PushedSessionStore] UnregisterConnection IGNORED (not active): tenant={tenant.ToLogString()}, director={directorId}, conn={Short(connectionId)}, active={Short(entry.ActiveConnectionId)}");
                 return false;
             }
             entry.ActiveConnectionId = null;
         }
-        FileLog.Write($"[PushedSessionStore] UnregisterConnection: tenant={tenant}, director={directorId}, conn={Short(connectionId)} cleared; aggregation will fall back to pull");
+        FileLog.Write($"[PushedSessionStore] UnregisterConnection: tenant={tenant.ToLogString()}, director={directorId}, conn={Short(connectionId)} cleared; aggregation will fall back to pull");
         return true;
     }
 
@@ -329,12 +329,12 @@ public sealed class PushedSessionStore
     {
         if (!string.Equals(entry.ActiveConnectionId, connectionId, StringComparison.Ordinal))
         {
-            FileLog.Write($"[PushedSessionStore] {kind} DROPPED (not the active connection): tenant={tenant}, director={directorId}, conn={Short(connectionId)}, active={Short(entry.ActiveConnectionId)}");
+            FileLog.Write($"[PushedSessionStore] {kind} DROPPED (not the active connection): tenant={tenant.ToLogString()}, director={directorId}, conn={Short(connectionId)}, active={Short(entry.ActiveConnectionId)}");
             return false;
         }
         if (sequence <= entry.LastSequence)
         {
-            FileLog.Write($"[PushedSessionStore] {kind} DROPPED (stale sequence {sequence} <= last {entry.LastSequence}): tenant={tenant}, director={directorId}, conn={Short(connectionId)}");
+            FileLog.Write($"[PushedSessionStore] {kind} DROPPED (stale sequence {sequence} <= last {entry.LastSequence}): tenant={tenant.ToLogString()}, director={directorId}, conn={Short(connectionId)}");
             return false;
         }
         return true;

--- a/src/CcDirector.Gateway/Tenancy/HostedTenantBoundary.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedTenantBoundary.cs
@@ -1,0 +1,63 @@
+using System;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Pairing;
+
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// The auth-boundary tenant binder (Hosted Multi-Tenancy increment 1). It is the ONE place a boundary - the
+/// Director tunnel's <c>Hello</c> and the device-key HTTP middleware - turns an AUTHENTICATED per-device key
+/// into the tenant the stores resolve. The tenant is derived ONLY from the verified device key's binding
+/// (<see cref="DeviceRegistry.TenantForKey"/>), never from anything the client claims in a payload.
+///
+/// On the hosted Gateway it enters the <see cref="AsyncLocalTenantContext"/>; on self-host it is inert (the
+/// <see cref="SingleTenantContext"/> already answers <see cref="TenantId.Local"/>, so there is nothing to
+/// enter and every authenticated caller is the single Local tenant). DENY-BY-DEFAULT: on hosted, a key with
+/// no bound tenant resolves to null and the caller MUST deny - it never falls back to Local or to the
+/// reserved SYSTEM tenant.
+/// </summary>
+public sealed class HostedTenantBoundary
+{
+    // Non-null ONLY on the hosted Gateway (the ITenantContext is the AsyncLocalTenantContext there). Null on
+    // self-host, which is how IsHosted and the inert behavior are decided - no separate flag to drift.
+    private readonly AsyncLocalTenantContext? _ambient;
+    private readonly DeviceRegistry _devices;
+
+    public HostedTenantBoundary(ITenantContext tenantContext, DeviceRegistry devices)
+    {
+        _ambient = tenantContext as AsyncLocalTenantContext;
+        _devices = devices ?? throw new ArgumentNullException(nameof(devices));
+    }
+
+    /// <summary>True on the hosted Gateway (per-account, fail-closed); false on self-host (always Local).</summary>
+    public bool IsHosted => _ambient is not null;
+
+    /// <summary>
+    /// Resolve the tenant for an AUTHENTICATED device key. On self-host every authenticated caller is the one
+    /// Local tenant. On hosted the tenant is the key's binding, or NULL when the key is null/blank or has no
+    /// bound tenant - a null is a DENY (never Local, never SYSTEM). The key must already have been proven
+    /// valid by the auth layer; this only maps a proven key to its tenant.
+    /// </summary>
+    public TenantId? ResolveForDeviceKey(string? deviceKey)
+    {
+        if (_ambient is null)
+            return TenantId.Local;
+
+        var bound = _devices.TenantForKey(deviceKey);
+        return string.IsNullOrEmpty(bound) ? (TenantId?)null : new TenantId(bound);
+    }
+
+    /// <summary>
+    /// Enter the scope for an already-resolved tenant (e.g. the tunnel's Hello-bound tenant on each push, or a
+    /// resolved HTTP request). On self-host this is a no-op (Local is the ambient answer); on hosted it enters
+    /// the ambient scope. The caller must have resolved a valid tenant first (the deny happened at resolution).
+    /// </summary>
+    public IDisposable EnterScope(TenantId tenant)
+        => _ambient is null ? NoOpDisposable.Instance : _ambient.Enter(tenant);
+
+    private sealed class NoOpDisposable : IDisposable
+    {
+        public static readonly NoOpDisposable Instance = new();
+        public void Dispose() { }
+    }
+}

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -58,6 +58,16 @@ internal static class AuthMiddleware
     public const string DeviceTypeItemKey = "cc.stats.DeviceType";
 
     /// <summary>
+    /// HttpContext.Items key under which <see cref="HasValidToken"/> stashes the per-device key that
+    /// authenticated the request, or leaves absent when the caller used the shared machine token (no device).
+    /// The hosted tenant boundary (Hosted Multi-Tenancy increment 1) reads it to resolve the request's tenant
+    /// from the SAME verified key that authenticated the call - the tenant is derived from the authenticated
+    /// credential, never from anything the client claims. The key is already present in the request headers,
+    /// so stashing it in request-scoped Items exposes nothing new.
+    /// </summary>
+    public const string DeviceKeyItemKey = "cc.auth.DeviceKey";
+
+    /// <summary>
     /// The desktop Cockpit's sign-in route (issue #1088): the shared client-core enrollment screen a
     /// signed-out browser navigation is redirected to. Must match the route in apps/cockpit/src/main.tsx.
     /// </summary>
@@ -92,6 +102,11 @@ internal static class AuthMiddleware
         // tailnet/LAN attacker gains nothing), the Gateway signed in (409 otherwise), and an idempotent
         // mint (the #1136 leak guard). Loopback = same machine = already inside the trust boundary.
         "/devices/enroll-signed-in",
+        // Hosted Multi-Tenancy increment 1: the hosted enrollment front door. A fresh REMOTE Director has no
+        // Gateway device key yet, so it cannot pass the token gate; this route carries its OWN authorization -
+        // the caller's verified Supabase ACCOUNT token, which the endpoint validates itself (aud/iss/sig/exp)
+        // before minting a device key. It is exact-match public, exactly like the loopback enroll route above.
+        Api.HostedEnrollmentEndpoint.Path,
         // Issue #1076 (epic #1069): the credential-free cloud sign-in START front door. A signed-out
         // browser must reach this to BEGIN cloud sign-in, so it cannot sit behind the raw-token wall
         // (that is the deadlock the epic breaks). It is exact-match, so ONLY /account/sign-in-start is
@@ -211,6 +226,9 @@ internal static class AuthMiddleware
                 if (deviceType is not null)
                 {
                     ctx.Items[DeviceTypeItemKey] = deviceType;
+                    // Hosted Multi-Tenancy increment 1: stash the authenticated key so the tenant boundary can
+                    // resolve this request's tenant from the same verified credential.
+                    ctx.Items[DeviceKeyItemKey] = provided;
                     return true;
                 }
             }
@@ -235,6 +253,9 @@ internal static class AuthMiddleware
             if (cookieDeviceType is not null)
             {
                 ctx.Items[DeviceTypeItemKey] = cookieDeviceType;
+                // Hosted Multi-Tenancy increment 1: same authenticated-key stash as the Bearer branch (the
+                // live terminal stream authenticates via this cookie).
+                ctx.Items[DeviceKeyItemKey] = cookieValue;
                 return true;
             }
         }


### PR DESCRIPTION
## What

Increment 2a of the Hosted Multi-Tenancy mission: the hosted Gateway now resolves each connection's tenant from its VERIFIED account and isolates every account's data. Two different accounts get their own tenant id and cannot see each other's rows.

Follows the merged foundation (#1833). This is the revert-provable activation slice; the residual non-account paths (cron, remaining stores) are wired to fail-closed in **2b**, which makes the hosted Gateway deployable. **2a is deliberately NOT deployable alone** — it fails closed on the not-yet-wired paths. The live psql two-account run happens after 2b on the fully-wired build.

## Changes

- **`TenantId.System`** — a reserved, well-known tenant for the Gateway's legitimate non-account writes (startup / built-in seeding). Distinct from `local` (self-host) and from every real account; isolated by the same query filter. Reached ONLY by explicitly-system code — never the answer to "no tenant resolved".
- **`AsyncLocalTenantContext`** — the hosted tenant context. Resolves the unit of work's tenant from an ambient scope a boundary enters, and **fails closed (throws) when no scope is in effect** — deny-by-default, never a defaulted tenant.
- **GatewayHost** — hosted selects the ambient context (self-host keeps single-tenant `Local`); startup store construction runs in an explicit **SYSTEM scope** so the gateway boots fail-closed; the ambient context is the **same instance** the stores read.
- **`HostedTenantBoundary`** — the one place a boundary turns an AUTHENTICATED device key into a tenant. `DirectorHub.Hello` resolves the connection's tenant from the device key the auth layer stashed (never from the Hello payload), and **denies the connection** when a key has no bound tenant. A device-key HTTP middleware scopes each request the same way.
- **`POST /devices/enroll-hosted`** — a remote Director enrolls with its own Supabase account token; the Gateway validates it (signature + expiry + audience + issuer), maps the subject to a tenant, and returns a per-device key bound to it. Subject and email are never logged. (`Enroll` is extracted as a pure function for unit testing.)

## Proof

- **Two-account isolation** at both the EF-store and tunnel levels (`HostedTenancyActivationTests`, 6).
- **Revert-proven on the real lines:** reverting `DirectorHub.Hello`'s resolution → tenant A's snapshot comes back empty (RED); reverting `HostedTenantBoundary.ResolveForDeviceKey` → tenant A sees both accounts' rows (RED); both restored to green.
- **Enrollment** with a real ES256-signed token through the production validator: valid → device key bound to the account tenant; wrong `iss`/`aud` → 401; same account's second device → same tenant (`HostedEnrollmentEndpointTests`, 7).
- **Deny-by-default:** an unbound device key at `Hello` aborts the connection; the ambient context's fail-closed + scope-flow contract (`AsyncLocalTenantContextTests`).
- **Regression:** Core 3283/0, Gateway 2842/0 (10 Postgres-only skips), existing `DirectorHubTests` 12/0.