### PR TITLE
Color sync: push seam folds voice facts; desktop offline blue/red floor

### DIFF
--- a/src/CcDirector.Avalonia.Tests/OfflineFloorRailColorTests.cs
+++ b/src/CcDirector.Avalonia.Tests/OfflineFloorRailColorTests.cs
@@ -1,0 +1,73 @@
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The gateway-offline floor (owner's ruling, 2026-07-19). The desktop rail renders the Gateway's stamped
+/// colour while the tunnel is Connected, but when the Gateway is unreachable the stamp is frozen stale, so
+/// the Director - the one surface that HOSTS the session and sees its terminal - paints the single fact it
+/// owns firsthand: blue when the agent is producing output, red when it is idle. Two colours only; it never
+/// runs the Gateway fold locally (which would wedge every voice-mode session yellow, since VoiceAudioReady is
+/// a Gateway-only fact the Director cannot know). Design: docs/new_architecture/session-state.html.
+/// </summary>
+public sealed class OfflineFloorRailColorTests
+{
+    // ----- ONLINE: render the Gateway stamp verbatim, compute nothing (unchanged behaviour) -----
+
+    [Theory]
+    [InlineData("blue")]
+    [InlineData("red")]
+    [InlineData("yellow")]
+    [InlineData("grey")]
+    [InlineData("orange")]
+    public void Online_RendersGatewayStampVerbatim_RegardlessOfLocalActivity(string stamp)
+    {
+        // Even a locally-working session shows the Gateway's stamp when online - e.g. yellow "preparing
+        // voice", which the Director could never compute for itself.
+        Assert.Equal(stamp, SessionViewModel.RailColor(
+            gatewayOffline: false, gatewayStamp: stamp, localActivity: ActivityState.Working));
+    }
+
+    [Fact]
+    public void Online_NoStamp_IsNeutralUnknown()
+    {
+        Assert.Equal("unknown", SessionViewModel.RailColor(
+            gatewayOffline: false, gatewayStamp: null, localActivity: ActivityState.Working));
+    }
+
+    // ----- OFFLINE FLOOR: blue when working, red otherwise, ignoring the stale stamp -----
+
+    [Theory]
+    [InlineData(ActivityState.Working)]
+    [InlineData(ActivityState.Starting)]
+    public void Offline_Working_IsBlue(ActivityState state)
+    {
+        // The stale stamp says yellow (frozen "preparing voice"), but the agent is working -> blue.
+        Assert.Equal("blue", SessionViewModel.RailColor(
+            gatewayOffline: true, gatewayStamp: "yellow", localActivity: state));
+    }
+
+    [Theory]
+    [InlineData(ActivityState.WaitingForInput)]
+    [InlineData(ActivityState.WaitingForPerm)]
+    [InlineData(ActivityState.Idle)]
+    [InlineData(ActivityState.Exited)]
+    public void Offline_NotWorking_IsRed(ActivityState state)
+    {
+        // Stale stamp says yellow; the agent is idle/waiting -> red. Never yellow: the Director cannot know
+        // VoiceAudioReady, so it must not paint "preparing voice".
+        Assert.Equal("red", SessionViewModel.RailColor(
+            gatewayOffline: true, gatewayStamp: "yellow", localActivity: state));
+    }
+
+    [Fact]
+    public void Offline_IgnoresTheStaleStampEntirely()
+    {
+        // Whatever the Gateway last stamped before it dropped, the offline floor is a pure function of local
+        // activity - a working session is blue even if the frozen stamp was red/grey/orange.
+        Assert.Equal("blue", SessionViewModel.RailColor(true, "red", ActivityState.Working));
+        Assert.Equal("blue", SessionViewModel.RailColor(true, "grey", ActivityState.Working));
+        Assert.Equal("red", SessionViewModel.RailColor(true, "blue", ActivityState.WaitingForInput));
+    }
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -505,7 +505,16 @@ public partial class MainWindow : Window
         if (host is null) return;
 
         _gatewayMonitor = host.GatewayMonitor;
-        _gatewayMonitor.Changed += () => Dispatcher.UIThread.Post(UpdateGatewayStatusBox);
+        _gatewayMonitor.Changed += () => Dispatcher.UIThread.Post(() =>
+        {
+            UpdateGatewayStatusBox();
+            // The rail's offline floor (SessionViewModel.EffectiveColor) renders blue/red from local activity
+            // whenever the tunnel is not Connected, and Connected's stamp otherwise. A connect/disconnect
+            // carries none of the per-session events a row hears, so repaint every row from here - the one
+            // place that owns the GatewayConnectionMonitor subscription - or a settled row keeps its old dot
+            // until an unrelated event happens to repaint it.
+            foreach (var vm in _sessions) vm.RefreshGatewayFloor();
+        });
 
         // Same host: wire the Control-API status indicator. The bind may have already failed
         // in the background before we attached, so paint the current state now AND subscribe

--- a/src/CcDirector.Avalonia/SessionViewModel.cs
+++ b/src/CcDirector.Avalonia/SessionViewModel.cs
@@ -190,7 +190,58 @@ public class SessionViewModel : INotifyPropertyChanged
     /// unrecognised stamp value still falls through to the magenta sentinel in <see cref="StatusColorBrush"/>,
     /// which is the real fail-loud. (docs/new_architecture/session-state.html.)
     /// </summary>
-    private string EffectiveColor => FoldInput.EffectiveColor ?? "unknown";
+    private string EffectiveColor => RailColor(IsGatewayOffline, FoldInput.EffectiveColor, Session.ActivityState);
+
+    /// <summary>
+    /// The rail dot's colour name. Pure so it is tested without an Avalonia app - the getter above binds the
+    /// three live inputs.
+    ///
+    /// ONLINE (<paramref name="gatewayOffline"/> false): render the Gateway's stamped answer VERBATIM, or a
+    /// neutral placeholder ("unknown" -&gt; grey) when there is no stamp yet. The desktop computes NOTHING; the
+    /// Gateway owns every colour. This is the law.
+    ///
+    /// GATEWAY-OFFLINE FLOOR (owner's ruling, 2026-07-19): the desktop HOSTS these sessions and is the one
+    /// surface that can still tell the truth with no Gateway to ask. When the tunnel is down the Gateway
+    /// stamp is frozen on whatever it last sent (a stale yellow / red / grey), so instead paint the ONE fact
+    /// this Director owns firsthand - is the agent producing terminal output right now - as blue (working) or
+    /// red (idle), and NOTHING else. NEVER run the Gateway fold (SessionOrdering) here: it reads Gateway-only
+    /// facts - VoiceAudioReady, dictation, the snooze clock - that are false/absent on the Director, so a
+    /// local fold would wedge every voice-mode session permanently yellow "Preparing voice". Two colours
+    /// only; every richer state waits for the Gateway to come back and stamp it. The phone and Cockpit keep
+    /// the neutral placeholder when offline because, unlike the Director, they do not host the session and
+    /// cannot know what it is doing. (docs/new_architecture/session-state.html.)
+    /// </summary>
+    internal static string RailColor(bool gatewayOffline, string? gatewayStamp, ActivityState localActivity)
+    {
+        if (gatewayOffline)
+            return localActivity is ActivityState.Working or ActivityState.Starting ? "blue" : "red";
+
+        return gatewayStamp ?? "unknown";
+    }
+
+    /// <summary>
+    /// The owning Director's tunnel to its Gateway is not up, so no fresh fold can arrive and the last stamp
+    /// is stale. <see cref="GatewayConnectionStatus.Connected"/> is the ONLY state that renders the Gateway's
+    /// pushed answer; every other one - dialing, reconnecting, failed, or a local-only Director with no
+    /// Gateway configured at all - falls to the two-colour activity floor in <see cref="EffectiveColor"/>.
+    /// Resolved live off the app's single <see cref="GatewayConnectionMonitor"/> (the same instance the
+    /// sidebar indicator reads). Null (host not started yet) counts as NOT offline, so a just-launched
+    /// Director shows the neutral placeholder until its monitor exists rather than flashing the floor.
+    /// </summary>
+    private static bool IsGatewayOffline
+    {
+        get
+        {
+            var monitor = (global::Avalonia.Application.Current as App)?.ControlApiHost?.GatewayMonitor;
+            return monitor is not null && monitor.Status != GatewayConnectionStatus.Connected;
+        }
+    }
+
+    /// <summary>Repaint the rail dot because the Gateway connection flipped (connected &lt;-&gt; offline).
+    /// The offline floor in <see cref="EffectiveColor"/> reads the connection status, and that status change
+    /// carries none of the per-session events the row already hears - so MainWindow, which owns the one
+    /// <see cref="GatewayConnectionMonitor"/> subscription, calls this on every row when the status changes.</summary>
+    public void RefreshGatewayFloor() => Dispatcher.UIThread.Post(RaiseFoldProjection);
 
     /// <summary>
     /// The sidebar colour strip's brush: the shared fold's colour, mapped through the ONE palette.

--- a/src/CcDirector.Gateway.Tests/DisplayPushVoiceEnrichmentTests.cs
+++ b/src/CcDirector.Gateway.Tests/DisplayPushVoiceEnrichmentTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The display-state PUSH seam (FleetDisplayStateObserver) must fold from the SAME inputs the roster folds
+/// from. The pushed snapshot carries only Director-owned facts; the two voice-readiness booleans
+/// (VoiceGenerating / VoiceAudioReady) are Gateway-only, so <see cref="GatewayHost.EnrichVoiceThenFoldForPush"/>
+/// stamps them onto each session from the live voice lookups BEFORE folding - exactly as the roster handler
+/// does.
+///
+/// The bug these defend against: without the enrichment the push seam sees VoiceAudioReady=false for every
+/// session and, since #1841 made IsVoicePreparing key on <c>!VoiceAudioReady</c>, held every voice-mode
+/// waiting session yellow "Preparing voice" forever - never red once the voice was ready. The roster path
+/// enriched these, so the browsers folded red while the push-only desktop rail stuck yellow. Remove either
+/// enrichment line in EnrichVoiceThenFoldForPush and the matching test below goes red.
+/// </summary>
+public sealed class DisplayPushVoiceEnrichmentTests
+{
+    // A voice-mode session as it arrives in the PUSH snapshot: raw-red (turn ended, waiting) and with the
+    // Gateway-only voice booleans still at their default false - the Director never sets them.
+    private static SessionDto PushedVoiceSession(bool snapshotAudioReady = false) => new()
+    {
+        SessionId = "v",
+        StatusColor = "red",
+        ActivityState = "WaitingForInput",
+        VoiceMode = true,
+        VoiceGenerating = false,
+        VoiceAudioReady = snapshotAudioReady,
+    };
+
+    [Fact]
+    public void PushSeam_WhenGatewayVoiceReady_FoldsRed_NotStuckYellow()
+    {
+        // The Gateway knows the voice is ready (HasVoice == true). The push seam must enrich that fact and
+        // fold RED, the same answer the roster serves. This is the exact stuck-yellow regression.
+        var s = PushedVoiceSession(snapshotAudioReady: false);
+
+        GatewayHost.EnrichVoiceThenFoldForPush(
+            new List<SessionDto> { s },
+            voiceGeneratingFor: _ => false,
+            voiceAudioReadyFor: _ => true,
+            needsYouStampFor: null,
+            snoozeRegistry: null);
+
+        Assert.True(s.VoiceAudioReady);           // enrichment overwrote the snapshot's stale false
+        Assert.Equal("red", s.EffectiveColor);    // -> red, not the frozen yellow
+    }
+
+    [Fact]
+    public void PushSeam_WhenGatewayVoiceNotReady_FoldsYellow()
+    {
+        // The Gateway knows the voice is NOT ready. Even if the snapshot carried a stale audioReady=true,
+        // the enrichment must overwrite it from the live lookup so the seam folds yellow "preparing voice".
+        var s = PushedVoiceSession(snapshotAudioReady: true);
+
+        GatewayHost.EnrichVoiceThenFoldForPush(
+            new List<SessionDto> { s },
+            voiceGeneratingFor: _ => false,
+            voiceAudioReadyFor: _ => false,
+            needsYouStampFor: null,
+            snoozeRegistry: null);
+
+        Assert.False(s.VoiceAudioReady);          // enrichment overwrote the snapshot's stale true
+        Assert.Equal("yellow", s.EffectiveColor);
+    }
+
+    [Fact]
+    public void PushSeam_WhileGenerating_FoldsYellow()
+    {
+        // Actively generating the spoken summary -> yellow, regardless of a stale cached-audio flag.
+        var s = PushedVoiceSession(snapshotAudioReady: false);
+
+        GatewayHost.EnrichVoiceThenFoldForPush(
+            new List<SessionDto> { s },
+            voiceGeneratingFor: _ => true,
+            voiceAudioReadyFor: _ => true,
+            needsYouStampFor: null,
+            snoozeRegistry: null);
+
+        Assert.Equal("yellow", s.EffectiveColor);
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -737,11 +737,22 @@ public sealed class GatewayHost : IAsyncDisposable
         // roster serves from (StampFleetRolesAndFold with THIS host's NeedsYouClock and snooze registry), so
         // the answer pushed to the desktop is byte-identical to the answer every browser gets - one fold, one
         // authority. Like FleetRoles it holds the change gate that stops the stamp echoing back up forever.
+        //
+        // The snapshot carries only Director-owned facts (it is what the Director pushed up); the two voice
+        // readiness booleans are Gateway-only (_voiceService), so they MUST be enriched onto each session
+        // here BEFORE the fold - exactly as the roster handler does before its own StampFleetRolesAndFold
+        // call - or the push seam folds VoiceAudioReady=false for every session and holds every voice-mode
+        // session permanently "Preparing voice" (yellow), never moving it to red once the voice is ready.
+        // The voice-ready flip arrives on no Director push, so only the 5s backstop sweep would catch it -
+        // and without this enrichment the sweep re-derives the same yellow every tick and the change gate
+        // suppresses the update forever. The roster path enriched these (GatewayHost roster map below), so
+        // the browsers folded red while the push-only desktop stuck yellow. Same source, same answer.
         FleetDisplayState = new Fleet.FleetDisplayStateObserver(
             () => PushedSessions.SnapshotFresh(TenantId.Local, AutoDismissStaleAfter),
-            sessions => Api.GatewayEndpoints.StampFleetRolesAndFold(
+            sessions => EnrichVoiceThenFoldForPush(
                 sessions,
-                sessions,
+                voiceGeneratingFor: sid => _voiceService?.IsGenerating(sid) == true,
+                voiceAudioReadyFor: sid => _voiceService?.HasVoice(sid) == true,
                 needsYouStampFor: (sid, isRed) => _needsYouClock.Stamp(sid, isRed),
                 snoozeRegistry: _snoozeRegistry),
             SendCommandAsync);
@@ -2182,6 +2193,35 @@ public sealed class GatewayHost : IAsyncDisposable
     /// The cron sweep timer callback (a boundary - it owns the try/catch so a sweep failure never
     /// crashes the timer thread). Fires due jobs; per-job failures are isolated inside the engine.
     /// </summary>
+    /// <summary>
+    /// The stamp delegate for the display-state PUSH seam (FleetDisplayStateObserver). The pushed snapshot
+    /// carries only Director-owned facts, but the color fold reads two Gateway-only voice booleans
+    /// (VoiceGenerating / VoiceAudioReady from _voiceService). This enriches each session with them BEFORE
+    /// folding - the same order the roster handler uses (GatewayEndpoints roster map) - so the push seam and
+    /// the roster fold IDENTICAL inputs and therefore the identical color.
+    ///
+    /// Without this the push seam sees VoiceAudioReady=false for every session and, since #1841 made
+    /// IsVoicePreparing key on <c>!VoiceAudioReady</c>, holds every voice-mode waiting session yellow
+    /// ("Preparing voice") forever, never moving to red once the voice is ready. The voice-ready flip
+    /// arrives on no Director push, so only the 5s backstop sweep could carry it - and unenriched the sweep
+    /// re-derives the same yellow every tick and the change gate suppresses the update permanently. This is
+    /// exercised directly by the tests so the enrichment cannot silently regress again.
+    /// </summary>
+    internal static void EnrichVoiceThenFoldForPush(
+        List<SessionDto> sessions,
+        Func<string, bool> voiceGeneratingFor,
+        Func<string, bool> voiceAudioReadyFor,
+        Func<string, bool, DateTime?>? needsYouStampFor,
+        Snooze.SnoozeRegistry? snoozeRegistry)
+    {
+        foreach (var s in sessions)
+        {
+            s.VoiceGenerating = voiceGeneratingFor(s.SessionId);
+            s.VoiceAudioReady = voiceAudioReadyFor(s.SessionId);
+        }
+        Api.GatewayEndpoints.StampFleetRolesAndFold(sessions, sessions, needsYouStampFor, snoozeRegistry);
+    }
+
     private void SweepCron()
     {
         try


### PR DESCRIPTION
Two related desktop colour-sync fixes.

## Bug A (gateway) - voice-mode sessions stuck yellow on the desktop
The display-state push seam (`FleetDisplayStateObserver`) folded from a snapshot carrying only Director-owned facts, so the two Gateway-only voice booleans (`VoiceGenerating`, `VoiceAudioReady`) were always false in the pushed answer. Since #1841 made the voice-mode colour rule key on `!VoiceAudioReady`, every voice-mode waiting session was held yellow "Preparing voice" in the push forever, never moving to red once the voice was ready. The roster path enriches these, so cockpit/mobile folded red while the push-only desktop rail stuck yellow.

Proven live: the gateway folded four voice sessions red while the desktop's last received stamp for each stayed yellow, unchanged for minutes.

Fix: enrich each session with the live voice facts before folding, from the same `_voiceService` lookups the roster uses (`EnrichVoiceThenFoldForPush`). Tests fail if either enrichment line is removed.

## Bug B (desktop) - gateway-offline floor
When the Director's tunnel is down, the pushed stamp freezes on whatever the Gateway last sent, so a working session could keep a stale red/yellow dot. The Director hosts these sessions and is the one surface that can still tell the truth, so when the Gateway is not Connected the rail paints the single fact it owns firsthand - is the agent producing output - as blue (working) or red (idle), and nothing else. It never runs the Gateway fold locally (which would wedge every voice session yellow, since `VoiceAudioReady` is Gateway-only). Phone and Cockpit keep the neutral placeholder offline because they do not host the session.

## Tests
- Full Avalonia suite 247/247, full Gateway suite 549/549.
- New: `DisplayPushVoiceEnrichmentTests` (Bug A), `OfflineFloorRailColorTests` (Bug B).

## Follow-up
- `docs/new_architecture/session-state.html` note for the offline floor + push-seam voice enrichment.