### PR TITLE
fix(gateway): trust the hosted front end so hosted stops minting http:// URLs

### DIFF
--- a/src/CcDirector.Gateway.Tests/ForwardedHeadersPolicyTests.cs
+++ b/src/CcDirector.Gateway.Tests/ForwardedHeadersPolicyTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1870: on the hosted Gateway every ViewUrl was minted as <c>gw=http://...</c> on an HTTPS-only
+/// host. The cause was proxy trust, not URL building - forwarded headers were accepted from loopback only,
+/// which is right for the self-hosted Tailscale Serve front end but discards
+/// <c>X-Forwarded-Proto: https</c> from the Azure App Service front end, which forwards from a non-loopback
+/// platform address.
+///
+/// These tests pin both halves of that decision. The options tests state the policy; the two end-to-end
+/// tests run a real <see cref="ForwardedHeadersMiddleware"/> and assert on the scheme a request handler
+/// actually observes, because the options being set is not the same claim as the scheme surviving the
+/// middleware.
+/// </summary>
+public class ForwardedHeadersPolicyTests
+{
+    private static ForwardedHeadersOptions Apply(bool isHosted)
+    {
+        var options = new ForwardedHeadersOptions();
+        ForwardedHeadersPolicy.Apply(options, isHosted);
+        return options;
+    }
+
+    [Fact]
+    public void SelfHosted_TrustsLoopbackAndNothingElse()
+    {
+        var o = Apply(isHosted: false);
+
+        Assert.Equal(new[] { IPAddress.Loopback, IPAddress.IPv6Loopback }, o.KnownProxies);
+        Assert.Empty(o.KnownIPNetworks);
+    }
+
+    [Fact]
+    public void Hosted_LeavesTheKnownProxySetEmptySoThePlatformFrontEndIsAccepted()
+    {
+        var o = Apply(isHosted: true);
+
+        // An empty known-proxy AND known-network set is how ForwardedHeadersMiddleware is told to accept a
+        // front end it cannot enumerate. A loopback entry here is the #1870 defect.
+        Assert.Empty(o.KnownProxies);
+        Assert.Empty(o.KnownIPNetworks);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void BothDeployments_ReadProtoHostAndFor(bool isHosted)
+    {
+        var o = Apply(isHosted);
+
+        Assert.True(o.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedProto));
+        Assert.True(o.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedHost));
+        Assert.True(o.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedFor));
+    }
+
+    [Fact]
+    public void Apply_NullOptions_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => ForwardedHeadersPolicy.Apply(null!, isHosted: true));
+
+    /// <summary>
+    /// Run a request through a real ForwardedHeadersMiddleware from a NON-loopback address, exactly as the
+    /// Azure App Service front end does, and assert on the scheme the handler observes. This is the test
+    /// that actually reproduces #1870: with the hosted policy the handler sees "https"; with the self-host
+    /// policy the same request is seen as "http", which is what every hosted ViewUrl was built from.
+    /// </summary>
+    private static async Task<string> ObservedSchemeAsync(bool isHosted, string frontEndAddress)
+    {
+        var options = new ForwardedHeadersOptions();
+        ForwardedHeadersPolicy.Apply(options, isHosted);
+
+        var observed = "";
+        var middleware = new ForwardedHeadersMiddleware(
+            next: ctx => { observed = ctx.Request.Scheme; return Task.CompletedTask; },
+            loggerFactory: NullLoggerFactory.Instance,
+            options: Options.Create(options));
+
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "http";                       // what the front end forwards as
+        context.Connection.RemoteIpAddress = IPAddress.Parse(frontEndAddress);
+        context.Request.Headers["X-Forwarded-Proto"] = "https";
+        context.Request.Headers["X-Forwarded-For"] = frontEndAddress;
+
+        await middleware.Invoke(context);
+        return observed;
+    }
+
+    [Fact]
+    public async Task Hosted_HttpsFromANonLoopbackFrontEnd_IsSeenAsHttps()
+    {
+        // 169.254.x.x is the shape of an App Service platform forwarder: not loopback, not enumerable.
+        Assert.Equal("https", await ObservedSchemeAsync(isHosted: true, frontEndAddress: "169.254.130.5"));
+    }
+
+    [Fact]
+    public async Task SelfHosted_HttpsFromANonLoopbackSender_IsIgnored()
+    {
+        // The self-host guard that must NOT be weakened: an arbitrary sender cannot claim HTTPS.
+        Assert.Equal("http", await ObservedSchemeAsync(isHosted: false, frontEndAddress: "169.254.130.5"));
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1428,24 +1428,14 @@ public sealed class GatewayHost : IAsyncDisposable
         // SendLauncherCommandAsync share this one connection registry.
         builder.Services.AddSingleton(LauncherConnections);
 
-        // Honor X-Forwarded-Proto/Host/For from a Tailscale Serve front-end so
-        // ctx.Request.Scheme reflects the public scheme the user actually used.
-        // Without this, every request appears as plain "http" to the Gateway
-        // (Tailscale terminates TLS at :443 and forwards plaintext to loopback),
-        // and ViewUrl ends up with the wrong scheme on the phone.
-        //
-        // Trust only loopback as a forwarding proxy: anything else must not be
-        // allowed to claim "I'm HTTPS" by spoofing the header.
-        builder.Services.Configure<ForwardedHeadersOptions>(o =>
-        {
-            o.ForwardedHeaders = ForwardedHeaders.XForwardedFor
-                               | ForwardedHeaders.XForwardedProto
-                               | ForwardedHeaders.XForwardedHost;
-            o.KnownProxies.Clear();
-            o.KnownProxies.Add(IPAddress.Loopback);
-            o.KnownProxies.Add(IPAddress.IPv6Loopback);
-            o.KnownIPNetworks.Clear();
-        });
+        // Honor X-Forwarded-Proto/Host/For from the TLS-terminating front end so ctx.Request.Scheme
+        // reflects the public scheme the user actually used. Which senders may be believed differs
+        // between the two deployments - self-host trusts loopback only (Tailscale Serve), hosted must
+        // also accept the Azure App Service front end, which forwards from a non-loopback platform
+        // address (issue #1870). See ForwardedHeadersPolicy for why that is safe there and only there.
+        var isHostedDeployment = _tenantBoundary.IsHosted;
+        builder.Services.Configure<ForwardedHeadersOptions>(
+            o => Tenancy.ForwardedHeadersPolicy.Apply(o, isHostedDeployment));
 
         _app = builder.Build();
 

--- a/src/CcDirector.Gateway/Tenancy/ForwardedHeadersPolicy.cs
+++ b/src/CcDirector.Gateway/Tenancy/ForwardedHeadersPolicy.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// Decides which forwarding proxies the Gateway will believe when they say "this request arrived over HTTPS".
+///
+/// The Gateway always runs behind a TLS-terminating front end, and that front end forwards plaintext. So
+/// <c>ctx.Request.Scheme</c> is only correct if <c>X-Forwarded-Proto</c> is honoured - and honouring it from
+/// the wrong sender is how anything on the network gets to claim it is HTTPS. The two deployments have
+/// genuinely different front ends, so they get genuinely different answers:
+///
+/// <list type="bullet">
+/// <item><b>Self-hosted</b> sits behind Tailscale Serve, which terminates TLS at :443 and forwards to
+/// LOOPBACK. Loopback is therefore the only sender that may be believed, and nothing else on the tailnet or
+/// the LAN can spoof its way to HTTPS.</item>
+/// <item><b>Hosted</b> sits behind the Azure App Service front end, which terminates TLS and forwards from a
+/// PLATFORM address that is not loopback and is not a fixed, documentable value. Restricting to loopback
+/// there means <c>X-Forwarded-Proto: https</c> is discarded on every request, so the Gateway believes it is
+/// serving plain HTTP on an HTTPS-only host.</item>
+/// </list>
+///
+/// The hosted container is not addressable except through that front end - inbound traffic cannot reach it
+/// any other way - so accepting the platform's forwarded headers there does not widen anything a caller
+/// could exploit. This is the standard configuration for ASP.NET Core on App Service, and it is applied
+/// ONLY when hosted: the self-host restriction is deliberately left exactly as it was.
+///
+/// What went wrong without this (issue #1870): every hosted <c>ViewUrl</c> was minted as
+/// <c>gw=http://...</c> on an HTTPS-only host, handing clients a plaintext address for the API base. The
+/// same discarded scheme also reached the remote sign-in URL builder and the Director base-URL helper, so
+/// this is fixed once here at the transport layer rather than patched at each of the three call sites.
+/// </summary>
+public static class ForwardedHeadersPolicy
+{
+    /// <summary>The forwarded headers the Gateway reads, in both deployments.</summary>
+    public const ForwardedHeaders Headers =
+        ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost;
+
+    /// <summary>
+    /// Apply the proxy-trust policy for this deployment. When <paramref name="isHosted"/> is false the known
+    /// proxy set is loopback and nothing else; when it is true the set is left empty, which is how
+    /// <see cref="ForwardedHeadersMiddleware"/> is told to accept the platform front end it cannot enumerate.
+    /// </summary>
+    /// <param name="options">The options instance to configure.</param>
+    /// <param name="isHosted">True on the hosted, multi-tenant Gateway; false for a self-hosted Gateway.</param>
+    public static void Apply(ForwardedHeadersOptions options, bool isHosted)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.ForwardedHeaders = Headers;
+        options.KnownProxies.Clear();
+        options.KnownIPNetworks.Clear();
+
+        if (isHosted)
+            return;
+
+        options.KnownProxies.Add(IPAddress.Loopback);
+        options.KnownProxies.Add(IPAddress.IPv6Loopback);
+    }
+}


### PR DESCRIPTION
Fixes #1870. Found by driving the live hosted Gateway with a real Director.

## The symptom

Every session deep-link the hosted Gateway minted carried a plaintext gateway base, on an HTTPS-only host. Observed live in both the roster and the by-id read:

```
"viewUrl": "/sessions/e3252e8f-.../view?gw=http%3A%2F%2Fdevthrottle-gw.azurewebsites.net"
```

That `gw=` value is the API base the client then calls.

## The cause is proxy trust, not URL building

The Gateway always sits behind a TLS-terminating front end that forwards plaintext, so `Request.Scheme` is only correct if `X-Forwarded-Proto` is honoured. Forwarded headers were accepted from **loopback only**:

- **correct for self-host** — Tailscale Serve terminates TLS at :443 and forwards to loopback, and nothing else on the tailnet or LAN should be able to claim HTTPS by spoofing a header
- **wrong for hosted** — the Azure App Service front end forwards from a platform address that is neither loopback nor a fixed value we could enumerate, so the header was discarded on every request

## Why the fix is at the transport layer

The discarded scheme reached **three** readers, not one:

| Reader | What it builds |
|---|---|
| `DeriveGatewayBaseUrl` | the `gw=` parameter on every `ViewUrl` |
| `DeriveDirectorBaseUrl` | the Director base address |
| `AccountSignInStartEndpoint` | the **remote sign-in URL** |

Patching only the URL helper would have left the other two minting `http://` — a partial fix that reads as a whole one. Correcting `Request.Scheme` fixes all three at once.

## What is deliberately unchanged

Self-host still trusts loopback and nothing else. The hosted container is not addressable except through its front end, so accepting that front end's headers **there** widens nothing a caller can reach. The decision is a pure function (`ForwardedHeadersPolicy.Apply`) so it is testable without standing up a web host.

## Proof

Revert-proven: with the hosted branch removed, exactly the two hosted tests fail and the five self-host and shared controls stay green.

| Production line reverted | Result |
|---|---|
| the `if (isHosted) return;` that leaves the known-proxy set empty | `Hosted_LeavesTheKnownProxySetEmptySoThePlatformFrontEndIsAccepted` **fails**, `Hosted_HttpsFromANonLoopbackFrontEnd_IsSeenAsHttps` **fails**, 5 controls green |

The end-to-end tests run a **real `ForwardedHeadersMiddleware`** and assert on the scheme a request handler actually observes, because the options being set is a different claim from the scheme surviving the middleware.

- Gateway suite: **2882 passed, 0 failed**, 10 skipped
- Gateway project builds with 0 warnings

## Honest scope

Live confirmation on the hosted box has to wait for the next hosted deploy — this changes what the Gateway believes about its own scheme, which cannot be observed from outside until the image ships. I have the rig standing and will verify it on the live box at that deploy, alongside the #1869 verification.

Coordinated with the gw-tenancy Manager, who is taking #1869 in the same file: their work is in the per-session route call sites, this is the forwarded-header configuration and `DeriveGatewayBaseUrl`. Different regions; rebased onto origin/main before pushing regardless.