### PR TITLE
fix(setup): declare --hosted as a valueless flag so it cannot be swallowed

### DIFF
--- a/tools/cc-director-setup-cli.Tests/CliArgsTests.cs
+++ b/tools/cc-director-setup-cli.Tests/CliArgsTests.cs
@@ -27,6 +27,23 @@ public class CliArgsTests
         Assert.True(args.HasFlag("json"));
     }
 
+    /// <summary>
+    /// --hosted takes no value, so it must be declared as a known flag rather than relying on what happens
+    /// to follow it. Undeclared, it is only read as a flag when the next token starts with "--" or the
+    /// command ends there: anything else following it is silently swallowed as its "value", --hosted is
+    /// never seen, and the enroll quietly falls through to the SELF-HOSTED discovery path - a machine
+    /// joining a different gateway than the one the operator asked for, with no error.
+    /// </summary>
+    [Fact]
+    public void Parse_HostedIsAFlag_EvenWhenFollowedByAnotherArgument()
+    {
+        var args = CliArgs.Parse(["enroll", "--hosted", "extra"]);
+
+        Assert.True(args.HasFlag("hosted"));
+        Assert.Null(args.Option("hosted"));
+        Assert.Equal("extra", Assert.Single(args.Positionals));
+    }
+
     [Fact]
     public void Parse_DefaultsToHelp()
     {

--- a/tools/cc-director-setup-cli/CliArgs.cs
+++ b/tools/cc-director-setup-cli/CliArgs.cs
@@ -12,7 +12,7 @@ public sealed class CliArgs
     private readonly HashSet<string> _flags;
 
     private static readonly HashSet<string> KnownFlags =
-        new(StringComparer.OrdinalIgnoreCase) { "json", "dry-run", "help" };
+        new(StringComparer.OrdinalIgnoreCase) { "json", "dry-run", "help", "hosted" };
 
     private CliArgs(string command, List<string> positionals, Dictionary<string, string> options, HashSet<string> flags)
     {


### PR DESCRIPTION
Follow-up from an independent review of #1857, which merged without a review.

## The defect

`enroll --hosted` reads the choice with `args.HasFlag("hosted")`, but `--hosted` was never added to `CliArgs.KnownFlags`. The parser only treats an undeclared `--x` as a flag when the next token starts with `--` or the command ends there; otherwise it consumes the next token as that option's value.

So `enroll --hosted` works today purely because nothing follows it. Put any further argument after it and:

- `--hosted` is parsed as an *option*, not a flag
- `HasFlag("hosted")` returns false
- the enroll silently falls through to the **self-hosted discovery** path

The machine then joins a different gateway than the operator asked for, with no error and nothing in the output to reveal it. That is a silent wrong-gateway enrollment, which is precisely what the guards in #1857 were written to make impossible.

## The change

One word: `--hosted` joins `json`, `dry-run`, and `help` in `KnownFlags`, which is what that set exists for. No behaviour change for any invocation that works today.

## Proof

The new test was run against the unfixed parser first and observed **red**, then green with the change; the rest of both suites stayed green throughout.

| Suite | Result |
|---|---|
| `Parse_HostedIsAFlag_EvenWhenFollowedByAnotherArgument`, fix reverted | **fails** |
| Setup CLI suite, fix applied | 20/20 |
| Setup engine suite (control) | 331/331 |