### PR TITLE
docs(testing): correct the migration size - ~118 MB copied, not ~567 MB

### DIFF
--- a/docs/testing/hosted-real-director-test-rig.md
+++ b/docs/testing/hosted-real-director-test-rig.md
@@ -36,10 +36,28 @@ This is the trap that makes an "isolated" root not isolated.
 On first boot `CcStorageMigration.EnsureMigrated()` copies from **fixed legacy paths** -
 `%LOCALAPPDATA%\CcDirector`, `Environment.SpecialFolder.MyDocuments` + `\CcDirector`,
 `%LOCALAPPDATA%\cc-myvault`, the comm queue - into the current root, whatever `CC_DIRECTOR_ROOT`
-says. So a brand-new test root fills with the machine owner's real accounts, repository list,
-session history and vault. Measured on one machine: **~567 MB**, including **224 session history
-files, 7 of them carrying a `FirstPromptSnippet` and 36 carrying `TurnSummaries`** - real prompt
-text.
+says. So a brand-new test root fills with the machine owner's real accounts, repository list and
+session history.
+
+Measured precisely on one machine, by deleting it again and reading back:
+
+| What migrated | Size |
+|---|---|
+| Director logs (`logs\director`, 187 files, oldest 5 months old) | **118.1 MB** |
+| Session history (`config\director\sessions`, 227 files) | 134 KB |
+| `accounts.json`, `recent-sessions.json`, `repositories.json`, `root-directories.json` | ~7 KB |
+| **Total copied owner data** | **~118 MB** |
+
+The session history is the sensitive part by content rather than size: of those files, **7 carried a
+`FirstPromptSnippet` and 36 carried `TurnSummaries`** - real prompt text, including client-project
+material.
+
+**Do not size this by the test root itself.** That root reached ~568 MB, and an earlier version of
+this document reported the whole figure as copied data. It is not: ~450 MB of it is a Python
+runtime and virtual environment that the Director **provisions itself** on first run. Sizing the
+migration by total root size overstates it roughly five-fold. The vault did not migrate here at
+all, despite being in the migration's source list - so check what actually arrived rather than
+assuming the full list did.
 
 Tracked as issue #1879.
 


### PR DESCRIPTION
Corrects a number I published in #1877. It was wrong, and it was wrong in the direction that overstates the problem.

## The error

The runbook reported **~567 MB** of copied owner data. That was the size of the **whole test root**, not the size of the migration. I equated the two without decomposing them.

## The measurement

Taken properly, by deleting the migrated data and reading back:

| What migrated | Size |
|---|---|
| Director logs (187 files, oldest five months old) | **118.1 MB** |
| Session history (227 files) | 134 KB |
| Four config json files | ~7 KB |
| **Total** | **~118 MB** |

About **450 MB** of that root is a Python runtime and virtual environment the Director **provisions itself** on first run. Sizing the migration by total root size overstates it roughly five-fold.

## What does not change

The sensitive part is unchanged, and it was never about size: **7 of those history files carry a `FirstPromptSnippet` and 36 carry `TurnSummaries`** — real prompt text including client-project material. 134 KB of prompt text matters more than 450 MB of a virtual environment.

Also newly recorded: the **vault did not migrate at all** on this machine, despite being in the migration's source list. So the document now tells the reader to check what actually arrived rather than assuming the full list did — I had assumed it, and I was wrong about that too.

## Why it is worth a pull request rather than a quiet edit

This is precisely the failure the rest of the document warns about: a number that looked like a measurement but was a different measurement wearing its clothes. It was caught only because the cleanup forced me to enumerate what was actually there, which is a second mechanism that did not share the first one's assumption.

#1879 carries the same wrong figure and is being corrected too.