### PR TITLE
feat(cockpit): split the Fleet Map "By repository" pivot into repository and working tree

### DIFF
--- a/apps/cockpit/src/fleet/FleetMapView.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.tsx
@@ -10,7 +10,7 @@ import {
   type DirectorReachability,
 } from "@devthrottle/client-core/fleet/fleetClient";
 import { useSharedRoster } from "@devthrottle/client-core/fleet/rosterStore";
-import { repoBasename, relativeTime } from "./format";
+import { repoBasename, repoIdentity, relativeTime } from "./format";
 import { agentBadgeText, buildControllerTree } from "./fleetMapFormat";
 import { MissionsBoard, missionCounts } from "../missions/MissionsBoard";
 
@@ -23,9 +23,17 @@ const ReachabilityContext = createContext<DirectorReachability[]>([]);
 // node for the Gateway branching down to grouped "lane" panels of terminal-window session cards,
 // joined by SVG elbow connectors, with one status dot per node. The same fleet is re-laid-out on the
 // fly several ways (the pivot switch): by machine (machine -> Director -> session, the topology), by
-// repository (what we are building), by agent (Claude/Codex/Gemini/... - the workforce), a flat Fleet
-// list, or by Mission - the way the owner actually thinks about the work. Missions used to be its own
-// left-rail page; it is now a pivot of this one page (issue #1405), so the fleet has a single home.
+// repository (the GitHub "owner/repo" we are building - worktrees and clones fold together), by working
+// tree (the on-disk checkout folder - each worktree stands alone), by agent (Claude/Codex/Gemini/... -
+// the workforce), a flat Fleet list, or by Mission - the way the owner actually thinks about the work.
+// Missions used to be its own left-rail page; it is now a pivot of this one page (issue #1405), so the
+// fleet has a single home.
+//
+// "By repository" and "By working tree" are two DIFFERENT truths about the same fleet: a session cut in a
+// worktree at "devthrottle-enroll-fix" belongs to the repository "thefrederiksen/devthrottle" (repository
+// pivot folds it in) yet lives in its own checkout folder (working-tree pivot keeps it separate). The
+// repository identity comes from SessionDto.repoName, which the owning Director resolves from the
+// checkout's git origin remote; the working-tree identity is just the folder leaf of repoPath.
 //
 // It reads the ONE shared fleet roster store (issue #1239) - the same GET /sessions?envelope=true
 // envelope Sessions and Directors read, from a single poll loop - never a Director address - and reuses
@@ -33,11 +41,15 @@ const ReachabilityContext = createContext<DirectorReachability[]>([]);
 // fleet page reads that one store, this map and the Sessions roster always agree on the fleet at the
 // same moment, and a hidden tab makes no roster requests at all.
 
-type Pivot = "machine" | "repo" | "agent" | "list" | "mission";
+type Pivot = "machine" | "repo" | "worktree" | "agent" | "list" | "mission";
 
 const PIVOTS: ReadonlyArray<{ key: Pivot; label: string; kindLabel: string }> = [
   { key: "machine", label: "By machine", kindLabel: "Machine" },
+  // "By repository" groups by the GitHub "owner/repo" (SessionDto.repoName), so every worktree and clone
+  // of one repository rolls up together. "By working tree" groups by the on-disk checkout folder, so each
+  // worktree stands on its own - the two sit side by side because they answer two different questions.
   { key: "repo", label: "By repository", kindLabel: "Repository" },
+  { key: "worktree", label: "By working tree", kindLabel: "Working tree" },
   { key: "agent", label: "By agent", kindLabel: "Agent" },
   // The flat "Fleet list" pivot (issue #1212) absorbs the retired Fleet page: every session once, as
   // the same node card, no lane grouping (machines are already their own pivot).
@@ -50,7 +62,7 @@ const PIVOTS: ReadonlyArray<{ key: Pivot; label: string; kindLabel: string }> = 
 
 // The pivots that lay the fleet out on the node canvas (root -> lanes). "list" is a flat grid and
 // "mission" is its own board; neither uses the canvas or the title search.
-const CANVAS_PIVOTS: ReadonlySet<Pivot> = new Set<Pivot>(["machine", "repo", "agent"]);
+const CANVAS_PIVOTS: ReadonlySet<Pivot> = new Set<Pivot>(["machine", "repo", "worktree", "agent"]);
 
 // The grouping is sticky per browser: the map opens on whatever the user last chose (rather than a
 // "smart" default that guesses from the fleet shape), so returning to the map lands them exactly where
@@ -63,6 +75,7 @@ function initialPivot(): Pivot {
     if (
       saved === "machine" ||
       saved === "repo" ||
+      saved === "worktree" ||
       saved === "agent" ||
       saved === "list" ||
       saved === "mission"
@@ -138,9 +151,11 @@ export function FleetMapView() {
     for (const s of list) set.add((s.machineName ?? "").toLowerCase());
     return set.size;
   }, [list]);
+  // "N repos" counts distinct GitHub repositories, not checkouts: two worktrees of one repository are one
+  // repo here (matching the "By repository" pivot). The "By working tree" pivot is where checkouts split.
   const repoCount = useMemo(() => {
     const set = new Set<string>();
-    for (const s of list) set.add(repoBasename(s.repoPath).toLowerCase());
+    for (const s of list) set.add(repoIdentity(s.repoName, s.repoPath).toLowerCase());
     return set.size;
   }, [list]);
   const redCount = list.filter((s) => effectiveColor(s) === "red").length;
@@ -579,6 +594,12 @@ function buildLanes(sessions: SessionDto[], pivot: Pivot): Lane[] {
       return { key: title.toLowerCase(), title };
     }
     if (pivot === "repo") {
+      // GitHub "owner/repo" identity - worktrees and clones of one repository fold into one lane.
+      const title = repoIdentity(s.repoName, s.repoPath);
+      return { key: title.toLowerCase(), title };
+    }
+    if (pivot === "worktree") {
+      // On-disk checkout folder - each worktree stands alone, even when it belongs to the same repository.
       const title = repoBasename(s.repoPath);
       return { key: title.toLowerCase(), title };
     }
@@ -685,18 +706,27 @@ function cardTags(s: SessionDto, pivot: Pivot): Array<{ k: string; v: string }> 
   const dir = (s.directorId ?? "").trim();
   const machine = (s.machineName ?? "").trim();
   if (pivot === "machine") {
-    // Lane = machine, sub-grouped by Director; the missing coordinate is the repo.
-    return [{ k: "repo", v: repoBasename(s.repoPath) }];
+    // Lane = machine, sub-grouped by Director; the missing coordinate is the repository.
+    return [{ k: "repo", v: repoIdentity(s.repoName, s.repoPath) }];
   }
   if (pivot === "repo") {
-    // Lane = repo; show where it runs (machine + Director) and which agent.
+    // Lane = repository; show where it runs (machine + Director) and which working tree, so two worktrees
+    // of the same repository sharing a lane are still told apart.
     const out: Array<{ k: string; v: string }> = [];
     if (machine.length > 0) out.push({ k: machine, v: dir.length > 0 ? shortDir(dir) : "-" });
+    out.push({ k: "tree", v: repoBasename(s.repoPath) });
     return out;
   }
-  // Lane = agent, or the flat Fleet list (no lane at all); show machine + repo.
+  if (pivot === "worktree") {
+    // Lane = working tree; show where it runs (machine + Director) and which repository it belongs to.
+    const out: Array<{ k: string; v: string }> = [];
+    if (machine.length > 0) out.push({ k: machine, v: dir.length > 0 ? shortDir(dir) : "-" });
+    out.push({ k: "repo", v: repoIdentity(s.repoName, s.repoPath) });
+    return out;
+  }
+  // Lane = agent, or the flat Fleet list (no lane at all); show machine + repository.
   const out: Array<{ k: string; v: string }> = [];
-  if (machine.length > 0) out.push({ k: machine, v: repoBasename(s.repoPath) });
+  if (machine.length > 0) out.push({ k: machine, v: repoIdentity(s.repoName, s.repoPath) });
   return out;
 }
 

--- a/apps/cockpit/src/fleet/format.test.ts
+++ b/apps/cockpit/src/fleet/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { portLabel, repoBasename, shortId, uptime } from "./format";
+import { portLabel, repoBasename, repoIdentity, shortId, uptime } from "./format";
 
 // These lock the shared formatting helpers that issue #1261 consolidated: the Wingman and Feedback pages
 // deleted their local copies and now import exactly these, so a regression here would be a regression on
@@ -33,6 +33,40 @@ describe("repoBasename", () => {
   it("names an absent repository plainly", () => {
     expect(repoBasename("")).toBe("(no repo)");
     expect(repoBasename(null)).toBe("(no repo)");
+  });
+});
+
+describe("repoIdentity", () => {
+  it("uses the GitHub owner/repo when present, ignoring the checkout folder", () => {
+    // A worktree cut at "devthrottle-enroll-fix" still belongs to the repository it was cut from, so it
+    // rolls up under the repoName - this is the whole point of the "By repository" pivot.
+    expect(repoIdentity("thefrederiksen/devthrottle", "D:\\ReposFred\\devthrottle-enroll-fix")).toBe(
+      "thefrederiksen/devthrottle",
+    );
+    expect(repoIdentity("thefrederiksen/devthrottle", "D:\\ReposFred\\devthrottle")).toBe(
+      "thefrederiksen/devthrottle",
+    );
+  });
+
+  it("folds two worktrees of one repository to the same identity", () => {
+    const a = repoIdentity("thefrederiksen/devthrottle", "D:\\ReposFred\\devthrottle");
+    const b = repoIdentity("thefrederiksen/devthrottle", "D:\\ReposFred\\devthrottle-enroll-fix");
+    expect(a).toBe(b);
+  });
+
+  it("falls back to the working-tree leaf when there is no recognized remote", () => {
+    expect(repoIdentity("", "D:\\ReposFred\\local-only")).toBe("local-only");
+    expect(repoIdentity(null, "/home/soren/scratch/")).toBe("scratch");
+    expect(repoIdentity(undefined, "D:\\ReposFred\\local-only")).toBe("local-only");
+  });
+
+  it("trims whitespace-only repoName and treats it as absent", () => {
+    expect(repoIdentity("   ", "D:\\ReposFred\\devthrottle")).toBe("devthrottle");
+  });
+
+  it("names a session with neither remote nor path plainly", () => {
+    expect(repoIdentity("", "")).toBe("(no repo)");
+    expect(repoIdentity(null, null)).toBe("(no repo)");
   });
 });
 

--- a/apps/cockpit/src/fleet/format.ts
+++ b/apps/cockpit/src/fleet/format.ts
@@ -4,12 +4,28 @@
 // the same way. Session color/order helpers are NOT re-implemented here - those live in the shared
 // client-core/sessions/ordering module and are reused directly.
 
-// The leaf repo name for a card/table cell, e.g. "C:\\repos\\devthrottle" -> "devthrottle".
+// The leaf repo name for a card/table cell, e.g. "C:\\repos\\devthrottle" -> "devthrottle". This is the
+// WORKING-TREE identity: every worktree and every clone of one repository has a different leaf, so a
+// worktree cut at "D:\\ReposFred\\devthrottle-enroll-fix" reads as its own thing here, distinct from the
+// repository it belongs to.
 export function repoBasename(path: string | null | undefined): string {
   if (path === null || path === undefined || path.trim().length === 0) return "(no repo)";
   const norm = path.replace(/\\/g, "/").replace(/\/+$/, "");
   const i = norm.lastIndexOf("/");
   return i >= 0 ? norm.slice(i + 1) : norm;
+}
+
+// The GITHUB REPOSITORY identity for a session: the "owner/repo" name the owning Director resolved from
+// the checkout's git origin remote (SessionDto.repoName). Every worktree and every per-machine clone of
+// one repository shares this, so grouping by it folds a worktree back into the repository it was cut
+// from - unlike repoBasename, which splits them. When the checkout is on no host we recognize (a
+// local-only repo with no GitHub/Azure origin), repoName is empty and we fall back to the working-tree
+// leaf so the session still lands somewhere named rather than in one anonymous bucket. This is the exact
+// rule the DevThrottle Stats repo rollup uses (GatewayInputStatsAggregator: repoName ?? repo leaf), kept
+// identical here so the Fleet Map and the Repos page agree on what "a repository" is.
+export function repoIdentity(repoName: string | null | undefined, repoPath: string | null | undefined): string {
+  if (repoName !== null && repoName !== undefined && repoName.trim().length > 0) return repoName.trim();
+  return repoBasename(repoPath);
 }
 
 // There is deliberately NO humanizeState here. It was a port of the Blazor HumanizeState vocabulary

--- a/packages/client-core/src/api/schema.ts
+++ b/packages/client-core/src/api/schema.ts
@@ -7682,6 +7682,7 @@ export interface components {
             remoteThreadUrl?: string;
             remoteRunUrl?: string;
             remoteRunStatus?: string;
+            repoName?: string;
             inputStats?: null | components["schemas"]["InputStatsDto"];
         };
         SessionNumberAllocateRequest: {


### PR DESCRIPTION
## What

The Fleet Map's **By repository** pivot grouped by the checkout *folder leaf*, so a worktree cut at `devthrottle-enroll-fix` showed as its own "repository" separate from the repository it was cut from. This splits the one grouping into the two truths it was conflating:

- **By repository** groups by `SessionDto.repoName` (the GitHub `owner/repo` the owning Director resolves from the checkout's git `origin` remote) - worktrees and clones fold together.
- **By working tree** (new pivot) groups by the checkout folder leaf - each checkout stands alone.

## Why

`repoName` was already stamped by every Director (since #1738) and passes through the Gateway roster unchanged (`SessionDto.Clone()` is a `MemberwiseClone`). Only the generated Cockpit type was stale, so the live view never saw it and fell back to folder names. Surfacing the field lets the map answer both "which repository is this" and "which checkout is this" instead of silently answering the second while labelled as the first.

## Changes

- `packages/client-core/src/api/schema.ts` - add the already-shipped `repoName` field to the generated `SessionDto` type.
- `apps/cockpit/src/fleet/format.ts` - new pure `repoIdentity(repoName, repoPath)` helper: the GitHub `owner/repo` when present, else the working-tree leaf (the exact rule the Repos stats rollup uses, so the two surfaces agree).
- `apps/cockpit/src/fleet/FleetMapView.tsx` - add the `worktree` pivot; repurpose `repo` to group by repository identity; the header "N repos" count and every card's repo tag now use the repository identity; cards gain the complementary coordinate (`tree` on the repository lane, `repo` on the working-tree lane).
- `apps/cockpit/src/fleet/format.test.ts` - 5 new cases for `repoIdentity` (fold two worktrees, fall back for local-only repos, whitespace/empty handling).

## Proof

- Typecheck (all three workspaces), Cockpit 150 tests + client-core 544 tests, Cockpit + mobile builds, lint - all green.
- Deployed to the local Gateway `wwwroot/c` (Cockpit-only, no exe swap, no restart; healthz stayed `ok`) and driven in a browser against the live fleet:
  - **By repository** renders lanes `REPOSITORY thefrederiksen/devthrottle`, `.../devthrottle_internal`, `.../cc-consult`, each card carrying its `tree` folder.
  - **By working tree** renders lanes `WORKING TREE devthrottle`, `devthrottle_internal`, `cc-consult`, each card carrying its `repo` slug.