### PR TITLE
fix(gateway): keep a voice-mode session yellow until its voice is ready

### DIFF
--- a/src/CcDirector.Avalonia.Tests/AgreementCheckFaultInjectionTests.cs
+++ b/src/CcDirector.Avalonia.Tests/AgreementCheckFaultInjectionTests.cs
@@ -237,21 +237,44 @@ public sealed class AgreementCheckFaultInjectionTests
     }
 
     [Fact]
-    public void VoiceBeingPrepared_IsYellowOnTheGatewayAndRedOnTheDesktop_AndIsReported()
+    public void VoiceAudioReady_IsRedOnTheGatewayAndYellowOnTheDesktop_AndIsReported()
     {
-        // THIS IS NOW THE ROW THE LIVE GATEWAY ACTUALLY SERVES, which it was not when this was written.
-        // A companion test used to sit below this one arguing that the real Gateway stamps BriefingState
-        // ="Briefing" in the same breath as VoiceGenerating, so this row was a shape production never
-        // emitted. That stamp is deleted (gap 5) - the Gateway adds VoiceGenerating and nothing else - so
-        // this row is exactly what the fleet serves, and the companion went with the stamp it described.
-        var row = Waiting("voice");
+        // THE VOICE DIVERGENCE, as it stands since the 2026-07-19 widening of IsVoicePreparing (yellow while
+        // !VoiceAudioReady). A voice-mode session whose audio the Gateway HAS ready folds red "needs you" on
+        // the Gateway - VoiceGenerating false, VoiceAudioReady true, so it is no longer preparing. The desktop
+        // cannot see the Gateway's audio store, so it still folds yellow "preparing voice". Gateway red,
+        // desktop yellow - a real divergence, and VoiceAudioReady is the Gateway-only fact behind it.
+        var row = Waiting("voice-ready");
         row.VoiceMode = true;
-        row.VoiceGenerating = true;
+        row.VoiceAudioReady = true;   // the GATEWAY holds playable audio; the desktop cannot see it
+        AsGatewayServesIt(row);
+        Assert.Equal("red", row.EffectiveColor);
+
+        var findings = Run(row);
+        Assert.Contains(findings, f => f.Kind == "desktop-vs-gateway");
+        Assert.Contains(findings, f => f.Detail.Contains("voice audio ready", StringComparison.Ordinal));
+        Assert.Equal("yellow", SessionOrdering.EffectiveColor(AgreementCheck.ToDesktopInput(row)));
+    }
+
+    /// <summary>
+    /// The behaviour change of 2026-07-19 made visible: voice BEING PREPARED (generating, or simply no audio
+    /// yet) now AGREES across the two surfaces. Because IsVoicePreparing holds yellow while !VoiceAudioReady,
+    /// and the desktop reconstruction also has no audio, BOTH fold yellow. This row used to be the divergence
+    /// (its yellow came only from the Gateway-only VoiceGenerating); it is now the agreement, because the
+    /// yellow no longer depends on a fact only the Gateway can see. VoiceAudioReady (the test above) is now
+    /// the fact that actually diverges.
+    /// </summary>
+    [Fact]
+    public void VoiceBeingPrepared_NowAgrees_BecauseNoAudioFoldsYellowOnBothSurfaces()
+    {
+        var row = Waiting("voice-preparing");
+        row.VoiceMode = true;
+        row.VoiceGenerating = true;   // Gateway-only, but stripping it still leaves !VoiceAudioReady -> yellow
         AsGatewayServesIt(row);
         Assert.Equal("yellow", row.EffectiveColor);
 
-        Assert.Contains(Run(row), f => f.Kind == "desktop-vs-gateway");
-        Assert.Equal("red", SessionOrdering.EffectiveColor(AgreementCheck.ToDesktopInput(row)));
+        Assert.Empty(Run(row));
+        Assert.Equal("yellow", SessionOrdering.EffectiveColor(AgreementCheck.ToDesktopInput(row)));
     }
     /// <summary>
     /// The control for the one above, and the reason it is not just "report everything with a briefing
@@ -366,6 +389,7 @@ public sealed class AgreementCheckFaultInjectionTests
         row.IsTranscribing = true;
         row.VoiceMode = true;
         row.VoiceGenerating = true;
+        row.VoiceAudioReady = true;
         row.BriefingState = "Briefing";
         AsGatewayServesIt(row);
 

--- a/src/CcDirector.Core/Wingman/SessionStatusWingman.cs
+++ b/src/CcDirector.Core/Wingman/SessionStatusWingman.cs
@@ -177,15 +177,16 @@ public sealed class SessionStatusWingman : IDisposable
     // once". It was shared with nothing: it had ZERO production callers - only its own five tests - and its
     // comment's claim that "the Gateway's SessionOrdering.EffectiveColor and the /m client's effColor apply
     // the same rule" was false in both halves. The /m client has no such rule at all, and the Gateway
-    // applies a strictly NARROWER one on purpose: this copy still held yellow while `!voiceAudioReady`, and
-    // a text-to-speech failure produces no audio, so voiceAudioReady stayed false and the session wedged
-    // YELLOW forever. SessionOrdering.IsVoicePreparing gates on VoiceGenerating ALONE precisely so the rule
-    // has a terminal exit - it says so in its own comment, and it has said so since 8 July.
+    // applies its own on the roster.
     //
-    // So this was a dead copy of a rule, carrying the bug the live one had already fixed, while claiming to
-    // agree with it. Its five tests asserted the wedge and were green. Deleted rather than corrected: a
-    // shared rule definition that nothing shares is just a corpse with a footnote, and the next agent to
-    // read it would have copied the bug back out. The live rule is SessionOrdering.IsVoicePreparing.
+    // So this was a dead copy of a rule that nothing shared - deleted rather than corrected, because a
+    // shared rule definition that nothing shares is just a corpse with a footnote. The live rule is
+    // SessionOrdering.IsVoicePreparing.
+    //
+    // NOTE (owner's ruling, 2026-07-19): the live rule DOES hold yellow while `!voiceAudioReady` - by
+    // design, so a voice-mode session never flashes red before its voice is ready. Do not read this
+    // tombstone as evidence that "yellow until audio" is a bug; the wedge it once caused is now prevented by
+    // voice-generation reliability, not by narrowing the color. See IsVoicePreparing's own summary.
 
     public void Dispose()
     {

--- a/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
@@ -105,18 +105,28 @@ public static class SessionOrdering
         string.IsNullOrWhiteSpace(s.DictationStatus) ? null : s.DictationStatus;
 
     /// <summary>
-    /// Issue #553: true while a VOICE-MODE waiting session is ACTIVELY generating its spoken summary,
-    /// so the roster holds yellow ("preparing voice") rather than flashing red mid-generation. Once
-    /// generation ends the session shows its real color - red "needs you", with the roster play
-    /// triangle appearing separately when <see cref="SessionDto.VoiceAudioReady"/> is true.
+    /// Issue #553: true while a VOICE-MODE waiting session does not yet have playable audio - either it is
+    /// actively generating its spoken summary (<see cref="SessionDto.VoiceGenerating"/>) OR there is simply
+    /// no audio ready yet (<c>!VoiceAudioReady</c>). The roster holds YELLOW ("preparing voice") the WHOLE
+    /// time - across the gaps between generation attempts, not just while one is in flight - until the audio
+    /// is ready.
     ///
-    /// This used to ALSO hold yellow whenever audio was not yet ready (<c>|| !VoiceAudioReady</c>),
-    /// on the assumption that audio always eventually arrives. It does not: a text-to-speech
-    /// failure (a DevThrottle/DeepInfra 504 or timeout) produces NO audio, so <c>VoiceAudioReady</c>
-    /// stayed false with nothing generating - and the session was stuck yellow/orange FOREVER while
-    /// it actually needed the user (the "stuck orange, says needs you" report, 2026-07-08). Gating
-    /// the hold on <see cref="SessionDto.VoiceGenerating"/> alone gives a terminal exit: when a turn's
-    /// voice fails, the session correctly becomes red/needs-you instead of a permanent wedge.
+    /// Voice mode is a FIRST-CLASS state, not an overlay on a red session. A voice session that has finished
+    /// its turn does need the user, but until the voice is ready there is nothing to act on - so it presents
+    /// as "needs you, preparing voice" (yellow), and you can read the text if you choose. It becomes red only
+    /// once <see cref="SessionDto.VoiceAudioReady"/> is true - now there is something to play and act on.
+    ///
+    /// OWNER'S RULING, 2026-07-19: in voice mode the user must NEVER see red until the voice is available.
+    /// This restores the <c>|| !VoiceAudioReady</c> hold that was removed on 2026-07-08. That removal narrowed
+    /// the hold to <see cref="SessionDto.VoiceGenerating"/> ALONE to make it wedge-proof - the yellow could
+    /// never get stuck - but it fell back to red in EVERY gap between retry attempts, so a phone in voice mode
+    /// flashed red while its voice was still on the way. The wedge the 2026-07-08 change feared (a permanent
+    /// text-to-speech failure sitting yellow forever, because "no audio yet" and "gave up" were the same
+    /// value) is NOT re-introduced by widening this COLOR rule. It is prevented where it belongs: by making
+    /// voice generation reliable (a sub-minute average; anything over three minutes is an exception to be
+    /// flagged and fixed) and, separately, by giving voice a terminal "gave up" state. So do NOT re-narrow
+    /// this to VoiceGenerating alone to "fix" a session stuck yellow - a stuck session is a voice-reliability
+    /// bug, not a color bug, and narrowing the color only hides it behind a red flicker again.
     ///
     /// Gated on raw red and on WaitingForInput/WaitingForPerm so a working (blue) session is untouched.
     /// </summary>
@@ -138,7 +148,10 @@ public static class SessionOrdering
         var waiting = string.Equals(state, "WaitingForInput", StringComparison.OrdinalIgnoreCase)
                    || string.Equals(state, "WaitingForPerm", StringComparison.OrdinalIgnoreCase);
         if (!waiting) return false;
-        return s.VoiceGenerating;
+        // Yellow while generating OR while there is simply no audio yet - held across the gaps between
+        // attempts, until VoiceAudioReady flips true. See the summary for why this is not the 2026-07-08
+        // wedge: a permanently failing voice is a reliability bug to fix at the source, not a color to hide.
+        return s.VoiceGenerating || !s.VoiceAudioReady;
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Tests/GatewayAddsAFactTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayAddsAFactTests.cs
@@ -117,13 +117,17 @@ public sealed class GatewayAddsAFactTests
         Assert.Equal("None", s.BriefingState);
     }
 
-    /// <summary>No generation, no window. The control: if this ever goes yellow the fix has invented a
-    /// state rather than moved one.</summary>
+    /// <summary>Outside the voice window - nothing generating AND the audio is already ready - the row is
+    /// red "needs you", and the Director's "None" is still readable. The control: a session the Gateway is
+    /// NOT preparing voice for folds red on the Gateway's own rule, not on a hijacked field. (Since the
+    /// 2026-07-19 widening, "not generating" alone is no longer outside the window - a session with no audio
+    /// yet is still yellow; it is READY audio that ends the yellow, so this control pins audioReady=true.)</summary>
     [Fact]
-    public void NotGenerating_IsNotTheGatewayWindow()
+    public void NotGenerating_AudioReady_IsNotTheGatewayWindow()
     {
         var s = VoiceGenerating(directorBriefingState: "None");
         s.VoiceGenerating = false;
+        s.VoiceAudioReady = true;
 
         Assert.Equal("red", SessionOrdering.EffectiveColor(s));
         Assert.Equal("None", s.BriefingState);

--- a/src/CcDirector.Gateway.Tests/SessionOrderingTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionOrderingTests.cs
@@ -252,13 +252,14 @@ public sealed class SessionOrderingTests
     };
 
     [Fact]
-    public void EffectiveColor_VoiceWaiting_NoAudio_NotGenerating_IsRed_NotStuckYellow()
+    public void EffectiveColor_VoiceWaiting_NoAudio_NotGenerating_IsYellow_UntilAudioReady()
     {
-        // Regression (2026-07-08): a text-to-speech failure (DeepInfra 504/timeout) produces no
-        // audio, so a voice-mode waiting session ends with audioReady=false and nothing generating.
-        // This must resolve to red "needs you" - NOT the old permanent yellow/orange wedge that had
-        // no exit when audio never arrived. The hold is now gated on VoiceGenerating alone.
-        Assert.Equal("red", SessionOrdering.EffectiveColor(
+        // Owner's ruling (2026-07-19): a voice-mode waiting session with no audio yet is YELLOW
+        // "preparing voice", held across the gaps between generation attempts - NOT red. In voice
+        // mode the user must never see red until the voice is available. (This deliberately reverses
+        // the 2026-07-08 "red when not generating" narrowing; the wedge that change feared is now a
+        // voice-reliability concern, not a color rule - see IsVoicePreparing's summary.)
+        Assert.Equal("yellow", SessionOrdering.EffectiveColor(
             Voice("red", "WaitingForInput", generating: false, audioReady: false)));
     }
 
@@ -304,13 +305,22 @@ public sealed class SessionOrderingTests
     }
 
     [Fact]
-    public void Classify_VoiceWaiting_NoAudio_NotGenerating_IsNeedsYou()
+    public void Classify_VoiceWaiting_NoAudio_NotGenerating_IsActive_PreparingVoice()
     {
-        // Regression (2026-07-08): once generation has ended with no audio (text-to-speech failed),
-        // the session genuinely needs the user - it must surface in NEEDS YOU, not hide in Active
-        // behind a stuck "preparing voice" state forever.
-        Assert.Equal(SessionOrdering.TriageBucket.NeedsYou, SessionOrdering.Classify(
+        // Owner's ruling (2026-07-19): a voice-mode waiting session with no audio yet is "preparing
+        // voice" (yellow), so it triages Active, not NeedsYou - there is nothing to act on until the
+        // voice is ready. It only enters NeedsYou once audio is ready (see the AudioReady test below).
+        Assert.Equal(SessionOrdering.TriageBucket.Active, SessionOrdering.Classify(
             Voice("red", "WaitingForInput", generating: false, audioReady: false)));
+    }
+
+    [Fact]
+    public void Classify_VoiceWaiting_AudioReady_IsNeedsYou()
+    {
+        // Voice is ready - now there is something to play and act on, so the session genuinely needs
+        // the user and surfaces in NEEDS YOU. This is the terminal exit from the yellow hold.
+        Assert.Equal(SessionOrdering.TriageBucket.NeedsYou, SessionOrdering.Classify(
+            Voice("red", "WaitingForInput", generating: false, audioReady: true)));
     }
 
     // Classify_RedWhileExplaining_IsActive_NotNeedsYou lived here and is deleted with the rule it covered

--- a/src/CcDirector.StateAgreementCheck/AgreementCheck.cs
+++ b/src/CcDirector.StateAgreementCheck/AgreementCheck.cs
@@ -438,12 +438,18 @@ public static class AgreementCheck
     /// StatusColor - and SessionRole, read from Session.GatewayResolvedRole, written ONLY by the Gateway's
     /// set-resolved-role verb (defect 5's fix).
     ///
-    /// It does NOT carry these four, which the Gateway stamps in its roster loop (GatewayEndpoints.cs
+    /// It does NOT carry these five, which the Gateway stamps in its roster loop (GatewayEndpoints.cs
     /// ~:770-790) and which NOTHING pushes down - the Gateway sends exactly two verbs to a Director,
     /// "launch" and "set-resolved-role". Each is a fold input, so each is a real divergence:
     ///   * DictationStatus - the durable phone-dictation record. Gateway: orange. Desktop: cannot see it.
     ///   * Transcribing - the Gateway's active-run mark. Gateway: orange. Desktop: cannot see it.
-    ///   * VoiceGenerating - drives IsVoicePreparing. Gateway: yellow. Desktop: cannot see it.
+    ///   * VoiceGenerating - drives IsVoicePreparing (yellow). Gateway can see it; desktop cannot. Note that
+    ///     since the 2026-07-19 widening of IsVoicePreparing to "yellow while !VoiceAudioReady", stripping
+    ///     VoiceGenerating no longer flips the desktop fold on its own: with no audio either, the desktop
+    ///     still folds yellow. VoiceAudioReady (below) is now the voice fact that actually diverges.
+    ///   * VoiceAudioReady - the Gateway holds playable audio (VoiceGenerating false, !VoiceAudioReady false),
+    ///     so it folds RED "needs you". The desktop cannot see the Gateway's audio, so it still folds YELLOW
+    ///     "preparing voice". Gateway: red. Desktop: yellow. A real divergence, reported below.
     ///   * The OnHold expiry overlay - the Gateway owns the snooze clock and overlays OnHold=false BEFORE
     ///     the fold. The desktop reads the Director's raw hold. This one is TRANSIENT, not structural: the
     ///     reliable display-state channel reconciles the Director's raw hold at fold cadence (there is no
@@ -490,6 +496,11 @@ public static class AgreementCheck
         copy.DictationStatus = null;
         copy.Transcribing = false;
         copy.VoiceGenerating = false;
+        // The Gateway stamps VoiceAudioReady from its own voice store (GatewayEndpoints -> _voiceService
+        // .HasVoice); the Director never sets it. Since IsVoicePreparing now reads !VoiceAudioReady, the
+        // desktop's real value (false) must drive the reconstruction, not the Gateway's - otherwise a row
+        // whose voice is READY would look identical on both screens when the desktop actually cannot see it.
+        copy.VoiceAudioReady = false;
 
         // Un-apply the Gateway's expiry overlay: it set OnHold=false and flagged SnoozeExpired, so the
         // Director's own hold still reads Held until the sweep's nudge reaches it.
@@ -520,6 +531,8 @@ public static class AgreementCheck
             reasons.Add("the Gateway can see its own transcription mark and the desktop cannot");
         if (row.VoiceGenerating)
             reasons.Add("the Gateway can see voice being prepared and the desktop cannot");
+        if (row.VoiceAudioReady)
+            reasons.Add("the Gateway has this session's voice audio ready (so it reads red 'needs you') and the desktop cannot see it (so it still reads yellow 'preparing voice')");
         if (row.SnoozeExpired)
             reasons.Add("the Gateway's snooze clock has expired and the Director has not been nudged off hold yet");
         return reasons.Count == 0


### PR DESCRIPTION
## What

On the phone, a voice-mode session was flashing **red \"needs you\"** in the gaps between voice-generation attempts, then flipping back to yellow when the next attempt began - until the voice was finally ready. It should stay **yellow \"preparing voice\"** the whole time.

## Why it happened

The rail color and the Voice screen are two separate Gateway folds. The Voice screen (`VoiceDisplayFold`) already stays yellow while retrying. The rail (`SessionOrdering.IsVoicePreparing`) held yellow **only while a synthesis attempt was literally in flight** (`VoiceGenerating`), so it fell back to the base red state in every gap. Voice was modeled as a transient overlay on a red session rather than as a state of its own.

## The change

Voice mode is now a first-class state. `IsVoicePreparing` holds yellow while the session is in voice mode, waiting, and has **no playable audio yet** (`VoiceGenerating || !VoiceAudioReady`) - held across the gaps and retries - and turns red only once `VoiceAudioReady` is true (there is finally something to play and act on).

This restores the `|| !VoiceAudioReady` hold that was removed on 2026-07-08. That removal traded the flicker for a wedge-proof rule, but the wedge it feared (a permanently failing voice sitting yellow forever, because \"no audio yet\" and \"gave up\" were the same value) is a **voice-reliability** concern to fix at the source - not a reason to flash red. The target is a sub-minute average; anything over three minutes is an exception to be flagged and fixed, and voice will get a terminal \"gave up\" state separately.

## Agreement check

`VoiceAudioReady` is a Gateway-only fact (the desktop never sets it), and it is now a fold input for the first time. The `StateAgreementCheck` treats it accordingly: the desktop reconstruction strips it, and a voice-ready row (Gateway red, desktop yellow) is reported as a real divergence. The old \"voice being prepared diverges\" case now **agrees** (both yellow).

The phone renders `effectiveColorHex`/`stateLabel` verbatim, so this one Gateway fold change fixes every surface.

## Tests

- `SessionOrderingTests`: no-audio-not-generating now asserts **yellow** / Active; added audio-ready = NeedsYou.
- `GatewayAddsAFactTests`: the red control now pins `VoiceAudioReady = true` (the real out-of-window case).
- `AgreementCheckFaultInjectionTests`: new audio-ready divergence test; companion proving voice-being-prepared now agrees.

Targeted suites green: Gateway.Tests 119 passed, Avalonia.Tests fault-injection 18 passed.