### PR TITLE
fix(gateway): tenant-scope the prompt log (#1848, prompts half)

### DIFF
--- a/src/CcDirector.Gateway.Tests/PromptLogTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/PromptLogTenantIsolationTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -39,6 +41,7 @@ public sealed class PromptLogTenantIsolationTests : IAsyncLifetime
 
     // The thing one account must never be able to read out of the other.
     private const string SecretTextA = "alpha-account-secret-prompt-text";
+    private const string SecretTextB = "bravo-account-secret-prompt-text";
 
     private GatewayHost _gateway = null!;
     private HttpClient _http = null!;
@@ -86,22 +89,87 @@ public sealed class PromptLogTenantIsolationTests : IAsyncLifetime
     [Fact]
     public async Task One_account_never_reads_another_accounts_prompt_text()
     {
+        // BIDIRECTIONAL, on purpose. An earlier version of this test asserted only that B could not see A's
+        // text. An implementation that leaked A's read while keeping B correctly scoped would have passed it
+        // unnoticed - and a leak conditional on tenant, key or enrollment order hides in exactly the
+        // direction you did not check. Every absence claim in this work is checked both ways.
         var today = DateTime.UtcNow;
         Assert.Equal(HttpStatusCode.OK, (await PostPrompt(_keyA, SecretTextA, today)).StatusCode);
-        Assert.Equal(HttpStatusCode.OK, (await PostPrompt(_keyB, "bravo-account-prompt-text", today)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await PostPrompt(_keyB, SecretTextB, today)).StatusCode);
 
-        // The account that wrote it reads its own text back...
-        var ownBody = await ReadPromptsBody(_keyA, today);
-        Assert.Contains(SecretTextA, ownBody);
+        var bodyA = await ReadPromptsBody(_keyA, today);
+        var bodyB = await ReadPromptsBody(_keyB, today);
 
-        // ...and the OTHER account can read neither the text nor the record. This is the whole defect: the
-        // handler used to have no request context, so this body was every account's log.
-        var otherBody = await ReadPromptsBody(_keyB, today);
-        Assert.DoesNotContain(SecretTextA, otherBody);
-        Assert.Contains("bravo-account-prompt-text", otherBody);
+        // Positive control in FRONT of each absence claim: each account really does read its own text back.
+        // Without these, "A cannot see B's text" would also hold if the read returned nothing at all.
+        Assert.Contains(SecretTextA, bodyA);
+        Assert.Contains(SecretTextB, bodyB);
 
-        using var doc = JsonDocument.Parse(otherBody);
-        Assert.Equal(1, doc.RootElement.GetProperty("count").GetInt32());
+        // The absence claims, both directions. This is the whole defect: neither handler took an HttpContext,
+        // so neither could resolve a tenant even in principle and this body was every account's prompt TEXT.
+        Assert.DoesNotContain(SecretTextB, bodyA);   // A cannot see B
+        Assert.DoesNotContain(SecretTextA, bodyB);   // B cannot see A
+
+        // And neither read merely FILTERED a shared set down: each account sees exactly its own one record,
+        // so nothing of the other's is present in any form - not the text, not the record.
+        using var docA = JsonDocument.Parse(bodyA);
+        using var docB = JsonDocument.Parse(bodyB);
+        Assert.Equal(1, docA.RootElement.GetProperty("count").GetInt32());
+        Assert.Equal(1, docB.RootElement.GetProperty("count").GetInt32());
+    }
+
+    [Fact]
+    public void A_failed_read_never_writes_the_raw_tenant_id_to_the_log()
+    {
+        // The prompt-log partition IS the tenant's account id - it is a directory name - so any failure that
+        // logs a path, or an exception message containing one, prints account identifiers into a log that is
+        // otherwise free of them. Every other tenant-bearing log line uses the hashed form; these two did not.
+        //
+        // Driven behaviourally through the REAL log writer via its test seam, and through a REAL failing read
+        // - a directory standing where the daily file should be, so the file read genuinely throws - rather
+        // than by unit-testing the redaction helper, which would prove the helper and not the call site.
+        //
+        // Revert-prove: put {path} and the raw {ex.Message} back into either catch block in GatewayPromptLog
+        // and this goes RED on the raw tenant id appearing in the log.
+        var root = Path.Combine(Path.GetTempPath(), "cc-plog-" + Guid.NewGuid().ToString("N"));
+        var tenant = new CcDirector.Core.Tenancy.TenantId("11111111-2222-3333-4444-555555555555");
+        try
+        {
+            var log = new CcDirector.Gateway.Prompts.GatewayPromptLog(root);
+            var day = DateTime.UtcNow;
+            // Make the daily file exist but be genuinely unreadable - another process holding it exclusively,
+            // which is the ordinary way a real read fails. A directory in its place would NOT do: Read checks
+            // File.Exists first and would skip the day without ever attempting a read, so nothing would be
+            // logged and this test would pass while proving nothing. The positive control below caught exactly
+            // that on the first attempt.
+            var file = log.FileFor(tenant, day);
+            Directory.CreateDirectory(Path.GetDirectoryName(file)!);
+            File.WriteAllText(file, "{}");
+
+            IReadOnlyList<string> lines;
+            using (var hold = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.None))
+            using (var capture = CcDirector.Core.Utilities.FileLog.RedirectForTests())
+            {
+                log.Read(tenant, day, day);
+                lines = capture.DrainAndReadLines();
+            }
+
+            // Positive control FIRST: the failure really was logged. Without this, "the id is absent" would
+            // also hold if nothing had been written at all - which is the shape of a vacuous privacy check.
+            var failures = lines.Where(l => l.Contains("Read FAILED", StringComparison.Ordinal)).ToList();
+            Assert.NotEmpty(failures);
+
+            // The id itself never appears, in the path or inside the exception message.
+            Assert.DoesNotContain(lines, l => l.Contains(tenant.Value, StringComparison.OrdinalIgnoreCase));
+
+            // And the line is still USEFUL - it names the partition in hashed form, so a failure is
+            // diagnosable. Redacted, not silenced.
+            Assert.Contains(failures, l => l.Contains(tenant.ToLogString(), StringComparison.Ordinal));
+        }
+        finally
+        {
+            try { if (Directory.Exists(root)) Directory.Delete(root, true); } catch { /* best-effort */ }
+        }
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/PromptLogTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/PromptLogTenantIsolationTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1848: the prompt log is TENANT-SCOPED on the hosted Gateway, proven over real HTTP with two accounts.
+///
+/// This is the CONTENT-disclosure surface. Before this, <c>GET /prompts</c> did not take an HttpContext at all -
+/// so it could not resolve a request tenant even in principle - and it answered fleet-globally: one account
+/// read every other account's full prompt TEXT. This drives the REAL mapped endpoints through the REAL auth
+/// middleware, exactly as SessionServingReadIsolationTests does for the cockpit read path.
+///
+/// THE PRODUCTION LINES THESE TESTS PROTECT (each revert-provable - revert it, watch these go red):
+///   - <c>PromptEndpoints.ResolveTenant</c>, and the <c>store.Read(tenant.Value, ...)</c> /
+///     <c>store.Append(tenant.Value, ...)</c> calls in the two /prompts handlers. Revert the resolution to a
+///     fixed TenantId.Local and both accounts share one partition, so "B never sees A's text" goes RED and the
+///     403 deny collapses to a 200.
+///   - <c>GatewayPromptLog.DirectoryFor</c> - the ONE helper every read and write path goes through, which is
+///     what makes the partition structural rather than conventional. Return the root directory for every
+///     tenant and the same assertion goes RED.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is
+/// reset in DisposeAsync.
+/// </summary>
+public sealed class PromptLogTenantIsolationTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    // The thing one account must never be able to read out of the other.
+    private const string SecretTextA = "alpha-account-secret-prompt-text";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    private string _keyA = "";
+    private string _keyB = "";
+    private string _keyUnbound = "";
+
+    private readonly string _tempDir =
+        Path.Combine(Path.GetTempPath(), "cc-prompt-iso-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        // The prompt log is pinned into a throwaway directory; it otherwise defaults to the running user's real one.
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _tempDir,
+            workListsPath: Path.Combine(_tempDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_tempDir, "snooze", "snooze.json"),
+            promptLogPath: Path.Combine(_tempDir, "prompt-log"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // Two accounts: two device keys, each bound to its OWN tenant, plus one registered-but-unbound key.
+        _keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        _keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        _keyUnbound = _gateway.Devices.Register("dev-x", "MX").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", "tenant-alice");
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", "tenant-bob");
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task One_account_never_reads_another_accounts_prompt_text()
+    {
+        var today = DateTime.UtcNow;
+        Assert.Equal(HttpStatusCode.OK, (await PostPrompt(_keyA, SecretTextA, today)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await PostPrompt(_keyB, "bravo-account-prompt-text", today)).StatusCode);
+
+        // The account that wrote it reads its own text back...
+        var ownBody = await ReadPromptsBody(_keyA, today);
+        Assert.Contains(SecretTextA, ownBody);
+
+        // ...and the OTHER account can read neither the text nor the record. This is the whole defect: the
+        // handler used to have no request context, so this body was every account's log.
+        var otherBody = await ReadPromptsBody(_keyB, today);
+        Assert.DoesNotContain(SecretTextA, otherBody);
+        Assert.Contains("bravo-account-prompt-text", otherBody);
+
+        using var doc = JsonDocument.Parse(otherBody);
+        Assert.Equal(1, doc.RootElement.GetProperty("count").GetInt32());
+    }
+
+    [Fact]
+    public async Task Prompts_deny_a_device_key_with_no_bound_tenant()
+    {
+        // Deny-by-default, on BOTH verbs: an authenticated but tenant-unbound key never falls back to the
+        // Local partition - not to read it, and not to write into it.
+        Assert.Equal(HttpStatusCode.Forbidden, (await ReadPrompts(_keyUnbound, DateTime.UtcNow)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await PostPrompt(_keyUnbound, "should never land", DateTime.UtcNow)).StatusCode);
+    }
+
+    private Task<HttpResponseMessage> Get(string path, string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private Task<HttpResponseMessage> ReadPrompts(string deviceKey, DateTime day)
+        => Get($"prompts?from={day:yyyy-MM-dd}&to={day:yyyy-MM-dd}", deviceKey);
+
+    private async Task<string> ReadPromptsBody(string deviceKey, DateTime day)
+    {
+        var resp = await ReadPrompts(deviceKey, day);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadAsStringAsync();
+    }
+
+    private Task<HttpResponseMessage> PostPrompt(string deviceKey, string text, DateTime tsUtc)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "prompts")
+        {
+            Content = JsonContent.Create(new PromptIngestRequest
+            {
+                Records = new List<PromptRecord>
+                {
+                    new()
+                    {
+                        TsUtc = tsUtc,
+                        Machine = "M",
+                        SessionId = "s",
+                        Agent = "ClaudeCode",
+                        Role = "user",
+                        TimestampFromAgent = true,
+                        CharCount = text.Length,
+                        WordCount = 1,
+                        Text = text,
+                    },
+                },
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/PromptLogTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/PromptLogTenantIsolationTests.cs
@@ -254,12 +254,35 @@ public sealed class PromptLogTenantIsolationTests : IAsyncLifetime
         var log = new CcDirector.Gateway.Prompts.GatewayPromptLog(
             Path.Combine(Path.GetTempPath(), "cc-plog-" + Guid.NewGuid().ToString("N")));
 
-        foreach (var bad in new[] { "..", ".", "a/b", "a\b", "not-a-guid", "tenants" })
-            Assert.ThrowsAny<ArgumentException>(() => log.DirectoryFor(new CcDirector.Core.Tenancy.TenantId(bad)));
+        // NOTE the verbatim string on the separator case. It was written "a\b" first, which in C# is a
+        // BACKSPACE character, not a backslash - so that canary tested a control character and would have
+        // passed however broken the separator handling was. A dead canary looks exactly like coverage.
+        foreach (var bad in new[]
+        {
+            "..", ".", "a/b", @"a\b", "not-a-guid", "tenants",
+            // The casing alias. The registry mints canonical LOWERCASE guids and the tenants table uses a
+            // case-sensitive collation, so this is a DIFFERENT IDENTITY to the database - while Windows and
+            // Azure Files name the SAME directory as its lowercase twin. Accepting it is one tenant reading
+            // another's prompt text, with no special character involved at all.
+            // NOTE the letters. This canary was first written against 1111...-5555, which is ALL DIGITS, so
+            // ToUpperInvariant was a no-op and the "uppercase" case was really the valid lowercase id - the
+            // test caught it by reporting that id as accepted. A casing canary needs a value that HAS a case.
+            "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE",
+            "aaaaaaaa-bbbb-4ccc-8ddd-EEEEEEEEEEEE",
+            // Other spellings of a real guid that are not the minted form.
+            "{11111111-2222-3333-4444-555555555555}",
+            "11111111222233334444555555555555",
+            // The reserved system tenant owns no prompt text, so it gets no partition rather than a folder.
+            CcDirector.Core.Tenancy.TenantId.System.Value,
+        })
+        {
+            var ex = Record.Exception(() => log.DirectoryFor(new CcDirector.Core.Tenancy.TenantId(bad)));
+            Assert.True(ex is ArgumentException, $"tenant id {bad} was ACCEPTED as a partition name");
+        }
 
         // Positive controls, so this is not passing because DirectoryFor refuses everything: the two shapes
         // that ARE real still work, and land in different places.
-        var minted = new CcDirector.Core.Tenancy.TenantId("11111111-2222-3333-4444-555555555555");
+        var minted = new CcDirector.Core.Tenancy.TenantId("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee");
         Assert.NotEqual(log.DirectoryFor(CcDirector.Core.Tenancy.TenantId.Local),
                         log.DirectoryFor(minted));
         Assert.Contains(minted.Value, log.DirectoryFor(minted), StringComparison.Ordinal);

--- a/src/CcDirector.Gateway.Tests/PromptLogTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/PromptLogTenantIsolationTests.cs
@@ -73,8 +73,14 @@ public sealed class PromptLogTenantIsolationTests : IAsyncLifetime
         _keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
         _keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
         _keyUnbound = _gateway.Devices.Register("dev-x", "MX").DeviceKey;
-        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", "tenant-alice");
-        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", "tenant-bob");
+        // Bound to tenants MINTED BY THE REAL REGISTRY, exactly as POST /devices/enroll-hosted does, rather
+        // than to invented strings. That matters here specifically: the prompt log turns a tenant id into a
+        // DIRECTORY NAME and now enforces the real minted shape, so a test binding a made-up id would be
+        // testing a partition production can never create.
+        var tenantA = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        var tenantB = _gateway.TenantRegistry.MintOrLookupBySubject("sub-bob", "bob@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", tenantA.Value);
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", tenantB.Value);
     }
 
     public async Task DisposeAsync()
@@ -129,8 +135,11 @@ public sealed class PromptLogTenantIsolationTests : IAsyncLifetime
         // - a directory standing where the daily file should be, so the file read genuinely throws - rather
         // than by unit-testing the redaction helper, which would prove the helper and not the call site.
         //
-        // Revert-prove: put {path} and the raw {ex.Message} back into either catch block in GatewayPromptLog
-        // and this goes RED on the raw tenant id appearing in the log.
+        // Revert-prove: put {path} and the raw {ex.Message} back into the READ catch in GatewayPromptLog and
+        // this goes RED on the raw tenant id appearing in the log. An earlier version of this comment said
+        // "either catch block", which was FALSE - review reverted only the Append catch and all three tests
+        // still passed, so that second leak could have regressed unnoticed. The Append catch has its own
+        // test below now; a comment claiming coverage is not coverage.
         var root = Path.Combine(Path.GetTempPath(), "cc-plog-" + Guid.NewGuid().ToString("N"));
         var tenant = new CcDirector.Core.Tenancy.TenantId("11111111-2222-3333-4444-555555555555");
         try
@@ -170,6 +179,90 @@ public sealed class PromptLogTenantIsolationTests : IAsyncLifetime
         {
             try { if (Directory.Exists(root)) Directory.Delete(root, true); } catch { /* best-effort */ }
         }
+    }
+
+    [Fact]
+    public void A_failed_append_never_writes_the_raw_tenant_id_to_the_log()
+    {
+        // The SECOND raw-account-id leak, and it existed unprotected while a comment claimed otherwise. Append
+        // swallows its failure by design - a logging failure must not fail a Director's push - so the only
+        // trace is the log line, and that line carried an exception message containing the full path, which on
+        // hosted IS the account id.
+        //
+        // Driven the same way as the read proof: a real exclusive lock on the tenant's own daily file, so the
+        // real Append catch runs, through the real log writer.
+        //
+        // Revert-prove: put the raw {ex.Message} back in the Append catch and this goes RED on the raw id.
+        var root = Path.Combine(Path.GetTempPath(), "cc-plog-" + Guid.NewGuid().ToString("N"));
+        var tenant = new CcDirector.Core.Tenancy.TenantId("11111111-2222-3333-4444-555555555555");
+        try
+        {
+            var log = new CcDirector.Gateway.Prompts.GatewayPromptLog(root);
+            var day = DateTime.UtcNow;
+            var file = log.FileFor(tenant, day);
+            Directory.CreateDirectory(Path.GetDirectoryName(file)!);
+            File.WriteAllText(file, "");
+
+            IReadOnlyList<string> lines;
+            var written = 0;
+            using (var hold = new FileStream(file, FileMode.Open, FileAccess.Write, FileShare.None))
+            using (var capture = CcDirector.Core.Utilities.FileLog.RedirectForTests())
+            {
+                written = log.Append(tenant, new[] { new PromptRecord
+                {
+                    TsUtc = day,
+                    Machine = "MA",
+                    SessionId = "session-1",
+                    ContextId = "ctx-1",
+                    RepoPath = "/repo",
+                    Agent = "ClaudeCode",
+                    Role = "user",
+                    TimestampFromAgent = true,
+                    CharCount = 5,
+                    WordCount = 1,
+                    Text = "hello",
+                } });
+                lines = capture.DrainAndReadLines();
+            }
+
+            // Positive control FIRST: the append really did fail and really did log. Without this, "the id is
+            // absent" would also hold if the write had quietly succeeded.
+            Assert.Equal(0, written);
+            var failures = lines.Where(l => l.Contains("Append FAILED", StringComparison.Ordinal)).ToList();
+            Assert.NotEmpty(failures);
+
+            Assert.DoesNotContain(lines, l => l.Contains(tenant.Value, StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(failures, l => l.Contains(tenant.ToLogString(), StringComparison.Ordinal));
+        }
+        finally
+        {
+            try { if (Directory.Exists(root)) Directory.Delete(root, true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void A_tenant_id_that_is_not_a_minted_account_cannot_name_a_partition()
+    {
+        // Traversal canary. The validator used to be a character allow-list that accepted "..", and
+        // Path.Combine(root, "tenants", "..") canonicalizes to exactly root - the LOCAL partition. So a tenant
+        // id of ".." would have read and written the local tenant's prompt text. The dangerous values here are
+        // STRUCTURAL, not exotic, which is why a "looks harmless" character rule is not a validator.
+        //
+        // Hosted mints GUIDs today, but this is a storage boundary taking the general TenantId type and device
+        // bindings persist arbitrary strings, so the boundary enforces its own domain rather than trusting its
+        // callers.
+        var log = new CcDirector.Gateway.Prompts.GatewayPromptLog(
+            Path.Combine(Path.GetTempPath(), "cc-plog-" + Guid.NewGuid().ToString("N")));
+
+        foreach (var bad in new[] { "..", ".", "a/b", "a\b", "not-a-guid", "tenants" })
+            Assert.ThrowsAny<ArgumentException>(() => log.DirectoryFor(new CcDirector.Core.Tenancy.TenantId(bad)));
+
+        // Positive controls, so this is not passing because DirectoryFor refuses everything: the two shapes
+        // that ARE real still work, and land in different places.
+        var minted = new CcDirector.Core.Tenancy.TenantId("11111111-2222-3333-4444-555555555555");
+        Assert.NotEqual(log.DirectoryFor(CcDirector.Core.Tenancy.TenantId.Local),
+                        log.DirectoryFor(minted));
+        Assert.Contains(minted.Value, log.DirectoryFor(minted), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/Prompts/GatewayPromptLogTests.cs
+++ b/src/CcDirector.Gateway.Tests/Prompts/GatewayPromptLogTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Prompts;
 using Xunit;
@@ -46,10 +47,10 @@ public sealed class GatewayPromptLogTests : IDisposable
     {
         var ts = new DateTime(2026, 7, 14, 9, 30, 0, DateTimeKind.Utc);
 
-        var written = _log.Append(new[] { Rec(ts, "fix the login bug") });
+        var written = _log.Append(TenantId.Local, new[] { Rec(ts, "fix the login bug") });
 
         Assert.Equal(1, written);
-        var only = Assert.Single(_log.Read(ts, ts));
+        var only = Assert.Single(_log.Read(TenantId.Local, ts, ts));
         Assert.Equal("fix the login bug", only.Text);
         Assert.Equal("SOREN_NORTH", only.Machine);
         Assert.Equal("ctx-1", only.ContextId);
@@ -61,10 +62,10 @@ public sealed class GatewayPromptLogTests : IDisposable
     public void Append_adds_to_what_is_already_there()
     {
         var ts = new DateTime(2026, 7, 14, 9, 30, 0, DateTimeKind.Utc);
-        _log.Append(new[] { Rec(ts, "first") });
-        _log.Append(new[] { Rec(ts.AddMinutes(1), "second", "assistant") });
+        _log.Append(TenantId.Local, new[] { Rec(ts, "first") });
+        _log.Append(TenantId.Local, new[] { Rec(ts.AddMinutes(1), "second", "assistant") });
 
-        Assert.Equal(new[] { "first", "second" }, _log.Read(ts, ts).Select(r => r.Text));
+        Assert.Equal(new[] { "first", "second" }, _log.Read(TenantId.Local, ts, ts).Select(r => r.Text));
     }
 
     /// <summary>
@@ -77,11 +78,11 @@ public sealed class GatewayPromptLogTests : IDisposable
         var day1 = new DateTime(2026, 7, 14, 23, 59, 0, DateTimeKind.Utc);
         var day2 = new DateTime(2026, 7, 15, 0, 1, 0, DateTimeKind.Utc);
 
-        var written = _log.Append(new[] { Rec(day1, "before midnight"), Rec(day2, "after midnight") });
+        var written = _log.Append(TenantId.Local, new[] { Rec(day1, "before midnight"), Rec(day2, "after midnight") });
 
         Assert.Equal(2, written);
-        Assert.Equal("before midnight", Assert.Single(_log.Read(day1, day1)).Text);
-        Assert.Equal("after midnight", Assert.Single(_log.Read(day2, day2)).Text);
+        Assert.Equal("before midnight", Assert.Single(_log.Read(TenantId.Local, day1, day1)).Text);
+        Assert.Equal("after midnight", Assert.Single(_log.Read(TenantId.Local, day2, day2)).Text);
     }
 
     [Fact]
@@ -89,27 +90,27 @@ public sealed class GatewayPromptLogTests : IDisposable
     {
         var day1 = new DateTime(2026, 7, 14, 9, 0, 0, DateTimeKind.Utc);
         var day3 = new DateTime(2026, 7, 16, 9, 0, 0, DateTimeKind.Utc);
-        _log.Append(new[] { Rec(day1, "monday"), Rec(day3, "wednesday") });
+        _log.Append(TenantId.Local, new[] { Rec(day1, "monday"), Rec(day3, "wednesday") });
 
-        Assert.Equal(new[] { "monday", "wednesday" }, _log.Read(day1, day3).Select(r => r.Text));
+        Assert.Equal(new[] { "monday", "wednesday" }, _log.Read(TenantId.Local, day1, day3).Select(r => r.Text));
     }
 
     [Fact]
     public void Read_of_a_day_with_nothing_in_it_is_empty_rather_than_throwing()
     {
         var ts = new DateTime(2026, 7, 14, 9, 0, 0, DateTimeKind.Utc);
-        Assert.Empty(_log.Read(ts, ts));
+        Assert.Empty(_log.Read(TenantId.Local, ts, ts));
     }
 
     [Fact]
     public void A_corrupt_line_does_not_hide_the_good_ones()
     {
         var ts = new DateTime(2026, 7, 14, 9, 0, 0, DateTimeKind.Utc);
-        _log.Append(new[] { Rec(ts, "good one") });
-        File.AppendAllText(_log.FileFor(ts), "{ this is not json" + Environment.NewLine);
-        _log.Append(new[] { Rec(ts.AddMinutes(1), "good two") });
+        _log.Append(TenantId.Local, new[] { Rec(ts, "good one") });
+        File.AppendAllText(_log.FileFor(TenantId.Local, ts), "{ this is not json" + Environment.NewLine);
+        _log.Append(TenantId.Local, new[] { Rec(ts.AddMinutes(1), "good two") });
 
-        Assert.Equal(new[] { "good one", "good two" }, _log.Read(ts, ts).Select(r => r.Text));
+        Assert.Equal(new[] { "good one", "good two" }, _log.Read(TenantId.Local, ts, ts).Select(r => r.Text));
     }
 
     [Fact]
@@ -117,9 +118,9 @@ public sealed class GatewayPromptLogTests : IDisposable
     {
         var ts = new DateTime(2026, 7, 14, 9, 0, 0, DateTimeKind.Utc);
         var text = "line one\nline two\nline three";
-        _log.Append(new[] { Rec(ts, text) });
+        _log.Append(TenantId.Local, new[] { Rec(ts, text) });
 
-        Assert.Equal(text, Assert.Single(_log.Read(ts, ts)).Text);
+        Assert.Equal(text, Assert.Single(_log.Read(TenantId.Local, ts, ts)).Text);
     }
 
     [Fact]
@@ -128,10 +129,10 @@ public sealed class GatewayPromptLogTests : IDisposable
         var ts = new DateTime(2026, 7, 14, 9, 0, 0, DateTimeKind.Utc);
 
         // The whole point of the log living on the Gateway: it holds the fleet, not one machine.
-        _log.Append(new[] { Rec(ts, "from north", machine: "SOREN_NORTH") });
-        _log.Append(new[] { Rec(ts.AddMinutes(1), "from laptop", machine: "SOREN_LAPTOP") });
+        _log.Append(TenantId.Local, new[] { Rec(ts, "from north", machine: "SOREN_NORTH") });
+        _log.Append(TenantId.Local, new[] { Rec(ts.AddMinutes(1), "from laptop", machine: "SOREN_LAPTOP") });
 
-        var records = _log.Read(ts, ts);
+        var records = _log.Read(TenantId.Local, ts, ts);
         Assert.Equal(2, records.Count);
         Assert.Equal(new[] { "SOREN_NORTH", "SOREN_LAPTOP" }, records.Select(r => r.Machine));
     }
@@ -139,6 +140,6 @@ public sealed class GatewayPromptLogTests : IDisposable
     [Fact]
     public void Appending_nothing_writes_nothing()
     {
-        Assert.Equal(0, _log.Append(Array.Empty<PromptRecord>()));
+        Assert.Equal(0, _log.Append(TenantId.Local, Array.Empty<PromptRecord>()));
     }
 }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -456,7 +456,7 @@ public sealed class GatewayHost : IAsyncDisposable
     // uses it, so a tenant id can reach the storage layer in a later pull request. Same default paths as
     // the retired statics; no behavior change. The voice-turn upload store (VoiceTurnUploads root) is
     // distinct from _dictationUploads above (DictationUploads root) - two roots, two subsystems.
-    private readonly Prompts.GatewayPromptLog _promptLog = new();
+    private readonly Prompts.GatewayPromptLog _promptLog;
     private readonly Transcription.TranscriptionTelemetryLog _transcriptionTelemetry = new();
     private readonly Transcription.TranscriptionAudioArchive _transcriptionAudioArchive = new();
     private readonly Voice.VoiceUploadStore _voiceTurnUploads = new();
@@ -570,7 +570,7 @@ public sealed class GatewayHost : IAsyncDisposable
     /// Shared instances that write to the real user's directories). Production omits it and the host builds
     /// the service over its own key vault, exactly as before.
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? pushSubscriptionsPath = null, string? wingmanInstructionsPath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null, Core.Agents.AgentKind? brainTool = null)
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? promptLogPath = null, string? snoozePath = null, string? pushSubscriptionsPath = null, string? wingmanInstructionsPath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null, Core.Agents.AgentKind? brainTool = null)
     {
         // Resolve and VALIDATE the warm-brain tool up front, before any resource is opened: a brain tool
         // that cannot be hosted is a configuration error that must fail loudly at construction, not
@@ -593,6 +593,7 @@ public sealed class GatewayHost : IAsyncDisposable
         Missions = new Core.Sessions.MissionStore(missionsPath ?? Path.Combine(CcStorage.Root(), "missions.json"));
         StreamRegistry = new Streaming.GatewayStreamRegistry();
         InputStats = new Stats.GatewayInputStatsAggregator(inputStatsPath);
+        _promptLog = new Prompts.GatewayPromptLog(promptLogPath);
         SessionConcurrency = new Stats.GatewaySessionConcurrencyStats();
         RosterCache = new Discovery.FleetRosterCache();
         // Issue #1215: when a Director is unregistered or evicted from the registry, forget its cached
@@ -2103,7 +2104,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // wanting history reads GET /prompts. It lives here, not on a Director, because the Gateway is
         // what the whole fleet reports to - so the history is already present rather than scattered
         // across machines - and because the Gateway is what moves to the server.
-        Prompts.PromptEndpoints.Map(_app, _promptLog);
+        Prompts.PromptEndpoints.Map(_app, _promptLog, _tenantBoundary);
 
         Mobile.MobileApp.Map(_app, Token);
 

--- a/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
+++ b/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
@@ -44,9 +44,16 @@ public sealed class GatewayPromptLog
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
-    // A tenant id becomes a directory name, so it must be a plain identifier. Real ids are the well-known
-    // "local"/"system" words or an account GUID; anything else is refused rather than scrubbed.
-    private static readonly Regex SafeTenantId = new("^[A-Za-z0-9._-]{1,64}$", RegexOptions.Compiled);
+    // A tenant id becomes a DIRECTORY NAME, so it must be one of the shapes this system actually mints -
+    // not merely "characters that look harmless". The earlier rule here was ^[A-Za-z0-9._-]{1,64}$, which
+    // accepts ".." - and Path.Combine(root, "tenants", "..") canonicalizes to exactly root, the LOCAL
+    // partition. A character allow-list that permits a path segment with MEANING is not a validator; the
+    // dangerous values here are structural, not exotic. So this matches the real domain instead: an account
+    // tenant is a code-generated GUID (see TenantRegistry), and the two well-known words are handled
+    // separately below.
+    private static readonly Regex AccountTenantId = new(
+        "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        RegexOptions.Compiled);
 
     private readonly object _gate = new();
     private readonly string _directory;
@@ -82,10 +89,29 @@ public sealed class GatewayPromptLog
     {
         if (!tenant.IsValid)
             throw new ArgumentException("A prompt-log partition needs a valid tenant; an unresolved tenant is denied, never defaulted.", nameof(tenant));
-        if (!SafeTenantId.IsMatch(tenant.Value))
-            throw new ArgumentException($"Tenant '{tenant.ToLogString()}' is not a plain identifier and cannot name a prompt-log partition.", nameof(tenant));
+        // The local tenant is the root directory it has always used - self-host unchanged, nothing migrates.
+        if (tenant.IsLocal)
+            return _directory;
 
-        return tenant.IsLocal ? _directory : Path.Combine(_directory, "tenants", tenant.Value);
+        // Every other partition must be a minted account tenant. A value that is not one is REFUSED, never
+        // coerced: this folder holds prompt TEXT, and scrubbing a bad name is how two tenants quietly end up
+        // sharing a folder.
+        if (!AccountTenantId.IsMatch(tenant.Value))
+            throw new ArgumentException(
+                $"Tenant '{tenant.ToLogString()}' is not a minted account tenant and cannot name a prompt-log partition.",
+                nameof(tenant));
+
+        var combined = Path.Combine(_directory, "tenants", tenant.Value);
+
+        // Belt and braces, because the cost of being wrong here is one tenant reading another's prompts: the
+        // result must actually LIE INSIDE the partition root. The pattern above already excludes traversal,
+        // so this can only fire if that pattern is ever loosened - which is exactly when it is wanted.
+        var expectedRoot = Path.GetFullPath(Path.Combine(_directory, "tenants")) + Path.DirectorySeparatorChar;
+        if (!Path.GetFullPath(combined).StartsWith(expectedRoot, StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException(
+                $"Tenant '{tenant.ToLogString()}' resolves outside the prompt-log partition root.", nameof(tenant));
+
+        return combined;
     }
 
     /// <summary>The daily file a message at <paramref name="utcNow"/> lands in, for one tenant.</summary>

--- a/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
+++ b/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
@@ -61,6 +61,18 @@ public sealed class GatewayPromptLog
     public static string DefaultDirectory() => CcStorage.PromptLog();
 
     /// <summary>
+    /// Replace a tenant's raw account id with its hashed log form anywhere it appears in text bound for the
+    /// log - in practice a file path inside an exception message, since the partition directory IS the tenant
+    /// id. This is a single exact substitution of a value we hold, not a general-purpose scrub: it is
+    /// complete for the one way the id can get in here, and it keeps the failure LOUD rather than swallowing
+    /// the message to be safe.
+    /// </summary>
+    private static string Redact(string text, TenantId tenant)
+        => string.IsNullOrEmpty(text) || !tenant.IsValid
+            ? text
+            : text.Replace(tenant.Value, tenant.ToLogString(), StringComparison.Ordinal);
+
+    /// <summary>
     /// The directory one tenant's daily files live in. The local tenant keeps the root directory it has
     /// always used; every other tenant gets its own folder beneath it. A tenant id that is not a plain
     /// identifier is refused loudly rather than scrubbed - scrubbing is how two tenants quietly share a
@@ -106,7 +118,11 @@ public sealed class GatewayPromptLog
         }
         catch (Exception ex)
         {
-            FileLog.Write($"[GatewayPromptLog] Append FAILED (swallowed): {ex.Message}");
+            // The exception message from a file operation carries the FULL PATH, and on hosted that path
+            // contains the tenant's raw account id - so logging it verbatim would print account identifiers
+            // into a log that is otherwise free of them. Redacted, not dropped: the failure still says what
+            // went wrong and which partition, in the same hashed form every other tenant-bearing log uses.
+            FileLog.Write($"[GatewayPromptLog] Append FAILED (swallowed) for tenant={tenant.ToLogString()}: {Redact(ex.Message, tenant)}");
         }
         return written;
     }
@@ -129,7 +145,9 @@ public sealed class GatewayPromptLog
             }
             catch (Exception ex)
             {
-                FileLog.Write($"[GatewayPromptLog] Read FAILED for {path}: {ex.Message}");
+                // Same reason as Append: the path itself names the tenant on hosted. The daily FILE name is
+                // safe and is what actually identifies which read failed.
+                FileLog.Write($"[GatewayPromptLog] Read FAILED for tenant={tenant.ToLogString()} file={Path.GetFileName(path)}: {Redact(ex.Message, tenant)}");
                 continue;
             }
             foreach (var line in lines)

--- a/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
+++ b/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
@@ -44,16 +43,29 @@ public sealed class GatewayPromptLog
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
-    // A tenant id becomes a DIRECTORY NAME, so it must be one of the shapes this system actually mints -
-    // not merely "characters that look harmless". The earlier rule here was ^[A-Za-z0-9._-]{1,64}$, which
-    // accepts ".." - and Path.Combine(root, "tenants", "..") canonicalizes to exactly root, the LOCAL
-    // partition. A character allow-list that permits a path segment with MEANING is not a validator; the
-    // dangerous values here are structural, not exotic. So this matches the real domain instead: an account
-    // tenant is a code-generated GUID (see TenantRegistry), and the two well-known words are handled
-    // separately below.
-    private static readonly Regex AccountTenantId = new(
-        "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-        RegexOptions.Compiled);
+    /// <summary>
+    /// True only for the EXACT form <see cref="Tenancy.TenantRegistry"/> mints: a canonical lowercase GUID.
+    ///
+    /// A tenant id becomes a DIRECTORY NAME, so it must be a shape this system actually produces - not merely
+    /// "characters that look harmless". Two structural aliases have already been found here, and both were
+    /// the same class of defect:
+    ///
+    ///  - The first rule was <c>^[A-Za-z0-9._-]{1,64}$</c>, which accepts <c>".."</c> - and combining the root
+    ///    with <c>tenants</c> and <c>".."</c> canonicalizes to exactly the root, the LOCAL partition.
+    ///  - The second accepted <c>A-F</c> as well as <c>a-f</c>. The registry mints canonical LOWERCASE guids
+    ///    and the tenants table uses a CASE-SENSITIVE collation, so two ids differing only in case are
+    ///    DIFFERENT IDENTITIES to the database - while Windows and Azure Files name the SAME directory for
+    ///    both. That is one tenant reading another's prompt text through a casing alias.
+    ///
+    /// The lesson both times: at a path boundary the dangerous values are built from harmless characters, and
+    /// a collision does not need a special character - it needs two accepted spellings of one path. So this
+    /// accepts ONE spelling: parse strictly, then require the value to equal its own canonical round-trip.
+    /// Anything else is refused rather than normalised, because normalising is how two identities quietly
+    /// share a folder.
+    /// </summary>
+    private static bool IsMintedAccountTenant(string value)
+        => Guid.TryParseExact(value, "D", out var parsed)
+           && string.Equals(value, parsed.ToString("D"), StringComparison.Ordinal);
 
     private readonly object _gate = new();
     private readonly string _directory;
@@ -93,10 +105,11 @@ public sealed class GatewayPromptLog
         if (tenant.IsLocal)
             return _directory;
 
-        // Every other partition must be a minted account tenant. A value that is not one is REFUSED, never
-        // coerced: this folder holds prompt TEXT, and scrubbing a bad name is how two tenants quietly end up
-        // sharing a folder.
-        if (!AccountTenantId.IsMatch(tenant.Value))
+        // Every other partition must be a minted account tenant - including the reserved SYSTEM tenant, which
+        // is deliberately REFUSED here rather than given a folder: no prompt text belongs to it, so the safe
+        // answer is that it has no partition at all. A value that is not a minted account is refused, never
+        // coerced: this folder holds prompt TEXT, and scrubbing a bad name is how two tenants share a folder.
+        if (!IsMintedAccountTenant(tenant.Value))
             throw new ArgumentException(
                 $"Tenant '{tenant.ToLogString()}' is not a minted account tenant and cannot name a prompt-log partition.",
                 nameof(tenant));

--- a/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
+++ b/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -23,6 +25,13 @@ namespace CcDirector.Gateway.Prompts;
 ///
 /// One JSON line per message in a daily file: base/prompt-log/conversation-yyyyMMdd.jsonl.
 ///
+/// PARTITIONED BY TENANT (issue #1848). Prompt text is customer content, so on the hosted Gateway one
+/// account's messages must never be readable by another. The partition is the DIRECTORY, not a predicate on
+/// the read: a tenant's history lives in its own folder, so a read physically cannot open another tenant's
+/// file. <see cref="TenantId.Local"/> keeps today's path exactly (self-host is unchanged and nothing
+/// migrates); a hosted account tenant lands under tenants/&lt;id&gt;/. The tenant is always supplied by the
+/// caller, which resolved it from the authenticated device key at the boundary - this type never guesses one.
+///
 /// Retention is unbounded. The point is looking back across weeks and months, and the text is small.
 /// (Contrast TurnReviewLog, which holds terminal SCREENS and expires at 7 days.) Nothing prunes this.
 ///
@@ -34,6 +43,10 @@ public sealed class GatewayPromptLog
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
+
+    // A tenant id becomes a directory name, so it must be a plain identifier. Real ids are the well-known
+    // "local"/"system" words or an account GUID; anything else is refused rather than scrubbed.
+    private static readonly Regex SafeTenantId = new("^[A-Za-z0-9._-]{1,64}$", RegexOptions.Compiled);
 
     private readonly object _gate = new();
     private readonly string _directory;
@@ -47,16 +60,33 @@ public sealed class GatewayPromptLog
     /// <summary>The Gateway's prompt-log directory.</summary>
     public static string DefaultDirectory() => CcStorage.PromptLog();
 
-    /// <summary>The daily file a message at <paramref name="utcNow"/> lands in.</summary>
-    public string FileFor(DateTime utcNow)
-        => Path.Combine(_directory, $"conversation-{utcNow:yyyyMMdd}.jsonl");
+    /// <summary>
+    /// The directory one tenant's daily files live in. The local tenant keeps the root directory it has
+    /// always used; every other tenant gets its own folder beneath it. A tenant id that is not a plain
+    /// identifier is refused loudly rather than scrubbed - scrubbing is how two tenants quietly share a
+    /// folder, and this folder holds prompt TEXT.
+    /// </summary>
+    public string DirectoryFor(TenantId tenant)
+    {
+        if (!tenant.IsValid)
+            throw new ArgumentException("A prompt-log partition needs a valid tenant; an unresolved tenant is denied, never defaulted.", nameof(tenant));
+        if (!SafeTenantId.IsMatch(tenant.Value))
+            throw new ArgumentException($"Tenant '{tenant.ToLogString()}' is not a plain identifier and cannot name a prompt-log partition.", nameof(tenant));
+
+        return tenant.IsLocal ? _directory : Path.Combine(_directory, "tenants", tenant.Value);
+    }
+
+    /// <summary>The daily file a message at <paramref name="utcNow"/> lands in, for one tenant.</summary>
+    public string FileFor(TenantId tenant, DateTime utcNow)
+        => Path.Combine(DirectoryFor(tenant), $"conversation-{utcNow:yyyyMMdd}.jsonl");
 
     /// <summary>
-    /// Append messages pushed by a Director. Returns how many were written. Never throws: a logging
-    /// failure must not fail the Director's push.
+    /// Append messages pushed by a Director, into that Director's tenant partition. Returns how many were
+    /// written. Never throws: a logging failure must not fail the Director's push.
     /// </summary>
-    public int Append(IEnumerable<PromptRecord> records)
+    public int Append(TenantId tenant, IEnumerable<PromptRecord> records)
     {
+        var directory = DirectoryFor(tenant);
         var written = 0;
         try
         {
@@ -65,10 +95,10 @@ public sealed class GatewayPromptLog
             foreach (var day in records.GroupBy(r => r.TsUtc.Date))
             {
                 var lines = day.Select(r => JsonSerializer.Serialize(r, JsonOpts)).ToList();
-                var path = FileFor(day.Key);
+                var path = FileFor(tenant, day.Key);
                 lock (_gate)
                 {
-                    Directory.CreateDirectory(_directory);
+                    Directory.CreateDirectory(directory);
                     File.AppendAllLines(path, lines);
                 }
                 written += lines.Count;
@@ -82,15 +112,15 @@ public sealed class GatewayPromptLog
     }
 
     /// <summary>
-    /// Read every message in the inclusive UTC day range, oldest first. Skips unparseable lines rather
-    /// than failing the whole read, so one bad line cannot hide a month of work.
+    /// Read every message in the inclusive UTC day range for ONE tenant, oldest first. Skips unparseable
+    /// lines rather than failing the whole read, so one bad line cannot hide a month of work.
     /// </summary>
-    public IReadOnlyList<PromptRecord> Read(DateTime fromUtc, DateTime toUtc)
+    public IReadOnlyList<PromptRecord> Read(TenantId tenant, DateTime fromUtc, DateTime toUtc)
     {
         var results = new List<PromptRecord>();
         for (var day = fromUtc.Date; day <= toUtc.Date; day = day.AddDays(1))
         {
-            var path = FileFor(day);
+            var path = FileFor(tenant, day);
             if (!File.Exists(path)) continue;
             string[] lines;
             try

--- a/src/CcDirector.Gateway/Prompts/PromptEndpoints.cs
+++ b/src/CcDirector.Gateway/Prompts/PromptEndpoints.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using Microsoft.AspNetCore.Builder;
@@ -14,35 +15,62 @@ namespace CcDirector.Gateway.Prompts;
 ///
 /// GET /prompts  - anyone asking for history asks here. That is the point of the log living on the
 /// Gateway: it already has the whole fleet's record, so nothing has to go hunting across machines.
+///
+/// TENANT-SCOPED (issue #1848). "The whole fleet's record" means the REQUESTING ACCOUNT'S fleet. Both verbs
+/// resolve the request's tenant from the authenticated device key with the same seam the cockpit read path
+/// uses, and write into / read out of only that tenant's partition. Before this, neither handler took an
+/// <c>HttpContext</c> at all - so neither could resolve a tenant even in principle, and a hosted GET returned
+/// every account's full prompt TEXT. On hosted a request whose key has no bound tenant is DENIED (403); it is
+/// never served the Local partition. Self-host (no boundary) is always Local, exactly as before.
 /// </summary>
 public static class PromptEndpoints
 {
-    public static void Map(IEndpointRouteBuilder app, GatewayPromptLog log)
+    public static void Map(IEndpointRouteBuilder app, GatewayPromptLog log,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null)
     {
         var store = log ?? throw new ArgumentNullException(nameof(log));
 
-        app.MapPost("/prompts", (PromptIngestRequest? request) =>
+        app.MapPost("/prompts", (HttpContext ctx, PromptIngestRequest? request) =>
         {
+            var tenant = ResolveTenant(ctx, tenantBoundary);
+            if (tenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+
             if (request?.Records is null || request.Records.Count == 0)
                 return Results.BadRequest(new { error = "records is required and must not be empty" });
 
-            var written = store.Append(request.Records);
-            FileLog.Write($"[PromptEndpoints] POST /prompts: received {request.Records.Count}, wrote {written}");
+            var written = store.Append(tenant.Value, request.Records);
+            FileLog.Write($"[PromptEndpoints] POST /prompts: tenant={tenant.Value.ToLogString()}, received {request.Records.Count}, wrote {written}");
             return Results.Ok(new PromptIngestResponse { Written = written });
         });
 
-        app.MapGet("/prompts", (string? from, string? to) =>
+        app.MapGet("/prompts", (HttpContext ctx, string? from, string? to) =>
         {
+            var tenant = ResolveTenant(ctx, tenantBoundary);
+            if (tenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+
             // Default to today so a bare GET /prompts is useful rather than an error.
             var fromUtc = ParseDay(from) ?? DateTime.UtcNow.Date;
             var toUtc = ParseDay(to) ?? DateTime.UtcNow.Date;
             if (toUtc < fromUtc)
                 return Results.BadRequest(new { error = "'to' is earlier than 'from'" });
 
-            var records = store.Read(fromUtc, toUtc);
+            var records = store.Read(tenant.Value, fromUtc, toUtc);
             return Results.Ok(new { count = records.Count, records });
         });
     }
+
+    /// <summary>
+    /// Resolve the request's tenant from the AUTHENTICATED device key the auth middleware stashed - the same
+    /// seam the tenant-aware cockpit read path uses. Null means DENY: on hosted an authenticated request whose
+    /// key has no bound tenant is refused, never served the Local partition. Self-host, or no boundary (older
+    /// callers and tests), is always Local.
+    /// </summary>
+    private static TenantId? ResolveTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
+        => boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
 
     /// <summary>Parse a yyyy-MM-dd day, or null when absent/unparseable.</summary>
     private static DateTime? ParseDay(string? value)


### PR DESCRIPTION
Part of thefrederiksen/devthrottle#1848 - the **prompt log half**. The `/stats/data` half is deliberately not here; see the bottom.

## The defect

`GET /prompts` returned every account's full prompt TEXT on the hosted Gateway. This is the content-disclosure surface that gates a second human ever touching hosted.

The root cause was a **signature, not a missing predicate**: the handler did not take an `HttpContext`, so as written it could not resolve a request tenant even in principle.

## The fix

Thread the context in, resolve the tenant with the SAME seam the tenant-aware cockpit read path uses (`HostedTenantBoundary.ResolveRequestTenant`, from the authenticated device key the auth middleware stashed), and serve only that tenant. A request whose key has no bound tenant is DENIED 403 - on **both** verbs - never served the Local partition.

The partition is the **directory**, matching how voice clips are isolated: the tenant is in the path, handed out by ONE helper (`GatewayPromptLog.DirectoryFor`) that takes a `TenantId` and returns the folder. `FileFor` goes through it and both `Append` and `Read` go through `FileFor`, so no caller can name a path itself - that funnel is what makes the partition structural rather than conventional. A read physically cannot open another tenant's file.

The Local tenant keeps TODAY'S path exactly, so **self-host is unchanged and nothing migrates**: single-tenant stays the multi-tenant system with N = 1.

**The partition name is validated against the exact form this system actually mints**, not against "characters that look harmless". Review found **two** structural aliases here, in successive rounds, and both were the same class:

1. The first rule was a character allow-list, which accepts `..` - and combining the root with `tenants` and `..` canonicalizes to **exactly the root, the Local partition**. A tenant id of `..` would have read and written the local tenant's prompt text.
2. The second accepted uppercase hex. The registry mints **canonical lowercase** identifiers and the tenants table uses a **case-sensitive collation**, so two ids differing only in case are **different identities to the database** while Windows and Azure Files name the **same directory** for both.

The lesson both times: at a path boundary the dangerous values are built from harmless characters, and a collision does not need a special character - it needs **two accepted spellings of one path**. So exactly one spelling is accepted: parse strictly, then require the value to equal its own canonical round-trip. Anything else is refused rather than normalised, because normalising is how two identities quietly share a folder. A containment assertion sits behind it as a second line if that ever loosens.

The reserved **system** tenant is refused too, not handled: no prompt text belongs to it, so it gets no partition rather than a folder.

The WRITE side is partitioned in the same move, or the read would have nothing correct to read: `POST /prompts` writes into the posting Director's tenant.

### Two questions any directory-partitioned design has to answer

- **A machine that has never seen that tenant before.** The folder is created on demand and starts empty - an honest empty history, never another tenant's, never an error, never a fallback. Nothing to provision ahead of time.
- **Two processes reaching one tenant's log at once.** Ordinary append-only file writes under the existing process lock, unchanged from today's single-directory behaviour - the partition adds folders, not a new concurrency problem.

## Tests

Adds `PromptLogTenantIsolationTests`: two accounts over real HTTP, through the real auth middleware, with tenants **minted by the real registry** rather than invented strings - a test binding an id production cannot create would be testing a partition that cannot exist.

**The isolation proof is bidirectional.** The first version asserted only that B could not read A's text; an implementation leaking A's read while keeping B correctly scoped would have passed it unnoticed, and a leak conditional on tenant, key or enrollment order hides in exactly the direction not checked. Now: A contains A's text, B contains B's, A does **not** contain B's, B does **not** contain A's - each absence behind its own positive control - plus a count assertion on **both** sides, so neither read is merely a filtered view of a shared set.

**Two failure logs printed the raw account identifier.** The partition directory *is* the tenant id, so the read failure logged the full path and both catches logged exception messages carrying it. They now name the partition in the hashed form every other tenant-bearing line uses, with the identifier replaced rather than the message dropped, so the failure stays loud and diagnosable.

Both are proven **behaviourally**, through the real log writer's test seam against a real failing operation - an exclusive lock on the tenant's own daily file - not by unit-testing the redaction helper. Each has a positive control that the operation genuinely failed and genuinely logged, so "the identifier is absent" cannot pass because nothing happened.

Worth recording: the first attempt at the read proof made the daily file a **directory**, and passed while proving nothing - `Read` checks `File.Exists` first and skips a directory before attempting a read, so nothing was logged at all. Its positive control caught that.

And a comment previously claimed reverting **either** catch would redden the redaction test. Review reverted only the `Append` one and every test still passed - so that second leak could have regressed unnoticed. `Append` has its own test now. A comment claiming coverage is not coverage.

**Two canaries in the traversal test could not fail, and both are fixed.** The separator case was written with a C# escape that is a *backspace character*, not a backslash, so it tested a control character and would have passed however broken separator handling was - review caught that one. The casing case was then written against an identifier of **all digits**, so upper-casing it was a no-op and the "uppercase" case was really the valid lowercase id; the test caught that itself by reporting that id as accepted. Two dead canaries in one change, for two different reasons. Each now uses a value that actually has the property it tests, and the loop reports **which** id was accepted rather than a bare "no exception was thrown" - that message is what turned both into one-line diagnoses.

**Revert-proven on two production lines**, each reverted and watched go red, then restored:

| Production line | Reverted to | Result |
| --- | --- | --- |
| `PromptEndpoints.ResolveTenant` | fixed `TenantId.Local` | 2 tests RED (cross-tenant text found; the 403 deny collapses to 200) |
| `GatewayPromptLog.DirectoryFor` | root directory for every tenant | 1 test RED (both accounts share one folder) |

All seven test projects green, solution builds with 0 warnings.

## Why `/stats/data` is not in this pull request

Its store is one SQLite database holding several structured stores, kept on a mounted Azure file share. A per-tenant file there would fork every store inside it (including ones nobody has considered in a tenancy context), break the cross-tenant aggregation the business needs for spend and cost reconciliation, and multiply write-ahead-log sets on SMB without fixing the concurrency hazard. It is scoped separately as a tenant column, following the composite-primary-key precedent. Physical partition is strongest when the state is already files and weakest when it is a shared database engine - hence the split.

Out of scope and untouched: thefrederiksen/devthrottle#1847, thefrederiksen/devthrottle_internal#874, thefrederiksen/devthrottle_internal#875.

