### PR TITLE
fix(core): authenticate the director-startup telemetry report

### DIFF
--- a/src/CcDirector.Core.Tests/Account/DevThrottleDirectorStartupTelemetryReporterTests.cs
+++ b/src/CcDirector.Core.Tests/Account/DevThrottleDirectorStartupTelemetryReporterTests.cs
@@ -42,7 +42,7 @@ public sealed class DevThrottleDirectorStartupTelemetryReporterTests
     }
 
     [Fact]
-    public async Task ReportStartupAsync_SendsNoAuthorizationHeader()
+    public async Task ReportStartupAsync_SendsNoAuthorizationHeader_WhenNoGatewayTokenIsConfigured()
     {
         var handler = new CapturingHandler(HttpStatusCode.OK);
         var reporter = new DevThrottleDirectorStartupTelemetryReporter(
@@ -50,10 +50,100 @@ public sealed class DevThrottleDirectorStartupTelemetryReporterTests
 
         await reporter.ReportStartupAsync("dir-abc");
 
-        // Issue #642: the Director holds no credential; the Gateway attaches its own token on the
-        // forward (issue #639), so the Director's startup POST carries NO Authorization header.
+        // This test used to assert the POST carries NO Authorization header EVER, on the #642 reasoning that
+        // "the Director holds no credential, and the Gateway attaches its own token on the cloud forward
+        // (#639)". The second half is still true and is enforced Gateway-side; the first half conflated two
+        // different hops. The Director does hold a credential for the GATEWAY - the per-device key enrollment
+        // writes to gateway.token - and the inbound hop is gated host-wide like every other Gateway route, so
+        // sending nothing meant a 401 that the best-effort caller swallowed (issue #1855).
+        //
+        // What survives is this: with NO gateway token configured there is nothing to send, and the reporter
+        // must not invent one. The credential-carrying case is proven below.
         Assert.NotNull(handler.Request);
         Assert.Null(handler.Request.Headers.Authorization);
+    }
+
+    [Fact]
+    public async Task ReportStartupAsync_SendsTheConfiguredGatewayTokenAsBearer()
+    {
+        // Issue #1855: the fix. A correctly enrolled Director was refused 401 because this report was the one
+        // Director-to-Gateway call that carried no credential, and the failure was swallowed - so the only
+        // symptom was startup telemetry that never arrived, which is indistinguishable from nobody starting a
+        // Director. It now sends the same gateway.token Bearer every other call sends.
+        //
+        // Revert-prove, run verbatim against the final file: delete the two lines
+        //     if (authenticated)
+        //         request.Headers.Authorization = new ...AuthenticationHeaderValue("Bearer", _gatewayToken);
+        // from ReportStartupAsync. The build succeeds, and EXACTLY TWO tests redden on a null Authorization
+        // header - this one and SendsTheCredentialWhenTheOverridePointsAtItsOwnGateway, which is the other
+        // test asserting the header is sent. The remaining nine stay green, including the cross-host test,
+        // which asserts the header is ABSENT and therefore cannot detect this revert at all. That is exactly
+        // why the own-gateway control exists: without it, deleting the assignment would leave the cross-host
+        // guard green and the deletion would look harmless.
+        var handler = new CapturingHandler(HttpStatusCode.OK);
+        var reporter = new DevThrottleDirectorStartupTelemetryReporter(
+            new HttpClient(handler), machineName: "TEST-MACHINE", gatewayUrl: TestGatewayUrl, gatewayToken: "device-key-1855");
+
+        await reporter.ReportStartupAsync("dir-abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.NotNull(handler.Request.Headers.Authorization);
+        Assert.Equal("Bearer", handler.Request.Headers.Authorization!.Scheme);
+        Assert.Equal("device-key-1855", handler.Request.Headers.Authorization.Parameter);
+    }
+
+    [Fact]
+    public async Task ReportStartupAsync_NeverSendsTheGatewayCredentialToAnotherHost()
+    {
+        // The credential rides ONLY to this Director's own configured Gateway. DEVTHROTTLE_STARTUP_TELEMETRY_URL
+        // can point the report at an arbitrary address for a test, proof or staging run, and attaching the key
+        // unconditionally would hand this machine's per-device Gateway key - which authenticates every
+        // Director-to-Gateway call - to whatever host that variable names, by setting one environment variable.
+        var previous = Environment.GetEnvironmentVariable(DevThrottleDirectorStartupTelemetryReporter.EndpointEnvVar);
+        Environment.SetEnvironmentVariable(DevThrottleDirectorStartupTelemetryReporter.EndpointEnvVar, "http://evil.example.com/collect");
+        try
+        {
+            var handler = new CapturingHandler(HttpStatusCode.OK);
+            var reporter = new DevThrottleDirectorStartupTelemetryReporter(
+                new HttpClient(handler), machineName: "TEST-MACHINE", gatewayUrl: TestGatewayUrl, gatewayToken: "device-key-1855");
+
+            await reporter.ReportStartupAsync("dir-abc");
+
+            Assert.NotNull(handler.Request);
+            Assert.Equal("http://evil.example.com/collect", handler.Request.RequestUri!.ToString());
+            Assert.Null(handler.Request.Headers.Authorization);           // the key did not travel
+            Assert.DoesNotContain("device-key-1855", handler.Body ?? ""); // and is not in the body either
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(DevThrottleDirectorStartupTelemetryReporter.EndpointEnvVar, previous);
+        }
+    }
+
+    [Fact]
+    public async Task ReportStartupAsync_SendsTheCredentialWhenTheOverridePointsAtItsOwnGateway()
+    {
+        // Control for the test above, and it is the one that stops that guard being a blanket "never
+        // authenticate when the override is set". An override naming this Director's OWN Gateway is still its
+        // own Gateway, so the credential travels and the report is accepted. Without this control, deleting the
+        // Authorization assignment entirely would leave the cross-host test green.
+        var previous = Environment.GetEnvironmentVariable(DevThrottleDirectorStartupTelemetryReporter.EndpointEnvVar);
+        Environment.SetEnvironmentVariable(DevThrottleDirectorStartupTelemetryReporter.EndpointEnvVar, $"{TestGatewayUrl}/telemetry/director-startup");
+        try
+        {
+            var handler = new CapturingHandler(HttpStatusCode.OK);
+            var reporter = new DevThrottleDirectorStartupTelemetryReporter(
+                new HttpClient(handler), machineName: "TEST-MACHINE", gatewayUrl: TestGatewayUrl, gatewayToken: "device-key-1855");
+
+            await reporter.ReportStartupAsync("dir-abc");
+
+            Assert.NotNull(handler.Request);
+            Assert.Equal("device-key-1855", handler.Request.Headers.Authorization?.Parameter);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(DevThrottleDirectorStartupTelemetryReporter.EndpointEnvVar, previous);
+        }
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Account/DevThrottleDirectorStartupTelemetryReporterTests.cs
+++ b/src/CcDirector.Core.Tests/Account/DevThrottleDirectorStartupTelemetryReporterTests.cs
@@ -93,6 +93,53 @@ public sealed class DevThrottleDirectorStartupTelemetryReporterTests
     }
 
     [Fact]
+    public async Task ReportStartupAsync_DoesNotFollowARedirect_SoTheCredentialCannotBeBouncedOffHost()
+    {
+        // Issue #1855, the redirect hole - closed structurally rather than left to framework behaviour.
+        //
+        // The Bearer is attached only when the target host matches the configured Gateway, but a redirect
+        // moves the destination AFTER that check has passed: a request that legitimately starts at this
+        // Director's own Gateway could be bounced anywhere, carrying a key that authenticates every
+        // Director-to-Gateway call. So the reporter's own client has AllowAutoRedirect=false.
+        //
+        // This drives the REAL handler the reporter ships with (CreateDefaultHandler), over REAL sockets,
+        // against a server that answers 302 to a DIFFERENT origin - it does not assert a configuration flag and
+        // call that a proof. The second server is watched: it must never be contacted at all.
+        //
+        // Deliberately NOT resting on ".NET strips Authorization across origins". That is true today and it is
+        // framework internals; this guard has to be visible in our own file and provable here.
+        //
+        // Revert-prove, run verbatim against the final file: set AllowAutoRedirect = true in
+        // CreateDefaultHandler. The build succeeds and EXACTLY THIS ONE test reddens, on
+        // Assert.Equal(0, destination.Requests) with Expected 0 / Actual 1 - the redirect target really was
+        // contacted - while the other eleven stay green.
+        using var destination = new LoopbackServer(_ => (200, null));
+        using var redirector = new LoopbackServer(_ => (302, destination.Url));
+
+        var reporter = new DevThrottleDirectorStartupTelemetryReporter(
+            new HttpClient(DevThrottleDirectorStartupTelemetryReporter.CreateDefaultHandler()),
+            machineName: "TEST-MACHINE", gatewayUrl: redirector.Url.TrimEnd('/'), gatewayToken: "device-key-1855");
+
+        // The exception is RECORDED rather than required, so the SECURITY fact is the assertion under proof
+        // and reddens first. Requiring the throw up front would make this test fail on "the redirect was
+        // followed at all" and never reach the question that matters, which is whether the credential moved.
+        var thrown = await Record.ExceptionAsync(() => reporter.ReportStartupAsync("dir-abc"));
+
+        Assert.Equal(0, destination.Requests);       // the redirect target was never contacted
+        Assert.Null(destination.LastAuthorization);  // so the credential could not have reached it
+        Assert.Equal(1, redirector.Requests);
+
+        // Positive control: the redirecting server IS the configured Gateway, so it legitimately received the
+        // credential. Without this, "the destination saw no Authorization" would also hold if the reporter had
+        // simply never sent one - which is the failure mode this whole pull request is about.
+        Assert.Equal("Bearer device-key-1855", redirector.LastAuthorization);
+
+        // And the unfollowed 302 stays a non-success response, so it still surfaces as the throw the
+        // best-effort caller logs rather than being mistaken for a delivered report.
+        Assert.IsType<HttpRequestException>(thrown);
+    }
+
+    [Fact]
     public async Task ReportStartupAsync_NeverSendsTheGatewayCredentialToAnotherHost()
     {
         // The credential rides ONLY to this Director's own configured Gateway. DEVTHROTTLE_STARTUP_TELEMETRY_URL
@@ -239,6 +286,65 @@ public sealed class DevThrottleDirectorStartupTelemetryReporterTests
             Request = request;
             Body = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
             return new HttpResponseMessage(_status);
+        }
+    }
+
+    /// <summary>
+    /// A real loopback HTTP server, so the redirect guard is proven over REAL sockets with the reporter's REAL
+    /// handler rather than by asserting a configuration flag. Records how many requests it received and the
+    /// Authorization header of the last one, which is what lets the test say the credential did not travel.
+    /// </summary>
+    private sealed class LoopbackServer : IDisposable
+    {
+        private readonly System.Net.HttpListener _listener = new();
+        private readonly Func<System.Net.HttpListenerRequest, (int Status, string? Location)> _respond;
+        private readonly CancellationTokenSource _cts = new();
+
+        public string Url { get; }
+        public int Requests { get; private set; }
+        public string? LastAuthorization { get; private set; }
+
+        public LoopbackServer(Func<System.Net.HttpListenerRequest, (int Status, string? Location)> respond)
+        {
+            _respond = respond;
+            Url = $"http://localhost:{FreePort()}/";
+            _listener.Prefixes.Add(Url);
+            _listener.Start();
+            _ = Task.Run(LoopAsync);
+        }
+
+        private async Task LoopAsync()
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                System.Net.HttpListenerContext ctx;
+                try { ctx = await _listener.GetContextAsync(); }
+                catch { return; /* listener stopped */ }
+
+                Requests++;
+                LastAuthorization = ctx.Request.Headers["Authorization"];
+                var (status, location) = _respond(ctx.Request);
+                ctx.Response.StatusCode = status;
+                if (location is not null)
+                    ctx.Response.Headers["Location"] = location;
+                ctx.Response.Close();
+            }
+        }
+
+        private static int FreePort()
+        {
+            var l = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            l.Start();
+            try { return ((System.Net.IPEndPoint)l.LocalEndpoint).Port; }
+            finally { l.Stop(); }
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            try { _listener.Stop(); } catch { }
+            try { _listener.Close(); } catch { }
+            _cts.Dispose();
         }
     }
 }

--- a/src/CcDirector.Core/Account/DevThrottleDirectorStartupTelemetryReporter.cs
+++ b/src/CcDirector.Core/Account/DevThrottleDirectorStartupTelemetryReporter.cs
@@ -20,8 +20,20 @@ namespace CcDirector.Core.Account;
 /// Issue #1855: the report is AUTHENTICATED, with the same <c>gateway.token</c> Bearer every other
 /// Director-to-Gateway call carries. It previously sent no credential at all, so a Gateway with its
 /// host-wide gate on refused it 401 - and because the caller swallows failures by design, the only symptom
-/// was startup telemetry that silently never arrived. The credential rides ONLY to this Director's own
-/// configured Gateway, never to an address the <see cref="EndpointEnvVar"/> override names.
+/// was startup telemetry that silently never arrived. The credential rides ONLY to a target that IS this
+/// Director's own configured Gateway - which an <see cref="EndpointEnvVar"/> override naming that same
+/// Gateway still is, and which an override naming any other address is not.
+///
+/// SCOPE, so nobody reads more into this than it does: authenticating the hop makes the report ARRIVE. It
+/// does NOT make it attributed to an account. The receiving endpoint records a process-global line and, when
+/// forwarding is configured, enqueues the body globally with no tenant on it, so this is GLOBAL OPERATIONAL
+/// telemetry by design - a ruled scope, not an oversight.
+///
+/// That is safe ONLY because there is no tenant-facing read route for this telemetry: nothing serves one
+/// account's startup record to another, so there is nothing to isolate. IF ANYONE EVER ADDS SUCH A READ,
+/// ATTRIBUTION MUST COME FIRST - at that point this stops being operational data and becomes tenant data.
+/// The deferred attribution work, and the unsolved part of it (how a hosted Gateway authenticates a
+/// per-account forward to the cloud when it holds no account token), are recorded on issue #1875.
 /// </summary>
 public sealed class DevThrottleDirectorStartupTelemetryReporter : IDirectorStartupTelemetryReporter
 {

--- a/src/CcDirector.Core/Account/DevThrottleDirectorStartupTelemetryReporter.cs
+++ b/src/CcDirector.Core/Account/DevThrottleDirectorStartupTelemetryReporter.cs
@@ -16,6 +16,12 @@ namespace CcDirector.Core.Account;
 /// Phase 1 is transitional: when no Gateway URL is configured the reporter is a NO-OP that logs a skip
 /// line - it never crashes and never falls back to a direct cloud call. The caller fires this detached
 /// (off the user-interface thread) so a slow or failing report never delays the main window appearing.
+///
+/// Issue #1855: the report is AUTHENTICATED, with the same <c>gateway.token</c> Bearer every other
+/// Director-to-Gateway call carries. It previously sent no credential at all, so a Gateway with its
+/// host-wide gate on refused it 401 - and because the caller swallows failures by design, the only symptom
+/// was startup telemetry that silently never arrived. The credential rides ONLY to this Director's own
+/// configured Gateway, never to an address the <see cref="EndpointEnvVar"/> override names.
 /// </summary>
 public sealed class DevThrottleDirectorStartupTelemetryReporter : IDirectorStartupTelemetryReporter
 {
@@ -36,6 +42,7 @@ public sealed class DevThrottleDirectorStartupTelemetryReporter : IDirectorStart
     private readonly string _machineName;
     private readonly string? _appVersion;
     private readonly string _gatewayUrl;
+    private readonly string _gatewayToken;
 
     /// <summary>
     /// Creates the reporter. <paramref name="client"/> defaults to a shared <see cref="HttpClient"/>;
@@ -46,12 +53,23 @@ public sealed class DevThrottleDirectorStartupTelemetryReporter : IDirectorStart
     /// <c>gateway.url</c> from config.json (<see cref="GatewayConfig.Load"/>). An empty Gateway URL with
     /// no <see cref="EndpointEnvVar"/> override makes the reporter a logged no-op.
     /// </summary>
-    public DevThrottleDirectorStartupTelemetryReporter(HttpClient? client = null, string? machineName = null, string? appVersion = null, string? gatewayUrl = null)
+    /// <param name="gatewayToken">
+    /// The Gateway credential this Director already holds - <c>gateway.token</c> from config.json, which is
+    /// the per-device key enrollment wrote there (issue #1855). Sent as the Bearer on the Gateway-derived
+    /// target so this report authenticates like every other Director-to-Gateway call. Defaults to the
+    /// configured value; tests pass it explicitly.
+    /// </param>
+    public DevThrottleDirectorStartupTelemetryReporter(HttpClient? client = null, string? machineName = null, string? appVersion = null, string? gatewayUrl = null, string? gatewayToken = null)
     {
         _client = client ?? SharedClient;
         _machineName = string.IsNullOrWhiteSpace(machineName) ? Environment.MachineName : machineName.Trim();
         _appVersion = appVersion ?? AppVersion.Semver;
-        _gatewayUrl = (gatewayUrl ?? GatewayConfig.Load().Url).Trim();
+        // config.json is read ONLY when the target was not supplied. A caller that names the Gateway is
+        // configuring this reporter explicitly - which every test does, so a test never picks up the machine's
+        // own gateway.token and the credential under test is always the one the test chose.
+        var config = gatewayUrl is null ? GatewayConfig.Load() : null;
+        _gatewayUrl = (gatewayUrl ?? config!.Url).Trim();
+        _gatewayToken = (gatewayToken ?? config?.Token ?? "").Trim();
     }
 
     /// <summary>
@@ -69,6 +87,32 @@ public sealed class DevThrottleDirectorStartupTelemetryReporter : IDirectorStart
             return null;
 
         return $"{_gatewayUrl.TrimEnd('/')}{GatewayStartupPath}";
+    }
+
+    /// <summary>
+    /// True when the target is THIS Director's own configured Gateway - the only host the Gateway credential
+    /// may be sent to (issue #1855).
+    ///
+    /// <see cref="EndpointEnvVar"/> can point the report at an ARBITRARY address for a test, proof or staging
+    /// run. Attaching the credential unconditionally would hand this machine's per-device Gateway key to
+    /// whatever host that variable names - a key that authenticates every Director-to-Gateway call, handed
+    /// over by setting one environment variable. So the Bearer rides only on the Gateway-derived target, and
+    /// an override that happens to point back at the configured Gateway still qualifies because it IS that
+    /// Gateway.
+    /// </summary>
+    private bool TargetIsOwnGateway(string endpoint)
+    {
+        if (string.IsNullOrWhiteSpace(_gatewayUrl))
+            return false;
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var target)
+            || !Uri.TryCreate(_gatewayUrl, UriKind.Absolute, out var gateway))
+            return false;
+
+        // Same host, port and scheme. A different scheme is not the same destination: sending the key over
+        // plain http to a host we know as https is exactly the downgrade this check exists to refuse.
+        return string.Equals(target.Scheme, gateway.Scheme, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(target.Host, gateway.Host, StringComparison.OrdinalIgnoreCase)
+            && target.Port == gateway.Port;
     }
 
     public async Task ReportStartupAsync(string directorId, CancellationToken ct = default)
@@ -98,9 +142,37 @@ public sealed class DevThrottleDirectorStartupTelemetryReporter : IDirectorStart
             Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json"),
         };
 
-        FileLog.Write($"[DevThrottleDirectorStartupTelemetryReporter] ReportStartupAsync: POSTing director-startup event to gateway {endpoint} (director_id={directorId}, machine_name={_machineName})");
+        // Issue #1855: AUTHENTICATE THE REPORT. This request used to carry no Authorization header at all,
+        // while every other Director-to-Gateway call sends `Bearer gateway.token`. The Gateway gate is
+        // host-wide, so the report was refused 401 by any Gateway with auth on - and the failure was
+        // swallowed, so the only symptom was an absence, which looks exactly like nobody having started a
+        // Director. It surfaced on hosted because hosted is authenticated by construction. The credential is
+        // the same per-device key enrollment already wrote to gateway.token and that the tunnel and the
+        // cockpit reads use in the same boot; the Gateway resolves the tenant from it, so the event lands
+        // against the right account with nothing further to plumb.
+        var authenticated = !string.IsNullOrEmpty(_gatewayToken) && TargetIsOwnGateway(endpoint);
+        if (authenticated)
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _gatewayToken);
+
+        FileLog.Write($"[DevThrottleDirectorStartupTelemetryReporter] ReportStartupAsync: POSTing director-startup event to gateway {endpoint} (director_id={directorId}, machine_name={_machineName}, authenticated={authenticated})");
         using var response = await _client.SendAsync(request, ct).ConfigureAwait(false);
         FileLog.Write($"[DevThrottleDirectorStartupTelemetryReporter] ReportStartupAsync: response status={(int)response.StatusCode}");
+
+        // A REFUSED CREDENTIAL IS NOT A TRANSIENT, and it must not read like one. The caller swallows every
+        // failure here by design - a telemetry report must never delay or fail startup - so a 401 or 403 that
+        // logged like any other error left a permanently broken configuration indistinguishable from a blip.
+        // Say plainly what was refused and what to do, and say it once, at the moment it happens.
+        if (response.StatusCode is System.Net.HttpStatusCode.Unauthorized or System.Net.HttpStatusCode.Forbidden)
+        {
+            FileLog.Write(
+                $"[DevThrottleDirectorStartupTelemetryReporter] ReportStartupAsync: the Gateway REFUSED this Director's credential " +
+                $"({(int)response.StatusCode}) for {endpoint}. This is a configuration fault, not a transient failure - it will not " +
+                $"recover on its own, and startup telemetry from this machine will be MISSING until it is fixed. " +
+                (authenticated
+                    ? "The credential sent was gateway.token from config.json; re-enroll this machine to obtain a valid one."
+                    : "NO credential was sent, because gateway.token is not set in config.json or the target is not this Director's own configured Gateway."));
+        }
+
         response.EnsureSuccessStatusCode();
     }
 }

--- a/src/CcDirector.Core/Account/DevThrottleDirectorStartupTelemetryReporter.cs
+++ b/src/CcDirector.Core/Account/DevThrottleDirectorStartupTelemetryReporter.cs
@@ -36,7 +36,27 @@ public sealed class DevThrottleDirectorStartupTelemetryReporter : IDirectorStart
 
     // A single shared client (best practice - avoids socket exhaustion). The short timeout keeps a
     // best-effort report from lingering; the caller fires it detached anyway.
-    private static readonly HttpClient SharedClient = new() { Timeout = TimeSpan.FromSeconds(10) };
+    private static readonly HttpClient SharedClient = new(CreateDefaultHandler()) { Timeout = TimeSpan.FromSeconds(10) };
+
+    /// <summary>
+    /// The handler this reporter's own client uses. REDIRECTS ARE DISABLED, and that is a security guard, not
+    /// a performance choice (issue #1855).
+    ///
+    /// The Bearer is attached only when the target host matches the configured Gateway
+    /// (<see cref="TargetIsOwnGateway"/>), but a redirect would move the destination AFTER that check has
+    /// passed: a request that legitimately starts at this Director's own Gateway could be bounced anywhere,
+    /// carrying a key that authenticates every Director-to-Gateway call. Refusing to follow redirects at all
+    /// makes an off-host header leak STRUCTURALLY IMPOSSIBLE rather than merely unlikely, and a fire-and-forget
+    /// telemetry POST has no legitimate reason to follow one.
+    ///
+    /// This deliberately does NOT rest on the fact that .NET strips the Authorization header on a cross-origin
+    /// redirect. That is true today, but it is framework internals: a security guarantee should be explicit and
+    /// visible to a reviewer in this file, not dependent on behaviour a future framework version could change
+    /// and nobody here would notice.
+    ///
+    /// Internal so a test can assert the guard and drive the real no-redirect behaviour.
+    /// </summary>
+    internal static HttpMessageHandler CreateDefaultHandler() => new SocketsHttpHandler { AllowAutoRedirect = false };
 
     private readonly HttpClient _client;
     private readonly string _machineName;
@@ -148,8 +168,12 @@ public sealed class DevThrottleDirectorStartupTelemetryReporter : IDirectorStart
         // swallowed, so the only symptom was an absence, which looks exactly like nobody having started a
         // Director. It surfaced on hosted because hosted is authenticated by construction. The credential is
         // the same per-device key enrollment already wrote to gateway.token and that the tunnel and the
-        // cockpit reads use in the same boot; the Gateway resolves the tenant from it, so the event lands
-        // against the right account with nothing further to plumb.
+        // cockpit reads use in the same boot.
+        //
+        // What this does NOT do: attribute the event to an account. The receiving endpoint does not read the
+        // request's tenant - it writes a process-global record line and enqueues the raw body globally - so
+        // sending the credential makes the report ARRIVE and be recorded, nothing more. Claiming otherwise
+        // was an error in the first version of this change.
         var authenticated = !string.IsNullOrEmpty(_gatewayToken) && TargetIsOwnGateway(endpoint);
         if (authenticated)
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _gatewayToken);

--- a/src/CcDirector.Gateway.Tests/DirectorStartupTelemetryAuthTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorStartupTelemetryAuthTests.cs
@@ -29,6 +29,13 @@ namespace CcDirector.Gateway.Tests;
 /// test previously covered: this route accepts a per-device key exactly like every other gated route, so
 /// sending the credential is sufficient. If that ever stopped being true the client fix would silently stop
 /// working and the failure would again be invisible.
+///
+/// WHAT THEY DELIBERATELY DO NOT PROVE: anything about tenancy. This endpoint does not read the request's
+/// tenant - it writes a process-global record line and, when forwarding is configured, enqueues the raw body
+/// globally with no tenant on it. So the credential here is an ADMISSION check, not an attribution: any valid
+/// key gets in, including one bound to no tenant, and that is the correct behaviour for telemetry that is
+/// global by construction. These tests assert exactly that and no more. Per-account attribution would need a
+/// tenant-aware record and queue contract, which is a separate piece of work.
 /// </summary>
 public sealed class DirectorStartupTelemetryAuthTests : IAsyncLifetime
 {

--- a/src/CcDirector.Gateway.Tests/DirectorStartupTelemetryAuthTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorStartupTelemetryAuthTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1855: the Gateway half of the director-startup telemetry 401.
+///
+/// The reported symptom was that a correctly enrolled hosted Director could not report its startup: the
+/// route answered 401 to the very per-device key the hosted Gateway had just issued it, and the report is
+/// best-effort with the exception swallowed, so nothing surfaced anywhere. The only symptom was an ABSENCE -
+/// hosted Directors simply never appeared in startup telemetry - and an absence looks exactly like nobody
+/// having started a Director.
+///
+/// The cause turned out NOT to be hosted rejecting the key. The reporter sent NO Authorization header at all
+/// (fixed in DevThrottleDirectorStartupTelemetryReporter), so the host-wide gate refused it - which would
+/// happen on ANY Gateway with auth on, self-host included. Hosted merely surfaced it first, because hosted is
+/// authenticated by construction.
+///
+/// These tests pin the Gateway side of that conclusion, which the client-side fix depends on and which no
+/// test previously covered: this route accepts a per-device key exactly like every other gated route, so
+/// sending the credential is sufficient. If that ever stopped being true the client fix would silently stop
+/// working and the failure would again be invisible.
+/// </summary>
+public sealed class DirectorStartupTelemetryAuthTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string Path_ = "telemetry/director-startup";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _deviceKey = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(System.IO.Path.GetTempPath(), "cc-dst-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _deviceKey = _gateway.Devices.Register("dev-telemetry", "MT").DeviceKey;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task A_per_device_key_is_accepted()
+    {
+        // The claim the client fix rests on: this route takes a per-device key like every other gated route,
+        // so a Director that simply SENDS its gateway.token is accepted. 202 is the endpoint's success answer
+        // ("received and recorded"), not 200.
+        var resp = await Post(_deviceKey);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task The_shared_gateway_token_is_also_accepted()
+    {
+        // Control: the device-key branch is not the only way in, so a self-host Director configured with the
+        // shared machine token reports its startup too. Without this, a route that ONLY took device keys would
+        // satisfy the test above while breaking every self-host install.
+        var resp = await Post(Token);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task No_credential_is_refused()
+    {
+        // The reported failure, reproduced at the wire: this is EXACTLY what the reporter used to send - a
+        // POST with no Authorization header at all - and it is exactly what it got back. The route is gated,
+        // as it should be; the client was the one at fault.
+        var req = new HttpRequestMessage(HttpMethod.Post, Path_)
+        {
+            Content = new StringContent("{\"director_id\":\"dir-1\"}", Encoding.UTF8, "application/json"),
+        };
+        var resp = await _http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_bogus_key_is_refused()
+    {
+        // Control on the acceptance tests above: they must pass because the CREDENTIAL was valid, not because
+        // the route waves everything through. A route that accepted anything would pass both of them.
+        var resp = await Post("not-a-real-key");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    private Task<HttpResponseMessage> Post(string credential)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, Path_)
+        {
+            Content = new StringContent("{\"director_id\":\"dir-1\",\"machine_name\":\"MT\"}", Encoding.UTF8, "application/json"),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", credential);
+        return _http.SendAsync(req);
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}


### PR DESCRIPTION
Closes thefrederiksen/devthrottle#1855.

## The root cause is broader than the issue title says

The issue reads as "hosted rejects the very device key it just issued". It is not that.

`DevThrottleDirectorStartupTelemetryReporter` built its request as:

```csharp
using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
{
    Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json"),
};
```

**No `Authorization` header, on any path.** Every other Director-to-Gateway call sets `Bearer {_config.Token}` from `GatewayConfig` (see `GatewayClient`), and the Gateway's gate is host-wide. So this report was refused by *any* Gateway with auth on - **self-host included** - and it has been since the gate went on by default. Hosted surfaced it first only because hosted is authenticated by construction.

The credential was never missing. `GatewayCredentialStore.SaveEnrolledKey` writes the enrolled per-device key straight into `gateway.token` in `config.json`, which is the same key the tunnel and the cockpit reads use in the same boot. The reporter loaded `gateway.url` from that config and simply never read `.token`.

The second half of the issue - that it **fails silently** - is what made this survive. The caller swallows every failure by design, so the only symptom was an absence, and an absence looks exactly like nobody having started a Director.

**Suggested issue re-scope:** this is "the startup telemetry reporter never authenticates", not "hosted rejects the key". Worth correcting, because the current framing blames hosted for a general auth omission.

**Scope, ruled.** thefrederiksen/devthrottle#1855 originally expected the route to "record the event against that device's tenant". That expectation has been **dropped and the issue rescoped**: director-startup telemetry is **global operational data with no per-account attribution**.

The decisive fact, verified by reading the endpoint rather than inferred: it writes a process-global record line and, only when a forward URL is set, enqueues the body with `bearer: null` and no tenant field - and **there is no tenant-facing read route for this telemetry anywhere**. Nothing serves one tenant's startup record to another, so there is no cross-tenant leak here to close. This is the operator seeing operational data - the attribution side of the isolation-versus-attribution distinction, not a tenancy boundary.

Attribution is deferred to **#1875**, which records the hard part: the unsolved problem is how a hosted Gateway authenticates a per-account forward to the cloud when it holds no account token. That will recur for any hosted-to-cloud attributed forward, so it needs its own design rather than a tenant column bolted onto the queue - a tenant field on a queue whose forward cannot authenticate is a half-partition.

**The safeguard that makes this rescope honest rather than a quiet drop**, also recorded on thefrederiksen/devthrottle_internal#886: it is safe *only* because there is no tenant-facing read of this telemetry. If anyone ever adds one, attribution must come first - at that point it stops being operational data and becomes tenant data.

**Related, verified while here:** `DevThrottleLoginTelemetryReporter` has the structurally identical omission - it POSTs `/telemetry/login` with no `Authorization` header, and that path is not on the auth middleware's exact-match public list, so the same default gate refuses it. Booked as **#1876**, to get the same fix shape *and* the same two security guards (host-match, no-redirect), each with its own revert-proof - rather than being widened into this pull request.

## The fix

1. **Send the credential.** The report attaches `Authorization: Bearer <gateway.token>`, exactly as every other Director-to-Gateway call does, so the report ARRIVES and is recorded instead of being silently refused.

   **Scope, corrected.** The first version of this pull request claimed the Gateway "resolves the tenant from that key, so the event lands against the right account with nothing further to plumb". **That was false and I had not verified it.** The receiving endpoint never reads the request's tenant: it writes a process-global log line and, when forwarding is configured, enqueues the raw body globally with `bearer: null` and no tenant field. So this fixes the 401 and the local record; it does **not** attribute the event to an account. Caught in review.

2. **Only to its own Gateway.** `DEVTHROTTLE_STARTUP_TELEMETRY_URL` can point the report at an arbitrary address for a test, proof or staging run. Attaching the key unconditionally would hand this machine's per-device Gateway key - which authenticates *every* Director-to-Gateway call - to whatever host that variable names, by setting one environment variable. The Bearer therefore rides only on a target whose scheme, host and port match the configured Gateway. A different scheme does not qualify: sending the key over plain `http` to a host we know as `https` is exactly the downgrade this refuses.

3. **A refused credential no longer reads like a transient.** 401 and 403 get their own loud log line saying what was refused, that it is a configuration fault that will not recover on its own, that telemetry from this machine will be missing until it is fixed, and whether a credential was sent at all. The report stays best-effort - it must never delay or fail startup.

## A prior decision this reverses, deliberately

`ReportStartupAsync_SendsNoAuthorizationHeader` asserted the POST carries **no** `Authorization` header, ever, on the #642 reasoning that "the Director holds no credential, and the Gateway attaches its own token on the cloud forward (#639)".

The second half is still true and is enforced Gateway-side. The first half conflated two different hops: the Director does hold a credential **for the Gateway**, and the inbound hop is gated like every other Gateway route. The test is kept, narrowed to what survives - with no gateway token configured there is nothing to send and the reporter must not invent one - and the reasoning is recorded in place.

Also fixed while here: the constructor now reads `config.json` **only** when the target was not supplied, so the test-isolation guarantee the existing tests rely on ("every test passes an explicit `gatewayUrl` so the reporter never reads the test machine's config.json") extends to the credential. A test can never pick up the developer's own `gateway.token`.

## Proof

**Revert-prove, run verbatim against the final file.** Delete the two lines:

```csharp
if (authenticated)
    request.Headers.Authorization = new ...AuthenticationHeaderValue("Bearer", _gatewayToken);
```

The build succeeds, and **exactly two** tests redden on a null `Authorization` header: `SendsTheConfiguredGatewayTokenAsBearer` and `SendsTheCredentialWhenTheOverridePointsAtItsOwnGateway`. The remaining nine stay green - **including the cross-host test, which asserts the header is absent and therefore cannot detect this revert at all.**

That last point is why the own-gateway control exists. Without it, deleting the credential entirely would leave the cross-host guard green and the deletion would look harmless - a guard that only ever asserts absence cannot tell "correctly withheld" from "never sent".

**Redirect guard.** `AllowAutoRedirect = false` on the reporter's own handler, because a redirect moves the destination *after* the host-match check has passed. Proven behaviourally over real sockets against a server that 302s to a different origin, driving the real shipped handler - not by asserting a configuration flag. Revert-prove: set `AllowAutoRedirect = true`; the build succeeds and exactly this one test reddens on `Assert.Equal(0, destination.Requests)` with `Expected 0 / Actual 1` - the redirect target really was contacted - eleven others green. The exception is *recorded* rather than required so the security fact is the assertion that reddens first, not "the redirect was followed at all".

This deliberately does not rest on .NET clearing `Authorization` across origins. That is true today and it is framework internals; the guard should be visible in our own file.

**Gateway side.** Four new wire tests pin the half the client fix depends on and that nothing covered: a per-device key is accepted (202), the shared machine token is also accepted (so self-host is not broken by a device-key-only route), no credential is refused (401 - the reported failure reproduced exactly at the wire), and a bogus key is refused (so the two acceptance tests pass because the credential was valid, not because the route waves everything through).

These prove **admission, not attribution**. Any valid key gets in, including one bound to no tenant - which is the correct behaviour for telemetry that is global by construction, and the tests now say so explicitly rather than implying a tenancy property they do not test.

## Tests

All seven test projects run, green:

| Project | Passed | Skipped | Total |
|---|---|---|---|
| Gateway | 2872 | 10 | 2882 |
| Core | 3306 | 8 | 3314 |
| Avalonia | 247 | 0 | 247 |
| HostedAgent | 86 | 0 | 86 |
| Engine | 62 | 0 | 62 |
| Launcher | 27 | 0 | 27 |
| Terminal.Avalonia | 21 | 0 | 21 |

Gateway 2882 total against the ~2861 baseline (four added here); Core 3314 total (four added here).

## Note on CI coverage

The `#1864` repair of folding the setup test projects into `cc-director.sln` is **not** load-bearing for this change. The reporter is `src/CcDirector.Core/Account/`, the endpoint is `src/CcDirector.Gateway/Api/`, and both projects' tests are already in the solution and already gate a merge. Checked rather than assumed.
