### PR TITLE
fix(gateway): /healthz omits fleet counts on hosted; auto-dismiss denies without a tenant; a faulting subscriber can no longer kill the Gateway

### DIFF
--- a/apps/mobile/src/pages/About.tsx
+++ b/apps/mobile/src/pages/About.tsx
@@ -50,8 +50,8 @@ export function About() {
         <AboutRow label="Mobile bundle" value={bundle} />
         <AboutRow label="Gateway status" value={health?.status ?? "Loading..."} />
         <AboutRow label="Gateway time" value={formatTime(health?.serverTime)} />
-        <AboutRow label="Directors" value={health ? String(health.directors) : "Loading..."} />
-        <AboutRow label="Sessions" value={health ? String(health.sessions) : "Loading..."} />
+        <AboutRow label="Directors" value={formatCount(health, health?.directors)} />
+        <AboutRow label="Sessions" value={formatCount(health, health?.sessions)} />
         <AboutRow label="Service worker" value={sw} />
         <AboutRow label="Display" value={displayMode} />
       </section>
@@ -93,6 +93,18 @@ function shortSha(version: string): string {
   const plus = version.indexOf("+");
   if (plus < 0) return "";
   return version.substring(plus + 1, plus + 8);
+}
+
+/**
+ * A fleet count for the About list. Three genuinely different states, told apart honestly:
+ * health not fetched yet -> "Loading..."; the Gateway answered but OMITTED the count (the hosted
+ * Gateway does, because a public tenant-less probe has no correct number to give) -> "Not reported";
+ * otherwise the number. Never String(undefined), and never a substituted 0 - a zero here would read
+ * as "your fleet is empty" when the truth is "this Gateway does not say".
+ */
+function formatCount(health: unknown, value: number | undefined): string {
+  if (!health) return "Loading...";
+  return value === undefined || value === null ? "Not reported" : String(value);
 }
 
 function formatTime(value: string | undefined): string {

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -44,11 +44,18 @@ export interface DirectorInfo {
   controlEndpoint: string;
 }
 
-/** GET /healthz - what the running Gateway reports about itself. Backs the mobile About screen. */
+/**
+ * GET /healthz - what the running Gateway reports about itself. Backs the mobile About screen.
+ *
+ * `directors` and `sessions` are OPTIONAL: the hosted Gateway omits them entirely, because /healthz is
+ * public and carries no credential, so it has no tenant and a fleet-global count would span every
+ * account. Render an absent count as "not reported" - never coerce it, or `String(undefined)` puts the
+ * literal text "undefined" on the screen and a `?? 0` would claim the fleet is empty.
+ */
 export interface GatewayHealth {
   status: string;
-  directors: number;
-  sessions: number;
+  directors?: number;
+  sessions?: number;
   version: string;
   serverTime: string;
 }

--- a/src/CcDirector.Core.Tests/SettingsDetectionServiceTests.cs
+++ b/src/CcDirector.Core.Tests/SettingsDetectionServiceTests.cs
@@ -35,6 +35,25 @@ public class SettingsDetectionServiceTests
     }
 
     [Fact]
+    public async Task TestGatewayAsync_AbsentCounts_ReportsThemAbsent_NotZero()
+    {
+        // Hosted Multi-Tenancy: the hosted Gateway OMITS directors/sessions from /healthz, because that probe
+        // is public and tenant-less and a fleet-global aggregate would span every account. A missing field
+        // must therefore read as "not reported", never be coerced to 0 - "0 director(s)" on the Test-gateway
+        // button turns an absence into a claim that the person's fleet is empty.
+        var svc = WithResponse(HttpStatusCode.OK, """{"status":"ok","version":"1.5.0"}""");
+
+        var r = await svc.TestGatewayAsync("http://gw:7878");
+
+        Assert.True(r.Ok);
+        Assert.Equal("1.5.0", r.Version);
+        Assert.Null(r.Directors);
+        Assert.Null(r.Sessions);
+        Assert.DoesNotContain("0 director(s)", r.Message);
+        Assert.Contains("not reported", r.Message);
+    }
+
+    [Fact]
     public async Task TestGatewayAsync_CaseInsensitiveKeys_StillParses()
     {
         var svc = WithResponse(HttpStatusCode.OK,

--- a/src/CcDirector.Core/Settings/SettingsDetectionService.cs
+++ b/src/CcDirector.Core/Settings/SettingsDetectionService.cs
@@ -7,7 +7,10 @@ using CcDirector.Core.Utilities;
 namespace CcDirector.Core.Settings;
 
 /// <summary>Result of probing a gateway's /healthz.</summary>
-public sealed record GatewayTestResult(bool Ok, string Message, string? Version, int Directors, int Sessions);
+/// <param name="Directors">Fleet counts, or NULL when the gateway did not report them - the hosted Gateway
+/// omits them from /healthz because a public, tenant-less probe has no honest number to give. Null must be
+/// rendered as "not reported", never coerced to 0, or the absence becomes a claim of an empty fleet.</param>
+public sealed record GatewayTestResult(bool Ok, string Message, string? Version, int? Directors, int? Sessions);
 
 /// <summary>Result of scanning for a gateway: the first reachable URL (or null) and every URL tried.</summary>
 public sealed record GatewayDetectResult(string? Url, IReadOnlyList<string> Scanned);
@@ -40,7 +43,7 @@ public sealed class SettingsDetectionService
     public async Task<GatewayTestResult> TestGatewayAsync(string baseUrl, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(baseUrl))
-            return new GatewayTestResult(false, "No gateway URL provided.", null, 0, 0);
+            return new GatewayTestResult(false, "No gateway URL provided.", null, null, null);
 
         var healthz = baseUrl.TrimEnd('/') + "/healthz";
         FileLog.Write($"[SettingsDetectionService] TestGateway: {healthz}");
@@ -52,11 +55,11 @@ public sealed class SettingsDetectionService
         }
         catch (Exception ex)
         {
-            return new GatewayTestResult(false, $"Cannot reach {baseUrl}: {ex.Message}", null, 0, 0);
+            return new GatewayTestResult(false, $"Cannot reach {baseUrl}: {ex.Message}", null, null, null);
         }
 
         if (!resp.IsSuccessStatusCode)
-            return new GatewayTestResult(false, $"Gateway returned {(int)resp.StatusCode} {resp.ReasonPhrase} for {healthz}.", null, 0, 0);
+            return new GatewayTestResult(false, $"Gateway returned {(int)resp.StatusCode} {resp.ReasonPhrase} for {healthz}.", null, null, null);
 
         var json = await resp.Content.ReadAsStringAsync(ct);
         try
@@ -64,16 +67,22 @@ public sealed class SettingsDetectionService
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
             if (GetStringProp(root, "status") is null)
-                return new GatewayTestResult(false, $"{baseUrl} answered but does not look like a DevThrottle gateway.", null, 0, 0);
+                return new GatewayTestResult(false, $"{baseUrl} answered but does not look like a DevThrottle gateway.", null, null, null);
 
             var version = GetStringProp(root, "version") ?? "?";
+            // Absent counts are reported as absent. The hosted Gateway omits them (a public probe has no
+            // tenant, so it has no correct number), and printing "0 director(s)" for a missing field would
+            // turn "not reported" into "your fleet is empty" on the Test-gateway button.
             var directors = GetIntProp(root, "directors");
             var sessions = GetIntProp(root, "sessions");
-            return new GatewayTestResult(true, $"OK: gateway v{version}, {directors} director(s), {sessions} session(s).", version, directors, sessions);
+            var counts = directors is null && sessions is null
+                ? " (fleet counts not reported)"
+                : $", {directors?.ToString() ?? "?"} director(s), {sessions?.ToString() ?? "?"} session(s)";
+            return new GatewayTestResult(true, $"OK: gateway v{version}{counts}.", version, directors, sessions);
         }
         catch (JsonException)
         {
-            return new GatewayTestResult(false, $"{baseUrl} answered but the response was not valid gateway JSON.", null, 0, 0);
+            return new GatewayTestResult(false, $"{baseUrl} answered but the response was not valid gateway JSON.", null, null, null);
         }
     }
 
@@ -152,11 +161,12 @@ public sealed class SettingsDetectionService
         return null;
     }
 
-    private static int GetIntProp(JsonElement obj, string name)
+    /// <summary>The integer property, or NULL when it is absent (or not a number) - never a coerced 0.</summary>
+    private static int? GetIntProp(JsonElement obj, string name)
     {
         foreach (var p in obj.EnumerateObject())
             if (string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase) && p.Value.ValueKind == JsonValueKind.Number)
                 return p.Value.GetInt32();
-        return 0;
+        return null;
     }
 }

--- a/src/CcDirector.Gateway.Contracts/HealthDto.cs
+++ b/src/CcDirector.Gateway.Contracts/HealthDto.cs
@@ -6,8 +6,24 @@ namespace CcDirector.Gateway.Contracts;
 public sealed class HealthDto
 {
     public string Status { get; set; } = "ok";
-    public int Directors { get; set; }
-    public int Sessions { get; set; }
+
+    /// <summary>
+    /// Fleet counts, or NULL when the responder has no honest number to give - in which case they are
+    /// OMITTED from the JSON entirely rather than serialized as 0.
+    ///
+    /// Hosted Multi-Tenancy: /healthz is the PUBLIC unauthenticated liveness probe, so on the hosted
+    /// Gateway it carries no credential and therefore has no tenant - and a fleet-GLOBAL count across every
+    /// account is a cross-tenant disclosure. The aggregate is not computed there at all. These were plain
+    /// <c>int</c> before, so "not computed" serialized as <c>0</c>: not a leak (0 is not the real count),
+    /// but a FALSE statement rather than an absent one. /healthz is what every Director and endpoint
+    /// selector dials, so a permanent 0 reads as a dead fleet. Absent is honest; zero is misleading.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    public int? Directors { get; set; }
+
+    /// <inheritdoc cref="Directors"/>
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    public int? Sessions { get; set; }
     public string Version { get; set; } = "";
     public DateTime ServerTime { get; set; } = DateTime.UtcNow;
 

--- a/src/CcDirector.Gateway.Tests/DirectorRemovedSubscriberFaultTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorRemovedSubscriberFaultTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// A faulting <c>OnDirectorRemoved</c> subscriber must not escape the registry.
+///
+/// Every raise of that event happens on a thread-pool thread with NO enclosing try/catch - a
+/// FileSystemWatcher callback (file deleted / renamed) or the stale-sweep timer. An exception thrown by a
+/// subscriber there is UNHANDLED, so it does not merely fail the removal: it terminates the whole Gateway
+/// process. One subscriber writes the tenant-scoped snooze store, and when that store's database was
+/// unavailable the throw came up exactly this path and killed the process - observed as a test run that
+/// ABORTED partway through while still reporting exit code 0, which is also why it is worth a guard rather
+/// than a comment.
+///
+/// Revert-prove: change <c>DirectorRegistry.RaiseDirectorRemoved</c> back to a bare
+/// <c>OnDirectorRemoved?.Invoke(...)</c> and <see cref="A_throwing_subscriber_does_not_escape_the_removal"/>
+/// goes RED - the exception propagates out of the removal call instead of being logged and contained.
+/// </summary>
+public sealed class DirectorRemovedSubscriberFaultTests
+{
+    [Fact]
+    public async Task A_throwing_subscriber_does_not_escape_the_removal()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cc-dr-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var registry = new DirectorRegistry(dir);
+        try
+        {
+            var good = 0;
+            // Two subscribers: the first throws (the snooze-store shape), the second must still be reached -
+            // containing a fault must not silently drop the remaining subscribers along with it.
+            registry.OnDirectorRemoved += _ => throw new InvalidOperationException("subscriber blew up");
+            registry.OnDirectorRemoved += _ => good++;
+
+            registry.Upsert(new DirectorRegistrationRequest
+            {
+                DirectorId = "dir-fault",
+                TailnetEndpoint = "http://127.0.0.1:1/",
+                MachineName = "M",
+                Pid = 1,
+                Version = "test",
+                StartedAt = DateTime.UtcNow,
+            });
+
+            // The removal path the watcher and the sweeper both reach. It must return normally.
+            var removed = registry.Remove("dir-fault");
+
+            Assert.True(removed);
+            Assert.Equal(1, good);
+            await Task.CompletedTask;
+        }
+        finally
+        {
+            registry.Dispose();
+            try { Directory.Delete(dir, true); } catch { /* best-effort */ }
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HealthzTenantLeakTests.cs
+++ b/src/CcDirector.Gateway.Tests/HealthzTenantLeakTests.cs
@@ -38,14 +38,21 @@ public sealed class HealthzTenantLeakTests
     [Fact]
     public async Task Hosted_healthz_reports_no_fleet_counts()
     {
-        var health = await ProbeHealthz(hosted: true);
+        var (health, rawJson) = await ProbeHealthz(hosted: true);
+
+        // ABSENT, not zero. The fields were plain ints before, so "not computed" serialized as 0 - which is
+        // not a leak (0 is not the real count) but IS a false statement, and /healthz is what every Director
+        // and endpoint selector dials, so a permanent 0 reads as a dead fleet. Assert on the RAW body: a
+        // deserialized null cannot tell "field absent" from "field present and null".
+        Assert.DoesNotContain("\"directors\"", rawJson);
+        Assert.DoesNotContain("\"sessions\"", rawJson);
 
         // The Gateway HAS a registered Director (see ProbeHealthz) - the hosted probe simply must not say so.
         // This is the assertion that pins the change: with the hosted branch removed, the anonymous probe
-        // reports that Director again. (Sessions is deliberately NOT asserted: it already read the empty Local
-        // partition before this change, so asserting it would pass either way and prove nothing.)
+        // reports that Director again.
         Assert.Equal("ok", health.Status);
-        Assert.Equal(0, health.Directors);
+        Assert.Null(health.Directors);
+        Assert.Null(health.Sessions);
         // Liveness is still answered: a probe needs to know it is alive and what version it is.
         Assert.False(string.IsNullOrWhiteSpace(health.Version));
     }
@@ -57,13 +64,13 @@ public sealed class HealthzTenantLeakTests
         // ONLY difference being CC_GATEWAY_HOSTED, and the counts are still served. This one deliberately does
         // NOT pin the changed line - it exists to prove the hosted assertion above is about the tenancy branch
         // and not about a Gateway that simply has no Directors to count.
-        var health = await ProbeHealthz(hosted: false);
+        var (health, _) = await ProbeHealthz(hosted: false);
 
         Assert.Equal("ok", health.Status);
         Assert.Equal(1, health.Directors);
     }
 
-    private static async Task<HealthDto> ProbeHealthz(bool hosted)
+    private static async Task<(HealthDto Health, string RawJson)> ProbeHealthz(bool hosted)
     {
         var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
@@ -90,8 +97,11 @@ public sealed class HealthzTenantLeakTests
             using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{gateway.Port}/") };
             var resp = await http.GetAsync("healthz");
             resp.EnsureSuccessStatusCode();
-            return await resp.Content.ReadFromJsonAsync<HealthDto>()
-                   ?? throw new InvalidOperationException("healthz returned no body");
+            var raw = await resp.Content.ReadAsStringAsync();
+            var dto = System.Text.Json.JsonSerializer.Deserialize<HealthDto>(raw,
+                          new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web))
+                      ?? throw new InvalidOperationException("healthz returned no body");
+            return (dto, raw);
         }
         finally
         {

--- a/src/CcDirector.Gateway.Tests/SessionServingLoopIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionServingLoopIsolationTests.cs
@@ -172,6 +172,27 @@ public sealed class SessionServingLoopIsolationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task AutoDismiss_sweep_denies_when_no_tenant_is_in_scope()
+    {
+        // DENY-BY-DEFAULT for the sweeper itself. Calling SweepAsync directly with NO tenant scope is the
+        // shape an unconverted background caller would have. It must refuse outright and close nothing -
+        // not coin a partition to file its close-marks under and rely on the snapshot happening to be empty.
+        // (PR2 shipped an empty-string prefix here; benign only because the snapshot was empty in that state,
+        // which is safety that depends on a DIFFERENT function not changing.)
+        var closed = 0;
+        var sweeper = new Running.AutoDismissSweeper(
+            snapshot: () => new[] { ("dir-a", Sample(SessA, autoDismiss: true)) },
+            sendCommand: (_, _, _) => { closed++; return Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success("{}")); },
+            tenantKey: () => null);
+
+        var result = await sweeper.SweepAsync(CancellationToken.None);
+
+        // A fully dismissable session is offered and still nothing is closed - the deny, not an empty fleet.
+        Assert.Equal(0, result);
+        Assert.Equal(0, closed);
+    }
+
+    [Fact]
     public async Task AutoDismiss_close_marks_are_partitioned_per_tenant()
     {
         // The sweeper keeps a "already issued a kill" mark so a session lingering one extra sweep is not

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -369,6 +369,9 @@ internal static class GatewayEndpoints
             // connectivity self-test and the settings gateway probe read.
             if (tenantBoundary?.IsHosted == true)
             {
+                // Directors/Sessions left NULL, which OMITS them from the JSON (HealthDto). Leaving them to
+                // serialize as 0 would state a fleet of zero to every probe on hosted - false rather than
+                // merely absent, and this is the endpoint the Director's connectivity self-test reads.
                 return Results.Json(new HealthDto
                 {
                     Status = "ok",

--- a/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
@@ -69,6 +69,40 @@ public sealed class DirectorRegistry : IDisposable
     /// <summary>Raised when a Director disappears (file removed, HTTP unregister, or stale).</summary>
     public event Action<string>? OnDirectorRemoved;
 
+    /// <summary>
+    /// Raise <see cref="OnDirectorRemoved"/> without letting a subscriber kill the process.
+    ///
+    /// This is an ENTRY-POINT boundary in the CodingStyle sense (an external event subscription): every
+    /// caller is either a FileSystemWatcher callback or the stale-sweep timer, both of which run on
+    /// thread-pool threads with NO enclosing try/catch. An exception thrown by a subscriber there is
+    /// UNHANDLED, so it does not merely fail the removal - it terminates the whole Gateway process.
+    ///
+    /// Not hypothetical: a subscriber writes the tenant-scoped snooze store, and when that store's database
+    /// was unavailable the throw came straight up this path and took the process down - observed as a test
+    /// run that ABORTED partway through while still reporting exit code 0. Failing to clear one removed
+    /// Director's snoozes is a bounded, cosmetic loss; losing the Gateway is not. The failure is logged
+    /// LOUD - this catches to keep the process alive, not to hide the fault.
+    ///
+    /// Each subscriber is invoked INDEPENDENTLY. A plain Invoke on a multicast delegate stops at the first
+    /// handler that throws, so one faulting subscriber would silently deprive every later one of the event
+    /// (the session-number release and the roster-cache forget are on this list) - trading a process crash
+    /// for a quiet partial removal, which is harder to notice and just as wrong.
+    /// </summary>
+    private void RaiseDirectorRemoved(string directorId)
+    {
+        foreach (var handler in OnDirectorRemoved?.GetInvocationList() ?? Array.Empty<Delegate>())
+        {
+            try
+            {
+                ((Action<string>)handler)(directorId);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[DirectorRegistry] OnDirectorRemoved subscriber FAILED for director={directorId}: {ex}");
+            }
+        }
+    }
+
     // ===== HTTP path =====
 
     /// <summary>
@@ -195,7 +229,7 @@ public sealed class DirectorRegistry : IDisposable
         {
             _everReachable.TryRemove(directorId, out _); // graceful goodbye: next process starts blank
             FileLog.Write($"[DirectorRegistry] Remove (http): id={directorId}");
-            OnDirectorRemoved?.Invoke(directorId);
+            RaiseDirectorRemoved(directorId);
             return true;
         }
         return false;
@@ -273,7 +307,7 @@ public sealed class DirectorRegistry : IDisposable
         if (_directors.TryGetValue(id, out var existing) && existing.Source == "file")
         {
             if (_directors.TryRemove(id, out _))
-                OnDirectorRemoved?.Invoke(id);
+                RaiseDirectorRemoved(id);
         }
     }
 
@@ -285,7 +319,7 @@ public sealed class DirectorRegistry : IDisposable
             && existing.Source == "file"
             && _directors.TryRemove(oldId, out _))
         {
-            OnDirectorRemoved?.Invoke(oldId);
+            RaiseDirectorRemoved(oldId);
         }
         TryParseAndAdd(e.FullPath);
     }
@@ -352,7 +386,7 @@ public sealed class DirectorRegistry : IDisposable
                         {
                             _everReachable.TryRemove(kv.Key, out _);
                             FileLog.Write($"[DirectorRegistry] Sweeper removed stale {kv.Value.Source} entry: {kv.Key} (last seen {(now - lastSeen).TotalSeconds:F0}s ago)");
-                            OnDirectorRemoved?.Invoke(kv.Key);
+                            RaiseDirectorRemoved(kv.Key);
                         }
                     }
                     continue;
@@ -365,7 +399,7 @@ public sealed class DirectorRegistry : IDisposable
                     if (_directors.TryRemove(kv.Key, out _))
                     {
                         FileLog.Write($"[DirectorRegistry] Sweeper removed orphan (file gone): {kv.Key}");
-                        OnDirectorRemoved?.Invoke(kv.Key);
+                        RaiseDirectorRemoved(kv.Key);
                     }
                     continue;
                 }
@@ -388,7 +422,7 @@ public sealed class DirectorRegistry : IDisposable
                         if (_directors.TryRemove(kv.Key, out _))
                         {
                             FileLog.Write($"[DirectorRegistry] Sweeper removed orphan (pid {pid} dead): {kv.Key}");
-                            OnDirectorRemoved?.Invoke(kv.Key);
+                            RaiseDirectorRemoved(kv.Key);
                         }
                     }
                     catch { /* permission errors etc - leave it for next pass */ }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2139,7 +2139,8 @@ public sealed class GatewayHost : IAsyncDisposable
             () => AmbientSnapshotFresh(AutoDismissStaleAfter),
             SendCommandAsync,
             // Partition the close-marks by the tenant of the pass currently running (see AutoDismissSweeper).
-            tenantKey: () => _tenantPass.Current?.Value ?? "");
+            // Null (no tenant in scope on hosted) is a DENY inside the sweeper, not an empty prefix.
+            tenantKey: () => _tenantPass.Current?.Value);
         _autoDismissTimer = new System.Threading.Timer(_ => SweepAutoDismiss(), null, AutoDismissSweepInterval, AutoDismissSweepInterval);
         FileLog.Write($"[GatewayHost] auto-dismiss sweep started: every {AutoDismissSweepInterval.TotalSeconds:0}s");
 

--- a/src/CcDirector.Gateway/Running/AutoDismissSweeper.cs
+++ b/src/CcDirector.Gateway/Running/AutoDismissSweeper.cs
@@ -24,7 +24,7 @@ internal sealed class AutoDismissSweeper
 {
     private readonly Func<IReadOnlyList<(string DirectorId, SessionDto Session)>> _snapshot;
     private readonly DirectorCommandRouter.SendDirectorCommandAsync _sendCommand;
-    private readonly Func<string> _tenantKey;
+    private readonly Func<string?> _tenantKey;
 
     // Sessions we have already issued a kill for, so a session that lingers one extra sweep (before its
     // removal tombstone propagates up the stream) is not killed twice. Pruned opportunistically each sweep.
@@ -38,21 +38,23 @@ internal sealed class AutoDismissSweeper
 
     /// <param name="snapshot">Returns the fresh pushed sessions across all stream-connected Directors (PushedSessionStore.SnapshotFresh).</param>
     /// <param name="sendCommand">The down-channel command sender (GatewayHost.SendCommandAsync); required - the feature only runs with the stream on.</param>
-    /// <param name="tenantKey">Hosted Multi-Tenancy (session-serving PR2): identifies the tenant of the pass
-    /// currently running, so the close-marks below are partitioned per tenant. Omitted (null) means the
-    /// single-tenant shape - one constant partition - which is self-host and the unit tests.</param>
+    /// <param name="tenantKey">Hosted Multi-Tenancy: identifies the tenant of the pass currently running, so
+    /// the close-marks below are partitioned per tenant. It may RETURN null, which means no tenant is in
+    /// scope - a DENY: the sweep does nothing rather than coining a partition. Omitting the parameter
+    /// entirely means the single-tenant shape (one constant partition), which is self-host and the unit
+    /// tests.</param>
     public AutoDismissSweeper(
         Func<IReadOnlyList<(string DirectorId, SessionDto Session)>> snapshot,
         DirectorCommandRouter.SendDirectorCommandAsync sendCommand,
-        Func<string>? tenantKey = null)
+        Func<string?>? tenantKey = null)
     {
         _snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
         _sendCommand = sendCommand ?? throw new ArgumentNullException(nameof(sendCommand));
         _tenantKey = tenantKey ?? (static () => "local");
     }
 
-    /// <summary>The close-mark key for a session within the tenant of the pass currently running.</summary>
-    private string MarkKey(string sessionId) => _tenantKey() + "|" + sessionId;
+    /// <summary>The close-mark key for a session within <paramref name="tenant"/>.</summary>
+    private static string MarkKey(string tenant, string sessionId) => tenant + "|" + sessionId;
 
     /// <summary>The verdict string (see <c>Session.DismissVerdict</c>) that authorizes an auto-close.</summary>
     public const string VerdictDone = "done";
@@ -103,16 +105,28 @@ internal sealed class AutoDismissSweeper
     /// </summary>
     public async Task<int> SweepAsync(CancellationToken ct)
     {
-        var snapshot = _snapshot();
-        PruneClosing(snapshot);
+        // Hosted Multi-Tenancy: resolve the tenant of THIS pass first. A null is a DENY - the sweep does
+        // nothing rather than coining a partition to file its close-marks under. This mirrors
+        // GatewayHost.SendCommandAsync: everywhere else in this path an unresolved tenant refuses, so this
+        // must refuse too rather than being the one place that invents a key and relies on the caller's
+        // snapshot happening to be empty.
+        var tenant = _tenantKey();
+        if (string.IsNullOrEmpty(tenant))
+        {
+            FileLog.Write("[AutoDismissSweeper] sweep DENIED: no tenant in scope");
+            return 0;
+        }
 
-        var picks = SelectDismissable(snapshot, sid => _closing.ContainsKey(MarkKey(sid)));
+        var snapshot = _snapshot();
+        PruneClosing(tenant, snapshot);
+
+        var picks = SelectDismissable(snapshot, sid => _closing.ContainsKey(MarkKey(tenant, sid)));
         var closed = 0;
         foreach (var (directorId, session) in picks)
         {
             ct.ThrowIfCancellationRequested();
             // Mark before sending so a slow round-trip cannot let the next sweep issue a duplicate kill.
-            _closing.TryAdd(MarkKey(session.SessionId), 0);
+            _closing.TryAdd(MarkKey(tenant, session.SessionId), 0);
             try
             {
                 var result = await DirectorCommandRouter.TrySendAsync(
@@ -120,7 +134,7 @@ internal sealed class AutoDismissSweeper
                 if (result is null)
                 {
                     // No active stream right now; drop the mark so a later sweep retries once the stream is back.
-                    _closing.TryRemove(MarkKey(session.SessionId), out _);
+                    _closing.TryRemove(MarkKey(tenant, session.SessionId), out _);
                     FileLog.Write($"[AutoDismissSweeper] session={session.SessionId} director={directorId}: no stream, will retry");
                     continue;
                 }
@@ -138,7 +152,7 @@ internal sealed class AutoDismissSweeper
             }
             catch (Exception ex)
             {
-                _closing.TryRemove(MarkKey(session.SessionId), out _);
+                _closing.TryRemove(MarkKey(tenant, session.SessionId), out _);
                 FileLog.Write($"[AutoDismissSweeper] close FAILED: session={session.SessionId} director={directorId}: {ex.Message}");
             }
         }
@@ -153,12 +167,12 @@ internal sealed class AutoDismissSweeper
     /// dropped). Scoped to THIS PASS'S TENANT: the snapshot only ever contains that tenant's sessions, so
     /// pruning across the whole map would delete every other tenant's marks on every pass.
     /// </summary>
-    private void PruneClosing(IReadOnlyList<(string DirectorId, SessionDto Session)> snapshot)
+    private void PruneClosing(string tenant, IReadOnlyList<(string DirectorId, SessionDto Session)> snapshot)
     {
         if (_closing.IsEmpty)
             return;
-        var prefix = _tenantKey() + "|";
-        var present = new HashSet<string>(snapshot.Select(t => MarkKey(t.Session.SessionId)), StringComparer.Ordinal);
+        var prefix = tenant + "|";
+        var present = new HashSet<string>(snapshot.Select(t => MarkKey(tenant, t.Session.SessionId)), StringComparer.Ordinal);
         foreach (var key in _closing.Keys)
         {
             if (key.StartsWith(prefix, StringComparison.Ordinal) && !present.Contains(key))


### PR DESCRIPTION
## What

Hosted Multi-Tenancy follow-ups from the **PR2 (#1851) live proof**, plus one production crash found while gathering the evidence for them. Reviewed against `origin/main` at **`f5c642ee`** (the sha this branch was cut from and the sha now running in the hosted container).

Three fixes. Two are the same shape - **a place that COINED a value where it had no honest one to give** - which is precisely the failure mode deny-by-default exists to prevent.

## 1. `/healthz` omits the fleet counts on hosted instead of reporting zero

PR2 stopped computing the fleet-global aggregate on hosted - correct, because `/healthz` is the **public unauthenticated** liveness probe, so it carries no credential, has no tenant, and a count spanning every account is a disclosure. But `Directors`/`Sessions` were plain `int`, so "not computed" serialized as `0`. Live body after PR2:

```
{"status":"ok","directors":0,"sessions":0,"version":"1.5.0",...}
```

Not a leak - `0` is not the real count and discloses nothing. But an always-`0` count is a **false statement rather than an absent one**, and `/healthz` is what every Director and endpoint selector dials, so a permanent `0` reads as a dead fleet to anything monitoring it. **Omission is honest; zero is misleading.**

The fields are now `int?` with `JsonIgnore(WhenWritingNull)`, so the hosted response genuinely omits them. Self-host still reports real counts.

**Both consumers were fixed too**, so the lie is not simply relocated one layer up:
- `SettingsDetectionService.TestGatewayAsync` reports `"fleet counts not reported"` instead of `"0 director(s)"`, and its `GetIntProp` returns `null` for an absent field rather than coercing to `0`. Failed probes now report `null` counts rather than `0`.
- The mobile **About** screen renders `"Not reported"` instead of `String(undefined)`. **This one was found by Codex, not by me** - `GatewayHealth` modelled the counts as mandatory `number`, so hosted would have printed the literal text `undefined` on screen. Fixing the contract without fixing the consumer would have moved the false statement to a surface the owner actually looks at.

## 2. The auto-dismiss sweeper denies instead of coining a partition

PR2 shipped `tenantKey: () => _tenantPass.Current?.Value ?? ""` - an empty-string partition when no tenant is in scope, where **every other path in that flow denies**. It was benign only because `AmbientSnapshotFresh` returns empty in that state, so no marks were ever filed under it: safety that depends on a *different* function not changing.

`SweepAsync` now resolves the tenant first and **refuses outright** - closes nothing, returns 0 - when it is null. Omitting the parameter still means the single-tenant `"local"` partition, so self-host and the unit tests are untouched.

The revert-proof shows this was not merely theoretical bookkeeping: with the coined prefix restored, the sweep **actually closes a session** it should have refused (`Expected 0, Actual 1`).

## 3. A faulting `OnDirectorRemoved` subscriber can no longer kill the Gateway

This is issue **#1850**, and I pulled it in deliberately - see "Why this is here" below.

Every raise of `OnDirectorRemoved` happens on a **thread-pool thread with no enclosing try/catch**: a FileSystemWatcher callback (file deleted / renamed) or the stale-sweep timer. An exception from a subscriber there is **unhandled**, so it does not merely fail the removal - it terminates the process. One subscriber writes the tenant-scoped snooze store; when that store's database was unavailable, the throw came straight up this path and killed the host:

```
at CcDirector.Gateway.Snooze.SnoozeRegistry.ClearForDirector(String directorId)
at CcDirector.Gateway.GatewayHost.<.ctor>b__158_3(String id)
at CcDirector.Gateway.Discovery.DirectorRegistry.OnFileDeleted(Object sender, FileSystemEventArgs e)
at System.IO.FileSystemWatcher.NotifyFileSystemEventArgs(...)
at System.Threading.ThreadPoolBoundHandleOverlapped.CompletionCallback(...)
```

Every raise now routes through one guarded helper that invokes each subscriber **independently**. The independence matters as much as the guard: a plain `Invoke` on a multicast delegate stops at the first handler that throws, so containing the fault *without* splitting the list would silently deprive every later subscriber of the event (the session-number release and the roster-cache forget are on that list) - trading a loud crash for a quiet partial removal. **My own test caught that**: the first version of the guard passed the "does not escape" check but left the second subscriber unreached.

This is an entry-point boundary in the CodingStyle sense (an external event subscription), which is exactly where rule 4 reserves try/catch. The failure is logged **loud** - it catches to keep the process alive, not to hide the fault.

### Why this is here rather than left in thefrederiksen/devthrottle_internal#875

It was **destroying the test-count evidence this mission requires**. On this branch the Gateway suite aborted mid-run in 2 of 3 attempts (at 345 and at 1435 of ~2867) while still reporting exit code 0 - a suite that dies reporting success. I cannot quote a trustworthy full-suite count against the 2861 baseline while a background thread can kill the runner at random, and quoting the count is a standing requirement. The fix is ~10 lines at one boundary.

The **CI minimum-test-count floor**, also tracked under thefrederiksen/devthrottle_internal#875, is *not* in this pull request.

## Revert-proofs - each guard independently, with RED output

**1. `HealthDto.Directors`/`Sessions` nullability + `JsonIgnore`** -> back to plain `int` (the true pre-change state, attribute removed too). Reproduces exactly today's shipped body:

```
Failed HealthzTenantLeakTests.Hosted_healthz_reports_no_fleet_counts
   Assert.DoesNotContain() Failure: Sub-string found
                        ↓ (pos 15)
   String: "{"status":"ok","directors":0,"sessions":0"···
   Found:  ""directors""
```

**2. `SettingsDetectionService.GetIntProp`** -> back to returning `0` for an absent field:

```
Failed SettingsDetectionServiceTests.TestGatewayAsync_AbsentCounts_ReportsThemAbsent_NotZero
   Assert.Null() Failure: Value of type 'Nullable<int>' has a value
   Expected: null
   Actual:   0
```

**3. `AutoDismissSweeper.SweepAsync` tenant deny** -> back to `_tenantKey() ?? ""`. The sweep closes a session it must have refused:

```
Failed SessionServingLoopIsolationTests.AutoDismiss_sweep_denies_when_no_tenant_is_in_scope
   Assert.Equal() Failure: Values differ
   Expected: 0
   Actual:   1
```

**4. `DirectorRegistry.RaiseDirectorRemoved`** -> back to a bare `OnDirectorRemoved?.Invoke(...)`. The exception escapes the removal instead of being contained:

```
Failed DirectorRemovedSubscriberFaultTests.A_throwing_subscriber_does_not_escape_the_removal
   System.InvalidOperationException : subscriber blew up
     at CcDirector.Gateway.Discovery.DirectorRegistry.RaiseDirectorRemoved(String directorId)
     at CcDirector.Gateway.Discovery.DirectorRegistry.Remove(String directorId)
```

The `/healthz` hosted test asserts on the **raw response body**, not the deserialized object - a deserialized `null` cannot tell "field absent" from "field present and null".

## Test results

Full .NET suite green, counts quoted:

| Project | Result |
|---|---|
| **Gateway** | **2868 passed**, 0 failed, 10 skipped, **no abort** |
| Core | 3302 passed, 0 failed |
| Setup.Engine | 320 passed, 0 failed |
| Avalonia | 247 passed, 0 failed |
| HostedAgent | 86 passed, 0 failed |
| Engine | 62 passed, 0 failed |
| CcDirectorSetup | 32 passed, 0 failed |
| Launcher | 27 passed, 0 failed |
| Terminal.Avalonia | 21 passed, 0 failed |
| Setup.Cli | 19 passed, 0 failed |

Gateway: **2866** on `f5c642ee` -> **2868** here = baseline + the 2 new tests. Web: all three workspaces (`client-core`, `cockpit`, `mobile`) typecheck clean and the mobile bundle builds. (`npm run lint` reports 2 errors in `apps/mobile/src/pages/VoiceMode.tsx`, a file this branch does not touch - **verified pre-existing** by stashing this branch's changes and re-running on the clean tree.)

**On the abort claim:** I am not asserting the flake is eliminated on one clean run - it was intermittent. What I can say is that the guard addresses the exact stack captured above, and the suite has run clean end-to-end since. The earlier aborted run's stack was lost because my own `grep` filter discarded it, which is itself worth noting: filter test output for the summary line and you throw away the crash that explains it.

## Codex adversarial review

Pointed at (a) every `/healthz` reader in the repo, across C#, TypeScript, PowerShell, scripts and workflows, (b) whether the omission is genuinely achieved given the serializer configuration, (c) whether the deny breaks self-host, and (d) tests that would still pass after reverting.

It found the mobile consumer defect quoted in section 1:

> **[P2] Hosted mobile About screen renders `undefined` for fleet counts.** `About.tsx:53` and `client.ts:50` still model `directors`/`sessions` as mandatory numbers. Hosted JSON omits them, so `String(health.directors)` and `String(health.sessions)` silently display `"undefined"`.

That was fixed. On the other categories:

> **JSON omission:** Clean. [...] no repository serializer configuration overrides the attributes. The hosted initializer leaves both values null, while `GatewayEndpoints.cs:396` assigns both counts on self-host. The raw-body integration test confirms actual omission.

> **Auto-dismiss:** Clean. The omitted-parameter default remains non-null `"local"` [...] no legitimate self-host path returns null.

> **Revert-proof tests:** Clean and non-vacuous. **NONE WOULD STILL PASS AFTER THE CORRESPONDING PRODUCTION REVERT.**

It also cleared the remaining `/healthz` consumers individually: the Director's connectivity self-test uses the Gateway response only for 2xx reachability and parses its *own* `/healthz` for identity (where the fields are still always populated); `ControlApiHost` and `manager.html` read only `directorId`/`machineName`; self-probes, endpoint selection, installers and deploy scripts inspect only HTTP status or `version`; the cockpit has no `/healthz` reader; no GitHub workflow reads it.

## Still ahead on this mission

Unchanged and **not** in this pull request:

- **The hard precondition for converting the voice sweep**: partition the `WingmanVoiceService` caches by tenant and tenant-check `/wingman/voice/ready` **before** any per-tenant voice generation. Converting the loop first would arm a cross-tenant audio path rather than close one.
- The standing rule this mission paid twice to learn: **a loop is not converted to per-tenant until the state it MUTATES is partitioned**; if the gate cannot be partitioned in the same pull request, the loop is not converted in it either.
- The display-state, role and turn-end sweeps remain on `TenantId.Local`, each with a `BLOCKED ON:` comment naming the field to partition first.
- Pre-existing, filed, untouched here: **#1847** (fleet-global `DirectorRegistry` + `Hello` trusts a client-chosen director id - a cross-tenant *write*), **#1848** (`/prompts`, `/stats/data`), **#1849** (director-shutdown safety gate fails open on hosted).
