### PR TITLE
fix(gateway): deny the stats dashboard on hosted (#1848, stats half)

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedStatsDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedStatsDenyTests.cs
@@ -496,14 +496,21 @@ public sealed class HostedStatsSelfHostControlTests : IDisposable
     }
 
     /// <summary>
-    /// The mirror of the future-route probe: on self-host the group filter lets a route added to the group
-    /// through untouched. Without this, "the filter refuses everything, always" would pass every hosted test
-    /// in this file.
+    /// THE SECOND HALF OF THE FUTURE-ROUTE PROOF, and the review asked for both halves by name: the probe
+    /// route must be REFUSED on hosted and SERVED with hosted mode EXPLICITLY off. The hosted half is
+    /// <see cref="HostedStatsGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own"/>;
+    /// this is its mirror, on the SAME probe path, with hosted mode stated rather than assumed - and stated in
+    /// both non-hosted forms, absent and present-but-"0".
+    ///
+    /// Without this half, "the filter refuses everything, always" would pass every hosted test in this file
+    /// while having silently killed the route for self-host too. One direction alone cannot tell a working
+    /// gate apart from a brick.
     /// </summary>
-    [Fact]
-    public async Task A_route_added_to_the_group_still_serves_on_self_host()
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task A_route_added_to_the_group_still_serves_on_self_host(string? hostedValue)
     {
-        DeclareSelfHost(null);
+        DeclareSelfHost(hostedValue);
 
         var (app, http) = await StatsGroupProbeHost.StartAsync(
             SeededAggregator(),

--- a/src/CcDirector.Gateway.Tests/HostedStatsDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedStatsDenyTests.cs
@@ -3,7 +3,9 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Linq;
 using System.Net.Sockets;
+using System.Text.Json;
 using System.Threading.Tasks;
 using CcDirector.Gateway;
 using Xunit;
@@ -27,8 +29,9 @@ namespace CcDirector.Gateway.Tests;
 ///
 /// IT IS A REFUSAL, NOT AN EMPTY DASHBOARD. Serving zeroed series would be a FALSE statement rather than an
 /// absent one - the same mistake /healthz made when it zeroed its fleet counts and anything monitoring them
-/// read a permanently dead fleet. The tests below assert the refusal AND the absence of the payload keys, so
-/// a future "helpful" empty-shape response fails here rather than passing as a deny.
+/// read a permanently dead fleet. The refusal body is asserted as an EXACT PROPERTY SET - one error field and
+/// nothing else - rather than as an absence of known payload keys. A deny-list of today's keys was tried and
+/// review broke it in one move; see the note on that test for why an allow-list is the only shape that holds.
 ///
 /// Revert-prove: delete the <c>DenyOnHosted()</c> guard from either route and that route's tests go RED -
 /// the data route with a 200 carrying the fleet-global keys, the page route with the HTML dashboard.
@@ -84,16 +87,33 @@ public sealed class HostedStatsDenyTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
-    [Fact]
-    public async Task The_stats_feed_discloses_none_of_its_payload()
+    [Theory]
+    [InlineData("stats/data")]
+    [InlineData("stats")]
+    public async Task The_refusal_carries_nothing_but_the_refusal(string path)
     {
-        // Asserting the status alone would let a future "helpful" change serve an empty-but-shaped payload
-        // under some other code and still pass. These are the keys that carry the disclosure - repository
-        // names, agent and model tallies, token spend - and none of them may appear in any form.
-        var body = await (await Get("stats/data", _key)).Content.ReadAsStringAsync();
+        // AN ALLOW-LIST, NOT A DENY-LIST, and the difference is the whole test.
+        //
+        // This first asserted that a handful of known payload keys were absent. Review broke it in one move:
+        // a denial envelope carrying generatedAtUtc, timeZone, concurrency and notCaptured passed all five
+        // tests. Worse, the real feed has keys a substring deny-list silently misses - "tokenSpendByHour"
+        // does not contain the string "tokenSpend" once the closing quote is included - so a data-bearing
+        // partial dashboard could pass while every listed key was "absent".
+        //
+        // A deny-list also rots by construction: it protects against the payload as it is TODAY, and every
+        // field added to the feed later is unprotected until someone remembers to add it here. Asserting the
+        // property set is EXACTLY one error field inverts that - anything empty-shaped, anything new, and
+        // anything metadata-looking reddens automatically without this test being touched.
+        var resp = await Get(path, _key);
+        var body = await resp.Content.ReadAsStringAsync();
 
-        foreach (var key in new[] { "repos", "agents", "models", "tokenSpend", "hourlyTurns", "buckets", "wingman" })
-            Assert.DoesNotContain($"\"{key}\"", body, StringComparison.Ordinal);
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+
+        var properties = doc.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Equal(new[] { "error" }, properties);
+        Assert.Equal("the stats dashboard is not available on the hosted gateway",
+            doc.RootElement.GetProperty("error").GetString());
     }
 
     [Fact]
@@ -111,6 +131,8 @@ public sealed class HostedStatsDenyTests : IAsyncLifetime
     {
         // The /healthz lesson, applied here on purpose: a zeroed count is a FALSE statement where an absent
         // one is merely absent. A caller must not be handed a dashboard that reads "no work has been done".
+        // The exact-property-set test above is what actually enforces this; this one states the intent in the
+        // terms the mistake was originally made in, so the reason survives even if the shape of the check changes.
         var body = await (await Get("stats/data", _key)).Content.ReadAsStringAsync();
 
         Assert.DoesNotContain("\"turns\":0", body, StringComparison.Ordinal);

--- a/src/CcDirector.Gateway.Tests/HostedStatsDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedStatsDenyTests.cs
@@ -154,6 +154,15 @@ public sealed class HostedStatsDenyTests : IAsyncLifetime
         var resp = await Get(path, _key);
         var body = await resp.Content.ReadAsStringAsync();
 
+        // ASSERT THE STATUS AND THE MEDIA TYPE BEFORE PARSING, so this test reddens as a STATEMENT rather
+        // than as a crash. Without these two lines, deleting the guard makes /stats serve the HTML dashboard
+        // and JsonDocument.Parse dies with "'<' is an invalid start of a value" - the test still goes red, but
+        // it goes red as a JsonReaderException, which proves only that the mutation broke something upstream.
+        // A crash cannot tell you WHAT was served in place of the refusal; an assertion can, and that is the
+        // difference between a revert-proof and a coincidence.
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
         using var doc = JsonDocument.Parse(body);
         Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
 
@@ -246,6 +255,11 @@ internal static class StatsGroupProbeHost
     public static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp)
     {
         var body = await resp.Content.ReadAsStringAsync();
+
+        // Media type first, for the same reason as above: if the guard is gone and the route serves the HTML
+        // dashboard, this must redden as "expected application/json, got text/html" and not as a JSON parser
+        // exception. A red that is a crash proves the mutation landed, not that the guard was what held.
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
 
         using var doc = JsonDocument.Parse(body);
         Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);

--- a/src/CcDirector.Gateway.Tests/HostedStatsDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedStatsDenyTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1848, the stats half: the DevThrottle Stats dashboard is DENIED on the hosted Gateway.
+///
+/// <c>GET /stats/data</c> served, fleet-globally and to any tenant's device key: every repository name the
+/// fleet has driven, the per-agent and per-model tallies, the token SPEND, and the hourly activity series.
+/// Its handler took no <c>HttpContext</c> at all, so it could not resolve a tenant even in principle - the
+/// same signature-level shape as the prompt log.
+///
+/// WHY A DENY AND NOT A PARTITION. These are PRE-AGGREGATED FLEET TOTALS with no tenant anywhere in the
+/// schema, so there is nothing to partition by without a migration and a re-model, and a per-tenant answer
+/// would have to be recomputed from an attribution that was never recorded. Inventing one is a
+/// half-partition, which this mission has a law against. The concept does not survive either: this is the
+/// OWNER'S private view of HIS OWN gateway, and on shared hosted infrastructure "the owner" is not a thing,
+/// so there is no correct per-tenant answer to serve - only a disclosure to close.
+///
+/// IT IS A REFUSAL, NOT AN EMPTY DASHBOARD. Serving zeroed series would be a FALSE statement rather than an
+/// absent one - the same mistake /healthz made when it zeroed its fleet counts and anything monitoring them
+/// read a permanently dead fleet. The tests below assert the refusal AND the absence of the payload keys, so
+/// a future "helpful" empty-shape response fails here rather than passing as a deny.
+///
+/// Revert-prove: delete the <c>DenyOnHosted()</c> guard from either route and that route's tests go RED -
+/// the data route with a 200 carrying the fleet-global keys, the page route with the HTML dashboard.
+///
+/// Self-host is the control and is covered by <see cref="StatsPageEndpointTests"/>, which run with hosted
+/// mode off and are untouched by this change.
+/// </summary>
+public sealed class HostedStatsDenyTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _key = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-stats-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // A fully enrolled, tenant-bound device key - the strongest caller hosted has. The point is that even
+        // this one is refused: there is no credential that makes the owner's private dashboard correct here.
+        _key = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var tenant = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", tenant.Value);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task The_stats_feed_is_refused_to_an_enrolled_tenant()
+    {
+        var resp = await Get("stats/data", _key);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task The_stats_feed_discloses_none_of_its_payload()
+    {
+        // Asserting the status alone would let a future "helpful" change serve an empty-but-shaped payload
+        // under some other code and still pass. These are the keys that carry the disclosure - repository
+        // names, agent and model tallies, token spend - and none of them may appear in any form.
+        var body = await (await Get("stats/data", _key)).Content.ReadAsStringAsync();
+
+        foreach (var key in new[] { "repos", "agents", "models", "tokenSpend", "hourlyTurns", "buckets", "wingman" })
+            Assert.DoesNotContain($"\"{key}\"", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task The_stats_page_is_refused_too()
+    {
+        // The page and the feed are one surface. Refusing the JSON while still serving the dashboard shell
+        // would leave the disclosure surface half-closed and look closed from the outside.
+        var resp = await Get("stats", _key);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.DoesNotContain("Your Throttle", await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task The_refusal_is_not_a_zeroed_dashboard()
+    {
+        // The /healthz lesson, applied here on purpose: a zeroed count is a FALSE statement where an absent
+        // one is merely absent. A caller must not be handed a dashboard that reads "no work has been done".
+        var body = await (await Get("stats/data", _key)).Content.ReadAsStringAsync();
+
+        Assert.DoesNotContain("\"turns\":0", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"characters\":0", body, StringComparison.Ordinal);
+        Assert.Contains("not available", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_caller_is_still_rejected()
+    {
+        // Control: the deny must not have opened the route up as a side effect of running before the gate.
+        // Without a key the host-wide auth middleware still refuses first.
+        Assert.Equal(HttpStatusCode.Unauthorized, (await _http.GetAsync("stats/data")).StatusCode);
+    }
+
+    private Task<HttpResponseMessage> Get(string path, string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedStatsDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedStatsDenyTests.cs
@@ -56,10 +56,13 @@ namespace CcDirector.Gateway.Tests;
 /// answer "do my new tests fire?"; it cannot see whether some existing test already covered the behaviour,
 /// and it cannot see collateral damage elsewhere.
 ///
-/// Observed with the filter deleted: 9 failed, 2947 passed, 10 skipped, 2966 total. The 9 decompose as the
-/// 8 guard canaries below plus one KNOWN pre-existing failure unrelated to this change
-/// (<c>Account.HostedAccountStatusTests.Enrolled_without_a_recorded_email_is_signed_in_with_the_identity_absent</c>,
-/// tracked as #1894 / #1905 / #1911), which reproduces on unmodified origin/main:
+/// Observed with the filter deleted, on a box verified to have no other Gateway-assembly run anywhere in the
+/// process tree: 9 failed, 2947 passed, 10 skipped, 2966 total. The 9 decomposed as the 8 guard canaries
+/// below plus one pre-existing failure unrelated to this change
+/// (<c>Account.HostedAccountStatusTests.Enrolled_without_a_recorded_email_is_signed_in_with_the_identity_absent</c>),
+/// which reproduced on unmodified origin/main at that time and has since been FIXED by #1916. A revert run
+/// repeated at or after #1916 should therefore show exactly the 8 below and nothing else - that failure is no
+/// longer an allowance, and if it appears it is a real defect. The 8:
 ///
 ///   HostedStatsDenyTests.The_stats_feed_is_refused_to_an_enrolled_tenant
 ///   HostedStatsDenyTests.The_refusal_carries_nothing_but_the_refusal (both cases)

--- a/src/CcDirector.Gateway.Tests/HostedStatsDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedStatsDenyTests.cs
@@ -8,6 +8,12 @@ using System.Net.Sockets;
 using System.Text.Json;
 using System.Threading.Tasks;
 using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Stats;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
@@ -33,11 +39,49 @@ namespace CcDirector.Gateway.Tests;
 /// nothing else - rather than as an absence of known payload keys. A deny-list of today's keys was tried and
 /// review broke it in one move; see the note on that test for why an allow-list is the only shape that holds.
 ///
-/// Revert-prove: delete the <c>DenyOnHosted()</c> guard from either route and that route's tests go RED -
-/// the data route with a 200 carrying the fleet-global keys, the page route with the HTML dashboard.
+/// ONE GROUP FILTER, NOT A GUARD PER ROUTE. The refusal is an endpoint filter on the group both routes are
+/// mapped into, so it runs before every route in that group INCLUDING ROUTES THAT DO NOT EXIST YET. A guard
+/// repeated in each handler rots by construction: the moment somebody adds a route to that file it is
+/// undefended and nothing fails. <see cref="HostedStatsGroupFilterTests"/> proves the difference by mapping a
+/// brand-new probe route onto the group and finding it already refused with no deny written for it.
 ///
-/// Self-host is the control and is covered by <see cref="StatsPageEndpointTests"/>, which run with hosted
-/// mode off and are untouched by this change.
+/// REVERT-PROOF - THE RECIPE ACTUALLY RUN, against the final head, on a box verified to have no other
+/// Gateway suite executing. In <c>src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs</c> DELETE the
+/// <c>app.AddEndpointFilter(...)</c> block outright, leaving <c>var app = outer.MapGroup("");</c> in place so
+/// the group still exists and the file still compiles - the hosted deny is then absent ENTIRELY, with no
+/// per-route guard put back in its place. Deleting is the only correct way to revert here: wrapping the
+/// filter in <c>if (false)</c> leaves unreachable code, which is a BUILD ERROR in this repository, and a test
+/// run after a failed build silently executes the previous binary and reports a false pass. Rebuild, CONFIRM
+/// ZERO ERRORS, then run the FULL suite - not a filter over this class. A filtered revert-proof can only
+/// answer "do my new tests fire?"; it cannot see whether some existing test already covered the behaviour,
+/// and it cannot see collateral damage elsewhere.
+///
+/// Observed with the filter deleted: 9 failed, 2947 passed, 10 skipped, 2966 total. The 9 decompose as the
+/// 8 guard canaries below plus one KNOWN pre-existing failure unrelated to this change
+/// (<c>Account.HostedAccountStatusTests.Enrolled_without_a_recorded_email_is_signed_in_with_the_identity_absent</c>,
+/// tracked as #1894 / #1905 / #1911), which reproduces on unmodified origin/main:
+///
+///   HostedStatsDenyTests.The_stats_feed_is_refused_to_an_enrolled_tenant
+///   HostedStatsDenyTests.The_refusal_carries_nothing_but_the_refusal (both cases)
+///   HostedStatsDenyTests.The_stats_page_is_refused_too
+///   HostedStatsDenyTests.The_refusal_is_not_a_zeroed_dashboard
+///   HostedStatsGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own
+///   HostedStatsGroupFilterTests.Both_stats_routes_are_refused_on_hosted_through_the_group_filter (both cases)
+///
+/// TWO THINGS THAT RUN PROVED BEYOND "the tests fire". No test ANYWHERE ELSE in the suite reddened, so this
+/// behaviour was NOT already covered - before this change nothing in the Gateway suite would have noticed the
+/// stats dashboard serving fleet-global totals on hosted. And there was no collateral red, so the guard is
+/// not entangled with unrelated behaviour.
+///
+/// The unauthenticated control, <see cref="HostedStatsGroupFilterTests.A_route_outside_the_group_still_serves_on_hosted"/>
+/// and the whole of <see cref="HostedStatsSelfHostControlTests"/> stayed GREEN through the revert - they are
+/// the controls, and a control that moves with the change under test is not a control. Restore the block,
+/// rebuild, run the full suite again, confirm green.
+///
+/// SELF-HOST IS PROVED, NOT INHERITED. <see cref="HostedStatsSelfHostControlTests"/> EXPLICITLY clears
+/// <c>CC_GATEWAY_HOSTED</c> and asserts both routes still serve their real payloads. Leaning on
+/// <see cref="StatsPageEndpointTests"/> would prove nothing about self-host, because those rest on the test
+/// runner's ambient default: if that default ever flips they keep passing while self-host is broken.
 /// </summary>
 public sealed class HostedStatsDenyTests : IAsyncLifetime
 {
@@ -161,5 +205,313 @@ public sealed class HostedStatsDenyTests : IAsyncLifetime
         listener.Start();
         try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
         finally { listener.Stop(); }
+    }
+}
+
+/// <summary>
+/// Boots ONLY the stats group on an ephemeral port, exactly as <see cref="StatsPageEndpointTests"/> does, and
+/// hands the caller the route group back so a test can map routes onto it. That is what makes the
+/// future-route proof possible at all: the group is created inside <c>StatsPageEndpoint.Map</c>, so nothing
+/// outside that method could otherwise state a property about routes added to it.
+/// </summary>
+internal static class StatsGroupProbeHost
+{
+    public static async Task<(WebApplication app, HttpClient http)> StartAsync(
+        GatewayInputStatsAggregator aggregator,
+        Action<RouteGroupBuilder>? mapIntoGroup = null,
+        Action<IEndpointRouteBuilder>? mapOutsideGroup = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        var group = StatsPageEndpoint.Map(app, aggregator);
+        mapIntoGroup?.Invoke(group);
+        mapOutsideGroup?.Invoke(app);
+
+        await app.StartAsync();
+        var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+        return (app, http);
+    }
+
+    /// <summary>
+    /// Asserts the body is the hosted refusal and NOTHING ELSE, by parsing the JSON and comparing the whole
+    /// property set to a one-name allow-list. A substring check cannot see an extra leaked field; enumerating
+    /// the property set reddens automatically on anything extra, without this file being touched.
+    /// </summary>
+    public static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp)
+    {
+        var body = await resp.Content.ReadAsStringAsync();
+
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+
+        var properties = doc.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Equal(new[] { "error" }, properties);
+        Assert.Equal("the stats dashboard is not available on the hosted gateway",
+            doc.RootElement.GetProperty("error").GetString());
+    }
+}
+
+/// <summary>
+/// THE POINT OF THE WHOLE CHANGE: the hosted refusal is a filter on the stats route GROUP, so it covers
+/// routes that have not been written yet.
+///
+/// A guard line repeated in every handler passes exactly the same tests as a group filter for the routes that
+/// exist today, which is precisely why it is dangerous - the difference only shows up on the route somebody
+/// adds NEXT, when it is open by default and nothing fails. That difference is not observable by driving
+/// /stats and /stats/data, so this class maps a BRAND-NEW probe route onto the group and asserts it is
+/// refused with no deny of its own written anywhere. That single test is the one that distinguishes the two
+/// implementations, and it is the reason <c>StatsPageEndpoint.Map</c> returns its group.
+///
+/// The revert recipe and the full expected-red list live on <see cref="HostedStatsDenyTests"/>.
+/// </summary>
+public sealed class HostedStatsGroupFilterTests : IDisposable
+{
+    private const string ProbePayloadSentinel = "probe-payload-that-must-never-be-served-on-hosted";
+
+    private readonly string _dir;
+    private readonly string? _priorHosted;
+
+    public HostedStatsGroupFilterTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cc-stats-group-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+
+        // EXPLICIT, not ambient: this class asserts hosted behaviour, so it states hosted mode itself rather
+        // than inheriting whatever the runner happened to leave set.
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { Directory.Delete(_dir, recursive: true); } catch (Exception) { /* best effort */ }
+    }
+
+    private GatewayInputStatsAggregator Aggregator() =>
+        new(Path.Combine(_dir, "s-" + Guid.NewGuid().ToString("N") + ".db"));
+
+    /// <summary>
+    /// A route that did not exist when the refusal was written is refused anyway. NOTHING in
+    /// <c>StatsPageEndpoint</c> mentions this path, and no guard is written for it here - the only thing
+    /// standing between the caller and the probe payload is the group filter. Delete the filter and this test
+    /// serves the probe payload with a 200, which is the future-route hole stated out loud.
+    /// </summary>
+    [Fact]
+    public async Task A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own()
+    {
+        var (app, http) = await StatsGroupProbeHost.StartAsync(
+            Aggregator(),
+            mapIntoGroup: group => group.MapGet("/stats/added-after-the-deny-was-written",
+                () => Results.Json(new { probe = ProbePayloadSentinel })));
+        try
+        {
+            var resp = await http.GetAsync("/stats/added-after-the-deny-was-written");
+
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+            await StatsGroupProbeHost.AssertBodyIsNothingButTheRefusal(resp);
+            Assert.DoesNotContain(ProbePayloadSentinel, await resp.Content.ReadAsStringAsync(),
+                StringComparison.Ordinal);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>
+    /// The two production routes, refused through that same filter rather than through a guard of their own.
+    /// </summary>
+    [Theory]
+    [InlineData("/stats")]
+    [InlineData("/stats/data")]
+    public async Task Both_stats_routes_are_refused_on_hosted_through_the_group_filter(string path)
+    {
+        var (app, http) = await StatsGroupProbeHost.StartAsync(Aggregator());
+        try
+        {
+            var resp = await http.GetAsync(path);
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+            await StatsGroupProbeHost.AssertBodyIsNothingButTheRefusal(resp);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>
+    /// CONTROL: the filter is scoped to the stats group, not a blanket refusal on the whole application. A
+    /// route mapped OUTSIDE the group still serves on hosted, so the passing tests above are the filter
+    /// doing its job and not the host refusing everything.
+    /// </summary>
+    [Fact]
+    public async Task A_route_outside_the_group_still_serves_on_hosted()
+    {
+        var (app, http) = await StatsGroupProbeHost.StartAsync(
+            Aggregator(),
+            mapOutsideGroup: routes => routes.MapGet("/not-a-stats-route", () => Results.Json(new { ok = true })));
+        try
+        {
+            var resp = await http.GetAsync("/not-a-stats-route");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Contains("true", await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+}
+
+/// <summary>
+/// THE SELF-HOST CONTROL, STATED EXPLICITLY.
+///
+/// Self-host is the control for this entire hosted-tenancy mission, so it has to be PROVEN rather than
+/// INHERITED. <see cref="StatsPageEndpointTests"/> does not prove it: those tests never mention
+/// <c>CC_GATEWAY_HOSTED</c> and pass only because the runner happens to leave it unset. If that ambient
+/// default ever flipped - one leaked environment variable, one continuous-integration image change, one test
+/// that forgot to restore it - they would keep passing while self-host was completely broken, because they
+/// assert nothing about which mode they are in.
+///
+/// So this class sets the variable itself, to BOTH non-hosted values that occur in practice: absent, and
+/// present-but-not-"1". It then asserts the routes serve their REAL PAYLOADS - the seeded counts, the ranked
+/// repository, the honesty caveats, the dashboard markup - and not merely that the refusal string is absent.
+/// An empty-but-successful response would satisfy "the refusal is absent" while still being a broken
+/// self-host, so absence of the refusal is not the assertion.
+///
+/// These tests must stay GREEN through the revert described on <see cref="HostedStatsDenyTests"/>. A control
+/// that moves with the change under test is not a control.
+/// </summary>
+public sealed class HostedStatsSelfHostControlTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string? _priorHosted;
+
+    public HostedStatsSelfHostControlTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cc-stats-selfhost-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { Directory.Delete(_dir, recursive: true); } catch (Exception) { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Puts the process into a stated non-hosted mode and proves it took, so no test below can silently be
+    /// running in the mode it thinks it is not in.
+    /// </summary>
+    private static void DeclareSelfHost(string? value)
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", value);
+        Assert.False(GatewayHostedMode.IsHosted);
+    }
+
+    private GatewayInputStatsAggregator SeededAggregator()
+    {
+        var agg = new GatewayInputStatsAggregator(Path.Combine(_dir, "s-" + Guid.NewGuid().ToString("N") + ".db"));
+        agg.Observe(new SessionDto
+        {
+            SessionId = "s1",
+            RepoPath = @"D:\ReposFred\devthrottle",
+            InputStats = new InputStatsDto
+            {
+                Buckets = { new InputStatBucketDto { Modality = "voice", Surface = "phone", Turns = 7, Characters = 700 } },
+            },
+        });
+        return agg;
+    }
+
+    /// <summary>
+    /// null = the variable is absent. "0" = the variable is present and explicitly not hosted. Both are real
+    /// non-hosted deployments and both must serve.
+    /// </summary>
+    public static TheoryData<string?> NonHostedValues => new() { null, "0" };
+
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task The_stats_page_still_serves_its_real_dashboard_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+
+        var (app, http) = await StatsGroupProbeHost.StartAsync(SeededAggregator());
+        try
+        {
+            var resp = await http.GetAsync("/stats");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.StartsWith("text/html", resp.Content.Headers.ContentType!.ToString());
+
+            // The REAL page, asserted by what it contains - not by the refusal being absent. An empty 200
+            // would pass "no refusal" and still be a dead dashboard.
+            var html = await resp.Content.ReadAsStringAsync();
+            Assert.Contains("Your Throttle", html);
+            Assert.Contains("/stats/data", html);
+            Assert.Contains("What you have spent", html);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task The_stats_feed_still_serves_its_real_totals_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+
+        var (app, http) = await StatsGroupProbeHost.StartAsync(SeededAggregator());
+        try
+        {
+            var resp = await http.GetAsync("/stats/data");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            var root = doc.RootElement;
+
+            // The refusal envelope has exactly one property named "error". Proving the real feed means
+            // proving the payload it actually carries is here, one field at a time.
+            var properties = root.EnumerateObject().Select(p => p.Name).ToArray();
+            Assert.DoesNotContain("error", properties);
+            foreach (var expected in new[]
+                     {
+                         "buckets", "hourlyTurns", "wingman", "repos", "agents", "models",
+                         "tokenSpend", "tokenSpendByHour", "tokenSpendByModel", "notCaptured",
+                     })
+                Assert.Contains(expected, properties);
+
+            // The seeded numbers themselves, so an empty-but-shaped payload cannot pass as "serving".
+            var bucket = Assert.Single(root.GetProperty("buckets").EnumerateArray());
+            Assert.Equal("voice", bucket.GetProperty("modality").GetString());
+            Assert.Equal("phone", bucket.GetProperty("surface").GetString());
+            Assert.Equal(7, bucket.GetProperty("turns").GetInt64());
+            Assert.Equal(700, bucket.GetProperty("characters").GetInt64());
+
+            var repo = Assert.Single(root.GetProperty("repos").EnumerateArray());
+            Assert.Equal("devthrottle", repo.GetProperty("repoName").GetString());
+            Assert.Equal(7, repo.GetProperty("turns").GetInt64());
+
+            Assert.True(root.GetProperty("notCaptured").GetArrayLength() > 0);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>
+    /// The mirror of the future-route probe: on self-host the group filter lets a route added to the group
+    /// through untouched. Without this, "the filter refuses everything, always" would pass every hosted test
+    /// in this file.
+    /// </summary>
+    [Fact]
+    public async Task A_route_added_to_the_group_still_serves_on_self_host()
+    {
+        DeclareSelfHost(null);
+
+        var (app, http) = await StatsGroupProbeHost.StartAsync(
+            SeededAggregator(),
+            mapIntoGroup: group => group.MapGet("/stats/added-after-the-deny-was-written",
+                () => Results.Json(new { probe = "served" })));
+        try
+        {
+            var resp = await http.GetAsync("/stats/added-after-the-deny-was-written");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Contains("served", await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
     }
 }

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -18,6 +18,28 @@ namespace CcDirector.Gateway.Stats;
 ///
 /// Only counts and ratios are ever served - never the text of anything typed or said (mission decision 5).
 /// The page states plainly which input paths are counted and which are not-captured (no-fallback rule).
+///
+/// DENIED ON HOSTED (issue #1848). Both routes are refused on the hosted Gateway. This is the OWNER'S
+/// private view of HIS OWN gateway, and on shared hosted infrastructure "the owner" does not survive as a
+/// concept - so there is no correct per-tenant answer to serve here, only a disclosure to close. What the
+/// feed actually carries makes that concrete: every repository name the fleet has driven, the per-agent and
+/// per-model tallies, and the token SPEND - all fleet-global, and reachable by any tenant's device key
+/// through the host-wide gate.
+///
+/// It is a DENY rather than a partition because there is nothing to partition BY. These are pre-aggregated
+/// fleet totals with no tenant anywhere in the schema, so a per-tenant answer would have to be recomputed
+/// from an attribution that was never recorded - and inventing one is a half-partition, which is worse than
+/// an honest refusal. The store behind it is also the SQLite-plus-write-ahead-log-on-a-file-share hazard
+/// booked as #1861, so a per-tenant partition would either multiply that hazard per tenant or force a
+/// schema change for a dashboard nobody has asked to be multi-tenant. Per-tenant stats are booked as a
+/// deferred product decision, blocked on that.
+///
+/// The refusal is a REFUSAL, not an empty dashboard. Serving zeroed or empty series would be a false
+/// statement rather than an absent one - the same mistake /healthz made when it zeroed its fleet counts and
+/// anything monitoring them read a permanently dead fleet. A caller is told the route is not available
+/// here; it is never shown a dashboard implying no work has been done.
+///
+/// Self-host is COMPLETELY unchanged, and that is the control.
 /// </summary>
 public static class StatsPageEndpoint
 {
@@ -32,13 +54,37 @@ public static class StatsPageEndpoint
         "Surface (phone / cockpit) for remote input is read from the signed-in device. Remote input with no device identity (a shared-token or fleet call) is not counted as an operator surface.",
     };
 
+    /// <summary>
+    /// The hosted refusal for both stats routes (issue #1848), or null on self-host where nothing changes.
+    ///
+    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> - the INDEPENDENT signal - and not on a boundary
+    /// or tenant argument being passed in. A security branch that depends on an optional argument fails
+    /// OPEN when a caller forgets it, which is exactly how the hosted account-status fix nearly shipped a
+    /// hole: omit the argument and a hosted Gateway silently takes the self-host path. Asking hosted mode
+    /// directly means these routes cannot serve the fleet-global feed on hosted however this is wired.
+    ///
+    /// 404 rather than 403: on hosted this route does not exist as a concept, so "not here" is the truthful
+    /// answer. 403 would imply the right credential could reach it, and none can - there is no owner.
+    /// </summary>
+    private static IResult? DenyOnHosted()
+    {
+        if (!GatewayHostedMode.IsHosted) return null;
+
+        FileLog.Write("[StatsPageEndpoint] DENIED on hosted: the stats feed is fleet-global and has no per-tenant answer to serve");
+        return Results.Json(
+            new { error = "the stats dashboard is not available on the hosted gateway" },
+            statusCode: StatusCodes.Status404NotFound);
+    }
+
     public static void Map(IEndpointRouteBuilder app, GatewayInputStatsAggregator aggregator,
         GatewaySessionConcurrencyStats? concurrency = null)
     {
         FileLog.Write("[StatsPageEndpoint] serving /stats (embedded, always available)");
 
-        app.MapGet("/stats/data", () =>
+        app.MapGet("/stats/data", (HttpContext ctx) =>
         {
+            if (DenyOnHosted() is { } denied) return denied;
+
             var totals = aggregator.CurrentTotals();
             return Results.Json(new
             {
@@ -94,6 +140,8 @@ public static class StatsPageEndpoint
 
         app.MapGet("/stats", (HttpContext ctx) =>
         {
+            if (DenyOnHosted() is { } denied) return denied.ExecuteAsync(ctx);
+
             ctx.Response.Headers.CacheControl = "no-cache";
             ctx.Response.ContentType = "text/html; charset=utf-8";
             return ctx.Response.WriteAsync(PageHtml);

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -20,7 +20,9 @@ namespace CcDirector.Gateway.Stats;
 /// Only counts and ratios are ever served - never the text of anything typed or said (mission decision 5).
 /// The page states plainly which input paths are counted and which are not-captured (no-fallback rule).
 ///
-/// DENIED ON HOSTED (issue #1848). Both routes are refused on the hosted Gateway. This is the OWNER'S
+/// DENIED IN WHOLE ON HOSTED (issue #1848). EVERY route in this group is refused on the hosted Gateway,
+/// through ONE group filter rather than a guard repeated per route - so a route added here later is refused
+/// too, without anyone remembering to defend it. This is the OWNER'S
 /// private view of HIS OWN gateway, and on shared hosted infrastructure "the owner" does not survive as a
 /// concept - so there is no correct per-tenant answer to serve here, only a disclosure to close. What the
 /// feed actually carries makes that concrete: every repository name the fleet has driven, the per-agent and
@@ -77,15 +79,31 @@ public static class StatsPageEndpoint
             statusCode: StatusCodes.Status404NotFound);
     }
 
-    public static void Map(IEndpointRouteBuilder app, GatewayInputStatsAggregator aggregator,
+    /// <summary>
+    /// Maps the stats group and returns it, so the refusal can be proved to cover routes that do not exist
+    /// yet: a test maps a NEW probe route onto the returned group and finds it already refused on hosted,
+    /// without anyone having written a deny for it. Returning the group is the only way to state that
+    /// property from outside this file.
+    /// </summary>
+    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, GatewayInputStatsAggregator aggregator,
         GatewaySessionConcurrencyStats? concurrency = null)
     {
-        FileLog.Write($"[StatsPageEndpoint] mapping /stats (embedded); hosted={GatewayHostedMode.IsHosted} - on hosted BOTH routes are refused (issue #1848)");
+        FileLog.Write($"[StatsPageEndpoint] mapping /stats (embedded); hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1848)");
 
-        app.MapGet("/stats/data", (HttpContext ctx) =>
+        // The whole group behind ONE filter, rather than a guard line repeated in every handler.
+        // A repeated guard is a thing to forget: the route added to this file next year would be open by
+        // default and nothing would fail. A group filter runs before EVERY route mapped below, including
+        // routes that do not exist yet, so the refusal cannot rot as the group grows. The empty prefix keeps
+        // the route paths written out in full, exactly as before, so the self-host surface is unchanged.
+        var app = outer.MapGroup("");
+        app.AddEndpointFilter(async (ctx, next) =>
         {
             if (DenyOnHosted() is { } denied) return denied;
+            return await next(ctx);
+        });
 
+        app.MapGet("/stats/data", () =>
+        {
             var totals = aggregator.CurrentTotals();
             return Results.Json(new
             {
@@ -141,12 +159,12 @@ public static class StatsPageEndpoint
 
         app.MapGet("/stats", (HttpContext ctx) =>
         {
-            if (DenyOnHosted() is { } denied) return denied.ExecuteAsync(ctx);
-
             ctx.Response.Headers.CacheControl = "no-cache";
             ctx.Response.ContentType = "text/html; charset=utf-8";
             return ctx.Response.WriteAsync(PageHtml);
         });
+
+        return app;
     }
 
     // Self-contained: all CSS and JavaScript inline, no external requests, ASCII only. Light/dark aware.

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -6,13 +6,14 @@ using Microsoft.AspNetCore.Routing;
 namespace CcDirector.Gateway.Stats;
 
 /// <summary>
-/// The DevThrottle Stats private dashboard: the always-available page the owner opens on the Gateway to
+/// The DevThrottle Stats private dashboard: the page the owner opens on his OWN Gateway to
 /// see, from real usage, how much of his development is spoken vs typed and how much comes from the phone,
 /// the desktop, or the cockpit. Served as a SELF-CONTAINED page embedded in this binary (not a wwwroot
 /// React route), so it works even on a plain dev build where the React apps are not built (mission
 /// New build B, core finding 8). It reads the Gateway's own aggregated totals with no cloud round-trip.
 ///
-/// Two routes, both behind the normal Gateway auth (the owner's signed-in browser reaches them):
+/// Two routes, both behind the normal Gateway auth (the owner's signed-in browser reaches them) - and both
+/// REFUSED on hosted, so "always available" describes self-host only:
 ///   GET /stats       - the HTML dashboard (this embedded page).
 ///   GET /stats/data  - the aggregated totals as JSON, which the page fetches and refreshes.
 ///
@@ -79,7 +80,7 @@ public static class StatsPageEndpoint
     public static void Map(IEndpointRouteBuilder app, GatewayInputStatsAggregator aggregator,
         GatewaySessionConcurrencyStats? concurrency = null)
     {
-        FileLog.Write("[StatsPageEndpoint] serving /stats (embedded, always available)");
+        FileLog.Write($"[StatsPageEndpoint] mapping /stats (embedded); hosted={GatewayHostedMode.IsHosted} - on hosted BOTH routes are refused (issue #1848)");
 
         app.MapGet("/stats/data", (HttpContext ctx) =>
         {


### PR DESCRIPTION
Closes the **stats half** of thefrederiksen/devthrottle#1848. The prompts half landed separately as thefrederiksen/devthrottle#1860.

## The defect

`GET /stats/data` served, **fleet-globally and to any tenant's device key**: every repository name the fleet has driven, the per-agent and per-model tallies, the **token spend**, and the hourly activity series. `GET /stats` serves the dashboard that reads it.

The handler was a **parameterless lambda** - it took no `HttpContext` at all, so it could not resolve a tenant even in principle. Same signature-level shape as the prompt log.

## Denied, not partitioned - and why

There is **nothing to partition by**. These are pre-aggregated fleet totals with **no tenant anywhere in the schema**, so a per-tenant answer would have to be recomputed from an attribution that was never recorded. Inventing one is a **half-partition**, which is worse than an honest refusal because it looks like isolation.

The concept does not survive the move either: this is the **owner's private view of his own gateway**, and on shared hosted infrastructure "the owner" is not a thing. There is no correct per-tenant answer to serve here - only a disclosure to close.

Contrast the prompts half, which *was* partitioned: prompt text is per-session, already tenant-attributable when it arrives, and its storage unit can physically carry the tenant. That is the test - **partition when the data is already attributable and its storage unit can carry the tenant; deny when it is an aggregate whose tenant was never recorded.**

## What changed in the rework

Rejected in review on **four** points. Each is answered below, in the review's own order.

| Review point | Answered by | State |
|---|---|---|
| 1. One `MapGroup` filter, not `DenyOnHosted` per handler; prove a newly mapped probe route **refused on hosted AND served with hosted mode explicitly off** | group filter + probe test in **both** directions | done |
| 2. An explicit hosted-off control driving both routes and their **real** page/feed payloads | `HostedStatsSelfHostControlTests` | done |
| 3. A **named** un-deny row per denied route with its real restore condition | two rows on thefrederiksen/devthrottle_internal#891 | done |
| 4. Each real production-line revert preceded by a successful build and run through the **full** Gateway suite; then restore, rebuild, rerun full | revert leg done; **restored leg outstanding** | 1 of 2 |

### 1. ONE group filter, not a guard per route

The deny is now a single `AddEndpointFilter` on the route **group** both stats routes are mapped into, replacing the `DenyOnHosted()` call that was repeated in each handler. It follows the owner-settings deny in `SettingsEndpoints.cs`, which is our own better pattern and which this pull request originally did not carry over.

A per-route guard **rots**: the moment someone adds a route to that file it is undefended, and nothing fails. A group filter runs before every route in the group **including routes that do not exist yet**.

That difference is invisible to any test that only drives `/stats` and `/stats/data` - a per-route guard and a group filter behave identically on the routes that exist today, which is exactly what makes the per-route shape dangerous. So the proof is a **future-route probe**:

`HostedStatsGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own`

It maps a **brand-new route** onto the group and asserts it is refused, with **no deny written for it anywhere**. `StatsPageEndpoint.Map` now returns its `RouteGroupBuilder` so that property is statable from outside the file - that return value exists solely to make this test possible.

**Proven in both directions, as the review asked.** The same probe path is also driven with hosted mode **explicitly off** by `HostedStatsSelfHostControlTests.A_route_added_to_the_group_still_serves_on_self_host`, over **both** non-hosted forms (absent, and present-but-`"0"`), asserting it is **served**. One direction alone cannot tell a working gate apart from a brick: without the served half, a filter that refused everything unconditionally would pass every hosted assertion in the file while having silently killed the route for self-host too.

A second control, `A_route_outside_the_group_still_serves_on_hosted`, maps a route **outside** the group and shows it still serves on hosted — so the passing hosted tests are the filter doing its job rather than the host refusing everything.

### 2. The self-host control is now EXPLICIT

`HostedStatsSelfHostControlTests` sets `CC_GATEWAY_HOSTED` **itself**, to **both** non-hosted forms that occur in practice - **absent**, and **present-but-`"0"`** - asserts `GatewayHostedMode.IsHosted` is actually false so no test can silently run in the mode it thinks it is not in, and then drives **both** routes.

It asserts the **real payloads**, not the absence of the refusal string: the seeded bucket counts (7 turns / 700 characters, voice / phone), the ranked repository (`devthrottle`, 7 turns), the honesty caveats, the feed's full property set, and the dashboard markup (`Your Throttle`, `/stats/data`, `What you have spent`). An empty-but-successful response would satisfy "the refusal is absent" while still being a broken self-host, so absence is not the assertion.

Leaning on `StatsPageEndpointTests` - as this pull request previously did - proves nothing about self-host: those tests never mention `CC_GATEWAY_HOSTED` and pass only because the runner happens to leave it unset. If that ambient default ever flipped they would keep passing while self-host was completely broken.

### 3. Un-deny debt, booked SEPARATELY per route

Two named rows under thefrederiksen/devthrottle_internal#891, one for `/stats` and one for `/stats/data` **individually**, each stating what self-host still does with it, what hosted does now, and the real condition before the guard comes off: https://github.com/thefrederiksen/devthrottle_internal/issues/891#issuecomment-5017821923

They are separate because their conditions are different. `/stats/data` is blocked on the stats database being partitioned or remodelled to record a tenant at aggregation time - today it is one SQLite file with **no tenant column** - plus thefrederiksen/devthrottle_internal#880, plus an unasked product question. `/stats` is blocked on **all of that AND** a rewrite of the page, which is written as the single owner's view. One shared row would let the schema work read as satisfying both, and the dashboard would come back on hosted still rendering an owner's-eye view.

## The deny shape, unchanged

- Gated on `GatewayHostedMode.IsHosted` **directly**, never an optional or nullable argument - a security branch that depends on an optional argument **fails open** when a caller forgets it.
- **404** with a body of **exactly one `error` property**, asserted by parsing the JSON and enumerating the property set as an **allow-list** - not a substring match, which cannot see an extra leaked field. 404 rather than 403 because on hosted this route does not exist as a concept; 403 would imply the right credential could reach it, and none can.
- It **REFUSES**, it does not serve empty. A zeroed series is a **false statement** where an absent one is merely absent - the mistake `/healthz` made when it zeroed its fleet counts and anything monitoring them read a permanently dead fleet.

## Revert-proof

Both legs on the **same head** (`90cf460f`), each preceded by a build confirmed at **0 errors, 0 warnings**, both run through the **full** Gateway suite under the machine-wide test lock (#1918). A run after a failed build executes a stale binary and reports a false pass; a filtered slice cannot see whether an existing test already covered the behaviour, nor collateral damage.

The revert **deletes the `AddEndpointFilter` block outright**, leaving `MapGroup("")` so the file still compiles, with **no per-route guard put back** - the hosted deny is absent entirely. Never `if (false)`: unreachable code is a build error here.

| Leg | Failed | Passed | Skipped | Total |
|---|---|---|---|---|
| Restored (filter in place) | **0** | 2965 | 10 | 2975 |
| Reverted (filter deleted) | **8** | 2957 | 10 | 2975 |

**The counts reconcile arithmetically:** 2957 + 8 = 2965, the restored passed count, with total and skipped unchanged. Nothing else moved.

**All 8 reds arrived as ASSERTIONS. Zero crashes** - seven `Assert.Equal() Failure: Values differ`, one `Assert.DoesNotContain() Failure: Sub-string found`:

| Reddened with the filter deleted | Arrived as |
|---|---|
| `HostedStatsGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own` | assertion |
| `HostedStatsGroupFilterTests.Both_stats_routes_are_refused_on_hosted_through_the_group_filter` (`/stats`) | assertion |
| `HostedStatsGroupFilterTests.Both_stats_routes_are_refused_on_hosted_through_the_group_filter` (`/stats/data`) | assertion |
| `HostedStatsDenyTests.The_stats_feed_is_refused_to_an_enrolled_tenant` | assertion |
| `HostedStatsDenyTests.The_stats_page_is_refused_too` | assertion |
| `HostedStatsDenyTests.The_refusal_is_not_a_zeroed_dashboard` | assertion |
| `HostedStatsDenyTests.The_refusal_carries_nothing_but_the_refusal` (`stats`) | assertion |
| `HostedStatsDenyTests.The_refusal_carries_nothing_but_the_refusal` (`stats/data`) | assertion |

**That last row is why this pull request has an extra commit.** An earlier revert leg reconciled perfectly to the same eight - and one of them was a **crash**, not an assertion: `JsonDocument.Parse` threw `'<' is an invalid start of a value`, because with the guard deleted `/stats` serves the HTML dashboard and the test parsed the body before establishing it was JSON. It still went red, so it looked correct in every count-based check. But a crash proves only that the mutation broke something upstream; it cannot say **what** was served in place of the refusal, which is the entire claim a deny revert-proof makes. Parsing is itself an unstated assertion about format. Both parse sites now assert status and media type first, so the same revert reddens as *"expected NotFound, got OK"* and *"expected application/json, got text/html"*.

**Two things only the full suite could show.** Nothing **anywhere else** in the suite reddened, so this behaviour was **not already covered**. And there was **no collateral red**.

**Green in BOTH directions, deliberately** - each is a control, and a control that moves with the change under test is not a control:

| Green through the revert | Why it must be |
|---|---|
| `An_unauthenticated_caller_is_still_rejected` | The host-wide auth gate runs before the group filter, so the deny must not have opened the route up as a side effect. |
| `A_route_outside_the_group_still_serves_on_hosted` | Proves the filter is scoped to the group, not a blanket refusal on the whole application. |
| all of `HostedStatsSelfHostControlTests` | Self-host is the control for this mission and must not move when the hosted guard does. Includes the served half of the probe proof. |

**The tests were confirmed to have EXECUTED, by name** - all 16 stats cases listed individually, 16/16 passed - rather than inferred from a green total. A green suite does not tell you your tests ran; it tells you nothing failed, and those differ exactly when a harness silently drops a class.

## Tests - all seven projects

| Project | Failed | Passed | Skipped | Total |
|---|---|---|---|---|
| Gateway | 0 | 2965 | 10 | 2975 |
| Core | 0 | 3306 | 8 | 3314 |
| Avalonia | 0 | 247 | 0 | 247 |
| HostedAgent | 0 | 86 | 0 | 86 |
| Engine | 0 | 62 | 0 | 62 |
| Launcher | 0 | 27 | 0 | 27 |
| Terminal.Avalonia | 0 | 21 | 0 | 21 |

Gateway is at head `90cf460f`. The six non-Gateway projects were run at the pre-rebase head and are unaffected by this diff, which touches only `CcDirector.Gateway` and its test project.

Rebased onto `e1b8825c`, which carries the test lock (#1918), thefrederiksen/devthrottle#1916 and v1.6.0. The branch continuous-integration red previously noted was the known unrelated account-status case; thefrederiksen/devthrottle#1916 fixes it, and it did **not** appear in either leg here - the allowance is retired.

## The pattern, for the other hosted deny pull requests to normalize onto

Four things make a hosted deny reviewable. Copy all four; each exists because leaving it out produced a defect that got through review at least once on this mission.

### 1. One group filter, never a guard per route

```csharp
var app = outer.MapGroup("");
app.AddEndpointFilter(async (ctx, next) =>
{
    if (DenyOnHosted() is { } denied) return denied;
    return await next(ctx);
});
```

The empty prefix keeps every route path written out in full, so the self-host surface is unchanged and the diff stays readable.

**Why it is not a guard per handler.** A repeated guard passes *exactly the same tests* as a group filter for the routes that exist today. That is what makes it dangerous rather than merely untidy: the difference only appears on the route somebody adds next, when it is open on hosted by default and **nothing fails**. The deny rots silently as the file grows.

Gate on `GatewayHostedMode.IsHosted` **directly** — never an optional or nullable argument, which **fails open** the moment a caller omits it.

### 2. The probe test — and it must be proven in BOTH directions

This is the assertion the whole change exists for, and it is the one most likely to be skipped, because everything looks green without it.

- **Refused on hosted:** map a **brand-new** route onto the group and assert it is refused, with **no deny written for it anywhere**. This is the only test that distinguishes a group filter from a per-route guard.
- **Served with hosted mode explicitly off:** drive the **same** probe path with hosted mode explicitly disabled and assert it is **served**.

One direction alone cannot tell a working gate apart from a brick. Without the served half, a filter that refused everything unconditionally would pass every hosted assertion in the file while having silently killed the route for self-host too.

To make this statable at all, the map method must **return its `RouteGroupBuilder`** — otherwise nothing outside the file can say anything about routes added to the group.

Add the scoping control too: a route mapped **outside** the group still serves on hosted, proving the filter is scoped rather than a blanket refusal.

### 3. Self-host proven explicitly, never inherited

Set `CC_GATEWAY_HOSTED` **yourself**, to **both** non-hosted forms — **absent**, and **present-but-`"0"`** — and assert `GatewayHostedMode.IsHosted` is actually false so no test can silently run in the mode it thinks it is not in.

Then assert the **real payloads**: the seeded counts, the ranked rows, the actual page markup. **Not** the absence of the refusal string — an empty-but-successful response satisfies "the refusal is absent" while still being a completely broken self-host.

A control that rests on the test runner's ambient default proves nothing: if that default ever flips, it keeps passing while self-host is broken.

### 4. Assert the refusal shape as an allow-list, and make every red an ASSERTION

- **404**, not 403 — on hosted the route does not exist as a concept; 403 would imply the right credential could reach it, and none can.
- Body is **exactly one `error` property**, asserted by parsing the JSON and **enumerating the property set** as an allow-list. Not a substring match, which cannot see an extra leaked field, and not a deny-list of today's keys, which rots as the payload grows.
- **Refuse, never serve empty.** A zeroed series is a *false statement* where an absent one is merely absent.
- **Assert the status and media type BEFORE parsing the body.** This one is easy to miss and this pull request got it wrong first time round: with the guard deleted, `/stats` serves the HTML dashboard, and `JsonDocument.Parse` died with `'<' is an invalid start of a value`. The test still went red, so it looked fine in a count — but a **crash** proves only that the mutation broke something upstream, and cannot say **what** was served in place of the refusal. That is the whole claim a revert-proof makes. Assert status and media type first and the same revert reddens as *"expected NotFound, got OK"* and *"expected application/json, got text/html"*.

### The proof standard

Both legs on the **same head**, each preceded by a build confirmed at **0 errors** — a run after a failed build executes a stale binary and reports a false pass. Revert by **deleting** the filter outright; never `if (false)`, which is unreachable code and a build error here.

Run the **full** Gateway suite both ways, not a filtered slice. A filtered revert-proof answers only "do my new tests fire?" — it cannot see whether an existing test already covered the behaviour, and it cannot see collateral damage.

Then reconcile the counts arithmetically rather than eyeballing them: **revert passed + revert failed must equal restored passed**, with total and skipped unchanged. If it does not reconcile, something else moved and that needs finding before either number is reported.

Confirm your tests **executed**, by name — a green suite does not tell you your tests ran, it tells you nothing failed, and those differ exactly when a harness silently drops a class.
