### PR TITLE
feat(setup): give the hosted gateway enrollment endpoint a client

### DIFF
--- a/src/CcDirector.Core/Configuration/HostedGateway.cs
+++ b/src/CcDirector.Core/Configuration/HostedGateway.cs
@@ -1,0 +1,50 @@
+namespace CcDirector.Core.Configuration;
+
+/// <summary>
+/// Where DevThrottle's HOSTED Gateway lives. Hosted is ONE shared, multi-tenant Gateway that every hosted
+/// account joins - it is NOT a gateway per customer and there is nothing to provision. An account does not
+/// receive a gateway; it BECOMES A TENANT on this one, and that tenant binding is created by the enrollment
+/// itself (<c>POST /devices/enroll-hosted</c>).
+///
+/// This is a single named address rather than something the person types, because the whole point of the
+/// hosted choice is that there is no address to know: a machine that picks hosted enrolls here. The
+/// self-hosted path is unchanged - it still discovers (or is told) the address of the gateway the account
+/// runs itself.
+///
+/// <see cref="ResolveUrl"/> honours the <c>DEVTHROTTLE_HOSTED_GATEWAY_URL</c> environment variable so a test
+/// or staging run can point the same code at a different hosted box. That is an explicit operator override,
+/// not a fallback: when it is absent the shipped address is used, and when it is set and unusable the caller
+/// gets a hard failure rather than a silent redirect to production.
+/// </summary>
+public static class HostedGateway
+{
+    /// <summary>The environment variable an operator sets to point the hosted choice at a different box.</summary>
+    public const string UrlEnvironmentVariable = "DEVTHROTTLE_HOSTED_GATEWAY_URL";
+
+    /// <summary>The shipped address of DevThrottle's hosted, multi-tenant Gateway.</summary>
+    public const string DefaultUrl = "https://devthrottle-gw.azurewebsites.net";
+
+    /// <summary>
+    /// The hosted Gateway URL this machine should enroll against: the operator override when
+    /// <c>DEVTHROTTLE_HOSTED_GATEWAY_URL</c> is set to an absolute http/https address, otherwise
+    /// <see cref="DefaultUrl"/>. An override that is set but not a usable absolute URL throws, so a typo
+    /// fails loudly instead of quietly enrolling the machine into production.
+    /// </summary>
+    public static string ResolveUrl()
+    {
+        var raw = Environment.GetEnvironmentVariable(UrlEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(raw))
+            return DefaultUrl;
+
+        var trimmed = raw.Trim().TrimEnd('/');
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var parsed)
+            || (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new InvalidOperationException(
+                $"{UrlEnvironmentVariable} is set to '{raw}', which is not an absolute http:// or https:// address. " +
+                $"Set it to a full hosted Gateway address, or clear it to use {DefaultUrl}.");
+        }
+
+        return trimmed;
+    }
+}

--- a/tools/cc-director-setup-cli/Commands.cs
+++ b/tools/cc-director-setup-cli/Commands.cs
@@ -176,6 +176,11 @@ internal static class Commands
     /// that address (proven reachable first); without it, it discovers the account's gateways and joins the one
     /// it finds. Idempotent: a machine already connected reports so and succeeds. Device keys are never printed
     /// or logged (security rule DT-05).
+    ///
+    /// With <c>--hosted</c> it joins DevThrottle's HOSTED gateway instead of one the account runs itself: the
+    /// same browser sign-in, but the account token goes straight to the hosted gateway, which mints this
+    /// machine's key bound to the account's tenant. There is no address to give and nothing to discover, so
+    /// <c>--hosted</c> and <c>--gateway</c> are mutually exclusive.
     /// </summary>
     public static async Task<int> EnrollAsync(CliArgs args, bool json)
     {
@@ -195,11 +200,26 @@ internal static class Commands
         var machineName = Environment.MachineName;
         var runner = new GatewayAccountEnrollRunner();
         var gatewayUrl = args.Option("gateway");
+        var hosted = args.HasFlag("hosted");
+
+        // Hosted has no address to give and nothing to discover, so naming a gateway alongside it is a
+        // contradiction, not a preference to resolve silently.
+        if (hosted && !string.IsNullOrWhiteSpace(gatewayUrl))
+            throw new UsageException("--hosted joins DevThrottle's hosted gateway, so it cannot be combined with --gateway <url>.");
 
         if (!json)
         {
             Console.WriteLine("Opening your browser to sign in to DevThrottle...");
             Console.WriteLine("Sign in - or create a free account - in the browser. Waiting for you to finish (up to 5 minutes)...");
+        }
+
+        // Hosted: the account token goes straight to the hosted gateway, which mints this machine's key bound
+        // to the account's tenant. No address to prove reachable and no discovery - enrolling IS the join.
+        if (hosted)
+        {
+            if (!json) Console.WriteLine("Joining the DevThrottle hosted gateway...");
+            var host = await runner.SignInAndEnrollHostedAsync(deviceId, machineName);
+            return ReportEnroll(host.Success, host.ErrorMessage, json);
         }
 
         // A given gateway URL is proven reachable BEFORE we sign in against it (wizard parity: never register

--- a/tools/cc-director-setup-cli/Program.cs
+++ b/tools/cc-director-setup-cli/Program.cs
@@ -136,6 +136,7 @@ public static class Program
               install --role <r>         Install/update all components for a role
               signin                     Sign in (or create a free account); store it for the Gateway (Windows)
               enroll [--gateway <url>]   Join this workstation to its gateway (sign in, then enroll)
+              enroll --hosted            Join DevThrottle's hosted gateway instead of your own
               uninstall --role <r>       Remove install-owned files (preserves your data)
               rollback <component>       Restore the previous build and pin away from current
               version                    Print this CLI's product version
@@ -143,6 +144,7 @@ public static class Program
             Options:
               --role workstation|gateway     Install type (default workstation)
               --gateway <url>                Gateway to enroll against (enroll; else auto-discover)
+              --hosted                       Enroll at DevThrottle's hosted gateway (enroll; not with --gateway)
               --manifest <path|latest>       Release source (default latest)
               --release-dir <dir>            Use a local directory as the release (offline)
               --component <id|all>           Limit update to one component (default all)

--- a/tools/cc-director-setup-engine.Tests/GatewayHostedEnrollRunnerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/GatewayHostedEnrollRunnerTests.cs
@@ -1,0 +1,246 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Account;
+using CcDirector.Core.Configuration;
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// Tests for the HOSTED gateway join - the leg that gives <c>POST /devices/enroll-hosted</c> a client. They
+/// prove the hosted enrollment logic without a real browser, a live hosted gateway, or real disk writes: an
+/// injected sign-in stands in for the browser hand-back, a capturing fake HTTP handler stands in for the
+/// hosted gateway, and a capturing action stands in for the config.json persist.
+///
+/// What is proven, and which production line each proof protects:
+///  - The hosted call presents the ACCOUNT ACCESS TOKEN as its Bearer and goes to <c>/devices/enroll-hosted</c>
+///    (protects the <c>http.DefaultRequestHeaders.Authorization = Bearer accountAccessToken</c> +
+///    <c>PostAsJsonAsync("devices/enroll-hosted", ...)</c> lines in <c>EnrollAtHostedGatewayAsync</c>). This is
+///    the one place hosted does NOT mirror self-host: there is no device-registry exchange and no cloud device
+///    key - the account token itself is the authorization - so the test also asserts NO cloud register call is
+///    made and the cloud device key never appears.
+///  - Success persists the hosted URL + the issued key (protects the <c>_persist(hostedUrl, body.DeviceKey)</c> line).
+///  - A 401, a non-2xx, and a 2xx carrying no device key each BLOCK with a clear reason and persist NOTHING
+///    (protects the three guards ahead of that persist), so a machine can never be left pointed at the hosted
+///    gateway holding a key the hosted gateway did not issue.
+/// </summary>
+[Collection(HostedGatewayUrlCollection.Name)]
+public class GatewayHostedEnrollRunnerTests
+{
+    private const string DeviceId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    private const string MachineName = "WORKSTATION-HOSTED";
+    private const string AccountToken = "account-access-token-xyz";
+
+    private static readonly DevThrottleTokens GoodTokens = new(AccountToken, "refresh-token-xyz");
+
+    /// <summary>One captured request: where it went, what it carried, and - the point of this file - what it
+    /// presented as its Bearer.</summary>
+    private sealed record Captured(string Url, string Path, string Body, string? Bearer);
+
+    private sealed class CapturingHandler(Func<HttpRequestMessage, HttpResponseMessage> responder, List<Captured> log)
+        : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var body = request.Content is null ? "" : await request.Content.ReadAsStringAsync(ct);
+            log.Add(new Captured(request.RequestUri!.ToString(), request.RequestUri.AbsolutePath, body,
+                request.Headers.Authorization?.Parameter));
+            return responder(request);
+        }
+    }
+
+    private static HttpResponseMessage Raw(HttpStatusCode status, string json) =>
+        new(status) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private static HttpResponseMessage Obj(HttpStatusCode status, object body) =>
+        Raw(status, JsonSerializer.Serialize(body));
+
+    private static (GatewayAccountEnrollRunner runner, List<(string url, string key)> saved, List<Captured> reqs)
+        BuildRunner(Func<HttpRequestMessage, HttpResponseMessage> responder,
+                    Func<CancellationToken, Task<DevThrottleTokens>>? signIn = null)
+    {
+        var saved = new List<(string, string)>();
+        var reqs = new List<Captured>();
+        var runner = new GatewayAccountEnrollRunner(
+            signIn: signIn ?? (_ => Task.FromResult(GoodTokens)),
+            handlerFactory: () => new CapturingHandler(responder, reqs),
+            persist: (url, key) => saved.Add((url, key)));
+        return (runner, saved, reqs);
+    }
+
+    [Fact]
+    public async Task SignInAndEnrollHosted_PresentsTheAccountTokenToEnrollHostedAndPersists()
+    {
+        var (runner, saved, reqs) = BuildRunner(_ => Obj(HttpStatusCode.OK, new { deviceKey = "hosted-key-abc", deviceCount = 1 }));
+
+        var result = await runner.SignInAndEnrollHostedAsync(DeviceId, MachineName, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Equal("hosted-key-abc", result.Value!.DeviceKey);
+
+        // It went to the hosted enrollment seam, carrying the ACCOUNT token as its Bearer.
+        var enroll = Assert.Single(reqs, r => r.Path == "/devices/enroll-hosted");
+        Assert.Equal(AccountToken, enroll.Bearer);
+        Assert.Contains(DeviceId, enroll.Body);
+        Assert.Contains(MachineName, enroll.Body);
+
+        // Hosted skips the device-registry exchange entirely: no cloud registration, and no /m/enroll.
+        Assert.DoesNotContain(reqs, r => r.Path.EndsWith("/devices/register"));
+        Assert.DoesNotContain(reqs, r => r.Path == "/m/enroll");
+        Assert.Single(reqs);
+
+        // The hosted URL and the issued key are persisted exactly once.
+        var save = Assert.Single(saved);
+        Assert.Equal(HostedGateway.DefaultUrl, save.url);
+        Assert.Equal("hosted-key-abc", save.key);
+    }
+
+    [Fact]
+    public async Task SignInAndEnrollHosted_TokenRejected_BlocksAndDoesNotPersist()
+    {
+        var (runner, saved, _) = BuildRunner(_ => Raw(HttpStatusCode.Unauthorized, "{\"error\":\"the account token is not valid\"}"));
+
+        var result = await runner.SignInAndEnrollHostedAsync(DeviceId, MachineName, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("did not accept your sign-in", result.ErrorMessage);
+        Assert.Empty(saved);
+    }
+
+    [Fact]
+    public async Task SignInAndEnrollHosted_NonSuccessStatus_BlocksAndDoesNotPersist()
+    {
+        var (runner, saved, _) = BuildRunner(_ => Raw(HttpStatusCode.BadRequest, "{\"error\":\"deviceId is required\"}"));
+
+        var result = await runner.SignInAndEnrollHostedAsync(DeviceId, MachineName, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("refused the enrollment", result.ErrorMessage);
+        Assert.Empty(saved);
+    }
+
+    [Fact]
+    public async Task SignInAndEnrollHosted_SuccessWithNoDeviceKey_BlocksAndDoesNotPersist()
+    {
+        var (runner, saved, _) = BuildRunner(_ => Obj(HttpStatusCode.OK, new { deviceCount = 1 }));
+
+        var result = await runner.SignInAndEnrollHostedAsync(DeviceId, MachineName, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("returned no device key", result.ErrorMessage);
+        Assert.Empty(saved);
+    }
+
+    [Fact]
+    public async Task SignInAndEnrollHosted_Unreachable_BlocksAndDoesNotPersist()
+    {
+        var (runner, saved, _) = BuildRunner(_ => throw new HttpRequestException("no route to host"));
+
+        var result = await runner.SignInAndEnrollHostedAsync(DeviceId, MachineName, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("Could not reach the DevThrottle hosted gateway", result.ErrorMessage);
+        Assert.Empty(saved);
+    }
+
+    [Fact]
+    public async Task SignInAndEnrollHosted_SignInCancelled_BlocksAndMakesNoCall()
+    {
+        var (runner, saved, reqs) = BuildRunner(
+            _ => throw new InvalidOperationException("no HTTP expected"),
+            signIn: _ => throw new OperationCanceledException());
+
+        var result = await runner.SignInAndEnrollHostedAsync(DeviceId, MachineName, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Empty(reqs);
+        Assert.Empty(saved);
+    }
+
+    [Fact]
+    public async Task EnrollWithHostedGateway_WithoutSignInFirst_BlocksAndMakesNoCall()
+    {
+        var (runner, saved, reqs) = BuildRunner(_ => throw new InvalidOperationException("no HTTP expected"));
+
+        var result = await runner.EnrollWithHostedGatewayAsync(DeviceId, MachineName, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("sign in", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(reqs);
+        Assert.Empty(saved);
+    }
+
+    [Fact]
+    public async Task SignInAndEnrollHosted_HonoursTheOperatorUrlOverride()
+    {
+        using var _override = new HostedGatewayUrlOverride("https://hosted.test:8443");
+        var (runner, saved, reqs) = BuildRunner(_ => Obj(HttpStatusCode.OK, new { deviceKey = "hosted-key-override" }));
+
+        var result = await runner.SignInAndEnrollHostedAsync(DeviceId, MachineName, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Equal("https://hosted.test:8443/devices/enroll-hosted", Assert.Single(reqs).Url);
+        Assert.Equal("https://hosted.test:8443", Assert.Single(saved).url);
+    }
+}
+
+/// <summary>
+/// The hosted gateway address is resolved from a PROCESS-WIDE environment variable, so every test that sets or
+/// depends on it shares one collection - xUnit runs a collection's classes one at a time, which keeps a test
+/// that points the override at a stub host from leaking into a test that expects the shipped address.
+/// </summary>
+[CollectionDefinition(Name)]
+public class HostedGatewayUrlCollection
+{
+    public const string Name = "hosted-gateway-url";
+}
+
+/// <summary>Sets <c>DEVTHROTTLE_HOSTED_GATEWAY_URL</c> for the life of the scope and restores whatever was
+/// there before, so an override test cannot change what the next test sees.</summary>
+internal sealed class HostedGatewayUrlOverride : IDisposable
+{
+    private readonly string? _previous;
+
+    public HostedGatewayUrlOverride(string? value)
+    {
+        _previous = Environment.GetEnvironmentVariable(HostedGateway.UrlEnvironmentVariable);
+        Environment.SetEnvironmentVariable(HostedGateway.UrlEnvironmentVariable, value);
+    }
+
+    public void Dispose() =>
+        Environment.SetEnvironmentVariable(HostedGateway.UrlEnvironmentVariable, _previous);
+}
+
+/// <summary>
+/// Tests for <see cref="HostedGateway.ResolveUrl"/> - the production line that decides WHICH hosted gateway a
+/// machine enrolls against. A typo in the operator override must fail loudly rather than quietly sending the
+/// machine to production, so the throw is the guard under test.
+/// </summary>
+[Collection(HostedGatewayUrlCollection.Name)]
+public class HostedGatewayTests
+{
+    [Fact]
+    public void ResolveUrl_NoOverride_UsesTheShippedAddress()
+    {
+        using var _ = new HostedGatewayUrlOverride(null);
+        Assert.Equal(HostedGateway.DefaultUrl, HostedGateway.ResolveUrl());
+    }
+
+    [Fact]
+    public void ResolveUrl_Override_UsesItWithoutATrailingSlash()
+    {
+        using var _ = new HostedGatewayUrlOverride("https://hosted.test:8443/");
+        Assert.Equal("https://hosted.test:8443", HostedGateway.ResolveUrl());
+    }
+
+    [Fact]
+    public void ResolveUrl_OverrideIsNotAnAbsoluteUrl_Throws()
+    {
+        using var _ = new HostedGatewayUrlOverride("hosted.test");
+        var ex = Assert.Throws<InvalidOperationException>(() => HostedGateway.ResolveUrl());
+        Assert.Contains(HostedGateway.UrlEnvironmentVariable, ex.Message);
+    }
+}

--- a/tools/cc-director-setup-engine/GatewayAccountEnrollRunner.cs
+++ b/tools/cc-director-setup-engine/GatewayAccountEnrollRunner.cs
@@ -283,6 +283,183 @@ public sealed class GatewayAccountEnrollRunner
     }
 
     /// <summary>
+    /// Join this machine to DevThrottle's HOSTED gateway instead of a gateway the account runs itself: sign in
+    /// with the DevThrottle account and enroll at <see cref="HostedGateway"/> for a local, revocable device
+    /// key bound to this account's tenant. On success it persists the hosted URL + issued key exactly as the
+    /// self-hosted paths do, so everything downstream - the Director's stream connection, the local cc-* tools -
+    /// is unchanged.
+    ///
+    /// THIS PATH IS SHORTER THAN THE SELF-HOSTED ONE, AND DELIBERATELY SO. Self-hosted registers the machine in
+    /// the account DEVICE REGISTRY to obtain a cloud device key, then exchanges THAT key at the target gateway
+    /// via <c>/m/enroll</c>, because a gateway the account runs has no way to judge an account token itself. The
+    /// hosted gateway does: <c>POST /devices/enroll-hosted</c> takes the ACCOUNT ACCESS TOKEN directly, verifies
+    /// it (signature, expiry, audience, issuer), maps its subject to a tenant, and mints the per-device key in
+    /// ONE step. So there is no device-registry exchange here - not a missing step, an unnecessary one. There is
+    /// also nothing to provision and nothing to discover: hosted is ONE shared multi-tenant gateway, and
+    /// enrolling is what makes this account a tenant on it.
+    ///
+    /// The captured account token is held in memory ONLY for the duration of this call and is never persisted or
+    /// logged (security rule DT-05), matching the self-hosted paths - a workstation holds no account credential.
+    /// </summary>
+    /// <param name="deviceId">This machine's stable device/install id, sent as the hosted device id.</param>
+    /// <param name="machineName">A human-readable device name recorded on the hosted gateway.</param>
+    /// <param name="ct">Cancelled by the caller while the sign-in or enroll is in flight.</param>
+    public async Task<OperationResult<MobileEnrollmentResponse>> SignInAndEnrollHostedAsync(
+        string deviceId, string machineName, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(deviceId))
+            return OperationResult<MobileEnrollmentResponse>.Fail("This machine has no device id.");
+
+        string hostedUrl;
+        try
+        {
+            hostedUrl = HostedGateway.ResolveUrl();
+        }
+        catch (Exception ex)
+        {
+            EngineLog.Write($"[GatewayAccountEnrollRunner] SignInAndEnrollHostedAsync: hosted address unusable: {ex.Message}");
+            return OperationResult<MobileEnrollmentResponse>.Fail(ex.Message);
+        }
+
+        EngineLog.Write($"[GatewayAccountEnrollRunner] SignInAndEnrollHostedAsync: hosted={hostedUrl}, deviceId={deviceId}, machine={machineName}");
+
+        DevThrottleTokens tokens;
+        try
+        {
+            tokens = await _signIn(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            EngineLog.Write("[GatewayAccountEnrollRunner] SignInAndEnrollHostedAsync: sign-in cancelled before a credential arrived");
+            return OperationResult<MobileEnrollmentResponse>.Fail(
+                "Sign-in was cancelled. Click \"Sign in to DevThrottle\" to try again.");
+        }
+        catch (Exception ex)
+        {
+            EngineLog.Write($"[GatewayAccountEnrollRunner] SignInAndEnrollHostedAsync: sign-in failed: {ex.Message}");
+            return OperationResult<MobileEnrollmentResponse>.Fail(
+                "Sign-in did not complete. Please return to your browser and finish signing in, then try again.");
+        }
+
+        if (tokens is null || string.IsNullOrWhiteSpace(tokens.AccessToken))
+            return OperationResult<MobileEnrollmentResponse>.Fail(
+                "Sign-in did not return a usable credential. Please try again.");
+
+        return await EnrollAtHostedGatewayAsync(hostedUrl, tokens.AccessToken, deviceId, machineName, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Enroll at the HOSTED gateway using the account token already captured by a preceding
+    /// <see cref="SignInAndDiscoverGatewaysAsync"/> in the same run - the seam for a chooser that offers
+    /// "DevThrottle hosted" alongside the account's own gateways, so picking hosted costs no second sign-in.
+    /// Fails with a clear reason if no captured token is held, rather than silently signing in again.
+    /// </summary>
+    /// <param name="deviceId">This machine's stable device/install id.</param>
+    /// <param name="machineName">A human-readable device name recorded on the hosted gateway.</param>
+    /// <param name="ct">Cancels the enroll call.</param>
+    public async Task<OperationResult<MobileEnrollmentResponse>> EnrollWithHostedGatewayAsync(
+        string deviceId, string machineName, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(deviceId))
+            return OperationResult<MobileEnrollmentResponse>.Fail("This machine has no device id.");
+
+        var tokens = _pendingTokens;
+        if (tokens is null || string.IsNullOrWhiteSpace(tokens.AccessToken))
+            return OperationResult<MobileEnrollmentResponse>.Fail(
+                "Please sign in to DevThrottle first.");
+
+        string hostedUrl;
+        try
+        {
+            hostedUrl = HostedGateway.ResolveUrl();
+        }
+        catch (Exception ex)
+        {
+            EngineLog.Write($"[GatewayAccountEnrollRunner] EnrollWithHostedGatewayAsync: hosted address unusable: {ex.Message}");
+            return OperationResult<MobileEnrollmentResponse>.Fail(ex.Message);
+        }
+
+        EngineLog.Write($"[GatewayAccountEnrollRunner] EnrollWithHostedGatewayAsync: hosted={hostedUrl}, deviceId={deviceId}, machine={machineName}");
+        return await EnrollAtHostedGatewayAsync(hostedUrl, tokens.AccessToken, deviceId, machineName, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// POST the ACCOUNT ACCESS TOKEN to the hosted gateway's <c>/devices/enroll-hosted</c> and map the reply to
+    /// a success-or-reason result, persisting the hosted URL + issued local device key on success ONLY. A
+    /// transport failure, a 401 (the account token was not accepted), any other non-2xx, or a 2xx carrying no
+    /// device key all return a clear reason and persist NOTHING - so a machine can never end up pointed at the
+    /// hosted gateway without a key that the hosted gateway actually issued. Neither the account token nor the
+    /// issued device key is ever logged (security rule DT-05).
+    /// </summary>
+    private async Task<OperationResult<MobileEnrollmentResponse>> EnrollAtHostedGatewayAsync(
+        string hostedUrl, string accountAccessToken, string deviceId, string machineName, CancellationToken ct)
+    {
+        var request = new EnrollSignedInRequest
+        {
+            DeviceId = deviceId,
+            MachineName = machineName,
+            Platform = WorkstationPlatform,
+            DeviceType = WorkstationDeviceType,
+        };
+
+        using var http = new HttpClient(_handlerFactory(), disposeHandler: true) { Timeout = _httpTimeout };
+        http.BaseAddress = new Uri(hostedUrl.TrimEnd('/') + "/");
+        http.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accountAccessToken);
+
+        HttpResponseMessage resp;
+        try
+        {
+            resp = await http.PostAsJsonAsync("devices/enroll-hosted", request, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            EngineLog.Write($"[GatewayAccountEnrollRunner] EnrollAtHostedGatewayAsync transport FAILED: {ex.Message}");
+            return OperationResult<MobileEnrollmentResponse>.Fail(
+                $"Could not reach the DevThrottle hosted gateway at {hostedUrl}. Please check your connection and try again.");
+        }
+
+        if (resp.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            EngineLog.Write("[GatewayAccountEnrollRunner] EnrollAtHostedGatewayAsync rejected: HTTP 401 (account token not accepted)");
+            return OperationResult<MobileEnrollmentResponse>.Fail(
+                "The DevThrottle hosted gateway did not accept your sign-in. Please sign in again and try once more.");
+        }
+        if (!resp.IsSuccessStatusCode)
+        {
+            EngineLog.Write($"[GatewayAccountEnrollRunner] EnrollAtHostedGatewayAsync failed: HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+            return OperationResult<MobileEnrollmentResponse>.Fail(
+                $"The DevThrottle hosted gateway refused the enrollment: HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}.");
+        }
+
+        DeviceRegistrationResponse? body;
+        try
+        {
+            body = await resp.Content.ReadFromJsonAsync<DeviceRegistrationResponse>(ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            EngineLog.Write($"[GatewayAccountEnrollRunner] EnrollAtHostedGatewayAsync: could not read reply: {ex.Message}");
+            return OperationResult<MobileEnrollmentResponse>.Fail(
+                "The DevThrottle hosted gateway accepted the sign-in but its reply could not be read.");
+        }
+
+        if (body is null || string.IsNullOrWhiteSpace(body.DeviceKey))
+        {
+            EngineLog.Write("[GatewayAccountEnrollRunner] EnrollAtHostedGatewayAsync: 2xx with no device key in reply");
+            return OperationResult<MobileEnrollmentResponse>.Fail(
+                "The DevThrottle hosted gateway accepted the sign-in but returned no device key.");
+        }
+
+        _persist(hostedUrl, body.DeviceKey);
+        EngineLog.Write($"[GatewayAccountEnrollRunner] EnrollAtHostedGatewayAsync: persisted hosted url + local per-device key (machine={machineName})");
+
+        // The hosted reply carries the registry echo as well as the key; the callers of every enroll path only
+        // need the key, so it is handed back in the same shape the self-hosted paths return.
+        return OperationResult<MobileEnrollmentResponse>.Ok(new MobileEnrollmentResponse { DeviceKey = body.DeviceKey });
+    }
+
+    /// <summary>
     /// Test that a gateway is actually reachable at a user-entered address BEFORE the install commits to it
     /// (issue #1233 - the mandatory Test gate). Accepts either a bare computer name plus <paramref name="port"/>
     /// (built into <c>http://name:port</c> - the primary manual form) or a full address pasted into


### PR DESCRIPTION
`POST /devices/enroll-hosted` has existed on the Gateway with **nothing in the repo calling it** - a server endpoint with no client, exercised only by curl in live proofs. This gives it one.

With this, a real Director joins the hosted, multi-tenant Gateway and the whole chain runs end to end.

## What changed

- **`HostedGateway`** (new, Core) - where the hosted Gateway lives, plus a `DEVTHROTTLE_HOSTED_GATEWAY_URL` operator override for pointing a test at a different box. An override that is set but unusable **throws**, so a typo fails loudly instead of quietly enrolling the machine into production.
- **`GatewayAccountEnrollRunner`** - a hosted path reusing the browser loopback sign-in it already performs, then persisting through `GatewayCredentialStore.SaveEnrolledKey` **unchanged**. Everything downstream (the stream connection, the local cc-* tools) is untouched.
- **`enroll --hosted`** on the setup CLI - how a person chooses hosted instead of their own gateway. Mutually exclusive with `--gateway`, which is a usage error rather than a silently resolved preference.

## Why the hosted path is shorter than the self-hosted one

This is the one place hosted does not mirror self-host, and it is deliberate.

Self-hosted registers the machine in the account **device registry** for a cloud device key, then exchanges that key at the target gateway via `/m/enroll` - because a gateway the account runs itself cannot judge an account token. The hosted Gateway can: it takes the **account access token** directly, verifies it (signature, expiry, audience, issuer), maps its subject to a tenant, and mints the per-device key in one step.

So there is **no device-registry exchange here - not a missing step, an unnecessary one**. Anyone mirroring `/m/enroll` step-for-step will go hunting for a cloud device key that hosted does not have.

There is also nothing to provision. Hosted is **one shared multi-tenant Gateway**, not a gateway per account; enrolling is what makes an account a tenant on it.

The account token stays **in memory only** and is never persisted or logged - a workstation holds no account credential, exactly as the self-hosted paths behave.

## Guards

A 401, any other non-2xx, a 2xx carrying no device key, and an unreachable host each block with a clear reason and persist **nothing**, so a machine can never be left pointed at the hosted Gateway holding a key it never issued.

Each guard was revert-proven: the real production line reverted one at a time, the guard watched go red, restored, watched go green, controls green throughout.

| Production line reverted | Result |
|---|---|
| The `Bearer accountAccessToken` header | presents-token test fails |
| The `devices/enroll-hosted` route (swapped to `/m/enroll`) | 2 tests fail |
| The 401 guard | token-rejected test fails |
| The non-2xx guard | refused test fails |
| The no-device-key guard | keyless-2xx test fails **and it persists** - the credential bug the guard exists to prevent |
| The `_persist(hostedUrl, deviceKey)` line | 2 tests fail |
| The throw on an unusable hosted-URL override | throw test fails |

331/331 in the engine suite with everything intact.

## Verified against the live hosted Gateway

A real Director (slot build, isolated storage root) enrolled with `enroll --hosted` through real Google SSO, then:

- `GatewayStreamClient connected` -> `reseeded full snapshot seq=1` -> `tunnel connected (two-way stream up)`
- a session spawned on it reached hosted and came back **with session number 100** - the hosted Gateway assigned the number, so it ruled on the roster rather than passing it through
- `GET /directors` and `GET /sessions` returned exactly this Director and its session, tenant-scoped; both 401 without the key
- the persisted config held the hosted URL, a 43-char device key and `streamMode=true`, the credential file matched, and **no token or key appeared anywhere in the log**

## Deliberately not included

**No installer wizard button.** Hosted stays closed while the known cross-tenant issues are open, and a wizard button is a door. Enrolment is CLI-only on purpose. `EnrollWithHostedGatewayAsync` is in place as the seam for a chooser when that changes.

## WARNING - read this before you set up an isolated test root

**`CC_DIRECTOR_ROOT` redirects where a Director WRITES, but not where it MIGRATES FROM.**

On first boot, `CcStorageMigration` copied the machine owner's **real sessions and logs** out of OneDrive and LocalAppData into a root that had every reason to look clean. Nothing was written back to the owner's locations, but the "isolated" root was not isolated.

**Do this:**

- **Treat any such test root as containing real user data.** Do not commit it, do not attach it to a pull request, do not paste its contents. (This branch excludes it locally for that reason.)
- **Expect that data to leave the machine.** The Director then reseeded a full snapshot to the Gateway it was pointed at, so the owner's real session data reached the hosted box. Here that was his own account and his own tenant, so it was not a cross-tenant leak - but on a shared Gateway with cross-tenant issues open, point a test Director somewhere only after you have accepted that whatever the migration dragged in goes with it.
- **Check what landed in your root before you start the Director**, not after.

## Findings booked separately

Two defects found on this first real contact, filed rather than fixed here to keep this scoped to the client leg:

- #1855 - hosted `director-startup` telemetry 401s for a correctly enrolled Director, and fails silently
- #1856 - a correctly enrolled hosted machine reports itself as SIGNED OUT
