### PR TITLE
fix(gateway): tenant-aware down-channel + per-tenant auto-dismiss sweep; /healthz stops leaking fleet counts (session-serving PR2)

### DIFF
--- a/src/CcDirector.Gateway.Tests/HealthzTenantLeakTests.cs
+++ b/src/CcDirector.Gateway.Tests/HealthzTenantLeakTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Hosted Multi-Tenancy (session-serving PR2): <c>/healthz</c> reports NO per-tenant facts on the hosted
+/// Gateway.
+///
+/// <c>/healthz</c> is deliberately PUBLIC - it is the unauthenticated liveness probe the Director's
+/// connectivity self-test, the gateway endpoint selector, and the settings gateway test all dial - so it
+/// carries no credential and therefore has NO TENANT. Its Directors/Sessions counts are fleet-GLOBAL
+/// aggregates, so on a hosted Gateway an anonymous caller was reading a count over EVERY account's Directors.
+/// That is not fixable by making the count tenant-aware: a request with no tenant has no correct number to
+/// print. So on hosted the aggregate is not computed at all - deny-by-default applies to metrics too.
+///
+/// POSITIVE CONTROL / self-host-untouched: the same handler on a NON-hosted Gateway still reports the counts,
+/// which is what proves the hosted assertion is about the tenancy branch and not about a Gateway that simply
+/// has no Directors registered.
+///
+/// Revert-prove: delete the <c>tenantBoundary?.IsHosted == true</c> branch from the <c>/healthz</c> handler in
+/// <c>GatewayEndpoints.Map</c> and <see cref="Hosted_healthz_reports_no_fleet_counts"/> goes RED - the hosted
+/// probe reports the registered Director again.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe.
+/// </summary>
+public sealed class HealthzTenantLeakTests
+{
+    private const string Token = "test-token";
+
+    [Fact]
+    public async Task Hosted_healthz_reports_no_fleet_counts()
+    {
+        var health = await ProbeHealthz(hosted: true);
+
+        // The Gateway HAS a registered Director (see RunAsync) - the hosted probe simply must not say so.
+        Assert.Equal("ok", health.Status);
+        Assert.Equal(0, health.Directors);
+        Assert.Equal(0, health.Sessions);
+        // Liveness is still answered: a probe needs to know it is alive and what version it is.
+        Assert.False(string.IsNullOrWhiteSpace(health.Version));
+    }
+
+    [Fact]
+    public async Task Selfhost_healthz_still_reports_its_fleet_counts()
+    {
+        // POSITIVE CONTROL for the test above, and the self-host-untouched proof: identical arrangement, the
+        // ONLY difference being CC_GATEWAY_HOSTED, and the counts are still served.
+        var health = await ProbeHealthz(hosted: false);
+
+        Assert.Equal("ok", health.Status);
+        Assert.Equal(1, health.Directors);
+    }
+
+    private static async Task<HealthDto> ProbeHealthz(bool hosted)
+    {
+        var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+        var instancesDir = Path.Combine(Path.GetTempPath(), "cc-hz-" + Guid.NewGuid().ToString("N"));
+        var gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: instancesDir,
+            workListsPath: Path.Combine(instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        try
+        {
+            await gateway.StartAsync();
+            gateway.Registry.Upsert(new DirectorRegistrationRequest
+            {
+                DirectorId = "dir-health",
+                TailnetEndpoint = "http://127.0.0.1:1/",
+                MachineName = "MH",
+                Pid = 1,
+                Version = "test",
+                StartedAt = DateTime.UtcNow,
+            });
+
+            // NO credential: /healthz is public, which is exactly why it must not carry per-tenant facts.
+            using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{gateway.Port}/") };
+            var resp = await http.GetAsync("healthz");
+            resp.EnsureSuccessStatusCode();
+            return await resp.Content.ReadFromJsonAsync<HealthDto>()
+                   ?? throw new InvalidOperationException("healthz returned no body");
+        }
+        finally
+        {
+            await gateway.StopAsync();
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior);
+            try { if (Directory.Exists(instancesDir)) Directory.Delete(instancesDir, true); }
+            catch { /* best-effort */ }
+        }
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HealthzTenantLeakTests.cs
+++ b/src/CcDirector.Gateway.Tests/HealthzTenantLeakTests.cs
@@ -40,10 +40,12 @@ public sealed class HealthzTenantLeakTests
     {
         var health = await ProbeHealthz(hosted: true);
 
-        // The Gateway HAS a registered Director (see RunAsync) - the hosted probe simply must not say so.
+        // The Gateway HAS a registered Director (see ProbeHealthz) - the hosted probe simply must not say so.
+        // This is the assertion that pins the change: with the hosted branch removed, the anonymous probe
+        // reports that Director again. (Sessions is deliberately NOT asserted: it already read the empty Local
+        // partition before this change, so asserting it would pass either way and prove nothing.)
         Assert.Equal("ok", health.Status);
         Assert.Equal(0, health.Directors);
-        Assert.Equal(0, health.Sessions);
         // Liveness is still answered: a probe needs to know it is alive and what version it is.
         Assert.False(string.IsNullOrWhiteSpace(health.Version));
     }
@@ -52,7 +54,9 @@ public sealed class HealthzTenantLeakTests
     public async Task Selfhost_healthz_still_reports_its_fleet_counts()
     {
         // POSITIVE CONTROL for the test above, and the self-host-untouched proof: identical arrangement, the
-        // ONLY difference being CC_GATEWAY_HOSTED, and the counts are still served.
+        // ONLY difference being CC_GATEWAY_HOSTED, and the counts are still served. This one deliberately does
+        // NOT pin the changed line - it exists to prove the hosted assertion above is about the tenancy branch
+        // and not about a Gateway that simply has no Directors to count.
         var health = await ProbeHealthz(hosted: false);
 
         Assert.Equal("ok", health.Status);
@@ -93,8 +97,10 @@ public sealed class HealthzTenantLeakTests
         {
             await gateway.StopAsync();
             Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior);
-            try { if (Directory.Exists(instancesDir)) Directory.Delete(instancesDir, true); }
-            catch { /* best-effort */ }
+            // Deliberately NOT deleting instancesDir. Registering a Director writes a discovery file there, and
+            // deleting the directory raises a FileSystemWatcher delete event on a thread-pool thread that can
+            // land AFTER the host is torn down - reaching a disposed database and killing the whole test
+            // process (the run aborts mid-suite). The directory is a unique temp path the OS reclaims.
         }
     }
 

--- a/src/CcDirector.Gateway.Tests/SessionServingLoopIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionServingLoopIsolationTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Hosted Multi-Tenancy (session-serving PR2): the Gateway's BACKGROUND LOOPS are tenant-aware, and the ONE
+/// down-channel lookup every command routes through resolves the tenant of the current unit of work instead
+/// of a hard-coded <see cref="TenantId.Local"/>.
+///
+/// Two Directors connect on two DIFFERENT tenants over the real tunnel, each authenticated with its OWN
+/// per-device key, exactly as <c>SessionServingReadIsolationTests</c> arranges the read path. This drives the
+/// REAL production loop functions - <c>GatewayHost.SendCommandAsync</c> and <c>GatewayHost.SweepAutoDismiss</c>
+/// (the auto-dismiss timer callback) - not a helper or a re-implementation.
+///
+/// Every absence claim here is preceded by a POSITIVE CONTROL in the same test: we first prove the command
+/// DOES arrive for the tenant that owns the Director, then prove it does NOT arrive for the tenant that does
+/// not. Without that ordering a total failure to deliver anything would satisfy every "did not arrive"
+/// assertion and the test would pass vacuously.
+///
+/// REVERT-PROOFS (each guard independently, against the real production line):
+///  - <c>GatewayHost.SendCommandAsync</c>: replace its <c>_tenantPass.Current</c> resolution with
+///    <c>TenantId.Local</c> and <see cref="SendCommand_reaches_only_the_owning_tenants_director"/> goes RED on
+///    its positive control - the Local partition holds no Director on hosted, so the same-tenant send that
+///    must succeed returns null.
+///  - <c>GatewayHost.SweepAutoDismiss</c>: replace its <c>_tenantPass.ForEachTenant(...)</c> with a single
+///    direct call (the pre-PR2 implicit single pass) and
+///    <see cref="AutoDismiss_sweep_runs_one_pass_per_tenant_and_closes_only_that_tenants_sessions"/> goes RED -
+///    the unscoped pass reads no tenant's fleet, so neither session is closed.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is
+/// reset in DisposeAsync.
+/// </summary>
+public sealed class SessionServingLoopIsolationTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string SessA = "loop-sess-a";
+    private const string SessB = "loop-sess-b";
+    private static readonly TenantId TenantA = new("tenant-alice");
+    private static readonly TenantId TenantB = new("tenant-bob");
+
+    private GatewayHost _gateway = null!;
+    private FakeTunnelDirector _dirA = null!;
+    private FakeTunnelDirector _dirB = null!;
+
+    // Every command each Director received over the tunnel, so a test can assert BOTH that the right one
+    // arrived and that the wrong one never did.
+    private readonly ConcurrentQueue<DirectorCommand> _seenByA = new();
+    private readonly ConcurrentQueue<DirectorCommand> _seenByB = new();
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-loop-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+
+        // Two accounts: two device keys, each bound to its OWN tenant. The tunnel Hello binds each Director
+        // into its key's tenant, so its pushed sessions land in that tenant's partition.
+        var keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", TenantA.Value);
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", TenantB.Value);
+
+        _dirA = await FakeTunnelDirector.StartAsync(_gateway, keyA, "dir-a", "MA",
+            dispatch: cmd => { _seenByA.Enqueue(cmd); return FakeTunnelDirector.Ok(new { ok = true }); });
+        _dirB = await FakeTunnelDirector.StartAsync(_gateway, keyB, "dir-b", "MB",
+            dispatch: cmd => { _seenByB.Enqueue(cmd); return FakeTunnelDirector.Ok(new { ok = true }); });
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _dirA.DisposeAsync();
+        await _dirB.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task SendCommand_reaches_only_the_owning_tenants_director()
+    {
+        await _dirA.PushSnapshotAsync(Sample(SessA, autoDismiss: false));
+        await _dirB.PushSnapshotAsync(Sample(SessB, autoDismiss: false));
+
+        // POSITIVE CONTROL FIRST: inside tenant A's scope, a command for A's OWN Director is delivered. If
+        // this did not hold, every absence assertion below would pass vacuously.
+        DirectorCommandResult? sameTenant;
+        using (_gateway.TenantBoundary.EnterScope(TenantA))
+            sameTenant = await _gateway.SendCommandAsync("dir-a", Prompt("hello-a"));
+
+        Assert.NotNull(sameTenant);
+        Assert.Contains(_seenByA, c => c.PayloadJson.Contains("hello-a") == true);
+
+        // ABSENCE: inside tenant B's scope, the SAME command aimed at tenant A's Director resolves nothing.
+        // The connection lookup runs in B's partition, which holds no dir-a, so the send is denied - B can
+        // never drive A's Director even by naming its id directly.
+        DirectorCommandResult? crossTenant;
+        using (_gateway.TenantBoundary.EnterScope(TenantB))
+            crossTenant = await _gateway.SendCommandAsync("dir-a", Prompt("cross-tenant"));
+
+        Assert.Null(crossTenant);
+        Assert.DoesNotContain(_seenByA, c => c.PayloadJson.Contains("cross-tenant") == true);
+        Assert.DoesNotContain(_seenByB, c => c.PayloadJson.Contains("cross-tenant") == true);
+
+        // DENY-BY-DEFAULT: with NO tenant scope at all (an unconverted background caller), the send resolves
+        // no tenant and delivers nothing - it must never fall back to the Local partition.
+        var unscoped = await _gateway.SendCommandAsync("dir-a", Prompt("unscoped"));
+
+        Assert.Null(unscoped);
+        Assert.DoesNotContain(_seenByA, c => c.PayloadJson.Contains("unscoped") == true);
+    }
+
+    [Fact]
+    public async Task AutoDismiss_sweep_runs_one_pass_per_tenant_and_closes_only_that_tenants_sessions()
+    {
+        // Both tenants have a session that qualifies for auto-dismiss (auto-dismiss + "done" verdict + settled
+        // at a turn end). A single implicit pass can serve at most ONE tenant; a correct per-tenant pass
+        // serves both, and each kill goes down its OWN tenant's Director.
+        await _dirA.PushSnapshotAsync(Sample(SessA, autoDismiss: true));
+        await _dirB.PushSnapshotAsync(Sample(SessB, autoDismiss: true));
+
+        // The REAL timer callback - the production function, not a helper.
+        _gateway.SweepAutoDismiss();
+
+        // POSITIVE CONTROL FIRST: BOTH tenants' sessions were closed. This is what proves the sweep iterated
+        // tenants at all; without it the two absence assertions below would hold trivially in a sweep that did
+        // nothing whatsoever.
+        var killA = await WaitForKill(_seenByA, SessA);
+        var killB = await WaitForKill(_seenByB, SessB);
+        Assert.NotNull(killA);
+        Assert.NotNull(killB);
+
+        // ABSENCE: neither Director was ever asked to kill the OTHER tenant's session. The per-tenant pass
+        // sees one tenant's fleet at a time, so a session id from the other partition never enters the pick
+        // list, and the down-channel send could not have reached the wrong Director anyway.
+        Assert.DoesNotContain(_seenByA, c => c.SessionId == SessB);
+        Assert.DoesNotContain(_seenByB, c => c.SessionId == SessA);
+    }
+
+    /// <summary>
+    /// Poll for the kill verb rather than sleeping a fixed time: the sweep is fire-and-forget onto the thread
+    /// pool and the tunnel round-trip is asynchronous, so a fixed wait would be either flaky or slow.
+    /// </summary>
+    private static async Task<DirectorCommand?> WaitForKill(ConcurrentQueue<DirectorCommand> seen, string sessionId)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            var hit = seen.FirstOrDefault(c => c.Verb == "kill" && c.SessionId == sessionId);
+            if (hit is not null) return hit;
+            await Task.Delay(50);
+        }
+        return null;
+    }
+
+    private static DirectorCommand Prompt(string marker) => new()
+    {
+        CommandId = Guid.NewGuid().ToString("N"),
+        Verb = "prompt",
+        PayloadJson = $"{{\"text\":\"{marker}\"}}",
+    };
+
+    private static SessionDto Sample(string sid, bool autoDismiss) => new()
+    {
+        SessionId = sid,
+        Agent = "claude",
+        RepoPath = "/repo",
+        // Settled at a turn end, which is what auto-dismiss requires before it will close anything.
+        ActivityState = "WaitingForInput",
+        Status = "Running",
+        StatusColor = "red",
+        AutoDismiss = autoDismiss,
+        DismissVerdict = autoDismiss ? "done" : null,
+        CreatedAt = DateTime.UtcNow,
+        LastActivityAt = DateTime.UtcNow,
+    };
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/SessionServingLoopIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionServingLoopIsolationTests.cs
@@ -37,6 +37,9 @@ namespace CcDirector.Gateway.Tests;
 ///    direct call (the pre-PR2 implicit single pass) and
 ///    <see cref="AutoDismiss_sweep_runs_one_pass_per_tenant_and_closes_only_that_tenants_sessions"/> goes RED -
 ///    the unscoped pass reads no tenant's fleet, so neither session is closed.
+///  - <c>AutoDismissSweeper.MarkKey</c>: drop the tenant prefix (back to a session-id-only close-mark) and
+///    <see cref="AutoDismiss_close_marks_are_partitioned_per_tenant"/> goes RED - the second tenant's pass
+///    finds the first tenant's mark and skips its own close.
 ///
 /// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is
 /// reset in DisposeAsync.
@@ -112,6 +115,16 @@ public sealed class SessionServingLoopIsolationTests : IAsyncLifetime
         Assert.NotNull(sameTenant);
         Assert.Contains(_seenByA, c => c.PayloadJson.Contains("hello-a") == true);
 
+        // SECOND POSITIVE CONTROL, for the B side: tenant B CAN drive its OWN Director. Without this, the
+        // "B never received the cross-tenant command" assertion below would also be satisfied by a tenant B
+        // that simply cannot receive anything at all.
+        DirectorCommandResult? sameTenantB;
+        using (_gateway.TenantBoundary.EnterScope(TenantB))
+            sameTenantB = await _gateway.SendCommandAsync("dir-b", Prompt("hello-b"));
+
+        Assert.NotNull(sameTenantB);
+        Assert.Contains(_seenByB, c => c.PayloadJson.Contains("hello-b") == true);
+
         // ABSENCE: inside tenant B's scope, the SAME command aimed at tenant A's Director resolves nothing.
         // The connection lookup runs in B's partition, which holds no dir-a, so the send is denied - B can
         // never drive A's Director even by naming its id directly.
@@ -156,6 +169,30 @@ public sealed class SessionServingLoopIsolationTests : IAsyncLifetime
         // list, and the down-channel send could not have reached the wrong Director anyway.
         Assert.DoesNotContain(_seenByA, c => c.SessionId == SessB);
         Assert.DoesNotContain(_seenByB, c => c.SessionId == SessA);
+    }
+
+    [Fact]
+    public async Task AutoDismiss_close_marks_are_partitioned_per_tenant()
+    {
+        // The sweeper keeps a "already issued a kill" mark so a session lingering one extra sweep is not
+        // killed twice. Running the sweep once PER TENANT makes that gate a cross-tenant hazard: keyed by
+        // session id alone, tenant A's mark suppresses tenant B's close, and each pass prunes the other
+        // tenants' marks against its own snapshot.
+        //
+        // Two tenants using the SAME session id is the case that separates a partitioned gate from a shared
+        // one - and session ids are not globally unique across accounts, so this is a real arrangement, not a
+        // contrived one. BOTH must be closed.
+        const string Shared = "shared-sid";
+        await _dirA.PushSnapshotAsync(Sample(Shared, autoDismiss: true));
+        await _dirB.PushSnapshotAsync(Sample(Shared, autoDismiss: true));
+
+        _gateway.SweepAutoDismiss();
+
+        // Each tenant's OWN Director must have been told to kill its OWN session of that id. With a
+        // session-id-only mark, whichever tenant's pass ran second finds the mark already set and skips - so
+        // exactly one of these two goes null.
+        Assert.NotNull(await WaitForKill(_seenByA, Shared));
+        Assert.NotNull(await WaitForKill(_seenByB, Shared));
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -356,12 +356,33 @@ internal static class GatewayEndpoints
         // ===== REST =====
         app.MapGet("/healthz", () =>
         {
+            // Hosted Multi-Tenancy (session-serving PR2): /healthz is PUBLIC - it is the unauthenticated
+            // liveness probe every Director and endpoint selector dials, so it carries no credential and
+            // therefore has NO TENANT. On the hosted Gateway the fleet counts below are fleet-GLOBAL: an
+            // anonymous caller reading "directors: 2" is reading an aggregate over every account's Directors.
+            // That is a cross-tenant leak, and it cannot be fixed by making the count tenant-aware, because a
+            // request with no tenant has no correct number to print. So on hosted the aggregate is not
+            // computed at all - deny-by-default applies to metrics exactly as it applies to data. Liveness
+            // (status, version, server time) is what a probe actually needs and stays public.
+            //
+            // Self-host is untouched: one tenant, one owner, and the counts are what the Director's own
+            // connectivity self-test and the settings gateway probe read.
+            if (tenantBoundary?.IsHosted == true)
+            {
+                return Results.Json(new HealthDto
+                {
+                    Status = "ok",
+                    Version = version,
+                    ServerTime = DateTime.UtcNow,
+                });
+            }
+
             var directors = registry.ListDirectors();
             // Post-cut: the roster lives ONLY in the push store, so count from there. A Director with no
             // fresh pushed snapshot is not connected to the tunnel and contributes zero.
             int totalSessions = directors.Sum(d =>
             {
-                // Stage 3b: single-tenant core serves the Local tenant (the request's tenant in Stage 3c).
+                // Self-host only (see above): the single tenant is Local.
                 var cached = pushedSessions?.TryGetFresh(TenantId.Local, d.DirectorId, streamStaleResolved);
                 return cached?.Count ?? 0;
             });

--- a/src/CcDirector.Gateway/Briefing/TurnEndWatcher.cs
+++ b/src/CcDirector.Gateway/Briefing/TurnEndWatcher.cs
@@ -53,6 +53,7 @@ public sealed class TurnEndWatcher : IDisposable
     private readonly Action<TurnEndSignal> _onTurnEnd;
     private readonly Action<string> _onSessionWorking;
     private readonly TimeSpan _interval;
+    private readonly Tenancy.ITenantPass _tenantPass;
     private readonly ConcurrentDictionary<string, string> _lastActivity = new();
     private Timer? _timer;
     private int _polling;
@@ -63,14 +64,19 @@ public sealed class TurnEndWatcher : IDisposable
     /// push store instead of HTTP-pulling it, so the watcher no longer dials the Director. A Director that
     /// never pushes (stream mode off / file-discovered legacy) is still pulled over HTTP, byte-identical.</param>
     /// <param name="streamStale">Freshness window for the push store read; defaults to the roster's window.</param>
+    /// <param name="tenantPass">Hosted Multi-Tenancy (session-serving PR2): the background-loop tenant seam
+    /// the reconcile sweep iterates. Omitted (null) means the single-tenant pass - exactly one Local pass -
+    /// which is what self-host and the unit tests want.</param>
     public TurnEndWatcher(
         Action<TurnEndSignal> onTurnEnd,
         Action<string> onSessionWorking,
         TimeSpan? reconcileInterval = null,
         PushedSessionStore? pushedSessions = null,
-        TimeSpan? streamStale = null)
+        TimeSpan? streamStale = null,
+        Tenancy.ITenantPass? tenantPass = null)
     {
         _pushedSessions = pushedSessions;
+        _tenantPass = tenantPass ?? Tenancy.SingleTenantPass.Instance;
         _streamStale = streamStale ?? TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
         _onTurnEnd = onTurnEnd ?? throw new ArgumentNullException(nameof(onTurnEnd));
         _onSessionWorking = onSessionWorking ?? throw new ArgumentNullException(nameof(onSessionWorking));
@@ -144,14 +150,20 @@ public sealed class TurnEndWatcher : IDisposable
         _ = sweepAll;
         if (_pushedSessions is not null)
         {
-            // Stage 3b: the single-tenant core sweeps the one Local tenant. When more than one tenant
-            // exists (Stage 3c), this background sweep iterates every tenant and addresses each session
-            // with its owning tenant - it never reaches across tenants.
-            foreach (var (directorId, session) in _pushedSessions.SnapshotFresh(TenantId.Local, _streamStale))
+            // Hosted Multi-Tenancy (session-serving PR2): this reconcile is a background loop, so it runs ONE
+            // PASS PER TENANT through the tenant seam and reads each pass inside that tenant's own scope,
+            // instead of the single implicit TenantId.Local pass it used to hard-code. Self-host has exactly
+            // one tenant (Local) and so runs exactly one pass - the same read as before. A pass with no tenant
+            // in scope on hosted reads NOTHING (the deny), never another tenant's partition.
+            _tenantPass.ForEachTenant(() =>
             {
-                if (_disposed) return Task.CompletedTask;
-                Observe(session.SessionId, session.ActivityState, directorId);
-            }
+                if (_tenantPass.Current is not { } tenant) return;
+                foreach (var (directorId, session) in _pushedSessions.SnapshotFresh(tenant, _streamStale))
+                {
+                    if (_disposed) return;
+                    Observe(session.SessionId, session.ActivityState, directorId);
+                }
+            });
         }
         return Task.CompletedTask;
     }

--- a/src/CcDirector.Gateway/Briefing/TurnEndWatcher.cs
+++ b/src/CcDirector.Gateway/Briefing/TurnEndWatcher.cs
@@ -53,7 +53,6 @@ public sealed class TurnEndWatcher : IDisposable
     private readonly Action<TurnEndSignal> _onTurnEnd;
     private readonly Action<string> _onSessionWorking;
     private readonly TimeSpan _interval;
-    private readonly Tenancy.ITenantPass _tenantPass;
     private readonly ConcurrentDictionary<string, string> _lastActivity = new();
     private Timer? _timer;
     private int _polling;
@@ -64,19 +63,14 @@ public sealed class TurnEndWatcher : IDisposable
     /// push store instead of HTTP-pulling it, so the watcher no longer dials the Director. A Director that
     /// never pushes (stream mode off / file-discovered legacy) is still pulled over HTTP, byte-identical.</param>
     /// <param name="streamStale">Freshness window for the push store read; defaults to the roster's window.</param>
-    /// <param name="tenantPass">Hosted Multi-Tenancy (session-serving PR2): the background-loop tenant seam
-    /// the reconcile sweep iterates. Omitted (null) means the single-tenant pass - exactly one Local pass -
-    /// which is what self-host and the unit tests want.</param>
     public TurnEndWatcher(
         Action<TurnEndSignal> onTurnEnd,
         Action<string> onSessionWorking,
         TimeSpan? reconcileInterval = null,
         PushedSessionStore? pushedSessions = null,
-        TimeSpan? streamStale = null,
-        Tenancy.ITenantPass? tenantPass = null)
+        TimeSpan? streamStale = null)
     {
         _pushedSessions = pushedSessions;
-        _tenantPass = tenantPass ?? Tenancy.SingleTenantPass.Instance;
         _streamStale = streamStale ?? TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
         _onTurnEnd = onTurnEnd ?? throw new ArgumentNullException(nameof(onTurnEnd));
         _onSessionWorking = onSessionWorking ?? throw new ArgumentNullException(nameof(onSessionWorking));
@@ -150,20 +144,17 @@ public sealed class TurnEndWatcher : IDisposable
         _ = sweepAll;
         if (_pushedSessions is not null)
         {
-            // Hosted Multi-Tenancy (session-serving PR2): this reconcile is a background loop, so it runs ONE
-            // PASS PER TENANT through the tenant seam and reads each pass inside that tenant's own scope,
-            // instead of the single implicit TenantId.Local pass it used to hard-code. Self-host has exactly
-            // one tenant (Local) and so runs exactly one pass - the same read as before. A pass with no tenant
-            // in scope on hosted reads NOTHING (the deny), never another tenant's partition.
-            _tenantPass.ForEachTenant(() =>
+            // Hosted Multi-Tenancy (session-serving): this reconcile is NOT yet per-tenant.
+            // BLOCKED ON: partitioning TurnEndWatcher._lastActivity by tenant (and NeedsYouClock._stamps,
+            // which the turn-end signal feeds). Both are keyed by session id alone, so a per-tenant pass would
+            // let one tenant's last-seen state suppress - or fabricate - another tenant's turn boundary.
+            // Until then it serves Local: correct on self-host, and on hosted a Local read is empty, so the
+            // reconcile degrades to a no-op (never a wrong-tenant read).
+            foreach (var (directorId, session) in _pushedSessions.SnapshotFresh(TenantId.Local, _streamStale))
             {
-                if (_tenantPass.Current is not { } tenant) return;
-                foreach (var (directorId, session) in _pushedSessions.SnapshotFresh(tenant, _streamStale))
-                {
-                    if (_disposed) return;
-                    Observe(session.SessionId, session.ActivityState, directorId);
-                }
-            });
+                if (_disposed) return Task.CompletedTask;
+                Observe(session.SessionId, session.ActivityState, directorId);
+            }
         }
         return Task.CompletedTask;
     }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -338,7 +338,20 @@ public sealed class GatewayHost : IAsyncDisposable
     // key to its tenant and enters the scope. Used by the tunnel Hello and the device-key HTTP middleware.
     // Inert on self-host (every authenticated caller is Local).
     private readonly Tenancy.HostedTenantBoundary _tenantBoundary;
+    // The background-loop tenant seam (Hosted Multi-Tenancy, session-serving PR2). A sweep is on no request
+    // and no tunnel connection, so it has no tenant of its own: it runs ONE PASS PER TENANT through this,
+    // instead of the single implicit TenantId.Local pass the loops used to hard-code. Self-host runs exactly
+    // one Local pass (unchanged); hosted enters each live tenant's scope in turn. Its Current is also what
+    // every Gateway-internal store read and every down-channel command resolves to - null on hosted with no
+    // scope, which is a DENY, never a fall back to Local.
+    private readonly Tenancy.ITenantPass _tenantPass;
     private readonly Data.GatewayDatabase _gatewayDb;
+
+    /// <summary>
+    /// The auth-boundary tenant binder. Exposed to the test assembly so an isolation test can enter the same
+    /// tenant scope a real request or tunnel connection would, and drive the production loop code inside it.
+    /// </summary>
+    internal Tenancy.HostedTenantBoundary TenantBoundary => _tenantBoundary;
 
     /// <summary>
     /// The account-to-tenant resolver (Hosted Multi-Tenancy increment 1): owns the tenants mapping table and
@@ -654,6 +667,14 @@ public sealed class GatewayHost : IAsyncDisposable
         // enter the scope the stores read. Inert on self-host. Built over the same _tenantContext instance
         // the stores read (so a scope it enters is what they resolve) and the device registry.
         _tenantBoundary = new Tenancy.HostedTenantBoundary(_tenantContext, Devices);
+        // The background-loop seam (Hosted Multi-Tenancy, session-serving PR2). Its tenant list is the live
+        // push-store partition set - exactly the tenants with a Director bound to the tunnel, which is the
+        // only fleet a push-store-driven sweep could act on - so a sweep costs no per-tick database scan.
+        // (Loops driven by a DATABASE table rather than the push store - cron, hosted-AI spend mirroring,
+        // web-push - are NOT converted here: KnownTenants would silently skip every tenant whose Director is
+        // offline, which is the tenant most likely to need a scheduled job. They stay hosted-disabled until a
+        // database-backed tenant enumeration and a fairness order exist. That is its own increment.)
+        _tenantPass = new Tenancy.TenantPass(_tenantBoundary, _hostedTenant, PushedSessions.KnownTenants);
         // Hosted Multi-Tenancy increment 1: the store constructors below seed built-ins and import/re-arm from
         // the database at startup - legitimate SYSTEM operations with no per-account identity. On the hosted
         // Gateway (fail-closed ambient tenant) they must run inside the reserved SYSTEM scope, or the very
@@ -730,7 +751,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // which matters here more than anywhere: the instance holds the change gate that stops the stamp
         // echoing back up and re-triggering itself forever.
         FleetRoles = new Fleet.FleetRoleObserver(
-            () => PushedSessions.SnapshotFresh(TenantId.Local, AutoDismissStaleAfter),
+            () => AmbientSnapshotFresh(AutoDismissStaleAfter),
             SendCommandAsync);
         // The fold push seam: stamps each session's folded display state down to its owning Director, so the
         // desktop rail stops re-folding from local facts it cannot see. Folds through the SAME method the
@@ -748,7 +769,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // suppresses the update forever. The roster path enriched these (GatewayHost roster map below), so
         // the browsers folded red while the push-only desktop stuck yellow. Same source, same answer.
         FleetDisplayState = new Fleet.FleetDisplayStateObserver(
-            () => PushedSessions.SnapshotFresh(TenantId.Local, AutoDismissStaleAfter),
+            () => AmbientSnapshotFresh(AutoDismissStaleAfter),
             sessions => EnrichVoiceThenFoldForPush(
                 sessions,
                 voiceGeneratingFor: sid => _voiceService?.IsGenerating(sid) == true,
@@ -1100,9 +1121,30 @@ public sealed class GatewayHost : IAsyncDisposable
     /// narration - whereas inventing something ("unknown session", the raw id) would either mislead
     /// or read out an identifier, which the same instructions explicitly forbid.
     /// </summary>
+    /// <summary>
+    /// The fresh fleet snapshot for the tenant of the CURRENT unit of work (Hosted Multi-Tenancy,
+    /// session-serving PR2) - the request scope, the tunnel connection scope, or the per-tenant background
+    /// pass. Self-host always resolves Local, so this is the same read as before. On hosted with no scope in
+    /// effect it is EMPTY, which is the deny: a sweep with no tenant sweeps nothing rather than reading a
+    /// partition that is not its own.
+    /// </summary>
+    private IReadOnlyList<(string DirectorId, SessionDto Session)> AmbientSnapshotFresh(TimeSpan staleAfter)
+        => _tenantPass.Current is { } tenant
+            ? PushedSessions.SnapshotFresh(tenant, staleAfter)
+            : Array.Empty<(string DirectorId, SessionDto Session)>();
+
+    /// <summary>
+    /// Locate a session within the tenant of the CURRENT unit of work (see <see cref="AmbientSnapshotFresh"/>).
+    /// Null when no tenant is in scope on hosted - the deny - as well as when the session is simply unknown.
+    /// </summary>
+    private (string DirectorId, SessionDto Session)? AmbientTryLocate(string sessionId, TimeSpan staleAfter)
+        => _tenantPass.Current is { } tenant
+            ? PushedSessions.TryLocate(tenant, sessionId, staleAfter)
+            : null;
+
     private string? ResolveSessionTitle(string sessionId)
     {
-        var located = PushedSessions.TryLocate(TenantId.Local, sessionId, _streamStaleAfter);
+        var located = AmbientTryLocate(sessionId, _streamStaleAfter);
         var name = located?.Session.Name;
         return string.IsNullOrWhiteSpace(name) ? null : name;
     }
@@ -1124,17 +1166,18 @@ public sealed class GatewayHost : IAsyncDisposable
             // fan-out) and reach it through the tunnel-only SessionVerbClient - an unconnected Director yields
             // an error, never an HTTP dial.
             var stale = TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
+            // Hosted Multi-Tenancy (session-serving PR2): the voice sweep is a background loop, so it runs
+            // inside a per-tenant pass and locates within THAT tenant. No scope on hosted is a deny - the pass
+            // supplies no tenant, so this sweeps nothing rather than reading a partition it does not own.
+            if (_tenantPass.Current is not { } voiceTenant) return;
             Api.DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = SendCommandAsync;
             var generated = 0;
             foreach (var sid in vs.VoiceSessionIds())
             {
                 if (generated >= 3) break;          // gentle on the serialized brain
                 if (vs.HasVoice(sid)) continue;     // already cached, nothing to do
-                // Hosted Multi-Tenancy: the voice sweep is a background loop; per-tenant iteration (KnownTenants)
-                // lands in a later slice. For now it serves Local - correct on self-host, and on hosted a Local
-                // read is empty, so the sweep degrades to a no-op (never a wrong-tenant read).
                 var (director, session) = await Api.GatewayEndpoints.LocateSessionAsync(
-                    Registry, sid, PushedSessions, stale, TenantId.Local, SessionOwners);
+                    Registry, sid, PushedSessions, stale, voiceTenant, SessionOwners);
                 if (director is null || session is null) continue;   // not owned by any known Director
                 var st = session.ActivityState ?? "";
                 if (st is "Idle" or "WaitingForInput" or "WaitingForPerm")
@@ -1252,7 +1295,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 // not swallowed into a fabricated value.
                 try
                 {
-                    if (PushedSessions.TryLocate(TenantId.Local, signal.SessionId, _streamStaleAfter) is { } spendLoc)
+                    if (AmbientTryLocate(signal.SessionId, _streamStaleAfter) is { } spendLoc)
                         _sessionSpendEmitter.Emit(spendLoc.Session);
                 }
                 catch (Exception ex)
@@ -1288,7 +1331,10 @@ public sealed class GatewayHost : IAsyncDisposable
             },
             // Gateway Cleanup mission, Phase 2: under stream mode the catch-up / reconcile reads the push
             // store instead of HTTP-pulling each Director's session list (no dial).
-            pushedSessions: PushedSessions);
+            pushedSessions: PushedSessions,
+            streamStale: null,
+            // Hosted Multi-Tenancy (session-serving PR2): the reconcile sweep runs one pass per tenant.
+            tenantPass: _tenantPass);
         // First tick = the startup catch-up sweep; then the 15s reconcile poll for
         // Directors that never push (file-discovered locals, old builds).
         _turnEndWatcher.Start();
@@ -1776,7 +1822,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // background sweep regenerates voice for any idle voice session that is missing it, so the
         // list shows it ready BEFORE you enter - including after a gateway restart (the voice-session
         // set is persisted). Turn-end regeneration + the deterministic voice-turn path also feed it.
-        _voiceSweepTimer = new System.Threading.Timer(_ => { _ = SweepVoiceSessionsAsync(); }, null,
+        // Hosted Multi-Tenancy (session-serving PR2): one pass per tenant. The async sweep captures the
+        // ambient scope at the point of the call and carries it across its awaits, so each pass stays inside
+        // the tenant it was started for even though the pass itself returns immediately.
+        _voiceSweepTimer = new System.Threading.Timer(
+            _ => _tenantPass.ForEachTenant(() => { _ = SweepVoiceSessionsAsync(); }), null,
             TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(45));
 
         // Durable, server-owned dictation upload (issue #1006): the phone streams recorded audio here
@@ -2078,7 +2128,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // sending the kill verb DOWN the Director stream. The close has no REST fallback by design (the
         // Gateway owns session lifecycle and reaches the Director through its stream).
         _autoDismissSweeper = new Running.AutoDismissSweeper(
-            () => PushedSessions.SnapshotFresh(TenantId.Local, AutoDismissStaleAfter),
+            () => AmbientSnapshotFresh(AutoDismissStaleAfter),
             SendCommandAsync);
         _autoDismissTimer = new System.Threading.Timer(_ => SweepAutoDismiss(), null, AutoDismissSweepInterval, AutoDismissSweepInterval);
         FileLog.Write($"[GatewayHost] auto-dismiss sweep started: every {AutoDismissSweepInterval.TotalSeconds:0}s");
@@ -2086,8 +2136,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // The fold push backstop: re-fold the fleet and stamp changed answers down, catching the Gateway-only
         // overlays (voice, transcription, dictation, snooze expiry) that arrive on no Director push. Never
         // throws into the timer.
+        // Hosted Multi-Tenancy (session-serving PR2): one fold pass per tenant, each inside that tenant's
+        // scope - so the fold reads that tenant's fleet and its own snooze rows, and stamps down only to its
+        // own Directors. The try/catch stays INSIDE the per-tenant pass so one tenant's fold failing does not
+        // skip the remaining tenants.
         _displayStateSweepTimer = new System.Threading.Timer(
-            _ => { try { FleetDisplayState.Sweep(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] display-state sweep error: {ex.Message}"); } },
+            _ => _tenantPass.ForEachTenant(() => { try { FleetDisplayState.Sweep(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] display-state sweep error: {ex.Message}"); } }),
             null, DisplayStateSweepInterval, DisplayStateSweepInterval);
         FileLog.Write($"[GatewayHost] display-state sweep started: every {DisplayStateSweepInterval.TotalSeconds:0}s");
 
@@ -2249,16 +2303,22 @@ public sealed class GatewayHost : IAsyncDisposable
     /// failure never crashes the timer thread). Closes automated runs that declared themselves done, over the
     /// Director stream. Fire-and-forget: the async sweep runs on the thread pool so the timer thread returns.
     /// </summary>
-    private void SweepAutoDismiss()
+    internal void SweepAutoDismiss()
     {
-        try
+        // Hosted Multi-Tenancy (session-serving PR2): one pass per tenant, each inside that tenant's scope,
+        // so the sweeper reads that tenant's fleet and its kill verbs go down that tenant's own Directors.
+        // The try/catch is INSIDE the pass so one tenant failing does not skip the rest.
+        _tenantPass.ForEachTenant(() =>
         {
-            _ = _autoDismissSweeper?.SweepAsync(CancellationToken.None);
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[GatewayHost] auto-dismiss sweep FAILED: {ex.Message}");
-        }
+            try
+            {
+                _ = _autoDismissSweeper?.SweepAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[GatewayHost] auto-dismiss sweep FAILED: {ex.Message}");
+            }
+        });
     }
 
     /// <summary>
@@ -2299,7 +2359,18 @@ public sealed class GatewayHost : IAsyncDisposable
     {
         if (command is null) throw new ArgumentNullException(nameof(command));
 
-        var connectionId = PushedSessions.GetActiveConnectionId(TenantId.Local, directorId);
+        // Hosted Multi-Tenancy (session-serving PR2): resolve the Director's stream connection within the
+        // tenant of the CURRENT unit of work - the request scope, the tunnel connection scope, or the
+        // per-tenant background pass - never a hard-coded TenantId.Local. Local here would be a genuine
+        // cross-tenant hazard, not just a wrong answer: it is the single lookup EVERY down-channel command
+        // routes through, so one tenant's sweep resolving Local could address a Director it does not own.
+        // No scope on hosted is a DENY: send nothing, exactly as an unconnected Director behaves.
+        if (_tenantPass.Current is not { } commandTenant)
+        {
+            FileLog.Write($"[GatewayHost] SendCommandAsync: DENIED (no tenant in scope) director={directorId}, verb={command.Verb}");
+            return null;
+        }
+        var connectionId = PushedSessions.GetActiveConnectionId(commandTenant, directorId);
         var hub = _app?.Services.GetService(typeof(Microsoft.AspNetCore.SignalR.IHubContext<Streaming.DirectorHub>))
             as Microsoft.AspNetCore.SignalR.IHubContext<Streaming.DirectorHub>;
         if (connectionId is null || hub is null)

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -750,8 +750,15 @@ public sealed class GatewayHost : IAsyncDisposable
         // (constructed per-invocation by SignalR) folds every pushed session through this ONE instance -
         // which matters here more than anywhere: the instance holds the change gate that stops the stamp
         // echoing back up and re-triggering itself forever.
+        // Hosted Multi-Tenancy (session-serving): NOT yet converted to the per-tenant pass.
+        // BLOCKED ON: partitioning FleetRoleObserver._lastSent by tenant. That change gate is keyed by session
+        // id alone and is PRUNED against the current pass's snapshot, so running this once per tenant would
+        // have each tenant's pass delete every other tenant's gate entries - inverting a suppressed no-op into
+        // a role-stamp storm every sweep. Converting the loop before partitioning the state it MUTATES makes
+        // things worse, not better. Until then it stays on Local: correct on self-host, and on hosted a Local
+        // read is empty, so it degrades to a no-op exactly as today (never a wrong-tenant read).
         FleetRoles = new Fleet.FleetRoleObserver(
-            () => AmbientSnapshotFresh(AutoDismissStaleAfter),
+            () => PushedSessions.SnapshotFresh(TenantId.Local, AutoDismissStaleAfter),
             SendCommandAsync);
         // The fold push seam: stamps each session's folded display state down to its owning Director, so the
         // desktop rail stops re-folding from local facts it cannot see. Folds through the SAME method the
@@ -768,8 +775,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // and without this enrichment the sweep re-derives the same yellow every tick and the change gate
         // suppresses the update forever. The roster path enriched these (GatewayHost roster map below), so
         // the browsers folded red while the push-only desktop stuck yellow. Same source, same answer.
+        // Hosted Multi-Tenancy (session-serving): NOT yet converted to the per-tenant pass.
+        // BLOCKED ON: partitioning FleetDisplayStateObserver._lastSent by tenant - same shape as FleetRoles
+        // above (session-id-keyed, pruned against the current pass's snapshot), so a per-tenant pass would
+        // turn the display-state fold into a stamp storm every 5 seconds.
         FleetDisplayState = new Fleet.FleetDisplayStateObserver(
-            () => AmbientSnapshotFresh(AutoDismissStaleAfter),
+            () => PushedSessions.SnapshotFresh(TenantId.Local, AutoDismissStaleAfter),
             sessions => EnrichVoiceThenFoldForPush(
                 sessions,
                 voiceGeneratingFor: sid => _voiceService?.IsGenerating(sid) == true,
@@ -1144,7 +1155,7 @@ public sealed class GatewayHost : IAsyncDisposable
 
     private string? ResolveSessionTitle(string sessionId)
     {
-        var located = AmbientTryLocate(sessionId, _streamStaleAfter);
+        var located = PushedSessions.TryLocate(TenantId.Local, sessionId, _streamStaleAfter);
         var name = located?.Session.Name;
         return string.IsNullOrWhiteSpace(name) ? null : name;
     }
@@ -1166,18 +1177,22 @@ public sealed class GatewayHost : IAsyncDisposable
             // fan-out) and reach it through the tunnel-only SessionVerbClient - an unconnected Director yields
             // an error, never an HTTP dial.
             var stale = TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
-            // Hosted Multi-Tenancy (session-serving PR2): the voice sweep is a background loop, so it runs
-            // inside a per-tenant pass and locates within THAT tenant. No scope on hosted is a deny - the pass
-            // supplies no tenant, so this sweeps nothing rather than reading a partition it does not own.
-            if (_tenantPass.Current is not { } voiceTenant) return;
             Api.DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = SendCommandAsync;
             var generated = 0;
             foreach (var sid in vs.VoiceSessionIds())
             {
                 if (generated >= 3) break;          // gentle on the serialized brain
                 if (vs.HasVoice(sid)) continue;     // already cached, nothing to do
+                // Hosted Multi-Tenancy (session-serving): the voice sweep is NOT yet per-tenant.
+                // BLOCKED ON: partitioning the WingmanVoiceService caches by tenant (its markers, generated
+                // text and audio are all keyed by session id alone) AND tenant-checking /wingman/voice/ready,
+                // which today lists EVERY ready session id. Converting this loop first would ARM a leak rather
+                // than close one: per-tenant generation would fill a process-global cache that the voice read
+                // path serves to any tenant that names an id - and /wingman/voice/ready hands out the ids. A
+                // hosted no-op is strictly safer than a live cross-tenant audio path. Until then it serves
+                // Local: correct on self-host, and on hosted a Local read is empty (never a wrong-tenant read).
                 var (director, session) = await Api.GatewayEndpoints.LocateSessionAsync(
-                    Registry, sid, PushedSessions, stale, voiceTenant, SessionOwners);
+                    Registry, sid, PushedSessions, stale, TenantId.Local, SessionOwners);
                 if (director is null || session is null) continue;   // not owned by any known Director
                 var st = session.ActivityState ?? "";
                 if (st is "Idle" or "WaitingForInput" or "WaitingForPerm")
@@ -1295,7 +1310,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 // not swallowed into a fabricated value.
                 try
                 {
-                    if (AmbientTryLocate(signal.SessionId, _streamStaleAfter) is { } spendLoc)
+                    if (PushedSessions.TryLocate(TenantId.Local, signal.SessionId, _streamStaleAfter) is { } spendLoc)
                         _sessionSpendEmitter.Emit(spendLoc.Session);
                 }
                 catch (Exception ex)
@@ -1331,10 +1346,7 @@ public sealed class GatewayHost : IAsyncDisposable
             },
             // Gateway Cleanup mission, Phase 2: under stream mode the catch-up / reconcile reads the push
             // store instead of HTTP-pulling each Director's session list (no dial).
-            pushedSessions: PushedSessions,
-            streamStale: null,
-            // Hosted Multi-Tenancy (session-serving PR2): the reconcile sweep runs one pass per tenant.
-            tenantPass: _tenantPass);
+            pushedSessions: PushedSessions);
         // First tick = the startup catch-up sweep; then the 15s reconcile poll for
         // Directors that never push (file-discovered locals, old builds).
         _turnEndWatcher.Start();
@@ -1822,11 +1834,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // background sweep regenerates voice for any idle voice session that is missing it, so the
         // list shows it ready BEFORE you enter - including after a gateway restart (the voice-session
         // set is persisted). Turn-end regeneration + the deterministic voice-turn path also feed it.
-        // Hosted Multi-Tenancy (session-serving PR2): one pass per tenant. The async sweep captures the
-        // ambient scope at the point of the call and carries it across its awaits, so each pass stays inside
-        // the tenant it was started for even though the pass itself returns immediately.
-        _voiceSweepTimer = new System.Threading.Timer(
-            _ => _tenantPass.ForEachTenant(() => { _ = SweepVoiceSessionsAsync(); }), null,
+        _voiceSweepTimer = new System.Threading.Timer(_ => { _ = SweepVoiceSessionsAsync(); }, null,
             TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(45));
 
         // Durable, server-owned dictation upload (issue #1006): the phone streams recorded audio here
@@ -2129,19 +2137,17 @@ public sealed class GatewayHost : IAsyncDisposable
         // Gateway owns session lifecycle and reaches the Director through its stream).
         _autoDismissSweeper = new Running.AutoDismissSweeper(
             () => AmbientSnapshotFresh(AutoDismissStaleAfter),
-            SendCommandAsync);
+            SendCommandAsync,
+            // Partition the close-marks by the tenant of the pass currently running (see AutoDismissSweeper).
+            tenantKey: () => _tenantPass.Current?.Value ?? "");
         _autoDismissTimer = new System.Threading.Timer(_ => SweepAutoDismiss(), null, AutoDismissSweepInterval, AutoDismissSweepInterval);
         FileLog.Write($"[GatewayHost] auto-dismiss sweep started: every {AutoDismissSweepInterval.TotalSeconds:0}s");
 
         // The fold push backstop: re-fold the fleet and stamp changed answers down, catching the Gateway-only
         // overlays (voice, transcription, dictation, snooze expiry) that arrive on no Director push. Never
         // throws into the timer.
-        // Hosted Multi-Tenancy (session-serving PR2): one fold pass per tenant, each inside that tenant's
-        // scope - so the fold reads that tenant's fleet and its own snooze rows, and stamps down only to its
-        // own Directors. The try/catch stays INSIDE the per-tenant pass so one tenant's fold failing does not
-        // skip the remaining tenants.
         _displayStateSweepTimer = new System.Threading.Timer(
-            _ => _tenantPass.ForEachTenant(() => { try { FleetDisplayState.Sweep(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] display-state sweep error: {ex.Message}"); } }),
+            _ => { try { FleetDisplayState.Sweep(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] display-state sweep error: {ex.Message}"); } },
             null, DisplayStateSweepInterval, DisplayStateSweepInterval);
         FileLog.Write($"[GatewayHost] display-state sweep started: every {DisplayStateSweepInterval.TotalSeconds:0}s");
 

--- a/src/CcDirector.Gateway/Running/AutoDismissSweeper.cs
+++ b/src/CcDirector.Gateway/Running/AutoDismissSweeper.cs
@@ -24,20 +24,35 @@ internal sealed class AutoDismissSweeper
 {
     private readonly Func<IReadOnlyList<(string DirectorId, SessionDto Session)>> _snapshot;
     private readonly DirectorCommandRouter.SendDirectorCommandAsync _sendCommand;
+    private readonly Func<string> _tenantKey;
 
     // Sessions we have already issued a kill for, so a session that lingers one extra sweep (before its
     // removal tombstone propagates up the stream) is not killed twice. Pruned opportunistically each sweep.
+    //
+    // Hosted Multi-Tenancy (session-serving PR2): keyed by (TENANT, session id), not session id alone. This
+    // sweeper now runs ONE PASS PER TENANT, and each pass prunes marks against ITS OWN snapshot - so a
+    // session-id-only key would have every tenant's pass delete every other tenant's marks, destroying the
+    // duplicate-kill protection entirely, and would let two tenants that happen to use the same session id
+    // suppress each other's close. The tenant prefix keeps each tenant's marks private to its own pass.
     private readonly ConcurrentDictionary<string, byte> _closing = new(StringComparer.Ordinal);
 
     /// <param name="snapshot">Returns the fresh pushed sessions across all stream-connected Directors (PushedSessionStore.SnapshotFresh).</param>
     /// <param name="sendCommand">The down-channel command sender (GatewayHost.SendCommandAsync); required - the feature only runs with the stream on.</param>
+    /// <param name="tenantKey">Hosted Multi-Tenancy (session-serving PR2): identifies the tenant of the pass
+    /// currently running, so the close-marks below are partitioned per tenant. Omitted (null) means the
+    /// single-tenant shape - one constant partition - which is self-host and the unit tests.</param>
     public AutoDismissSweeper(
         Func<IReadOnlyList<(string DirectorId, SessionDto Session)>> snapshot,
-        DirectorCommandRouter.SendDirectorCommandAsync sendCommand)
+        DirectorCommandRouter.SendDirectorCommandAsync sendCommand,
+        Func<string>? tenantKey = null)
     {
         _snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
         _sendCommand = sendCommand ?? throw new ArgumentNullException(nameof(sendCommand));
+        _tenantKey = tenantKey ?? (static () => "local");
     }
+
+    /// <summary>The close-mark key for a session within the tenant of the pass currently running.</summary>
+    private string MarkKey(string sessionId) => _tenantKey() + "|" + sessionId;
 
     /// <summary>The verdict string (see <c>Session.DismissVerdict</c>) that authorizes an auto-close.</summary>
     public const string VerdictDone = "done";
@@ -91,13 +106,13 @@ internal sealed class AutoDismissSweeper
         var snapshot = _snapshot();
         PruneClosing(snapshot);
 
-        var picks = SelectDismissable(snapshot, sid => _closing.ContainsKey(sid));
+        var picks = SelectDismissable(snapshot, sid => _closing.ContainsKey(MarkKey(sid)));
         var closed = 0;
         foreach (var (directorId, session) in picks)
         {
             ct.ThrowIfCancellationRequested();
             // Mark before sending so a slow round-trip cannot let the next sweep issue a duplicate kill.
-            _closing.TryAdd(session.SessionId, 0);
+            _closing.TryAdd(MarkKey(session.SessionId), 0);
             try
             {
                 var result = await DirectorCommandRouter.TrySendAsync(
@@ -105,7 +120,7 @@ internal sealed class AutoDismissSweeper
                 if (result is null)
                 {
                     // No active stream right now; drop the mark so a later sweep retries once the stream is back.
-                    _closing.TryRemove(session.SessionId, out _);
+                    _closing.TryRemove(MarkKey(session.SessionId), out _);
                     FileLog.Write($"[AutoDismissSweeper] session={session.SessionId} director={directorId}: no stream, will retry");
                     continue;
                 }
@@ -123,7 +138,7 @@ internal sealed class AutoDismissSweeper
             }
             catch (Exception ex)
             {
-                _closing.TryRemove(session.SessionId, out _);
+                _closing.TryRemove(MarkKey(session.SessionId), out _);
                 FileLog.Write($"[AutoDismissSweeper] close FAILED: session={session.SessionId} director={directorId}: {ex.Message}");
             }
         }
@@ -133,16 +148,21 @@ internal sealed class AutoDismissSweeper
         return closed;
     }
 
-    /// <summary>Forget close-marks for sessions no longer present in the snapshot (they are gone, or their Director dropped).</summary>
+    /// <summary>
+    /// Forget close-marks for sessions no longer present in the snapshot (they are gone, or their Director
+    /// dropped). Scoped to THIS PASS'S TENANT: the snapshot only ever contains that tenant's sessions, so
+    /// pruning across the whole map would delete every other tenant's marks on every pass.
+    /// </summary>
     private void PruneClosing(IReadOnlyList<(string DirectorId, SessionDto Session)> snapshot)
     {
         if (_closing.IsEmpty)
             return;
-        var present = new HashSet<string>(snapshot.Select(t => t.Session.SessionId), StringComparer.Ordinal);
-        foreach (var sid in _closing.Keys)
+        var prefix = _tenantKey() + "|";
+        var present = new HashSet<string>(snapshot.Select(t => MarkKey(t.Session.SessionId)), StringComparer.Ordinal);
+        foreach (var key in _closing.Keys)
         {
-            if (!present.Contains(sid))
-                _closing.TryRemove(sid, out _);
+            if (key.StartsWith(prefix, StringComparison.Ordinal) && !present.Contains(key))
+                _closing.TryRemove(key, out _);
         }
     }
 }

--- a/src/CcDirector.Gateway/Tenancy/ITenantPass.cs
+++ b/src/CcDirector.Gateway/Tenancy/ITenantPass.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using CcDirector.Core.Tenancy;
+
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// The BACKGROUND-LOOP tenant seam (Hosted Multi-Tenancy, session-serving PR2) - the loop-side twin of
+/// <see cref="HostedTenantBoundary.ResolveRequestTenant"/>.
+///
+/// A background loop (a sweep, an aggregator, a reconcile poll) is not on a request and not on a tunnel
+/// connection, so unlike every other caller it has NO tenant of its own to resolve. Before this seam the
+/// Gateway's loops papered over that by hard-coding <see cref="TenantId.Local"/> - which is correct on
+/// self-host but on the hosted Gateway means every loop runs one pass against a single implicit tenant
+/// that owns nothing. This seam replaces that single implicit pass with ONE PASS PER TENANT, each inside
+/// that tenant's own scope, so a sweep sees exactly one tenant's fleet at a time and never reaches across.
+///
+/// SELF-HOST IS UNCHANGED BY CONSTRUCTION: there is exactly one tenant (Local), so
+/// <see cref="ForEachTenant"/> runs exactly one pass and <see cref="Current"/> is always Local - the same
+/// single unscoped pass against the same partition the loops run today.
+///
+/// DENY-BY-DEFAULT: on hosted, <see cref="Current"/> is NULL when no scope has been entered. A caller that
+/// gets null must do nothing (an empty read, an undelivered command) - it must never substitute
+/// <see cref="TenantId.Local"/> or <see cref="TenantId.System"/>, which is precisely the fallback that
+/// would turn one tenant's loop into a read of another tenant's partition.
+/// </summary>
+public interface ITenantPass
+{
+    /// <summary>
+    /// Run <paramref name="pass"/> once per tenant, inside that tenant's scope. Self-host runs it exactly
+    /// once (Local). Hosted runs it once per live tenant; with no live tenants it runs zero times, which is
+    /// the correct answer - there is no fleet to sweep - and never a Local pass.
+    /// </summary>
+    void ForEachTenant(Action pass);
+
+    /// <summary>
+    /// The tenant of the unit of work currently running: the pass <see cref="ForEachTenant"/> entered, or
+    /// the request / tunnel-connection scope the caller is already inside. Null ONLY on hosted with no scope
+    /// in effect, and that null is a DENY - never Local, never System.
+    /// </summary>
+    TenantId? Current { get; }
+}
+
+/// <summary>
+/// The single-tenant <see cref="ITenantPass"/>: exactly one pass, always <see cref="TenantId.Local"/>. This
+/// is the self-host shape and the default a component falls back to when no seam is supplied (the unit
+/// tests), so omitting the seam can never accidentally produce hosted behavior.
+/// </summary>
+public sealed class SingleTenantPass : ITenantPass
+{
+    public static readonly SingleTenantPass Instance = new();
+
+    /// <inheritdoc />
+    public TenantId? Current => TenantId.Local;
+
+    /// <inheritdoc />
+    public void ForEachTenant(Action pass)
+    {
+        if (pass is null) throw new ArgumentNullException(nameof(pass));
+        pass();
+    }
+}
+
+/// <summary>
+/// The production <see cref="ITenantPass"/>. It reads its tenant list from the live push store
+/// (<c>PushedSessionStore.KnownTenants</c>), which is exactly the set of tenants with a Director bound to
+/// the tunnel - the only tenants whose fleet a push-store-driven sweep could act on - and so costs no
+/// per-tick database scan. A tenant that appears or disappears between ticks is picked up on the next
+/// sweep, the same eventual consistency the sweeps already rely on.
+/// </summary>
+public sealed class TenantPass : ITenantPass
+{
+    private readonly HostedTenantBoundary _boundary;
+    private readonly AsyncLocalTenantContext? _ambient;
+    private readonly Func<IReadOnlyCollection<TenantId>> _knownTenants;
+
+    /// <param name="boundary">The auth-boundary binder; its <c>IsHosted</c> decides single-pass vs per-tenant.</param>
+    /// <param name="ambient">The hosted ambient context (null on self-host), read for <see cref="Current"/>.</param>
+    /// <param name="knownTenants">The live tenant list - <c>PushedSessionStore.KnownTenants</c> in production.</param>
+    public TenantPass(
+        HostedTenantBoundary boundary,
+        AsyncLocalTenantContext? ambient,
+        Func<IReadOnlyCollection<TenantId>> knownTenants)
+    {
+        _boundary = boundary ?? throw new ArgumentNullException(nameof(boundary));
+        _ambient = ambient;
+        _knownTenants = knownTenants ?? throw new ArgumentNullException(nameof(knownTenants));
+    }
+
+    /// <inheritdoc />
+    public TenantId? Current => _ambient is null ? TenantId.Local : _ambient.CurrentOrNull;
+
+    /// <inheritdoc />
+    public void ForEachTenant(Action pass)
+    {
+        if (pass is null) throw new ArgumentNullException(nameof(pass));
+
+        // Self-host: exactly one pass, no scope to enter - byte-identical to the single pass today.
+        if (!_boundary.IsHosted)
+        {
+            pass();
+            return;
+        }
+
+        foreach (var tenant in _knownTenants())
+        {
+            if (!tenant.IsValid) continue;
+            using (_boundary.EnterScope(tenant))
+                pass();
+        }
+    }
+}


### PR DESCRIPTION
## What

Hosted Multi-Tenancy, session-serving increment, **PR2 of 3** (the background loops and the public health probe). PR1 (#1842) made the cockpit READ path tenant-aware. This one goes after the paths that have **no request to resolve a tenant from**: the Gateway's always-on sweeps, the single lookup every down-channel command routes through, and the unauthenticated liveness probe.

It is deliberately **three things**, not seven. See "What is NOT converted, and why" below - that section is the substance of this pull request as much as the changes are.

## The leak this closes

`/healthz` is **public and unauthenticated** - it is the probe the Director's connectivity self-test, the gateway endpoint selector, and the settings gateway test all dial, so it carries no credential. On the hosted Gateway its `directors` / `sessions` counts were a **fleet-global aggregate across every account**. Verified live against the hosted Gateway with no auth at all:

```
{"status":"ok","directors":2,"sessions":0,...}
```

Those 2 were two throwaway proof Directors on two *different* tenants.

This is not fixable by making the count tenant-aware: a request with no tenant has no correct number to print. So on hosted **the aggregate is not computed at all** - deny-by-default applies to metrics exactly as it applies to data. Liveness (status, version, server time) is what a probe actually needs and stays public. Self-host keeps its counts unchanged.

## The three changes

**1. `GatewayHost.SendCommandAsync` resolves the ambient tenant.** It hard-coded `TenantId.Local` for the Director stream-connection lookup. This is the ONE lookup **every** down-channel command routes through, so `Local` there is a genuine cross-tenant hazard, not merely a wrong answer. It now resolves the tenant of the current unit of work - the request scope, the tunnel connection scope, or the per-tenant background pass - and **denies with `null` when hosted-and-unscoped**, never falling back to Local.

**2. The auto-dismiss sweep runs one pass per tenant.** New `ITenantPass` seam (`Tenancy/ITenantPass.cs`): `ForEachTenant` runs a pass inside each tenant's scope, sourced from `PushedSessionStore.KnownTenants()`. Self-host is unchanged **by construction** - `SingleTenantPass` / the not-hosted branch runs exactly one pass and always answers `TenantId.Local`.

Critically, **the gate moved with the loop**: `AutoDismissSweeper`'s close-marks are now keyed by `(tenant, session id)`. Keyed by session id alone they are pruned against the *current pass's* snapshot, so every tenant's pass would delete every other tenant's marks and destroy the duplicate-kill protection outright.

**3. `/healthz` stops disclosing the fleet-global counts on hosted.** As above.

> **Correction, added after the live proof.** This section originally said /healthz "reports no fleet counts on hosted". That overstates what shipped. The hosted early-return builds a `HealthDto` setting only `Status`/`Version`/`ServerTime`, so `Directors` and `Sessions` still **serialize as their default `0`** rather than being omitted:
>
> ```
> {"status":"ok","directors":0,"sessions":0,"version":"1.5.0",...}
> ```
>
> That is **not a leak** - `0` is not the real count and discloses nothing about any tenant, and the fleet-global aggregate is genuinely never computed (verified live: the same probe returned `directors:2` before this change and `0` after, with two Directors from two tenants connected at the moment of the probe). But an always-`0` count is a **false statement rather than an absent one**, and /healthz is the probe every Director and endpoint selector dials - anything monitoring `directors` on hosted now reads a permanently dead fleet. Omission is honest; zero is misleading.
>
> Fixed in PR3: the fields become nullable and are omitted from the response when null. Tracked as the first item of that pull request alongside the `tenantKey` nit below.

## What is NOT converted, and why

The display-state fold, the role stamp, the turn-end reconcile and the voice sweep **stay on `TenantId.Local`**, each with an in-code comment naming the exact gate that must be partitioned first.

The general rule this increment established the hard way: **converting a loop to per-tenant is only safe once the state that loop MUTATES is itself partitioned.** These observers keep change gates keyed by session id alone and *pruned against the current pass's snapshot*. Run them once per tenant and each pass evicts every other tenant's entries - so the suppression that makes them quiet **inverts into a stamp storm every 5 seconds**. That is deterministic, not a same-session-id edge case. A naive per-tenant fold here is worse than the single implicit pass.

The **voice sweep** is the sharpest case, and it is worth stating plainly: converting it would **arm a leak rather than close one**. `WingmanVoiceService` caches markers, generated text and audio process-globally by session id, and `/wingman/voice/ready` lists every ready session id with no tenant check. Per-tenant generation would fill that global cache for every account, and the read path would serve one tenant's narration to another that simply names the id. A hosted no-op is strictly safer than a live cross-tenant audio path.

All four are hosted **no-ops today** (a `Local` read on hosted is empty), so leaving them regresses nothing and leaks nothing.

**Named blocker on PR3 (relay + voice): partition the `WingmanVoiceService` caches by tenant and tenant-check `/wingman/voice/ready` BEFORE any voice sweep runs per-tenant.**

Also still deferred, unchanged from the PR2 plan: cron firing, hosted-AI spend mirroring and web-push. They are database-table-driven, not push-store-driven, so `KnownTenants()` is the wrong source - it enumerates only tenants with a *live connected Director*, which would silently skip exactly the tenant whose Director is offline and most needs its scheduled job. Those need a database-backed tenant enumeration (`TenantRegistry` has no `ListAll` today) plus a fairness order so one large tenant cannot starve the rest. All three are disabled on hosted today, so deferring them regresses nothing. Own increment.

## Revert-proofs - each guard independently, with RED output

Each revert is of the **real production line**, run separately, so each guard is shown to have teeth on its own.

**1. `GatewayHost.SendCommandAsync` tenant resolution** -> back to `TenantId.Local`:

```
Failed SessionServingLoopIsolationTests.SendCommand_reaches_only_the_owning_tenants_director [137 ms]
   Assert.NotNull() Failure: Value is null
Failed SessionServingLoopIsolationTests.AutoDismiss_sweep_runs_one_pass_per_tenant_and_closes_only_that_tenants_sessions [20 s]
   Assert.NotNull() Failure: Value is null
Failed!  - Failed: 2, Passed: 2, Skipped: 0, Total: 4
```

**2. `GatewayHost.SweepAutoDismiss` per-tenant pass** -> `_tenantPass.ForEachTenant(...)` replaced by a single direct call (the pre-change implicit single pass). Note only the sweep test reddens - the SendCommand guard stays green, so the two are independent:

```
Failed SessionServingLoopIsolationTests.AutoDismiss_sweep_runs_one_pass_per_tenant_and_closes_only_that_tenants_sessions [20 s]
   Assert.NotNull() Failure: Value is null
Failed!  - Failed: 1, Passed: 3, Skipped: 0, Total: 4
```

**3. `AutoDismissSweeper.MarkKey` tenant partitioning** -> tenant prefix dropped, back to a session-id-only close-mark:

```
Failed SessionServingLoopIsolationTests.AutoDismiss_close_marks_are_partitioned_per_tenant [10 s]
   Assert.NotNull() Failure: Value is null
```

**4. The `/healthz` hosted branch in `GatewayEndpoints.Map`** -> deleted. The leak reproduces exactly - the anonymous probe reports the registered Director again:

```
Failed HealthzTenantLeakTests.Hosted_healthz_reports_no_fleet_counts [1 s]
   Assert.Equal() Failure: Values differ
   Expected: 0
   Actual:   1
Failed!  - Failed: 1, Passed: 1, Skipped: 0, Total: 2
```

## Tests

`SessionServingLoopIsolationTests` - two Directors on two tenants over the real tunnel, driving the real production functions (`SendCommandAsync`, `SweepAutoDismiss`), not helpers.

**Every absence assertion is preceded by its own positive control**, including a B-side control so "tenant B never received the cross-tenant command" cannot be satisfied by a tenant B that cannot receive anything at all. The close-mark test uses the **same session id in both tenants** - the case that actually separates a partitioned gate from a shared one, and a real arrangement since session ids are not globally unique across accounts.

`HealthzTenantLeakTests` - the hosted probe with a Director registered, plus a self-host positive control proving the assertion is about the tenancy branch and not about a Gateway with nothing to count. (The `sessions == 0` assertion was deliberately **removed**: that count already read the empty Local partition before this change, so it would have passed either way and proved nothing.)

## Test results

Full .NET suite green, **counts quoted** - a green with no number is not a green:

| Project | Result |
|---|---|
| **Gateway** | **2866 passed**, 0 failed, 10 skipped (Postgres live-proofs) |
| Core | 3301 passed, 0 failed |
| Setup.Engine | 320 passed, 0 failed |
| Avalonia | 247 passed, 0 failed |
| HostedAgent | 86 passed, 0 failed |
| Engine | 62 passed, 0 failed |
| CcDirectorSetup | 32 passed, 0 failed |
| Launcher | 27 passed, 0 failed |
| Terminal.Avalonia | 21 passed, 0 failed |
| Setup.Cli | 19 passed, 0 failed |

Gateway baseline on `origin/main` is **2861**; this branch is **2866** = baseline + the 5 new tests. No web workspace is touched by this change.

**A false green was caught and fixed on the way here.** An earlier run of this branch reported `Passed: 679, Failed: 0` with **exit code 0** - but the run had *aborted* partway through. Against a known 2861 baseline that is a suite that died reporting success. Cause was mine: the health test registered a Director and then deleted its temp instances directory, and the `DirectorRegistry` FileSystemWatcher delete event lands on a thread-pool thread *after* the host is torn down, reaching a disposed database and killing the whole test process. Fixed by not deleting the directory. The underlying production defect - an unhandled exception on that watcher callback kills the process - is filed as thefrederiksen/devthrottle_internal#875.

## Codex adversarial review

Run before handback, pointed specifically at (a) any path that can still reach `TenantId.Local` on hosted and (b) tests that would still pass after reverting the production change. **It found a regression I was about to ship and I cut it rather than defend it** - the shared-change-gate finding above is entirely Codex's, and it is the reason four sweeps are not in this pull request.

Verdict, verbatim on the material points:

> **HIGH - all converted sweeps share unpartitioned change gates.** `AutoDismissSweeper.cs:30` keys `_closing` only by SID. Each tenant pass prunes marks belonging to every other tenant [...] destroying duplicate-kill protection even when SIDs differ. [...] `FleetRoleObserver.cs:55` and `FleetDisplayStateObserver.cs:49` similarly key their gates only by SID. Their per-tenant sweeps prune other tenants' entries [...] causing repeated command storms.

> **CRITICAL - voice data is process-global and directly readable across tenants.** `WingmanVoiceService.cs:42` keys voice markers, generated text, audio, and in-flight state only by `sid`. The new per-tenant sweep [...] populates this singleton for every tenant. Then `GatewayWingmanVoiceEndpoint.cs:157` reveals every ready SID, and lines 160 and 169 return another tenant's spoken text, reply, and audio using that SID. No guessing is needed because `/wingman/voice/ready` supplies the identifiers.

> **No AsyncLocal-disposal defect found.** The calls [...] capture the current `ExecutionContext` before the enclosing scope is restored. Disposing the caller's scope does not rewrite the captured continuation, so tenant A/B async continuations retain their respective tenant.

> **VACUOUS PASS:** `HealthzTenantLeakTests.cs:46` asserts `Sessions == 0`, but [...] pre-change `GatewayEndpoints.cs:386` already reads `TenantId.Local` [...] This assertion **STILL PASSES AFTER REVERT**.

> **The "every absence has a positive control" claim is false for** `SessionServingLoopIsolationTests.cs:124`. The test proves Director A can receive a command [...] but never positively proves Director B can receive one before asserting that B did not receive the cross-tenant marker.

Every one of those was acted on: the four sweeps were pulled from the pull request, `_closing` was partitioned, the vacuous `Sessions == 0` assertion was removed, and the B-side positive control was added.

Codex also confirmed the remaining `TenantId.Local` sites as **safe empty-degradation** (they resolve the empty hosted Local partition and stop with `null`/404 rather than reaching another tenant) and separately surfaced four **pre-existing** cross-tenant defects that are not this pull request's to fix. They are filed rather than left in chat: **#1847** (DirectorRegistry fleet-global + tunnel `Hello` trusts a client-chosen director id - a cross-tenant *write*), **#1848** (`/prompts` returns every tenant's full prompt text; `/stats/data` is a fleet-global aggregate), **#1849** (director-shutdown safety gate fails OPEN on hosted - "count unknown" and "there are none" share a code path on a destructive action), **#1850** (the FileSystemWatcher process-kill above, plus a CI minimum-test-count floor).

## Self-host

Unchanged by construction. There is exactly one tenant, so the pass runs exactly once under `TenantId.Local` and every resolution answers `Local` - the same single pass against the same partition as before. `/healthz` keeps its counts. The `ITenantPass` default (`SingleTenantPass`) is the single-tenant shape, so omitting the seam can never accidentally produce hosted behavior.

