### PR TITLE
docs(testing): a plain-English guide to trying the hosted gateway

### DIFF
--- a/docs/testing/hosted-dogfood/Show what the cloud sees.cmd
+++ b/docs/testing/hosted-dogfood/Show what the cloud sees.cmd
@@ -1,0 +1,27 @@
+@echo off
+REM =====================================================================
+REM  Asks the CLOUD gateway what it can see, and prints the answer.
+REM
+REM  This is the honest check that you are really on hosted. It does not
+REM  ask the program on this PC - it asks the cloud directly, over the
+REM  internet, and prints whatever the cloud says.
+REM
+REM  If your sessions appear here, they genuinely reached the cloud.
+REM =====================================================================
+
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$key = (Get-Content 'D:\ReposFred\_wt\hosted-clientleg\testroot\config\director\gateway-token.txt' -Raw).Trim();" ^
+  "$gw  = 'https://devthrottle-gw.azurewebsites.net';" ^
+  "Write-Host '';" ^
+  "Write-Host ('Asking the cloud gateway: ' + $gw);" ^
+  "Write-Host '';" ^
+  "try { $d = (Invoke-WebRequest \"$gw/directors\" -Headers @{Authorization=\"Bearer $key\"} -UseBasicParsing -TimeoutSec 45).Content | ConvertFrom-Json } catch { Write-Host 'Could not reach the cloud gateway.'; Write-Host $_.Exception.Message; exit 1 }" ^
+  "if ($d.Count -eq 0) { Write-Host 'DevThrottles the cloud can see: none.'; Write-Host '(If you just started it, wait ten seconds and run this again.)' } else { Write-Host ('DevThrottles the cloud can see: ' + $d.Count); foreach ($x in $d) { Write-Host ('   on ' + $x.machineName + ', version ' + $x.version) } }" ^
+  "Write-Host '';" ^
+  "$s = (Invoke-WebRequest \"$gw/sessions\" -Headers @{Authorization=\"Bearer $key\"} -UseBasicParsing -TimeoutSec 45).Content | ConvertFrom-Json;" ^
+  "if ($s.Count -eq 0) { Write-Host 'Sessions the cloud can see: none yet.' } else { Write-Host ('Sessions the cloud can see: ' + $s.Count); foreach ($x in $s) { Write-Host ('   #' + $x.number + '  ' + $x.name + '   [' + $x.stateLabel + ']') } }" ^
+  "Write-Host '';" ^
+  "Write-Host 'These came from the cloud, not from this PC. If a session is listed here, it made it.'"
+
+echo.
+pause

--- a/docs/testing/hosted-dogfood/Start hosted DevThrottle.cmd
+++ b/docs/testing/hosted-dogfood/Start hosted DevThrottle.cmd
@@ -1,0 +1,32 @@
+@echo off
+REM =====================================================================
+REM  Starts the HOSTED DevThrottle - a SEPARATE DevThrottle that talks to
+REM  the cloud gateway instead of the one on this PC.
+REM
+REM  Your normal DevThrottle is NOT touched. This one has its own folder,
+REM  its own settings and its own sessions. Both can run at the same time.
+REM
+REM  CC_DIRECTOR_ROOT is set here, inside this window only. It is never
+REM  set for the whole machine, so it cannot affect your normal DevThrottle.
+REM =====================================================================
+
+set CC_DIRECTOR_ROOT=D:\ReposFred\_wt\hosted-clientleg\testroot
+
+tasklist /FI "IMAGENAME eq cc-director16.exe" 2>nul | find /I "cc-director16.exe" >nul
+if not errorlevel 1 (
+    echo The hosted DevThrottle is already running.
+    echo Look for its window, or run "Stop hosted DevThrottle.cmd" first.
+    pause
+    exit /b 0
+)
+
+echo Starting the hosted DevThrottle...
+start "" "D:\ReposFred\_wt\hosted-clientleg\local_builds\cc-director16.exe"
+echo.
+echo Started. A DevThrottle window will open in a few seconds.
+echo It is already signed in to the cloud gateway - there is nothing to log into.
+echo.
+echo To check it really is talking to the cloud, run:
+echo     "Show what the cloud sees.cmd"
+echo.
+timeout /t 5 >nul

--- a/docs/testing/hosted-dogfood/Stop hosted DevThrottle.cmd
+++ b/docs/testing/hosted-dogfood/Stop hosted DevThrottle.cmd
@@ -1,0 +1,44 @@
+@echo off
+REM =====================================================================
+REM  Stops the HOSTED DevThrottle cleanly.
+REM
+REM  It asks the program to shut itself down, which lets it close its own
+REM  sessions tidily. That is why this exists rather than just closing the
+REM  window or ending the task: a hard kill leaves a stray "interrupted"
+REM  entry behind.
+REM
+REM  Your normal DevThrottle is never touched by this - it only ever stops
+REM  the one named cc-director16.
+REM =====================================================================
+
+tasklist /FI "IMAGENAME eq cc-director16.exe" 2>nul | find /I "cc-director16.exe" >nul
+if errorlevel 1 (
+    echo The hosted DevThrottle is not running. Nothing to stop.
+    pause
+    exit /b 0
+)
+
+echo Asking the hosted DevThrottle to shut down...
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$log = Get-ChildItem 'D:\ReposFred\_wt\hosted-clientleg\testroot\logs\director\*.log' -EA SilentlyContinue | Sort-Object LastWriteTime -Desc | Select-Object -First 1;" ^
+  "if (-not $log) { Write-Host 'Could not find its log, so could not find its port. Close the window by hand.'; exit 1 }" ^
+  "$m = Select-String -Path $log.FullName -Pattern 'Kestrel listening on http://127.0.0.1:(\d+)' | Select-Object -Last 1;" ^
+  "if (-not $m) { Write-Host 'Could not read its port from the log. Close the window by hand.'; exit 1 }" ^
+  "$port = $m.Matches[0].Groups[1].Value;" ^
+  "try { Invoke-WebRequest \"http://127.0.0.1:$port/shutdown\" -Method POST -UseBasicParsing -TimeoutSec 30 | Out-Null; Write-Host \"Shutdown sent (port $port).\" } catch { Write-Host 'It did not answer. Close the window by hand.' }"
+
+echo.
+echo Waiting for it to close...
+for /L %%i in (1,1,20) do (
+    tasklist /FI "IMAGENAME eq cc-director16.exe" 2>nul | find /I "cc-director16.exe" >nul
+    if errorlevel 1 (
+        echo Stopped.
+        timeout /t 2 >nul
+        exit /b 0
+    )
+    timeout /t 2 >nul
+)
+
+echo.
+echo It is still running. Close its window by hand if you need it gone.
+pause

--- a/docs/testing/trying-hosted-devthrottle.md
+++ b/docs/testing/trying-hosted-devthrottle.md
@@ -88,6 +88,14 @@ you see here came from the cloud copy.
 None of these are things you are doing wrong. They are known, they have owners, and they are
 listed here so nothing surprises you.
 
+> **To whoever maintains this page: do not delete an item below because its fix merged.**
+> Delete it when the fix is **on the deployed cloud gateway and you have seen the thing work**.
+> Merged is not deployed - the cloud runs a container image, and merging to main does not change
+> what is running on it. That distinction has already cost this project real time more than once,
+> including a verification held back specifically because a merged fix was deliberately not yet on
+> the box. An item removed early turns an honest warning into a lie, and the person reading this
+> page has no way to tell.
+
 **There is no cockpit and no phone view on the cloud gateway.** This is the big one. The cloud
 image is deliberately built without the cockpit and mobile web apps, so `https://devthrottle-gw.azurewebsites.net`
 in a browser will not give you a usable page. For now the **desktop window is the only way to see

--- a/docs/testing/trying-hosted-devthrottle.md
+++ b/docs/testing/trying-hosted-devthrottle.md
@@ -1,0 +1,131 @@
+# Trying the hosted DevThrottle
+
+A short guide to running DevThrottle against the **cloud** gateway instead of the one on your own PC.
+
+---
+
+## The one thing to know first
+
+**This does not change your normal DevThrottle.**
+
+It is a **second, separate** DevThrottle. It has its own folder, its own settings and its own
+sessions, and it runs alongside your usual one. Your everyday DevThrottle keeps running exactly as
+it does now, with all your sessions, and nothing about it is touched.
+
+This matters because your normal DevThrottle on this PC is the one running the whole agent fleet.
+It must not be pointed at the cloud, because that would drag every running session with it. So
+trying the cloud is done with a separate copy instead - which is what these three files are.
+
+---
+
+## Starting it
+
+Double-click:
+
+```
+Start hosted DevThrottle.cmd
+```
+
+A DevThrottle window opens after a few seconds. It is **already signed in** to the cloud gateway -
+there is nothing to log into and no code to paste.
+
+If it is already running, it tells you so and does nothing.
+
+## Stopping it
+
+Double-click:
+
+```
+Stop hosted DevThrottle.cmd
+```
+
+This asks the program to close itself down tidily rather than killing it, so it does not leave a
+stray "interrupted" entry behind. It waits and tells you when it has stopped.
+
+Closing the window by hand also works, but the script is the cleaner way.
+
+## Making sure you are really on the cloud
+
+Double-click:
+
+```
+Show what the cloud sees.cmd
+```
+
+This is the honest check. It does **not** ask the program on your PC - it goes out to the cloud
+gateway over the internet and prints whatever the cloud says back:
+
+```
+Asking the cloud gateway: https://devthrottle-gw.azurewebsites.net
+
+DevThrottles the cloud can see: 1
+   on SOREN_NORTH, version 1.5.0
+
+Sessions the cloud can see: 2
+   #100  my first hosted session   [Needs you]
+   #101  another one               [Working]
+```
+
+If your sessions are listed there, they genuinely reached the cloud. If it says "none" right after
+starting, wait about ten seconds and run it again.
+
+**Your normal DevThrottle's sessions will never appear in this list.** That is the point: anything
+you see here came from the cloud copy.
+
+---
+
+## What to expect
+
+- Start it, open a session in it as you normally would, and that session runs on your PC as usual -
+  but it is **reported to the cloud** rather than to your own gateway.
+- Session numbers are handed out by the cloud, starting at 100.
+- Colours, labels and "Needs you" states are decided by the cloud and shown to you.
+
+---
+
+## What does not work yet
+
+None of these are things you are doing wrong. They are known, they have owners, and they are
+listed here so nothing surprises you.
+
+**There is no cockpit and no phone view on the cloud gateway.** This is the big one. The cloud
+image is deliberately built without the cockpit and mobile web apps, so `https://devthrottle-gw.azurewebsites.net`
+in a browser will not give you a usable page. For now the **desktop window is the only way to see
+and drive** the hosted sessions. Tracked as **issue #1892**, which is being treated as a go-live
+gate rather than a bug - the reason the assets were excluded is out of date.
+
+**Dictation does not work on the cloud gateway.** Deliberately left switched off, because turning
+it on would have exposed a hole where one account could request another account's transcript.
+Tracked as **issue #1884**.
+
+**Cross-account separation is not something you can see from here.** You are the only account on
+the cloud gateway at the moment, so there is nothing to compare against. It has been tested
+separately with two accounts.
+
+**The browser sign-in page will reject your key.** If you find `/login` on the cloud gateway and
+paste a device key into it, it will say no. That is a quirk of that page, not a sign that anything
+is wrong with your setup. Noted in **issue #1892**.
+
+---
+
+## If something looks wrong
+
+1. Run `Show what the cloud sees.cmd`. It tells you whether the cloud can see your DevThrottle at
+   all, which separates "not connected" from "connected but misbehaving".
+2. If it says the cloud can see no DevThrottles while the window is open, the connection is the
+   problem, not the sessions.
+3. The log lives in `testroot\logs\director\` - newest file, one per run.
+
+---
+
+## For whoever maintains this
+
+The engineering detail behind this setup - the isolated storage root, why it is a separate slot
+build, how it was enrolled and how each leg was verified - is in
+[hosted-real-director-test-rig.md](hosted-real-director-test-rig.md). Read that before changing
+anything here, particularly the section on `CC_DIRECTOR_ROOT` and the storage migration.
+
+Copies of the three scripts are kept in
+[hosted-dogfood/](hosted-dogfood/) so they survive the machine they were written on. **They contain
+absolute paths** for the setup they were built for, so check the paths inside before reusing them
+elsewhere.


### PR DESCRIPTION
The Architect has ruled the owner can dogfood hosted as the only tenant. This is what he needs to actually do it.

## Why it is a separate Director

His everyday Director on this machine **is** the one running the whole agent fleet. Enrolling it at hosted would move every running session with it. So dogfooding has to be a second, isolated Director — not a reconfiguration of his.

The guide opens with that, in those terms, because it is the one thing that must not be misunderstood.

## What it gives him

Three double-clickable scripts, and a page written for him rather than for an engineer:

| Script | What it does |
|---|---|
| `Start hosted DevThrottle.cmd` | starts it; refuses politely if already running |
| `Stop hosted DevThrottle.cmd` | asks it to shut down cleanly, so it leaves no stray "interrupted" entry |
| `Show what the cloud sees.cmd` | asks the **cloud** over the internet and prints the answer |

The third is the important one. It does not ask the program on his PC whether it thinks it is connected — it queries the hosted gateway directly and prints the Directors and sessions it reports. "Am I really on hosted?" becomes something he can **see** rather than something he is told.

## What does not work yet, stated plainly

Listed so none of it reads as his mistake:

- **No cockpit and no phone view on the cloud image at all** — the assets are deliberately excluded from the container, so the desktop window is the only way to see hosted sessions today (#1892, now being treated as a go-live gate, since the stated reason for excluding them is out of date)
- **Dictation is off by design** (#1884)
- **Cross-account separation is not observable** from a single account
- **`/login` rejects a device key** that works fine as a cookie — a usability landmine that would otherwise convince him his key is wrong (#1892)

## Note on the migration guard

This guide is only safe to hand over **after thefrederiksen/devthrottle#1891 merges** and the slot build is rebuilt from it. Until then, starting a Director against a cleaned isolated root re-copies the owner's real session history straight back into it — `CopyFileIfNewer` copies whenever the destination is missing, and the migration runs on every start.

Script copies live beside the guide because their absolute paths make them machine-specific, and one-copy knowledge has cost this project real time today.