### PR TITLE
feat(core): a gateway-less Director keeps and reads its own account credential

### DIFF
--- a/src/CcDirector.Avalonia/App.axaml.cs
+++ b/src/CcDirector.Avalonia/App.axaml.cs
@@ -258,17 +258,16 @@ public partial class App : Application
         UpdateSplashStatus(splash, "Checking account...");
         try
         {
-            if (DevThrottleCredentialMigration.ShouldDeleteDirectorCredential(GatewayConfig.Load()))
+            var outcome = DevThrottleCredentialMigration.RunStartupMigration(GatewayConfig.Load());
+            log(outcome switch
             {
-                var deleted = DevThrottleCredentialMigration.DeleteStaleDirectorCredential();
-                log(deleted
-                    ? "DevThrottle credential migration: deleted a stale Director credential blob (Gateway is the authority now, issue #642)"
-                    : "DevThrottle credential migration: no stale Director credential blob to delete (issue #642)");
-            }
-            else
-            {
-                log("DevThrottle credential migration: no gateway configured -> keeping the Director's own credential (Slice A exception to issue #642 for a gateway-less Director)");
-            }
+                DirectorCredentialStartupOutcome.DeletedStaleBlob =>
+                    "DevThrottle credential migration: deleted a stale Director credential blob (Gateway is the authority now, issue #642)",
+                DirectorCredentialStartupOutcome.NoBlobToDelete =>
+                    "DevThrottle credential migration: no stale Director credential blob to delete (issue #642)",
+                _ =>
+                    "DevThrottle credential migration: no gateway configured -> keeping the Director's own credential (Slice A exception to issue #642 for a gateway-less Director)",
+            });
         }
         catch (Exception ex)
         {

--- a/src/CcDirector.Avalonia/App.axaml.cs
+++ b/src/CcDirector.Avalonia/App.axaml.cs
@@ -249,22 +249,30 @@ public partial class App : Application
         WorkspaceStore = new WorkspaceStore();
         log("Workspace store initialized");
 
-        // Gateway Centralization Phase 2 migration (issue #642): the Gateway is the single account
-        // authority, so the Director holds NO credential of its own (issue #651: the Director no longer
-        // builds a local credential service or startup gate at all). Delete any stale local credential
-        // blob an older build left behind, with a log line. A failure here only logs (it must never
-        // block startup).
+        // Gateway Centralization Phase 2 migration (issue #642), with the two-step install exception
+        // (Slice A): the deletion of the Director's own credential blob is GATED on gateway presence.
+        // With a gateway configured the Gateway is the single account authority (issue #651) and the
+        // Director copy is genuinely stale, so it is deleted exactly as before. With NO gateway the
+        // Director blob is the LIVE credential a gateway-less Director legitimately keeps, so it is kept.
+        // A failure here only logs (it must never block startup).
         UpdateSplashStatus(splash, "Checking account...");
         try
         {
-            var deleted = DevThrottleCredentialMigration.DeleteStaleDirectorCredential();
-            log(deleted
-                ? "DevThrottle credential migration: deleted a stale Director credential blob (Gateway is the authority now, issue #642)"
-                : "DevThrottle credential migration: no stale Director credential blob to delete (issue #642)");
+            if (DevThrottleCredentialMigration.ShouldDeleteDirectorCredential(GatewayConfig.Load()))
+            {
+                var deleted = DevThrottleCredentialMigration.DeleteStaleDirectorCredential();
+                log(deleted
+                    ? "DevThrottle credential migration: deleted a stale Director credential blob (Gateway is the authority now, issue #642)"
+                    : "DevThrottle credential migration: no stale Director credential blob to delete (issue #642)");
+            }
+            else
+            {
+                log("DevThrottle credential migration: no gateway configured -> keeping the Director's own credential (Slice A exception to issue #642 for a gateway-less Director)");
+            }
         }
         catch (Exception ex)
         {
-            log($"DevThrottle credential migration FAILED (ignored, the Director holds no credential regardless): {ex.Message}");
+            log($"DevThrottle credential migration FAILED (ignored, startup must not block): {ex.Message}");
         }
 
         UpdateSplashStatus(splash, "Starting engine...");

--- a/src/CcDirector.Avalonia/SettingsDialog.axaml
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml
@@ -124,7 +124,7 @@
                             <StackPanel Spacing="8">
                                 <TextBlock Classes="sectionTitle" Margin="0" Text="DevThrottle account" />
                                 <TextBlock Classes="hint"
-                                           Text="Your account is managed by your Gateway. This Director no longer signs in or out on its own - sign-in, identity, and the usage-sharing choice are handled centrally by the Gateway your Directors connect to. This panel just shows what the Gateway reports." />
+                                           Text="When this Director is connected to a Gateway, your account is managed there - sign-in, identity, and the usage-sharing choice are handled centrally by the Gateway. With no Gateway connected, this panel shows this Director's own DevThrottle sign-in. Either way it is informational; manage the connection and sign-in from the Gateway tab." />
 
                                 <Grid ColumnDefinitions="110,*" Margin="0,8,0,0" RowDefinitions="Auto,Auto">
                                     <TextBlock Grid.Row="0" Grid.Column="0" Classes="fieldLabel" Text="Gateway" VerticalAlignment="Center" />

--- a/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
@@ -150,9 +150,16 @@ public partial class SettingsDialog : Window
 
         if (!configured)
         {
-            // No Gateway configured: there is nothing to read an identity from. This is informational,
-            // never a gate - the Director still runs.
-            GatewayIdentityText.Text = "No Gateway configured. Connect this Director to a Gateway on the Gateway tab.";
+            // No gateway configured: this is the Director's OWN local account state, so the Director
+            // decides it (there is no Gateway to rule it; two-step install, Slice A). Ask the local
+            // account-state provider and render its verdict verbatim - a gateway-less Director that holds
+            // its own credential now reads "Signed in to DevThrottle - connect a gateway to use AI"
+            // instead of the old blanket "No Gateway configured." On a non-Windows host there is no
+            // per-user DPAPI credential store, so it is treated as not signed in locally.
+            var localState = OperatingSystem.IsWindows()
+                ? DirectorAccountStateProvider.ResolveForWindows(new GatewayConfig { Url = gatewayUrl })
+                : DirectorAccountState.NotSignedIn;
+            GatewayIdentityText.Text = DirectorAccountStateProvider.DescribeNoGateway(localState);
             return;
         }
 

--- a/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
@@ -151,15 +151,12 @@ public partial class SettingsDialog : Window
         if (!configured)
         {
             // No gateway configured: this is the Director's OWN local account state, so the Director
-            // decides it (there is no Gateway to rule it; two-step install, Slice A). Ask the local
-            // account-state provider and render its verdict verbatim - a gateway-less Director that holds
-            // its own credential now reads "Signed in to DevThrottle - connect a gateway to use AI"
-            // instead of the old blanket "No Gateway configured." On a non-Windows host there is no
-            // per-user DPAPI credential store, so it is treated as not signed in locally.
-            var localState = OperatingSystem.IsWindows()
-                ? DirectorAccountStateProvider.ResolveForWindows(new GatewayConfig { Url = gatewayUrl })
-                : DirectorAccountState.NotSignedIn;
-            GatewayIdentityText.Text = DirectorAccountStateProvider.DescribeNoGateway(localState);
+            // decides it (there is no Gateway to rule it; two-step install, Slice A). Render the provider
+            // verdict verbatim - a gateway-less Director that holds its own credential now reads "Signed
+            // in to DevThrottle - connect a gateway to use AI" instead of the old blanket "No Gateway
+            // configured." The read is scoped so a failure reading the local credential degrades ONLY
+            // this identity line and never takes down the Settings dialog (see ResolveLocalAccountLine).
+            GatewayIdentityText.Text = ResolveLocalAccountLine(gatewayUrl);
             return;
         }
 
@@ -169,6 +166,31 @@ public partial class SettingsDialog : Window
         // signed-out states are surfaced as plain text on the identity line, never as a blocking error.
         var config = new GatewayConfig { Url = gatewayUrl, Token = gatewayToken };
         _ = LoadGatewayIdentityAsync(config);
+    }
+
+    /// <summary>
+    /// The Director's OWN local account line when no gateway is configured (two-step install, Slice A):
+    /// the provider decides the state and this returns the verbatim string for it. The read is SCOPED -
+    /// any failure reading the local credential store degrades this one informational line to a safe
+    /// message and is logged, so a corrupt or wrong-user Director credential can never take down the
+    /// Settings dialog (responsive-UI rule). This is not a problem-hiding fallback: the failure is logged
+    /// and the line says the status is unavailable, while the dialog stays usable. On a non-Windows host
+    /// there is no per-user Data Protection store, so it reads as not signed in locally.
+    /// </summary>
+    private static string ResolveLocalAccountLine(string gatewayUrl)
+    {
+        try
+        {
+            var state = OperatingSystem.IsWindows()
+                ? DirectorAccountStateProvider.ResolveForWindows(new GatewayConfig { Url = gatewayUrl })
+                : DirectorAccountState.NotSignedIn;
+            return DirectorAccountStateProvider.DescribeNoGateway(state);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SettingsDialog] ResolveLocalAccountLine: could not read the local Director account state -> degrading this identity line only (dialog stays usable): {ex.Message}");
+            return "Account status unavailable. This Director is running; connect a Gateway on the Gateway tab.";
+        }
     }
 
     /// <summary>

--- a/src/CcDirector.Core.Tests/Account/DevThrottleCredentialMigrationTests.cs
+++ b/src/CcDirector.Core.Tests/Account/DevThrottleCredentialMigrationTests.cs
@@ -1,4 +1,5 @@
 using CcDirector.Core.Account;
+using CcDirector.Core.Configuration;
 using Xunit;
 
 namespace CcDirector.Core.Tests.Account;
@@ -65,6 +66,61 @@ public sealed class DevThrottleCredentialMigrationTests : IDisposable
 
         Assert.True(first);
         Assert.False(second);
+        Assert.False(File.Exists(_blobPath));
+    }
+
+    // --- Two-step install, Slice A: the delete is GATED on gateway presence -------------------------
+
+    // The gate decision itself: with no gateway configured (IsEnabled == false) the Director keeps its
+    // own credential, so the migration must NOT delete it. This is the production method App.axaml.cs
+    // calls; making it return true unconditionally reds the "blob kept when no gateway" seam test below.
+    [Fact]
+    public void ShouldDeleteDirectorCredential_NoGatewayConfigured_ReturnsFalse()
+    {
+        var config = new GatewayConfig { Url = "" };
+        Assert.False(config.IsEnabled);
+
+        Assert.False(DevThrottleCredentialMigration.ShouldDeleteDirectorCredential(config));
+    }
+
+    // The gate decision: with a gateway configured (IsEnabled == true) the Gateway is the account
+    // authority and the stale Director copy must still be deleted (issue #642/#651 unchanged).
+    [Fact]
+    public void ShouldDeleteDirectorCredential_GatewayConfigured_ReturnsTrue()
+    {
+        var config = new GatewayConfig { Url = "https://gateway.example.com" };
+        Assert.True(config.IsEnabled);
+
+        Assert.True(DevThrottleCredentialMigration.ShouldDeleteDirectorCredential(config));
+    }
+
+    // Revert-proof #1 (the seam): reproduce the exact startup decision - "if
+    // ShouldDeleteDirectorCredential(config) then DeleteStaleDirectorCredential(blob)" - and prove that
+    // with NO gateway a present Director blob is KEPT. Reverting the production
+    // ShouldDeleteDirectorCredential to => true reds this test.
+    [Fact]
+    public void StartupDecision_NoGateway_KeepsPresentDirectorBlob()
+    {
+        File.WriteAllBytes(_blobPath, new byte[] { 1, 2, 3, 4 });
+        var config = new GatewayConfig { Url = "" };
+
+        if (DevThrottleCredentialMigration.ShouldDeleteDirectorCredential(config))
+            DevThrottleCredentialMigration.DeleteStaleDirectorCredential(_blobPath);
+
+        Assert.True(File.Exists(_blobPath));
+    }
+
+    // Control (Manager point #3): the gateway-PRESENT path still deletes the stale Director blob, so the
+    // #642/#651 authority behavior is provably NOT broken by the gate.
+    [Fact]
+    public void StartupDecision_GatewayPresent_DeletesStaleDirectorBlob()
+    {
+        File.WriteAllBytes(_blobPath, new byte[] { 1, 2, 3, 4 });
+        var config = new GatewayConfig { Url = "https://gateway.example.com" };
+
+        if (DevThrottleCredentialMigration.ShouldDeleteDirectorCredential(config))
+            DevThrottleCredentialMigration.DeleteStaleDirectorCredential(_blobPath);
+
         Assert.False(File.Exists(_blobPath));
     }
 }

--- a/src/CcDirector.Core.Tests/Account/DevThrottleCredentialMigrationTests.cs
+++ b/src/CcDirector.Core.Tests/Account/DevThrottleCredentialMigrationTests.cs
@@ -94,33 +94,46 @@ public sealed class DevThrottleCredentialMigrationTests : IDisposable
         Assert.True(DevThrottleCredentialMigration.ShouldDeleteDirectorCredential(config));
     }
 
-    // Revert-proof #1 (the seam): reproduce the exact startup decision - "if
-    // ShouldDeleteDirectorCredential(config) then DeleteStaleDirectorCredential(blob)" - and prove that
-    // with NO gateway a present Director blob is KEPT. Reverting the production
-    // ShouldDeleteDirectorCredential to => true reds this test.
+    // Revert-proof #1 (the real startup wiring, NOT a copy of it): drive the ONE production method
+    // App.axaml.cs calls - RunStartupMigration - and prove that with NO gateway a present Director blob
+    // is KEPT. The if-then wiring lives inside RunStartupMigration, so reverting that if to an
+    // unconditional delete (the real production line) reds this test; the test does not re-implement the
+    // glue.
     [Fact]
-    public void StartupDecision_NoGateway_KeepsPresentDirectorBlob()
+    public void RunStartupMigration_NoGateway_KeepsPresentDirectorBlob()
     {
         File.WriteAllBytes(_blobPath, new byte[] { 1, 2, 3, 4 });
         var config = new GatewayConfig { Url = "" };
 
-        if (DevThrottleCredentialMigration.ShouldDeleteDirectorCredential(config))
-            DevThrottleCredentialMigration.DeleteStaleDirectorCredential(_blobPath);
+        var outcome = DevThrottleCredentialMigration.RunStartupMigration(config, _blobPath);
 
+        Assert.Equal(DirectorCredentialStartupOutcome.KeptNoGateway, outcome);
         Assert.True(File.Exists(_blobPath));
     }
 
-    // Control (Manager point #3): the gateway-PRESENT path still deletes the stale Director blob, so the
-    // #642/#651 authority behavior is provably NOT broken by the gate.
+    // Control (Manager point #3): the gateway-PRESENT path still deletes the stale Director blob through
+    // the same production method, so the #642/#651 authority behavior is provably NOT broken by the gate.
     [Fact]
-    public void StartupDecision_GatewayPresent_DeletesStaleDirectorBlob()
+    public void RunStartupMigration_GatewayPresent_DeletesStaleDirectorBlob()
     {
         File.WriteAllBytes(_blobPath, new byte[] { 1, 2, 3, 4 });
         var config = new GatewayConfig { Url = "https://gateway.example.com" };
 
-        if (DevThrottleCredentialMigration.ShouldDeleteDirectorCredential(config))
-            DevThrottleCredentialMigration.DeleteStaleDirectorCredential(_blobPath);
+        var outcome = DevThrottleCredentialMigration.RunStartupMigration(config, _blobPath);
 
+        Assert.Equal(DirectorCredentialStartupOutcome.DeletedStaleBlob, outcome);
+        Assert.False(File.Exists(_blobPath));
+    }
+
+    // The gateway-present path with no stale blob is a harmless no-op through the production method.
+    [Fact]
+    public void RunStartupMigration_GatewayPresentNoBlob_ReportsNoBlobToDelete()
+    {
+        var config = new GatewayConfig { Url = "https://gateway.example.com" };
+
+        var outcome = DevThrottleCredentialMigration.RunStartupMigration(config, _blobPath);
+
+        Assert.Equal(DirectorCredentialStartupOutcome.NoBlobToDelete, outcome);
         Assert.False(File.Exists(_blobPath));
     }
 }

--- a/src/CcDirector.Core.Tests/Account/DirectorAccountStateProviderTests.cs
+++ b/src/CcDirector.Core.Tests/Account/DirectorAccountStateProviderTests.cs
@@ -81,6 +81,44 @@ public sealed class DirectorAccountStateProviderTests
         Assert.Equal(DirectorAccountState.DeferToGateway, state);
     }
 
+    // Finding 1 (HIGH) regression: the verdict is presence-only and must NEVER decrypt the credential.
+    // A present-but-unreadable blob (a corrupt token or a wrong-user DPAPI blob) throws at decrypt; the
+    // real hazard was an unused identity read decrypting it and taking down the whole Settings dialog.
+    // This store reports present but throws if anything tries to decrypt (Load). ResolveFromStore must
+    // return SignedInLocalNoGateway WITHOUT throwing - proving it reads HasTokens only. Re-adding a
+    // decrypt/identity read to the verdict path reds this test.
+    [Fact]
+    public void ResolveFromStore_PresentButUnreadableCredential_ReportsSignedInLocalWithoutDecrypting()
+    {
+        var config = new GatewayConfig { Url = "" };
+        var store = new ThrowOnLoadTokenStore(hasTokens: true);
+
+        var state = DirectorAccountStateProvider.ResolveFromStore(config, store);
+
+        Assert.Equal(DirectorAccountState.SignedInLocalNoGateway, state);
+        Assert.False(store.LoadWasCalled);
+    }
+
+    // A store that reports a present credential but throws the moment anything tries to decrypt it,
+    // standing in for a corrupt token or a wrong-user DPAPI blob.
+    private sealed class ThrowOnLoadTokenStore : IProtectedTokenStore
+    {
+        public ThrowOnLoadTokenStore(bool hasTokens) => HasTokens = hasTokens;
+
+        public bool HasTokens { get; }
+        public bool LoadWasCalled { get; private set; }
+
+        public void Save(DevThrottleTokens tokens) => throw new InvalidOperationException("not used");
+
+        public DevThrottleTokens? Load()
+        {
+            LoadWasCalled = true;
+            throw new InvalidOperationException("the credential blob could not be decrypted (corrupt or wrong user)");
+        }
+
+        public void Clear() => throw new InvalidOperationException("not used");
+    }
+
     // --- The verbatim display strings the surface renders --------------------------------------------
 
     // Revert-proof #2 (the render): the signed-in-local state maps to the exact signed-in-local string

--- a/src/CcDirector.Core.Tests/Account/DirectorAccountStateProviderTests.cs
+++ b/src/CcDirector.Core.Tests/Account/DirectorAccountStateProviderTests.cs
@@ -1,0 +1,111 @@
+using CcDirector.Core.Account;
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Account;
+
+/// <summary>
+/// Proves the Director's own local account-state provider (two-step install, Slice A). A gateway-less
+/// Director that holds its own credential reads as signed in locally; with a gateway configured it
+/// defers to the Gateway (the account authority, issue #642/#651); with no credential it is not signed
+/// in. These tests use the cross-platform in-memory store so the read seam is provable without the
+/// Windows-only Data Protection store (that store is covered by <see cref="WindowsProtectedTokenStoreTests"/>).
+/// </summary>
+public sealed class DirectorAccountStateProviderTests
+{
+    // --- The pure decision ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Resolve_GatewayConfigured_DefersToGateway()
+    {
+        Assert.Equal(DirectorAccountState.DeferToGateway,
+            DirectorAccountStateProvider.Resolve(gatewayConfigured: true, directorCredentialPresent: true));
+        Assert.Equal(DirectorAccountState.DeferToGateway,
+            DirectorAccountStateProvider.Resolve(gatewayConfigured: true, directorCredentialPresent: false));
+    }
+
+    [Fact]
+    public void Resolve_NoGatewayWithCredential_IsSignedInLocal()
+    {
+        Assert.Equal(DirectorAccountState.SignedInLocalNoGateway,
+            DirectorAccountStateProvider.Resolve(gatewayConfigured: false, directorCredentialPresent: true));
+    }
+
+    [Fact]
+    public void Resolve_NoGatewayNoCredential_IsNotSignedIn()
+    {
+        Assert.Equal(DirectorAccountState.NotSignedIn,
+            DirectorAccountStateProvider.Resolve(gatewayConfigured: false, directorCredentialPresent: false));
+    }
+
+    // --- The read seam over an explicit store --------------------------------------------------------
+
+    // Revert-proof #2: with no gateway configured AND a Director credential present, the provider reads
+    // its own credential and reports SignedInLocalNoGateway. Making the provider ignore the credential
+    // (always return NotSignedIn when no gateway) reds this test.
+    [Fact]
+    public void ResolveFromStore_NoGatewayWithCredential_ReadsSignedInLocal()
+    {
+        var config = new GatewayConfig { Url = "" };
+        var store = new InMemoryTokenStore();
+        store.Save(new DevThrottleTokens("access-token", "refresh-token"));
+
+        var state = DirectorAccountStateProvider.ResolveFromStore(config, store);
+
+        Assert.Equal(DirectorAccountState.SignedInLocalNoGateway, state);
+    }
+
+    [Fact]
+    public void ResolveFromStore_NoGatewayNoCredential_IsNotSignedIn()
+    {
+        var config = new GatewayConfig { Url = "" };
+        var store = new InMemoryTokenStore();
+
+        var state = DirectorAccountStateProvider.ResolveFromStore(config, store);
+
+        Assert.Equal(DirectorAccountState.NotSignedIn, state);
+    }
+
+    // Control: with a gateway configured the provider defers to the Gateway and does NOT read the local
+    // credential as a local sign-in - so the gateway-present authority (issue #642/#651) is untouched,
+    // even when a Director blob happens to be present.
+    [Fact]
+    public void ResolveFromStore_GatewayConfigured_DefersEvenWithCredentialPresent()
+    {
+        var config = new GatewayConfig { Url = "https://gateway.example.com" };
+        var store = new InMemoryTokenStore();
+        store.Save(new DevThrottleTokens("access-token", "refresh-token"));
+
+        var state = DirectorAccountStateProvider.ResolveFromStore(config, store);
+
+        Assert.Equal(DirectorAccountState.DeferToGateway, state);
+    }
+
+    // --- The verbatim display strings the surface renders --------------------------------------------
+
+    // Revert-proof #2 (the render): the signed-in-local state maps to the exact signed-in-local string
+    // the SettingsDialog Account tab shows verbatim. A provider that returned NotSignedIn instead would
+    // render the "No Gateway configured" string, not this one.
+    [Fact]
+    public void DescribeNoGateway_SignedInLocal_RendersSignedInLocalString()
+    {
+        Assert.Equal("Signed in to DevThrottle - connect a gateway to use AI.",
+            DirectorAccountStateProvider.DescribeNoGateway(DirectorAccountState.SignedInLocalNoGateway));
+    }
+
+    [Fact]
+    public void DescribeNoGateway_NotSignedIn_RendersNoGatewayString()
+    {
+        Assert.Equal("No Gateway configured. Connect this Director to a Gateway on the Gateway tab.",
+            DirectorAccountStateProvider.DescribeNoGateway(DirectorAccountState.NotSignedIn));
+    }
+
+    // DeferToGateway has no Director-owned line (a gateway-configured Director defers to the Gateway
+    // status path), so asking for its string is a programming error rather than a silent fallback.
+    [Fact]
+    public void DescribeNoGateway_DeferToGateway_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            DirectorAccountStateProvider.DescribeNoGateway(DirectorAccountState.DeferToGateway));
+    }
+}

--- a/src/CcDirector.Core/Account/DevThrottleCredentialMigration.cs
+++ b/src/CcDirector.Core/Account/DevThrottleCredentialMigration.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Configuration;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
@@ -29,6 +30,27 @@ public static class DevThrottleCredentialMigration
     /// temporary path so the migration is provable without touching the real install.
     /// </param>
     /// <returns>True when a stale blob was present and deleted; false when none existed.</returns>
+    /// <summary>
+    /// Decides whether the startup migration should delete the Director's own credential blob, given the
+    /// current gateway configuration (two-step install, Slice A). The deletion is correct ONLY when a
+    /// gateway is present: then the Gateway is the single account authority (issue #642/#651) and the
+    /// Director copy is genuinely stale. When no gateway is configured the Director blob is the LIVE
+    /// credential a gateway-less Director legitimately keeps, so it must NOT be deleted.
+    ///
+    /// This is the production line the "delete is gated on gateway presence" revert-proof pins:
+    /// <c>App.axaml.cs</c> calls exactly this method, and making it return <c>true</c> unconditionally
+    /// reds the "blob kept when no gateway" test.
+    /// </summary>
+    /// <param name="config">The current gateway configuration (config.json). <c>IsEnabled</c> is true when a gateway URL is set.</param>
+    /// <returns>True when a gateway is present and the stale Director blob should be deleted; false when no gateway is configured and the credential must be kept.</returns>
+    public static bool ShouldDeleteDirectorCredential(GatewayConfig config)
+    {
+        if (config is null)
+            throw new ArgumentNullException(nameof(config));
+
+        return config.IsEnabled;
+    }
+
     public static bool DeleteStaleDirectorCredential(string? blobPath = null)
     {
         var path = blobPath ?? CcStorage.DevThrottleCredentialBlob();

--- a/src/CcDirector.Core/Account/DevThrottleCredentialMigration.cs
+++ b/src/CcDirector.Core/Account/DevThrottleCredentialMigration.cs
@@ -5,6 +5,22 @@ using CcDirector.Core.Utilities;
 namespace CcDirector.Core.Account;
 
 /// <summary>
+/// What the startup credential migration did on this launch (two-step install, Slice A), so the caller
+/// can log the outcome without re-deriving the gate decision.
+/// </summary>
+public enum DirectorCredentialStartupOutcome
+{
+    /// <summary>No gateway configured: the Director's own credential was KEPT (the Slice A exception).</summary>
+    KeptNoGateway,
+
+    /// <summary>A gateway is configured and a stale Director blob was present, so it was deleted (issue #642/#651).</summary>
+    DeletedStaleBlob,
+
+    /// <summary>A gateway is configured but there was no stale Director blob to delete.</summary>
+    NoBlobToDelete,
+}
+
+/// <summary>
 /// Migrates a Director that still holds a local DevThrottle credential onto the Gateway-centralized
 /// model (Gateway Centralization Phase 2, issue #642). The Gateway is the single account authority now,
 /// so the Director must hold NO credential of its own: any pre-existing
@@ -49,6 +65,34 @@ public static class DevThrottleCredentialMigration
             throw new ArgumentNullException(nameof(config));
 
         return config.IsEnabled;
+    }
+
+    /// <summary>
+    /// The complete startup credential-migration WIRING (two-step install, Slice A): the single method
+    /// <c>App.axaml.cs</c> calls at boot. It runs the gate and the delete together - deleting the stale
+    /// Director blob only when <see cref="ShouldDeleteDirectorCredential"/> says a gateway is present, and
+    /// keeping the Director's own credential when no gateway is configured - and returns what it did so
+    /// the caller can log it. The <c>if</c> lives HERE, in one production place a test pins directly, so
+    /// the wiring is never duplicated in a test: reverting this <c>if</c> to an unconditional delete reds
+    /// the "no gateway keeps the blob" test.
+    /// </summary>
+    /// <param name="config">The current gateway configuration (config.json).</param>
+    /// <param name="blobPath">The credential blob to act on. Defaults to the Director's credential path; tests inject a temporary path.</param>
+    /// <returns>What the migration did on this launch.</returns>
+    public static DirectorCredentialStartupOutcome RunStartupMigration(GatewayConfig config, string? blobPath = null)
+    {
+        if (config is null)
+            throw new ArgumentNullException(nameof(config));
+
+        if (!ShouldDeleteDirectorCredential(config))
+        {
+            FileLog.Write("[DevThrottleCredentialMigration] RunStartupMigration: no gateway configured -> keeping the Director's own credential (Slice A exception to issue #642)");
+            return DirectorCredentialStartupOutcome.KeptNoGateway;
+        }
+
+        return DeleteStaleDirectorCredential(blobPath)
+            ? DirectorCredentialStartupOutcome.DeletedStaleBlob
+            : DirectorCredentialStartupOutcome.NoBlobToDelete;
     }
 
     public static bool DeleteStaleDirectorCredential(string? blobPath = null)

--- a/src/CcDirector.Core/Account/DirectorAccountState.cs
+++ b/src/CcDirector.Core/Account/DirectorAccountState.cs
@@ -31,11 +31,13 @@ public enum DirectorAccountState
 /// it, so the dumb-client rule that governs Gateway verdicts does not apply here), and the surface only
 /// renders what this provider decides.
 ///
-/// The read seam revives the desktop credential service that issue #651 neutered: it builds the existing
-/// <see cref="DevThrottleAccountService"/> through <see cref="DevThrottleAccountFactory.Build(IProtectedTokenStore, string)"/>
-/// over the Director's own credential store and reads whether a credential is present. The token is never
-/// read into a log and is never returned from this provider (security rule DT-05); only the resolved
-/// state and a present/absent boolean ever leave it.
+/// The read seam revives the Director-side credential read that issue #651 removed: over its OWN
+/// credential store (<see cref="WindowsProtectedTokenStore"/> on Windows) it reads whether a credential
+/// is PRESENT via <see cref="IProtectedTokenStore.HasTokens"/>. It never decrypts the blob or parses a
+/// token for the verdict - a corrupt or wrong-user credential would throw at decrypt, and this feeds an
+/// informational surface that must not be taken down by a bad credential (token validity is Slice B's
+/// concern). The token is never read into a log and is never returned from this provider (security rule
+/// DT-05); only the resolved state and a present/absent boolean ever leave it.
 /// </summary>
 public static class DirectorAccountStateProvider
 {
@@ -66,10 +68,12 @@ public static class DirectorAccountStateProvider
     /// <summary>
     /// Resolves the Director's account state over an explicit credential store (the unit-testable seam).
     /// With a gateway configured it returns <see cref="DirectorAccountState.DeferToGateway"/> without
-    /// reading the local credential. With no gateway it revives the desktop credential service over the
-    /// supplied store and reads whether a credential is present. The stored token is never logged or
-    /// returned (DT-05); this reads only presence and, when present, exercises the revived local read by
-    /// decoding the cached identity claims (no network, no token in the log) so the seam is proven live.
+    /// touching the local credential. With no gateway it reads the Director's OWN store for whether a
+    /// credential is PRESENT - the presence check (<see cref="IProtectedTokenStore.HasTokens"/>) only,
+    /// which never decrypts the blob or parses a token. The verdict is deliberately presence-only: it
+    /// must never decrypt (a corrupt or wrong-user DPAPI blob would throw at decrypt, and this read feeds
+    /// an informational surface that must not be taken down by a bad credential). Token validity is a
+    /// later concern (Slice B). The stored token is never logged or returned from here (DT-05).
     /// </summary>
     public static DirectorAccountState ResolveFromStore(GatewayConfig config, IProtectedTokenStore store)
     {
@@ -84,25 +88,12 @@ public static class DirectorAccountStateProvider
             return DirectorAccountState.DeferToGateway;
         }
 
-        // Revive the desktop credential service (dead since issue #651): the factory reconstitutes the
-        // validator, event log, and refresher over the Director's OWN store, so a gateway-less Director
-        // can read the credential it now legitimately keeps (Slice A). No network at construction.
-        var service = DevThrottleAccountFactory.Build(store, CcStorage.DevThrottleAuthEventsLog());
-
+        // Presence only: HasTokens is a file-existence check that never decrypts the blob or parses a
+        // token, so a corrupt/wrong-user credential can never throw here. This IS the Director-side read
+        // that issue #651 removed - a gateway-less Director reading the credential it now legitimately
+        // keeps (Slice A).
         var present = store.HasTokens;
-        if (present)
-        {
-            // Exercise the revived read end to end without exposing the token: GetIdentity decodes the
-            // cached claims locally (no network call, and the token is never written to the log; DT-05),
-            // which confirms the read seam is live for the signed-in-local Director.
-            var identity = service.GetIdentity();
-            FileLog.Write($"[DirectorAccountStateProvider] ResolveFromStore: no gateway; director credential present (identity {(identity is null ? "unavailable" : "resolved")})");
-        }
-        else
-        {
-            FileLog.Write("[DirectorAccountStateProvider] ResolveFromStore: no gateway and no director credential present -> not signed in");
-        }
-
+        FileLog.Write($"[DirectorAccountStateProvider] ResolveFromStore: no gateway; director credential present={present} (presence only; the token is never read into a log)");
         return Resolve(config.IsEnabled, present);
     }
 

--- a/src/CcDirector.Core/Account/DirectorAccountState.cs
+++ b/src/CcDirector.Core/Account/DirectorAccountState.cs
@@ -1,0 +1,138 @@
+using System.Runtime.Versioning;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// The Director's OWN local DevThrottle account state, as decided by <see cref="DirectorAccountStateProvider"/>
+/// (two-step install, Slice A). This exists only for the gateway-less Director: when a gateway is
+/// configured the Gateway is the single account authority (issue #642/#651) and this defers to it. When
+/// no gateway is configured the Director legitimately holds and reads its own credential (the Slice A
+/// exception to that centralization), so this reports whether it is signed in locally.
+/// </summary>
+public enum DirectorAccountState
+{
+    /// <summary>A gateway is configured, so the Director defers to the Gateway's account status (issue #651). This slice does not change the gateway-present display.</summary>
+    DeferToGateway,
+
+    /// <summary>No gateway is configured and the Director holds its own credential: signed in locally, with no gateway to use AI through yet.</summary>
+    SignedInLocalNoGateway,
+
+    /// <summary>No gateway is configured and no Director credential is present: not signed in.</summary>
+    NotSignedIn,
+}
+
+/// <summary>
+/// Decides the Director's own local account state (two-step install, Slice A) and provides the exact
+/// display strings the account-status surface renders verbatim. This is the SINGLE place that rules the
+/// no-gateway account state: a gateway-less Director owns this state itself (there is no Gateway to rule
+/// it, so the dumb-client rule that governs Gateway verdicts does not apply here), and the surface only
+/// renders what this provider decides.
+///
+/// The read seam revives the desktop credential service that issue #651 neutered: it builds the existing
+/// <see cref="DevThrottleAccountService"/> through <see cref="DevThrottleAccountFactory.Build(IProtectedTokenStore, string)"/>
+/// over the Director's own credential store and reads whether a credential is present. The token is never
+/// read into a log and is never returned from this provider (security rule DT-05); only the resolved
+/// state and a present/absent boolean ever leave it.
+/// </summary>
+public static class DirectorAccountStateProvider
+{
+    /// <summary>The account-line text for a gateway-less Director that IS signed in locally. Rendered verbatim by the surface.</summary>
+    public const string SignedInLocalNoGatewayMessage =
+        "Signed in to DevThrottle - connect a gateway to use AI.";
+
+    /// <summary>The account-line text for a gateway-less Director that is NOT signed in. Rendered verbatim by the surface.</summary>
+    public const string NoGatewayNotSignedInMessage =
+        "No Gateway configured. Connect this Director to a Gateway on the Gateway tab.";
+
+    /// <summary>
+    /// The pure decision: with a gateway configured the Director defers to the Gateway; with no gateway
+    /// it is signed in locally when (and only when) its own credential is present, otherwise not signed
+    /// in. This is the production line the "reads+uses its own credential" revert-proof pins - making it
+    /// ignore <paramref name="directorCredentialPresent"/> reds the no-gateway signed-in test.
+    /// </summary>
+    public static DirectorAccountState Resolve(bool gatewayConfigured, bool directorCredentialPresent)
+    {
+        if (gatewayConfigured)
+            return DirectorAccountState.DeferToGateway;
+
+        return directorCredentialPresent
+            ? DirectorAccountState.SignedInLocalNoGateway
+            : DirectorAccountState.NotSignedIn;
+    }
+
+    /// <summary>
+    /// Resolves the Director's account state over an explicit credential store (the unit-testable seam).
+    /// With a gateway configured it returns <see cref="DirectorAccountState.DeferToGateway"/> without
+    /// reading the local credential. With no gateway it revives the desktop credential service over the
+    /// supplied store and reads whether a credential is present. The stored token is never logged or
+    /// returned (DT-05); this reads only presence and, when present, exercises the revived local read by
+    /// decoding the cached identity claims (no network, no token in the log) so the seam is proven live.
+    /// </summary>
+    public static DirectorAccountState ResolveFromStore(GatewayConfig config, IProtectedTokenStore store)
+    {
+        if (config is null)
+            throw new ArgumentNullException(nameof(config));
+        if (store is null)
+            throw new ArgumentNullException(nameof(store));
+
+        if (config.IsEnabled)
+        {
+            FileLog.Write("[DirectorAccountStateProvider] ResolveFromStore: a gateway is configured -> defer to the Gateway account authority (issue #642/#651)");
+            return DirectorAccountState.DeferToGateway;
+        }
+
+        // Revive the desktop credential service (dead since issue #651): the factory reconstitutes the
+        // validator, event log, and refresher over the Director's OWN store, so a gateway-less Director
+        // can read the credential it now legitimately keeps (Slice A). No network at construction.
+        var service = DevThrottleAccountFactory.Build(store, CcStorage.DevThrottleAuthEventsLog());
+
+        var present = store.HasTokens;
+        if (present)
+        {
+            // Exercise the revived read end to end without exposing the token: GetIdentity decodes the
+            // cached claims locally (no network call, and the token is never written to the log; DT-05),
+            // which confirms the read seam is live for the signed-in-local Director.
+            var identity = service.GetIdentity();
+            FileLog.Write($"[DirectorAccountStateProvider] ResolveFromStore: no gateway; director credential present (identity {(identity is null ? "unavailable" : "resolved")})");
+        }
+        else
+        {
+            FileLog.Write("[DirectorAccountStateProvider] ResolveFromStore: no gateway and no director credential present -> not signed in");
+        }
+
+        return Resolve(config.IsEnabled, present);
+    }
+
+    /// <summary>
+    /// Resolves the Director's account state on Windows, reading the Director's own DPAPI-protected
+    /// credential store. Windows-guarded because Windows Data Protection is per-user and Windows-only;
+    /// the caller must guard with <see cref="OperatingSystem.IsWindows"/>. Fails loud with no fallback:
+    /// a genuine read failure surfaces to the caller rather than masquerading as "not signed in".
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public static DirectorAccountState ResolveForWindows(GatewayConfig config)
+    {
+        if (config is null)
+            throw new ArgumentNullException(nameof(config));
+
+        var store = new WindowsProtectedTokenStore(CcStorage.DevThrottleCredentialBlob());
+        return ResolveFromStore(config, store);
+    }
+
+    /// <summary>
+    /// The exact display string the no-gateway account-status surface renders verbatim for a resolved
+    /// state. Only the two no-gateway states have a Director-owned line; a gateway-configured Director
+    /// defers to the Gateway status path instead, so passing <see cref="DirectorAccountState.DeferToGateway"/>
+    /// is a programming error.
+    /// </summary>
+    public static string DescribeNoGateway(DirectorAccountState state) => state switch
+    {
+        DirectorAccountState.SignedInLocalNoGateway => SignedInLocalNoGatewayMessage,
+        DirectorAccountState.NotSignedIn => NoGatewayNotSignedInMessage,
+        _ => throw new ArgumentOutOfRangeException(nameof(state), state,
+            "DescribeNoGateway is only for the no-gateway states; a gateway-configured Director defers to the Gateway status."),
+    };
+}


### PR DESCRIPTION
Two-step install, Slice A - the foundation for an install-time sign-in on a Director-only machine. Under Gateway Centralization (issues #642/#651) the Director holds no account credential and deletes its local blob on every startup, because the Gateway is the single account authority. This carves the exception a gateway-less Director needs:

- Startup deletion is gated on gateway presence. App calls one method, DevThrottleCredentialMigration.RunStartupMigration(GatewayConfig.Load()): with a gateway configured the stale Director blob is still deleted (authority unchanged); with no gateway the Director's own credential is kept. The gate and the deletion live together in that one method, so a test pins the real wiring rather than a duplicated conditional.
- A gateway-less Director reads its own state. DirectorAccountStateProvider resolves the Director's local account state from a presence-only check (never decrypting the credential), and the Settings Account tab renders that verdict - a signed-in Director shows "Signed in to DevThrottle - connect a gateway to use AI" instead of the old blanket "No Gateway configured." A failure reading the local credential is scoped to that one identity line and can never take down the Settings dialog.

Revert-proofs on the real production lines: reverting the gate inside RunStartupMigration reds the keep-blob test; making the provider ignore credential presence reds the signed-in-local test; re-introducing any decrypt on the read path reds the presence-only test. Gateway-present behavior is unchanged (control test green). The token is never logged or returned.

This slice deliberately stops here; the install-time sign-in step, the connect-time credential reuse, and the credential transition when a gateway is later connected are the next slice.