### PR TITLE
fix(gateway): key the Director registry by (tenant, director id)

### DIFF
--- a/src/CcDirector.Gateway.Tests/DirectorEventsAndFactsTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorEventsAndFactsTests.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using CcDirector.ControlApi;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Sessions;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using Xunit;
 
@@ -119,7 +120,7 @@ public sealed class DirectorEventsAndFactsTests : IAsyncLifetime
 
         // In production the Director is registered via its tunnel Hello before it rings the doorbell; this
         // test drives only the GatewayClient doorbell leg, so register it the same way (tunnel-only Source).
-        _gateway.Registry.RegisterFromStream(id, Environment.MachineName, "test", "9.9.9-test", 1, DateTime.UtcNow);
+        _gateway.Registry.RegisterFromStream(id, Environment.MachineName, "test", "9.9.9-test", 1, DateTime.UtcNow, TenantId.Local);
 
         client.NotifySessionState(sid, "Starting", DoorbellEvents.SessionCreated);
 

--- a/src/CcDirector.Gateway.Tests/DirectorRegistryTenantKeyTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorRegistryTenantKeyTests.cs
@@ -23,9 +23,25 @@ namespace CcDirector.Gateway.Tests;
 /// no cure but hand-editing the box - see <see cref="A_director_id_may_move_to_another_tenant"/>, which is
 /// that case and must keep working.
 ///
-/// Revert-prove: make <c>DirectorKey</c> equality ignore its tenant (which is precisely the pre-fix registry,
-/// keyed by the bare director id) and <see cref="One_tenants_registration_cannot_overwrite_anothers"/> goes
-/// RED with the victim's machine name replaced by the impostor's, while the controls below stay green.
+/// Revert-prove - USE THIS ONE, and read the note under it before substituting your own. In
+/// <c>RegisterFromStream</c>, immediately after the key is built, drop any OTHER tenant's entry for the same
+/// director id before writing:
+/// <code>
+/// foreach (var other in _directors.Keys.Where(k => k.DirectorId == directorId &amp;&amp; !k.Tenant.Equals(tenant)).ToArray())
+///     _directors.TryRemove(other, out _);
+/// </code>
+/// That is the pre-fix registry's behaviour - the id alone was the key, so the last writer simply took the
+/// entry over. <see cref="One_tenants_registration_cannot_overwrite_anothers"/> then goes RED at the victim
+/// losing its own Director, AFTER both of its positive controls have passed, and the other three tests in this
+/// class stay GREEN.
+///
+/// NOT the revert to use: making <c>DirectorKey</c> equality ignore its tenant. It compiles, and it does go
+/// red, but it goes red FOR THE WRONG REASON and takes three of the four tests with it. ConcurrentDictionary's
+/// indexer replaces a VALUE and keeps the ORIGINAL KEY, so the impostor's write lands on an entry still keyed
+/// to the victim's tenant: the impostor's own list comes back EMPTY and the test dies at the impostor's
+/// positive control, before it ever reaches the takeover assertion. A revert that reddens a test before the
+/// assertion under proof is not evidence about that assertion. Two earlier attempts at this proof failed
+/// exactly this way and were discarded rather than written up.
 ///
 /// These drive the registry directly, with no HTTP and no tunnel, so nothing about the result depends on a
 /// test harness's own registration side effects. The wired end-to-end proof over the real tunnel and the real

--- a/src/CcDirector.Gateway.Tests/DirectorRegistryTenantKeyTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorRegistryTenantKeyTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.IO;
+using System.Linq;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Discovery;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1847, the WRITE half, at the registry itself.
+///
+/// The tunnel Hello's director id is chosen by the CLIENT, and the registry used to be keyed by that id
+/// alone. So one account, holding its own perfectly valid device key, could say Hello naming ANOTHER
+/// account's director id and overwrite that account's entry - machine name, operating system user, process
+/// id, client version - and, with the fix for the read half in place but not this one, take ownership of it
+/// as well, removing the victim's own Director from the victim's own list.
+///
+/// The fix is that the registry key is COMPOSITE, (tenantId, directorId). A registration can only ever reach
+/// the entry belonging to the tenant doing the registering; naming another tenant's entry is not refused, it
+/// is unsayable. That shape was chosen over rejecting the Hello because a machine re-enrolled from one
+/// account to another keeps its local director id, and a rejection would abort its every Hello forever with
+/// no cure but hand-editing the box - see <see cref="A_director_id_may_move_to_another_tenant"/>, which is
+/// that case and must keep working.
+///
+/// Revert-prove: make <c>DirectorKey</c> equality ignore its tenant (which is precisely the pre-fix registry,
+/// keyed by the bare director id) and <see cref="One_tenants_registration_cannot_overwrite_anothers"/> goes
+/// RED with the victim's machine name replaced by the impostor's, while the controls below stay green.
+///
+/// These drive the registry directly, with no HTTP and no tunnel, so nothing about the result depends on a
+/// test harness's own registration side effects. The wired end-to-end proof over the real tunnel and the real
+/// mapped endpoint is in <c>SessionServingReadIsolationTests</c>.
+/// </summary>
+public sealed class DirectorRegistryTenantKeyTests : IDisposable
+{
+    private static readonly TenantId Alice = new("tenant-alice");
+    private static readonly TenantId Bob = new("tenant-bob");
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-drk-" + Guid.NewGuid().ToString("N"));
+    private readonly DirectorRegistry _registry;
+
+    public DirectorRegistryTenantKeyTests()
+    {
+        Directory.CreateDirectory(_instancesDir);
+        // Constructed but never Start()ed: no file watcher, no sweeper, so the only state under test is what
+        // these registrations put there.
+        _registry = new DirectorRegistry(_instancesDir);
+    }
+
+    public void Dispose()
+    {
+        _registry.Dispose();
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public void One_tenants_registration_cannot_overwrite_anothers()
+    {
+        Register(Alice, "dir-shared", "ALICE-BOX");
+
+        // Positive control: Alice's entry exists and is truthful BEFORE the attack. Without this, "Alice is
+        // untouched" would also hold if Alice had never had an entry at all.
+        Assert.Equal("ALICE-BOX", Single(Alice, "dir-shared").MachineName);
+
+        // The attack: Bob, authenticated as himself, registers under Alice's director id.
+        Register(Bob, "dir-shared", "BOB-TAKEOVER");
+
+        // Positive control on the attack: Bob's registration really was accepted - under BOB's own tenant.
+        // This is what stops the assertions below passing merely because the write silently did nothing.
+        Assert.Equal("BOB-TAKEOVER", Single(Bob, "dir-shared").MachineName);
+
+        // The takeover: Alice's entry still carries Alice's facts.
+        Assert.Equal("ALICE-BOX", Single(Alice, "dir-shared").MachineName);
+
+        // The denial of service: Alice's Director is still in Alice's own list.
+        Assert.Contains("dir-shared", _registry.ListDirectors(Alice).Select(d => d.DirectorId));
+    }
+
+    [Fact]
+    public void A_director_id_may_move_to_another_tenant()
+    {
+        // The case that rules OUT rejecting a Hello whose id is already registered elsewhere: a machine
+        // re-enrolled from one account to another keeps its local director id. Its registration under the new
+        // account must be ACCEPTED, not aborted - a refusal here would brick that machine permanently.
+        Register(Alice, "dir-moved", "THE-BOX");
+        Register(Bob, "dir-moved", "THE-BOX");
+
+        Assert.Equal("THE-BOX", Single(Bob, "dir-moved").MachineName);
+    }
+
+    [Fact]
+    public void A_tenant_still_updates_its_own_entry()
+    {
+        // Control against over-correction: the composite key must not make every re-registration a no-op.
+        // A Director re-saying Hello - reconnect, version upgrade, new process id - still refreshes ITS OWN
+        // entry in place, and does not accumulate duplicates.
+        Register(Alice, "dir-own", "BOX-V1", version: "1.0.0");
+        Register(Alice, "dir-own", "BOX-V2", version: "2.0.0");
+
+        var mine = Single(Alice, "dir-own");
+        Assert.Equal("BOX-V2", mine.MachineName);
+        Assert.Equal("2.0.0", mine.Version);
+    }
+
+    [Fact]
+    public void The_serving_list_partitions_while_the_internal_view_stays_fleet_global()
+    {
+        Register(Alice, "dir-a", "ALICE-BOX");
+        Register(Bob, "dir-b", "BOB-BOX");
+
+        // What a client is served: its own tenant's Directors, and nothing else.
+        Assert.Equal(new[] { "dir-a" }, _registry.ListDirectors(Alice).Select(d => d.DirectorId).ToArray());
+        Assert.Equal(new[] { "dir-b" }, _registry.ListDirectors(Bob).Select(d => d.DirectorId).ToArray());
+
+        // Control: the no-tenant overload is the internal aggregation view and DOES see both. Without this,
+        // a registry that had simply lost Bob's entry would satisfy the two assertions above.
+        var everything = _registry.ListDirectors().Select(d => d.DirectorId).ToArray();
+        Assert.Contains("dir-a", everything);
+        Assert.Contains("dir-b", everything);
+
+        // Deny by default on the by-id lookup too: Alice's tenant cannot fetch Bob's Director by naming it.
+        Assert.NotNull(_registry.Get(Alice, "dir-a"));
+        Assert.Null(_registry.Get(Alice, "dir-b"));
+        Assert.NotNull(_registry.Get(Bob, "dir-b"));
+        Assert.Null(_registry.Get(Bob, "dir-a"));
+    }
+
+    private void Register(TenantId tenant, string directorId, string machineName, string version = "test") =>
+        _registry.RegisterFromStream(directorId, machineName, "u", version, 1, DateTime.UtcNow, tenant);
+
+    private Gateway.Contracts.DirectorDto Single(TenantId tenant, string directorId) =>
+        Assert.Single(_registry.ListDirectors(tenant), d => d.DirectorId == directorId);
+}

--- a/src/CcDirector.Gateway.Tests/SessionServingReadIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionServingReadIsolationTests.cs
@@ -132,6 +132,74 @@ public sealed class SessionServingReadIsolationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Directors_list_serves_only_the_requesting_tenants_directors()
+    {
+        // Issue #1847: the ENUMERATION surface. GET /directors was fleet-global while the by-id legs were
+        // gated, so any authenticated account read back every other account's Director - id, machine name,
+        // operating system user, process id, client version, liveness - and, holding the id, could address it.
+        //
+        // Revert-prove: change the handler back to registry.ListDirectors() (the fleet-global overload) and
+        // A sees dir-b -> the DoesNotContain assertions go RED.
+        var seenByA = await DirectorIds(_keyA);
+        var seenByB = await DirectorIds(_keyB);
+
+        Assert.Contains("dir-a", seenByA);
+        Assert.DoesNotContain("dir-b", seenByA);
+
+        Assert.Contains("dir-b", seenByB);
+        Assert.DoesNotContain("dir-a", seenByB);
+
+        // Not merely the ids: none of the other tenant's host or identity facts may appear in the body either.
+        var bodyForA = await (await Get("directors", _keyA)).Content.ReadAsStringAsync();
+        Assert.DoesNotContain("dir-b", bodyForA);
+        Assert.DoesNotContain("\"MB\"", bodyForA);
+    }
+
+    [Fact]
+    public async Task Directors_list_denies_a_device_key_with_no_bound_tenant()
+    {
+        // Deny-by-default: an authenticated but tenant-unbound key is refused outright. It must never be
+        // served the Local partition, and never the fleet-global list.
+        Assert.Equal(HttpStatusCode.Forbidden, (await Get("directors", _keyUnbound)).StatusCode);
+    }
+
+    [Fact]
+    public async Task A_tenants_hello_cannot_overwrite_another_tenants_director_of_the_same_id()
+    {
+        // Issue #1847, the WRITE half - the worst of it. The tunnel Hello's director id is chosen by the
+        // CLIENT, and the registry used to be keyed by that id alone, so tenant B - holding its own perfectly
+        // valid device key - could say Hello naming tenant A's director id and overwrite A's entry with B's
+        // machine name, operating system user, process id and client version. Keying the registry by
+        // (tenant, id) makes that structurally impossible: B's Hello can only ever reach B's own partition.
+        //
+        // Revert-prove: change DirectorKey back to a bare director id (or drop the tenant from the key used by
+        // RegisterFromStream) and B's Hello lands on A's entry -> the "A still reads MA" assertion goes RED.
+
+        // Positive control BEFORE the attack: A really does have dir-a, and it really does say MA. Without
+        // this, an assertion that A's entry is untouched would also pass if A had no entry at all.
+        Assert.Equal("MA", (await DirectorFor(_keyA, "dir-a")).MachineName);
+
+        // The attack: tenant B, authenticated as itself, claims tenant A's director id.
+        await using var impostor = await FakeTunnelDirector.StartAsync(_gateway, _keyB, "dir-a", "MB-TAKEOVER");
+
+        // Positive control ON THE ATTACK: the impostor's Hello really was accepted and really did register -
+        // under B's OWN tenant. This is what stops the test passing merely because the impostor silently
+        // failed to connect, which would make every "A is untouched" assertion vacuous.
+        await WaitUntil(async () => (await DirectorFor(_keyB, "dir-a")).MachineName == "MB-TAKEOVER");
+
+        // The takeover: A's entry still carries A's own facts, not B's.
+        var aAfter = await DirectorFor(_keyA, "dir-a");
+        Assert.Equal("MA", aAfter.MachineName);
+
+        // The denial of service: A's Director has not been moved out of A's own list either.
+        Assert.Contains("dir-a", await DirectorIds(_keyA));
+
+        // And nothing of B's leaked into what A is served.
+        var bodyForA = await (await Get("directors", _keyA)).Content.ReadAsStringAsync();
+        Assert.DoesNotContain("MB-TAKEOVER", bodyForA);
+    }
+
+    [Fact]
     public async Task Session_by_id_is_isolated_across_tenants()
     {
         // B's own key reads B's session; A's key cannot see B's session at all.
@@ -188,6 +256,38 @@ public sealed class SessionServingReadIsolationTests : IAsyncLifetime
         resp.EnsureSuccessStatusCode();
         var sessions = await resp.Content.ReadFromJsonAsync<List<SessionDto>>(JsonOpts) ?? new();
         return sessions.Select(s => s.SessionId!).ToArray();
+    }
+
+    private async Task<string[]> DirectorIds(string deviceKey)
+    {
+        var resp = await Get("directors", deviceKey);
+        resp.EnsureSuccessStatusCode();
+        var directors = await resp.Content.ReadFromJsonAsync<List<DirectorDto>>(JsonOpts) ?? new();
+        return directors.Select(d => d.DirectorId!).ToArray();
+    }
+
+    private async Task<DirectorDto> DirectorFor(string deviceKey, string directorId)
+    {
+        var resp = await Get("directors", deviceKey);
+        resp.EnsureSuccessStatusCode();
+        var directors = await resp.Content.ReadFromJsonAsync<List<DirectorDto>>(JsonOpts) ?? new();
+        return Assert.Single(directors, d => d.DirectorId == directorId);
+    }
+
+    /// <summary>
+    /// Readiness barrier for a condition the Gateway reaches asynchronously. A timeout is a HARD FAILURE, never
+    /// a quiet pass - a barrier that gives up silently turns the assertion it guards into decoration.
+    /// </summary>
+    private static async Task WaitUntil(Func<Task<bool>> condition)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            try { if (await condition()) return; }
+            catch (Xunit.Sdk.XunitException) { /* not there yet */ }
+            await Task.Delay(50);
+        }
+        Assert.Fail("the condition was never reached before the deadline");
     }
 
     private static SessionDto Sample(string sid) => new()

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -519,9 +519,19 @@ internal static class GatewayEndpoints
             });
         });
 
-        app.MapGet("/directors", () =>
+        // Issue #1847: serve THIS request's tenant's Directors, resolved from its authenticated device key -
+        // the same seam the session read path uses. The list used to be fleet-global while the by-id legs
+        // were gated, which made it the ENUMERATION surface: any authenticated account could read back every
+        // other account's Director id, machine name, operating system user, process id, client version and
+        // liveness. A request with no bound tenant is DENIED (403), never served the Local partition.
+        app.MapGet("/directors", (HttpContext ctx) =>
         {
-            return Results.Json(registry.ListDirectors());
+            var reqTenant = ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+
+            return Results.Json(registry.ListDirectors(reqTenant.Value));
         });
 
         // ===== HTTP discovery (Phase 1) =====
@@ -3003,7 +3013,11 @@ internal static class GatewayEndpoints
             if (located is not null)
             {
                 var (directorId, pushedSession) = located.Value;
-                var owner = registry.Get(directorId);
+                // Issue #1847: resolve the owning Director IN THE SAME TENANT the session was located under.
+                // The pushed store is already tenant-scoped, but the registry lookup used to be by bare id, so
+                // once the registry could hold that id for more than one tenant, this line could stamp ANOTHER
+                // tenant's machine name, operating system user and version onto the session being served here.
+                var owner = registry.Get(tenant, directorId);
                 if (owner is not null)
                 {
                     FileLog.Write($"[GatewayEndpoints] LocateSessionAsync: sid={sid} located=pushed-cache, director={directorId}");

--- a/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -19,9 +20,14 @@ namespace CcDirector.Gateway.Discovery;
 ///      <see cref="Upsert"/> on startup, calls <see cref="Heartbeat"/> every 15 s, and
 ///      DELETEs via <see cref="Remove"/> on graceful shutdown.
 ///
-/// De-duplication: keys are <c>directorId</c>. If both paths report the same id,
-/// the HTTP entry wins because it carries <see cref="DirectorDto.TailnetEndpoint"/>
+/// De-duplication: keys are <c>(tenantId, directorId)</c> - see <see cref="DirectorKey"/> for why the
+/// tenant is part of the key and not merely recorded beside the entry. If both paths report the same id
+/// within one tenant, the HTTP entry wins because it carries <see cref="DirectorDto.TailnetEndpoint"/>
 /// which the FSW path cannot provide.
+///
+/// A client request is served <see cref="ListDirectors(TenantId)"/> or <see cref="Get(TenantId, string)"/>,
+/// which answer from one tenant's partition only. The no-tenant <see cref="ListDirectors()"/> and
+/// <see cref="Get(string)"/> overloads are fleet-global internal views and are NOT an answer to a client.
 /// </summary>
 public sealed class DirectorRegistry : IDisposable
 {
@@ -47,7 +53,62 @@ public sealed class DirectorRegistry : IDisposable
     // cooldown, unreachable-evict) and the advertised-endpoint re-verification state machine are DELETED.
     // Liveness is the tunnel connection itself now, not an HTTP probe, so there is nothing to circuit-break.
 
-    private readonly ConcurrentDictionary<string, DirectorDto> _directors = new();
+    /// <summary>
+    /// Issue #1847: the registry key. It is COMPOSITE - the owning tenant AND the director id - so a write
+    /// naming a director id can only ever reach the entry belonging to the tenant doing the writing.
+    ///
+    /// This is the whole fix for the cross-tenant WRITE. The tunnel Hello's director id is chosen by the
+    /// client, and the entry used to be keyed by that id alone, so tenant A saying Hello with tenant B's
+    /// director id (enumerated from the then-fleet-global <c>GET /directors</c>) overwrote B's machine name,
+    /// operating system user, process id and client version. Keying by (tenant, id) makes naming another
+    /// tenant's entry STRUCTURALLY IMPOSSIBLE rather than merely refused, so there is no id-ownership
+    /// judgement to make and - the reason this shape was chosen over rejecting the Hello - no lockout: a
+    /// machine re-enrolled from one account to another keeps its local director id and simply registers a
+    /// fresh entry under its new tenant, instead of having every Hello aborted forever.
+    ///
+    /// It matches the composite tenant primary keys this codebase already adopted for workflows, workflow
+    /// versions and mission notes.
+    /// </summary>
+    private readonly record struct DirectorKey(TenantId Tenant, string DirectorId);
+
+    private readonly ConcurrentDictionary<DirectorKey, DirectorDto> _directors = new();
+
+    /// <summary>
+    /// LEGACY bare-director-id resolution, for the accessors that still take an id with NO tenant beside it.
+    /// It answers with the freshest matching entry - the one seen most recently - which reproduces what the
+    /// single-keyed registry used to hold, because there the last writer for an id simply replaced every
+    /// earlier one. On a single tenant (every self-host install, and any hosted id held by one account) there
+    /// is only ever one match and this is an ordinary lookup.
+    ///
+    /// It deliberately does NOT fail closed on a collision. Failing closed looked safer and is not: the
+    /// credential-less POST /directors/register path can create a Local-tenant entry for ANY id, so a
+    /// refusal-on-collision would let an unauthenticated caller disable every by-id route for a chosen
+    /// Director - trading the cross-tenant write this issue closes for a cross-tenant denial of service.
+    ///
+    /// The remaining callers are the /directors/{id}/... routes, which resolve a Director from a
+    /// client-supplied id with no tenant at all. Those are ALREADY addressable by any caller today and are the
+    /// same defect as this issue in a different hat; they are booked as their own work, and each is converted
+    /// to <see cref="Get(TenantId, string)"/> as its route learns whose Director it means. Nothing on the
+    /// tenant-aware session-serving path uses this.
+    /// </summary>
+    private bool TryResolveLegacyKey(string directorId, out DirectorKey key)
+    {
+        key = default;
+        if (string.IsNullOrEmpty(directorId)) return false;
+
+        var best = DateTime.MinValue;
+        var found = false;
+        foreach (var kv in _directors)
+        {
+            if (!string.Equals(kv.Key.DirectorId, directorId, StringComparison.Ordinal)) continue;
+            var seen = kv.Value.LastSeen ?? DateTime.MinValue;
+            if (found && seen <= best) continue;
+            best = seen;
+            key = kv.Key;
+            found = true;
+        }
+        return found;
+    }
 
     /// <summary>
     /// Directors that have answered at least one fleet probe (issue #197). Deliberately
@@ -58,7 +119,10 @@ public sealed class DirectorRegistry : IDisposable
     /// graceful unregister and when the heartbeat-stale sweep removes a dead process -
     /// a future process under the same id starts with a truthful blank slate.
     /// </summary>
+    /// Keyed by BARE director id, not by the composite key: it records what a Director PROCESS has ever
+    /// done, it is never served to a client, and keeping it bare leaves its lifecycle exactly as it was.
     private readonly ConcurrentDictionary<string, bool> _everReachable = new();
+
     private FileSystemWatcher? _watcher;
     private Timer? _sweeper;
     private bool _disposed;
@@ -103,6 +167,16 @@ public sealed class DirectorRegistry : IDisposable
         }
     }
 
+    /// <summary>
+    /// THE single removal seam. Every path that drops a Director - graceful unregister, the stale sweep, the
+    /// instance-file delete/rename - goes through here, so there is ONE place that knows how an entry leaves
+    /// the registry. Returns true when an entry was actually present. It deliberately does NOT touch
+    /// <c>_everReachable</c>: that flag's clear-on-graceful-goodbye lifecycle is the callers' (see the note on
+    /// the field) and centralising it here would silently change it.
+    /// </summary>
+    private bool TryRemoveEntry(DirectorKey key, out DirectorDto? removed)
+        => _directors.TryRemove(key, out removed);
+
     // ===== HTTP path =====
 
     /// <summary>
@@ -134,8 +208,12 @@ public sealed class DirectorRegistry : IDisposable
             Source = "http",
         };
 
-        var existed = _directors.TryGetValue(req.DirectorId, out _);
-        _directors[req.DirectorId] = dto;
+        // The HTTP register path is the same-machine / self-host path; it carries no account credential, so
+        // its entries belong to the single Local tenant. On hosted, where a request's tenant is a real
+        // account, a Local-keyed entry is therefore served to no account - which is the correct answer.
+        var key = new DirectorKey(TenantId.Local, req.DirectorId);
+        var existed = _directors.TryGetValue(key, out _);
+        _directors[key] = dto;
         FileLog.Write(dto.EndpointUnreachableReason is null
             ? $"[DirectorRegistry] Upsert (http): id={dto.DirectorId}, endpoint={dto.TailnetEndpoint}, existed={existed}"
             : $"[DirectorRegistry] Upsert (http, FLAGGED no reachable endpoint): id={dto.DirectorId}, existed={existed}, reason={dto.EndpointUnreachableReason}");
@@ -150,17 +228,27 @@ public sealed class DirectorRegistry : IDisposable
     /// Director's presence. Stamped <c>Source="stream"</c> with an EMPTY control/tailnet endpoint - the Gateway
     /// never dials a Director, it only reaches it down this stream. Marks it state-reporting so the reconcile
     /// poll skips it. Idempotent; refreshes LastSeen on every Hello (connect + reconnect + periodic re-push).
+    ///
+    /// Issue #1847: <paramref name="tenant"/> is the tenant the Hello's AUTHENTICATED device key resolved to,
+    /// and it is REQUIRED - it is half of the registry key, so this call can only ever create or refresh THIS
+    /// tenant's own entry and is structurally incapable of naming another tenant's, however the client chose
+    /// its director id. It is never read from the Hello payload, and there is no default: an unresolved tenant
+    /// is a rejected Hello at the hub, not a registration under a guessed owner.
     /// </summary>
-    public DirectorDto RegisterFromStream(string directorId, string machineName, string user, string version, int pid, DateTime startedAt)
+    public DirectorDto RegisterFromStream(string directorId, string machineName, string user, string version, int pid, DateTime startedAt, TenantId tenant)
     {
         if (string.IsNullOrEmpty(directorId))
             throw new ArgumentException("directorId is required", nameof(directorId));
+        if (!tenant.IsValid)
+            throw new ArgumentException("a valid tenant is required to register a Director", nameof(tenant));
 
         var now = DateTime.UtcNow;
-        // Merge with any existing entry: a Hello field that arrives empty must not wipe a value the entry
-        // already carries (e.g. a file-discovered entry's machine name). Production Hellos always carry the
-        // full identity; this just makes re-registration and mixed-source ordering safe.
-        _directors.TryGetValue(directorId, out var existing);
+        var key = new DirectorKey(tenant, directorId);
+        // Merge with any existing entry - THIS TENANT'S entry for this id, never another's. A Hello field that
+        // arrives empty must not wipe a value the entry already carries (e.g. a file-discovered entry's machine
+        // name). Production Hellos always carry the full identity; this just makes re-registration and
+        // mixed-source ordering safe.
+        _directors.TryGetValue(key, out var existing);
         var dto = new DirectorDto
         {
             DirectorId = directorId,
@@ -176,7 +264,7 @@ public sealed class DirectorRegistry : IDisposable
             Source = "stream",
         };
         var existed = existing is not null;
-        _directors[directorId] = dto;
+        _directors[key] = dto;
         _stateReporting.TryAdd(directorId, true);
         if (!existed)
         {
@@ -192,8 +280,8 @@ public sealed class DirectorRegistry : IDisposable
     /// </summary>
     public bool Heartbeat(string directorId)
     {
-        if (string.IsNullOrEmpty(directorId)) return false;
-        if (!_directors.TryGetValue(directorId, out var existing)) return false;
+        if (!TryResolveLegacyKey(directorId, out var key)) return false;
+        if (!_directors.TryGetValue(key, out var existing)) return false;
         existing.LastSeen = DateTime.UtcNow;
         return true;
     }
@@ -216,7 +304,10 @@ public sealed class DirectorRegistry : IDisposable
     public bool IsStateReporting(string directorId)
         => !string.IsNullOrEmpty(directorId) && _stateReporting.ContainsKey(directorId);
 
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, bool> _stateReporting = new();
+    /// Keyed by BARE director id, like _everReachable: it is a capability flag about a Director PROCESS (does
+    /// it push its own session state, so the reconcile poll can skip it), it is never served to a client, and
+    /// no session content or identity rides on it. Keeping it bare leaves its behaviour untouched.
+    private readonly ConcurrentDictionary<string, bool> _stateReporting = new();
 
     /// <summary>
     /// Remove a Director from the registry (HTTP graceful shutdown). Returns true if
@@ -224,8 +315,8 @@ public sealed class DirectorRegistry : IDisposable
     /// </summary>
     public bool Remove(string directorId)
     {
-        if (string.IsNullOrEmpty(directorId)) return false;
-        if (_directors.TryRemove(directorId, out _))
+        if (!TryResolveLegacyKey(directorId, out var key)) return false;
+        if (TryRemoveEntry(key, out _))
         {
             _everReachable.TryRemove(directorId, out _); // graceful goodbye: next process starts blank
             FileLog.Write($"[DirectorRegistry] Remove (http): id={directorId}");
@@ -261,13 +352,51 @@ public sealed class DirectorRegistry : IDisposable
         _sweeper = new Timer(_ => SweepStale(), null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
     }
 
-    /// <summary>Snapshot of all currently-known Directors.</summary>
+    /// <summary>
+    /// Snapshot of all currently-known Directors, FLEET-GLOBAL - every tenant's. This is the internal
+    /// aggregation view (the roster fan-out, the reconcile poll); it must NEVER be the answer to a client
+    /// request. Serving a client is <see cref="ListDirectors(TenantId)"/>.
+    /// </summary>
     public IReadOnlyCollection<DirectorDto> ListDirectors()
         => _directors.Values.ToList().AsReadOnly();
 
-    /// <summary>Look up by Director ID. Null if unknown.</summary>
+    /// <summary>
+    /// Issue #1847: the Directors ONE tenant owns - what a client request is served. Before this, the
+    /// <c>GET /directors</c> list was fleet-global while the by-id legs were gated, so any authenticated
+    /// account could enumerate every other account's Directors and read back their machine name, operating
+    /// system user, process id, client version and liveness - and, having the id, address them.
+    ///
+    /// Deny by default: an entry whose owning tenant was never recorded matches nobody. There is no
+    /// fall-back to the fleet-global list for any caller, tenant, or deployment.
+    /// </summary>
+    public IReadOnlyCollection<DirectorDto> ListDirectors(TenantId tenant)
+        => _directors
+            .Where(kv => kv.Key.Tenant.Equals(tenant))
+            .Select(kv => kv.Value)
+            .ToList()
+            .AsReadOnly();
+
+    /// <summary>
+    /// Look up ONE tenant's Director by id. Null if that tenant has no such Director. This is the honest
+    /// lookup: the caller says whose Director it means, so no other tenant's entry can answer.
+    /// </summary>
+    public DirectorDto? Get(TenantId tenant, string directorId)
+        => !string.IsNullOrEmpty(directorId) && _directors.TryGetValue(new DirectorKey(tenant, directorId), out var d)
+            ? d
+            : null;
+
+    /// <summary>
+    /// LEGACY look-up by bare Director ID, with no tenant. Null if unknown; on the (hosted-only) chance that
+    /// two tenants hold the same id it answers with the freshest entry - see <see cref="TryResolveLegacyKey"/>
+    /// for why that, and not a refusal, is the safe choice.
+    ///
+    /// Every remaining caller of this overload is a route that resolves a Director from a client-supplied id
+    /// WITHOUT a tenant beside it. Those are the same defect as #1847 in a different hat and are recorded as
+    /// their own work; this overload exists so they keep behaving exactly as they do today while they are
+    /// converted to <see cref="Get(TenantId, string)"/> one at a time.
+    /// </summary>
     public DirectorDto? Get(string directorId)
-        => _directors.TryGetValue(directorId, out var d) ? d : null;
+        => TryResolveLegacyKey(directorId, out var key) && _directors.TryGetValue(key, out var d) ? d : null;
 
     private void LoadExisting()
     {
@@ -304,9 +433,12 @@ public sealed class DirectorRegistry : IDisposable
         if (string.IsNullOrEmpty(id)) return;
         // Only remove if the entry came from the FSW path. An HTTP entry must not be
         // wiped by a stray file delete - it lives by its own heartbeat lifecycle.
-        if (_directors.TryGetValue(id, out var existing) && existing.Source == "file")
+        // A file-discovered entry is always keyed to the Local tenant (see TryParseAndAdd), so a file event
+        // can only ever reach the Local partition - it can never disturb a hosted account's Director.
+        var key = new DirectorKey(TenantId.Local, id);
+        if (_directors.TryGetValue(key, out var existing) && existing.Source == "file")
         {
-            if (_directors.TryRemove(id, out _))
+            if (TryRemoveEntry(key, out _))
                 RaiseDirectorRemoved(id);
         }
     }
@@ -314,10 +446,11 @@ public sealed class DirectorRegistry : IDisposable
     private void OnFileRenamed(object sender, RenamedEventArgs e)
     {
         var oldId = Path.GetFileNameWithoutExtension(e.OldName ?? "");
+        var oldKey = new DirectorKey(TenantId.Local, oldId);
         if (!string.IsNullOrEmpty(oldId)
-            && _directors.TryGetValue(oldId, out var existing)
+            && _directors.TryGetValue(oldKey, out var existing)
             && existing.Source == "file"
-            && _directors.TryRemove(oldId, out _))
+            && TryRemoveEntry(oldKey, out _))
         {
             RaiseDirectorRemoved(oldId);
         }
@@ -338,9 +471,14 @@ public sealed class DirectorRegistry : IDisposable
             });
             if (dto is null || string.IsNullOrEmpty(dto.DirectorId)) return false;
 
+            // A file-discovered Director is by definition on THIS machine and carries no account credential,
+            // so it is keyed to the Local tenant (see the note on Upsert) - a file appearing on the Gateway's
+            // disk can therefore never write into a hosted account's partition.
+            var key = new DirectorKey(TenantId.Local, dto.DirectorId);
+
             // If an HTTP-registered entry exists for the same id, leave it alone.
             // HTTP carries the tailnet endpoint which FSW cannot supply.
-            if (_directors.TryGetValue(dto.DirectorId, out var existing) && existing.Source == "http")
+            if (_directors.TryGetValue(key, out var existing) && existing.Source == "http")
             {
                 FileLog.Write($"[DirectorRegistry] Skipping FSW upsert for id={dto.DirectorId}: HTTP entry already present");
                 return true;
@@ -348,8 +486,8 @@ public sealed class DirectorRegistry : IDisposable
 
             dto.LastSeen = DateTime.UtcNow;
             dto.Source = "file";
-            var wasNew = !_directors.ContainsKey(dto.DirectorId);
-            _directors[dto.DirectorId] = dto;
+            var wasNew = !_directors.ContainsKey(key);
+            _directors[key] = dto;
             if (wasNew) OnDirectorAdded?.Invoke(dto);
             FileLog.Write($"[DirectorRegistry] Added (file): id={dto.DirectorId}, endpoint={dto.ControlEndpoint}");
             return true;
@@ -382,24 +520,24 @@ public sealed class DirectorRegistry : IDisposable
                     var lastSeen = kv.Value.LastSeen ?? DateTime.MinValue;
                     if (now - lastSeen > HttpHeartbeatTimeout)
                     {
-                        if (_directors.TryRemove(kv.Key, out _))
+                        if (TryRemoveEntry(kv.Key, out _))
                         {
-                            _everReachable.TryRemove(kv.Key, out _);
-                            FileLog.Write($"[DirectorRegistry] Sweeper removed stale {kv.Value.Source} entry: {kv.Key} (last seen {(now - lastSeen).TotalSeconds:F0}s ago)");
-                            RaiseDirectorRemoved(kv.Key);
+                            _everReachable.TryRemove(kv.Key.DirectorId, out _);
+                            FileLog.Write($"[DirectorRegistry] Sweeper removed stale {kv.Value.Source} entry: {kv.Key.DirectorId} (last seen {(now - lastSeen).TotalSeconds:F0}s ago)");
+                            RaiseDirectorRemoved(kv.Key.DirectorId);
                         }
                     }
                     continue;
                 }
 
                 // FSW path: file gone or PID dead.
-                var f = Path.Combine(WatchDirectory, $"{kv.Key}.json");
+                var f = Path.Combine(WatchDirectory, $"{kv.Key.DirectorId}.json");
                 if (!File.Exists(f))
                 {
-                    if (_directors.TryRemove(kv.Key, out _))
+                    if (TryRemoveEntry(kv.Key, out _))
                     {
-                        FileLog.Write($"[DirectorRegistry] Sweeper removed orphan (file gone): {kv.Key}");
-                        RaiseDirectorRemoved(kv.Key);
+                        FileLog.Write($"[DirectorRegistry] Sweeper removed orphan (file gone): {kv.Key.DirectorId}");
+                        RaiseDirectorRemoved(kv.Key.DirectorId);
                     }
                     continue;
                 }
@@ -417,12 +555,12 @@ public sealed class DirectorRegistry : IDisposable
                         try { File.Delete(f); }
                         catch (Exception ex)
                         {
-                            FileLog.Write($"[DirectorRegistry] Sweeper could not delete instance file for {kv.Key} (pid {pid} dead); orphan sweep will retry: {ex.Message}");
+                            FileLog.Write($"[DirectorRegistry] Sweeper could not delete instance file for {kv.Key.DirectorId} (pid {pid} dead); orphan sweep will retry: {ex.Message}");
                         }
-                        if (_directors.TryRemove(kv.Key, out _))
+                        if (TryRemoveEntry(kv.Key, out _))
                         {
-                            FileLog.Write($"[DirectorRegistry] Sweeper removed orphan (pid {pid} dead): {kv.Key}");
-                            RaiseDirectorRemoved(kv.Key);
+                            FileLog.Write($"[DirectorRegistry] Sweeper removed orphan (pid {pid} dead): {kv.Key.DirectorId}");
+                            RaiseDirectorRemoved(kv.Key.DirectorId);
                         }
                     }
                     catch { /* permission errors etc - leave it for next pass */ }
@@ -465,7 +603,8 @@ public sealed class DirectorRegistry : IDisposable
         {
             var id = Path.GetFileNameWithoutExtension(f);
             // A file backing a still-known Director is the in-memory sweep's responsibility; leave it.
-            if (!string.IsNullOrEmpty(id) && _directors.ContainsKey(id))
+            // Local-keyed: an instance file on this disk only ever backs a Local-tenant entry.
+            if (!string.IsNullOrEmpty(id) && _directors.ContainsKey(new DirectorKey(TenantId.Local, id)))
                 continue;
 
             int pid;

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -110,7 +110,12 @@ public sealed class DirectorHub : Hub
         // Gateway Cleanup mission (tunnel-only): the stream IS the registration now (HTTP register is gone).
         // Register this Director from the Hello identity so registry.Get(id) - the gate on create-session and
         // the other director-level routes - resolves it. Source="stream", no dialable endpoint.
-        _registry.RegisterFromStream(directorId, hello.MachineName, hello.User, hello.Version, hello.Pid, hello.StartedAt);
+        // Issue #1847: register it UNDER THE RESOLVED TENANT. The tenant is half of the registry key, so this
+        // Hello can only create or refresh THIS account's own entry - naming another account's Director is
+        // structurally impossible, however the client chose hello.DirectorId. It also makes the entry visible
+        // to this account's /directors list and to no other. The tenant is the one resolved above from the
+        // authenticated device key - never the Hello payload, which the client writes.
+        _registry.RegisterFromStream(directorId, hello.MachineName, hello.User, hello.Version, hello.Pid, hello.StartedAt, tenant);
         FileLog.Write($"[DirectorHub] Hello: director={directorId} bound to conn={Short(Context.ConnectionId)} (version={hello.Version}, machine={hello.MachineName})");
     }
 


### PR DESCRIPTION
Closes #1847.

## The defect

The tunnel `Hello`'s director id is chosen by the **client**, and `DirectorRegistry` was keyed by that id alone. So one account, holding its own perfectly valid device key, could:

1. enumerate director ids from the then fleet-global `GET /directors`;
2. open a tunnel with its own key and say `Hello` naming another account's director id;
3. overwrite that account's registry entry - machine name, operating system user, process id, client version.

The tenant binding on the connection was already correct; the registry simply did not care whose entry it was writing. That is a cross-tenant **write**, and with the read half scoped it also becomes a denial of service, because the victim's Director leaves the victim's own list.

## The fix

**The registry key is composite: `(tenantId, directorId)`.** The tenant is recorded at registration from the **authenticated** credential - the device key the tunnel resolved - and never from anything the client sends. A registration can only ever create or refresh its own tenant's entry. Naming another tenant's entry is not refused, it is unsayable.

Composite key rather than rejecting such a `Hello`: a machine re-enrolled from one account to another **keeps its local director id**, so a rejection would abort its every `Hello` forever, with no cure but editing the box by hand. There is also no id-ownership judgement to make. `A_director_id_may_move_to_another_tenant` is that case, and it is a test.

Alongside it:

- `GET /directors` resolves the request's tenant through the same seam the session read path uses and serves only that tenant's Directors. A request with **no** bound tenant is denied, never served the local partition.
- The session locate resolves a located session's owning Director **in the tenant the session was located under**, so no other tenant's host facts can be stamped onto a session being served here.
- Every path that drops a Director - graceful unregister, the stale sweep, the instance-file delete and rename - goes through one removal seam.
- The credential-less register and file-discovery paths key to the local tenant, which is what they mean. Self-host behaviour is unchanged.

## What this pull request deliberately does NOT change

The `/directors/{id}/...` routes resolve a Director from a client-supplied id with **no tenant at all** - repos, facts, agents, settings, sessions, handovers, file listing, and the rest, about two dozen of them. They are already addressable by any caller today, and this pull request leaves them exactly as they are: the legacy bare-id lookup answers with the freshest matching entry, which is what the single-keyed registry held, since there the last writer for an id replaced every earlier one.

It deliberately does **not** fail closed on a collision. Failing closed was tried first and is worse: the credential-less `POST /directors/register` can create a local-tenant entry for any id, so refusing on collision would let an unauthenticated caller disable every by-id route for a chosen Director - trading the cross-tenant write this closes for a cross-tenant denial of service. Two existing tests caught exactly that, which is why the shipped shape is the freshest-entry one.

Those routes are the same defect in a different hat and are booked separately.

## Proof

Both halves revert-proven separately, on the real production line, with the controls green throughout.

**Write half.** In `RegisterFromStream`, immediately after the key is built, drop any other tenant's entry for the same director id before writing:

```csharp
foreach (var other in _directors.Keys.Where(k => k.DirectorId == directorId).ToArray())
    if (!other.Tenant.Equals(tenant)) _directors.TryRemove(other, out _);
```

That is the pre-fix registry's behaviour - the id alone was the key, so the last writer took the entry over. Re-run and watched: `One_tenants_registration_cannot_overwrite_anothers` fails, **and only it** - 1 of 4, the other three green - at the takeover assertion `Assert.Equal("ALICE-BOX", Single(Alice, "dir-shared").MachineName)`, *after* both of its positive controls have passed.

**Correction to the first version of this pull request.** It documented a different revert - making `DirectorKey` equality ignore its tenant - and claimed it reddened the victim assertion with the other three green. That was wrong, and the reviewer was right to reject it. `ConcurrentDictionary`'s indexer replaces a *value* and keeps the *original key*, so the impostor's write lands on an entry still keyed to the victim's tenant: the impostor's own list comes back empty and the test dies at the **impostor's positive control**, three of four red, before it ever reaches the assertion under proof. A revert that reddens a test at its own setup cannot distinguish the guard catching the takeover from the test collapsing - it is decoration. That variant had in fact been tried and discarded during development; the stale recipe was left in the test file's documentation and shipped. The recipe above is the one that was run, and the test file now records why the other does not qualify.

**Read half.** Revert the `/directors` handler to the fleet-global overload and `Directors_list_serves_only_the_requesting_tenants_directors` goes **red** with `dir-b` in `dir-a`'s list, six controls green.

Every absence claim has a positive control in front of it, so an assertion cannot pass because the thing was never there. The end-to-end test drives the real tunnel `Hello` and the real mapped endpoint over real HTTP; the registry-level tests drive the registry directly, so no harness registration side effect can flatter the result.

## Tests

All seven test projects run, green:

| Project | Passed | Skipped | Total |
|---|---|---|---|
| Gateway | 2875 | 10 | 2885 |
| Core | 3302 | 8 | 3310 |
| Avalonia | 247 | 0 | 247 |
| HostedAgent | 86 | 0 | 86 |
| Engine | 62 | 0 | 62 |
| Launcher | 27 | 0 | 27 |
| Terminal.Avalonia | 21 | 0 | 21 |

Gateway against the ~2861 baseline: 2885 total, up by the five tests added here (four registry-level, one end-to-end takeover) plus the two list tests.
