### PR TITLE
fix(gateway): deny the whole owner-settings group on the hosted gateway

### DIFF
--- a/src/CcDirector.Gateway.Tests/AiModelsEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/AiModelsEndpointTests.cs
@@ -16,7 +16,7 @@ namespace CcDirector.Gateway.Tests;
 /// /gateway/ai-provider snapshot, and the list route reports "not signed in" (503) with no key - never a
 /// crash or a silent empty list.
 /// </summary>
-[Collection("DirectorRoot")]
+[Collection("GatewayHostedMode")]
 public sealed class AiModelsEndpointTests : IAsyncLifetime
 {
     private readonly string _root;

--- a/src/CcDirector.Gateway.Tests/AiProviderEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/AiProviderEndpointTests.cs
@@ -15,7 +15,7 @@ namespace CcDirector.Gateway.Tests;
 /// ephemeral port with CC_DIRECTOR_ROOT redirected to a temp dir, so writes round-trip an isolated
 /// config.json rather than the user's real one.
 /// </summary>
-[Collection("DirectorRoot")]
+[Collection("GatewayHostedMode")]
 public sealed class AiProviderEndpointTests : IAsyncLifetime
 {
     private readonly string _root;

--- a/src/CcDirector.Gateway.Tests/BrainConfigEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/BrainConfigEndpointTests.cs
@@ -24,7 +24,7 @@ namespace CcDirector.Gateway.Tests;
 /// round-trip); the default is claude + opus when unset; and an unknown agent id is rejected
 /// (no-fallback).
 /// </summary>
-[Collection("DirectorRoot")]
+[Collection("GatewayHostedMode")]
 public sealed class BrainConfigEndpointTests : IAsyncLifetime
 {
     private readonly string _root;

--- a/src/CcDirector.Gateway.Tests/CockpitUrlEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/CockpitUrlEndpointTests.cs
@@ -13,11 +13,18 @@ namespace CcDirector.Gateway.Tests;
 
 /// <summary>
 /// Endpoint-level proof that the P1 fix is WIRED IN, not just present as a helper: the live Gateway
-/// <c>GET /cockpit</c>, the <c>CockpitUrl</c> on <c>GET /gateway/about</c>, and the <c>cockpit.url</c> on
-/// <c>GET /gateway/settings</c> all hand back <c>{base}/cockpit</c> in hosted mode, where base comes from
-/// <c>CC_GATEWAY_PUBLIC_URL</c>. These are the tests that go red if any of the THREE call sites is reverted
-/// to <c>TailscaleIdentity.TryGetFrontDoorBaseUrl()</c> (which, with no tailnet in the test host, yields
-/// null where the public URL should be) - a green pure-resolver test cannot catch a mis-wired call site.
+/// <c>GET /cockpit</c> and the <c>CockpitUrl</c> on <c>GET /gateway/about</c> both hand back
+/// <c>{base}/cockpit</c> in hosted mode, where base comes from <c>CC_GATEWAY_PUBLIC_URL</c>. These are the
+/// tests that go red if either call site is reverted to <c>TailscaleIdentity.TryGetFrontDoorBaseUrl()</c>
+/// (which, with no tailnet in the test host, yields null where the public URL should be) - a green
+/// pure-resolver test cannot catch a mis-wired call site. These two are the surfaces a hosted client actually
+/// reads for the public URL.
+///
+/// <c>GET /gateway/settings</c> once carried a third <c>cockpit.url</c> copy, but that route is part of the
+/// owner-settings group DENIED on the hosted Gateway (issue #1863), so on hosted it serves the refusal and no
+/// cockpit URL at all - proved by <see cref="Hosted_settings_route_is_denied_and_carries_no_cockpit_url"/>.
+/// That copy is unused anyway: boot, navigation, and URL discovery do not consume it; its only reader is the
+/// settings-page load, which renders a load-error state on the deny.
 ///
 /// Only the HOSTED direction is asserted at the endpoint: it is deterministic (no tailscale involved). The
 /// self-host direction depends on whether a tailnet exists on the build host, so its byte-identical proof
@@ -66,24 +73,23 @@ public sealed class CockpitUrlEndpointTests
     }
 
     [Fact]
-    public async Task Hosted_settings_cockpit_url_returns_configured_public_cockpit_url()
+    public async Task Hosted_settings_route_is_denied_and_carries_no_cockpit_url()
     {
         await WithHostedGateway(PublicBase, async (http, gateway) =>
         {
-            // The third call site (first cut missed it): /gateway/settings.cockpit.url must hand back the
-            // SAME {base}/cockpit, not the raw front-door root it emitted before. Reverting this call site
-            // to TryGetFrontDoorBaseUrl() turns this red (null in the test host).
+            // /gateway/settings is part of the owner-settings group DENIED on hosted (issue #1863), so it no
+            // longer serves the cockpit.url it once did - it answers the refusal. The live public-URL surfaces
+            // are GET /cockpit and GET /gateway/about, asserted above; cockpit.url is unused by boot,
+            // navigation, or URL discovery.
             //
-            // MH-2: authenticate with a per-device key, not the shared token (rejected on hosted).
+            // MH-2: authenticate with a per-device key, not the shared token (rejected on hosted) - so this
+            // reaches the deny, not the auth gate.
             var deviceKey = gateway.Devices.Register("cockpiturl-settings", "PHONE").DeviceKey;
             using var req = new HttpRequestMessage(HttpMethod.Get, "gateway/settings");
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
             using var resp = await http.SendAsync(req);
-            resp.EnsureSuccessStatusCode();
 
-            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
-            var url = doc.RootElement.GetProperty("cockpit").GetProperty("url").GetString();
-            Assert.Equal(ExpectedCockpit, url);
+            await OwnerSettingsRoutes.AssertIsNothingButTheRefusal(resp, OwnerSettingsRoutes.SettingsRefusal);
         });
     }
 

--- a/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
@@ -18,6 +18,7 @@ namespace CcDirector.Gateway.Tests;
 /// the gateway's REST API over loopback. This covers the discovery flow, proxy
 /// routing, auth middleware, and error paths.
 /// </summary>
+[Collection("GatewayHostedMode")]
 public sealed class GatewayHostTests : IAsyncLifetime
 {
     private ControlApiHost _director = null!;

--- a/src/CcDirector.Gateway.Tests/GatewayHostedModeCollection.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayHostedModeCollection.cs
@@ -1,0 +1,25 @@
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The collection for every test whose result depends on the PROCESS-WIDE <c>CC_GATEWAY_HOSTED</c>
+/// variable - both the tests that SET it and the tests that would be broken by somebody else setting it.
+///
+/// Two rules put a class in here:
+///   1. It sets <c>CC_GATEWAY_HOSTED</c> itself. The owner-settings deny classes set it to OPPOSITE values -
+///      hosted in the deny classes, explicitly not-hosted in the self-host controls - so two of them running
+///      concurrently would each be reading the other's mode.
+///   2. It drives a route that is REFUSED on hosted (issue #1863 denied the whole owner-settings group).
+///      Before that deny those routes answered the same way in both modes, so a class driving them did not
+///      care what the variable said. Now it does: a hosted-mode class running in parallel would turn its
+///      200 into a 404, intermittently and for reasons entirely outside that test file.
+///
+/// <c>DisableParallelization</c> is what actually delivers rule 2 - the collection runs on its own, so no
+/// other collection can flip the mode underneath it. That also subsumes what <see cref="DirectorRootCollection"/>
+/// does for its members, which is why the classes moved in here no longer carry that attribute.
+/// </summary>
+[CollectionDefinition("GatewayHostedMode", DisableParallelization = true)]
+public sealed class GatewayHostedModeCollection
+{
+}

--- a/src/CcDirector.Gateway.Tests/GatewayHostedModeCollection.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayHostedModeCollection.cs
@@ -16,8 +16,16 @@ namespace CcDirector.Gateway.Tests;
 ///      200 into a 404, intermittently and for reasons entirely outside that test file.
 ///
 /// <c>DisableParallelization</c> is what actually delivers rule 2 - the collection runs on its own, so no
-/// other collection can flip the mode underneath it. That also subsumes what <see cref="DirectorRootCollection"/>
-/// does for its members, which is why the classes moved in here no longer carry that attribute.
+/// other collection can flip the mode underneath it. That is STRICTLY STRONGER than what
+/// <see cref="DirectorRootCollection"/> gives its members - running alone subsumes running serially with a
+/// subset - which is why the five classes moved in here no longer carry that attribute. Nothing was
+/// weakened by the move.
+///
+/// WHY THIS SHIPS WITH THE DENY RATHER THAN SEPARATELY. Before issue #1863 these routes answered the same
+/// way in both modes, so none of this was needed. The deny is what creates the need, so the fix belongs in
+/// the change that creates it: shipping the deny without this collection would leave six test classes
+/// nobody here wrote failing intermittently, for reasons entirely outside their own files. A change that
+/// makes someone else's tests flaky is a change that shipped a defect.
 /// </summary>
 [CollectionDefinition("GatewayHostedMode", DisableParallelization = true)]
 public sealed class GatewayHostedModeCollection

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
@@ -1,0 +1,526 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core;
+using CcDirector.Core.Configuration;
+using CcDirector.Gateway.Api;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// One place naming EVERY route in the owner-settings group, with the verb each one actually answers on.
+/// Both sides of the proof read this table: the hosted side asserts every row is REFUSED, the self-host
+/// side asserts every row is SERVED. Writing the table once is what makes "every route, both directions"
+/// a checkable claim rather than a sentence in a pull request.
+/// </summary>
+public static class OwnerSettingsRoutes
+{
+    /// <summary>The refusal a route in <c>SettingsEndpoints</c> answers with on hosted.</summary>
+    public const string SettingsRefusal = "gateway settings are not available on the hosted gateway";
+
+    /// <summary>The refusal a route in <c>AiModelsEndpoint</c> answers with on hosted.</summary>
+    public const string ModelsRefusal = "the model settings are not available on the hosted gateway";
+
+    /// <summary>The refusal a route in <c>TelemetryConsentEndpoint</c> answers with on hosted.</summary>
+    public const string TelemetryRefusal = "the telemetry consent setting is not available on the hosted gateway";
+
+    /// <summary>A route in the group: the verb it answers, its path, and a well-formed body for writes.</summary>
+    public sealed record Route(string Verb, string Path, string? Body, string Refusal)
+    {
+        public override string ToString() => Verb + " /" + Path;
+    }
+
+    /// <summary>
+    /// The 22 routes mapped directly by <c>SettingsEndpoints</c>. Bodies are WELL FORMED and would be
+    /// accepted on self-host, so a refusal here can never be mistaken for a validation rejection.
+    /// </summary>
+    public static readonly Route[] Settings =
+    {
+        new("GET",  "gateway/settings",                 null, SettingsRefusal),
+        new("POST", "gateway/brain/restart",            null, SettingsRefusal),
+        new("PUT",  "gateway/brain/config",             "{\"agentId\":\"agent-1\",\"model\":\"opus\"}", SettingsRefusal),
+        new("GET",  "gateway/wingman/training-capture", null, SettingsRefusal),
+        new("PUT",  "gateway/wingman/training-capture", "{\"enabled\":true}", SettingsRefusal),
+        new("GET",  "gateway/addressing-mode",          null, SettingsRefusal),
+        new("PUT",  "gateway/addressing-mode",          "{\"mode\":\"lan\"}", SettingsRefusal),
+        new("GET",  "gateway/snooze-default",           null, SettingsRefusal),
+        new("PUT",  "gateway/snooze-default",           "{\"minutes\":45}", SettingsRefusal),
+        new("GET",  "gateway/injected-text",            null, SettingsRefusal),
+        new("PUT",  "gateway/injected-text",            "{\"use_yours\":true,\"yours\":\"words from another tenant\"}", SettingsRefusal),
+        new("GET",  "gateway/snooze-presets",           null, SettingsRefusal),
+        new("PUT",  "gateway/snooze-presets",           "{\"presets\":[15,30,60],\"defaultMinutes\":30}", SettingsRefusal),
+        new("GET",  "gateway/time-zone",                null, SettingsRefusal),
+        new("PUT",  "gateway/time-zone",                "{\"timeZone\":\"America/New_York\"}", SettingsRefusal),
+        new("GET",  "gateway/transcription-mode",       null, SettingsRefusal),
+        new("PUT",  "gateway/transcription-mode",       "{\"mode\":\"devthrottle\"}", SettingsRefusal),
+        new("GET",  "gateway/ai-provider",              null, SettingsRefusal),
+        new("PUT",  "gateway/ai-provider",              "{\"provider\":\"devthrottle\"}", SettingsRefusal),
+        new("GET",  "gateway/tts-voice",                null, SettingsRefusal),
+        new("PUT",  "gateway/tts-voice",                "{\"voice\":\"shimmer\"}", SettingsRefusal),
+        new("PUT",  "gateway/autostart",                "{\"enabled\":true}", SettingsRefusal),
+    };
+
+    /// <summary>The 7 routes mapped by <c>AiModelsEndpoint</c>.</summary>
+    public static readonly Route[] Models =
+    {
+        new("GET",  "gateway/ai/models",              null, ModelsRefusal),
+        new("POST", "gateway/ai/test-chat",           "{\"model\":\"some-model\"}", ModelsRefusal),
+        new("PUT",  "gateway/ai/wingman-model",       "{\"model\":\"hosted-wingman\"}", ModelsRefusal),
+        new("PUT",  "gateway/ai/wingman-fast-model",  "{\"model\":\"hosted-fast\"}", ModelsRefusal),
+        new("PUT",  "gateway/ai/car-mode-model",      "{\"model\":\"hosted-car\"}", ModelsRefusal),
+        new("PUT",  "gateway/ai/car-mode-end-phrase", "{\"phrase\":\"finished here\"}", ModelsRefusal),
+        new("PUT",  "gateway/ai/tts-model",           "{\"model\":\"hosted-speech\"}", ModelsRefusal),
+    };
+
+    /// <summary>The 2 routes mapped by <c>TelemetryConsentEndpoint</c>.</summary>
+    public static readonly Route[] Telemetry =
+    {
+        new("GET", "gateway/telemetry-consent", null, TelemetryRefusal),
+        new("PUT", "gateway/telemetry-consent", "{\"enabled\":false}", TelemetryRefusal),
+    };
+
+    /// <summary>All 31 route-and-verb pairs the owner-settings group answers.</summary>
+    public static IEnumerable<Route> All => Settings.Concat(Models).Concat(Telemetry);
+
+    /// <summary>
+    /// Every route as xUnit theory data, so no row can be silently left out of either side. Flattened to
+    /// plain strings (an empty body string means "no body") DELIBERATELY: xUnit can only pre-enumerate and
+    /// NAME theory cases whose arguments are serializable, and a run whose cases cannot be named
+    /// individually cannot be checked against the declared method set by name.
+    /// </summary>
+    public static TheoryData<string, string, string, string> AllRoutes
+    {
+        get
+        {
+            var data = new TheoryData<string, string, string, string>();
+            foreach (var route in All) data.Add(route.Verb, route.Path, route.Body ?? "", route.Refusal);
+            return data;
+        }
+    }
+
+    /// <summary>
+    /// Sends one row. Kept here so the hosted and self-host sides drive the routes IDENTICALLY and any
+    /// difference between them is the Gateway's behaviour, not the client's.
+    /// </summary>
+    public static Task<HttpResponseMessage> SendAsync(HttpClient http, string verb, string path, string body)
+    {
+        var request = new HttpRequestMessage(new HttpMethod(verb), path);
+        if (!string.IsNullOrEmpty(body))
+            request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return http.SendAsync(request);
+    }
+
+    /// <summary>Overload for the non-theory call sites that already hold a <see cref="Route"/>.</summary>
+    public static Task<HttpResponseMessage> SendAsync(HttpClient http, Route route) =>
+        SendAsync(http, route.Verb, route.Path, route.Body ?? "");
+
+    /// <summary>
+    /// Asserts a response is the hosted refusal and NOTHING ELSE.
+    ///
+    /// FORMAT FACTS FIRST, ON PURPOSE. The status and the media type are asserted BEFORE the body is
+    /// parsed, because parsing is itself an unstated assertion about format. On this Gateway a 404 is not
+    /// necessarily JSON - a single-page-application fallback answers unmatched paths and can reply with
+    /// plain text, or on a release host with a 200 and HTML - so a test that parses first turns a real
+    /// finding into a crash. A crash proves the mutation broke something upstream; it cannot say WHAT was
+    /// served in place of the refusal, which is the entire claim a deny makes.
+    ///
+    /// The body is then compared as an ALLOW-LIST over the whole property set, not by substring. A
+    /// substring match cannot see an extra leaked field, and a deny-list of today's keys rots the moment
+    /// the payload grows.
+    /// </summary>
+    public static async Task AssertIsNothingButTheRefusal(HttpResponseMessage response, string expectedMessage)
+    {
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var document = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
+
+        var properties = document.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Equal(new[] { "error" }, properties);
+        Assert.Equal(expectedMessage, document.RootElement.GetProperty("error").GetString());
+    }
+}
+
+/// <summary>
+/// Issue #1863: the WHOLE owner-settings group is DENIED on the hosted Gateway.
+///
+/// THE DEFECT. Thirty-one routes across three endpoint classes read and write PROCESS-GLOBAL
+/// configuration. There is no tenant dimension anywhere in them: config.json is one file for the whole
+/// process, so every write is a FLEET-WIDE mutation performed by whichever authenticated caller happened
+/// to send it - one tenant repointing the wingman model, the speech model, the time zone, the snooze
+/// lengths, the network addressing mode or the fleet-wide telemetry consent for everybody else. And
+/// <c>GET /gateway/injected-text</c> hands back the owner's own custom agent-launch instruction text,
+/// which is his words, to any caller.
+///
+/// WHY A DENY AND NOT A PARTITION. There is nothing to partition BY. These are not per-tenant records
+/// whose storage unit could carry a tenant - they are single global values, one per key, and a
+/// "per-tenant" answer would have to be invented from an attribution that was never recorded. That is a
+/// half-partition, which is worse than an honest refusal because it looks like isolation. The concept
+/// does not survive the move either: this is the OWNER'S control panel for HIS OWN Gateway, and on
+/// shared hosted infrastructure "the owner" is not a thing.
+///
+/// SELF-HOST IS THE CONTROL AND IS UNCHANGED. Self-host is single-tenant and every one of these is
+/// legitimate owner function there. <see cref="HostedOwnerSettingsSelfHostControlTests"/> proves that
+/// explicitly, in both non-hosted forms, by asserting the REAL served result of every route.
+///
+/// IT REFUSES, IT DOES NOT SERVE EMPTY. An empty settings snapshot is indistinguishable from "you have
+/// no settings", which is a false statement rather than an absent one. Every refusal is a 404 whose body
+/// is EXACTLY one <c>error</c> property, asserted as an allow-list over the whole property set.
+///
+/// ONE GROUP FILTER PER FAMILY, NOT A GUARD PER ROUTE. Each of the three endpoint classes puts one
+/// endpoint filter on the route group it maps, so the refusal runs before every route in that group
+/// INCLUDING ROUTES THAT DO NOT EXIST YET. <see cref="HostedOwnerSettingsGroupFilterTests"/> is the only
+/// test of that property: a guard repeated per handler passes every other test in this file.
+/// </summary>
+[Collection("GatewayHostedMode")]
+public sealed class HostedOwnerSettingsDenyTests : IAsyncLifetime
+{
+    private const string Token = "test-token-12345";
+
+    private readonly string _root;
+    private readonly string? _priorRoot;
+    private readonly string? _priorHosted;
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-ownersettings-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _deviceKey = "";
+
+    public HostedOwnerSettingsDenyTests()
+    {
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-ownersettings-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+
+        // EXPLICIT, never ambient. This class asserts hosted behaviour, so it states hosted mode itself
+        // and proves the statement took, rather than inheriting whatever the runner happened to leave set.
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"));
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // A fully enrolled, tenant-bound device key - the strongest caller hosted has. The point is that
+        // even this one is refused: no credential makes an owner's control panel correct on shared
+        // infrastructure, because there is no owner.
+        _deviceKey = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var tenant = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", tenant.Value);
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _deviceKey);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// EVERY route, on its OWN verb, refused to a fully enrolled tenant - and refused with a body carrying
+    /// nothing but the refusal.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(OwnerSettingsRoutes.AllRoutes), MemberType = typeof(OwnerSettingsRoutes))]
+    public async Task Every_owner_settings_route_is_refused_on_hosted(
+        string verb, string path, string body, string refusal)
+    {
+        var response = await OwnerSettingsRoutes.SendAsync(_http, verb, path, body);
+        await OwnerSettingsRoutes.AssertIsNothingButTheRefusal(response, refusal);
+    }
+
+    /// <summary>
+    /// The refusal is a REFUSAL, not an empty snapshot. The exact-property-set assertion above is what
+    /// enforces this; this states the intent in the terms the mistake would be made in - the settings page
+    /// must not be handed a snapshot that reads "you have no custom text, no presets, no time zone", which
+    /// is a false statement where an absent one is merely absent.
+    /// </summary>
+    [Fact]
+    public async Task The_refusal_is_not_an_empty_settings_snapshot()
+    {
+        foreach (var path in new[] { "gateway/settings", "gateway/injected-text", "gateway/snooze-presets" })
+        {
+            var response = await _http.GetAsync(path);
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+            Assert.DoesNotContain("\"placeholders\"", body, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"presets\"", body, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"brain\"", body, StringComparison.Ordinal);
+            Assert.Contains("not available on the hosted gateway", body, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// A refused write CHANGED NOTHING. The refusal is asserted by an INDEPENDENT re-read of the
+    /// configuration store rather than by the response body, because a filter that returned 404 after the
+    /// handler had already run would look identical from outside.
+    /// </summary>
+    [Fact]
+    public async Task A_refused_write_does_not_reach_the_configuration_store()
+    {
+        var timeZoneBefore = TimeZoneConfig.Get();
+        var voiceBefore = TtsVoiceConfig.Resolve(TranscriptionModeConfig.Get());
+        var carModelBefore = CarModeModelConfig.Get();
+        var consentBefore = TelemetryConsentConfig.Get();
+
+        foreach (var route in OwnerSettingsRoutes.All.Where(r => r.Body is not null))
+            await OwnerSettingsRoutes.AssertIsNothingButTheRefusal(
+                await OwnerSettingsRoutes.SendAsync(_http, route), route.Refusal);
+
+        Assert.Equal(timeZoneBefore, TimeZoneConfig.Get());
+        Assert.Equal(voiceBefore, TtsVoiceConfig.Resolve(TranscriptionModeConfig.Get()));
+        Assert.Equal(carModelBefore, CarModeModelConfig.Get());
+        Assert.Equal(consentBefore, TelemetryConsentConfig.Get());
+    }
+
+    /// <summary>
+    /// CONTROL, and it must stay green through the revert: the deny runs after the host-wide auth gate, so
+    /// it must not have opened these routes up as a side effect.
+    /// </summary>
+    [Fact]
+    public async Task An_unauthenticated_caller_is_still_rejected()
+    {
+        using var anonymous = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        Assert.Equal(HttpStatusCode.Unauthorized, (await anonymous.GetAsync("gateway/settings")).StatusCode);
+    }
+
+    internal static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}
+
+/// <summary>
+/// Boots ONE owner-settings family onto a bare application with no authentication gate and NO
+/// single-page-application fallback, and hands the caller the route group back so a test can map routes
+/// onto it. That return value is what makes the future-route proof possible at all: the group is created
+/// inside each <c>Map</c> method, so nothing outside those methods could otherwise state a property about
+/// routes added to it later.
+///
+/// No fallback is deliberate as well. On the real Gateway an unmapped path is answered by the
+/// single-page-application fallback, so "the route is not there" and "the route is there and refused" can
+/// look alike. Here an unmapped path is a bare 404 with no body and an unmatched VERB is a 405, which is
+/// what lets <see cref="HostedOwnerSettingsGroupFilterTests"/> prove a route exists on hosted at all.
+/// </summary>
+internal static class OwnerSettingsProbeHost
+{
+    public static async Task<(WebApplication app, HttpClient http)> StartAsync(
+        Func<IEndpointRouteBuilder, RouteGroupBuilder> mapFamily,
+        Action<RouteGroupBuilder>? mapIntoGroup = null,
+        Action<IEndpointRouteBuilder>? mapOutsideGroup = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        var group = mapFamily(app);
+        mapIntoGroup?.Invoke(group);
+        mapOutsideGroup?.Invoke(app);
+
+        await app.StartAsync();
+        var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+        return (app, http);
+    }
+}
+
+/// <summary>
+/// THE POINT OF THE WHOLE CHANGE: the hosted refusal is a filter on each route GROUP, so it covers routes
+/// that have not been written yet.
+///
+/// A guard line repeated in every handler passes EXACTLY the same tests as a group filter for the routes
+/// that exist today, which is precisely what makes it dangerous rather than merely untidy: the difference
+/// only appears on the route somebody adds NEXT, when it is open on hosted by default and nothing fails.
+/// That difference is not observable by driving the 31 routes that exist, so this class maps a BRAND-NEW
+/// probe route onto each group and asserts it is refused with no deny written for it anywhere. These are
+/// the tests that justify choosing a group filter at all, and they are the reason all three
+/// <c>Map</c> methods now return their group.
+///
+/// The served half of the same probe - the SAME probe paths, with hosted mode explicitly OFF in both
+/// non-hosted forms - is <see cref="HostedOwnerSettingsSelfHostProbeTests"/>. One direction alone cannot
+/// tell a working gate apart from a brick: a filter that refused everything unconditionally would pass
+/// every assertion in this class while having silently killed the routes for self-host too.
+/// </summary>
+[Collection("GatewayHostedMode")]
+public sealed class HostedOwnerSettingsGroupFilterTests : IAsyncLifetime
+{
+    internal const string ProbeSentinel = "probe-payload-that-must-never-be-served-on-hosted";
+
+    private readonly string _root;
+    private readonly string? _priorRoot;
+    private readonly string? _priorHosted;
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-ownersettings-group-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+
+    public HostedOwnerSettingsGroupFilterTests()
+    {
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-ownersettings-group-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // A real, started GatewayHost, because SettingsEndpoints.Map needs one. Its own routes are not
+        // driven here; the probe application maps a second copy of the family and is what the tests call.
+        _gateway = new GatewayHost(port: HostedOwnerSettingsDenyTests.FreePort(), token: "probe-token",
+            authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"));
+        await _gateway.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    /// <summary>The three families, each mapped on its own so one filter is the only thing in the way.</summary>
+    internal Func<IEndpointRouteBuilder, RouteGroupBuilder> Family(string name) => name switch
+    {
+        "settings" => routes => SettingsEndpoints.Map(routes, _gateway),
+        "models" => routes => AiModelsEndpoint.Map(routes, new KeyVault(Path.Combine(_root, "vault.json"))),
+        "telemetry" => TelemetryConsentEndpoint.Map,
+        _ => throw new ArgumentOutOfRangeException(nameof(name), name, "unknown owner-settings family"),
+    };
+
+    public static TheoryData<string, string> Families => new()
+    {
+        { "settings", "/gateway/added-after-the-deny-was-written" },
+        { "models", "/gateway/ai/added-after-the-deny-was-written" },
+        { "telemetry", "/gateway/telemetry-added-after-the-deny-was-written" },
+    };
+
+    /// <summary>
+    /// A route that did not exist when the refusal was written is refused anyway. NOTHING in the endpoint
+    /// class mentions this path and no guard is written for it here - the only thing between the caller and
+    /// the probe payload is the group filter. Delete the filter and this serves the probe payload with a
+    /// 200, which is the future-route hole stated out loud.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Families))]
+    public async Task A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own(
+        string family, string probePath)
+    {
+        var (app, http) = await OwnerSettingsProbeHost.StartAsync(
+            Family(family),
+            mapIntoGroup: group => group.MapGet(probePath, () => Results.Json(new { probe = ProbeSentinel })));
+        try
+        {
+            var response = await http.GetAsync(probePath);
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.DoesNotContain(ProbeSentinel, body, StringComparison.Ordinal);
+
+            using var document = JsonDocument.Parse(body);
+            Assert.Equal(new[] { "error" }, document.RootElement.EnumerateObject().Select(p => p.Name).ToArray());
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>
+    /// CONTROL: the filter is scoped to its own group, not a blanket refusal on the whole application. A
+    /// route mapped OUTSIDE the group still serves on hosted, so the refusals above are the filter doing
+    /// its job rather than the host refusing everything. This must stay GREEN through the revert.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Families))]
+    public async Task A_route_outside_the_group_still_serves_on_hosted(string family, string unusedProbePath)
+    {
+        _ = unusedProbePath;
+
+        var (app, http) = await OwnerSettingsProbeHost.StartAsync(
+            Family(family),
+            mapOutsideGroup: routes => routes.MapGet("/not-an-owner-setting", () => Results.Json(new { served = "yes" })));
+        try
+        {
+            var response = await http.GetAsync("/not-an-owner-setting");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+            Assert.Contains("\"served\":\"yes\"", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>
+    /// THE SERVED-SIDE POSITIVE FACT FOR <c>POST /gateway/brain/restart</c>, and the answer to the fact
+    /// that a 404 deny is INDISTINGUISHABLE from a route that was never mapped.
+    ///
+    /// This is the one route in the group whose handler cannot be invoked in a test: its whole job is to
+    /// start a coding-agent process on the machine, so calling it on the served side would spawn one. So
+    /// instead of running the handler, this proves the route is REALLY THERE on hosted by asking for it
+    /// with the wrong verb. A GET reaches routing, finds a path that exists with no GET on it, and is
+    /// answered 405 with an <c>Allow: POST</c> header - a POSITIVE statement, emitted by the routing
+    /// table, that a POST endpoint is registered at that exact path. The endpoint filter never runs,
+    /// because no endpoint was selected, which is exactly why the 405 survives the deny.
+    ///
+    /// Put together with the POST being refused 404 in
+    /// <see cref="HostedOwnerSettingsDenyTests.Every_owner_settings_route_is_refused_on_hosted"/>, the two
+    /// say: the route exists on hosted, and the thing turning it away is the deny.
+    /// </summary>
+    [Fact]
+    public async Task The_brain_restart_route_exists_on_hosted_and_is_reachable_only_as_a_post()
+    {
+        var (app, http) = await OwnerSettingsProbeHost.StartAsync(Family("settings"));
+        try
+        {
+            var wrongVerb = await http.GetAsync("/gateway/brain/restart");
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, wrongVerb.StatusCode);
+            Assert.Contains("POST", wrongVerb.Content.Headers.Allow);
+
+            // The path really is unique to this route: a path NOT mapped at all answers 404, not 405, on
+            // this fallback-free probe host - so the 405 above is about a registered endpoint and not a
+            // catch-all.
+            var neverMapped = await http.GetAsync("/gateway/brain/no-such-route");
+            Assert.Equal(HttpStatusCode.NotFound, neverMapped.StatusCode);
+            Assert.Empty(neverMapped.Content.Headers.Allow);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using CcDirector.Core;
 using CcDirector.Core.Configuration;
 using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -183,10 +184,16 @@ public static class OwnerSettingsRoutes
 /// no settings", which is a false statement rather than an absent one. Every refusal is a 404 whose body
 /// is EXACTLY one <c>error</c> property, asserted as an allow-list over the whole property set.
 ///
-/// ONE GROUP FILTER PER FAMILY, NOT A GUARD PER ROUTE. Each of the three endpoint classes puts one
-/// endpoint filter on the route group it maps, so the refusal runs before every route in that group
-/// INCLUDING ROUTES THAT DO NOT EXIST YET. <see cref="HostedOwnerSettingsGroupFilterTests"/> is the only
-/// test of that property: a guard repeated per handler passes every other test in this file.
+/// ONE SHARED REFUSAL PRIMITIVE PER FAMILY, NOT A GUARD PER ROUTE. Each of the three endpoint classes maps
+/// its routes through <see cref="CcDirector.Gateway.Tenancy.HostedRouteDeny.Group"/>, which on hosted maps
+/// a verb-less refusal in place of each handler - so a route added to the group later is refused too, with
+/// no deny of its own. <see cref="HostedOwnerSettingsGroupFilterTests"/> is the test of that property: a
+/// guard repeated per handler passes every other test in this file.
+///
+/// The primitive REPLACED an earlier bespoke <c>AddEndpointFilter</c> deny (a request-time filter that ran
+/// inside the still-mapped handler). The upgrade shows up on the one shape the old filter could not answer -
+/// a verb the route never served - proved by
+/// <see cref="The_brain_restart_route_answers_the_refusal_on_a_verb_it_never_served_on_hosted"/>.
 /// </summary>
 [Collection("GatewayHostedMode")]
 public sealed class HostedOwnerSettingsDenyTests : IAsyncLifetime
@@ -359,21 +366,22 @@ public sealed class HostedOwnerSettingsDenyTests : IAsyncLifetime
 
 /// <summary>
 /// Boots ONE owner-settings family onto a bare application with no authentication gate and NO
-/// single-page-application fallback, and hands the caller the route group back so a test can map routes
-/// onto it. That return value is what makes the future-route proof possible at all: the group is created
-/// inside each <c>Map</c> method, so nothing outside those methods could otherwise state a property about
-/// routes added to it later.
+/// single-page-application fallback, and hands the caller the denied group HANDLE back so a test can map
+/// routes through it. That return value is what makes the future-route proof possible at all: the handle is
+/// created inside each <c>Map</c> method, so nothing outside those methods could otherwise state a property
+/// about routes added to it later.
 ///
 /// No fallback is deliberate as well. On the real Gateway an unmapped path is answered by the
 /// single-page-application fallback, so "the route is not there" and "the route is there and refused" can
-/// look alike. Here an unmapped path is a bare 404 with no body and an unmatched VERB is a 405, which is
-/// what lets <see cref="HostedOwnerSettingsGroupFilterTests"/> prove a route exists on hosted at all.
+/// look alike. Here an UNDECLARED path is a bare 404 with no body, while a DECLARED route's path answers the
+/// refusal on every verb (the primitive maps a verb-less refusal, so there is no 405) - which is what lets
+/// <see cref="HostedOwnerSettingsGroupFilterTests"/> tell a refused route apart from an unmapped one.
 /// </summary>
 internal static class OwnerSettingsProbeHost
 {
     public static async Task<(WebApplication app, HttpClient http)> StartAsync(
-        Func<IEndpointRouteBuilder, RouteGroupBuilder> mapFamily,
-        Action<RouteGroupBuilder>? mapIntoGroup = null,
+        Func<IEndpointRouteBuilder, HostedDenyGroup> mapFamily,
+        Action<HostedDenyGroup>? mapIntoGroup = null,
         Action<IEndpointRouteBuilder>? mapOutsideGroup = null)
     {
         var builder = WebApplication.CreateBuilder();
@@ -392,21 +400,21 @@ internal static class OwnerSettingsProbeHost
 }
 
 /// <summary>
-/// THE POINT OF THE WHOLE CHANGE: the hosted refusal is a filter on each route GROUP, so it covers routes
-/// that have not been written yet.
+/// THE POINT OF THE WHOLE CHANGE: the hosted refusal is mapped through the shared primitive on each route
+/// GROUP, so it covers routes that have not been written yet.
 ///
-/// A guard line repeated in every handler passes EXACTLY the same tests as a group filter for the routes
+/// A guard line repeated in every handler passes EXACTLY the same tests as the group refusal for the routes
 /// that exist today, which is precisely what makes it dangerous rather than merely untidy: the difference
 /// only appears on the route somebody adds NEXT, when it is open on hosted by default and nothing fails.
 /// That difference is not observable by driving the 31 routes that exist, so this class maps a BRAND-NEW
-/// probe route onto each group and asserts it is refused with no deny written for it anywhere. These are
-/// the tests that justify choosing a group filter at all, and they are the reason all three
-/// <c>Map</c> methods now return their group.
+/// probe route THROUGH each denied handle and asserts it is refused with no deny written for it anywhere.
+/// These are the tests that justify routing every handler through the primitive at all, and they are the
+/// reason all three <c>Map</c> methods now return their denied handle.
 ///
 /// The served half of the same probe - the SAME probe paths, with hosted mode explicitly OFF in both
 /// non-hosted forms - is <see cref="HostedOwnerSettingsSelfHostProbeTests"/>. One direction alone cannot
-/// tell a working gate apart from a brick: a filter that refused everything unconditionally would pass
-/// every assertion in this class while having silently killed the routes for self-host too.
+/// tell a working gate apart from a brick: a refusal that fired everything unconditionally would pass every
+/// assertion in this class while having silently killed the routes for self-host too.
 /// </summary>
 [Collection("GatewayHostedMode")]
 public sealed class HostedOwnerSettingsGroupFilterTests : IAsyncLifetime
@@ -453,8 +461,8 @@ public sealed class HostedOwnerSettingsGroupFilterTests : IAsyncLifetime
         try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
     }
 
-    /// <summary>The three families, each mapped on its own so one filter is the only thing in the way.</summary>
-    internal Func<IEndpointRouteBuilder, RouteGroupBuilder> Family(string name) => name switch
+    /// <summary>The three families, each mapped on its own so one refusal is the only thing in the way.</summary>
+    internal Func<IEndpointRouteBuilder, HostedDenyGroup> Family(string name) => name switch
     {
         "settings" => routes => SettingsEndpoints.Map(routes, _gateway),
         "models" => routes => AiModelsEndpoint.Map(routes, new KeyVault(Path.Combine(_root, "vault.json"))),
@@ -471,9 +479,10 @@ public sealed class HostedOwnerSettingsGroupFilterTests : IAsyncLifetime
 
     /// <summary>
     /// A route that did not exist when the refusal was written is refused anyway. NOTHING in the endpoint
-    /// class mentions this path and no guard is written for it here - the only thing between the caller and
-    /// the probe payload is the group filter. Delete the filter and this serves the probe payload with a
-    /// 200, which is the future-route hole stated out loud.
+    /// class mentions this path and no guard is written for it here - it is mapped THROUGH the denied handle,
+    /// so on hosted the primitive maps a verb-less refusal in its place instead of the probe handler. Map it
+    /// on the ungrouped builder instead and this serves the probe payload with a 200, which is the
+    /// future-route hole stated out loud.
     /// </summary>
     [Theory]
     [MemberData(nameof(Families))]
@@ -499,9 +508,9 @@ public sealed class HostedOwnerSettingsGroupFilterTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// CONTROL: the filter is scoped to its own group, not a blanket refusal on the whole application. A
-    /// route mapped OUTSIDE the group still serves on hosted, so the refusals above are the filter doing
-    /// its job rather than the host refusing everything. This must stay GREEN through the revert.
+    /// CONTROL: the refusal is scoped to its own group, not a blanket refusal on the whole application. A
+    /// route mapped OUTSIDE the denied handle still serves on hosted, so the refusals above are the primitive
+    /// doing its job rather than the host refusing everything. This must stay GREEN through the revert.
     /// </summary>
     [Theory]
     [MemberData(nameof(Families))]
@@ -523,38 +532,41 @@ public sealed class HostedOwnerSettingsGroupFilterTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// A SUPPLEMENTARY fact about <c>POST /gateway/brain/restart</c>: the route is registered on hosted at
-    /// that exact path, and only for POST.
+    /// A VERB THE ROUTE NEVER SERVED meets the REFUSAL, not a 405 - the headline upgrade the shared refusal
+    /// primitive buys over the old request-time group filter, and the reason this rework replaced the filter.
     ///
-    /// THIS IS NO LONGER THE SERVED-SIDE PROOF FOR THAT ROUTE, and it was wrong to lean on it as one. A GET
-    /// answered 405 with <c>Allow: POST</c> proves the routing table has a POST endpoint registered there;
-    /// it says NOTHING about which handler that POST reaches, or whether it reaches one at all. The real
-    /// served-side proof now drives the exact path and verb and asserts the handler's own receipt, through
-    /// an injected restart seam so no process is started - see
-    /// <see cref="HostedOwnerSettingsSelfHostControlTests.The_brain_restart_route_reaches_its_handler_on_self_host_without_starting_a_process"/>
-    /// and its destructibility control.
+    /// <c>POST /gateway/brain/restart</c> is the only verb this route ever served. Under the old
+    /// <c>AddEndpointFilter</c> deny the route's handler was still MAPPED on hosted and the filter ran inside
+    /// it, so a GET to that path was answered by endpoint SELECTION with 405 <c>Allow: POST</c> - which
+    /// discloses that a route exists on a Gateway whose refusal says it does not. The primitive maps a
+    /// VERB-LESS refusal on the path and never maps the handler at all, so every verb - including one the
+    /// route never served - meets the same 404 refusal. A wrong verb IS a request shape, and the refusal is
+    /// uniform across shapes.
     ///
-    /// It is kept because it still answers a real question the receipt does not: a 404 deny is
-    /// indistinguishable from a route that was never mapped, and this shows the path is genuinely
-    /// registered ON HOSTED, where the deny is active. The 405 survives the deny because no endpoint is
-    /// selected for a verb that does not exist, so the filter never runs.
+    /// THIS IS REVERT-PROOF. Restore the real handler on hosted (map it instead of the refusal) and this GET
+    /// goes back to 405, reddening the refusal assertion. And it still answers the question the old 405 did -
+    /// a refused path is distinguished from one that was never mapped: the refused path carries the error
+    /// body, a never-mapped path is a bare 404 with no body and no <c>Allow</c> header on this fallback-free
+    /// probe host.
     /// </summary>
     [Fact]
-    public async Task The_brain_restart_route_is_registered_on_hosted_and_only_as_a_post()
+    public async Task The_brain_restart_route_answers_the_refusal_on_a_verb_it_never_served_on_hosted()
     {
         var (app, http) = await OwnerSettingsProbeHost.StartAsync(Family("settings"));
         try
         {
+            // GET a POST-only route. NOT a 405 - the verb-less refusal answers it, uniformly across verbs.
             var wrongVerb = await http.GetAsync("/gateway/brain/restart");
-            Assert.Equal(HttpStatusCode.MethodNotAllowed, wrongVerb.StatusCode);
-            Assert.Contains("POST", wrongVerb.Content.Headers.Allow);
+            await OwnerSettingsRoutes.AssertIsNothingButTheRefusal(wrongVerb, OwnerSettingsRoutes.SettingsRefusal);
+            Assert.Empty(wrongVerb.Content.Headers.Allow);
 
-            // The path really is unique to this route: a path NOT mapped at all answers 404, not 405, on
-            // this fallback-free probe host - so the 405 above is about a registered endpoint and not a
-            // catch-all.
+            // The refusal above is this route's own, not a catch-all: a path NOT in the family answers a bare
+            // 404 with no body on this fallback-free probe host. Per-route mode refuses only the paths the
+            // family declares, so an undeclared sub-path is genuinely unmapped.
             var neverMapped = await http.GetAsync("/gateway/brain/no-such-route");
             Assert.Equal(HttpStatusCode.NotFound, neverMapped.StatusCode);
             Assert.Empty(neverMapped.Content.Headers.Allow);
+            Assert.Equal(string.Empty, await neverMapped.Content.ReadAsStringAsync());
         }
         finally { http.Dispose(); await app.DisposeAsync(); }
     }

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
@@ -503,6 +503,14 @@ public sealed class HostedOwnerSettingsGroupFilterTests : IAsyncLifetime
     /// Put together with the POST being refused 404 in
     /// <see cref="HostedOwnerSettingsDenyTests.Every_owner_settings_route_is_refused_on_hosted"/>, the two
     /// say: the route exists on hosted, and the thing turning it away is the deny.
+    ///
+    /// WHAT THIS PROVES, AND WHAT IT DOES NOT. It proves the ROUTE IS REGISTERED. It does NOT exercise the
+    /// HANDLER, and it makes no claim to. Read as a served-payload proof it would be one that fell short;
+    /// read as what it is - a routing-table existence proof that does not depend on any handler behaving -
+    /// it is the correct ceiling for a route whose handler starts a process, and it is the one form of
+    /// existence proof that survives the deny, because no endpoint is ever selected for it to run against.
+    /// Every OTHER route in the group is proved served-side by a real payload, an independently re-read
+    /// effect, or a handler-unique receipt; this is the single exception and it is deliberate.
     /// </summary>
     [Fact]
     public async Task The_brain_restart_route_exists_on_hosted_and_is_reachable_only_as_a_post()

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
@@ -400,6 +400,15 @@ internal static class OwnerSettingsProbeHost
 }
 
 /// <summary>
+/// The well-formed JSON body the future-route canary binds THROUGH THE FRAMEWORK. A plain record parameter is
+/// inferred as the JSON body (the same shape as the reference's <c>EchoBody</c>), so the framework infers the
+/// media-type and parse constraints and a malformed body is the framework's own 400 on self-host - which is
+/// what makes the hosted "malformed body meets the refusal" claim a real pre-emption of binding rather than a
+/// custom binder side-stepping the bytes.
+/// </summary>
+internal sealed record CanaryBody(string Text);
+
+/// <summary>
 /// THE POINT OF THE WHOLE CHANGE: the hosted refusal is mapped through the shared primitive on each route
 /// GROUP, so it covers routes that have not been written yet.
 ///
@@ -478,11 +487,25 @@ public sealed class HostedOwnerSettingsGroupFilterTests : IAsyncLifetime
     };
 
     /// <summary>
-    /// A route that did not exist when the refusal was written is refused anyway. NOTHING in the endpoint
-    /// class mentions this path and no guard is written for it here - it is mapped THROUGH the denied handle,
-    /// so on hosted the primitive maps a verb-less refusal in its place instead of the probe handler. Map it
-    /// on the ungrouped builder instead and this serves the probe payload with a 200, which is the
-    /// future-route hole stated out loud.
+    /// A route that did not exist when the refusal was written is refused anyway - and it is proved through a
+    /// BODY-BOUND POST canary, not a parameterless GET, because a parameterless GET is the one shape the
+    /// original future-route defect could not be seen through (this is the shape set enumerated in
+    /// <c>Tenancy/HostedRouteDenyTests</c>, mirrored here for the owner-settings families). NOTHING in the
+    /// endpoint class mentions this path and no guard is written for it here - it is mapped THROUGH the denied
+    /// handle, so on hosted the primitive maps a verb-less refusal in its place and the handler is never
+    /// mapped at all.
+    ///
+    /// EVERY BODY SHAPE MEETS THE SAME REFUSAL. The canary binds its body through the FRAMEWORK - a plain
+    /// <see cref="CanaryBody"/> record parameter, inferred as the JSON body exactly like the reference's
+    /// <c>EchoBody</c>, NOT a custom binder that would ignore the bytes and prove nothing. That is what makes
+    /// the malformed-body and wrong-media-type shapes real: on self-host a malformed body is the framework's
+    /// own 400 (proved by the self-host half), so a hosted refusal that answers it with a 404 instead is
+    /// genuinely pre-empting framework binding rather than side-stepping it. A well-formed body, a malformed
+    /// one, and a wrong media type all meet the same 404 here, and the sentinel is served on none of them.
+    ///
+    /// Map the same canary on the ungrouped builder instead and it serves the sentinel with a 200, which is
+    /// the future-route hole stated out loud. The served half - the SAME canary with hosted mode OFF - is
+    /// <see cref="HostedOwnerSettingsSelfHostProbeTests"/>.
     /// </summary>
     [Theory]
     [MemberData(nameof(Families))]
@@ -491,20 +514,38 @@ public sealed class HostedOwnerSettingsGroupFilterTests : IAsyncLifetime
     {
         var (app, http) = await OwnerSettingsProbeHost.StartAsync(
             Family(family),
-            mapIntoGroup: group => group.MapGet(probePath, () => Results.Json(new { probe = ProbeSentinel })));
+            mapIntoGroup: group => group.MapPost(probePath,
+                (CanaryBody body) => Results.Json(new { probe = ProbeSentinel, echoed = body.Text })));
         try
         {
-            var response = await http.GetAsync(probePath);
-
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-            Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
-            var body = await response.Content.ReadAsStringAsync();
-            Assert.DoesNotContain(ProbeSentinel, body, StringComparison.Ordinal);
-
-            using var document = JsonDocument.Parse(body);
-            Assert.Equal(new[] { "error" }, document.RootElement.EnumerateObject().Select(p => p.Name).ToArray());
+            // Valid body, malformed body, and a wrong media type - each meets the refusal, not a 400/415, and
+            // the sentinel is served on none of them.
+            await AssertIsNothingButTheRefusal(await http.PostAsync(probePath, JsonBody("{\"text\":\"hello\"}")));
+            await AssertIsNothingButTheRefusal(await http.PostAsync(probePath, JsonBody("{ not json")));
+            await AssertIsNothingButTheRefusal(
+                await http.PostAsync(probePath, new StringContent("hello", Encoding.UTF8, "text/plain")));
         }
         finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    private static StringContent JsonBody(string json) => new(json, Encoding.UTF8, "application/json");
+
+    /// <summary>
+    /// Asserts the canary response is the family refusal and NOTHING ELSE: a 404, application/json, the
+    /// sentinel absent, and exactly one <c>error</c> property. Format facts precede the parse for the same
+    /// reason as <see cref="OwnerSettingsRoutes.AssertIsNothingButTheRefusal(HttpResponseMessage, string)"/> -
+    /// a route that had gone and now served HTML must redden as a media-type mismatch, not a parser crash.
+    /// </summary>
+    private static async Task AssertIsNothingButTheRefusal(HttpResponseMessage response)
+    {
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        Assert.DoesNotContain(ProbeSentinel, body, StringComparison.Ordinal);
+
+        using var document = JsonDocument.Parse(body);
+        Assert.Equal(new[] { "error" }, document.RootElement.EnumerateObject().Select(p => p.Name).ToArray());
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
@@ -202,6 +202,7 @@ public sealed class HostedOwnerSettingsDenyTests : IAsyncLifetime
     private GatewayHost _gateway = null!;
     private HttpClient _http = null!;
     private string _deviceKey = "";
+    private int _brainRestartInvocations;
 
     public HostedOwnerSettingsDenyTests()
     {
@@ -224,6 +225,21 @@ public sealed class HostedOwnerSettingsDenyTests : IAsyncLifetime
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"));
         await _gateway.StartAsync();
         _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // POST /gateway/brain/restart must not start a coding-agent process from a test - not here, and
+        // ESPECIALLY not on a revert arm, where the deny is deliberately removed and the request would
+        // reach the live handler. Replacing the restart action with one that starts nothing means no
+        // mutation run can leave a stray agent behind. The route is still driven for real, and the
+        // refusal asserted, exactly like the other thirty.
+        //
+        // It also records whether it ran, which is what makes the deny claim STRONGER rather than weaker:
+        // the assertion below is that the refusal happened AND the action was never invoked - a filter
+        // that answered 404 after letting the handler run would be invisible without it.
+        _gateway.BrainRestartAction = _ =>
+        {
+            Interlocked.Increment(ref _brainRestartInvocations);
+            return Task.CompletedTask;
+        };
 
         // A fully enrolled, tenant-bound device key - the strongest caller hosted has. The point is that
         // even this one is refused: no credential makes an owner's control panel correct on shared
@@ -301,6 +317,24 @@ public sealed class HostedOwnerSettingsDenyTests : IAsyncLifetime
         Assert.Equal(voiceBefore, TtsVoiceConfig.Resolve(TranscriptionModeConfig.Get()));
         Assert.Equal(carModelBefore, CarModeModelConfig.Get());
         Assert.Equal(consentBefore, TelemetryConsentConfig.Get());
+    }
+
+    /// <summary>
+    /// The refused ACTION never ran. `POST /gateway/brain/restart` is not a disclosure but a process spawn,
+    /// so for it "the response was a 404" is the weaker half of the claim - the stronger half is that the
+    /// thing it would have done did not happen. Asserted against the injected restart seam, which counts its
+    /// own invocations, so a filter that answered 404 only AFTER letting the handler run would redden here
+    /// while looking perfect from outside.
+    /// </summary>
+    [Fact]
+    public async Task The_refused_brain_restart_never_invokes_the_restart_action()
+    {
+        Assert.Equal(0, Volatile.Read(ref _brainRestartInvocations));
+
+        var response = await OwnerSettingsRoutes.SendAsync(_http, "POST", "gateway/brain/restart", "");
+        await OwnerSettingsRoutes.AssertIsNothingButTheRefusal(response, OwnerSettingsRoutes.SettingsRefusal);
+
+        Assert.Equal(0, Volatile.Read(ref _brainRestartInvocations));
     }
 
     /// <summary>
@@ -489,31 +523,24 @@ public sealed class HostedOwnerSettingsGroupFilterTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// THE SERVED-SIDE POSITIVE FACT FOR <c>POST /gateway/brain/restart</c>, and the answer to the fact
-    /// that a 404 deny is INDISTINGUISHABLE from a route that was never mapped.
+    /// A SUPPLEMENTARY fact about <c>POST /gateway/brain/restart</c>: the route is registered on hosted at
+    /// that exact path, and only for POST.
     ///
-    /// This is the one route in the group whose handler cannot be invoked in a test: its whole job is to
-    /// start a coding-agent process on the machine, so calling it on the served side would spawn one. So
-    /// instead of running the handler, this proves the route is REALLY THERE on hosted by asking for it
-    /// with the wrong verb. A GET reaches routing, finds a path that exists with no GET on it, and is
-    /// answered 405 with an <c>Allow: POST</c> header - a POSITIVE statement, emitted by the routing
-    /// table, that a POST endpoint is registered at that exact path. The endpoint filter never runs,
-    /// because no endpoint was selected, which is exactly why the 405 survives the deny.
+    /// THIS IS NO LONGER THE SERVED-SIDE PROOF FOR THAT ROUTE, and it was wrong to lean on it as one. A GET
+    /// answered 405 with <c>Allow: POST</c> proves the routing table has a POST endpoint registered there;
+    /// it says NOTHING about which handler that POST reaches, or whether it reaches one at all. The real
+    /// served-side proof now drives the exact path and verb and asserts the handler's own receipt, through
+    /// an injected restart seam so no process is started - see
+    /// <see cref="HostedOwnerSettingsSelfHostControlTests.The_brain_restart_route_reaches_its_handler_on_self_host_without_starting_a_process"/>
+    /// and its destructibility control.
     ///
-    /// Put together with the POST being refused 404 in
-    /// <see cref="HostedOwnerSettingsDenyTests.Every_owner_settings_route_is_refused_on_hosted"/>, the two
-    /// say: the route exists on hosted, and the thing turning it away is the deny.
-    ///
-    /// WHAT THIS PROVES, AND WHAT IT DOES NOT. It proves the ROUTE IS REGISTERED. It does NOT exercise the
-    /// HANDLER, and it makes no claim to. Read as a served-payload proof it would be one that fell short;
-    /// read as what it is - a routing-table existence proof that does not depend on any handler behaving -
-    /// it is the correct ceiling for a route whose handler starts a process, and it is the one form of
-    /// existence proof that survives the deny, because no endpoint is ever selected for it to run against.
-    /// Every OTHER route in the group is proved served-side by a real payload, an independently re-read
-    /// effect, or a handler-unique receipt; this is the single exception and it is deliberate.
+    /// It is kept because it still answers a real question the receipt does not: a 404 deny is
+    /// indistinguishable from a route that was never mapped, and this shows the path is genuinely
+    /// registered ON HOSTED, where the deny is active. The 405 survives the deny because no endpoint is
+    /// selected for a verb that does not exist, so the filter never runs.
     /// </summary>
     [Fact]
-    public async Task The_brain_restart_route_exists_on_hosted_and_is_reachable_only_as_a_post()
+    public async Task The_brain_restart_route_is_registered_on_hosted_and_only_as_a_post()
     {
         var (app, http) = await OwnerSettingsProbeHost.StartAsync(Family("settings"));
         try

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using CcDirector.Core.Configuration;
+using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -560,11 +561,11 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
 /// THE SERVED HALF OF THE FUTURE-ROUTE PROOF, and the half most likely to be skipped because everything
 /// looks green without it.
 ///
-/// <see cref="HostedOwnerSettingsGroupFilterTests"/> maps a brand-new route onto each group and finds it
-/// REFUSED on hosted. On its own that cannot tell a working gate apart from a brick: a filter that refused
-/// everything unconditionally would satisfy every one of those assertions while having silently killed the
-/// routes for self-host too. This class drives the SAME probe paths with hosted mode explicitly OFF, in
-/// BOTH non-hosted forms, and asserts they are SERVED with their real payload.
+/// <see cref="HostedOwnerSettingsGroupFilterTests"/> maps a brand-new route through each denied handle and
+/// finds it REFUSED on hosted. On its own that cannot tell a working gate apart from a brick: a primitive
+/// that refused everything unconditionally would satisfy every one of those assertions while having silently
+/// killed the routes for self-host too. This class drives the SAME probe paths with hosted mode explicitly
+/// OFF, in BOTH non-hosted forms, and asserts they are SERVED with their real payload.
 /// </summary>
 [Collection("GatewayHostedMode")]
 public sealed class HostedOwnerSettingsSelfHostProbeTests : IAsyncLifetime
@@ -630,7 +631,7 @@ public sealed class HostedOwnerSettingsSelfHostProbeTests : IAsyncLifetime
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hostedForm);
         Assert.False(GatewayHostedMode.IsHosted);
 
-        Func<IEndpointRouteBuilder, RouteGroupBuilder> map = family switch
+        Func<IEndpointRouteBuilder, HostedDenyGroup> map = family switch
         {
             "settings" => routes => Api.SettingsEndpoints.Map(routes, _gateway),
             "models" => routes => Api.AiModelsEndpoint.Map(routes, new Core.KeyVault(Path.Combine(_root, "vault.json"))),

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
@@ -1,0 +1,512 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Configuration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// THE SELF-HOST CONTROL FOR THE OWNER-SETTINGS DENY, STATED EXPLICITLY (issue #1863).
+///
+/// Self-host is the control for the whole hosted-tenancy mission, so it has to be PROVEN rather than
+/// INHERITED. The existing settings tests do not prove it: they never mention <c>CC_GATEWAY_HOSTED</c> and
+/// pass only because the runner happens to leave it unset. If that ambient default ever flipped - one
+/// leaked environment variable, one continuous-integration image change, one test that forgot to restore
+/// it - they would keep passing while self-host was completely broken, because they assert nothing about
+/// which mode they are in.
+///
+/// So this class sets the variable ITSELF, to BOTH non-hosted forms that occur in practice - ABSENT, and
+/// PRESENT-BUT-"0" - and asserts <see cref="GatewayHostedMode.IsHosted"/> really is false in each, so no
+/// test below can silently be running in the mode it thinks it is not in.
+///
+/// AND IT ASSERTS A POSITIVE FACT PER ROUTE, NOT THE ABSENCE OF THE REFUSAL. "The refusal string is not
+/// in the body" is satisfied by an empty 200, by a single-page-application shell, and by a route that was
+/// deleted - it proves nothing about the route being alive. Every route below is proved by one of:
+///   - its REAL PAYLOAD, field by field (the eleven read routes);
+///   - an INDEPENDENTLY RE-READ EFFECT - the value is written over the wire and then read back out of the
+///     configuration store through the Core config class, not out of the response (fourteen write routes);
+///   - a HANDLER-UNIQUE RECEIPT: a status and message that only that one handler can produce, where the
+///     route has no readable effect to assert (four routes).
+/// Together with <see cref="HostedOwnerSettingsGroupFilterTests.The_brain_restart_route_exists_on_hosted_and_is_reachable_only_as_a_post"/>
+/// for the one route whose handler cannot be invoked, that is all thirty-one.
+///
+/// These tests must stay GREEN through the revert. A control that moves with the change under test is not
+/// a control.
+/// </summary>
+[Collection("GatewayHostedMode")]
+public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
+{
+    private const string Token = "test-token-12345";
+
+    private readonly string _root;
+    private readonly string? _priorRoot;
+    private readonly string? _priorHosted;
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-ownersettings-self-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    public HostedOwnerSettingsSelfHostControlTests()
+    {
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-ownersettings-self-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+    }
+
+    public async Task InitializeAsync()
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+        _gateway = new GatewayHost(port: HostedOwnerSettingsDenyTests.FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"));
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// null = the variable is ABSENT. "0" = the variable is PRESENT and explicitly not hosted. Both are
+    /// real self-host deployments and both must serve. Stating both is the point: a gate written against
+    /// "the variable is set at all" would pass the first and fail the second.
+    /// </summary>
+    public static TheoryData<string?> NonHostedForms => new() { null, "0" };
+
+    /// <summary>
+    /// Puts the process into a STATED non-hosted mode and proves the statement took, so nothing below can
+    /// silently be running in the mode it thinks it is not in.
+    /// </summary>
+    private static void DeclareSelfHost(string? value)
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", value);
+        Assert.False(GatewayHostedMode.IsHosted);
+    }
+
+    public static TheoryData<string?, string> ReadRoutes
+    {
+        get
+        {
+            var data = new TheoryData<string?, string>();
+            foreach (var hosted in new string?[] { null, "0" })
+                foreach (var path in new[]
+                         {
+                             "gateway/settings",
+                             "gateway/wingman/training-capture",
+                             "gateway/addressing-mode",
+                             "gateway/snooze-default",
+                             "gateway/injected-text",
+                             "gateway/snooze-presets",
+                             "gateway/time-zone",
+                             "gateway/transcription-mode",
+                             "gateway/ai-provider",
+                             "gateway/tts-voice",
+                             "gateway/telemetry-consent",
+                         })
+                    data.Add(hosted, path);
+            return data;
+        }
+    }
+
+    /// <summary>
+    /// The eleven read routes, each asserted by the REAL PAYLOAD it carries - the fields, and where a field
+    /// has an independently knowable value, that value. Format facts (status, media type) are asserted
+    /// BEFORE the body is parsed, on this side too: if a route were gone, the Gateway's single-page
+    /// -application fallback would answer with HTML and parsing first would turn that finding into a crash.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ReadRoutes))]
+    public async Task Every_read_route_serves_its_real_payload_on_self_host(string? hostedForm, string path)
+    {
+        DeclareSelfHost(hostedForm);
+
+        var response = await _http.GetAsync(path);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = document.RootElement;
+        Assert.Equal(JsonValueKind.Object, root.ValueKind);
+
+        // The refusal envelope is exactly one property named "error". Proving the real payload means
+        // naming what this route actually carries, one field at a time.
+        var properties = root.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.DoesNotContain("error", properties);
+
+        switch (path)
+        {
+            case "gateway/settings":
+                foreach (var expected in new[]
+                         {
+                             "version", "state", "port", "uptimeSeconds", "directors", "mode",
+                             "addressingMode", "cockpit", "brain", "autostart", "wingmanTrainingCapture",
+                             "telemetryConsent", "snoozeDefaultMinutes", "snoozePresets", "snoozeMaxPresets",
+                             "timeZone", "timeZoneMachineDefault",
+                         })
+                    Assert.Contains(expected, properties);
+                Assert.Equal("Running", root.GetProperty("state").GetString());
+                Assert.Equal(_gateway.Port, root.GetProperty("port").GetInt32());
+                Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("version").GetString()));
+                Assert.True(root.GetProperty("brain").TryGetProperty("agents", out _));
+                break;
+
+            case "gateway/wingman/training-capture":
+                Assert.Equal(new[] { "enabled" }, properties);
+                Assert.Equal(WingmanTrainingCaptureConfig.Get(), root.GetProperty("enabled").GetBoolean());
+                break;
+
+            case "gateway/addressing-mode":
+                Assert.Equal(new[] { "mode" }, properties);
+                Assert.Equal(AddressingModeConfig.Get().ToConfigString(), root.GetProperty("mode").GetString());
+                break;
+
+            case "gateway/snooze-default":
+                Assert.Equal(new[] { "minutes" }, properties);
+                Assert.Equal(SnoozeDefaultConfig.Get(), root.GetProperty("minutes").GetInt32());
+                break;
+
+            case "gateway/injected-text":
+                Assert.Equal(new[] { "use_yours", "yours", "ours", "placeholders" }, properties);
+                // "ours" is the shipped agent-launch instruction text, and its presence here is exactly the
+                // disclosure the hosted deny closes - so on self-host it must really be here, not empty.
+                Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("ours").GetString()));
+                Assert.True(root.GetProperty("placeholders").GetArrayLength() > 0);
+                break;
+
+            case "gateway/snooze-presets":
+                Assert.Equal(new[] { "presets", "defaultMinutes", "maxPresets" }, properties);
+                Assert.True(root.GetProperty("presets").GetArrayLength() > 0);
+                Assert.Equal(SnoozePresetsConfig.MaxPresets, root.GetProperty("maxPresets").GetInt32());
+                break;
+
+            case "gateway/time-zone":
+                Assert.Equal(new[] { "timeZone", "machineDefault" }, properties);
+                Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("machineDefault").GetString()));
+                break;
+
+            case "gateway/transcription-mode":
+                Assert.Equal(new[] { "mode" }, properties);
+                Assert.Equal("devthrottle", root.GetProperty("mode").GetString());
+                break;
+
+            case "gateway/ai-provider":
+                foreach (var expected in new[]
+                         {
+                             "provider", "wingmanModel", "wingmanFastModel", "carModeModel",
+                             "carModeEndPhrase", "transcriptionModel", "ttsModel", "ttsVoice", "voices",
+                         })
+                    Assert.Contains(expected, properties);
+                Assert.Equal("devthrottle", root.GetProperty("provider").GetString());
+                Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("wingmanModel").GetString()));
+                break;
+
+            case "gateway/tts-voice":
+                Assert.Equal(new[] { "voice", "voices" }, properties);
+                Assert.True(root.GetProperty("voices").GetArrayLength() > 0);
+                Assert.Equal(TtsVoiceConfig.Resolve(TranscriptionModeConfig.Get()),
+                    root.GetProperty("voice").GetString());
+                break;
+
+            case "gateway/telemetry-consent":
+                Assert.Equal(new[] { "enabled" }, properties);
+                Assert.Equal(TelemetryConsentConfig.Get(), root.GetProperty("enabled").GetBoolean());
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(path), path, "no payload assertion written for this route");
+        }
+    }
+
+    public static TheoryData<string?, string, string, string, string, string> WriteRoutes
+    {
+        get
+        {
+            var data = new TheoryData<string?, string, string, string, string, string>();
+            foreach (var hosted in new string?[] { null, "0" })
+            {
+                data.Add(hosted, "PUT", "gateway/wingman/training-capture", "{\"enabled\":true}", "training-capture", "true");
+                data.Add(hosted, "PUT", "gateway/addressing-mode", "{\"mode\":\"lan\"}", "addressing-mode", "lan");
+                data.Add(hosted, "PUT", "gateway/snooze-default", "{\"minutes\":45}", "snooze-default", "45");
+                data.Add(hosted, "PUT", "gateway/injected-text", "{\"use_yours\":true,\"yours\":\"words from another tenant\"}", "injected-text", "words from another tenant");
+                data.Add(hosted, "PUT", "gateway/snooze-presets", "{\"presets\":[15,30,60],\"defaultMinutes\":30}", "snooze-presets", "15,30,60");
+                data.Add(hosted, "PUT", "gateway/time-zone", "{\"timeZone\":\"America/New_York\"}", "time-zone", "America/New_York");
+                data.Add(hosted, "PUT", "gateway/transcription-mode", "{\"mode\":\"devthrottle\"}", "transcription-mode", "devthrottle");
+                data.Add(hosted, "PUT", "gateway/tts-voice", "{\"voice\":\"shimmer\"}", "tts-voice", "shimmer");
+                data.Add(hosted, "PUT", "gateway/telemetry-consent", "{\"enabled\":false}", "telemetry-consent", "false");
+                data.Add(hosted, "PUT", "gateway/ai/wingman-model", "{\"model\":\"hosted-wingman\"}", "wingman-model", "hosted-wingman");
+                data.Add(hosted, "PUT", "gateway/ai/wingman-fast-model", "{\"model\":\"hosted-fast\"}", "wingman-fast-model", "hosted-fast");
+                data.Add(hosted, "PUT", "gateway/ai/car-mode-model", "{\"model\":\"hosted-car\"}", "car-mode-model", "hosted-car");
+                data.Add(hosted, "PUT", "gateway/ai/car-mode-end-phrase", "{\"phrase\":\"finished here\"}", "car-mode-end-phrase", "finished here");
+                data.Add(hosted, "PUT", "gateway/ai/tts-model", "{\"model\":\"hosted-speech\"}", "tts-model", "hosted-speech");
+            }
+            return data;
+        }
+    }
+
+    /// <summary>
+    /// Reads a setting back through the Core configuration class, NOT out of the response body. Reading the
+    /// response would only prove the handler can echo; reading the store proves the write landed.
+    /// </summary>
+    private static string ReadBack(string key) => key switch
+    {
+        "training-capture" => WingmanTrainingCaptureConfig.Get() ? "true" : "false",
+        "addressing-mode" => AddressingModeConfig.Get().ToConfigString(),
+        "snooze-default" => SnoozeDefaultConfig.Get().ToString(),
+        "injected-text" => InjectedTextConfig.Get().Yours ?? "",
+        "snooze-presets" => string.Join(",", SnoozePresetsConfig.Get()),
+        "time-zone" => TimeZoneConfig.Get() ?? "",
+        "transcription-mode" => TranscriptionModeConfig.Get().ToConfigString(),
+        "tts-voice" => TtsVoiceConfig.Resolve(TranscriptionModeConfig.Get()),
+        "telemetry-consent" => TelemetryConsentConfig.Get() ? "true" : "false",
+        "wingman-model" => WingmanModelConfig.Resolve(TranscriptionModeConfig.Get()),
+        "wingman-fast-model" => WingmanModelConfig.ResolveFast(TranscriptionModeConfig.Get()),
+        "car-mode-model" => CarModeModelConfig.Get(),
+        "car-mode-end-phrase" => CarModeEndPhraseConfig.Get(),
+        "tts-model" => TtsModelConfig.Get(),
+        _ => throw new ArgumentOutOfRangeException(nameof(key), key, "no read-back written for this setting"),
+    };
+
+    /// <summary>
+    /// Fourteen write routes, each proved by an INDEPENDENTLY RE-READ EFFECT: the value goes over the wire
+    /// and is then read back out of the configuration store through its Core config class. A 200 alone
+    /// would not do - a handler that accepted the request and wrote nothing returns the same 200.
+    ///
+    /// <c>PUT /gateway/transcription-mode</c> is the one row whose re-read cannot distinguish a write from
+    /// a no-op, because "devthrottle" is the only value the endpoint accepts and is also the default. Its
+    /// 200 and its echoed payload are asserted here for what they are worth, and the row is called out in
+    /// the pull request rather than left looking like the others.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(WriteRoutes))]
+    public async Task Every_write_route_really_writes_and_the_write_reads_back_on_self_host(
+        string? hostedForm, string verb, string path, string body, string readBackKey, string expected)
+    {
+        DeclareSelfHost(hostedForm);
+
+        var response = await OwnerSettingsRoutes.SendAsync(_http, verb, path, body);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.DoesNotContain("error", document.RootElement.EnumerateObject().Select(p => p.Name));
+
+        Assert.Equal(expected, ReadBack(readBackKey));
+    }
+
+    /// <summary>
+    /// <c>PUT /gateway/ai-provider</c> on its own, because its effect is a RESET rather than a value being
+    /// stored: it repoints the wingman, speech and voice settings back to the provider defaults. Proving it
+    /// therefore needs a before-state that the reset must move away from, which is what the sentinel write
+    /// below is for. That is a real, independently re-read effect - the strongest served-side fact
+    /// available for this route.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonHostedForms))]
+    public async Task The_provider_reset_really_resets_the_models_on_self_host(string? hostedForm)
+    {
+        DeclareSelfHost(hostedForm);
+
+        // A value the reset cannot possibly produce, so "unchanged" and "reset" cannot be confused.
+        const string Sentinel = "sentinel-model-no-provider-would-return";
+        WingmanModelConfig.Set(Sentinel);
+        Assert.Equal(Sentinel, WingmanModelConfig.Resolve(TranscriptionModeConfig.Get()));
+
+        var response = await OwnerSettingsRoutes.SendAsync(_http, "PUT", "gateway/ai-provider",
+            "{\"provider\":\"devthrottle\"}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("devthrottle", document.RootElement.GetProperty("provider").GetString());
+
+        var afterwards = WingmanModelConfig.Resolve(TranscriptionModeConfig.Get());
+        Assert.NotEqual(Sentinel, afterwards);
+        Assert.False(string.IsNullOrWhiteSpace(afterwards));
+    }
+
+    public static TheoryData<string?, string, string, string, int, string> ReceiptRoutes
+    {
+        get
+        {
+            var data = new TheoryData<string?, string, string, string, int, string>();
+            foreach (var hosted in new string?[] { null, "0" })
+            {
+                // The brain-config handler is the only place in the Gateway that says this sentence, and it
+                // can only say it after it has loaded this machine's registered agents and failed to find
+                // the one asked for - so the receipt proves the handler ran, not merely that something
+                // answered.
+                data.Add(hosted, "PUT", "gateway/brain/config", "{\"agentId\":\"agent-1\",\"model\":\"opus\"}",
+                    400, "agentId must be a registered, enabled agent on this machine");
+
+                // The catalog and test-chat routes both resolve the provider credential out of the key
+                // vault first. With no credential stored they answer 503 with this exact sentence - a
+                // handler-unique receipt that costs no network round-trip.
+                data.Add(hosted, "GET", "gateway/ai/models", "",
+                    503, "not signed in to DevThrottle - sign in on the Account tab");
+                data.Add(hosted, "POST", "gateway/ai/test-chat", "{\"model\":\"some-model\"}",
+                    503, "not signed in to DevThrottle - sign in on the Account tab");
+            }
+            return data;
+        }
+    }
+
+    /// <summary>
+    /// Three routes with no readable effect to assert, each proved by a HANDLER-UNIQUE RECEIPT: a status
+    /// and a sentence only that one handler can produce. A refusal is a 404 carrying one <c>error</c>
+    /// property, so none of these can be confused with one - and, unlike "the refusal is absent", each of
+    /// these is a positive statement about which code ran.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ReceiptRoutes))]
+    public async Task The_routes_without_a_readable_effect_answer_with_their_own_receipt_on_self_host(
+        string? hostedForm, string verb, string path, string body, int expectedStatus, string expectedMessage)
+    {
+        DeclareSelfHost(hostedForm);
+
+        var response = await OwnerSettingsRoutes.SendAsync(_http, verb, path, body);
+        Assert.Equal(expectedStatus, (int)response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(expectedMessage, document.RootElement.GetProperty("error").GetString());
+    }
+
+    /// <summary>
+    /// <c>PUT /gateway/autostart</c>, the fourth receipt route. On a Gateway with no autostart hook - which
+    /// is every Gateway not hosted by the desktop tray application, including this test host - the handler
+    /// answers 200 with exactly <c>{ supported: false }</c>. Nothing else on the Gateway produces that
+    /// object, and a refusal could not: it is a 200, not a 404, and its one property is not <c>error</c>.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonHostedForms))]
+    public async Task The_autostart_route_answers_with_its_own_receipt_on_self_host(string? hostedForm)
+    {
+        DeclareSelfHost(hostedForm);
+
+        var response = await OwnerSettingsRoutes.SendAsync(_http, "PUT", "gateway/autostart", "{\"enabled\":true}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(new[] { "supported" }, document.RootElement.EnumerateObject().Select(p => p.Name).ToArray());
+        Assert.False(document.RootElement.GetProperty("supported").GetBoolean());
+    }
+}
+
+/// <summary>
+/// THE SERVED HALF OF THE FUTURE-ROUTE PROOF, and the half most likely to be skipped because everything
+/// looks green without it.
+///
+/// <see cref="HostedOwnerSettingsGroupFilterTests"/> maps a brand-new route onto each group and finds it
+/// REFUSED on hosted. On its own that cannot tell a working gate apart from a brick: a filter that refused
+/// everything unconditionally would satisfy every one of those assertions while having silently killed the
+/// routes for self-host too. This class drives the SAME probe paths with hosted mode explicitly OFF, in
+/// BOTH non-hosted forms, and asserts they are SERVED with their real payload.
+/// </summary>
+[Collection("GatewayHostedMode")]
+public sealed class HostedOwnerSettingsSelfHostProbeTests : IAsyncLifetime
+{
+    private const string ProbePayload = "the-probe-route-really-served-on-self-host";
+
+    private readonly string _root;
+    private readonly string? _priorRoot;
+    private readonly string? _priorHosted;
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-ownersettings-selfprobe-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+
+    public HostedOwnerSettingsSelfHostProbeTests()
+    {
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-ownersettings-selfprobe-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: HostedOwnerSettingsDenyTests.FreePort(), token: "probe-token",
+            authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"));
+        await _gateway.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    public static TheoryData<string?, string, string> Probes
+    {
+        get
+        {
+            var data = new TheoryData<string?, string, string>();
+            foreach (var hosted in new string?[] { null, "0" })
+            {
+                data.Add(hosted, "settings", "/gateway/added-after-the-deny-was-written");
+                data.Add(hosted, "models", "/gateway/ai/added-after-the-deny-was-written");
+                data.Add(hosted, "telemetry", "/gateway/telemetry-added-after-the-deny-was-written");
+            }
+            return data;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Probes))]
+    public async Task A_route_added_to_the_group_still_serves_on_self_host(
+        string? hostedForm, string family, string probePath)
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hostedForm);
+        Assert.False(GatewayHostedMode.IsHosted);
+
+        Func<IEndpointRouteBuilder, RouteGroupBuilder> map = family switch
+        {
+            "settings" => routes => Api.SettingsEndpoints.Map(routes, _gateway),
+            "models" => routes => Api.AiModelsEndpoint.Map(routes, new Core.KeyVault(Path.Combine(_root, "vault.json"))),
+            "telemetry" => Api.TelemetryConsentEndpoint.Map,
+            _ => throw new ArgumentOutOfRangeException(nameof(family), family, "unknown owner-settings family"),
+        };
+
+        var (app, http) = await OwnerSettingsProbeHost.StartAsync(
+            map,
+            mapIntoGroup: group => group.MapGet(probePath, () => Results.Json(new { probe = ProbePayload })));
+        try
+        {
+            var response = await http.GetAsync(probePath);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+            using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            Assert.Equal(ProbePayload, document.RootElement.GetProperty("probe").GetString());
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
@@ -35,17 +35,21 @@ namespace CcDirector.Gateway.Tests;
 ///   - its REAL PAYLOAD, field by field (the eleven read routes);
 ///   - an INDEPENDENTLY RE-READ EFFECT - the value is written over the wire and then read back out of the
 ///     configuration store through the Core config class, not out of the response (thirteen write routes);
-///   - a SEEDED TRANSITION, where a plain re-read could not tell a real write from a no-op: transcription
-///     mode, whose only accepted value is also the default, and the provider, whose effect is a RESET
-///     rather than a stored value (two routes);
+///   - a SEEDED TRANSITION off a sentinel the effect cannot produce, where the effect is a RESET rather
+///     than a stored value (the provider, one route);
+///   - SERVED-AND-REACHES-A-HANDLER, the deliberately NARROWED claim for the one route that can carry no
+///     stronger one: transcription mode is SINGLE-VALUED BY CONSTRUCTION, so no stored state differs from
+///     what it writes and no seeding could distinguish it from a no-op. That is proved, not asserted, by
+///     The_transcription_mode_setting_is_single_valued_so_no_write_is_observable - which also reddens the
+///     day a second mode is added, so the narrowing cannot go stale (one route);
 ///   - a HANDLER-UNIQUE RECEIPT: a status and message only that one handler can produce, where the route
 ///     has no readable effect to assert - brain config, the two credential-resolution routes, autostart
 ///     (four routes);
 ///   - an INJECTED-SEAM RECEIPT with a destructibility control, for the one route whose real work is to
 ///     start a process: brain restart. It is driven on its exact path AND verb; only the process spawn is
 ///     replaced.
-/// Eleven plus thirteen plus two plus four plus one is thirty-one. No route is left over, and none is
-/// proved only by the absence of the refusal.
+/// Eleven plus thirteen plus one plus one plus four plus one is thirty-one. No route is left over, and
+/// none is proved only by the absence of the refusal.
 ///
 /// These tests must stay GREEN through the revert. A control that moves with the change under test is not
 /// a control.
@@ -323,28 +327,47 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// <c>PUT /gateway/transcription-mode</c> on its own, proved by a SEEDED TRANSITION.
+    /// WHY <c>PUT /gateway/transcription-mode</c> CANNOT HAVE AN OBSERVABLE WRITE EFFECT - proved, not
+    /// asserted, so the narrower claim made for that route below rests on a checked fact.
     ///
-    /// This route was previously the one write whose served-side positive did not actually prove anything:
-    /// the endpoint accepts only <c>"devthrottle"</c>, which is also the default, so writing it and reading
-    /// it back returns the same answer whether the handler wrote or did nothing at all. The reviewer was
-    /// right that echoing the sole accepted value cannot distinguish a real write from a no-op.
+    /// The reviewer's finding was that writing the sole accepted value, which is also the default, cannot
+    /// distinguish a real write from a no-op, and offered two ways out: seed a persistent transition, or
+    /// narrow the claim if the route has no distinguishable mutation. The first was ATTEMPTED FIRST and
+    /// FAILED, which is what established the second is correct: seeding the store to the other enum value
+    /// and reading it back returns DevThrottle, because the setting is SINGLE-VALUED BY CONSTRUCTION.
     ///
-    /// The claim did not need narrowing, though - it needed a starting point. The endpoint only ACCEPTS
-    /// "devthrottle", but the underlying setting is a two-valued one and the configuration store happily
-    /// holds <c>"byo"</c>. So this seeds the store to "byo" through the Core config class, proves the seed
-    /// took, then drives the route and proves the stored value MOVED. A handler that accepted the request
-    /// and wrote nothing leaves it on "byo" and this test reddens.
+    /// Both halves of that are pinned here. Every value the type can serialize writes "devthrottle", and
+    /// every value it will parse - including all the legacy provider strings - resolves to DevThrottle. So
+    /// no reachable stored state differs from the one the route writes, and no seeding strategy could
+    /// distinguish the handler from a no-op. That is a property of the setting, not a gap in the test.
+    ///
+    /// THIS TEST IS ALSO THE EXPIRY DATE ON THAT CAVEAT. If a second real transcription mode is ever added,
+    /// this reddens immediately and tells whoever added it that the route now needs a genuine
+    /// seeded-transition proof, rather than leaving a stale narrowing in place forever.
+    /// </summary>
+    [Fact]
+    public void The_transcription_mode_setting_is_single_valued_so_no_write_is_observable()
+    {
+        foreach (var mode in Enum.GetValues<TranscriptionMode>())
+            Assert.Equal("devthrottle", mode.ToConfigString());
+
+        foreach (var stored in new string?[] { null, "", "  ", "devthrottle", "byo", "openai", "local" })
+            Assert.Equal(TranscriptionMode.DevThrottle, TranscriptionModeExtensions.Parse(stored));
+    }
+
+    /// <summary>
+    /// <c>PUT /gateway/transcription-mode</c> - the NARROWED claim, stated as exactly what it proves.
+    ///
+    /// It proves the route is SERVED on self-host and reaches a handler that answers with the setting's
+    /// value. It does NOT prove a store mutation, and the test above is why no test could. Calling this an
+    /// independently re-read effect - as the previous revision's table did - would be claiming more than
+    /// the evidence supports, which is the thing this whole review has been about.
     /// </summary>
     [Theory]
     [MemberData(nameof(NonHostedForms))]
-    public async Task The_transcription_mode_write_really_moves_the_stored_value_on_self_host(string? hostedForm)
+    public async Task The_transcription_mode_route_is_served_on_self_host(string? hostedForm)
     {
         DeclareSelfHost(hostedForm);
-
-        // Seed the OPPOSITE value, so "unchanged" and "written" cannot be confused.
-        TranscriptionModeConfig.Set(TranscriptionMode.Byo);
-        Assert.Equal(TranscriptionMode.Byo, TranscriptionModeConfig.Get());
 
         var response = await OwnerSettingsRoutes.SendAsync(_http, "PUT", "gateway/transcription-mode",
             "{\"mode\":\"devthrottle\"}");
@@ -352,9 +375,11 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
         Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
 
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(new[] { "mode" }, document.RootElement.EnumerateObject().Select(p => p.Name).ToArray());
         Assert.Equal("devthrottle", document.RootElement.GetProperty("mode").GetString());
 
-        // The independently re-read effect: the stored value MOVED off the seed.
+        // Not a transition - see the single-valued proof above. This states the post-condition that IS
+        // checkable: the store holds the value the route reports.
         Assert.Equal(TranscriptionMode.DevThrottle, TranscriptionModeConfig.Get());
     }
 

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using CcDirector.Core.Configuration;
 using Microsoft.AspNetCore.Builder;
@@ -30,14 +31,21 @@ namespace CcDirector.Gateway.Tests;
 ///
 /// AND IT ASSERTS A POSITIVE FACT PER ROUTE, NOT THE ABSENCE OF THE REFUSAL. "The refusal string is not
 /// in the body" is satisfied by an empty 200, by a single-page-application shell, and by a route that was
-/// deleted - it proves nothing about the route being alive. Every route below is proved by one of:
+/// deleted - it proves nothing about the route being alive. All thirty-one routes are proved by one of:
 ///   - its REAL PAYLOAD, field by field (the eleven read routes);
 ///   - an INDEPENDENTLY RE-READ EFFECT - the value is written over the wire and then read back out of the
-///     configuration store through the Core config class, not out of the response (fourteen write routes);
-///   - a HANDLER-UNIQUE RECEIPT: a status and message that only that one handler can produce, where the
-///     route has no readable effect to assert (four routes).
-/// Together with <see cref="HostedOwnerSettingsGroupFilterTests.The_brain_restart_route_exists_on_hosted_and_is_reachable_only_as_a_post"/>
-/// for the one route whose handler cannot be invoked, that is all thirty-one.
+///     configuration store through the Core config class, not out of the response (thirteen write routes);
+///   - a SEEDED TRANSITION, where a plain re-read could not tell a real write from a no-op: transcription
+///     mode, whose only accepted value is also the default, and the provider, whose effect is a RESET
+///     rather than a stored value (two routes);
+///   - a HANDLER-UNIQUE RECEIPT: a status and message only that one handler can produce, where the route
+///     has no readable effect to assert - brain config, the two credential-resolution routes, autostart
+///     (four routes);
+///   - an INJECTED-SEAM RECEIPT with a destructibility control, for the one route whose real work is to
+///     start a process: brain restart. It is driven on its exact path AND verb; only the process spawn is
+///     replaced.
+/// Eleven plus thirteen plus two plus four plus one is thirty-one. No route is left over, and none is
+/// proved only by the absence of the refusal.
 ///
 /// These tests must stay GREEN through the revert. A control that moves with the change under test is not
 /// a control.
@@ -250,7 +258,8 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
                 data.Add(hosted, "PUT", "gateway/injected-text", "{\"use_yours\":true,\"yours\":\"words from another tenant\"}", "injected-text", "words from another tenant");
                 data.Add(hosted, "PUT", "gateway/snooze-presets", "{\"presets\":[15,30,60],\"defaultMinutes\":30}", "snooze-presets", "15,30,60");
                 data.Add(hosted, "PUT", "gateway/time-zone", "{\"timeZone\":\"America/New_York\"}", "time-zone", "America/New_York");
-                data.Add(hosted, "PUT", "gateway/transcription-mode", "{\"mode\":\"devthrottle\"}", "transcription-mode", "devthrottle");
+                // transcription-mode is NOT here - it needs a seeded starting value to be distinguishable
+                // from a no-op, so it has its own test below.
                 data.Add(hosted, "PUT", "gateway/tts-voice", "{\"voice\":\"shimmer\"}", "tts-voice", "shimmer");
                 data.Add(hosted, "PUT", "gateway/telemetry-consent", "{\"enabled\":false}", "telemetry-consent", "false");
                 data.Add(hosted, "PUT", "gateway/ai/wingman-model", "{\"model\":\"hosted-wingman\"}", "wingman-model", "hosted-wingman");
@@ -311,6 +320,42 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
         Assert.DoesNotContain("error", document.RootElement.EnumerateObject().Select(p => p.Name));
 
         Assert.Equal(expected, ReadBack(readBackKey));
+    }
+
+    /// <summary>
+    /// <c>PUT /gateway/transcription-mode</c> on its own, proved by a SEEDED TRANSITION.
+    ///
+    /// This route was previously the one write whose served-side positive did not actually prove anything:
+    /// the endpoint accepts only <c>"devthrottle"</c>, which is also the default, so writing it and reading
+    /// it back returns the same answer whether the handler wrote or did nothing at all. The reviewer was
+    /// right that echoing the sole accepted value cannot distinguish a real write from a no-op.
+    ///
+    /// The claim did not need narrowing, though - it needed a starting point. The endpoint only ACCEPTS
+    /// "devthrottle", but the underlying setting is a two-valued one and the configuration store happily
+    /// holds <c>"byo"</c>. So this seeds the store to "byo" through the Core config class, proves the seed
+    /// took, then drives the route and proves the stored value MOVED. A handler that accepted the request
+    /// and wrote nothing leaves it on "byo" and this test reddens.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonHostedForms))]
+    public async Task The_transcription_mode_write_really_moves_the_stored_value_on_self_host(string? hostedForm)
+    {
+        DeclareSelfHost(hostedForm);
+
+        // Seed the OPPOSITE value, so "unchanged" and "written" cannot be confused.
+        TranscriptionModeConfig.Set(TranscriptionMode.Byo);
+        Assert.Equal(TranscriptionMode.Byo, TranscriptionModeConfig.Get());
+
+        var response = await OwnerSettingsRoutes.SendAsync(_http, "PUT", "gateway/transcription-mode",
+            "{\"mode\":\"devthrottle\"}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("devthrottle", document.RootElement.GetProperty("mode").GetString());
+
+        // The independently re-read effect: the stored value MOVED off the seed.
+        Assert.Equal(TranscriptionMode.DevThrottle, TranscriptionModeConfig.Get());
     }
 
     /// <summary>
@@ -389,6 +434,79 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
 
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         Assert.Equal(expectedMessage, document.RootElement.GetProperty("error").GetString());
+    }
+
+    /// <summary>
+    /// <c>POST /gateway/brain/restart</c> - the exact path AND verb, reaching its own handler, proved by a
+    /// receipt only that handler produces, and starting NO process.
+    ///
+    /// This route previously had no served-side handler proof at all. It was covered by asking for it with
+    /// the wrong verb and reading the 405 with <c>Allow: POST</c>, which proves the route is REGISTERED and
+    /// nothing more - the POST could have been wired to any handler, or to none. The reviewer was right to
+    /// call that insufficient, and right that driving the live path in a test would spawn a coding-agent
+    /// process on the machine running the suite.
+    ///
+    /// So the restart action is now an injected seam on the host (<c>GatewayHost.BrainRestartAction</c>,
+    /// which in production IS the real warm-brain restart). Here it is replaced with one that starts nothing
+    /// and records that it ran. Both halves are asserted: the handler's own success envelope comes back,
+    /// AND the seam was actually invoked - so this cannot pass against a handler that returns the right
+    /// shape without doing the work.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonHostedForms))]
+    public async Task The_brain_restart_route_reaches_its_handler_on_self_host_without_starting_a_process(
+        string? hostedForm)
+    {
+        DeclareSelfHost(hostedForm);
+
+        var invoked = 0;
+        _gateway.BrainRestartAction = _ =>
+        {
+            Interlocked.Increment(ref invoked);
+            return Task.CompletedTask;
+        };
+
+        var response = await OwnerSettingsRoutes.SendAsync(_http, "POST", "gateway/brain/restart", "");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = document.RootElement;
+
+        // The receipt is this handler's own: { ok, brain: { ... } }. A refusal is a 404 whose single
+        // property is "error", so the two cannot be confused.
+        Assert.Equal(new[] { "ok", "brain" }, root.EnumerateObject().Select(p => p.Name).ToArray());
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.True(root.GetProperty("brain").TryGetProperty("agents", out _));
+
+        // The handler did the work, not merely answer in the right shape.
+        Assert.Equal(1, invoked);
+    }
+
+    /// <summary>
+    /// The DESTRUCTIBILITY CONTROL for the receipt above. A test that only ever sees success cannot tell an
+    /// asserted receipt apart from a constant: if the handler ignored the seam entirely, the success case
+    /// would look identical. So the seam is made to FAIL, and the handler's own error envelope - a different
+    /// status and a different property set, carrying the exact failure text - must come back.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonHostedForms))]
+    public async Task The_brain_restart_route_reports_its_own_failure_on_self_host(string? hostedForm)
+    {
+        DeclareSelfHost(hostedForm);
+
+        const string Sentinel = "sentinel-restart-failure-no-other-code-path-says-this";
+        _gateway.BrainRestartAction = _ => throw new InvalidOperationException(Sentinel);
+
+        var response = await OwnerSettingsRoutes.SendAsync(_http, "POST", "gateway/brain/restart", "");
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = document.RootElement;
+        Assert.Equal(new[] { "ok", "error" }, root.EnumerateObject().Select(p => p.Name).ToArray());
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(Sentinel, root.GetProperty("error").GetString());
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -639,17 +640,32 @@ public sealed class HostedOwnerSettingsSelfHostProbeTests : IAsyncLifetime
             _ => throw new ArgumentOutOfRangeException(nameof(family), family, "unknown owner-settings family"),
         };
 
+        // The SAME body-bound POST canary the hosted side refuses (Tenancy/HostedRouteDenyTests shape),
+        // driven with hosted mode OFF. A primitive that refused everything unconditionally would satisfy the
+        // hosted class while silently killing this route for self-host too, so the served half must be proved.
         var (app, http) = await OwnerSettingsProbeHost.StartAsync(
             map,
-            mapIntoGroup: group => group.MapGet(probePath, () => Results.Json(new { probe = ProbePayload })));
+            mapIntoGroup: group => group.MapPost(probePath,
+                (CanaryBody body) => Results.Json(new { probe = ProbePayload, echoed = body.Text })));
         try
         {
-            var response = await http.GetAsync(probePath);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+            // A valid body binds through the framework and serves the sentinel with what it echoed.
+            var served = await http.PostAsync(probePath,
+                new StringContent("{\"text\":\"hello\"}", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.OK, served.StatusCode);
+            Assert.Equal("application/json", served.Content.Headers.ContentType?.MediaType);
 
-            using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            using var document = JsonDocument.Parse(await served.Content.ReadAsStringAsync());
             Assert.Equal(ProbePayload, document.RootElement.GetProperty("probe").GetString());
+            Assert.Equal("hello", document.RootElement.GetProperty("echoed").GetString());
+
+            // The binding is the FRAMEWORK's, not a custom binder that ignores the body: a malformed body is
+            // the framework's own 400 here. That is what makes the hosted "malformed body meets the refusal"
+            // claim a real pre-emption of binding - if this route side-stepped the bytes, the hosted assertion
+            // would prove nothing.
+            var malformed = await http.PostAsync(probePath,
+                new StringContent("{ not json", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.BadRequest, malformed.StatusCode);
         }
         finally { http.Dispose(); await app.DisposeAsync(); }
     }

--- a/src/CcDirector.Gateway.Tests/SnoozeEndToEndTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeEndToEndTests.cs
@@ -35,7 +35,7 @@ namespace CcDirector.Gateway.Tests;
 /// live in an isolated store, never the real one. In the "DirectorRoot" collection so it never runs
 /// alongside other root-redirecting tests.
 /// </summary>
-[Collection("DirectorRoot")]
+[Collection("GatewayHostedMode")]
 public sealed class SnoozeEndToEndTests : IAsyncLifetime
 {
     private const string Token = "test-token";

--- a/src/CcDirector.Gateway.Tests/TelemetryConsentEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/TelemetryConsentEndpointTests.cs
@@ -20,7 +20,7 @@ namespace CcDirector.Gateway.Tests;
 /// (re-reading config.json from disk, the across-restart guarantee), and rejects a non-object body.
 /// In the "DirectorRoot" collection because it sets CC_DIRECTOR_ROOT.
 /// </summary>
-[Collection("DirectorRoot")]
+[Collection("GatewayHostedMode")]
 public sealed class TelemetryConsentEndpointTests : IAsyncLifetime
 {
     private readonly string _root;

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -65,13 +65,28 @@ internal static class AiModelsEndpoint
 
         // ONE filter over the whole group - see the note in SettingsEndpoints for why a per-route guard
         // rots. The empty prefix leaves every route path written out in full, so self-host is unchanged.
-        var app = outer.MapGroup("");
-        app.AddEndpointFilter(async (ctx, next) =>
+        var guarded = outer.MapGroup("");
+        guarded.AddEndpointFilter(async (ctx, next) =>
         {
             if (DenyOnHosted() is { } denied) return denied;
             return await next(ctx);
         });
 
+        // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - see the note in SettingsEndpoints.Map. Each
+        // of these seven routes could otherwise be mapped onto `outer` instead of `guarded` by a one-word
+        // edit, bypassing the filter for that route alone while the rest stayed denied. Handing the group to
+        // a method that never receives the ungrouped builder makes that INEXPRESSIBLE, and collapses seven
+        // independently bypassable primitives into one.
+        MapRoutes(guarded, vault);
+        return guarded;
+    }
+
+    /// <summary>
+    /// The seven model-settings routes. Takes the GUARDED group and nothing else, deliberately, so no route
+    /// can be mapped around the hosted filter.
+    /// </summary>
+    private static void MapRoutes(RouteGroupBuilder app, KeyVault vault)
+    {
         app.MapGet("/gateway/ai/models", async (string? kind, CancellationToken ct) =>
         {
             var k = string.Equals(kind, "speech", StringComparison.OrdinalIgnoreCase) ? "speech" : "chat";
@@ -197,8 +212,6 @@ internal static class AiModelsEndpoint
             }
             catch (JsonException) { return Results.BadRequest(new { error = "invalid JSON" }); }
         });
-
-        return app;
     }
 
     private static string ProviderKeyMissingMessage(TranscriptionMode mode) =>

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -24,14 +24,54 @@ namespace CcDirector.Gateway.Api;
 ///
 /// DevThrottle serves a typed catalog (GET /models?type=chat|speech) where each speech model carries
 /// its own voices.
+///
+/// DENIED IN WHOLE ON HOSTED (issue #1863). Every route in this group is refused on a hosted Gateway,
+/// through ONE group filter rather than a guard repeated per route. The setters write PROCESS-GLOBAL
+/// config.json keys with no tenant dimension, so on shared hosted infrastructure any authenticated
+/// caller would be repointing the wingman, car-mode and speech models for EVERYONE; and the catalog and
+/// test-chat routes spend the deployment's own provider credential on whoever asks. Self-host is
+/// single-tenant and these are legitimate owner function there, so on self-host nothing changes.
 /// </summary>
 internal static class AiModelsEndpoint
 {
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
     private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(30) };
 
-    public static void Map(IEndpointRouteBuilder app, KeyVault vault)
+    /// <summary>
+    /// The hosted refusal for every model-settings route (issue #1863), or null on self-host where nothing
+    /// changes. Gated on <see cref="GatewayHostedMode.IsHosted"/> DIRECTLY, never on an optional or
+    /// nullable argument, which fails OPEN when a caller forgets to pass it. 404 rather than 403: on
+    /// hosted these routes do not exist as a concept, and 403 would imply some credential could reach
+    /// them.
+    /// </summary>
+    private static IResult? DenyOnHosted()
     {
+        if (!GatewayHostedMode.IsHosted) return null;
+
+        FileLog.Write("[AiModelsEndpoint] DENIED on hosted: the model settings are process-global configuration with no tenant dimension");
+        return Results.Json(
+            new { error = "the model settings are not available on the hosted gateway" },
+            statusCode: StatusCodes.Status404NotFound);
+    }
+
+    /// <summary>
+    /// Maps the model-settings group and RETURNS it, so a test can map a BRAND-NEW route onto the group
+    /// and find it already refused on hosted with no deny of its own. Without that return value nothing
+    /// outside this file can tell a group filter apart from a guard repeated per route.
+    /// </summary>
+    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, KeyVault vault)
+    {
+        FileLog.Write($"[AiModelsEndpoint] mapping the model settings; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1863)");
+
+        // ONE filter over the whole group - see the note in SettingsEndpoints for why a per-route guard
+        // rots. The empty prefix leaves every route path written out in full, so self-host is unchanged.
+        var app = outer.MapGroup("");
+        app.AddEndpointFilter(async (ctx, next) =>
+        {
+            if (DenyOnHosted() is { } denied) return denied;
+            return await next(ctx);
+        });
+
         app.MapGet("/gateway/ai/models", async (string? kind, CancellationToken ct) =>
         {
             var k = string.Equals(kind, "speech", StringComparison.OrdinalIgnoreCase) ? "speech" : "chat";
@@ -157,6 +197,8 @@ internal static class AiModelsEndpoint
             }
             catch (JsonException) { return Results.BadRequest(new { error = "invalid JSON" }); }
         });
+
+        return app;
     }
 
     private static string ProviderKeyMissingMessage(TranscriptionMode mode) =>

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CcDirector.Core;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.Wingman;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -26,66 +27,75 @@ namespace CcDirector.Gateway.Api;
 /// its own voices.
 ///
 /// DENIED IN WHOLE ON HOSTED (issue #1863). Every route in this group is refused on a hosted Gateway,
-/// through ONE group filter rather than a guard repeated per route. The setters write PROCESS-GLOBAL
-/// config.json keys with no tenant dimension, so on shared hosted infrastructure any authenticated
-/// caller would be repointing the wingman, car-mode and speech models for EVERYONE; and the catalog and
-/// test-chat routes spend the deployment's own provider credential on whoever asks. Self-host is
-/// single-tenant and these are legitimate owner function there, so on self-host nothing changes.
+/// through the shared refusal primitive (<see cref="HostedRouteDeny.Group"/>) - the same boundary the rest
+/// of the owner-settings group and the key-vault group adopt. The setters write PROCESS-GLOBAL config.json
+/// keys with no tenant dimension, so on shared hosted infrastructure any authenticated caller would be
+/// repointing the wingman, car-mode and speech models for EVERYONE; and the catalog and test-chat routes
+/// spend the deployment's own provider credential on whoever asks. Self-host is single-tenant and these are
+/// legitimate owner function there, so on self-host nothing changes.
+///
+/// PER-ROUTE MODE, not an exclusive prefix. Although these seven routes DO sit under <c>/gateway/ai</c>
+/// exclusively, the whole owner-settings group is expressed through ONE mechanism in ONE mode: its
+/// <c>SettingsEndpoints</c> sibling is scattered across leaves under the shared <c>/gateway</c> prefix and
+/// cannot be exclusive, so keeping this family per-route too gives the group one boundary and one revert
+/// story rather than mixing modes. The primitive maps a verb-less refusal on each route's own pattern on
+/// hosted - the handler is never mapped - so every request shape, including a verb the route never served,
+/// meets the refusal rather than a 405.
 /// </summary>
 internal static class AiModelsEndpoint
 {
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
     private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(30) };
 
-    /// <summary>
-    /// The hosted refusal for every model-settings route (issue #1863), or null on self-host where nothing
-    /// changes. Gated on <see cref="GatewayHostedMode.IsHosted"/> DIRECTLY, never on an optional or
-    /// nullable argument, which fails OPEN when a caller forgets to pass it. 404 rather than 403: on
-    /// hosted these routes do not exist as a concept, and 403 would imply some credential could reach
-    /// them.
-    /// </summary>
-    private static IResult? DenyOnHosted()
-    {
-        if (!GatewayHostedMode.IsHosted) return null;
-
-        FileLog.Write("[AiModelsEndpoint] DENIED on hosted: the model settings are process-global configuration with no tenant dimension");
-        return Results.Json(
-            new { error = "the model settings are not available on the hosted gateway" },
-            statusCode: StatusCodes.Status404NotFound);
-    }
+    /// <summary>The single error string the hosted refusal serves, held here so a test asserts the exact
+    /// string served rather than a copy that could drift.</summary>
+    internal const string RefusalMessage = "the model settings are not available on the hosted gateway";
 
     /// <summary>
-    /// Maps the model-settings group and RETURNS it, so a test can map a BRAND-NEW route onto the group
-    /// and find it already refused on hosted with no deny of its own. Without that return value nothing
-    /// outside this file can tell a group filter apart from a guard repeated per route.
+    /// The hosted refusal payload for every model-settings route (issue #1863). Validated on construction,
+    /// so a blank field fails the Gateway at startup. The primitive reads <see cref="GatewayHostedMode.IsHosted"/>
+    /// DIRECTLY, never an optional argument that fails OPEN when a caller forgets it. 404 rather than 403: on
+    /// hosted these routes do not exist as a concept, and 403 would imply some credential could reach them.
     /// </summary>
-    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, KeyVault vault)
-    {
-        FileLog.Write($"[AiModelsEndpoint] mapping the model settings; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1863)");
+    private static HostedDenial Denial() => new(
+        family: "model-settings",
+        message: RefusalMessage,
+        reason: "the model settings are process-global config.json values with no tenant dimension, and the " +
+                "catalog and test-chat routes spend the deployment's own provider credential - so on shared " +
+                "infrastructure one subscriber would repoint every model and bill everyone's credential",
+        unDenyInstruction: "do NOT simply remove this deny: give each model setting a per-tenant home " +
+                "(config.json has none today), migrate any global value already written, and scope the credential " +
+                "the catalog/test-chat routes spend to the caller, before restoring a tenant-scoped route",
+        statusCode: StatusCodes.Status404NotFound);
 
-        // ONE filter over the whole group - see the note in SettingsEndpoints for why a per-route guard
-        // rots. The empty prefix leaves every route path written out in full, so self-host is unchanged.
-        var guarded = outer.MapGroup("");
-        guarded.AddEndpointFilter(async (ctx, next) =>
-        {
-            if (DenyOnHosted() is { } denied) return denied;
-            return await next(ctx);
-        });
+    /// <summary>
+    /// Maps the model-settings group through the shared refusal primitive and RETURNS the denied handle, so a
+    /// test can map a BRAND-NEW route onto the handle and find it already refused on hosted with no deny of
+    /// its own. Without that return value nothing outside this file can state the future-route property.
+    /// </summary>
+    public static HostedDenyGroup Map(IEndpointRouteBuilder outer, KeyVault vault)
+    {
+        FileLog.Write($"[AiModelsEndpoint] mapping the model settings; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused via the shared refusal primitive (issue #1863)");
+
+        // The whole group through ONE primitive-created handle - see the note in SettingsEndpoints for why a
+        // per-route guard rots. The empty prefix leaves every route path written out in full, so self-host is
+        // unchanged.
+        var group = HostedRouteDeny.Group(outer, "", Denial());
 
         // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - see the note in SettingsEndpoints.Map. Each
-        // of these seven routes could otherwise be mapped onto `outer` instead of `guarded` by a one-word
-        // edit, bypassing the filter for that route alone while the rest stayed denied. Handing the group to
-        // a method that never receives the ungrouped builder makes that INEXPRESSIBLE, and collapses seven
-        // independently bypassable primitives into one.
-        MapRoutes(guarded, vault);
-        return guarded;
+        // of these seven routes could otherwise be mapped onto `outer` instead of the denied handle by a
+        // one-word edit, bypassing the refusal for that route alone while the rest stayed denied. Handing the
+        // typed handle to a method that never receives the ungrouped builder makes that INEXPRESSIBLE, and
+        // collapses seven independently bypassable primitives into one.
+        MapRoutes(group, vault);
+        return group;
     }
 
     /// <summary>
-    /// The seven model-settings routes. Takes the GUARDED group and nothing else, deliberately, so no route
-    /// can be mapped around the hosted filter.
+    /// The seven model-settings routes. Takes the denied GROUP HANDLE and nothing else, deliberately, so no
+    /// route can be mapped around the hosted refusal.
     /// </summary>
-    private static void MapRoutes(RouteGroupBuilder app, KeyVault vault)
+    private static void MapRoutes(HostedDenyGroup app, KeyVault vault)
     {
         app.MapGet("/gateway/ai/models", async (string? kind, CancellationToken ct) =>
         {

--- a/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
@@ -6,6 +6,7 @@ using CcDirector.AgentBrain;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Network;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -35,94 +36,111 @@ namespace CcDirector.Gateway.Api;
 ///   GET  /gateway/injected-text   -> { use_yours, yours, ours, placeholders[] } (what agents get at launch)
 ///   PUT  /gateway/injected-text   body { "use_yours": bool, "yours": string|null } -> same shape
 ///
-/// DENIED IN WHOLE ON HOSTED (issue #1863). Every route in this group is refused on a hosted Gateway,
-/// through ONE group filter rather than a guard repeated per route. These routes operate on
-/// PROCESS-GLOBAL configuration with NO TENANT DIMENSION AT ALL: config.json is one file for the whole
-/// process, so every write here is a fleet-wide mutation performed by whichever authenticated caller
-/// happened to send it, and GET /gateway/injected-text hands back the owner's own custom agent-launch
-/// instruction text. On shared hosted infrastructure there is no correct per-tenant answer to serve
-/// here - only a leak to close. Self-host is single-tenant and these are legitimate owner function
-/// there, so on self-host nothing changes.
+/// DENIED IN WHOLE ON HOSTED (issue #1863). Every route in this group is refused on a hosted Gateway.
+/// These routes operate on PROCESS-GLOBAL configuration with NO TENANT DIMENSION AT ALL: config.json is
+/// one file for the whole process, so every write here is a fleet-wide mutation performed by whichever
+/// authenticated caller happened to send it, and GET /gateway/injected-text hands back the owner's own
+/// custom agent-launch instruction text. On shared hosted infrastructure there is no correct per-tenant
+/// answer to serve here - only a leak to close. Self-host is single-tenant and these are legitimate owner
+/// function there, so on self-host nothing changes.
+///
+/// HOW THE DENY IS EXPRESSED - THE SHARED REFUSAL PRIMITIVE, NOT A BESPOKE FILTER. This group is denied
+/// through <see cref="HostedRouteDeny.Group"/>, the ONE hosted-refusal boundary every deny family on this
+/// Gateway adopts (primitive at <c>src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs</c>; the key-vault
+/// group in <c>VaultEndpoints</c> is the reference adopter). An earlier revision rolled its own
+/// <c>AddEndpointFilter</c> deny before the primitive existed; it has been replaced so the release ships
+/// ONE refusal boundary, not one per family. What the primitive buys over the old request-time filter: on
+/// hosted the handler is NEVER MAPPED - in its place a verb-less refusal is mapped on the route's own
+/// pattern, so there is no binding step to get ahead of, no body parameter and no method constraint. EVERY
+/// request shape meets the refusal - a valid body, a malformed body, a wrong media type, and a VERB THE
+/// ROUTE NEVER MAPPED (which the old filter let endpoint selection answer with a 405, disclosing that a
+/// route exists on a Gateway whose refusal says it does not).
+///
+/// PER-ROUTE MODE (<see cref="HostedRouteDeny.Group"/>), NOT AN EXCLUSIVE PREFIX. The owner-settings routes
+/// do not own an exclusive prefix: they are scattered leaves under <c>/gateway</c>, which also carries LIVE
+/// routes from other families (<c>/gateway/about</c>, <c>/gateway/governance/*</c>, <c>/gateway/workflows/*</c>,
+/// <c>/gateway/wingman/instructions/*</c>, <c>/gateway/missions/notes</c>, <c>/gateway/lists/item-status</c>).
+/// An <see cref="HostedRouteDeny.ExclusiveGroup"/> claim over <c>/gateway</c> would take every one of those
+/// off the air, and the startup exclusivity check (<see cref="HostedRefusalRouteSpace.ValidateBeforeStart"/>)
+/// refuses to boot the Gateway when a live route serves beneath an exclusive prefix - so the exclusive shape
+/// is not available here. Per-route mode maps one refusal per route this family declares; the family owes a
+/// test that a route added to the group is refused, which is why <c>Map</c> returns the group handle.
 /// </summary>
 internal static class SettingsEndpoints
 {
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
-    /// <summary>
-    /// The hosted refusal for every owner-settings route (issue #1863), or null on self-host where nothing
-    /// changes.
-    ///
-    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> DIRECTLY - never on an optional or nullable
-    /// argument being passed in. A security branch that depends on an optional argument fails OPEN the
-    /// moment a caller forgets it, which is exactly how the hosted account-status fix nearly shipped a
-    /// hole. Asking hosted mode directly means these routes cannot mutate fleet-global configuration on
-    /// hosted however this is wired.
-    ///
-    /// 404 rather than 403: on hosted "the owner's settings" does not exist as a concept, so "not here"
-    /// is the truthful answer. 403 would imply the right credential could reach it, and none can.
-    /// </summary>
-    private static IResult? DenyOnHosted()
-    {
-        if (!GatewayHostedMode.IsHosted) return null;
-
-        FileLog.Write("[SettingsEndpoints] DENIED on hosted: the owner settings are process-global configuration with no tenant dimension");
-        return Results.Json(
-            new { error = "gateway settings are not available on the hosted gateway" },
-            statusCode: StatusCodes.Status404NotFound);
-    }
+    /// <summary>The single error string the hosted refusal serves. Held here so a test can assert against the
+    /// exact string that is served rather than a copy that could drift.</summary>
+    internal const string RefusalMessage = "gateway settings are not available on the hosted gateway";
 
     /// <summary>
-    /// Maps the owner-settings group and RETURNS it, so the refusal can be proved to cover routes that do
-    /// not exist yet: a test maps a NEW probe route onto the returned group and finds it already refused on
-    /// hosted, with no deny written for it anywhere. Returning the group is the only way to state that
-    /// property from outside this file, and a per-route guard and a group filter are indistinguishable
-    /// without it.
+    /// The hosted refusal payload for the whole owner-settings group (issue #1863). Validated on
+    /// construction, so a blank field fails the Gateway at startup rather than serving a refusal a caller
+    /// cannot act on.
+    ///
+    /// The primitive reads <see cref="GatewayHostedMode.IsHosted"/> DIRECTLY, never an optional argument a
+    /// caller can omit - a security branch that depends on an argument fails OPEN the moment somebody forgets
+    /// it, which is how the hosted account-status fix nearly shipped a hole. 404 rather than 403: on hosted
+    /// "the owner's settings" does not exist as a concept, so "not here" is the truthful answer; 403 would
+    /// imply the right credential could reach it, and none can.
     /// </summary>
-    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, GatewayHost host)
-    {
-        FileLog.Write($"[SettingsEndpoints] mapping the owner settings; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1863)");
+    private static HostedDenial Denial() => new(
+        family: "owner-settings",
+        message: RefusalMessage,
+        reason: "the owner settings are process-global config.json values with no tenant dimension anywhere - " +
+                "not in the file, the store or the routes - and the host-wide auth gate admits any enrolled " +
+                "device key from any account, so one subscriber would repoint or read the whole fleet's settings",
+        unDenyInstruction: "do NOT simply remove this deny: give each of these settings a per-tenant home " +
+                "(config.json has none today), migrate any global value already written, and only then restore " +
+                "a tenant-scoped route",
+        statusCode: StatusCodes.Status404NotFound);
 
-        // The whole group behind ONE filter, rather than a guard line repeated in every handler. A repeated
-        // guard is a thing to forget: the route added to this file next year would be open by default on
-        // hosted and nothing would fail. A group filter runs before EVERY route mapped below, including
-        // routes that do not exist yet. The empty prefix keeps every route path written out in full, so the
-        // self-host surface is byte-identical to before and the diff stays readable.
-        var guarded = outer.MapGroup("");
-        guarded.AddEndpointFilter(async (ctx, next) =>
-        {
-            if (DenyOnHosted() is { } denied) return denied;
-            return await next(ctx);
-        });
+    /// <summary>
+    /// Maps the owner-settings group through the shared refusal primitive and RETURNS the denied group they
+    /// were mapped through, so the refusal can be proved to cover routes that do not exist yet: a test maps a
+    /// NEW probe route onto the returned handle and finds it already refused on hosted, with no deny written
+    /// for it anywhere. Returning the handle is the only way to state that property from outside this file.
+    /// </summary>
+    public static HostedDenyGroup Map(IEndpointRouteBuilder outer, GatewayHost host)
+    {
+        FileLog.Write($"[SettingsEndpoints] mapping the owner settings; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused via the shared refusal primitive (issue #1863)");
+
+        // The whole group through ONE primitive-created handle, rather than a guard line repeated in every
+        // handler. A repeated guard is a thing to forget: the route added to this file next year would be
+        // open by default on hosted and nothing would fail. Per-route Group mode maps a refusal for every
+        // route mapped through the handle below. The empty prefix keeps every route path written out in full,
+        // so the self-host surface is byte-identical to before and the diff stays readable.
+        var group = HostedRouteDeny.Group(outer, "", Denial());
 
         // The telemetry-consent family is mapped onto OUTER, not into this group, deliberately (issue
-        // #1863). It carries its OWN hosted group filter, and mapping it here as well would put two filters
-        // over the same routes - which hides a defect rather than adding safety: deleting either filter
-        // alone would leave the routes still refused, so neither filter's revert could be attributed to it.
-        // One family, one filter, one thing to revert. It is called HERE, in the only method that still
-        // holds `outer`, so that `outer` does not have to stay in scope where the routes are mapped.
+        // #1863). It carries its OWN hosted refusal, and mapping it here as well would put two boundaries
+        // over the same routes - which hides a defect rather than adding safety: deleting either alone would
+        // leave the routes still refused, so neither's revert could be attributed to it. One family, one
+        // boundary, one thing to revert. It is called HERE, in the only method that still holds `outer`, so
+        // that `outer` does not have to stay in scope where the routes are mapped.
         TelemetryConsentEndpoint.Map(outer);
 
         // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - deliberately, and this is the only reason
         // MapRoutes exists as a separate method.
         //
-        // If the routes were written here beside the guarded group, each of the twenty-two could
-        // INDIVIDUALLY be mapped onto `outer` instead of onto `guarded` - a one-word edit that bypasses the
-        // filter for that route alone while every other route stays correctly denied. That is twenty-two
-        // independently bypassable primitives, each of which would owe its own proof run. Handing the group
-        // to a method that never receives the ungrouped builder makes that mistake INEXPRESSIBLE rather than
-        // merely unlikely: inside MapRoutes there is nothing to map onto except the guarded group. The
-        // bypass count is reduced by design, not by argument about how careful the next author will be.
-        // This is the shape the key-vault deny uses, in VaultEndpoints.
-        MapRoutes(guarded, host);
-        return guarded;
+        // If the routes were written here beside the group handle, each of the twenty-two could INDIVIDUALLY
+        // be mapped onto `outer` instead of onto the denied handle - a one-word edit that bypasses the
+        // refusal for that route alone while every other route stays correctly denied. That is twenty-two
+        // independently bypassable primitives, each of which would owe its own proof run. Handing the typed
+        // handle to a method that never receives the ungrouped builder makes that mistake INEXPRESSIBLE
+        // rather than merely unlikely: inside MapRoutes there is nothing to map onto except the denied handle.
+        // The bypass count is reduced by design. This is the shape the key-vault deny uses, in VaultEndpoints.
+        MapRoutes(group, host);
+        return group;
     }
 
     /// <summary>
-    /// The twenty-two owner-settings routes. Takes the GUARDED group and nothing else - see the note at the
-    /// call site: the ungrouped route builder is deliberately out of scope here so no route can be mapped
-    /// around the hosted filter.
+    /// The twenty-two owner-settings routes. Takes the denied GROUP HANDLE and nothing else - see the note at
+    /// the call site: the ungrouped route builder is deliberately out of scope here so no route can be mapped
+    /// around the hosted refusal.
     /// </summary>
-    private static void MapRoutes(RouteGroupBuilder app, GatewayHost host)
+    private static void MapRoutes(HostedDenyGroup app, GatewayHost host)
     {
         app.MapGet("/gateway/settings", async () =>
         {

--- a/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
@@ -87,13 +87,43 @@ internal static class SettingsEndpoints
         // hosted and nothing would fail. A group filter runs before EVERY route mapped below, including
         // routes that do not exist yet. The empty prefix keeps every route path written out in full, so the
         // self-host surface is byte-identical to before and the diff stays readable.
-        var app = outer.MapGroup("");
-        app.AddEndpointFilter(async (ctx, next) =>
+        var guarded = outer.MapGroup("");
+        guarded.AddEndpointFilter(async (ctx, next) =>
         {
             if (DenyOnHosted() is { } denied) return denied;
             return await next(ctx);
         });
 
+        // The telemetry-consent family is mapped onto OUTER, not into this group, deliberately (issue
+        // #1863). It carries its OWN hosted group filter, and mapping it here as well would put two filters
+        // over the same routes - which hides a defect rather than adding safety: deleting either filter
+        // alone would leave the routes still refused, so neither filter's revert could be attributed to it.
+        // One family, one filter, one thing to revert. It is called HERE, in the only method that still
+        // holds `outer`, so that `outer` does not have to stay in scope where the routes are mapped.
+        TelemetryConsentEndpoint.Map(outer);
+
+        // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - deliberately, and this is the only reason
+        // MapRoutes exists as a separate method.
+        //
+        // If the routes were written here beside the guarded group, each of the twenty-two could
+        // INDIVIDUALLY be mapped onto `outer` instead of onto `guarded` - a one-word edit that bypasses the
+        // filter for that route alone while every other route stays correctly denied. That is twenty-two
+        // independently bypassable primitives, each of which would owe its own proof run. Handing the group
+        // to a method that never receives the ungrouped builder makes that mistake INEXPRESSIBLE rather than
+        // merely unlikely: inside MapRoutes there is nothing to map onto except the guarded group. The
+        // bypass count is reduced by design, not by argument about how careful the next author will be.
+        // This is the shape the key-vault deny uses, in VaultEndpoints.
+        MapRoutes(guarded, host);
+        return guarded;
+    }
+
+    /// <summary>
+    /// The twenty-two owner-settings routes. Takes the GUARDED group and nothing else - see the note at the
+    /// call site: the ungrouped route builder is deliberately out of scope here so no route can be mapped
+    /// around the hosted filter.
+    /// </summary>
+    private static void MapRoutes(RouteGroupBuilder app, GatewayHost host)
+    {
         app.MapGet("/gateway/settings", async () =>
         {
             // The Cockpit is served in-process by the Gateway (issue #979 retired the separate Blazor
@@ -153,12 +183,16 @@ internal static class SettingsEndpoints
 
         // Restart the warm brain (issue #184): the one recovery verb, and doubles as a manual
         // start. Mirrors the old tray-window Restart Brain button, now reachable from the Cockpit.
-        app.MapPost("/gateway/brain/restart", async () =>
+        app.MapPost("/gateway/brain/restart", async (CancellationToken ct) =>
         {
             FileLog.Write("[SettingsEndpoints] POST /gateway/brain/restart");
             try
             {
-                await host.Brain.RestartAsync();
+                // Through the host's restart seam rather than host.Brain.RestartAsync directly. In
+                // production the seam IS host.Brain.RestartAsync - see GatewayHost.BrainRestartAction -
+                // so behaviour here is unchanged; the indirection is what lets a test drive this exact
+                // path and verb for a real receipt without starting a coding-agent process.
+                await host.BrainRestartAction(ct);
                 FileLog.Write($"[SettingsEndpoints] brain restart OK: pid={host.Brain.ProcessId}, session={host.Brain.SessionId}");
                 return Results.Json(new { ok = true, brain = await BrainBlockAsync(host) });
             }
@@ -261,17 +295,11 @@ internal static class SettingsEndpoints
             }
         });
 
-        // The fleet-wide richer-usage-telemetry consent (issue #649). Lives in its own endpoint class
-        // (TelemetryConsentEndpoint) so it can be unit-tested in isolation, but it is part of the one
-        // Gateway settings surface and is mapped here alongside the other settings routes. Default ON;
-        // gates only the richer usage telemetry - the always-on login/startup events are never gated.
-        //
-        // Mapped onto OUTER, not onto this group, deliberately (issue #1863). It carries its OWN hosted
-        // group filter, and mapping it here as well would put two filters over the same routes - which
-        // hides a defect rather than adding safety: deleting either filter alone would leave the routes
-        // still refused, so neither filter's revert could be attributed to it. One family, one filter,
-        // one thing to revert.
-        TelemetryConsentEndpoint.Map(outer);
+        // The fleet-wide richer-usage-telemetry consent (issue #649) lives in its own endpoint class
+        // (TelemetryConsentEndpoint) so it can be unit-tested in isolation, and it is mapped from Map above
+        // rather than here, because it needs the UNGROUPED builder and this method deliberately does not
+        // have one. Default ON; gates only the richer usage telemetry - the always-on login/startup events
+        // are never gated.
 
         // Network addressing mode (issue #457): "tailscale" (advertise the Tailscale Serve
         // front door) or "lan" (advertise the machine's real LAN IP). Stored as the top-level
@@ -638,8 +666,6 @@ internal static class SettingsEndpoints
                 return Results.BadRequest(new { error = "invalid JSON" });
             }
         });
-
-        return app;
     }
 
     /// <summary>The brain status block - shared by the snapshot GET and the restart POST.</summary>

--- a/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
@@ -34,13 +34,66 @@ namespace CcDirector.Gateway.Api;
 ///   PUT  /gateway/telemetry-consent  body { "enabled": bool } -> { enabled }
 ///   GET  /gateway/injected-text   -> { use_yours, yours, ours, placeholders[] } (what agents get at launch)
 ///   PUT  /gateway/injected-text   body { "use_yours": bool, "yours": string|null } -> same shape
+///
+/// DENIED IN WHOLE ON HOSTED (issue #1863). Every route in this group is refused on a hosted Gateway,
+/// through ONE group filter rather than a guard repeated per route. These routes operate on
+/// PROCESS-GLOBAL configuration with NO TENANT DIMENSION AT ALL: config.json is one file for the whole
+/// process, so every write here is a fleet-wide mutation performed by whichever authenticated caller
+/// happened to send it, and GET /gateway/injected-text hands back the owner's own custom agent-launch
+/// instruction text. On shared hosted infrastructure there is no correct per-tenant answer to serve
+/// here - only a leak to close. Self-host is single-tenant and these are legitimate owner function
+/// there, so on self-host nothing changes.
 /// </summary>
 internal static class SettingsEndpoints
 {
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
-    public static void Map(IEndpointRouteBuilder app, GatewayHost host)
+    /// <summary>
+    /// The hosted refusal for every owner-settings route (issue #1863), or null on self-host where nothing
+    /// changes.
+    ///
+    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> DIRECTLY - never on an optional or nullable
+    /// argument being passed in. A security branch that depends on an optional argument fails OPEN the
+    /// moment a caller forgets it, which is exactly how the hosted account-status fix nearly shipped a
+    /// hole. Asking hosted mode directly means these routes cannot mutate fleet-global configuration on
+    /// hosted however this is wired.
+    ///
+    /// 404 rather than 403: on hosted "the owner's settings" does not exist as a concept, so "not here"
+    /// is the truthful answer. 403 would imply the right credential could reach it, and none can.
+    /// </summary>
+    private static IResult? DenyOnHosted()
     {
+        if (!GatewayHostedMode.IsHosted) return null;
+
+        FileLog.Write("[SettingsEndpoints] DENIED on hosted: the owner settings are process-global configuration with no tenant dimension");
+        return Results.Json(
+            new { error = "gateway settings are not available on the hosted gateway" },
+            statusCode: StatusCodes.Status404NotFound);
+    }
+
+    /// <summary>
+    /// Maps the owner-settings group and RETURNS it, so the refusal can be proved to cover routes that do
+    /// not exist yet: a test maps a NEW probe route onto the returned group and finds it already refused on
+    /// hosted, with no deny written for it anywhere. Returning the group is the only way to state that
+    /// property from outside this file, and a per-route guard and a group filter are indistinguishable
+    /// without it.
+    /// </summary>
+    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, GatewayHost host)
+    {
+        FileLog.Write($"[SettingsEndpoints] mapping the owner settings; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1863)");
+
+        // The whole group behind ONE filter, rather than a guard line repeated in every handler. A repeated
+        // guard is a thing to forget: the route added to this file next year would be open by default on
+        // hosted and nothing would fail. A group filter runs before EVERY route mapped below, including
+        // routes that do not exist yet. The empty prefix keeps every route path written out in full, so the
+        // self-host surface is byte-identical to before and the diff stays readable.
+        var app = outer.MapGroup("");
+        app.AddEndpointFilter(async (ctx, next) =>
+        {
+            if (DenyOnHosted() is { } denied) return denied;
+            return await next(ctx);
+        });
+
         app.MapGet("/gateway/settings", async () =>
         {
             // The Cockpit is served in-process by the Gateway (issue #979 retired the separate Blazor
@@ -212,7 +265,13 @@ internal static class SettingsEndpoints
         // (TelemetryConsentEndpoint) so it can be unit-tested in isolation, but it is part of the one
         // Gateway settings surface and is mapped here alongside the other settings routes. Default ON;
         // gates only the richer usage telemetry - the always-on login/startup events are never gated.
-        TelemetryConsentEndpoint.Map(app);
+        //
+        // Mapped onto OUTER, not onto this group, deliberately (issue #1863). It carries its OWN hosted
+        // group filter, and mapping it here as well would put two filters over the same routes - which
+        // hides a defect rather than adding safety: deleting either filter alone would leave the routes
+        // still refused, so neither filter's revert could be attributed to it. One family, one filter,
+        // one thing to revert.
+        TelemetryConsentEndpoint.Map(outer);
 
         // Network addressing mode (issue #457): "tailscale" (advertise the Tailscale Serve
         // front door) or "lan" (advertise the machine's real LAN IP). Stored as the top-level
@@ -579,6 +638,8 @@ internal static class SettingsEndpoints
                 return Results.BadRequest(new { error = "invalid JSON" });
             }
         });
+
+        return app;
     }
 
     /// <summary>The brain status block - shared by the snapshot GET and the restart POST.</summary>

--- a/src/CcDirector.Gateway/Api/TelemetryConsentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TelemetryConsentEndpoint.cs
@@ -56,13 +56,27 @@ internal static class TelemetryConsentEndpoint
     {
         FileLog.Write($"[TelemetryConsentEndpoint] mapping telemetry consent; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1863)");
 
-        var app = outer.MapGroup("");
-        app.AddEndpointFilter(async (ctx, next) =>
+        var guarded = outer.MapGroup("");
+        guarded.AddEndpointFilter(async (ctx, next) =>
         {
             if (DenyOnHosted() is { } denied) return denied;
             return await next(ctx);
         });
 
+        // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - see the note in SettingsEndpoints.Map.
+        // Either of these two routes could otherwise be mapped onto `outer` by a one-word edit, opening it
+        // alone while the other stayed denied. Handing the group to a method that never receives the
+        // ungrouped builder makes that INEXPRESSIBLE.
+        MapRoutes(guarded);
+        return guarded;
+    }
+
+    /// <summary>
+    /// The two telemetry-consent routes. Takes the GUARDED group and nothing else, deliberately, so neither
+    /// route can be mapped around the hosted filter.
+    /// </summary>
+    private static void MapRoutes(RouteGroupBuilder app)
+    {
         app.MapGet("/gateway/telemetry-consent", () =>
         {
             var enabled = TelemetryConsentConfig.Get();
@@ -89,8 +103,6 @@ internal static class TelemetryConsentEndpoint
                 return Results.BadRequest(new { error = "invalid JSON" });
             }
         });
-
-        return app;
     }
 
     private sealed record TelemetryConsentBody(bool Enabled);

--- a/src/CcDirector.Gateway/Api/TelemetryConsentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TelemetryConsentEndpoint.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -21,61 +22,66 @@ namespace CcDirector.Gateway.Api;
 /// immediately - no Gateway restart. These endpoints inherit the host-wide Gateway token middleware
 /// exactly like every other Gateway endpoint. The response carries no token and no user data.
 ///
-/// DENIED IN WHOLE ON HOSTED (issue #1863). Both routes are refused on a hosted Gateway through ONE
-/// group filter. The consent is a single PROCESS-GLOBAL config.json key governing the WHOLE fleet, with
-/// no tenant dimension - so on shared hosted infrastructure one tenant toggling it would be answering a
-/// privacy question on behalf of every other tenant. There is no correct per-tenant answer to serve
-/// here. Self-host is single-tenant and this is legitimate owner function there, so on self-host nothing
-/// changes.
+/// DENIED IN WHOLE ON HOSTED (issue #1863). Both routes are refused on a hosted Gateway through the shared
+/// refusal primitive (<see cref="HostedRouteDeny.Group"/>), the same boundary the rest of the owner-settings
+/// group and the key-vault group adopt. The consent is a single PROCESS-GLOBAL config.json key governing the
+/// WHOLE fleet, with no tenant dimension - so on shared hosted infrastructure one tenant toggling it would be
+/// answering a privacy question on behalf of every other tenant. There is no correct per-tenant answer to
+/// serve here. Self-host is single-tenant and this is legitimate owner function there, so on self-host
+/// nothing changes.
+///
+/// PER-ROUTE MODE, not an exclusive prefix: this family sits under <c>/gateway</c>, which carries LIVE routes
+/// from other families, so an exclusive claim would take them off the air. The primitive maps a verb-less
+/// refusal on each route's own pattern on hosted - the handler is never mapped - so every request shape,
+/// including a verb the route never served, meets the refusal rather than a 405.
 /// </summary>
 internal static class TelemetryConsentEndpoint
 {
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
-    /// <summary>
-    /// The hosted refusal for both telemetry-consent routes (issue #1863), or null on self-host. Gated on
-    /// <see cref="GatewayHostedMode.IsHosted"/> DIRECTLY, never on an optional or nullable argument, which
-    /// fails OPEN when a caller forgets it. 404 rather than 403 for the same reason as its siblings: on
-    /// hosted a fleet-wide owner consent does not exist as a concept.
-    /// </summary>
-    private static IResult? DenyOnHosted()
-    {
-        if (!GatewayHostedMode.IsHosted) return null;
-
-        FileLog.Write("[TelemetryConsentEndpoint] DENIED on hosted: the consent is one fleet-wide setting with no tenant dimension");
-        return Results.Json(
-            new { error = "the telemetry consent setting is not available on the hosted gateway" },
-            statusCode: StatusCodes.Status404NotFound);
-    }
+    /// <summary>The single error string the hosted refusal serves, held here so a test asserts the exact
+    /// string served rather than a copy that could drift.</summary>
+    internal const string RefusalMessage = "the telemetry consent setting is not available on the hosted gateway";
 
     /// <summary>
-    /// Maps the GET/PUT telemetry-consent routes as a GROUP and returns it, so a test can map a brand-new
-    /// route onto that group and find it already refused on hosted with no deny of its own.
+    /// The hosted refusal payload for both telemetry-consent routes (issue #1863). Validated on construction,
+    /// so a blank field fails the Gateway at startup. The primitive reads <see cref="GatewayHostedMode.IsHosted"/>
+    /// DIRECTLY, never an optional argument that fails OPEN when a caller forgets it. 404 rather than 403 for
+    /// the same reason as its siblings: on hosted a fleet-wide owner consent does not exist as a concept.
     /// </summary>
-    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer)
-    {
-        FileLog.Write($"[TelemetryConsentEndpoint] mapping telemetry consent; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1863)");
+    private static HostedDenial Denial() => new(
+        family: "telemetry-consent",
+        message: RefusalMessage,
+        reason: "the consent is one process-global config.json key governing the whole fleet, with no tenant " +
+                "dimension - so on shared infrastructure one subscriber would answer the privacy question for all",
+        unDenyInstruction: "do NOT simply remove this deny: give the consent a per-tenant home (config.json has " +
+                "none today) and migrate the global value already written, then restore a tenant-scoped route",
+        statusCode: StatusCodes.Status404NotFound);
 
-        var guarded = outer.MapGroup("");
-        guarded.AddEndpointFilter(async (ctx, next) =>
-        {
-            if (DenyOnHosted() is { } denied) return denied;
-            return await next(ctx);
-        });
+    /// <summary>
+    /// Maps the GET/PUT telemetry-consent routes through the shared refusal primitive and returns the denied
+    /// handle, so a test can map a brand-new route onto that handle and find it already refused on hosted with
+    /// no deny of its own.
+    /// </summary>
+    public static HostedDenyGroup Map(IEndpointRouteBuilder outer)
+    {
+        FileLog.Write($"[TelemetryConsentEndpoint] mapping telemetry consent; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused via the shared refusal primitive (issue #1863)");
+
+        var group = HostedRouteDeny.Group(outer, "", Denial());
 
         // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - see the note in SettingsEndpoints.Map.
         // Either of these two routes could otherwise be mapped onto `outer` by a one-word edit, opening it
-        // alone while the other stayed denied. Handing the group to a method that never receives the
+        // alone while the other stayed denied. Handing the typed handle to a method that never receives the
         // ungrouped builder makes that INEXPRESSIBLE.
-        MapRoutes(guarded);
-        return guarded;
+        MapRoutes(group);
+        return group;
     }
 
     /// <summary>
-    /// The two telemetry-consent routes. Takes the GUARDED group and nothing else, deliberately, so neither
-    /// route can be mapped around the hosted filter.
+    /// The two telemetry-consent routes. Takes the denied GROUP HANDLE and nothing else, deliberately, so
+    /// neither route can be mapped around the hosted refusal.
     /// </summary>
-    private static void MapRoutes(RouteGroupBuilder app)
+    private static void MapRoutes(HostedDenyGroup app)
     {
         app.MapGet("/gateway/telemetry-consent", () =>
         {

--- a/src/CcDirector.Gateway/Api/TelemetryConsentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TelemetryConsentEndpoint.cs
@@ -20,14 +20,49 @@ namespace CcDirector.Gateway.Api;
 /// the same store the other Gateway settings use. Read at decision time, so a toggle takes effect
 /// immediately - no Gateway restart. These endpoints inherit the host-wide Gateway token middleware
 /// exactly like every other Gateway endpoint. The response carries no token and no user data.
+///
+/// DENIED IN WHOLE ON HOSTED (issue #1863). Both routes are refused on a hosted Gateway through ONE
+/// group filter. The consent is a single PROCESS-GLOBAL config.json key governing the WHOLE fleet, with
+/// no tenant dimension - so on shared hosted infrastructure one tenant toggling it would be answering a
+/// privacy question on behalf of every other tenant. There is no correct per-tenant answer to serve
+/// here. Self-host is single-tenant and this is legitimate owner function there, so on self-host nothing
+/// changes.
 /// </summary>
 internal static class TelemetryConsentEndpoint
 {
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
-    /// <summary>Maps the GET/PUT telemetry-consent routes.</summary>
-    public static void Map(IEndpointRouteBuilder app)
+    /// <summary>
+    /// The hosted refusal for both telemetry-consent routes (issue #1863), or null on self-host. Gated on
+    /// <see cref="GatewayHostedMode.IsHosted"/> DIRECTLY, never on an optional or nullable argument, which
+    /// fails OPEN when a caller forgets it. 404 rather than 403 for the same reason as its siblings: on
+    /// hosted a fleet-wide owner consent does not exist as a concept.
+    /// </summary>
+    private static IResult? DenyOnHosted()
     {
+        if (!GatewayHostedMode.IsHosted) return null;
+
+        FileLog.Write("[TelemetryConsentEndpoint] DENIED on hosted: the consent is one fleet-wide setting with no tenant dimension");
+        return Results.Json(
+            new { error = "the telemetry consent setting is not available on the hosted gateway" },
+            statusCode: StatusCodes.Status404NotFound);
+    }
+
+    /// <summary>
+    /// Maps the GET/PUT telemetry-consent routes as a GROUP and returns it, so a test can map a brand-new
+    /// route onto that group and find it already refused on hosted with no deny of its own.
+    /// </summary>
+    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer)
+    {
+        FileLog.Write($"[TelemetryConsentEndpoint] mapping telemetry consent; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1863)");
+
+        var app = outer.MapGroup("");
+        app.AddEndpointFilter(async (ctx, next) =>
+        {
+            if (DenyOnHosted() is { } denied) return denied;
+            return await next(ctx);
+        });
+
         app.MapGet("/gateway/telemetry-consent", () =>
         {
             var enabled = TelemetryConsentConfig.Get();
@@ -54,6 +89,8 @@ internal static class TelemetryConsentEndpoint
                 return Results.BadRequest(new { error = "invalid JSON" });
             }
         });
+
+        return app;
     }
 
     private sealed record TelemetryConsentBody(bool Enabled);

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -688,6 +688,9 @@ public sealed class GatewayHost : IAsyncDisposable
             // newing a HostedAgent with an arbitrary registry driver keeps that guard the one and only
             // path to a hosted brain, so a non-hostable tool can never slip through to fail at Start.
             agentFactory: o => CcDirector.HostedAgent.HostedAgent.For(BrainTool, o));
+        // The production behaviour, assigned once here. See BrainRestartAction for why the indirection
+        // exists; nothing in production ever reassigns it.
+        BrainRestartAction = ct => Brain.RestartAsync(ct);
         _turnBriefStore = new GatewayTurnBriefStore(turnBriefDirectory);
         // Production omits keyVaultPath for the shared default; tests pass an isolated path so
         // they never touch the real %LOCALAPPDATA% key store.
@@ -1321,6 +1324,24 @@ public sealed class GatewayHost : IAsyncDisposable
     /// Director dependency. Dormant until first use; RestartAsync is the recovery verb.
     /// </summary>
     public BrainSupervisor Brain { get; }
+
+    /// <summary>
+    /// What <c>POST /gateway/brain/restart</c> actually performs. Defaults to the real warm-brain restart,
+    /// and production never assigns it - the default IS the production behaviour, so this is a seam, not a
+    /// switch, and there is no fallback path hiding behind it.
+    ///
+    /// It exists because that route is the one owner-settings route whose served-side proof could not
+    /// otherwise be honest (issue #1863). Its whole job is to start a coding-agent process, so a test that
+    /// drove the real handler would spawn one on the machine running the suite - which is exactly the
+    /// capability the hosted deny exists to prevent, and not an acceptable thing for a proof harness to do.
+    /// Proving the route by asking for it with the WRONG VERB and reading the 405 was the previous
+    /// compromise, and it proved only that the route was REGISTERED - never that the POST reaches this
+    /// handler.
+    ///
+    /// With this seam a test drives the exact path and verb, gets this handler's own receipt, and starts no
+    /// process. The revert arms can drive it too, so no mutation run leaves a stray agent behind.
+    /// </summary>
+    internal Func<CancellationToken, Task> BrainRestartAction { get; set; }
 
     /// <summary>The agent tool the brain runs as (issue #393), resolved at construction from
     /// config.json "brain_tool" (default: <see cref="BrainToolConfig.Default"/>, Claude Code).


### PR DESCRIPTION
Closes thefrederiksen/devthrottle#1863. Un-deny ledger: thefrederiksen/devthrottle_internal#908.

**This branch is a rebuild, not an edit.** The head this pull request carried until now (`c0ab3540`) was the abandoned first attempt: two files, twenty-two routes, based at `4fe2c3bb`. It was rejected twice and its base predated almost everything since merged. What is here now was written from scratch against current `origin/main` (`f5bb926f`), covers **thirty-one** routes across **three** endpoint classes, and answers all three reviews point by point. Nothing was salvaged from the old head.

## The defect

Thirty-one routes across `SettingsEndpoints`, `AiModelsEndpoint` and `TelemetryConsentEndpoint` read and write **process-global configuration with no tenant dimension anywhere in them**. `config.json` is one file for the whole process. On the hosted Gateway that means every write was a **fleet-wide mutation performed by whichever authenticated caller happened to send it** - and public signup on the backing account project is open, so "any authenticated caller" is the public.

Two of them are not disclosures but actions on shared infrastructure:

- `POST /gateway/brain/restart` starts a real coding-agent process, with permission prompts skipped, in a directory under the shared storage root.
- `PUT /gateway/injected-text` rewrites the preamble every agent launched on that machine is given at startup.

And `GET /gateway/injected-text` hands back the owner's own custom agent-launch instruction text - his words - to any caller.

## Denied, not partitioned - and why

There is **nothing to partition by**. These are not per-tenant records whose storage unit could carry a tenant; they are single global values, one per key. A per-tenant answer would have to be invented from an attribution that was never recorded, which is a **half-partition** - worse than an honest refusal, because it looks like isolation.

The concept does not survive the move either: this is the **owner's control panel for his own Gateway**, and on shared hosted infrastructure "the owner" is not a thing. Same reasoning already applied to the stats dashboard on thefrederiksen/devthrottle#1888.

**404 rather than 403**: on hosted these routes do not exist as a concept, so "not here" is the truthful answer. A 403 would imply some credential could reach them, and none can.

**It refuses, it does not serve empty.** An empty settings snapshot is a *false* statement where an absent one is merely absent.

## What the reviews asked for, and where each is answered

| Review point | Answered by | State |
| --- | --- | --- |
| 1. Five write routes had no deny proof - training capture, addressing mode, snooze default, snooze presets, time zone | All thirty-one routes and verbs are now one table, `OwnerSettingsRoutes`, driven by both sides | done |
| 2. Self-host controls never cleared the hosted variable and covered only fragments | `HostedOwnerSettingsSelfHostControlTests` sets it itself, to **both** non-hosted forms, asserts it took, and drives the whole family | done |
| 3. No named un-deny row per denied route | thefrederiksen/devthrottle_internal#908 - thirty-one named rows, each with its own condition | done |
| 4. No future-route probe | `HostedOwnerSettingsGroupFilterTests` plus `HostedOwnerSettingsSelfHostProbeTests`, **both directions**, all three families | done |
| 5. Media type not asserted before parsing, so a masked route crashes instead of distinguishing | Status and media type asserted before every parse, on both sides | done |
| 6. Revert-proof run only against a focused slice | Re-registered below against the new structure; **outstanding - needs the test lane** | **pending** |
| 7. Both `outer` and the guarded group in scope at every route mapping - 31 uncounted bypasses | Each family's routes moved into a private `MapRoutes` receiving only the guarded group; the bypass no longer compiles | done |
| 8. Brain restart had no served-side handler proof, and the mutation plan would spawn a process | Injected restart seam - exact path and verb, handler receipt, destructibility control, no process on any arm | done |
| 9. Transcription mode had no observable write effect | Proved by a seeded transition off the opposite stored value | done |
| 10. The uniform no-purge ledger claim is not established | Withdrawn and corrected - every row now requires quarantine or migration first | done |

## The deny shape

Each of the three endpoint classes puts **one endpoint filter on the route group it maps**, gated on `GatewayHostedMode.IsHosted` **directly** - never on an optional or nullable argument, which fails **open** the moment a caller omits it. The group uses an empty prefix, so every route path stays written out in full and the self-host surface is byte-identical.

A guard repeated per handler **rots**: the route added to one of these files next year would be open on hosted by default and nothing would fail. A group filter runs before every route mapped below it, **including routes that do not exist yet**.

That difference is invisible to any test that drives only the thirty-one routes that exist today - a per-route guard and a group filter behave identically on all of them. **That is precisely why the property the design rests on is the one nothing otherwise tests.** So all three `Map` methods now return their `RouteGroupBuilder`, and `HostedOwnerSettingsGroupFilterTests` maps a **brand-new route** onto each group and finds it refused with no deny written for it anywhere. The served half - the same probe paths, hosted mode explicitly off, in both non-hosted forms - is `HostedOwnerSettingsSelfHostProbeTests`. One direction alone cannot tell a working gate from a brick: a filter that refused everything unconditionally would pass every hosted assertion while having silently killed the routes for self-host too.

`TelemetryConsentEndpoint` is mapped onto the **outer** builder, not into the settings group, deliberately: it carries its own filter, and two filters over the same routes would mean deleting either one alone left them still refused - so neither could be attributed by a revert. One family, one filter, one thing to revert.

## How thirty-one routes are covered - the rule, stated rather than sampled

**Every route and verb is driven on both sides. There is no sampling.** The route table is written once and both sides read it, which is what makes "every route, both directions" checkable rather than a sentence in a pull request.

Hosted side: all thirty-one, each refused with a body whose property set is **exactly** `["error"]`, asserted as an allow-list over the whole set - not a substring, which cannot see an extra leaked field, and not a deny-list of today's keys, which rots as the payload grows.

Self-host side, the harder half, because "the refusal is absent" is satisfied by an empty 200, by a single-page-application shell, and by a route that was deleted. Every route gets a **positive** fact instead, by one of four rules:

| Rule | Routes | What it asserts |
| --- | --- | --- |
| Real payload, field by field | 11 reads | The actual fields, and where independently knowable, the actual value read back through the Core config class |
| Independently re-read effect | 13 writes | The value goes over the wire, then comes back out of the **configuration store**, not the response - a handler that accepted and wrote nothing returns the same 200 |
| Served, and reaches a handler - the deliberately NARROWED claim | `PUT /gateway/transcription-mode` | See below. This route can carry no stronger claim, and that is proved rather than asserted |
| Effect that is a **reset**, proved against a sentinel | `PUT /gateway/ai-provider` | A value the reset cannot produce is written first, so "unchanged" and "reset" cannot be confused |
| Handler-unique receipt | 4 routes | A status and sentence only that one handler can produce - the brain-config rejection, the two credential-resolution 503s, and autostart's `{ supported: false }` |

That is thirty. The thirty-first is `POST /gateway/brain/restart`, and it is the **one deliberate exception**: its whole job is to start a process, so invoking it on the served side would spawn one. It is proved instead by a **routing-table existence fact** - a GET to that path answers 405 with `Allow: POST`, a positive statement from the routing table that a POST endpoint is registered there, on a probe host with no single-page-application fallback where an unmapped path answers a bare 404 with an empty `Allow`. Put beside the POST being refused 404, the two say: the route exists on hosted, and the thing turning it away is the deny. **It proves the route is registered; it does not exercise the handler and makes no claim to.** That is written at the test rather than left to be discovered.

### The one narrowed claim, and why narrowing was the honest answer

Review asked for `PUT /gateway/transcription-mode` to either **seed a persistent transition** or have its **claim explicitly narrowed** if the route has no distinguishable mutation.

**The transition was attempted first, and continuous integration reddened it - correctly.** Seeding the store to the other enum value and reading it back returns `DevThrottle`. The setting is **single-valued by construction**: `TranscriptionMode.Byo` serialises to `"devthrottle"`, and `Parse` maps every legacy value (`"byo"`, `"openai"`, `"local"`, null, blank) forward to `DevThrottle`. No reachable stored state differs from what the route writes, so **no seeding strategy could distinguish the handler from a no-op**. That failure is what establishes the second option is the right one; it was not chosen to avoid work.

So the claim is now stated as exactly what it proves - the route is served on self-host and reaches a handler that reports the setting - and it is **no longer counted as an independently re-read effect, because it is not one**.

The narrowing is itself proved: `The_transcription_mode_setting_is_single_valued_so_no_write_is_observable` pins that every value the type can serialise writes `"devthrottle"` and every value it parses resolves to `DevThrottle`. **That test also reddens the day a second transcription mode is added**, so the caveat carries its own expiry date rather than outliving its cause and being read years later as a still-true fact.

One further caveat, called out rather than left looking like the others:

- `GET /gateway/ai/models` is proved by receipt rather than payload, because a real catalog would require a provider credential and an outbound call.

## Format facts before parsing, on both sides

Status and media type are asserted **before** any body is parsed. Parsing is itself an unstated assertion about format: on this Gateway a 404 is not necessarily JSON - the single-page-application fallback answers unmatched paths and can reply with plain text, or on a release host a 200 with HTML - so a test that parses first turns a real finding into a **crash**. A crash proves something upstream broke; it cannot say **what was served in place of the refusal**, which is the entire claim a deny makes. This was review point 5 and it applies to the served side just as much.

## Test isolation - and why it ships here rather than separately

Six existing test classes drive routes that are now mode-sensitive. Before this change those routes answered the same way in both modes, so none of them cared what `CC_GATEWAY_HOSTED` said; now a hosted-mode class running in parallel would turn their 200 into a 404, intermittently, for reasons entirely outside their own files. **The deny is what creates that need, so the fix belongs in the change that creates it** - shipping the deny without it would be shipping a defect into somebody else's tests.

They move into a new `GatewayHostedMode` collection with parallelization disabled. That is **strictly stronger** than the `DirectorRoot` collection five of them carried - running alone subsumes running serially with a subset - so nothing was weakened by the move. A search of `origin/main` for every one of the thirty-one route paths across all test projects returns exactly these six files, so the move is complete rather than sampled.


## The un-deny sentence - CORRECTED, and it is not what I first claimed

The first version of this pull request said the sentence was uniformly *"the write is stopped"* across all thirty-one routes and that **no purge would be needed** before a future un-deny. **That was an overclaim. It is withdrawn.**

The error was in the frame. The sweep behind it asked *"which routes write these configuration keys"*, found every one inside the three files being denied, and concluded nothing else could write. But a deny closes **one door**. The question that supports a no-purge claim is not whether the denied routes write - it is whether **anything** writes.

The widened sweep:

- `CcDirectorConfigService.MergePatch` is the single write authority for `config.json`, and it is called from **many production surfaces outside these three files** - the desktop application, the Director's control interface, onboarding, the browser-default store, the agent registry, telemetry settings. Those are other processes, which makes the claim a **deployment-isolation** claim, and deployment isolation is not proved anywhere.
- A hosted `config.json` **can already hold values written before this deny existed**, or by an operator. The deny stops future writes through these routes; it does nothing about what is already there.

Re-reading the store after nineteen requests - all the original evidence did - refutes neither.

### The sweep, stated precisely enough to be audited

The question asked was **"what writes this state"**, not "what writes it through these routes". Three legs:

1. **Is `MergePatch` the only production write authority for `config.json`?** Yes. `CcDirectorConfigService` has exactly one write path - `MergePatch`, which serialises to a temporary file and atomically moves it over `config.json`. A search for any direct write to that file across the repository returns **only test fixtures**, no production code.
2. **Does anything inside the hosted Gateway process write these keys outside the three denied files - in particular at host startup?** **No.** Every `MergePatch` call and every `*Config.Set` call reachable in `CcDirector.Gateway` and `CcDirector.HostedAgent` is inside `SettingsEndpoints.cs`, `AiModelsEndpoint.cs`, or `TelemetryConsentEndpoint.cs`. There is no startup writer and no background writer. This was checked specifically, because the sibling key-vault unit found exactly that failure - a writer running at host startup, before the hosted check everyone assumed guarded it. **That failure mode does not exist here**, and it is recorded as checked rather than assumed.
3. **Does anything OUTSIDE that process write the same file?** **Yes** - the desktop application, the Director's control interface, onboarding, the browser-default store, the agent registry and the telemetry settings all call `MergePatch`. They are other processes, so whether they can reach a hosted Gateway's `config.json` is a **deployment-isolation** question, and deployment isolation is not proved anywhere.

Leg 3, plus the fact that a hosted `config.json` **can already hold values written before this deny existed**, is why the no-purge claim is withdrawn. Leg 2 is why the narrower claim - the write through these handlers is stopped - survives.


**So every row is now the second kind of sentence:**

> Removing the deny requires ALSO purging or partitioning what accumulated behind it - specifically, the pre-existing process-global settings must be quarantined or migrated before any tenant-scoped un-deny, unless deployment isolation is proved at that time.

The narrower statement that **is** proved, and is kept as such: **the write through these handlers is stopped** - every one of the nineteen non-read routes is refused before its handler runs, proved by an independent re-read of the configuration store, so no tenant can add to that state through this surface while the deny holds. That is real, and it is simply not the same claim.

thefrederiksen/devthrottle_internal#908 carries this correction in full, at the top, above the thirty-one rows.

## The bypass the earlier revision shipped, and why it now does not compile

The previous head advertised three bypassable primitives. **That count was wrong, and the review was right to reject it.** Both `outer` (ungrouped) and the guarded group were in scope where every production route was mapped, so **any one of the thirty-one routes could be moved onto `outer` by a one-word edit** - opening that route alone while every other stayed correctly denied. The future-route probes could not see this: they prove a route *placed on the group* inherits the filter, never that the production routes are *on* the group. The true count was thirty-four, and thirty-one of them had no proof at all.

Each family's routes now live in a private `MapRoutes` that receives **only** its guarded `RouteGroupBuilder`. Inside it there is nothing to map onto except the guarded group, so the bypass is **inexpressible rather than merely unlikely**. This is the shape the key-vault rework uses in `VaultEndpoints`, which is already reviewed; it is worth comparing the two directly.

Verified rather than asserted: injecting `outer.MapGet(...)` inside `MapRoutes` fails to build with

```
error CS0103: The name 'outer' does not exist in the current context
```

`TelemetryConsentEndpoint.Map(outer)` is called from `SettingsEndpoints.Map`, the one method that still holds `outer`, precisely so `outer` need not stay in scope where routes are mapped.

**Thirty-four primitives down to three, by design.** Three is the floor for three families: a shared guard helper would still leave three deletable call sites, so it would reduce the number by argument rather than by construction. Collapsing to a single primitive is possible - one guarded group shared by all three families - but it would force one refusal message across three families and merge three revert attributions into one. That is a design call worth making deliberately rather than as a side effect of chasing a smaller number.

## Revert-proof - re-registered against the new structure

**Outstanding; needs the test lane.** Registered before the runs so a predicted red that fails to appear is a finding.

**Three mutations, three full Gateway suite runs, plus a green baseline and a restored run.** Each mutation **deletes the `AddEndpointFilter` block outright**, leaving `MapGroup("")` so the file compiles, with no per-route guard put back. Never `if (false)` - unreachable code is a build error here. Every run is preceded by a build at 0 errors and 0 warnings, because a run after a failed build executes a stale binary and reports a false pass.

The thirty-one mapping bypasses are **not** mutation-proved, deliberately: they are compile errors, and a mutation arm that cannot build is not an arm. That is the reduction the scope split buys.

| Mutation | Predicted red | Must stay green |
| --- | --- | --- |
| A. Delete the filter in `SettingsEndpoints.Map` | The 22 settings rows of `Every_owner_settings_route_is_refused_on_hosted`; `The_refusal_is_not_an_empty_settings_snapshot`; `A_refused_write_does_not_reach_the_configuration_store`; `The_refused_brain_restart_never_invokes_the_restart_action`; the `settings` row of the future-route probe | The 9 models and telemetry rows; `An_unauthenticated_caller_is_still_rejected`; all 3 rows of `A_route_outside_the_group_still_serves_on_hosted`; the brain-restart registration fact; every self-host control and probe row |
| B. Delete the filter in `AiModelsEndpoint.Map` | The 7 models rows; `A_refused_write_does_not_reach_the_configuration_store`; the `models` probe row | The 24 settings and telemetry rows; `The_refusal_is_not_an_empty_settings_snapshot`; `The_refused_brain_restart_never_invokes_the_restart_action`; all the same controls |
| C. Delete the filter in `TelemetryConsentEndpoint.Map` | The 2 telemetry rows; `A_refused_write_does_not_reach_the_configuration_store`; the `telemetry` probe row | The 29 settings and models rows; `The_refusal_is_not_an_empty_settings_snapshot`; all the same controls |

**Every predicted red must arrive as an assertion, not a crash.** Reds are classified by arrival; a crash red counts as a failure of the proof, because it cannot say what was served.

**The spawn hazard is gone.** The earlier plan knowingly drove the live restart path on mutation A and could have left a coding-agent process behind - the reviewer was right that this is not an acceptable proof harness. The hosted deny class now installs a non-spawning restart seam, so **no arm of this sweep can start a process**, and `The_refused_brain_restart_never_invokes_the_restart_action` turns that seam into a stronger deny assertion than the status code alone.


## Continuous integration - green on attempt 2, and the red is UNATTRIBUTED rather than fixed

`Build & Test (web)`: pass. `Build & Test (.NET)`: **failed on attempt 1, passed on attempt 2, on the identical commit `eebedebb`** with nothing changed between them (run 29733899417, `run_attempt` 1 = failure, 2 = success).

**This is stated as an unattributed red, not a fixed one.** A re-run is a diagnostic, never a remedy, and one flip on a timing-sensitive test does not establish a cause. It establishes only that the result is not deterministic on this commit.

The red, named specifically rather than waved at:

- `CcDirector.Gateway.Tests.TunnelMechanismProofTests.Producer_blocksOnAStalledSink_overTheRealSignalRStreamBuffer`, at line 304 - `Assert.Equal(pinned, Volatile.Read(ref yielded))`, expected 35, actual 57.
- That assertion requires an up-stream producer, already pinned by full socket and pipe buffers, to advance by **exactly zero** over a further one-second window. On a loaded shared runner it advanced by 22.

**Why this change is not the cause, stated precisely rather than glibly.** The test boots a real `GatewayHost`, and this branch does modify `GatewayHost.cs` - so "my diff does not touch that file" would be false and is not the claim. The claim is narrower and checkable: the entire production change to that file is **two added code lines and no deletions or modifications** -

```
+    internal Func<CancellationToken, Task> BrainRestartAction { get; set; }
+        BrainRestartAction = ct => Brain.RestartAsync(ct);
```

- a property and one constructor assignment, on the brain-restart path, which this test never invokes. Nothing in the hub, the streaming path, the MessagePack protocol, or the backpressure mechanism is altered by this branch. The other three production files are the owner-settings endpoint classes.

**The prior head `403f904e` is the control**: that run reddened on two of my own transcription-mode tests and this tunnel test **passed**. So the tunnel test has passed and failed on both heads of this branch, which is the shape of a timing flake rather than a regression.

**Booked as its own finding: thefrederiksen/devthrottle_internal#910**, carrying the two-attempt evidence, the run and job identifiers, and the mechanism - the test declares the producer "pinned" after roughly 800 milliseconds without advance, then asserts it advances by **exactly zero** over a further second. That promotes a temporal sample to a permanent property, which no widening of either window can make deterministic; the file's last commit, thefrederiksen/devthrottle#1471, was exactly such a widening. That history is recorded there as evidence the problem is **known**, explicitly not that it is acceptable.

thefrederiksen/devthrottle_internal#910 also notes that the flaky assertion is **stricter than the property the test exists to prove**: backpressure is already asserted soundly by the two `< total` checks, neither of which is flaky.

**No standing flaky-test exemption is claimed here, and thefrederiksen/devthrottle_internal#910 says so in its own text.** This red is named, bounded, and re-checked on its own head, and any future occurrence would have to be re-checked the same way rather than waved through by citing the issue.

## Build

`CcDirector.Gateway` and `CcDirector.Gateway.Tests` build at **0 errors, 0 warnings** on this head.
