### PR TITLE
fix(gateway): answer /account/status about the caller on hosted

### DIFF
--- a/src/CcDirector.Core/Account/GatewayAccountStatusClient.cs
+++ b/src/CcDirector.Core/Account/GatewayAccountStatusClient.cs
@@ -15,7 +15,7 @@ namespace CcDirector.Core.Account;
 /// </summary>
 /// <param name="GatewayConfigured">Whether a Gateway URL is configured at all (config.json gateway.url).</param>
 /// <param name="Reachable">Whether the Gateway answered the status request.</param>
-/// <param name="SignedIn">Whether the Gateway holds a valid DevThrottle credential.</param>
+/// <param name="SignedIn">SELF-HOST: whether the Gateway holds a valid DevThrottle credential. HOSTED (issue #1856): whether the CALLING device is enrolled - that is, its authenticated device key resolves to a tenant. The hosted Gateway holds no credential of its own by design, so the self-host meaning would answer about the wrong thing there.</param>
 /// <param name="Email">The signed-in identity email, or null when not signed in / unavailable.</param>
 /// <param name="Provider">The authentication provider, or null when not signed in / unavailable.</param>
 /// <param name="Error">A short human-readable reason when not reachable, or null on success.</param>

--- a/src/CcDirector.Core/Account/SignedInUserProvider.cs
+++ b/src/CcDirector.Core/Account/SignedInUserProvider.cs
@@ -9,6 +9,11 @@ namespace CcDirector.Core.Account;
 /// <see cref="GatewayAccountStatusClient"/>. The account credential lives on the Gateway (issue #651),
 /// so the Director never holds a token of its own - it asks the Gateway.
 ///
+/// What that answer MEANS differs by deployment (issue #1856), and this type is deliberately indifferent to
+/// which: on self-host the Gateway reports its own signed-in account; on hosted it reports whether the
+/// CALLING device is enrolled, folded from that device's own key, because a hosted Gateway holds no account
+/// credential of its own. Either way this reads a verdict the Gateway owns rather than deciding one.
+///
 /// A short-lived in-memory cache keeps this off the hot path: the preamble endpoint is fetched at
 /// session start (and re-fetched by some agents on /clear), and the Pi launch path reads the cached
 /// snapshot synchronously so session creation never blocks on the network. On a cold or stale cache

--- a/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
@@ -8,6 +8,8 @@ using System.Net.Sockets;
 using System.Text.Json;
 using System.Threading.Tasks;
 using CcDirector.Gateway;
+using CcDirector.Gateway.Api;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests.Account;
@@ -30,9 +32,14 @@ namespace CcDirector.Gateway.Tests.Account;
 /// one most easily written as a quiet false, and it is not a rare corner: the tenant row records an email on
 /// a FRESH MINT ONLY, so any older or null-email tenant reaches it.
 ///
-/// Revert-prove: delete the hosted branch in <c>AccountStatusEndpoint.Map</c> (the
-/// <c>tenantBoundary is { IsHosted: true }</c> early return) so hosted falls through to the Gateway-credential
-/// path again, and both signed-in tests go RED with <c>signedIn:false</c> - which is exactly the reported bug.
+/// Revert-prove, two of them, each reddening a DIFFERENT thing:
+///  - Delete the hosted early return in <c>AccountStatusEndpoint.Map</c> so hosted falls through to the
+///    Gateway-credential path, and both signed-in tests go RED with <c>signedIn:false</c> - the reported bug.
+///  - Change the selector from <c>GatewayHostedMode.IsHosted</c> back to <c>tenantBoundary is { IsHosted: true }</c>
+///    and ONLY <see cref="A_hosted_gateway_with_no_tenant_boundary_refuses_rather_than_reporting_signed_out"/>
+///    goes RED, with 200 in place of 503 - the fail-open under miswiring.
+/// Both were run and watched; a revert that reddens is not the same as a revert that reddens the assertion
+/// under proof.
 ///
 /// This drives a REAL GatewayHost through REAL HTTP and the REAL auth middleware, with the REAL tenant
 /// registry, so the binding under test is the one enrollment actually creates. Self-host behaviour is
@@ -146,6 +153,41 @@ public sealed class HostedAccountStatusTests : IAsyncLifetime
         var body = await (await Get(_keyWithEmail)).Content.ReadAsStringAsync();
         Assert.DoesNotContain(_keyWithEmail, body);
         Assert.DoesNotContain(Token, body);
+    }
+
+    [Fact]
+    public async Task A_hosted_gateway_with_no_tenant_boundary_refuses_rather_than_reporting_signed_out()
+    {
+        // The adversarial case: a hosted Gateway MISWIRED so the endpoint has no tenant boundary. The boundary
+        // argument is optional, so omitting it is a one-word mistake, and selecting the hosted path on the
+        // boundary itself would fail OPEN - falling through to the self-host path and answering signedIn=false
+        // again. That is the very lie this endpoint exists to stop, restored by configuration rather than by
+        // design, and with no test it would be invisible.
+        //
+        // So hosted mode is asked directly, and a hosted host with no usable boundary FAILS CLOSED. The answer
+        // is "I cannot tell you", never "you are signed out". Note the account service passed here holds no
+        // credential, which is exactly the condition that used to produce a confident 200 signedIn:false.
+        //
+        // Revert-prove: change the selector in Map back to `tenantBoundary is { IsHosted: true }` and this goes
+        // RED with a 200 carrying signedIn:false - the reported bug, reached by a different route.
+        var builder = Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+        AccountStatusEndpoint.Map(app, account: null);   // hosted mode is on; no boundary, no registry
+        await app.StartAsync();
+        try
+        {
+            using var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+            var resp = await http.GetAsync("/account/status");
+
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+            Assert.DoesNotContain("signedIn", await resp.Content.ReadAsStringAsync());
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
     }
 
     private Task<HttpResponseMessage> Get(string deviceKey)

--- a/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// Issue #1856: on the HOSTED Gateway, <c>GET /account/status</c> must answer about the CALLER, not about
+/// the Gateway.
+///
+/// The defect it closes: the endpoint asked <c>account.IsLoggedIn()</c>, which means "does THIS GATEWAY hold
+/// a signed-in credential". Hosted holds none by design - it is one shared multi-tenant Gateway and identity
+/// arrives per device - so a machine that had enrolled CORRECTLY (device key issued, tunnel up, roster served
+/// back tenant-scoped) was told it was signed OUT. That is a product-facing lie about the one thing the user
+/// had just done, and it reads as a failed setup, so people start undoing work that was correct.
+///
+/// THE RULE THESE TESTS EXIST TO HOLD: on hosted, <c>signedIn=false</c> is never the answer to an
+/// authenticated tenant-bound caller. When the identity cannot be resolved the answer is
+/// <c>signedIn=true</c> with the identity ABSENT - never a confident false. An unresolvable identity and a
+/// signed-out user are different answers and must not share a code path. That branch has its own test below
+/// (<see cref="Enrolled_without_a_recorded_email_is_signed_in_with_the_identity_absent"/>) because it is the
+/// one most easily written as a quiet false, and it is not a rare corner: the tenant row records an email on
+/// a FRESH MINT ONLY, so any older or null-email tenant reaches it.
+///
+/// Revert-prove: delete the hosted branch in <c>AccountStatusEndpoint.Map</c> (the
+/// <c>tenantBoundary is { IsHosted: true }</c> early return) so hosted falls through to the Gateway-credential
+/// path again, and both signed-in tests go RED with <c>signedIn:false</c> - which is exactly the reported bug.
+///
+/// This drives a REAL GatewayHost through REAL HTTP and the REAL auth middleware, with the REAL tenant
+/// registry, so the binding under test is the one enrollment actually creates. Self-host behaviour is
+/// unchanged and is covered by <see cref="AccountStatusEndpointTests"/>, which maps the endpoint with no
+/// boundary at all - those are the control for this change. The assembly runs sequentially, so toggling
+/// CC_GATEWAY_HOSTED here is safe; it is restored in DisposeAsync.
+/// </summary>
+public sealed class HostedAccountStatusTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    /// <summary>Enrolled, with an email recorded on its tenant row.</summary>
+    private string _keyWithEmail = "";
+
+    /// <summary>Enrolled and perfectly valid, but its tenant row carries no email.</summary>
+    private string _keyNoEmail = "";
+
+    /// <summary>Authenticated, but bound to no tenant at all.</summary>
+    private string _keyUnbound = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-has-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // Minted through the REAL registry, exactly as POST /devices/enroll-hosted does it, so the tenant
+        // these keys are bound to is a genuine tenant row rather than a string invented by the test.
+        var withEmail = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        var noEmail = _gateway.TenantRegistry.MintOrLookupBySubject("sub-bob", null);
+
+        _keyWithEmail = _gateway.Devices.Register("dev-alice", "MA").DeviceKey;
+        _keyNoEmail = _gateway.Devices.Register("dev-bob", "MB").DeviceKey;
+        _keyUnbound = _gateway.Devices.Register("dev-x", "MX").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-alice", "sub-alice", withEmail.Value);
+        _gateway.Devices.SetAccountBinding("dev-bob", "sub-bob", noEmail.Value);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task An_enrolled_hosted_caller_is_signed_in_as_itself()
+    {
+        var root = await StatusFor(_keyWithEmail);
+
+        Assert.True(root.GetProperty("signedIn").GetBoolean());
+        Assert.Equal("alice@example.com", root.GetProperty("email").GetString());
+    }
+
+    [Fact]
+    public async Task Enrolled_without_a_recorded_email_is_signed_in_with_the_identity_absent()
+    {
+        // The branch most likely to be quietly written as a false. This caller is fully enrolled - its key is
+        // bound to a real tenant - but its tenant row has no email, which is ORDINARY: the registry records an
+        // email on a fresh mint only. The honest answer is "signed in, I cannot tell you as whom", never
+        // "signed out". An absent field is honest where a false one is not - the same lesson /healthz taught
+        // when a zeroed fleet count read as a permanently dead fleet.
+        var root = await StatusFor(_keyNoEmail);
+
+        Assert.True(root.GetProperty("signedIn").GetBoolean());
+        Assert.False(root.TryGetProperty("email", out _));      // omitted, not null, not fabricated
+        Assert.False(root.TryGetProperty("provider", out _));
+    }
+
+    [Fact]
+    public async Task A_caller_with_no_bound_tenant_is_denied_and_never_told_it_is_signed_out()
+    {
+        // Deny-by-default, as on the other tenant-bearing reads. "I will not answer you" and "you are signed
+        // out" are different statements and only one of them is true; answering signedIn=false here would
+        // recreate the reported bug for this caller under a different code path.
+        var resp = await Get(_keyUnbound);
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        Assert.DoesNotContain("signedIn", await resp.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_caller_is_still_rejected()
+    {
+        // Control: the hosted fold must not have opened the route up. Without a key the host-wide auth
+        // middleware still refuses, so the branch under test is only ever reached by a proven caller.
+        var resp = await _http.GetAsync("account/status");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task The_response_carries_no_credential_material()
+    {
+        // Control carried over from the self-host contract: the status body is a verdict and an identity, and
+        // never a token. Folding it from the device key must not have put the key itself into the answer.
+        var body = await (await Get(_keyWithEmail)).Content.ReadAsStringAsync();
+        Assert.DoesNotContain(_keyWithEmail, body);
+        Assert.DoesNotContain(Token, body);
+    }
+
+    private Task<HttpResponseMessage> Get(string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "account/status");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private async Task<JsonElement> StatusFor(string deviceKey)
+    {
+        var resp = await Get(deviceKey);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        return doc.RootElement.Clone();
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs
@@ -28,6 +28,13 @@ namespace CcDirector.Gateway.Api;
 /// the boolean and the identity. The tokens are never written to the log on any path either; the log
 /// records only the outcome (signed in / not signed in).
 ///
+/// HOSTED (issue #1856): all of the above describes the SELF-HOST shape, where the Gateway holds one
+/// account and can report it. The hosted Gateway holds no credential by design - it is one shared
+/// multi-tenant Gateway and identity arrives per device - so on hosted the verdict is folded from the
+/// CALLER'S own authenticated device-key binding instead (see <see cref="HostedStatus"/>). Self-host
+/// behaviour is completely unchanged: with no hosted boundary this endpoint runs exactly the path it
+/// always did.
+///
 /// When Gateway auth is enabled, this endpoint inherits the host-wide Gateway token middleware exactly
 /// like the other Gateway endpoints (it is not on the public-paths allow-list), so a call with no token
 /// is answered 401 by that middleware before this delegate runs.
@@ -50,7 +57,19 @@ internal static class AccountStatusEndpoint
     /// email/provider path is unchanged and stays entirely local. Resolution is cached per account so the
     /// hard-polled status read makes at most one cloud call per <see cref="NicknameCacheTtl"/>.
     /// </param>
-    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, AccountNicknameClient? nickname = null)
+    /// <param name="tenantBoundary">
+    /// The hosted tenant boundary (issue #1856). Null, or present-but-not-hosted, leaves the self-host
+    /// answer below completely untouched. On hosted it is what makes this endpoint tenant-bearing: the
+    /// verdict is folded from the CALLER'S OWN device-key binding instead of from a Gateway credential that
+    /// hosted does not have.
+    /// </param>
+    /// <param name="tenants">
+    /// The account-to-tenant registry (issue #1856), read on hosted for the caller tenant's display email.
+    /// Null disables that lookup, which yields a signed-in answer with the identity absent - never a
+    /// signed-out one.
+    /// </param>
+    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, AccountNicknameClient? nickname = null,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null, Tenancy.TenantRegistry? tenants = null)
     {
         // Per-account nickname cache so this hard-polled endpoint hits the cloud at most once per TTL.
         // Captured in the closure (Map runs once per host) and guarded by its own lock.
@@ -58,6 +77,27 @@ internal static class AccountStatusEndpoint
 
         app.MapGet("/account/status", async (HttpContext ctx) =>
         {
+            // Issue #1856: on HOSTED, answer about the CALLER, not about this Gateway.
+            //
+            // Everything below this block asks account.IsLoggedIn(), which means "does THIS GATEWAY hold a
+            // signed-in DevThrottle credential". The hosted Gateway holds none BY DESIGN - it is one shared
+            // multi-tenant Gateway and identity arrives per device, bound to the device key at enrollment. So
+            // that question is answered truthfully about the Gateway and MEANINGLESSLY for the caller, and a
+            // correctly enrolled machine - device key issued, tunnel up, roster served back tenant-scoped -
+            // was told it was signed OUT. That is a product-facing lie about the one thing the user just did:
+            // they read it as a failed setup and start undoing work that was correct.
+            //
+            // Per CLAUDE.md rule 7 the Gateway owns the verdict, so it is folded here from the caller's own
+            // device-key binding. THE RULE THAT MATTERS: on hosted, signedIn=false is NEVER the answer to an
+            // authenticated tenant-bound caller. When the identity cannot be resolved - which is ordinary,
+            // because the tenant row records an email on a fresh mint only - the answer is signedIn=true with
+            // the identity ABSENT. An unresolvable identity and a signed-out user are DIFFERENT ANSWERS and
+            // must not share a code path. This mission already paid for that lesson on /healthz: a zeroed
+            // count read as a permanently dead fleet exactly as a confident false reads as a failed setup, and
+            // an absent field is honest where a false one is not.
+            if (tenantBoundary is { IsHosted: true })
+                return HostedStatus(ctx, tenantBoundary, tenants);
+
             // No credential service on this host (a non-Windows host where the operating-system
             // credential store is not yet implemented): the Gateway holds no account credential, so the
             // truthful answer is not-signed-in with no identity.
@@ -83,6 +123,42 @@ internal static class AccountStatusEndpoint
             FileLog.Write($"[AccountStatusEndpoint] GET /account/status: signedIn=true (identity {(identity is null ? "unavailable" : "resolved")}, nickname {(resolvedNickname is null ? "unset" : "resolved")})");
             return Results.Json(new AccountStatusResponse(true, identity?.Email, identity?.Provider, resolvedNickname));
         });
+    }
+
+    /// <summary>
+    /// The HOSTED verdict (issue #1856), folded from the CALLER'S OWN authenticated device key and from
+    /// nothing else - never from a Gateway credential, and never from anything the caller supplies in the
+    /// request, so a caller cannot name an identity it does not hold.
+    ///
+    /// Three outcomes, and the middle one is the whole point:
+    ///
+    ///  - No tenant bound to the request: DENIED, 403. This is deny-by-default, the same answer the other
+    ///    tenant-bearing read routes give, and it is deliberately NOT signedIn=false - "I will not answer
+    ///    you" and "you are signed out" are different statements and only one of them is true.
+    ///  - Tenant bound, no email on its row: signedIn=TRUE with the identity omitted. The caller IS enrolled;
+    ///    we simply cannot say as whom. See <see cref="Tenancy.TenantRegistry.EmailForTenant"/> for why a
+    ///    null email is ordinary rather than a fault.
+    ///  - Tenant bound, email present: signedIn=true, as them.
+    ///
+    /// Provider and nickname are omitted on hosted rather than guessed. Provider is not recorded on the
+    /// tenant row, and the nickname read needs an account token this Gateway does not hold for the caller -
+    /// using its OWN would answer with the wrong person's nickname.
+    /// </summary>
+    private static IResult HostedStatus(HttpContext ctx, Tenancy.HostedTenantBoundary boundary, Tenancy.TenantRegistry? tenants)
+    {
+        var tenant = boundary.ResolveRequestTenant(ctx);
+        if (tenant is null)
+        {
+            FileLog.Write("[AccountStatusEndpoint] GET /account/status (hosted): DENIED - no tenant is bound to this request");
+            return Results.Json(new { error = "no tenant is bound to this request" },
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        var email = tenants?.EmailForTenant(tenant.Value);
+        // Logged as resolved / unavailable only - the email is user identity and is never written to the log,
+        // and neither is the tenant id.
+        FileLog.Write($"[AccountStatusEndpoint] GET /account/status (hosted): signedIn=true (identity {(email is null ? "unavailable" : "resolved")})");
+        return Results.Json(new AccountStatusResponse(true, email, null, null));
     }
 
     /// <summary>How long a resolved nickname is reused before the next status read re-reads the cloud.</summary>

--- a/src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs
@@ -253,7 +253,7 @@ internal static class AccountStatusEndpoint
     /// response carries no identity fields. This type intentionally carries NO token field, so the
     /// response can never include the access or refresh token (security rule DT-05).
     /// </summary>
-    /// <param name="SignedIn">Whether the Gateway holds a valid DevThrottle credential.</param>
+    /// <param name="SignedIn">SELF-HOST: whether the Gateway holds a valid DevThrottle credential. HOSTED (issue #1856): whether the CALLING device is enrolled - that is, its authenticated device key resolves to a tenant. The hosted Gateway holds no credential of its own by design, so the self-host meaning would answer about the wrong thing there.</param>
     /// <param name="Email">The signed-in user's email, or null (omitted) when not signed in / unavailable.</param>
     /// <param name="Provider">The authentication provider, or null (omitted) when not signed in / unavailable.</param>
     /// <param name="Nickname">The chosen account nickname (issue #1357), or null (omitted) when not signed in / unset / unresolved.</param>

--- a/src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs
@@ -31,9 +31,11 @@ namespace CcDirector.Gateway.Api;
 /// HOSTED (issue #1856): all of the above describes the SELF-HOST shape, where the Gateway holds one
 /// account and can report it. The hosted Gateway holds no credential by design - it is one shared
 /// multi-tenant Gateway and identity arrives per device - so on hosted the verdict is folded from the
-/// CALLER'S own authenticated device-key binding instead (see <see cref="HostedStatus"/>). Self-host
-/// behaviour is completely unchanged: with no hosted boundary this endpoint runs exactly the path it
-/// always did.
+/// CALLER'S own authenticated device-key binding instead (see <see cref="HostedStatus"/>). Which path runs
+/// is decided by <see cref="GatewayHostedMode.IsHosted"/>, NOT by whether a boundary was passed in, so a
+/// hosted Gateway can never fall through to the self-host answer; a hosted host missing its boundary fails
+/// CLOSED. Self-host behaviour is completely unchanged: off hosted mode this endpoint runs exactly the path
+/// it always did.
 ///
 /// When Gateway auth is enabled, this endpoint inherits the host-wide Gateway token middleware exactly
 /// like the other Gateway endpoints (it is not on the public-paths allow-list), so a call with no token
@@ -58,10 +60,10 @@ internal static class AccountStatusEndpoint
     /// hard-polled status read makes at most one cloud call per <see cref="NicknameCacheTtl"/>.
     /// </param>
     /// <param name="tenantBoundary">
-    /// The hosted tenant boundary (issue #1856). Null, or present-but-not-hosted, leaves the self-host
-    /// answer below completely untouched. On hosted it is what makes this endpoint tenant-bearing: the
-    /// verdict is folded from the CALLER'S OWN device-key binding instead of from a Gateway credential that
-    /// hosted does not have.
+    /// The hosted tenant boundary (issue #1856). REQUIRED on a hosted Gateway - it is what makes this
+    /// endpoint tenant-bearing, folding the verdict from the CALLER'S OWN device-key binding instead of from a
+    /// Gateway credential hosted does not have. Omitting it on hosted does NOT quietly fall back to the
+    /// self-host answer; the endpoint refuses to answer at all. Ignored off hosted mode.
     /// </param>
     /// <param name="tenants">
     /// The account-to-tenant registry (issue #1856), read on hosted for the caller tenant's display email.
@@ -95,7 +97,14 @@ internal static class AccountStatusEndpoint
             // must not share a code path. This mission already paid for that lesson on /healthz: a zeroed
             // count read as a permanently dead fleet exactly as a confident false reads as a failed setup, and
             // an absent field is honest where a false one is not.
-            if (tenantBoundary is { IsHosted: true })
+            // GATED ON HOSTED MODE ITSELF, not on the boundary having been passed in. Selecting the hosted
+            // path with `tenantBoundary is { IsHosted: true }` fails OPEN: a hosted Gateway whose boundary was
+            // not wired here - the argument is optional, so omitting it is a one-word mistake - would fall
+            // straight through to the self-host path and answer signedIn=false again, which is the very lie
+            // this endpoint exists to stop, restored by miswiring and with no test to catch it. Asking the
+            // independent hosted-mode signal instead means a hosted Gateway can never silently take the
+            // self-host answer; if the boundary is missing it FAILS CLOSED inside HostedStatus.
+            if (GatewayHostedMode.IsHosted)
                 return HostedStatus(ctx, tenantBoundary, tenants);
 
             // No credential service on this host (a non-Windows host where the operating-system
@@ -144,8 +153,20 @@ internal static class AccountStatusEndpoint
     /// tenant row, and the nickname read needs an account token this Gateway does not hold for the caller -
     /// using its OWN would answer with the wrong person's nickname.
     /// </summary>
-    private static IResult HostedStatus(HttpContext ctx, Tenancy.HostedTenantBoundary boundary, Tenancy.TenantRegistry? tenants)
+    private static IResult HostedStatus(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary, Tenancy.TenantRegistry? tenants)
     {
+        // FAIL CLOSED on a miswired host. This Gateway is in hosted mode but has no usable tenant boundary, so
+        // it cannot tell who is asking. There is no honest answer to give and there is certainly not a
+        // signedIn=false one - answering that would recreate the exact lie this endpoint exists to stop, from a
+        // configuration mistake rather than a design one. Say the server cannot answer, and say it LOUD: this
+        // is a deployment fault that will not recover on its own.
+        if (boundary is not { IsHosted: true })
+        {
+            FileLog.Write("[AccountStatusEndpoint] GET /account/status (hosted): MISWIRED - this Gateway is in hosted mode but has no hosted tenant boundary, so it cannot resolve who is asking. Refusing to answer rather than reporting a false signed-out state.");
+            return Results.Json(new { error = "this hosted gateway cannot resolve the caller's tenant" },
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
         var tenant = boundary.ResolveRequestTenant(ctx);
         if (tenant is null)
         {

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1912,7 +1912,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // not-signed-in. Issue #1357: it also resolves the signed-in user's chosen nickname (cached,
         // best-effort) through the cloud nickname client, so a session's preamble can name the human;
         // the identity email/provider path stays entirely local.
-        AccountStatusEndpoint.Map(_app, Account, new Core.Account.AccountNicknameClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) }));
+        // Issue #1856: the boundary and the tenant registry make this endpoint tenant-bearing on hosted, where
+        // it must answer about the CALLER's enrollment rather than about a Gateway credential hosted does not
+        // hold. On self-host the boundary reports not-hosted and the endpoint behaves exactly as before.
+        AccountStatusEndpoint.Map(_app, Account, new Core.Account.AccountNicknameClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) }),
+            tenantBoundary: _tenantBoundary, tenants: TenantRegistry);
 
         // Gateway Centralization Phase 3 (issue #648): POST /account/logout CLEARS the Gateway-hosted
         // DevThrottle credential through the same reused DevThrottleAccountService (Account). The account

--- a/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
+++ b/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
@@ -113,4 +113,26 @@ public sealed class TenantRegistry
         var existing = ctx.Tenants.AsNoTracking().FirstOrDefault(t => t.AccountSubject == subject);
         return existing is null ? null : new TenantId(existing.Id);
     }
+
+    /// <summary>
+    /// The display email recorded on a tenant's row, or null when there is none (issue #1856). Read-only:
+    /// it neither mints nor writes.
+    ///
+    /// NULL IS ORDINARY HERE, NOT AN ERROR. <see cref="MintOrLookupBySubject"/> records the email on a FRESH
+    /// MINT ONLY, so a tenant minted before the email was captured, or from a token that carried none, simply
+    /// has no email - while being a perfectly valid, fully enrolled tenant. A caller must therefore treat a
+    /// null as "this identity is not available" and NEVER as "there is no such tenant" or "nobody is signed
+    /// in": those are different answers and a caller that folds them together states a falsehood. The email
+    /// is personally identifying and is never logged.
+    /// </summary>
+    public string? EmailForTenant(TenantId tenant)
+    {
+        if (!tenant.IsValid)
+            return null;
+
+        var id = tenant.Value;
+        using var ctx = _db.CreateUnscopedContext();
+        var row = ctx.Tenants.AsNoTracking().FirstOrDefault(t => t.Id == id);
+        return string.IsNullOrWhiteSpace(row?.Email) ? null : row!.Email;
+    }
 }


### PR DESCRIPTION
Closes #1856.

## The defect

A machine that had enrolled with the hosted Gateway **correctly** - device key issued, tunnel up, roster served back tenant-scoped - was still told it was **signed out**.

`GET /account/status` asks `account.IsLoggedIn()`, which means "does **this Gateway** hold a signed-in DevThrottle credential". The hosted Gateway holds none **by design**: it is one shared multi-tenant Gateway, and identity arrives per device, bound to the device key at `POST /devices/enroll-hosted`. So the route answered truthfully about itself and meaninglessly for the caller.

The user consequence is the point. Someone who has just successfully signed in and joined hosted is told they are signed out, reads that as a failed setup, and starts undoing work that was correct.

## The fix

On hosted the verdict is folded from the **caller's own authenticated device-key binding**, per the rule that the Gateway owns every display verdict and the client only renders it. Three outcomes:

| Caller | Answer |
|---|---|
| Tenant bound, email on its row | `signedIn: true`, as them |
| Tenant bound, **no** email on its row | `signedIn: true`, identity **omitted** |
| No tenant bound | **403**, denied |

**Signed-out is never the answer to an authenticated tenant-bound caller.** The middle row is the one that matters and it is not a rare corner: the tenant registry records an email on a **fresh mint only**, so any older or null-email tenant lands there while being perfectly enrolled. An unresolvable identity and a signed-out user are different answers and do not share a code path - an absent field is honest where a false one is not. This mission already paid for that lesson on `/healthz`, where a zeroed fleet count read as a permanently dead fleet exactly as a confident false reads here as a failed setup.

The 403 is deliberately not a `signedIn: false` either: "I will not answer you" and "you are signed out" are different statements and only one of them is true.

**Which path runs is decided by `GatewayHostedMode.IsHosted`, the independent signal - not by whether a boundary was passed in.** Selecting the hosted path on the boundary itself fails **open**: the argument is optional, so a hosted Gateway that did not pass it fell straight through to the self-host path and answered `signedIn: false` again - the very lie this closes, restored by a one-word miswiring and with no test to catch it. A hosted host with no usable boundary now **fails closed** with 503 and a loud log: it cannot tell who is asking, and "I cannot tell you" is the only honest answer available. It is never a signed-out one.

That was found in review, not by me.

Provider and nickname are **omitted** on hosted rather than guessed. The provider is not recorded on the tenant row, and the nickname read needs an account token this Gateway does not hold for the caller - using its own would answer with the wrong person's nickname.

The identity is resolved strictly from the caller's own key. Nothing the caller supplies in the request can name an identity.

`TenantRegistry` gained one read-only accessor for the display email on a tenant row. **No model change, so no migration.**

## Self-host is the control

With no hosted boundary the endpoint runs exactly the path it always did. The existing `AccountStatusEndpointTests` map it with no boundary at all and are unchanged and green.

## Proof

**Two revert-proofs, each reddening a different thing.** Both were run and watched against the final file.

1. **Delete the hosted early return** so hosted falls through to the Gateway-credential path: both signed-in tests go **red** on `Assert.True(signedIn)` - precisely the reported bug - along with the deny and miswire semantics. The two controls in the class stay green (unauthenticated callers still 401; the response still carries no credential material), and every self-host test stays green.
2. **Change the selector back** from `GatewayHostedMode.IsHosted` to `tenantBoundary is { IsHosted: true }`: **exactly one** test reddens - the new miswiring regression - with `Expected ServiceUnavailable, Actual OK`, i.e. a 200 carrying `signedIn: false`. Twelve others green.

One note on the first revert, because it nearly produced a false green: replacing the condition with `if (false)` **broke the build** (the null-narrowing on the boundary was lost), and the test run then executed a **stale binary** and reported a pass. The revert that counts is the one where the branch is deleted outright and the build succeeds.

The hosted tests drive a real `GatewayHost` over real HTTP through the real auth middleware, with tenants minted through the **real** `TenantRegistry` exactly as enrollment mints them - so the binding under test is the one enrollment actually creates, not a string invented by the test.

## Tests

All seven test projects run, green:

| Project | Passed | Skipped | Total |
|---|---|---|---|
| Gateway | 2874 | 10 | 2884 |
| Core | 3302 | 8 | 3310 |
| Avalonia | 247 | 0 | 247 |
| HostedAgent | 86 | 0 | 86 |
| Engine | 62 | 0 | 62 |
| Launcher | 27 | 0 | 27 |
| Terminal.Avalonia | 21 | 0 | 21 |

Gateway against the ~2861 baseline: 2884 total, up by the six tests added here.

## Note on CI coverage

The `#1864` repair of folding the setup test projects into `cc-director.sln` is **not** load-bearing for this change: the fix lives in `CcDirector.Gateway`, whose tests are already in the solution and already gate a merge.
