### PR TITLE
docs(session-state): record the #1843 push-seam hole and the gateway-offline floor

### DIFF
--- a/docs/new_architecture/session-state.html
+++ b/docs/new_architecture/session-state.html
@@ -402,6 +402,29 @@ instead.</strong></p>
 client that cannot get a stamped answer fails loudly rather than guessing - that rule already exists in
 <span class="file">packages/client-core/src/sessions/ordering.ts</span> and it works.</p>
 
+<div class="callout warn">
+<p><strong>The ONE exception, and it is deliberately two colours wide - the gateway-offline floor
+(owner's ruling, 19 July 2026, #1843).</strong> When the owning Director's tunnel to its Gateway is not
+up, the last stamp is <em>frozen</em> on whatever the Gateway happened to send last - a stale yellow, red
+or grey that gets less true every minute. The desktop is the only surface that can still tell the truth
+without asking, because <strong>it hosts the sessions</strong>. So while the Gateway is unreachable the
+rail paints the single fact this Director owns firsthand - is the agent producing terminal output right
+now - as <span class="dot d-blue"></span>blue (working) or <span class="dot d-red"></span>red (not), and
+<strong>nothing else</strong>. <span class="file">SessionViewModel.RailColor</span></p>
+<p><strong>Read the negative half, it is the whole design:</strong> the offline path must NEVER run the
+Gateway fold locally. <code>SessionOrdering</code> reads Gateway-only facts - <code>VoiceAudioReady</code>,
+dictation, the snooze clock - which are false or absent on a Director, so a local fold would answer
+"preparing voice" forever and wedge <strong>every voice-mode session permanently yellow</strong>. Two
+colours, no fold. Every richer state waits for the Gateway to come back and stamp it.</p>
+<p><strong>Why the phone and the Cockpit do NOT get a floor:</strong> they do not host the session and
+cannot know what it is doing, so they keep the neutral placeholder. The floor is not a relaxation of law
+3 - it is law 3 applied honestly: a client renders what it can <em>observe</em>, and the Director is the
+sensor. Note also what is NOT offline: <code>Connected</code> is the only status that renders the pushed
+answer, so dialing, reconnecting, failed, and a local-only Director with no Gateway at all all take the
+floor; a Director whose host has not started yet counts as online, so a fresh launch shows the neutral
+placeholder rather than flashing the floor.</p>
+</div>
+
 <h3>Every state, listed</h3>
 
 <p>This is the complete inventory. If a state is not in this table, it does not exist. The single most
@@ -966,6 +989,27 @@ longer forgets a snooze (defect 22), and a dead session reads Exited (defect 21)
 <li><span class="good">DONE 14 July 2026 - defect 5.</span> <strong>Send the session role down to the desktop</strong> so it stops being the one screen that cannot suppress a worker's red. The Gateway resolves the role from the whole fleet and pushes it down over the <code>set-resolved-role</code> verb; <code>ControlEndpoints.Map</code> reads it back off <code>Session.GatewayResolvedRole</code>. Proved end to end through the real verb, the real mapper and the real fold, with nothing hand-set, by <span class="file">DesktopRoleStampWireProofTests</span>.
 <div class="callout warn">
 <p><strong class="good">CLOSED 16 July 2026 - #1746 (a1d7471a).</strong> The owner made the scope decision this callout reserved for him, and it shipped: <strong>the desktop no longer folds at all.</strong> It renders the Gateway's stamped answer, pushed down over a new <code>set-display-state</code> verb by <span class="file">FleetDisplayStateObserver</span> - <code>EffectiveColor</code>, <code>StateLabel</code>, <code>TriageBucket</code>, <code>NeedsYouSince</code>, <code>SnoozeUntil</code> and <code>SnoozeExpired</code>, folded through the SAME <code>StampFleetRolesAndFold</code> the roster serves from, so the pushed answer is byte-identical to every browser's. <strong>All FIVE divergences below are gone</strong> - the rail, the phone and the Cockpit read one answer by construction, not by pushing four more fields down. The fold observer is change-gated (no echo) and records a rejection instead of re-storming, so a Gateway-ahead-of-Directors rollout is quiet. Verified end to end: <strong>zero <code>SessionOrdering.EffectiveColor/StateLabel/Classify</code> calls remain in the Avalonia app</strong> - the rail (<span class="file">SessionViewModel</span>), the voice-takeover queue (<span class="file">FifoWindow.BuildQueue</span>) and the fleet map all render <code>Session.EffectiveColor</code>/<code>StateLabel</code>/<code>TriageBucket</code> verbatim. The measurement below is kept as the record of the gap that was closed.</p>
+<p><strong class="bad">AND #1746 SHIPPED WITH A HOLE IN IT, FOUND 19 JULY 2026, FIXED BY #1843.</strong>
+The push seam folded <strong>without the two Gateway-only voice facts.</strong> The roster path enriched
+each session with <code>VoiceGenerating</code> and <code>VoiceAudioReady</code> before calling
+<code>StampFleetRolesAndFold</code>; <span class="file">FleetDisplayStateObserver</span> called the same
+fold on un-enriched sessions. So the two paths were <em>not</em> byte-identical after all: the browsers
+folded the true voice facts and moved on to red, while the desktop folded <code>VoiceAudioReady=false</code>
+and was held at <span class="dot d-yellow"></span>yellow "Preparing voice" <strong>forever</strong> - the
+stamp never changed, so the change-gate never pushed again. Fixed by
+<code>GatewayHost.EnrichVoiceThenFoldForPush</code>, which enriches then folds, in that order, on the push
+side too. <span class="file">GatewayHost.cs</span></p>
+<p><strong>The lesson is the one this document keeps paying for, in a new costume:</strong> "byte-identical,
+by construction" was true of <em>the fold</em> and false of <em>its inputs</em>. Sharing the function is not
+sharing the answer - a second caller that assembles the arguments differently is a second implementation
+wearing the first one's name. <strong>When you claim two paths agree, name the INPUTS you proved equal, not
+the function they both call.</strong> Two obvious wrong diagnoses were entertained first and both were
+disproven: it was NOT a stale desktop build, and it was NOT a surviving local fold in the Avalonia app
+(there are still zero). Defended by <span class="file">DisplayPushVoiceEnrichmentTests</span>.</p>
+<p><strong class="good">Shipped alongside it: the gateway-offline floor</strong> - see the callout in
+section 2, layer 3. Same pull request, opposite direction: #1843's first half made the desktop's
+<em>online</em> answer identical to the browsers', and its second half gave the desktop an honest
+<em>offline</em> answer instead of a frozen stale one.</p>
 <p><strong>MEASURED BY QA, 15 July 2026: the role was ONE OF FIVE, and this item's own closing sentence - "until then, desktop and phone disagree by construction" - was STILL TRUE for the other four until #1746 closed the lot (see the banner above). This was the largest surviving gap in this document, and neither the Architect nor the Manager saw it until it was measured; both had concluded, in writing, that agreement was now "by construction".</strong></p>
 <p><code>ControlEndpoints.Map</code> carries <code>SessionRole</code> and does NOT carry <strong>four other fold inputs</strong>, verified by reading the mapper and by enumerating every verb the Gateway can send a Director - there are exactly <strong>two</strong>, <code>launch</code> and <code>set-resolved-role</code>. So nothing pushes these down, and the fold reads all of them:</p>
 <table>

--- a/docs/new_architecture/session-state.html
+++ b/docs/new_architecture/session-state.html
@@ -417,7 +417,14 @@ dictation, the snooze clock - which are false or absent on a Director, so a loca
 "preparing voice" forever and wedge <strong>every voice-mode session permanently yellow</strong>. Two
 colours, no fold. Every richer state waits for the Gateway to come back and stamp it.</p>
 <p><strong>Why the phone and the Cockpit do NOT get a floor:</strong> they do not host the session and
-cannot know what it is doing, so they keep the neutral placeholder. The floor is not a relaxation of law
+cannot know what it is doing, so they keep the neutral placeholder. <strong>PROVEN LIVE 19 July 2026</strong>
+under an owner-approved outage of the production Gateway: dots read from the PIXELS of 60 desktop captures
+showed blue while the agent worked, red once it went idle, and blue again when it resumed - with the
+Gateway unreachable throughout. <strong>But it was floored on the DOT ONLY - see defect 24</strong>, which
+this same proof found. <em>The frequently-quoted "about ten seconds to red" is NOT ESTABLISHED and must not
+be written down: the sampling interval was six to seven seconds and the idle instant was never observed, so
+the transition is bounded to a six-second window and nothing narrower. Whoever measures it properly needs a
+KNOWN idle instant.</em> The floor is not a relaxation of law
 3 - it is law 3 applied honestly: a client renders what it can <em>observe</em>, and the Director is the
 sensor. Note also what is NOT offline: <code>Connected</code> is the only status that renders the pushed
 answer, so dialing, reconnecting, failed, and a local-only Director with no Gateway at all all take the
@@ -835,6 +842,7 @@ or its own hold expiry, so it cannot compute its own colour. It must ask.</p>
 <tr><td>7</td><td>In the Director detail table, the dot and the State cell beside it disagree.</td><td><span class="file">DirectorDetailView.tsx:185</span> uses the Gateway's answer; <span class="file">:195</span> ignores it and re-derives. Same row, two authorities.</td></tr>
 <tr><td>8</td><td>A snoozed, mid-brief, controlled sub-agent renders as plain teal "Idle".</td><td><span class="file">SessionRowViewModel.cs:61</span> receives a fully stamped session off the wire and throws all of it away, re-deriving from raw activity with a private palette where Idle is teal and Exited is red.</td></tr>
 <tr><td>9</td><td>A snoozed session reads "needs you" in the schedule picker.</td><td><span class="file">ScheduleView.tsx:1122</span> - an entire parallel triage fold deriving "needs you" from a timestamp instead of the bucket.</td></tr>
+<tr><td>24</td><td><strong>OPEN, found 19 July 2026 by the live outage proof.</strong> While the Gateway is unreachable, a snoozed session on the desktop rail shows a <span class="dot d-red"></span>red dot beside its own label reading "Snoozed wakes in 7h55m". One row, two sources, two eras - and red MEANS "needs you", so the desktop summons the owner to a session he deliberately deferred. Heals the instant the Gateway returns.</td><td><strong>The offline floor was applied to the dot and not to the words.</strong> <code>EffectiveColor</code> goes through <code>RailColor(IsGatewayOffline, ...)</code> and is floor-aware; <code>ActivityLabel =&gt; FoldInput.StateLabel ?? ""</code> is not, so it renders the frozen stamp. <strong>Note the <code>?? ""</code> fires only on a MISSING stamp and never on a STALE one</strong> - a fix aimed at the missing-stamp path sails straight past this. <strong>And that property's own summary ends "Empty until a Gateway stamps one (the no-Gateway floor)", asserting a coverage it does not have</strong> - a trap comment that must be corrected in the same pass as the fix, or it re-delivers this bug to the next reader. <em>Two questions, not one: extending the floor to the label is mechanical; whether an idle-while-offline session should be red AT ALL is a question about what red means, and is the owner's.</em> <span class="file">SessionViewModel.cs:193, :509</span></td></tr>
 </table>
 
 <h3>The ones you cannot see yet</h3>
@@ -1010,6 +1018,18 @@ disproven: it was NOT a stale desktop build, and it was NOT a surviving local fo
 section 2, layer 3. Same pull request, opposite direction: #1843's first half made the desktop's
 <em>online</em> answer identical to the browsers', and its second half gave the desktop an honest
 <em>offline</em> answer instead of a frozen stale one.</p>
+<p><strong>The voice window, MEASURED rather than asserted - 19 July 2026.</strong> The Gateway was sampled
+every two seconds across two real turn-ends of a voice-mode session. Both cycles folded correctly:
+<span class="dot d-blue"></span>blue while working &rarr; <span class="dot d-yellow"></span>yellow
+"Preparing voice" at turn end &rarr; <span class="dot d-red"></span>red the moment
+<code>VoiceAudioReady</code> flipped. <strong>The two windows were about 115 seconds and about 6 seconds</strong>
+- so this state is emphatically visible, and "I never see yellow" is not evidence that the fold is broken;
+it is far more likely a surface not refreshing, or a phone running a cached bundle. <strong>The 115-second
+cycle also proves the owner's ruling is doing real work:</strong> at 81 seconds <code>VoiceGenerating</code>
+went <em>false</em> while <code>VoiceAudioReady</code> was still false - the gap between retry attempts - and
+the row <strong>stayed yellow</strong> rather than flashing red, which is exactly what the
+<code>|| !VoiceAudioReady</code> hold exists to prevent. <em>A rule narrowed to <code>VoiceGenerating</code>
+alone would have shown red for 55 seconds in the middle of preparing the voice.</em></p>
 <p><strong>MEASURED BY QA, 15 July 2026: the role was ONE OF FIVE, and this item's own closing sentence - "until then, desktop and phone disagree by construction" - was STILL TRUE for the other four until #1746 closed the lot (see the banner above). This was the largest surviving gap in this document, and neither the Architect nor the Manager saw it until it was measured; both had concluded, in writing, that agreement was now "by construction".</strong></p>
 <p><code>ControlEndpoints.Map</code> carries <code>SessionRole</code> and does NOT carry <strong>four other fold inputs</strong>, verified by reading the mapper and by enumerating every verb the Gateway can send a Director - there are exactly <strong>two</strong>, <code>launch</code> and <code>set-resolved-role</code>. So nothing pushes these down, and the fold reads all of them:</p>
 <table>


### PR DESCRIPTION
Documentation only. No code, no tests, no behaviour change.

Records the two halves of #1843 in the one session-state document, which had no mention of either.

## Section 2, layer 3 - the gateway-offline floor

Added as the single exception to "clients draw and decide nothing". When the owning Director's tunnel is down the last Gateway stamp is frozen on whatever it last sent, so the desktop paints the one fact it owns firsthand - is the agent producing terminal output right now - as blue or red, and nothing else.

The negative half is the part that most needed writing down: the offline path must **never** run the Gateway fold locally. `SessionOrdering` reads Gateway-only facts (`VoiceAudioReady`, dictation, the snooze clock) that are false or absent on a Director, so a local fold would answer "preparing voice" forever and wedge every voice-mode session permanently yellow. The callout also records why the phone and Cockpit get no floor (they do not host the session), and that `Connected` is the only status that renders the pushed answer.

## Section 5 - #1746 shipped with a hole

The push seam folded without the two Gateway-only voice facts. The roster path enriched sessions with `VoiceGenerating` and `VoiceAudioReady` before calling `StampFleetRolesAndFold`; `FleetDisplayStateObserver` called the same fold on un-enriched sessions. So the browsers folded the true facts and moved on to red, while the desktop folded `VoiceAudioReady=false` and was held at yellow "Preparing voice" forever - the stamp never changed, so the change-gate never pushed again.

The lesson, in the document's own idiom: "byte-identical, by construction" was true of *the fold* and false of *its inputs*. Sharing the function is not sharing the answer. Both obvious wrong diagnoses were entertained first and disproven - it was not a stale desktop build, and not a surviving local fold in the Avalonia app.

## Verification

- HTML nesting validated: no unclosed and no mismatched tags.
- Statements are drawn from the shipped code on `origin/main` (`GatewayHost.EnrichVoiceThenFoldForPush`, `SessionViewModel.RailColor`), not from memory.
- The "about ten seconds after idle" timing that has been quoted informally is deliberately **not** asserted; the document says the floor flips when the Director's own activity state leaves Working/Starting. That number belongs to the live tail-proof, which has not reported yet.