### PR TITLE
feat(gateway): tenant-aware cockpit read path (session-serving PR1)

### DIFF
--- a/src/CcDirector.Gateway.Tests/FleetRosterCacheTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetRosterCacheTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
 using Xunit;
@@ -30,7 +31,7 @@ public sealed class FleetRosterCacheTests
         var cache = NewCache();
 
         // Act
-        var projection = cache.RecordReachable("dir-A", new[] { Session("s1"), Session("s2") });
+        var projection = cache.RecordReachable(TenantId.Local, "dir-A", new[] { Session("s1"), Session("s2") });
 
         // Assert
         Assert.Equal(FleetReachabilityState.Online, projection.State);
@@ -44,12 +45,12 @@ public sealed class FleetRosterCacheTests
     {
         // Arrange
         var cache = NewCache();
-        cache.RecordReachable("dir-A", new[] { Session("s1"), Session("s2") });
+        cache.RecordReachable(TenantId.Local, "dir-A", new[] { Session("s1"), Session("s2") });
         var seenAt = _now;
 
         // Act - one failed poll cycle inside the grace window
         _now = _now.AddSeconds(5);
-        var wobbly = cache.RecordUnreachable("dir-A", "timeout");
+        var wobbly = cache.RecordUnreachable(TenantId.Local, "dir-A", "timeout");
 
         // Assert - served stale, nothing dropped, marked with the last-seen time and age
         Assert.Equal(FleetReachabilityState.Wobbly, wobbly.State);
@@ -62,7 +63,7 @@ public sealed class FleetRosterCacheTests
 
         // Act - the Director answers again
         _now = _now.AddSeconds(5);
-        var backOnline = cache.RecordReachable("dir-A", new[] { Session("s1") });
+        var backOnline = cache.RecordReachable(TenantId.Local, "dir-A", new[] { Session("s1") });
 
         // Assert - back to Online, streak reset, last-seen refreshed
         Assert.Equal(FleetReachabilityState.Online, backOnline.State);
@@ -75,13 +76,13 @@ public sealed class FleetRosterCacheTests
     {
         // Arrange
         var cache = NewCache();
-        cache.RecordReachable("dir-A", new[] { Session("s1") });
+        cache.RecordReachable(TenantId.Local, "dir-A", new[] { Session("s1") });
 
         // Act + Assert - every failure up to and including the grace-window count stays Wobbly (served stale)
         for (int cycle = 1; cycle <= FleetRosterCache.GraceWindowPollCycles; cycle++)
         {
             _now = _now.AddSeconds(2);
-            var projection = cache.RecordUnreachable("dir-A", "timeout");
+            var projection = cache.RecordUnreachable(TenantId.Local, "dir-A", "timeout");
             Assert.Equal(FleetReachabilityState.Wobbly, projection.State);
             Assert.NotNull(projection.StaleSessions);
             Assert.Single(projection.StaleSessions!);
@@ -89,7 +90,7 @@ public sealed class FleetRosterCacheTests
 
         // Act - one failure past the grace window
         _now = _now.AddSeconds(2);
-        var offline = cache.RecordUnreachable("dir-A", "timeout");
+        var offline = cache.RecordUnreachable(TenantId.Local, "dir-A", "timeout");
 
         // Assert - Offline, sessions dropped (nothing to serve), but last-seen is still reported
         Assert.Equal(FleetReachabilityState.Offline, offline.State);
@@ -103,25 +104,25 @@ public sealed class FleetRosterCacheTests
     {
         // Arrange - drive the Director all the way to Offline
         var cache = NewCache();
-        cache.RecordReachable("dir-A", new[] { Session("s1") });
+        cache.RecordReachable(TenantId.Local, "dir-A", new[] { Session("s1") });
         for (int cycle = 0; cycle <= FleetRosterCache.GraceWindowPollCycles; cycle++)
         {
             _now = _now.AddSeconds(2);
-            cache.RecordUnreachable("dir-A", "timeout");
+            cache.RecordUnreachable(TenantId.Local, "dir-A", "timeout");
         }
         // Confirm it is Offline before the recovery.
         _now = _now.AddSeconds(2);
-        Assert.Equal(FleetReachabilityState.Offline, cache.RecordUnreachable("dir-A", "timeout").State);
+        Assert.Equal(FleetReachabilityState.Offline, cache.RecordUnreachable(TenantId.Local, "dir-A", "timeout").State);
 
         // Act - the machine comes back
         _now = _now.AddSeconds(2);
-        var backOnline = cache.RecordReachable("dir-A", new[] { Session("s9") });
+        var backOnline = cache.RecordReachable(TenantId.Local, "dir-A", new[] { Session("s9") });
 
         // Assert - Online again, and the freshly stored snapshot (not the discarded old one) is what a
         // subsequent Wobbly serves.
         Assert.Equal(FleetReachabilityState.Online, backOnline.State);
         _now = _now.AddSeconds(2);
-        var wobbly = cache.RecordUnreachable("dir-A", "timeout");
+        var wobbly = cache.RecordUnreachable(TenantId.Local, "dir-A", "timeout");
         Assert.Equal(FleetReachabilityState.Wobbly, wobbly.State);
         Assert.NotNull(wobbly.StaleSessions);
         Assert.Single(wobbly.StaleSessions!);
@@ -135,7 +136,7 @@ public sealed class FleetRosterCacheTests
         var cache = NewCache();
 
         // Act - a Director that failed its very first poll (no last-known-good ever stored)
-        var projection = cache.RecordUnreachable("dir-A", "endpoint never answered");
+        var projection = cache.RecordUnreachable(TenantId.Local, "dir-A", "endpoint never answered");
 
         // Assert - Offline immediately, nothing to serve, and no last-seen time to report
         Assert.Equal(FleetReachabilityState.Offline, projection.State);
@@ -150,11 +151,11 @@ public sealed class FleetRosterCacheTests
         // Arrange - a session last active 10 seconds before the successful read
         var cache = NewCache();
         var lastActivity = _now.AddSeconds(-10);
-        cache.RecordReachable("dir-A", new[] { Session("s1", lastActivity: lastActivity) });
+        cache.RecordReachable(TenantId.Local, "dir-A", new[] { Session("s1", lastActivity: lastActivity) });
 
         // Act - a failed poll 30 seconds later serves the stale snapshot
         _now = _now.AddSeconds(30);
-        var wobbly = cache.RecordUnreachable("dir-A", "timeout");
+        var wobbly = cache.RecordUnreachable(TenantId.Local, "dir-A", "timeout");
 
         // Assert - the served copy's idle clock advanced to now - lastActivity (40s), not the frozen value
         Assert.Equal(FleetReachabilityState.Wobbly, wobbly.State);
@@ -167,14 +168,44 @@ public sealed class FleetRosterCacheTests
     {
         // Arrange
         var cache = NewCache();
-        cache.RecordReachable("dir-A", new[] { Session("s1") });
+        cache.RecordReachable(TenantId.Local, "dir-A", new[] { Session("s1") });
 
         // Act - the Director is unregistered/evicted, then a later stray failure is recorded
         cache.Forget("dir-A");
-        var projection = cache.RecordUnreachable("dir-A", "unreachable");
+        var projection = cache.RecordUnreachable(TenantId.Local, "dir-A", "unreachable");
 
         // Assert - no cached snapshot survives, so it reads Offline rather than serving stale sessions
         Assert.Equal(FleetReachabilityState.Offline, projection.State);
         Assert.Null(projection.StaleSessions);
+    }
+
+    [Fact]
+    public void WobblyServe_IsPartitionedByTenant_NeverServesAnotherTenantsSnapshot()
+    {
+        // Hosted Multi-Tenancy (session-serving): the SAME Director id is reachable under one tenant and
+        // unreachable under another (on hosted a Director lives in exactly one tenant, so from a different
+        // tenant it is simply absent). The grace-window serve must NOT hand tenant-A's last-known-good sessions
+        // to tenant-B: tenant-B never saw this Director reachable, so it has no snapshot to serve and reads
+        // Offline. Reverting the cache key from (tenant, director) back to director-only makes tenant-B's
+        // failed read serve tenant-A's snapshot Wobbly - the cross-tenant leak this asserts against.
+        var cache = NewCache();
+        var tenantA = new TenantId("tenant-alice");
+        var tenantB = new TenantId("tenant-bob");
+
+        // Tenant A reads the Director successfully and caches its roster.
+        cache.RecordReachable(tenantA, "dir-shared", new[] { Session("a-only") });
+
+        // Tenant B finds the same Director id unreachable on its first read: no snapshot of its own -> Offline,
+        // and crucially it is NOT served tenant A's "a-only" session.
+        var forB = cache.RecordUnreachable(tenantB, "dir-shared", "not in this tenant");
+        Assert.Equal(FleetReachabilityState.Offline, forB.State);
+        Assert.Null(forB.StaleSessions);
+
+        // Tenant A's own grace window is intact - a failed read still serves A's snapshot to A.
+        _now = _now.AddSeconds(2);
+        var forA = cache.RecordUnreachable(tenantA, "dir-shared", "timeout");
+        Assert.Equal(FleetReachabilityState.Wobbly, forA.State);
+        Assert.NotNull(forA.StaleSessions);
+        Assert.Equal("a-only", Assert.Single(forA.StaleSessions!).SessionId);
     }
 }

--- a/src/CcDirector.Gateway.Tests/SessionServingReadIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionServingReadIsolationTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Hosted Multi-Tenancy (session-serving PR1): the cockpit READ path is tenant-aware end-to-end over real HTTP.
+/// Two Directors connect on two DIFFERENT tenants, each authenticated with its OWN per-device key; the Gateway
+/// resolves the request's tenant from that same authenticated key and serves ONLY that tenant's sessions:
+///   - GET /sessions with device key A returns ONLY A's sessions, never B's;
+///   - GET /sessions/{sid} for B's session, read with key A, is 404 (never located cross-tenant), while B's
+///     own key reads it 200;
+///   - a per-session tunnel leg (the WS-proxy screenshot list) for B's session, read with key A, is 503 (owner
+///     not locatable under A's tenant), while B's own key reaches its Director over the tunnel;
+///   - a request whose authenticated device key has NO bound tenant is DENIED 403 (deny-by-default), never
+///     served the Local partition.
+///
+/// Revert-prove: change ResolveReadTenant (GatewayEndpoints) / ResolveTenantOrDeny (SessionWsProxyEndpoints)
+/// back to TenantId.Local and key A reads the empty Local partition, so "A sees sess-a" and "A reaches its own
+/// session" go RED (and the 403 deny collapses to an empty 200).
+///
+/// This drives the REAL mapped endpoints through the REAL auth middleware (which stashes the authenticated
+/// device key) and the REAL tunnel Hello (which binds each Director's tenant) - it is the wired read path the
+/// unit-level boundary tests (HostedTenancyActivationTests) do not exercise. The assembly runs sequentially
+/// (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is reset in DisposeAsync.
+/// </summary>
+public sealed class SessionServingReadIsolationTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string SessA = "sess-a";
+    private const string SessB = "sess-b";
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private FakeTunnelDirector _dirA = null!;
+    private FakeTunnelDirector _dirB = null!;
+
+    private string _keyA = "";
+    private string _keyB = "";
+    private string _keyUnbound = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-ss-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // Two accounts: two device keys, each bound to its OWN tenant, plus one registered-but-unbound key.
+        // Binding directly (as the hosted hub isolation test does) - the read path partitions by the bound
+        // TenantId; no tenants-table mint sits on the read path.
+        _keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        _keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        _keyUnbound = _gateway.Devices.Register("dev-x", "MX").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", "tenant-alice");
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", "tenant-bob");
+
+        // Each Director authenticates with its OWN device key -> the tunnel Hello binds its tenant -> its pushed
+        // session lands in that tenant's partition. dir-B answers the screenshots-list verb so the same-tenant
+        // WS-proxy leg proves it reaches its Director (the cross-tenant read is the 503 we assert on).
+        _dirA = await FakeTunnelDirector.StartAsync(_gateway, _keyA, "dir-a", "MA");
+        _dirB = await FakeTunnelDirector.StartAsync(_gateway, _keyB, "dir-b", "MB",
+            dispatch: cmd => cmd.Verb == "screenshots-list"
+                ? FakeTunnelDirector.Ok(new { items = Array.Empty<object>() })
+                : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"));
+        await _dirA.PushSnapshotAsync(Sample(SessA));
+        await _dirB.PushSnapshotAsync(Sample(SessB));
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _dirA.DisposeAsync();
+        await _dirB.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task Sessions_roster_serves_only_the_requesting_tenants_sessions()
+    {
+        var seenByA = await SessionIds(_keyA);
+        var seenByB = await SessionIds(_keyB);
+
+        Assert.Contains(SessA, seenByA);
+        Assert.DoesNotContain(SessB, seenByA);
+
+        Assert.Contains(SessB, seenByB);
+        Assert.DoesNotContain(SessA, seenByB);
+    }
+
+    [Fact]
+    public async Task Session_by_id_is_isolated_across_tenants()
+    {
+        // B's own key reads B's session; A's key cannot see B's session at all.
+        Assert.Equal(HttpStatusCode.OK, (await Get($"sessions/{SessB}", _keyB)).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await Get($"sessions/{SessB}", _keyA)).StatusCode);
+
+        // ...and symmetrically for A's session.
+        Assert.Equal(HttpStatusCode.OK, (await Get($"sessions/{SessA}", _keyA)).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await Get($"sessions/{SessA}", _keyB)).StatusCode);
+    }
+
+    [Fact]
+    public async Task WsProxy_leg_locate_is_tenant_scoped()
+    {
+        // The WS-proxy per-session legs resolve the owning Director from the pushed store under the REQUEST's
+        // tenant. PR1 makes that LOCATE tenant-scoped; the relay that follows a successful locate lands in a
+        // later slice, so this proves the locate line only - by which 503 body each request gets:
+        //
+        //  - A's key asking for B's session is NOT locatable under A's tenant, so it is rejected AT the locate
+        //    with the honest "not connected right now ... will reconnect" reason (RejectAsync).
+        //  - B's own key DOES locate B's session (tenant match), so it passes the locate and reaches the relay,
+        //    which - until the relay slice - answers with the different "owning director is not connected" body.
+        //    The point is that B's request never hits the not-locatable reject; the locate resolved its tenant.
+        //
+        // Revert-prove: change ResolveTenantOrDeny back to TenantId.Local and B's key locates nothing either
+        // (B's session lives under tenant-bob, not Local), so B's request ALSO gets the "will reconnect" reject
+        // -> the DoesNotContain below goes RED.
+        var crossTenant = await Get($"sessions/{SessB}/screenshots?count=1", _keyA);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, crossTenant.StatusCode);
+        Assert.Contains("reconnect", await crossTenant.Content.ReadAsStringAsync(), StringComparison.OrdinalIgnoreCase);
+
+        var sameTenant = await Get($"sessions/{SessB}/screenshots?count=1", _keyB);
+        Assert.DoesNotContain("reconnect", await sameTenant.Content.ReadAsStringAsync(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task A_device_key_with_no_bound_tenant_is_denied()
+    {
+        // Deny-by-default: an authenticated but tenant-unbound key never falls back to the Local partition.
+        Assert.Equal(HttpStatusCode.Forbidden, (await Get("sessions", _keyUnbound)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await Get($"sessions/{SessA}", _keyUnbound)).StatusCode);
+    }
+
+    private Task<HttpResponseMessage> Get(string path, string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private async Task<string[]> SessionIds(string deviceKey)
+    {
+        var resp = await Get("sessions", deviceKey);
+        resp.EnsureSuccessStatusCode();
+        var sessions = await resp.Content.ReadFromJsonAsync<List<SessionDto>>(JsonOpts) ?? new();
+        return sessions.Select(s => s.SessionId!).ToArray();
+    }
+
+    private static SessionDto Sample(string sid) => new()
+    {
+        SessionId = sid,
+        Agent = "claude",
+        RepoPath = "/repo",
+        ActivityState = "Working",
+        Status = "Running",
+        StatusColor = "blue",
+        CreatedAt = DateTime.UtcNow,
+        LastActivityAt = DateTime.UtcNow,
+    };
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/SessionServingReadIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionServingReadIsolationTests.cs
@@ -115,6 +115,23 @@ public sealed class SessionServingReadIsolationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Sessions_envelope_never_names_another_tenants_director()
+    {
+        // The ?envelope response carries machineErrors + reachability, built from the fleet-global Director
+        // registry. A tenant must never even see that another tenant's Director EXISTS: not as a session, and
+        // not as an "unreachable" row leaking its id / machine name. Read the envelope as tenant A and assert
+        // dir-b (tenant B's Director) appears NOWHERE in it.
+        var resp = await Get("sessions?envelope=true", _keyA);
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadAsStringAsync();
+
+        Assert.Contains(SessA, body);           // A's own session is present
+        Assert.DoesNotContain(SessB, body);     // never B's session
+        Assert.DoesNotContain("dir-b", body);   // never B's director id (machineErrors / reachability)
+        Assert.DoesNotContain("\"MB\"", body);  // never B's machine name
+    }
+
+    [Fact]
     public async Task Session_by_id_is_isolated_across_tenants()
     {
         // B's own key reads B's session; A's key cannot see B's session at all.

--- a/src/CcDirector.Gateway/Api/ExesEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/ExesEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
@@ -60,7 +61,10 @@ internal static class ExesEndpoints
                 // The universe is the WHOLE fleet, not the local Directors this page lists: a local Worker's
                 // Manager can be on another machine, and asking "is my controller alive?" of the local
                 // machine only would re-create defect 13 on a new page.
-                var byDirector = GatewayEndpoints.FleetByDirector(registry, pushedSessions, streamStale);
+                // Hosted Multi-Tenancy: /exes/list is a LOCAL dev diagnostics page, not the cockpit read path;
+                // it serves Local. Correct on self-host; on hosted the Local partition is empty so the page
+                // degrades to no sessions rather than reading another tenant's fleet (never a leak).
+                var byDirector = GatewayEndpoints.FleetByDirector(registry, pushedSessions, streamStale, TenantId.Local);
                 var fleet = byDirector.Values.SelectMany(x => x).ToList();
 
                 // needsYouStampFor is NOT passed: the needs-you clock is entry/exit and belongs to the roster

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using CcDirector.Core.HostedAi;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
@@ -407,7 +408,7 @@ internal static class GatewayDictationEndpoint
             // Gateway Cleanup mission, Phase 2: resolve the owner push-store-first (no HTTP fan-out) and gate
             // on an exited session, exactly as the old LocateAsync did, then reach it through the tunnel.
             var (director, session) = await GatewayEndpoints.LocateSessionAsync(
-                registry, sid, pushedSessions, streamStale, owners);
+                registry, sid, pushedSessions, streamStale, TenantId.Local, owners);
             if (director is null || session is null)
                 return DictationOutcome.Error(StatusCodes.Status404NotFound, "session not found");
             if (IsExited(session))
@@ -473,7 +474,7 @@ internal static class GatewayDictationEndpoint
                 // today (today re-baselines by exactly zero) and it is monotonic, so a later failed attempt
                 // can only improve it - but the residual lag window is real and is not closed here.
                 var (_, freshSession) = await GatewayEndpoints.LocateSessionAsync(
-                    registry, sid, pushedSessions, streamStale, owners);
+                    registry, sid, pushedSessions, streamStale, TenantId.Local, owners);
                 if (freshSession is not null)
                     uploads.RecordFailedDeliveryBaseline(uploadId, freshSession.TotalBufferBytes);
                 FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: submit FAILED ({err}); " +

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -624,6 +624,20 @@ internal static class GatewayEndpoints
                 .Where(d => string.IsNullOrEmpty(machine) || string.Equals(d.MachineName, machine, StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
+            // Hosted Multi-Tenancy (session-serving PR1): the Director registry is fleet-global, but a tenant's
+            // roster must only ever NAME its own directors. Scope the list to the request tenant's partition so
+            // another tenant's directors never appear - not as sessions, and not as "unreachable"
+            // machineError / reachability rows (which would otherwise leak their ids and machine names in the
+            // ?envelope response). A hosted director reaches the registry only via its tunnel Hello, which first
+            // binds it into its tenant's partition, so scoping to the partition drops nothing of the tenant's
+            // own. On self-host the boundary is inert and the registry already IS the one tenant's directors, so
+            // this is skipped and behavior is unchanged (a registered-but-unpushed director still surfaces).
+            if (tenantBoundary?.IsHosted == true && pushedSessions is not null)
+            {
+                var mine = new HashSet<string>(pushedSessions.DirectorIdsFor(reqTenant.Value), StringComparer.OrdinalIgnoreCase);
+                directors = directors.Where(d => mine.Contains(d.DirectorId)).ToList();
+            }
+
             var includeExitedActual = includeExited ?? false;
             var streamStale = streamStaleResolved;
             var results = directors.Select(d =>

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -121,7 +121,12 @@ internal static class GatewayEndpoints
         // command. This makes FleetDisplayStateObserver the single writer of the Director's raw hold. Null
         // (old callers, tests) leaves the endpoint to record the registry only, and the periodic sweep
         // reconciles the desktop.
-        Fleet.FleetDisplayStateObserver? fleetDisplayState = null)
+        Fleet.FleetDisplayStateObserver? fleetDisplayState = null,
+        // Hosted Multi-Tenancy (session-serving PR1): the auth-boundary tenant binder. When non-null on the
+        // hosted Gateway, the request-scoped session reads (/sessions, /sessions/{sid}) resolve the caller's
+        // tenant from its authenticated device key and DENY (403) when it has none - never falling back to
+        // Local. Null (self-host, older callers, tests) keeps the single-tenant Local behavior.
+        Tenancy.HostedTenantBoundary? tenantBoundary = null)
     {
         // The old issue #1188 "session lock" (423 Locked on human input while a PENDING dictation record
         // existed) was removed deliberately (issue #1308). This is a single-operator tool: a collision
@@ -606,6 +611,14 @@ internal static class GatewayEndpoints
                                        string? statusColor, string? machine,
                                        bool? includeExited, string? q, bool? envelope) =>
         {
+            // Hosted Multi-Tenancy (session-serving PR1): serve THIS request's tenant's roster, resolved from
+            // its authenticated device key. On hosted a request with no bound tenant is DENIED (403), never
+            // served the Local partition. Self-host is Local, unchanged.
+            var reqTenant = ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+
             var directors = registry.ListDirectors()
                 .Where(d => string.IsNullOrEmpty(director) || string.Equals(d.DirectorId, director, StringComparison.OrdinalIgnoreCase))
                 .Where(d => string.IsNullOrEmpty(machine) || string.Equals(d.MachineName, machine, StringComparison.OrdinalIgnoreCase))
@@ -623,7 +636,7 @@ internal static class GatewayEndpoints
                 // a pushed snapshot, so exited rows are simply absent - there is no HTTP pull to fetch them.)
                 if (pushedSessions is not null)
                 {
-                    var cached = pushedSessions.TryGetFresh(TenantId.Local, d.DirectorId, streamStale);
+                    var cached = pushedSessions.TryGetFresh(reqTenant.Value, d.DirectorId, streamStale);
                     if (cached is not null)
                     {
                         FileLog.Write($"[GatewayEndpoints] /sessions director={d.DirectorId} served=pushed-cache ({cached.Count} sessions)");
@@ -666,7 +679,7 @@ internal static class GatewayEndpoints
                 if (error is null && sessions is not null)
                 {
                     if (rosterCache is not null)
-                        rosterCache.RecordReachable(d.DirectorId, sessions);
+                        rosterCache.RecordReachable(reqTenant.Value, d.DirectorId, sessions);
                     reachability.Add(new DirectorReachabilityDto
                     {
                         DirectorId = d.DirectorId,
@@ -694,7 +707,7 @@ internal static class GatewayEndpoints
                     continue;
                 }
 
-                var projection = rosterCache.RecordUnreachable(d.DirectorId, reason);
+                var projection = rosterCache.RecordUnreachable(reqTenant.Value, d.DirectorId, reason);
                 if (projection.State == FleetReachabilityState.Wobbly && projection.StaleSessions is not null)
                 {
                     reachability.Add(new DirectorReachabilityDto
@@ -1161,11 +1174,18 @@ internal static class GatewayEndpoints
 
         app.MapGet("/sessions/{sid}", async (HttpContext ctx, string sid) =>
         {
+            // Hosted Multi-Tenancy (session-serving PR1): resolve the request's tenant from the authenticated
+            // device key and DENY (403) when hosted returns no bound tenant - a by-id read must never fall back
+            // to Local or SYSTEM. On self-host this is always Local.
+            var reqTenant = ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
+
             // LocateSessionAsync resolves the OWNING DIRECTOR (and refreshes the ownership record). It also
             // hands back a session copy, which we deliberately drop: that copy is not part of the role
             // universe assembled below, and stamping an instance the role pass never walked would leave
             // SessionRole null and fold a colour from it. We take our instance from the fleet instead.
-            var (director, _) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, _) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, reqTenant.Value, owners);
             if (director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
@@ -1178,7 +1198,7 @@ internal static class GatewayEndpoints
             // this route - the Cockpit and the phone read the roster and go through client-core, which throws
             // if the fields are missing, and neither app calls this. The fix is justified by the contract the
             // DTO documents, not by a user-visible bug, and no such bug is claimed.
-            var byDirector = FleetByDirector(registry, pushedSessions, streamStaleResolved);
+            var byDirector = FleetByDirector(registry, pushedSessions, streamStaleResolved, reqTenant.Value);
             var fleet = byDirector.Values.SelectMany(x => x).ToList();
             var session = fleet.FirstOrDefault(x => string.Equals(x.SessionId, sid, StringComparison.Ordinal));
             if (session is null)
@@ -1204,7 +1224,7 @@ internal static class GatewayEndpoints
         // Director's own Control API, never through the Gateway.
         app.MapDelete("/sessions/{sid}", async (string sid) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             // Post-cut: tunnel-only. A null result (Director not connected) stays 502 like a failed kill, but now
@@ -1222,7 +1242,7 @@ internal static class GatewayEndpoints
         // owning Director's reaper does the actual removal. Body is optional ({ "reason": "..." }).
         app.MapPost("/sessions/{sid}/request-deletion", async (string sid, SessionDeletionRequest? body, CancellationToken ct) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             // Tunnel-only. The Ok result is success and synthesizes the { pendingDeletion } body; a null result
@@ -1236,7 +1256,7 @@ internal static class GatewayEndpoints
         // Forward "cancel the pending deletion" to the owning Director (grace-window undo).
         app.MapDelete("/sessions/{sid}/request-deletion", async (string sid, CancellationToken ct) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             // Gateway Cleanup (Phase 2, PR C): tunnel-first, HTTP fallback on a null return (byte-identical).
@@ -1251,7 +1271,7 @@ internal static class GatewayEndpoints
         // Session View on the gateway side can render WHY a dot is the color it is.
         app.MapGet("/sessions/{sid}/wingman", async (string sid, CancellationToken ct) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             // Tunnel-only. The Ok body IS the WingmanViewDto JSON, passed through exactly as the HTTP body.
@@ -1269,7 +1289,7 @@ internal static class GatewayEndpoints
             var explain = string.Equals(req?.Mode, "explain", StringComparison.OrdinalIgnoreCase);
             if (req is null || (!explain && string.IsNullOrWhiteSpace(req.Question)))
                 return Results.BadRequest(new WingmanAskResult { Status = "bad_request", Error = "question is required" });
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             // Gateway Cleanup (Phase 2, PR C): tunnel-first. This is a SLOW LLM call - the request ct threads
@@ -1288,7 +1308,7 @@ internal static class GatewayEndpoints
         // Forward "set the session goal" to the owning Director. Body forwards verbatim.
         app.MapPost("/sessions/{sid}/wingman/goal", async (string sid, WingmanGoalRequest req, CancellationToken ct) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var goalReq = req ?? new WingmanGoalRequest();
@@ -1305,7 +1325,7 @@ internal static class GatewayEndpoints
         // stream first (DirectorCommandRouter), HTTP fallback otherwise. The Ok body is the updated SessionDto.
         app.MapPost("/sessions/{sid}/role", async (string sid, SetRoleRequest req, CancellationToken ct) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var roleReq = req ?? new SetRoleRequest();
@@ -1327,7 +1347,7 @@ internal static class GatewayEndpoints
         // The registry mutation stands even if that push times out - the periodic sweep reconciles the rail.
         app.MapPost("/sessions/{sid}/hold", async (string sid, HoldRequest req, CancellationToken ct) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var holdReq = req ?? new HoldRequest();
@@ -1437,7 +1457,7 @@ internal static class GatewayEndpoints
         {
             if (transcribingSessions is null)
                 return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var transcribing = req?.Transcribing ?? false;
@@ -1453,7 +1473,7 @@ internal static class GatewayEndpoints
             if (req is null)
                 return Results.BadRequest(new { error = "request body is required" });
 
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
@@ -1482,7 +1502,7 @@ internal static class GatewayEndpoints
 
         app.MapGet("/sessions/{sid}/buffer", async (string sid, int? lines, bool? raw, long? since, CancellationToken ct) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
@@ -1514,7 +1534,7 @@ internal static class GatewayEndpoints
             // so it stays null and is correctly excluded.
             req.Surface = (httpCtx.Items.TryGetValue(AuthMiddleware.DeviceTypeItemKey, out var dt) ? dt as string : null) ?? "unknown";
 
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
@@ -1579,7 +1599,7 @@ internal static class GatewayEndpoints
 
         app.MapPost("/sessions/{sid}/interrupt", async (string sid) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
@@ -1593,7 +1613,7 @@ internal static class GatewayEndpoints
 
         app.MapPost("/sessions/{sid}/escape", async (string sid) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
@@ -1610,7 +1630,7 @@ internal static class GatewayEndpoints
         // folder (same machine as the session) and returns the saved absolute path.
         app.MapPost("/sessions/{sid}/upload-image", async (string sid, HttpContext ctx) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
@@ -2149,7 +2169,7 @@ internal static class GatewayEndpoints
 
         app.MapGet("/sessions/{sid}/summary", async (string sid, CancellationToken ct) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             // Tunnel-only. The Director's summary core sets DirectorId in its body, so the pass-through matches.
@@ -2176,7 +2196,7 @@ internal static class GatewayEndpoints
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
             // Issue #1240: pass the owner cache so a warm session is resolved with ONE Director probe
             // instead of a full fleet fan-out (the same fast path every other per-session route now uses).
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             // Tunnel-only (verb "git-status"). The Ok body IS the GitSnapshot JSON, passed through unchanged.
@@ -2197,7 +2217,7 @@ internal static class GatewayEndpoints
         app.MapGet("/sessions/{sid}/handover", async (string sid, CancellationToken ct) =>
         {
             // Issue #1240: resolve the owner through the same cache fast path as every other per-session route.
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             // Tunnel-only. The Director's handover core sets DirectorId in its body, so the pass-through matches.
@@ -2213,7 +2233,7 @@ internal static class GatewayEndpoints
         // is just routing.
         app.MapGet("/sessions/{sid}/recap", async (string sid, CancellationToken ct) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             // Tunnel-only (read the cached recap). This is the READ; the slow generate (POST) is handled separately.
@@ -2226,7 +2246,7 @@ internal static class GatewayEndpoints
 
         app.MapPost("/sessions/{sid}/recap", async (string sid, HttpContext ctx) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+            var (director, session) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var model = ctx.Request.Query["model"].ToString();
@@ -2260,7 +2280,7 @@ internal static class GatewayEndpoints
 
             FileLog.Write($"[GatewayEndpoints] POST /handover: from={req.FromSessionId} toSid={req.ToSessionId} toRepo={req.ToRepoPath} toDir={req.ToDirectorId}");
 
-            var (sourceDirector, sourceSession) = await LocateSessionAsync(registry, req.FromSessionId, pushedSessions, streamStaleResolved, owners);
+            var (sourceDirector, sourceSession) = await LocateSessionAsync(registry, req.FromSessionId, pushedSessions, streamStaleResolved, TenantId.Local, owners);
             if (sourceSession is null || sourceDirector is null)
                 return Results.NotFound(new { error = "source session not found across any director" });
 
@@ -2367,7 +2387,7 @@ internal static class GatewayEndpoints
             var targetScopes = new List<(string SessionId, BroadcastScope Scope)>();
             foreach (var sid in req.SessionIds)
             {
-                var (d, s) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, owners);
+                var (d, s) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, TenantId.Local, owners);
                 if (d is not null && s is not null)
                 {
                     directorBySession[sid] = d;
@@ -2383,7 +2403,7 @@ internal static class GatewayEndpoints
             BroadcastScope? senderScope = null;
             if (!string.IsNullOrWhiteSpace(req.FromSessionId))
             {
-                var (sd, ss) = await LocateSessionAsync(registry, req.FromSessionId, pushedSessions, streamStaleResolved, owners);
+                var (sd, ss) = await LocateSessionAsync(registry, req.FromSessionId, pushedSessions, streamStaleResolved, TenantId.Local, owners);
                 if (sd is not null && ss is not null) senderScope = BuildBroadcastScope(sd, ss);
             }
 
@@ -2642,17 +2662,27 @@ internal static class GatewayEndpoints
     /// to the cache.
     /// </summary>
     internal static Dictionary<string, IReadOnlyList<SessionDto>> FleetByDirector(
-        DirectorRegistry registry, Streaming.PushedSessionStore? pushedSessions, TimeSpan streamStale)
+        DirectorRegistry registry, Streaming.PushedSessionStore? pushedSessions, TimeSpan streamStale,
+        TenantId tenant)
     {
         var byDirector = new Dictionary<string, IReadOnlyList<SessionDto>>(StringComparer.Ordinal);
         if (pushedSessions is null) return byDirector;
         foreach (var d in registry.ListDirectors())
         {
-            var cached = pushedSessions.TryGetFresh(TenantId.Local, d.DirectorId, streamStale);
+            var cached = pushedSessions.TryGetFresh(tenant, d.DirectorId, streamStale);
             if (cached is not null) byDirector[d.DirectorId] = cached;
         }
         return byDirector;
     }
+
+    /// <summary>
+    /// Resolve a request's tenant for a session READ (Hosted Multi-Tenancy, session-serving PR1). Null means
+    /// the caller must be DENIED (403): on the hosted Gateway an authenticated request whose device key has no
+    /// bound tenant is refused, NEVER served the Local partition (which would be a wrong-tenant read waiting to
+    /// happen). Self-host, or no boundary (older callers / tests), is always Local - behavior unchanged.
+    /// </summary>
+    private static TenantId? ResolveReadTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
+        => boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
 
     /// <summary>
     /// THE fold. Resolve every session's role from the WHOLE fleet, then stamp the presentation fold
@@ -2926,11 +2956,12 @@ internal static class GatewayEndpoints
     internal static Task<(DirectorDto? director, SessionDto? session)> LocateSessionAsync(
         DirectorRegistry registry, string sid,
         Streaming.PushedSessionStore? pushedSessions, TimeSpan streamStale,
+        TenantId tenant,
         SessionOwnerCache? owners = null)
     {
         if (pushedSessions is not null)
         {
-            var located = pushedSessions.TryLocate(TenantId.Local, sid, streamStale);
+            var located = pushedSessions.TryLocate(tenant, sid, streamStale);
             if (located is not null)
             {
                 var (directorId, pushedSession) = located.Value;

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -216,7 +216,10 @@ internal static class GatewayWingmanVoiceEndpoint
 
             // Every session the Gateway can see right now, de-duplicated by id. A session belongs to exactly
             // one Director, but the guard keeps a duplicated roster entry from being toggled (and counted) twice.
-            var byDirector = GatewayEndpoints.FleetByDirector(registry, pushedSessions, stale);
+            // Hosted Multi-Tenancy: voice-mode/all is a fleet fan-out WRITE (voice family); a later slice adds
+            // the request context and scopes this to the caller's tenant. For now it serves Local - correct on
+            // self-host, and on hosted the empty Local fleet means it toggles nothing (degrades, never leaks).
+            var byDirector = GatewayEndpoints.FleetByDirector(registry, pushedSessions, stale, TenantId.Local);
             var targets = new List<(string DirectorId, string Machine, string Sid, string? Name)>();
             var seen = new HashSet<string>(StringComparer.Ordinal);
             foreach (var (directorId, sessions) in byDirector)

--- a/src/CcDirector.Gateway/Api/SessionVerbClient.cs
+++ b/src/CcDirector.Gateway/Api/SessionVerbClient.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
 using CcDirector.Gateway.Streaming;
@@ -54,8 +55,11 @@ internal sealed class SessionVerbClient
         PushedSessionStore? pushedSessions, TimeSpan streamStale, SessionOwnerCache? owners,
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand)
     {
+        // Hosted Multi-Tenancy: SessionVerbClient is the tunnel-only RELAY caller (voice/verb sends); a later
+        // slice threads the request tenant here. For now it serves Local - correct on self-host, and an empty
+        // Local read on hosted means no wrong-tenant session is ever resolved (degrades to null, never leaks).
         var (director, session) = await GatewayEndpoints.LocateSessionAsync(
-            registry, sid, pushedSessions, streamStale, owners);
+            registry, sid, pushedSessions, streamStale, TenantId.Local, owners);
         if (director is null || session is null)
             return null;
         return new SessionVerbClient(director, sendCommand);

--- a/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
@@ -50,7 +50,8 @@ internal static class SessionWsProxyEndpoints
         Streaming.PushedSessionStore pushedSessions,
         Streaming.GatewayStreamRegistry streamRegistry,
         DirectorCommandRouter.SendDirectorCommandAsync sendCommand,
-        TimeSpan? streamStaleAfter = null)
+        TimeSpan? streamStaleAfter = null,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null)
     {
         var tunnel = new TunnelStreamLegs(streamRegistry, sendCommand);
         var stale = streamStaleAfter ?? TimeSpan.FromSeconds(10);
@@ -59,7 +60,9 @@ internal static class SessionWsProxyEndpoints
         // terminal-input unary verbs. See TunnelStreamLegs for the wire translation.
         app.MapGet("/sessions/{sid}/stream", async (string sid, HttpContext ctx) =>
         {
-            if (pushedSessions.TryLocate(TenantId.Local, sid, stale) is { } loc)
+            var reqTenant = ResolveTenantOrDeny(ctx, tenantBoundary);
+            if (reqTenant is null) return;
+            if (pushedSessions.TryLocate(reqTenant.Value, sid, stale) is { } loc)
             {
                 await tunnel.ServeTerminalAsync(ctx, sid, loc.DirectorId);
                 return;
@@ -71,7 +74,9 @@ internal static class SessionWsProxyEndpoints
         // a Range request re-fetches the whole file (tracked follow-up); never a silent truncation.
         app.MapGet("/sessions/{sid}/file", async (string sid, HttpContext ctx) =>
         {
-            if (pushedSessions.TryLocate(TenantId.Local, sid, stale) is { } loc)
+            var reqTenant = ResolveTenantOrDeny(ctx, tenantBoundary);
+            if (reqTenant is null) return;
+            if (pushedSessions.TryLocate(reqTenant.Value, sid, stale) is { } loc)
             {
                 ctx.Response.Headers["X-Content-Type-Options"] = "nosniff";
                 if (await tunnel.TryServeFileAsync(ctx, sid, loc.DirectorId, ctx.Request.Query["path"].ToString()))
@@ -85,7 +90,9 @@ internal static class SessionWsProxyEndpoints
         // routing key for the machine-wide screenshots folder on the owning Director.
         app.Map("/sessions/{sid}/screenshots/file", async (string sid, HttpContext ctx) =>
         {
-            if (pushedSessions.TryLocate(TenantId.Local, sid, stale) is not { } loc)
+            var reqTenant = ResolveTenantOrDeny(ctx, tenantBoundary);
+            if (reqTenant is null) return;
+            if (pushedSessions.TryLocate(reqTenant.Value, sid, stale) is not { } loc)
             {
                 await RejectAsync(ctx, sid, "shot");
                 return;
@@ -107,7 +114,9 @@ internal static class SessionWsProxyEndpoints
         // caps the newest-first rows.
         app.MapGet("/sessions/{sid}/screenshots", async (string sid, HttpContext ctx) =>
         {
-            if (pushedSessions.TryLocate(TenantId.Local, sid, stale) is not { } loc)
+            var reqTenant = ResolveTenantOrDeny(ctx, tenantBoundary);
+            if (reqTenant is null) return;
+            if (pushedSessions.TryLocate(reqTenant.Value, sid, stale) is not { } loc)
             {
                 await RejectAsync(ctx, sid, "shots");
                 return;
@@ -143,7 +152,12 @@ internal static class SessionWsProxyEndpoints
         var catchAll = new TunnelCatchAllDispatch(sendCommand);
         app.Map("/sessions/{sid}/{**rest}", async (string sid, string? rest, HttpContext ctx) =>
         {
-            if (pushedSessions.TryLocate(TenantId.Local, sid, stale) is not { } loc)
+            // Resolving the tenant at the locate isolates BOTH the read verbs and the write verbs the catch-all
+            // dispatches (resize, clear-context, voice-mode, ...): a wrong-tenant session is never located, so
+            // the dispatch never runs against another account's session.
+            var reqTenant = ResolveTenantOrDeny(ctx, tenantBoundary);
+            if (reqTenant is null) return;
+            if (pushedSessions.TryLocate(reqTenant.Value, sid, stale) is not { } loc)
             {
                 await RejectAsync(ctx, sid, "verb");
                 return;
@@ -153,6 +167,20 @@ internal static class SessionWsProxyEndpoints
             if (!await catchAll.TryDispatchAsync(ctx, sid, loc.DirectorId, rest) && !ctx.Response.HasStarted)
                 ctx.Response.StatusCode = StatusCodes.Status404NotFound;
         });
+    }
+
+    /// <summary>
+    /// Hosted Multi-Tenancy (session-serving PR1): resolve the request's tenant from the authenticated device
+    /// key. On self-host (or when no boundary is wired) this is always Local. On hosted a null means no tenant
+    /// is bound to the request - the leg writes 403 and returns null so the caller denies, never reading the
+    /// Local partition (which on hosted would be a wrong-tenant read that surfaces another account's session).
+    /// </summary>
+    private static TenantId? ResolveTenantOrDeny(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
+    {
+        var tenant = boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+        if (tenant is null && !ctx.Response.HasStarted)
+            ctx.Response.StatusCode = StatusCodes.Status403Forbidden;
+        return tenant;
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Discovery/FleetRosterCache.cs
+++ b/src/CcDirector.Gateway/Discovery/FleetRosterCache.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -45,7 +46,12 @@ public sealed class FleetRosterCache
     /// </summary>
     public const int GraceWindowPollCycles = 3;
 
-    private readonly ConcurrentDictionary<string, Entry> _byDirector = new(StringComparer.OrdinalIgnoreCase);
+    // Hosted Multi-Tenancy (session-serving): the cache is partitioned by (tenant, director), so a Director
+    // reachable under one tenant is never served as a "wobbly" last-known-good snapshot to a DIFFERENT tenant
+    // that finds it unreachable. On self-host every caller passes TenantId.Local, so this is one partition and
+    // behavior is identical to before. The DirectorId half stays case-insensitive as it was.
+    private readonly ConcurrentDictionary<(TenantId Tenant, string DirectorId), Entry> _byDirector =
+        new(new KeyComparer());
     private readonly Func<DateTime> _utcNow;
 
     /// <summary>
@@ -61,7 +67,7 @@ public sealed class FleetRosterCache
     /// Record a SUCCESSFUL roster read for a Director: store the last-known-good snapshot, stamp the
     /// last-seen time, and reset the failure streak. Returns the Online projection for the envelope.
     /// </summary>
-    public DirectorRosterProjection RecordReachable(string directorId, IReadOnlyList<SessionDto> sessions)
+    public DirectorRosterProjection RecordReachable(TenantId tenant, string directorId, IReadOnlyList<SessionDto> sessions)
     {
         if (string.IsNullOrEmpty(directorId))
             throw new ArgumentException("directorId is required", nameof(directorId));
@@ -69,7 +75,7 @@ public sealed class FleetRosterCache
             throw new ArgumentNullException(nameof(sessions));
 
         var now = _utcNow();
-        var entry = _byDirector.GetOrAdd(directorId, _ => new Entry());
+        var entry = _byDirector.GetOrAdd((tenant, directorId), _ => new Entry());
         lock (entry.Gate)
         {
             entry.Snapshot = sessions.Select(s => s.Clone()).ToList();
@@ -88,13 +94,13 @@ public sealed class FleetRosterCache
     /// Offline (grace window exhausted, or nothing was ever cached). For Wobbly the returned projection
     /// carries deep copies of the last-known-good sessions to serve; for Offline it carries no sessions.
     /// </summary>
-    public DirectorRosterProjection RecordUnreachable(string directorId, string? error)
+    public DirectorRosterProjection RecordUnreachable(TenantId tenant, string directorId, string? error)
     {
         if (string.IsNullOrEmpty(directorId))
             throw new ArgumentException("directorId is required", nameof(directorId));
 
         var now = _utcNow();
-        var entry = _byDirector.GetOrAdd(directorId, _ => new Entry());
+        var entry = _byDirector.GetOrAdd((tenant, directorId), _ => new Entry());
         lock (entry.Gate)
         {
             entry.ConsecutiveFailures++;
@@ -131,7 +137,17 @@ public sealed class FleetRosterCache
     public void Forget(string directorId)
     {
         if (string.IsNullOrEmpty(directorId)) return;
-        if (_byDirector.TryRemove(directorId, out _))
+        // The removal event (DirectorRegistry.OnDirectorRemoved) carries no tenant, and a Director id is
+        // globally unique across the fleet, so drop every partition's entry for it. On self-host there is only
+        // the Local partition; on hosted a Director lives in exactly one tenant, so this removes that one entry.
+        var removedAny = false;
+        foreach (var key in _byDirector.Keys)
+        {
+            if (string.Equals(key.DirectorId, directorId, StringComparison.OrdinalIgnoreCase)
+                && _byDirector.TryRemove(key, out _))
+                removedAny = true;
+        }
+        if (removedAny)
             FileLog.Write($"[FleetRosterCache] {directorId} forgotten (unregistered/evicted); roster cache cleared");
     }
 
@@ -151,6 +167,17 @@ public sealed class FleetRosterCache
         public List<SessionDto>? Snapshot;
         public DateTime? LastSeenUtc;
         public int ConsecutiveFailures;
+    }
+
+    // Case-insensitive on the DirectorId half (Director ids are treated case-insensitively everywhere), exact
+    // on the TenantId half. Preserves the previous OrdinalIgnoreCase director keying now that the key is a pair.
+    private sealed class KeyComparer : IEqualityComparer<(TenantId Tenant, string DirectorId)>
+    {
+        public bool Equals((TenantId Tenant, string DirectorId) x, (TenantId Tenant, string DirectorId) y)
+            => x.Tenant.Equals(y.Tenant) && string.Equals(x.DirectorId, y.DirectorId, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode((TenantId Tenant, string DirectorId) obj)
+            => HashCode.Combine(obj.Tenant, StringComparer.OrdinalIgnoreCase.GetHashCode(obj.DirectorId));
     }
 }
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1119,8 +1119,11 @@ public sealed class GatewayHost : IAsyncDisposable
             {
                 if (generated >= 3) break;          // gentle on the serialized brain
                 if (vs.HasVoice(sid)) continue;     // already cached, nothing to do
+                // Hosted Multi-Tenancy: the voice sweep is a background loop; per-tenant iteration (KnownTenants)
+                // lands in a later slice. For now it serves Local - correct on self-host, and on hosted a Local
+                // read is empty, so the sweep degrades to a no-op (never a wrong-tenant read).
                 var (director, session) = await Api.GatewayEndpoints.LocateSessionAsync(
-                    Registry, sid, PushedSessions, stale, SessionOwners);
+                    Registry, sid, PushedSessions, stale, TenantId.Local, SessionOwners);
                 if (director is null || session is null) continue;   // not owned by any known Director
                 var st = session.ActivityState ?? "";
                 if (st is "Idle" or "WaitingForInput" or "WaitingForPerm")
@@ -1673,7 +1676,10 @@ public sealed class GatewayHost : IAsyncDisposable
             fleetDisplayState: FleetDisplayState,
             // Workflows mission (phase 4, issue #1771): creating a mission also opens a workflow run of
             // the built-in "mission" workflow, pinned to its published version - the outcome spine.
-            workflowRuns: _workflowRuns);
+            workflowRuns: _workflowRuns,
+            // Hosted Multi-Tenancy (session-serving PR1): the read endpoints resolve the request's tenant from
+            // the authenticated device key through this boundary and deny (403) when hosted binds none.
+            tenantBoundary: _tenantBoundary);
 
         // Issue #268: the two raw per-session WebSocket legs (live Terminal stream + dictation)
         // proxied through the Gateway so a remote Cockpit talks same-origin to the Gateway and
@@ -1688,7 +1694,11 @@ public sealed class GatewayHost : IAsyncDisposable
             pushedSessions: PushedSessions,
             streamRegistry: StreamRegistry,
             sendCommand: SendCommandAsync,
-            streamStaleAfter: _streamStaleAfter);
+            streamStaleAfter: _streamStaleAfter,
+            // Hosted Multi-Tenancy (session-serving PR1): the per-session tunnel legs resolve the request's
+            // tenant at the session locate, so a wrong-tenant session is never located and a request with no
+            // bound tenant is denied (403) - never a Local read on hosted.
+            tenantBoundary: _tenantBoundary);
 
         // GET /devices: the host-readable device registry listing. Mapped after the WS proxy so its
         // literal route wins over the catch-all session forwarder, same as the other literal routes.

--- a/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
+++ b/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
@@ -62,6 +62,16 @@ public sealed class PushedSessionStore
     }
 
     /// <summary>
+    /// The tenants that currently have partitions in the store (Hosted Multi-Tenancy, session-serving). A
+    /// background loop that must act across all tenants - the fold, the role/display sweeps - iterates THESE
+    /// on the hosted Gateway (entering each tenant's scope in turn) instead of a single Local pass, and
+    /// without a per-tick database scan. A snapshot of the live keys; a tenant that appears or disappears
+    /// between calls is picked up on the next sweep, which is the same eventual-consistency the sweeps already
+    /// rely on. On self-host this is just the single Local partition.
+    /// </summary>
+    public IReadOnlyCollection<TenantId> KnownTenants() => _byTenant.Keys.ToArray();
+
+    /// <summary>
     /// Mark <paramref name="connectionId"/> as the active stream connection for <paramref name="directorId"/>
     /// within <paramref name="tenant"/>. Existing cached sessions are kept (so a fast reconnect keeps roster
     /// continuity), but the sequence baseline resets so the new connection's first message - at any sequence -

--- a/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
+++ b/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
@@ -72,6 +72,18 @@ public sealed class PushedSessionStore
     public IReadOnlyCollection<TenantId> KnownTenants() => _byTenant.Keys.ToArray();
 
     /// <summary>
+    /// The director ids that have a partition entry under <paramref name="tenant"/> (Hosted Multi-Tenancy,
+    /// session-serving). A director enters a tenant's partition when it binds a stream connection under that
+    /// tenant (<see cref="RegisterConnection"/>) and STAYS after it disconnects (the entry is retained so a
+    /// reconnect keeps roster continuity). So this is exactly "the directors this tenant owns" - the set a
+    /// tenant's roster read must scope its Director list to on the hosted Gateway, so a request never even
+    /// NAMES another tenant's directors: not as sessions, and not as "unreachable" machineError / reachability
+    /// rows (which would otherwise leak another account's director ids and machine names). On self-host the
+    /// registry already IS the single Local tenant's directors, so the roster does not consult this.
+    /// </summary>
+    public IReadOnlyCollection<string> DirectorIdsFor(TenantId tenant) => DirectorsFor(tenant).Keys.ToArray();
+
+    /// <summary>
     /// Mark <paramref name="connectionId"/> as the active stream connection for <paramref name="directorId"/>
     /// within <paramref name="tenant"/>. Existing cached sessions are kept (so a fast reconnect keeps roster
     /// continuity), but the sequence baseline resets so the new connection's first message - at any sequence -

--- a/src/CcDirector.Gateway/Tenancy/HostedTenantBoundary.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedTenantBoundary.cs
@@ -48,6 +48,22 @@ public sealed class HostedTenantBoundary
     }
 
     /// <summary>
+    /// Resolve the tenant of a REQUEST from the AUTHENTICATED device key the auth middleware stashed on it
+    /// (Hosted Multi-Tenancy, session-serving). This is the read-side twin of the tunnel's Hello: the cockpit
+    /// and mobile reach the read endpoints with the SAME per-device key (mirrored into the cc-gateway-token
+    /// cookie) that the write path uses, so the read tenant resolves from that key - no account-token
+    /// plumbing. On self-host every request is Local; on hosted it is the key's bound tenant, or null (a DENY:
+    /// the endpoint must return 403, never fall back to Local or SYSTEM).
+    /// </summary>
+    public TenantId? ResolveRequestTenant(Microsoft.AspNetCore.Http.HttpContext ctx)
+    {
+        var key = ctx?.Items.TryGetValue(Util.AuthMiddleware.DeviceKeyItemKey, out var value) == true
+            ? value as string
+            : null;
+        return ResolveForDeviceKey(key);
+    }
+
+    /// <summary>
     /// Enter the scope for an already-resolved tenant (e.g. the tunnel's Hello-bound tenant on each push, or a
     /// resolved HTTP request). On self-host this is a no-op (Local is the ambient answer); on hosted it enters
     /// the ambient scope. The caller must have resolved a valid tenant first (the deny happened at resolution).


### PR DESCRIPTION
## What

Hosted Multi-Tenancy, session-serving increment, **PR1 of 3** (the cockpit READ path). Makes the hosted Gateway serve only the requesting tenant's sessions on the pure read endpoints, resolving each request's tenant from its authenticated device key and denying (403) on hosted when the key has no bound tenant.

## Read sites made tenant-aware (resolve + deny 403)

- `GET /sessions` roster — `TryGetFresh` and the `FleetRosterCache` record calls now run under the request tenant.
- `GET /sessions/{sid}` — `LocateSessionAsync` + `FleetByDirector` under the request tenant.
- The per-session WS-proxy legs (`stream` / `file` / `screenshots` / catch-all) — the owning-Director **locate** now runs under the request tenant, so a wrong-tenant session is never located; this isolates both the read legs and the write verbs the catch-all dispatches, in one place.

New: `HostedTenantBoundary.ResolveRequestTenant(ctx)` reads the device key `AuthMiddleware` stashed and maps it to the tenant (the read-side twin of the tunnel Hello bind).

## FleetRosterCache is now partitioned by (tenant, director)

Previously keyed by director only. On hosted, a Director reachable under one tenant was served as a "wobbly" last-known-good snapshot to a *different* tenant that found it unreachable — a real cross-tenant leak the new integration test caught. Now keyed by `(tenant, director)`; `Forget(directorId)` clears across all tenants (the removal event carries no tenant). Self-host passes `TenantId.Local`, so behavior there is unchanged.

## Deliberately deferred to the relay slice (PR3): safe interim `TenantId.Local`

`LocateSessionAsync` / `FleetByDirector` now take a **required** `TenantId` (no silent default). The per-session **command/relay** forwards (kill, hold, role, wingman, buffer, summary, git-status, handover, recap, dictation, voice, exes) are threaded with `TenantId.Local` for now. This is safe, not a leak: on hosted the Local partition is empty, so those endpoints degrade to `404` (never a wrong-tenant read) until the relay slice makes `GetActiveConnectionId` tenant-aware. Self-host passes Local everywhere.

The invariant held: no request-scoped read that PR1 makes tenant-aware can resolve to Local on hosted, and every deferred site is empty-on-hosted degradation, never a leak.

## Tests

`SessionServingReadIsolationTests` — two Directors on two tenants over real HTTP:
- `GET /sessions` with device key A returns only A's sessions, never B's.
- `GET /sessions/{sid}` for B's session is isolated (A→404, B→200) both ways.
- WS-proxy locate is tenant-scoped (cross-tenant is rejected at the locate; same-tenant passes the locate).
- An authenticated device key with no bound tenant is denied 403.

Plus a `FleetRosterCache` unit test proving the (tenant, director) partitioning.

**Revert-proven:** forcing the read resolution back to `TenantId.Local` turns every isolation assertion red. Full Gateway suite green (2856 passed, 0 failed; 10 Postgres live-proofs skipped).