### PR TITLE
fix(storage): do not migrate legacy data into an explicitly pinned root

### DIFF
--- a/src/CcDirector.Core.Tests/CcStorageMigrationPinnedRootTests.cs
+++ b/src/CcDirector.Core.Tests/CcStorageMigrationPinnedRootTests.cs
@@ -1,0 +1,63 @@
+using CcDirector.Core.Storage;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Issue #1879: <c>CC_DIRECTOR_ROOT</c> redirects where a Director WRITES but not where this migration
+/// READS. It copies from fixed legacy paths, so every explicitly pinned root filled on first boot with
+/// the machine owner's real accounts, repository list and session history - and that history carries
+/// first-prompt snippets and turn summaries, i.e. real prompt text.
+///
+/// The part that made it more than untidy: <see cref="CcStorageMigration"/> copies whenever the
+/// destination file is MISSING, and the migration runs on every process start. So deleting the copied
+/// data did not stop it - the next start put it straight back. A root cleaned today refilled tomorrow,
+/// silently.
+///
+/// These tests pin the guard. The predicate test states the rule; the behavioural test is the one that
+/// matters, because it asserts on what a real migration run actually does to a pinned root rather than
+/// on what the flag says it should do.
+/// </summary>
+public sealed class CcStorageMigrationPinnedRootTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DefaultRoot_StillMigrates(string? pinned) =>
+        Assert.True(CcStorageMigration.ShouldMigrate(pinned));
+
+    [Theory]
+    [InlineData(@"D:\some\test\root")]
+    [InlineData(@"C:\Users\someone\AppData\Local\cc-director")]
+    public void PinnedRoot_DoesNotMigrate(string pinned) =>
+        Assert.False(CcStorageMigration.ShouldMigrate(pinned));
+
+    /// <summary>
+    /// The behavioural proof: point CC_DIRECTOR_ROOT at an empty throwaway directory, run the real
+    /// migration, and assert it stayed empty. Without the guard the legacy sources on the developer's own
+    /// machine are copied in, which is the defect. Asserting "still empty" rather than "no specific file"
+    /// keeps the test honest about sources it does not know the names of.
+    /// </summary>
+    [Fact]
+    public void RunningTheMigrationWithAPinnedRoot_LeavesItCompletelyEmpty()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "ccdir-migration-guard-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var previous = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        try
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", root);
+
+            CcStorageMigration.EnsureMigrated();
+
+            var copied = Directory.GetFileSystemEntries(root, "*", SearchOption.AllDirectories);
+            Assert.Empty(copied);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", previous);
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+}

--- a/src/CcDirector.Core/Storage/CcStorageMigration.cs
+++ b/src/CcDirector.Core/Storage/CcStorageMigration.cs
@@ -11,12 +11,47 @@ public static class CcStorageMigration
     private static int _migrated;
 
     /// <summary>
-    /// Run migration if not already done. Safe to call multiple times.
+    /// The environment variable that pins storage to an explicit root. When it is set, this migration
+    /// does not run - see <see cref="ShouldMigrate"/>.
+    /// </summary>
+    private const string PinnedRootVariable = "CC_DIRECTOR_ROOT";
+
+    /// <summary>
+    /// Whether the legacy migration should run for this process, given the value of
+    /// <c>CC_DIRECTOR_ROOT</c>. It runs ONLY for the default root - an explicitly pinned root is
+    /// somebody deliberately asking for separate storage, and copying the machine owner's real data
+    /// into it is the opposite of what they asked for (issue #1879).
+    ///
+    /// This matters beyond tidiness. The migration reads from FIXED legacy paths that
+    /// <c>CC_DIRECTOR_ROOT</c> cannot redirect, so before this guard every alternate root filled on
+    /// first boot with the owner's real accounts, repository list and session history - and that history
+    /// carries first-prompt snippets and turn summaries, i.e. real prompt text. Worse, it re-fired:
+    /// <see cref="CopyFileIfNewer"/> copies whenever the destination is MISSING, so deleting the copied
+    /// data did not stop it coming back on the next start. A root cleaned today refilled tomorrow.
+    ///
+    /// The one-time move of legacy data into the real install is what this migration is for, and that
+    /// case is unaffected: the default root does not set the variable.
+    /// </summary>
+    /// <param name="pinnedRoot">The raw <c>CC_DIRECTOR_ROOT</c> value; null or blank means the default root.</param>
+    public static bool ShouldMigrate(string? pinnedRoot) => string.IsNullOrWhiteSpace(pinnedRoot);
+
+    /// <summary>
+    /// Run migration if not already done. Safe to call multiple times. Does nothing when storage has been
+    /// pinned to an explicit root via <c>CC_DIRECTOR_ROOT</c> - see <see cref="ShouldMigrate"/>.
     /// </summary>
     public static void EnsureMigrated()
     {
         if (Interlocked.CompareExchange(ref _migrated, 1, 0) != 0)
             return;
+
+        var pinnedRoot = Environment.GetEnvironmentVariable(PinnedRootVariable);
+        if (!ShouldMigrate(pinnedRoot))
+        {
+            FileLog.Write($"[CcStorageMigration] EnsureMigrated: SKIPPED - storage is pinned by {PinnedRootVariable}. " +
+                          "The legacy migration only ever targets the default root; it will not copy the machine " +
+                          "owner's data into a root that was deliberately kept separate.");
+            return;
+        }
 
         FileLog.Write("[CcStorageMigration] EnsureMigrated: checking for legacy data");
 


### PR DESCRIPTION
Fixes #1879. Needed now, because an isolated root is the shape we are about to hand the owner for dogfooding hosted.

## The defect

`CC_DIRECTOR_ROOT` redirects where a Director **writes** but not where `CcStorageMigration` **reads**. It copies from fixed legacy paths, so every explicitly pinned root fills on first boot with the machine owner's real accounts, repository list and session history.

Measured on one machine: **~118 MB**, including **227 session history files — 7 carrying a `FirstPromptSnippet` and 36 carrying `TurnSummaries`**. That is real prompt text, including client-project material.

## Why it is urgent rather than untidy

`CopyFileIfNewer` copies whenever the destination is **missing**, and `EnsureMigrated()` runs on **every process start**.

So deleting the copied data does not stop it. **A root cleaned today refills on the next start** — silently, with no signal to the person who cleaned it. I found this immediately after clearing that data out of a test root by hand: the next launch would have put all of it back.

## The change

The migration now runs only for the **default** root. A pinned root is somebody deliberately asking for separate storage, and copying the owner's real data into it is the opposite of what they asked for.

The case this migration exists for — the one-time move of legacy data into the real install — is untouched, because the default root does not set the variable.

## Proof

| | |
|---|---|
| Guard removed | the behavioural test **fails** |
| Guard present | 6/6 pass |
| Core suite | **3312 passed**, 0 failed |
| Build | 0 warnings |

The behavioural test points `CC_DIRECTOR_ROOT` at an empty throwaway directory, runs the **real** migration, and asserts the directory is still empty — rather than asserting on the predicate, which would only restate the flag.

That revert also does double duty: `EnsureMigrated` has a run-once static flag, so a test like this could pass **vacuously** if something else called it first. Watching it go red proves the migration genuinely ran.