### PR TITLE
fix(gateway): store per-device keys hashed at rest, never in plaintext

### DIFF
--- a/docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md
+++ b/docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md
@@ -25,6 +25,35 @@ token injected into the page**, so reaching the URL (or viewing page source) was
 unrevocable fleet control. That token is gone from the shell. The phone now holds only (C) - a local,
 per-device, individually revocable key that is not the master token and not a cloud credential.
 
+### 1a. The device registry is a high-value store (issue #1878)
+
+`DeviceRegistry` persists to `config/director/devices.json` under `CC_DIRECTOR_ROOT`. That one file is
+both the Gateway's credential store for credential (C) and, on the hosted Gateway, the authoritative
+device-to-account-to-tenant map for every tenant on the box - and on hosted it sits on a mounted Azure
+Files share. It must be treated as a high-value store wherever it is discussed, on self-host and on
+hosted alike.
+
+It used to hold each device key in **plaintext**, so anything that could read the file could impersonate
+every enrolled device - which is also what made a process spawned with a working directory on that same
+share (issue #1863) a credential-exfiltration problem rather than only a code-execution one.
+
+Each key is now stored **only as a one-way SHA-256 hash**. The Gateway never needs the key itself: it
+issues the plaintext to its owner once at enrollment and thereafter only VERIFIES a presented key, the
+same way a password store does. A read of `devices.json` therefore yields no usable credential. Two
+consequences follow and are deliberate:
+
+- The hash is a plain SHA-256, not a slow password-stretching function, because the secret is a 256-bit
+  value the Gateway generated with a cryptographic random number generator, not a human-chosen password.
+  There is no guessable search space to stretch against, and this lookup runs on the hot path of every
+  authenticated request.
+- A device that re-enrolls is issued a **fresh** key in place - the registry has no plaintext to hand
+  back. Its entry, its account and tenant binding, and its cloud mapping are all preserved, and it still
+  has exactly one valid key. A device that simply keeps using the key it already holds is unaffected: a
+  registry file written before the change is migrated on load, so keys issued before this keep working.
+
+The file remains a real target for its non-secret contents (which accounts and tenants exist, and which
+machines are enrolled). Hashing removes the bearer secret from it, not the metadata.
+
 ---
 
 ## 2. Trust boundaries (what crosses which line)
@@ -130,6 +159,7 @@ forever unseen.
 | A leaked phone key compromises the account/fleet | (C) is one revocable device key; it is not (A), (B), (D), or the master token |
 | A stolen/lost phone keeps access | Revoke the one device from the website; the reconcile sweep drops (C) |
 | Cloud outage locks the phone out | Steady-state validation of (C) is fully local; no cloud dependency after enrollment |
+| Reading the Gateway's registry file yields every device's key | (C) is stored only as a one-way hash, so `devices.json` holds no usable credential (issue #1878, section 1a) |
 
 ---
 

--- a/docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md
+++ b/docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md
@@ -51,8 +51,32 @@ consequences follow and are deliberate:
   has exactly one valid key. A device that simply keeps using the key it already holds is unaffected: a
   registry file written before the change is migrated on load, so keys issued before this keep working.
 
+Enrollment stays safe to RETRY. Because the registry can no longer hand back a stored key, a repeated
+enrollment would otherwise rotate the key on every call - and a caller that lost or had not yet saved the
+first response would then be holding a retired key and locked out. So an issued key stays replayable for a
+short window held **in this process's memory only**: a duplicate or retried enrollment inside that window
+gets the same key back and nothing rotates. It is never serialized and does not survive a restart, so the
+at-rest property is unaffected. Past the window a further enrollment rotates in place as described above.
+
 The file remains a real target for its non-secret contents (which accounts and tenants exist, and which
 machines are enrolled). Hashing removes the bearer secret from it, not the metadata.
+
+### What the migration does NOT do
+
+The migration rewrites the **live** registry file. That is the limit of the claim, and it should not be
+read as secure erasure. Rewriting a file cannot reach a copy of the old contents that something else
+already took - a storage-share snapshot, a backup, a soft-delete retention window, or file-system history
+all retain whatever the file held before, and no amount of writing from inside the Gateway touches them.
+
+On the hosted Gateway the registry sits on a mounted Azure Files share, where snapshots and soft delete are
+account-level and share-level settings held outside this repository; nothing in the repository configures or
+disables them, so whether pre-change copies are being retained is a property of the deployed storage account
+and has to be checked there rather than inferred from code. Where such retention is found, two things follow
+and both are separate operational work, tracked separately from this change:
+
+1. Purge the retained copies of the pre-change `devices.json`.
+2. Treat every key that appeared in plaintext in those copies as exposed and **rotate it**. Rotation, not
+   file cleanup, is what actually ends the exposure - a copy may already have been read.
 
 ---
 

--- a/docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md
+++ b/docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md
@@ -58,6 +58,19 @@ short window held **in this process's memory only**: a duplicate or retried enro
 gets the same key back and nothing rotates. It is never serialized and does not survive a restart, so the
 at-rest property is unaffected. Past the window a further enrollment rotates in place as described above.
 
+That in-memory window is a real, if small, exposure, and the thing that makes it acceptable is that it is
+short-lived - so short-livedness is **enforced, not assumed**. The registry starts a recurring eviction pass
+the moment it first retains a key, and that pass drops every issue whose window has closed regardless of
+whether any device ever enrolls again. Plaintext is held for at most one and a half windows, no more than
+seven and a half minutes by default, and shutting the registry down ends it at once.
+
+The subtlety is worth recording, because the first implementation got it wrong in a way that looked right:
+it checked an entry's age only when an already-enrolled device asked to replay. That correctly refuses to
+hand back an expired key, but it does nothing about retention, because the ordinary case - a device that
+enrolls once under its own identifier and never comes back - never reaches the check. Every such key stayed
+resident for the life of the process. Refusing to serve an expired secret and bounding how long the secret
+is kept are two different jobs, and only the second one needs a clock of its own.
+
 The file remains a real target for its non-secret contents (which accounts and tenants exist, and which
 machines are enrolled). Hashing removes the bearer secret from it, not the metadata.
 

--- a/src/CcDirector.Gateway.Contracts/DeviceEnrollment.cs
+++ b/src/CcDirector.Gateway.Contracts/DeviceEnrollment.cs
@@ -51,7 +51,9 @@ public sealed class DeviceRegistrationResponse
 /// <summary>
 /// One device's public-facing entry in the Gateway device registry (issue #469): the
 /// host-readable record used to list registered devices. The per-device key itself is NEVER
-/// included - the registry serves identity and status, not the secret.
+/// included - the registry serves identity and status, not the secret. It DOES carry a NON-SECRET
+/// masked key identity (<see cref="KeyPrefix"/> / <see cref="KeyLast4"/>, issue #1899) so a listing can
+/// tell devices apart by key without ever substituting or exposing the raw key.
 /// </summary>
 public sealed class RegisteredDeviceDto
 {
@@ -66,4 +68,15 @@ public sealed class RegisteredDeviceDto
 
     /// <summary>The device's status (e.g. <c>active</c>, <c>revoked</c>).</summary>
     public string Status { get; set; } = "";
+
+    /// <summary>
+    /// The NON-SECRET first few characters of the device's key (issue #1899) - masked display metadata so a
+    /// host can recognise which key a device holds without the registry ever returning the raw key. Reveals a
+    /// handful of a 256-bit key and is not a credential. Empty for a record with no recorded key identity.
+    /// </summary>
+    public string KeyPrefix { get; set; } = "";
+
+    /// <summary>The NON-SECRET last few characters of the device's key (issue #1899), the trailing half of the
+    /// masked key identity. Not a credential.</summary>
+    public string KeyLast4 { get; set; } = "";
 }

--- a/src/CcDirector.Gateway.Contracts/DeviceEnrollment.cs
+++ b/src/CcDirector.Gateway.Contracts/DeviceEnrollment.cs
@@ -3,8 +3,9 @@ namespace CcDirector.Gateway.Contracts;
 /// <summary>
 /// A co-located Director's request to enroll with its own Gateway using the DevThrottle account
 /// sign-in instead of a pairing code (issue #1069). The Director POSTs this to
-/// <c>/devices/enroll-signed-in</c>; the Gateway mints (or, if this device already has one, returns)
-/// the Director's own per-device key - gated on the Gateway being signed in to DevThrottle AND the
+/// <c>/devices/enroll-signed-in</c>; the Gateway issues the Director's own per-device key - a fresh one
+/// if this device is already enrolled, since the registry keeps only a hash of the key it issued and so
+/// has no plaintext to hand back (issue #1878) - gated on the Gateway being signed in to DevThrottle AND the
 /// caller being a loopback same-machine connection. There is no pairing code: signing in is the
 /// authorization. Carries no credential of its own; the loopback origin plus the Gateway's signed-in
 /// account are the proof.

--- a/src/CcDirector.Gateway.Tests/DeviceKeyAtRestTests.cs
+++ b/src/CcDirector.Gateway.Tests/DeviceKeyAtRestTests.cs
@@ -6,18 +6,21 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// Issue #1878: the device registry file used to hold every enrolled device's per-device key in
+/// Issue #1878 / #1899: the device registry file used to hold every enrolled device's per-device key in
 /// PLAINTEXT. That key is a bearer secret - it authenticates every Director-to-Gateway call - and on the
 /// hosted Gateway the one file holds every tenant's device on shared infrastructure, so anything that
 /// could read the file could impersonate every tenant's Director.
 ///
-/// These tests pin the fix from both ends:
+/// These tests pin the fix from several ends:
 ///   1. WHAT IS WRITTEN: the file must contain no usable credential - the plaintext key must not appear
 ///      in it, and what does appear must be the one-way hash.
 ///   2. WHAT KEEPS WORKING: a device enrolled BEFORE the change - whose key exists only in the plaintext
 ///      file and in that machine's credential file - must still authenticate afterwards, and must still
 ///      resolve to its bound tenant. There is no re-enrollment path that does not involve a human, so a
 ///      change that invalidated those keys would take the live hosted box down.
+///   3. NO PLAINTEXT IS EVER RETAINED (issue #1899): plaintext is disclosed at exactly one point - the
+///      enrollment response - and kept nowhere. A REPEAT enrollment cannot re-reveal the current key; it
+///      rotates to a fresh one instead. The registry holds no plaintext cache to leak or to replay.
 /// </summary>
 public sealed class DeviceKeyAtRestTests : IDisposable
 {
@@ -210,6 +213,23 @@ public sealed class DeviceKeyAtRestTests : IDisposable
     }
 
     [Fact]
+    public void Migration_RecordsTheMaskedKeyIdentity_FromThePlaintextBeforeDroppingIt()
+    {
+        // Issue #1899: a migrated device must gain the same non-secret masked key identity a freshly-enrolled
+        // one has, computed from the plaintext while it is still in hand and BEFORE it is dropped - otherwise a
+        // pre-change device would list with no key identity at all.
+        const string alreadyIssuedKey = "pre-change-key-Ab3xQ9zK-do-not-invalidate";
+        WritePreChangeStore("device-already-enrolled", alreadyIssuedKey, "tenant-already-enrolled");
+
+        var entry = Assert.Single(new DeviceRegistry(StorePath).List());
+
+        Assert.Equal(alreadyIssuedKey.Substring(0, 8), entry.KeyPrefix);
+        Assert.Equal(alreadyIssuedKey.Substring(alreadyIssuedKey.Length - 4), entry.KeyLast4);
+        // And the masked identity is not the whole key - it is a hint, never a credential.
+        Assert.False(alreadyIssuedKey.Contains(entry.KeyPrefix + "..." + entry.KeyLast4, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Migration_DoesNotMakeEveryKeyValid()
     {
         // The control on the migration: hashing an existing record must not turn the registry into
@@ -236,34 +256,88 @@ public sealed class DeviceKeyAtRestTests : IDisposable
         Assert.False(registry.IsValidDeviceKey(ExpectedHash(issued).ToUpperInvariant()));
     }
 
-    // ---- Re-enrollment: one entry, exactly one valid key ---------------------------------------
+    // ---- 3. No plaintext is ever retained: a repeat enrollment ROTATES, never replays -----------
     //
-    // A registry with a ZERO replay window is a registry in which every call is treated as being past the
-    // window, which is how these tests reach the rotate-in-place branch deterministically. The idempotence
-    // tests below use the default window and the same constructor, so the two branches are exercised by the
-    // same code under two settings rather than by two different code paths.
-
-    private DeviceRegistry PastTheReplayWindow() => new(StorePath, TimeSpan.Zero);
+    // Hashing the stored key removed the registry's ability to hand a re-enrolling device its existing key
+    // back. The first attempt at retry-safety kept a short-lived plaintext copy so a duplicate could REPLAY
+    // it - but that made the current bearer credential retrievable again by simply repeating enrollment,
+    // which defeats hashing at rest (issue #1899). The fix removes the plaintext cache entirely: a repeat
+    // enrollment rotates to a FRESH key and retires the previous one, so nothing is retained and nothing is
+    // re-revealed.
+    //
+    // Retry-safety survives because enrollment is a one-shot, deliberate act (never a poll-loop call): the
+    // retry that actually happens is a sequential re-attempt after a failed response, and each attempt hands
+    // back a fresh working key the caller writes down. These tests pin that, together with the #1136
+    // one-key-per-device cap.
 
     [Fact]
-    public void ReEnrollingADevice_PastTheReplayWindow_LeavesExactlyOneValidKeyAndOneEntry()
+    public void EnrollingTwice_RotatesToAFreshKey_AndNeverReplaysThePreviousOne()
     {
-        var registry = PastTheReplayWindow();
+        var registry = new DeviceRegistry(StorePath);
 
         var first = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
         var second = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
 
         Assert.NotEqual(first, second);
-        Assert.Equal(1, registry.Count);
-        Assert.True(registry.IsValidDeviceKey(second), "the key just handed to the caller must work");
+        Assert.True(registry.IsValidDeviceKey(second), "the freshly returned key must authenticate");
         Assert.False(registry.IsValidDeviceKey(first),
-            "re-enrolling must RETIRE the previous key, never leave two working credentials for one device");
+            "a repeat enrollment must NOT re-reveal or keep alive the previous key - that is the #1899 leak");
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public void ASequentialRetry_AlwaysReturnsAWorkingKey_SoTheCallerIsNeverLockedOut()
+    {
+        // The lost-response scenario stated directly: the caller never received the first key (so it holds
+        // nothing), retries, and must come away holding a valid credential. Rotation makes every attempt hand
+        // back a fresh working key - the caller writes whichever one it receives.
+        var registry = new DeviceRegistry(StorePath);
+
+        string last = "";
+        for (var retry = 0; retry < 5; retry++)
+            last = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+
+        Assert.True(registry.IsValidDeviceKey(last),
+            "the key from the caller's latest successful response must authenticate");
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public void EnrollingManyTimes_LeavesExactlyOneValidKey()
+    {
+        // Rotation must not have been bought by leaving OLD keys working alongside new ones - that is exactly
+        // the #1136 accumulation leak. One device, one key that validates, however many calls.
+        var registry = new DeviceRegistry(StorePath);
+
+        var keys = new List<string>();
+        for (var call = 0; call < 6; call++)
+            keys.Add(registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey);
+
+        Assert.Equal(6, keys.Distinct(StringComparer.Ordinal).Count()); // every call rotated
+        Assert.Single(keys, registry.IsValidDeviceKey);                 // and only the last still validates
+        Assert.Equal(keys[^1], keys.Single(registry.IsValidDeviceKey));
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public void ConcurrentEnrollmentsOfOneDevice_LeaveExactlyOneValidKey_AndOneEntry()
+    {
+        // Sixteen enrollment calls in flight at once must not corrupt the one-key-per-device invariant: the
+        // method is serialized, so they rotate one after another and end with a single entry and exactly one
+        // key that validates (the last winner).
+        var registry = new DeviceRegistry(StorePath);
+        var issued = new System.Collections.Concurrent.ConcurrentBag<string>();
+
+        Parallel.For(0, 16, _ => issued.Add(registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey));
+
+        Assert.Equal(1, registry.Count);
+        Assert.Single(issued, registry.IsValidDeviceKey);
     }
 
     [Fact]
     public void ReEnrollingADevice_KeepsItsAccountAndTenantBinding()
     {
-        var registry = PastTheReplayWindow();
+        var registry = new DeviceRegistry(StorePath);
         registry.RegisterIfAbsent("device-a", "MACHINE-A");
         registry.SetAccountBinding("device-a", "sub-alice", "tenant-alice");
 
@@ -272,90 +346,10 @@ public sealed class DeviceKeyAtRestTests : IDisposable
         Assert.Equal("tenant-alice", registry.TenantForKey(reissued));
     }
 
-    // ---- Enrollment is safe to retry (the idempotence property) --------------------------------
-    //
-    // Hashing the stored key removed the registry's ability to hand a re-enrolling device its existing key
-    // back, which turned every duplicate enrollment into a ROTATION. A caller that had not yet durably saved
-    // the first response - a lost or delayed response, a double submit, two calls in flight - would then be
-    // holding a key that the later call had already retired, and would be locked out until a human
-    // re-enrolled it. That is a production outage created by a security fix, and it only appears on a retry.
-    //
-    // These tests pin the property that closes it: inside the replay window a duplicate enrollment returns
-    // the SAME key and rotates nothing. Each is paired with the destructibility control below, so that "the
-    // key survived a second call" is read as protection and not as the registry having quietly lost the
-    // ability to retire keys at all.
-
     [Fact]
-    public void EnrollingTwice_ReturnsTheSameKey_SoARetryCannotLockTheCallerOut()
+    public void AnExplicitRePairing_AlsoRetiresThePreviousKey()
     {
-        var registry = new DeviceRegistry(StorePath);
-
-        var first = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
-        var second = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
-
-        Assert.Equal(first, second);
-        Assert.True(registry.IsValidDeviceKey(first),
-            "the key from the FIRST response must still authenticate - a caller may have saved that one and not the second");
-        Assert.Equal(1, registry.Count);
-    }
-
-    [Fact]
-    public void ARetriedEnrollment_DoesNotRetireTheKeyTheCallerAlreadyHolds()
-    {
-        // The lock-out scenario stated directly: the caller keeps the key from the first response, the
-        // enrollment call is retried because the response never arrived, and the held key must keep working.
-        var registry = new DeviceRegistry(StorePath);
-        var keyTheCallerSaved = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
-
-        for (var retry = 0; retry < 5; retry++)
-            registry.RegisterIfAbsent("device-a", "MACHINE-A");
-
-        Assert.True(registry.IsValidDeviceKey(keyTheCallerSaved),
-            "five retried enrollments must not lock out the device that is holding the key from the first response");
-        Assert.Equal(1, registry.Count);
-    }
-
-    [Fact]
-    public void ConcurrentEnrollmentsOfOneDevice_AllResolveToTheSameKey()
-    {
-        // Two (here, sixteen) enrollment calls in flight at once must converge on ONE issued key rather than
-        // racing to rotate, or the losers of the race are handed keys that are dead on arrival.
-        var registry = new DeviceRegistry(StorePath);
-        var issued = new System.Collections.Concurrent.ConcurrentBag<string>();
-
-        Parallel.For(0, 16, _ => issued.Add(registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey));
-
-        var distinct = issued.Distinct(StringComparer.Ordinal).ToList();
-        Assert.Single(distinct);
-        Assert.True(registry.IsValidDeviceKey(distinct[0]));
-        Assert.Equal(1, registry.Count);
-    }
-
-    [Fact]
-    public void EnrollingTwice_StillLeavesExactlyOneValidKey()
-    {
-        // Idempotence must not have been bought by leaving the OLD key working alongside a new one - that is
-        // precisely the #1136 accumulation leak. One device, one key that validates, however many calls.
-        var registry = new DeviceRegistry(StorePath);
-
-        var keys = new List<string>();
-        for (var call = 0; call < 6; call++)
-            keys.Add(registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey);
-
-        var distinct = keys.Distinct(StringComparer.Ordinal).ToList();
-        Assert.Single(distinct);
-        Assert.Single(distinct, registry.IsValidDeviceKey);
-    }
-
-    // ---- Destructibility controls ---------------------------------------------------------------
-    //
-    // Without these, every assertion above is satisfied just as well by a registry that has lost the ability
-    // to retire a key at all. These show the mechanism CAN retire one, on both of the paths that are supposed
-    // to: an explicit re-pairing, and a re-enrollment once the replay window has closed.
-
-    [Fact]
-    public void DestructibilityControl_AnExplicitRePairing_DoesRetireThePreviousKey()
-    {
+        // Register (a re-pairing) rotates in place too: the previous key stops validating.
         var registry = new DeviceRegistry(StorePath);
         var enrolled = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
 
@@ -364,184 +358,16 @@ public sealed class DeviceKeyAtRestTests : IDisposable
         Assert.NotEqual(enrolled, rePaired);
         Assert.True(registry.IsValidDeviceKey(rePaired));
         Assert.False(registry.IsValidDeviceKey(enrolled),
-            "an explicit re-pairing must retire the previous key - if it does not, the idempotence tests above prove nothing");
-    }
-
-    [Fact]
-    public void DestructibilityControl_OnceTheReplayWindowCloses_ARepeatEnrollmentRetiresThePreviousKey()
-    {
-        var registry = PastTheReplayWindow();
-        var first = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
-
-        var second = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
-
-        Assert.NotEqual(first, second);
-        Assert.False(registry.IsValidDeviceKey(first),
-            "past the replay window a repeat enrollment must rotate - the window bounds the idempotence, it does not remove rotation");
-    }
-
-    [Fact]
-    public void DestructibilityControl_AfterARePairing_TheSupersededKeyIsNotReplayedBack()
-    {
-        // The replay entry must be checked against what the record currently verifies, not handed out on age
-        // alone. An explicit re-pairing rotates the key without going through the replay path, so a following
-        // enrollment must NOT resurrect the key the re-pairing just retired.
-        var registry = new DeviceRegistry(StorePath);
-        var enrolled = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
-        var rePaired = registry.Register("device-a", "MACHINE-A").DeviceKey;
-
-        var afterRePairing = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
-
-        Assert.NotEqual(enrolled, afterRePairing);
-        Assert.False(registry.IsValidDeviceKey(enrolled),
-            "the key the re-pairing retired must stay retired - a stale replay entry must never hand it back");
-        Assert.True(registry.IsValidDeviceKey(afterRePairing));
+            "an explicit re-pairing must retire the previous key");
         Assert.Equal(1, registry.Count);
-        // The re-paired key is still fine on its own terms; the point is that the SUPERSEDED one is gone.
-        Assert.False(string.IsNullOrEmpty(rePaired));
-    }
-
-    // ---- Retention of the replayable plaintext is actually bounded ------------------------------
-    //
-    // The retry-safety window holds an issued key in memory. What made that acceptable is that it is
-    // SHORT-LIVED - and that was the property nothing tested. The first version pruned only when an
-    // already-enrolled device asked to replay, so the ordinary case (a device enrolls once under its own id
-    // and never comes back) never reached the prune and its plaintext key stayed resident for the life of the
-    // process. Checking an entry's age at replay time stops an expired key being RETURNED; it does not bound
-    // RETENTION. These tests assert retention directly rather than inferring it from behaviour that would
-    // still look correct while the plaintext sat in memory.
-    //
-    // A hand-driven scheduler is used so both halves are proven without waiting on a clock: that the registry
-    // SCHEDULES an eviction pass at all, and that the pass RELEASES the plaintext.
-
-    /// <summary>Captures the recurring eviction pass instead of running it on a timer, so a test can fire it
-    /// on demand. Waiting on a real timer would make the result depend on machine load, not on the code.</summary>
-    private sealed class HandDrivenEviction
-    {
-        public TimeSpan? Interval { get; private set; }
-        private Action? _pass;
-        public bool WasScheduled => _pass is not null;
-        public void Schedule(TimeSpan interval, Action pass) { Interval = interval; _pass = pass; }
-        public void RunOnce() => (_pass ?? throw new InvalidOperationException(
-            "the registry never scheduled an eviction pass, so there is nothing to run")).Invoke();
     }
 
     [Fact]
-    public void TheRegistry_SchedulesARecurringEvictionPass_AsSoonAsItRetainsAKey()
+    public void NothingReplayableSurvivesARestart_AndTheRegistryHoldsNoPlaintext()
     {
-        // Half one: without this, the eviction policy below is dead code that nothing ever calls. The pass
-        // must be running by the time there is any plaintext to release - retention and the clock that bounds
-        // it have to begin together.
-        var eviction = new HandDrivenEviction();
-        using var registry = new DeviceRegistry(StorePath, TimeSpan.FromMinutes(5), eviction.Schedule);
-        Assert.False(eviction.WasScheduled, "nothing is retained yet, so no clock is needed yet");
-
-        registry.RegisterIfAbsent("device-a", "MACHINE-A");
-
-        Assert.True(eviction.WasScheduled,
-            "the registry must schedule its own eviction pass - retention cannot depend on another caller arriving");
-        // Half the window, so worst-case retention is one and a half windows rather than two. The type
-        // documentation states that bound, so the interval that produces it is asserted rather than assumed.
-        Assert.Equal(TimeSpan.FromMinutes(2.5), eviction.Interval);
-    }
-
-    [Fact]
-    public void TheEvictionInterval_IsHalfTheWindow_AndNeverZero()
-    {
-        Assert.Equal(TimeSpan.FromMinutes(2.5), DeviceRegistry.EvictionIntervalFor(TimeSpan.FromMinutes(5)));
-        Assert.Equal(TimeSpan.FromSeconds(30), DeviceRegistry.EvictionIntervalFor(TimeSpan.FromMinutes(1)));
-        // A zero or tiny window must not turn the pass into a busy loop.
-        Assert.Equal(TimeSpan.FromSeconds(1), DeviceRegistry.EvictionIntervalFor(TimeSpan.Zero));
-        Assert.Equal(TimeSpan.FromSeconds(1), DeviceRegistry.EvictionIntervalFor(TimeSpan.FromMilliseconds(10)));
-    }
-
-    [Fact]
-    public void ADeviceThatEnrollsOnceAndNeverReturns_DoesNotRetainItsPlaintextKey()
-    {
-        // The exact path that was broken. One device, one enrollment, a distinct id, and nobody ever calls
-        // RegisterIfAbsent again - so nothing ever "knocks" to trigger a lazy prune.
-        var eviction = new HandDrivenEviction();
-        using var registry = new DeviceRegistry(StorePath, TimeSpan.Zero, eviction.Schedule);
-
-        var issued = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
-        Assert.Equal(1, registry.RetainedReplayableKeyCount); // held, as designed, until the window closes
-
-        eviction.RunOnce();
-
-        Assert.Equal(0, registry.RetainedReplayableKeyCount);
-        Assert.False(string.IsNullOrEmpty(issued));
-        Assert.True(registry.IsValidDeviceKey(issued),
-            "evicting the retained PLAINTEXT must not revoke the device - the stored hash still authenticates it");
-    }
-
-    [Fact]
-    public void ManyDevicesEnrollingOnceUnderDistinctIds_DoNotAccumulatePlaintextKeys()
-    {
-        // The growth half of the same defect: fresh device ids are the ordinary case on a Gateway that runs
-        // for weeks, and each one was leaving a plaintext key behind.
-        var eviction = new HandDrivenEviction();
-        using var registry = new DeviceRegistry(StorePath, TimeSpan.Zero, eviction.Schedule);
-
-        for (var i = 0; i < 25; i++)
-            registry.RegisterIfAbsent($"device-{i}", $"MACHINE-{i}");
-
-        Assert.Equal(25, registry.RetainedReplayableKeyCount);
-        eviction.RunOnce();
-
-        Assert.Equal(0, registry.RetainedReplayableKeyCount);
-        Assert.Equal(25, registry.Count); // the devices themselves are untouched; only the plaintext went
-    }
-
-    [Fact]
-    public void AnExplicitRePairing_DoesNotLeaveTheOlderReplayableKeyResident()
-    {
-        // Register does not go through the replay path, so a re-pairing used to leave the previous entry
-        // sitting there with nothing that would ever collect it.
-        var eviction = new HandDrivenEviction();
-        using var registry = new DeviceRegistry(StorePath, TimeSpan.Zero, eviction.Schedule);
-
-        registry.RegisterIfAbsent("device-a", "MACHINE-A");
-        registry.Register("device-a", "MACHINE-A");
-
-        eviction.RunOnce();
-
-        Assert.Equal(0, registry.RetainedReplayableKeyCount);
-    }
-
-    [Fact]
-    public void EvictionControl_AKeyStillInsideItsWindow_IsNotEvicted()
-    {
-        // The control for the three tests above. Without it, they are all satisfied by an eviction pass that
-        // simply clears everything unconditionally - which would silently destroy the retry-safety the window
-        // exists to provide. Eviction must be driven by the DEADLINE, not by being called.
-        var eviction = new HandDrivenEviction();
-        using var registry = new DeviceRegistry(StorePath, TimeSpan.FromMinutes(5), eviction.Schedule);
-
-        var issued = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
-        eviction.RunOnce();
-
-        Assert.Equal(1, registry.RetainedReplayableKeyCount);
-        Assert.Equal(issued, registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey);
-    }
-
-    [Fact]
-    public void Disposing_DropsEveryRetainedPlaintextKey()
-    {
-        var eviction = new HandDrivenEviction();
-        var registry = new DeviceRegistry(StorePath, TimeSpan.FromMinutes(5), eviction.Schedule);
-        registry.RegisterIfAbsent("device-a", "MACHINE-A");
-        Assert.Equal(1, registry.RetainedReplayableKeyCount);
-
-        registry.Dispose();
-
-        Assert.Equal(0, registry.RetainedReplayableKeyCount);
-    }
-
-    [Fact]
-    public void DestructibilityControl_ReplayIsNotOfferedAcrossARestart()
-    {
-        // The replayable key is memory-only. A registry re-read from disk holds no plaintext to replay, so a
-        // post-restart enrollment rotates - which is also the direct evidence that nothing was persisted.
+        // Direct evidence that no plaintext is persisted or cached: a registry re-read from disk holds only
+        // hashes, so a post-restart enrollment rotates and the previous key is gone - it is nowhere to replay
+        // from, and nowhere in the file.
         var first = new DeviceRegistry(StorePath).RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
 
         var afterRestart = new DeviceRegistry(StorePath);
@@ -550,5 +376,34 @@ public sealed class DeviceKeyAtRestTests : IDisposable
         Assert.NotEqual(first, second);
         Assert.False(afterRestart.IsValidDeviceKey(first));
         Assert.DoesNotContain(first, File.ReadAllText(StorePath));
+        Assert.DoesNotContain(second, File.ReadAllText(StorePath));
+    }
+
+    // ---- Masked key identity is present and non-secret (issue #1899) ----------------------------
+
+    [Fact]
+    public void AFreshlyEnrolledDevice_ListsWithAMaskedKeyIdentity_NeverTheRawKey()
+    {
+        var registry = new DeviceRegistry(StorePath);
+        var issued = registry.Register("device-a", "MACHINE-A").DeviceKey;
+
+        var entry = Assert.Single(registry.List());
+        Assert.Equal(issued.Substring(0, 8), entry.KeyPrefix);
+        Assert.Equal(issued.Substring(issued.Length - 4), entry.KeyLast4);
+
+        // The listing shape carries the mask, and the raw key never appears anywhere in it.
+        Assert.NotEqual(issued, entry.KeyPrefix);
+        Assert.True(issued.Length > entry.KeyPrefix.Length + entry.KeyLast4.Length,
+            "the masked identity must reveal only a fraction of the key");
+    }
+
+    [Fact]
+    public void TheMaskedIdentity_IsPersisted_AndSurvivesARestart()
+    {
+        var issued = new DeviceRegistry(StorePath).Register("device-a", "MACHINE-A").DeviceKey;
+
+        var entry = Assert.Single(new DeviceRegistry(StorePath).List());
+        Assert.Equal(issued.Substring(0, 8), entry.KeyPrefix);
+        Assert.Equal(issued.Substring(issued.Length - 4), entry.KeyLast4);
     }
 }

--- a/src/CcDirector.Gateway.Tests/DeviceKeyAtRestTests.cs
+++ b/src/CcDirector.Gateway.Tests/DeviceKeyAtRestTests.cs
@@ -237,15 +237,23 @@ public sealed class DeviceKeyAtRestTests : IDisposable
     }
 
     // ---- Re-enrollment: one entry, exactly one valid key ---------------------------------------
+    //
+    // A registry with a ZERO replay window is a registry in which every call is treated as being past the
+    // window, which is how these tests reach the rotate-in-place branch deterministically. The idempotence
+    // tests below use the default window and the same constructor, so the two branches are exercised by the
+    // same code under two settings rather than by two different code paths.
+
+    private DeviceRegistry PastTheReplayWindow() => new(StorePath, TimeSpan.Zero);
 
     [Fact]
-    public void ReEnrollingADevice_LeavesExactlyOneValidKeyAndOneEntry()
+    public void ReEnrollingADevice_PastTheReplayWindow_LeavesExactlyOneValidKeyAndOneEntry()
     {
-        var registry = new DeviceRegistry(StorePath);
+        var registry = PastTheReplayWindow();
 
         var first = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
         var second = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
 
+        Assert.NotEqual(first, second);
         Assert.Equal(1, registry.Count);
         Assert.True(registry.IsValidDeviceKey(second), "the key just handed to the caller must work");
         Assert.False(registry.IsValidDeviceKey(first),
@@ -255,12 +263,156 @@ public sealed class DeviceKeyAtRestTests : IDisposable
     [Fact]
     public void ReEnrollingADevice_KeepsItsAccountAndTenantBinding()
     {
-        var registry = new DeviceRegistry(StorePath);
+        var registry = PastTheReplayWindow();
         registry.RegisterIfAbsent("device-a", "MACHINE-A");
         registry.SetAccountBinding("device-a", "sub-alice", "tenant-alice");
 
         var reissued = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
 
         Assert.Equal("tenant-alice", registry.TenantForKey(reissued));
+    }
+
+    // ---- Enrollment is safe to retry (the idempotence property) --------------------------------
+    //
+    // Hashing the stored key removed the registry's ability to hand a re-enrolling device its existing key
+    // back, which turned every duplicate enrollment into a ROTATION. A caller that had not yet durably saved
+    // the first response - a lost or delayed response, a double submit, two calls in flight - would then be
+    // holding a key that the later call had already retired, and would be locked out until a human
+    // re-enrolled it. That is a production outage created by a security fix, and it only appears on a retry.
+    //
+    // These tests pin the property that closes it: inside the replay window a duplicate enrollment returns
+    // the SAME key and rotates nothing. Each is paired with the destructibility control below, so that "the
+    // key survived a second call" is read as protection and not as the registry having quietly lost the
+    // ability to retire keys at all.
+
+    [Fact]
+    public void EnrollingTwice_ReturnsTheSameKey_SoARetryCannotLockTheCallerOut()
+    {
+        var registry = new DeviceRegistry(StorePath);
+
+        var first = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+        var second = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+
+        Assert.Equal(first, second);
+        Assert.True(registry.IsValidDeviceKey(first),
+            "the key from the FIRST response must still authenticate - a caller may have saved that one and not the second");
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public void ARetriedEnrollment_DoesNotRetireTheKeyTheCallerAlreadyHolds()
+    {
+        // The lock-out scenario stated directly: the caller keeps the key from the first response, the
+        // enrollment call is retried because the response never arrived, and the held key must keep working.
+        var registry = new DeviceRegistry(StorePath);
+        var keyTheCallerSaved = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+
+        for (var retry = 0; retry < 5; retry++)
+            registry.RegisterIfAbsent("device-a", "MACHINE-A");
+
+        Assert.True(registry.IsValidDeviceKey(keyTheCallerSaved),
+            "five retried enrollments must not lock out the device that is holding the key from the first response");
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public void ConcurrentEnrollmentsOfOneDevice_AllResolveToTheSameKey()
+    {
+        // Two (here, sixteen) enrollment calls in flight at once must converge on ONE issued key rather than
+        // racing to rotate, or the losers of the race are handed keys that are dead on arrival.
+        var registry = new DeviceRegistry(StorePath);
+        var issued = new System.Collections.Concurrent.ConcurrentBag<string>();
+
+        Parallel.For(0, 16, _ => issued.Add(registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey));
+
+        var distinct = issued.Distinct(StringComparer.Ordinal).ToList();
+        Assert.Single(distinct);
+        Assert.True(registry.IsValidDeviceKey(distinct[0]));
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public void EnrollingTwice_StillLeavesExactlyOneValidKey()
+    {
+        // Idempotence must not have been bought by leaving the OLD key working alongside a new one - that is
+        // precisely the #1136 accumulation leak. One device, one key that validates, however many calls.
+        var registry = new DeviceRegistry(StorePath);
+
+        var keys = new List<string>();
+        for (var call = 0; call < 6; call++)
+            keys.Add(registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey);
+
+        var distinct = keys.Distinct(StringComparer.Ordinal).ToList();
+        Assert.Single(distinct);
+        Assert.Single(distinct, registry.IsValidDeviceKey);
+    }
+
+    // ---- Destructibility controls ---------------------------------------------------------------
+    //
+    // Without these, every assertion above is satisfied just as well by a registry that has lost the ability
+    // to retire a key at all. These show the mechanism CAN retire one, on both of the paths that are supposed
+    // to: an explicit re-pairing, and a re-enrollment once the replay window has closed.
+
+    [Fact]
+    public void DestructibilityControl_AnExplicitRePairing_DoesRetireThePreviousKey()
+    {
+        var registry = new DeviceRegistry(StorePath);
+        var enrolled = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+
+        var rePaired = registry.Register("device-a", "MACHINE-A").DeviceKey;
+
+        Assert.NotEqual(enrolled, rePaired);
+        Assert.True(registry.IsValidDeviceKey(rePaired));
+        Assert.False(registry.IsValidDeviceKey(enrolled),
+            "an explicit re-pairing must retire the previous key - if it does not, the idempotence tests above prove nothing");
+    }
+
+    [Fact]
+    public void DestructibilityControl_OnceTheReplayWindowCloses_ARepeatEnrollmentRetiresThePreviousKey()
+    {
+        var registry = PastTheReplayWindow();
+        var first = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+
+        var second = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+
+        Assert.NotEqual(first, second);
+        Assert.False(registry.IsValidDeviceKey(first),
+            "past the replay window a repeat enrollment must rotate - the window bounds the idempotence, it does not remove rotation");
+    }
+
+    [Fact]
+    public void DestructibilityControl_AfterARePairing_TheSupersededKeyIsNotReplayedBack()
+    {
+        // The replay entry must be checked against what the record currently verifies, not handed out on age
+        // alone. An explicit re-pairing rotates the key without going through the replay path, so a following
+        // enrollment must NOT resurrect the key the re-pairing just retired.
+        var registry = new DeviceRegistry(StorePath);
+        var enrolled = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+        var rePaired = registry.Register("device-a", "MACHINE-A").DeviceKey;
+
+        var afterRePairing = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+
+        Assert.NotEqual(enrolled, afterRePairing);
+        Assert.False(registry.IsValidDeviceKey(enrolled),
+            "the key the re-pairing retired must stay retired - a stale replay entry must never hand it back");
+        Assert.True(registry.IsValidDeviceKey(afterRePairing));
+        Assert.Equal(1, registry.Count);
+        // The re-paired key is still fine on its own terms; the point is that the SUPERSEDED one is gone.
+        Assert.False(string.IsNullOrEmpty(rePaired));
+    }
+
+    [Fact]
+    public void DestructibilityControl_ReplayIsNotOfferedAcrossARestart()
+    {
+        // The replayable key is memory-only. A registry re-read from disk holds no plaintext to replay, so a
+        // post-restart enrollment rotates - which is also the direct evidence that nothing was persisted.
+        var first = new DeviceRegistry(StorePath).RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+
+        var afterRestart = new DeviceRegistry(StorePath);
+        var second = afterRestart.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+
+        Assert.NotEqual(first, second);
+        Assert.False(afterRestart.IsValidDeviceKey(first));
+        Assert.DoesNotContain(first, File.ReadAllText(StorePath));
     }
 }

--- a/src/CcDirector.Gateway.Tests/DeviceKeyAtRestTests.cs
+++ b/src/CcDirector.Gateway.Tests/DeviceKeyAtRestTests.cs
@@ -1,0 +1,266 @@
+using System.Security.Cryptography;
+using System.Text;
+using CcDirector.Gateway.Pairing;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1878: the device registry file used to hold every enrolled device's per-device key in
+/// PLAINTEXT. That key is a bearer secret - it authenticates every Director-to-Gateway call - and on the
+/// hosted Gateway the one file holds every tenant's device on shared infrastructure, so anything that
+/// could read the file could impersonate every tenant's Director.
+///
+/// These tests pin the fix from both ends:
+///   1. WHAT IS WRITTEN: the file must contain no usable credential - the plaintext key must not appear
+///      in it, and what does appear must be the one-way hash.
+///   2. WHAT KEEPS WORKING: a device enrolled BEFORE the change - whose key exists only in the plaintext
+///      file and in that machine's credential file - must still authenticate afterwards, and must still
+///      resolve to its bound tenant. There is no re-enrollment path that does not involve a human, so a
+///      change that invalidated those keys would take the live hosted box down.
+/// </summary>
+public sealed class DeviceKeyAtRestTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cc-devkeys-" + Guid.NewGuid().ToString("N"));
+
+    private string StorePath => Path.Combine(_dir, "devices.json");
+
+    public DeviceKeyAtRestTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
+    }
+
+    private static string ExpectedHash(string key) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key))).ToLowerInvariant();
+
+    // ---- 1. What is written -------------------------------------------------------------------
+
+    [Fact]
+    public void EnrolledKey_IsNeverWrittenToTheRegistryFileInPlaintext()
+    {
+        var registry = new DeviceRegistry(StorePath);
+        var issued = registry.Register("device-a", "MACHINE-A").DeviceKey;
+
+        var onDisk = File.ReadAllText(StorePath);
+
+        // The canary. It names the value that got through, so a failure is a one-line diagnosis: if the
+        // plaintext key is in the file, the file IS the credential and a read of it is a full compromise.
+        Assert.False(
+            onDisk.Contains(issued, StringComparison.Ordinal),
+            $"devices.json still holds the plaintext device key. The key that got through is: {issued}");
+    }
+
+    [Fact]
+    public void RegistryFile_HoldsTheOneWayHashOfTheKey()
+    {
+        var registry = new DeviceRegistry(StorePath);
+        var issued = registry.Register("device-a", "MACHINE-A").DeviceKey;
+
+        var onDisk = File.ReadAllText(StorePath);
+
+        // The other half of the canary: the key is not merely absent (which an empty or broken file would
+        // also satisfy) - its hash is what took its place, so the record is still a usable verifier.
+        Assert.Contains(ExpectedHash(issued), onDisk, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EveryEnrolledKey_IsAbsentFromTheFile_EvenWithManyDevices()
+    {
+        var registry = new DeviceRegistry(StorePath);
+        var keys = new List<string>();
+        for (var i = 0; i < 5; i++)
+            keys.Add(registry.Register($"device-{i}", $"MACHINE-{i}").DeviceKey);
+
+        var onDisk = File.ReadAllText(StorePath);
+
+        foreach (var key in keys)
+            Assert.False(
+                onDisk.Contains(key, StringComparison.Ordinal),
+                $"devices.json still holds a plaintext device key. The key that got through is: {key}");
+    }
+
+    [Fact]
+    public void IssuedKey_StillAuthenticates_AndSurvivesARestart()
+    {
+        var registry = new DeviceRegistry(StorePath);
+        var issued = registry.Register("device-a", "MACHINE-A").DeviceKey;
+
+        Assert.True(registry.IsValidDeviceKey(issued));
+        Assert.True(new DeviceRegistry(StorePath).IsValidDeviceKey(issued),
+            "a per-device key must keep working across a Gateway restart");
+    }
+
+    [Fact]
+    public void AWrongKey_IsStillRejected()
+    {
+        var registry = new DeviceRegistry(StorePath);
+        registry.Register("device-a", "MACHINE-A");
+
+        Assert.False(registry.IsValidDeviceKey("not-a-real-key"));
+        Assert.False(registry.IsValidDeviceKey(""));
+        Assert.False(registry.IsValidDeviceKey(null));
+        Assert.Null(registry.TenantForKey("not-a-real-key"));
+        Assert.Null(registry.DeviceTypeForKey("not-a-real-key"));
+    }
+
+    // ---- 2. What keeps working: a device enrolled BEFORE the change ----------------------------
+
+    /// <summary>
+    /// A registry file in EXACTLY the shape the Gateway wrote before issue #1878: the plaintext key in
+    /// <c>DeviceKey</c>, no hash field at all, with the hosted account and tenant binding alongside it.
+    /// This is what sits on the live hosted box's file share right now.
+    /// </summary>
+    private void WritePreChangeStore(string deviceId, string plaintextKey, string tenantId)
+    {
+        File.WriteAllText(StorePath, $$"""
+        [
+          {
+            "DeviceId": "{{deviceId}}",
+            "MachineName": "ALREADY-ENROLLED-MACHINE",
+            "DeviceKey": "{{plaintextKey}}",
+            "IssuedAtUtc": "2026-07-01T12:00:00Z",
+            "Status": "active",
+            "Platform": "windows",
+            "DeviceType": "workstation",
+            "CloudDeviceId": "cloud-device-77",
+            "AccountSubject": "sub-already-enrolled",
+            "TenantId": "{{tenantId}}"
+          }
+        ]
+        """);
+    }
+
+    [Fact]
+    public void ADeviceEnrolledBeforeTheChange_StillAuthenticatesAfterIt()
+    {
+        // This is the test that stops the fix from taking the live hosted box down: the machine holds this
+        // key in its own credential file and there is no way to re-issue it without a human.
+        const string alreadyIssuedKey = "pre-change-key-Ab3xQ9zK-do-not-invalidate";
+        WritePreChangeStore("device-already-enrolled", alreadyIssuedKey, "tenant-already-enrolled");
+
+        var registry = new DeviceRegistry(StorePath);
+
+        Assert.True(registry.IsValidDeviceKey(alreadyIssuedKey),
+            "a device enrolled before the keys were hashed must keep authenticating with the key it already holds");
+    }
+
+    [Fact]
+    public void ADeviceEnrolledBeforeTheChange_StillResolvesToItsBoundTenant()
+    {
+        const string alreadyIssuedKey = "pre-change-key-Ab3xQ9zK-do-not-invalidate";
+        WritePreChangeStore("device-already-enrolled", alreadyIssuedKey, "tenant-already-enrolled");
+
+        var registry = new DeviceRegistry(StorePath);
+
+        // The hosted tenant boundary resolves the tenant from this same verified key on every request.
+        Assert.Equal("tenant-already-enrolled", registry.TenantForKey(alreadyIssuedKey));
+        Assert.Equal("workstation", registry.DeviceTypeForKey(alreadyIssuedKey));
+    }
+
+    [Fact]
+    public void LoadingAPreChangeStore_ScrubsThePlaintextKeyFromDisk()
+    {
+        const string alreadyIssuedKey = "pre-change-key-Ab3xQ9zK-do-not-invalidate";
+        WritePreChangeStore("device-already-enrolled", alreadyIssuedKey, "tenant-already-enrolled");
+        Assert.Contains(alreadyIssuedKey, File.ReadAllText(StorePath), StringComparison.Ordinal);
+
+        _ = new DeviceRegistry(StorePath);
+
+        var onDisk = File.ReadAllText(StorePath);
+        Assert.False(
+            onDisk.Contains(alreadyIssuedKey, StringComparison.Ordinal),
+            $"loading a pre-change registry must rewrite it without the plaintext. The key still on disk is: {alreadyIssuedKey}");
+        Assert.Contains(ExpectedHash(alreadyIssuedKey), onDisk, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AMigratedDevice_KeepsWorkingAcrossTheNextRestartToo()
+    {
+        const string alreadyIssuedKey = "pre-change-key-Ab3xQ9zK-do-not-invalidate";
+        WritePreChangeStore("device-already-enrolled", alreadyIssuedKey, "tenant-already-enrolled");
+
+        _ = new DeviceRegistry(StorePath);          // first start after the upgrade: migrates and rewrites
+        var afterRestart = new DeviceRegistry(StorePath); // and every start after that reads the hashed file
+
+        Assert.True(afterRestart.IsValidDeviceKey(alreadyIssuedKey));
+        Assert.Equal("tenant-already-enrolled", afterRestart.TenantForKey(alreadyIssuedKey));
+    }
+
+    [Fact]
+    public void Migration_KeepsEveryOtherFieldOfTheRecord()
+    {
+        const string alreadyIssuedKey = "pre-change-key-Ab3xQ9zK-do-not-invalidate";
+        WritePreChangeStore("device-already-enrolled", alreadyIssuedKey, "tenant-already-enrolled");
+
+        var registry = new DeviceRegistry(StorePath);
+
+        var entry = Assert.Single(registry.List());
+        Assert.Equal("device-already-enrolled", entry.DeviceId);
+        Assert.Equal("ALREADY-ENROLLED-MACHINE", entry.MachineName);
+        Assert.Equal(DeviceRegistry.StatusActive, entry.Status);
+
+        // The cloud mirror mapping must survive too, or the next reconcile would re-mirror the device.
+        var mirrored = Assert.Single(registry.MirrorSnapshot());
+        Assert.Equal("cloud-device-77", mirrored.CloudDeviceId);
+        Assert.Equal("windows", mirrored.Platform);
+        Assert.Equal("workstation", mirrored.DeviceType);
+    }
+
+    [Fact]
+    public void Migration_DoesNotMakeEveryKeyValid()
+    {
+        // The control on the migration: hashing an existing record must not turn the registry into
+        // something that accepts anything - only the one key that was already issued still works.
+        const string alreadyIssuedKey = "pre-change-key-Ab3xQ9zK-do-not-invalidate";
+        WritePreChangeStore("device-already-enrolled", alreadyIssuedKey, "tenant-already-enrolled");
+
+        var registry = new DeviceRegistry(StorePath);
+
+        Assert.False(registry.IsValidDeviceKey("pre-change-key-Ab3xQ9zK-do-not-invalidat"), "a truncated key must not pass");
+        Assert.False(registry.IsValidDeviceKey("PRE-CHANGE-KEY-AB3XQ9ZK-DO-NOT-INVALIDATE"), "a case-flipped key must not pass");
+        Assert.False(registry.IsValidDeviceKey(ExpectedHash(alreadyIssuedKey)), "presenting the STORED HASH must not pass as the key");
+    }
+
+    [Fact]
+    public void PresentingTheStoredHashInsteadOfTheKey_IsRejected()
+    {
+        // The stored value must be a verifier, not a password-equivalent: whoever reads devices.json must
+        // not be able to authenticate by replaying what they read.
+        var registry = new DeviceRegistry(StorePath);
+        var issued = registry.Register("device-a", "MACHINE-A").DeviceKey;
+
+        Assert.False(registry.IsValidDeviceKey(ExpectedHash(issued)));
+        Assert.False(registry.IsValidDeviceKey(ExpectedHash(issued).ToUpperInvariant()));
+    }
+
+    // ---- Re-enrollment: one entry, exactly one valid key ---------------------------------------
+
+    [Fact]
+    public void ReEnrollingADevice_LeavesExactlyOneValidKeyAndOneEntry()
+    {
+        var registry = new DeviceRegistry(StorePath);
+
+        var first = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+        var second = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+
+        Assert.Equal(1, registry.Count);
+        Assert.True(registry.IsValidDeviceKey(second), "the key just handed to the caller must work");
+        Assert.False(registry.IsValidDeviceKey(first),
+            "re-enrolling must RETIRE the previous key, never leave two working credentials for one device");
+    }
+
+    [Fact]
+    public void ReEnrollingADevice_KeepsItsAccountAndTenantBinding()
+    {
+        var registry = new DeviceRegistry(StorePath);
+        registry.RegisterIfAbsent("device-a", "MACHINE-A");
+        registry.SetAccountBinding("device-a", "sub-alice", "tenant-alice");
+
+        var reissued = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+
+        Assert.Equal("tenant-alice", registry.TenantForKey(reissued));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DeviceKeyAtRestTests.cs
+++ b/src/CcDirector.Gateway.Tests/DeviceKeyAtRestTests.cs
@@ -401,6 +401,142 @@ public sealed class DeviceKeyAtRestTests : IDisposable
         Assert.False(string.IsNullOrEmpty(rePaired));
     }
 
+    // ---- Retention of the replayable plaintext is actually bounded ------------------------------
+    //
+    // The retry-safety window holds an issued key in memory. What made that acceptable is that it is
+    // SHORT-LIVED - and that was the property nothing tested. The first version pruned only when an
+    // already-enrolled device asked to replay, so the ordinary case (a device enrolls once under its own id
+    // and never comes back) never reached the prune and its plaintext key stayed resident for the life of the
+    // process. Checking an entry's age at replay time stops an expired key being RETURNED; it does not bound
+    // RETENTION. These tests assert retention directly rather than inferring it from behaviour that would
+    // still look correct while the plaintext sat in memory.
+    //
+    // A hand-driven scheduler is used so both halves are proven without waiting on a clock: that the registry
+    // SCHEDULES an eviction pass at all, and that the pass RELEASES the plaintext.
+
+    /// <summary>Captures the recurring eviction pass instead of running it on a timer, so a test can fire it
+    /// on demand. Waiting on a real timer would make the result depend on machine load, not on the code.</summary>
+    private sealed class HandDrivenEviction
+    {
+        public TimeSpan? Interval { get; private set; }
+        private Action? _pass;
+        public bool WasScheduled => _pass is not null;
+        public void Schedule(TimeSpan interval, Action pass) { Interval = interval; _pass = pass; }
+        public void RunOnce() => (_pass ?? throw new InvalidOperationException(
+            "the registry never scheduled an eviction pass, so there is nothing to run")).Invoke();
+    }
+
+    [Fact]
+    public void TheRegistry_SchedulesARecurringEvictionPass_AsSoonAsItRetainsAKey()
+    {
+        // Half one: without this, the eviction policy below is dead code that nothing ever calls. The pass
+        // must be running by the time there is any plaintext to release - retention and the clock that bounds
+        // it have to begin together.
+        var eviction = new HandDrivenEviction();
+        using var registry = new DeviceRegistry(StorePath, TimeSpan.FromMinutes(5), eviction.Schedule);
+        Assert.False(eviction.WasScheduled, "nothing is retained yet, so no clock is needed yet");
+
+        registry.RegisterIfAbsent("device-a", "MACHINE-A");
+
+        Assert.True(eviction.WasScheduled,
+            "the registry must schedule its own eviction pass - retention cannot depend on another caller arriving");
+        // Half the window, so worst-case retention is one and a half windows rather than two. The type
+        // documentation states that bound, so the interval that produces it is asserted rather than assumed.
+        Assert.Equal(TimeSpan.FromMinutes(2.5), eviction.Interval);
+    }
+
+    [Fact]
+    public void TheEvictionInterval_IsHalfTheWindow_AndNeverZero()
+    {
+        Assert.Equal(TimeSpan.FromMinutes(2.5), DeviceRegistry.EvictionIntervalFor(TimeSpan.FromMinutes(5)));
+        Assert.Equal(TimeSpan.FromSeconds(30), DeviceRegistry.EvictionIntervalFor(TimeSpan.FromMinutes(1)));
+        // A zero or tiny window must not turn the pass into a busy loop.
+        Assert.Equal(TimeSpan.FromSeconds(1), DeviceRegistry.EvictionIntervalFor(TimeSpan.Zero));
+        Assert.Equal(TimeSpan.FromSeconds(1), DeviceRegistry.EvictionIntervalFor(TimeSpan.FromMilliseconds(10)));
+    }
+
+    [Fact]
+    public void ADeviceThatEnrollsOnceAndNeverReturns_DoesNotRetainItsPlaintextKey()
+    {
+        // The exact path that was broken. One device, one enrollment, a distinct id, and nobody ever calls
+        // RegisterIfAbsent again - so nothing ever "knocks" to trigger a lazy prune.
+        var eviction = new HandDrivenEviction();
+        using var registry = new DeviceRegistry(StorePath, TimeSpan.Zero, eviction.Schedule);
+
+        var issued = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+        Assert.Equal(1, registry.RetainedReplayableKeyCount); // held, as designed, until the window closes
+
+        eviction.RunOnce();
+
+        Assert.Equal(0, registry.RetainedReplayableKeyCount);
+        Assert.False(string.IsNullOrEmpty(issued));
+        Assert.True(registry.IsValidDeviceKey(issued),
+            "evicting the retained PLAINTEXT must not revoke the device - the stored hash still authenticates it");
+    }
+
+    [Fact]
+    public void ManyDevicesEnrollingOnceUnderDistinctIds_DoNotAccumulatePlaintextKeys()
+    {
+        // The growth half of the same defect: fresh device ids are the ordinary case on a Gateway that runs
+        // for weeks, and each one was leaving a plaintext key behind.
+        var eviction = new HandDrivenEviction();
+        using var registry = new DeviceRegistry(StorePath, TimeSpan.Zero, eviction.Schedule);
+
+        for (var i = 0; i < 25; i++)
+            registry.RegisterIfAbsent($"device-{i}", $"MACHINE-{i}");
+
+        Assert.Equal(25, registry.RetainedReplayableKeyCount);
+        eviction.RunOnce();
+
+        Assert.Equal(0, registry.RetainedReplayableKeyCount);
+        Assert.Equal(25, registry.Count); // the devices themselves are untouched; only the plaintext went
+    }
+
+    [Fact]
+    public void AnExplicitRePairing_DoesNotLeaveTheOlderReplayableKeyResident()
+    {
+        // Register does not go through the replay path, so a re-pairing used to leave the previous entry
+        // sitting there with nothing that would ever collect it.
+        var eviction = new HandDrivenEviction();
+        using var registry = new DeviceRegistry(StorePath, TimeSpan.Zero, eviction.Schedule);
+
+        registry.RegisterIfAbsent("device-a", "MACHINE-A");
+        registry.Register("device-a", "MACHINE-A");
+
+        eviction.RunOnce();
+
+        Assert.Equal(0, registry.RetainedReplayableKeyCount);
+    }
+
+    [Fact]
+    public void EvictionControl_AKeyStillInsideItsWindow_IsNotEvicted()
+    {
+        // The control for the three tests above. Without it, they are all satisfied by an eviction pass that
+        // simply clears everything unconditionally - which would silently destroy the retry-safety the window
+        // exists to provide. Eviction must be driven by the DEADLINE, not by being called.
+        var eviction = new HandDrivenEviction();
+        using var registry = new DeviceRegistry(StorePath, TimeSpan.FromMinutes(5), eviction.Schedule);
+
+        var issued = registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey;
+        eviction.RunOnce();
+
+        Assert.Equal(1, registry.RetainedReplayableKeyCount);
+        Assert.Equal(issued, registry.RegisterIfAbsent("device-a", "MACHINE-A").DeviceKey);
+    }
+
+    [Fact]
+    public void Disposing_DropsEveryRetainedPlaintextKey()
+    {
+        var eviction = new HandDrivenEviction();
+        var registry = new DeviceRegistry(StorePath, TimeSpan.FromMinutes(5), eviction.Schedule);
+        registry.RegisterIfAbsent("device-a", "MACHINE-A");
+        Assert.Equal(1, registry.RetainedReplayableKeyCount);
+
+        registry.Dispose();
+
+        Assert.Equal(0, registry.RetainedReplayableKeyCount);
+    }
+
     [Fact]
     public void DestructibilityControl_ReplayIsNotOfferedAcrossARestart()
     {

--- a/src/CcDirector.Gateway.Tests/DeviceListTenantScopingTests.cs
+++ b/src/CcDirector.Gateway.Tests/DeviceListTenantScopingTests.cs
@@ -158,6 +158,27 @@ public sealed class DeviceRegistryTenantScopeTests : IDisposable
     }
 
     [Fact]
+    public void ListForTenant_ReturnsTheMaskedKeyIdentity_NeverTheRawKey()
+    {
+        // Issue #1899: a tenant-scoped listing must carry the non-secret masked key identity (prefix/last4)
+        // so a device can be recognised by its key, and must NEVER substitute or expose the raw key.
+        var registry = new DeviceRegistry(_storePath);
+        var issuedKey = registry.Register("dev-a", "MACHINE-A").DeviceKey;
+        registry.SetAccountBinding("dev-a", "sub-alice", "tenant-alice");
+
+        var entry = Assert.Single(registry.ListForTenant(new TenantId("tenant-alice")));
+        Assert.Equal("dev-a", entry.DeviceId);
+        Assert.Equal(issuedKey.Substring(0, 8), entry.KeyPrefix);
+        Assert.Equal(issuedKey.Substring(issuedKey.Length - 4), entry.KeyLast4);
+
+        // The raw key is nowhere in the listed entry - not as any field, not substituted for the mask.
+        Assert.NotEqual(issuedKey, entry.KeyPrefix);
+        Assert.NotEqual(issuedKey, entry.KeyLast4);
+        Assert.True(entry.KeyPrefix.Length + entry.KeyLast4.Length < issuedKey.Length,
+            "the mask must reveal only a fraction of the key");
+    }
+
+    [Fact]
     public void ListForTenant_ForeignTenant_ReturnsNothing()
     {
         var registry = new DeviceRegistry(_storePath);

--- a/src/CcDirector.Gateway.Tests/SignedInEnrollmentTests.cs
+++ b/src/CcDirector.Gateway.Tests/SignedInEnrollmentTests.cs
@@ -9,9 +9,9 @@ namespace CcDirector.Gateway.Tests;
 /// <summary>
 /// Proves the two load-bearing guardrails of the sign-in enrollment path (issue #1069):
 /// the AUTH gate (POST /devices/enroll-signed-in only mints for a proven-loopback caller when the
-/// Gateway is signed in) and the IDEMPOTENT mint (a device that already holds a key gets the SAME key
-/// back, never a fresh one). The idempotency test pins the guardrail against the #1136 auto-mint key
-/// leak: enrolling the same device twice must not rotate or multiply keys.
+/// Gateway is signed in) and the ONE-KEY-PER-DEVICE rule (a device that already holds a key ends up with
+/// one registry entry and exactly one key that validates). The second pins the guardrail against the
+/// #1136 auto-mint key leak: enrolling the same device repeatedly must never MULTIPLY working keys.
 /// </summary>
 public sealed class SignedInEnrollmentTests
 {
@@ -72,10 +72,16 @@ public sealed class SignedInEnrollmentTests
             SignedInEnrollmentEndpoint.Evaluate(IPAddress.Parse("10.0.0.5"), isSignedIn: false, identity: null));
     }
 
-    // ---- Idempotent mint (DeviceRegistry.RegisterIfAbsent) -------------------------------------
+    // ---- One entry, exactly one valid key (DeviceRegistry.RegisterIfAbsent) --------------------
+    //
+    // Before issue #1878 the registry stored the plaintext key and handed the SAME key back on a repeat
+    // enrollment. It now stores only a hash, so there is no plaintext to return and a repeat enrollment
+    // re-issues the key in place. The #1136 property being defended is unchanged and is what these tests
+    // assert: enrollment can never ACCUMULATE credentials - one device identity, one registry entry, and
+    // exactly one key that validates at any moment.
 
     [Fact]
-    public void RegisterIfAbsent_SameDeviceTwice_ReturnsTheSameKey_NoReMint()
+    public void RegisterIfAbsent_SameDeviceTwice_LeavesOneEntryAndOneValidKey()
     {
         using var temp = new TempStore();
         var registry = new DeviceRegistry(temp.Path);
@@ -84,23 +90,28 @@ public sealed class SignedInEnrollmentTests
         var second = registry.RegisterIfAbsent("device-1", "MACHINE_A", "windows", "workstation");
 
         Assert.False(string.IsNullOrEmpty(first.DeviceKey));
-        Assert.Equal(first.DeviceKey, second.DeviceKey); // idempotent: the SAME key, not a fresh one
+        Assert.False(string.IsNullOrEmpty(second.DeviceKey));
         Assert.Equal(1, registry.Count); // exactly one device, no duplicates
+        Assert.True(registry.IsValidDeviceKey(second.DeviceKey));
+        Assert.False(registry.IsValidDeviceKey(first.DeviceKey), "the previous key must be retired, not left working alongside the new one");
     }
 
     [Fact]
-    public void RegisterIfAbsent_ManyCalls_MintOnlyOnce()
+    public void RegisterIfAbsent_ManyCalls_NeverAccumulateDevicesOrKeys()
     {
-        // The poll loop is guarded to never call enroll repeatedly, but the server is idempotent anyway:
-        // even ten calls yield one key and one device (the #1136 guardrail).
+        // The poll loop is guarded to never call enroll repeatedly, but the server holds the line anyway:
+        // even ten calls yield one device and one working key (the #1136 guardrail).
         using var temp = new TempStore();
         var registry = new DeviceRegistry(temp.Path);
 
-        var key = registry.RegisterIfAbsent("device-1", "MACHINE_A").DeviceKey;
+        var issued = new List<string> { registry.RegisterIfAbsent("device-1", "MACHINE_A").DeviceKey };
         for (var i = 0; i < 10; i++)
-            Assert.Equal(key, registry.RegisterIfAbsent("device-1", "MACHINE_A").DeviceKey);
+            issued.Add(registry.RegisterIfAbsent("device-1", "MACHINE_A").DeviceKey);
 
         Assert.Equal(1, registry.Count);
+        var live = issued.Where(registry.IsValidDeviceKey).ToList();
+        Assert.Single(live);
+        Assert.Equal(issued[^1], live[0]);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/SignedInEnrollmentTests.cs
+++ b/src/CcDirector.Gateway.Tests/SignedInEnrollmentTests.cs
@@ -75,41 +75,44 @@ public sealed class SignedInEnrollmentTests
     // ---- One entry, exactly one valid key (DeviceRegistry.RegisterIfAbsent) --------------------
     //
     // Before issue #1878 the registry stored the plaintext key and handed the SAME key back on a repeat
-    // enrollment. It now stores only a hash, so a repeat enrollment is answered from a short in-memory
-    // replay window (same key, nothing rotated) and rotates in place once that window has closed. The #1136
-    // property being defended is unchanged across both branches and is what these tests assert: enrollment
-    // can never ACCUMULATE credentials - one device identity, one registry entry, and exactly one key that
-    // validates at any moment. A zero replay window is how a test reaches the rotate branch deterministically.
+    // enrollment. It now stores only a hash and keeps NO plaintext at all (issue #1899), so it has nothing to
+    // hand back and deliberately keeps nothing: a repeat enrollment ROTATES - a fresh key is issued and the
+    // previous one is retired. The #1136 property these tests assert is unchanged: enrollment can never
+    // ACCUMULATE credentials - one device identity, one registry entry, and exactly one key that validates at
+    // any moment.
 
     [Fact]
     public void RegisterIfAbsent_SameDeviceTwice_LeavesOneEntryAndOneValidKey()
     {
-        using var temp = new TempStore();
-        var registry = new DeviceRegistry(temp.Path, TimeSpan.Zero);
-
-        var first = registry.RegisterIfAbsent("device-1", "MACHINE_A", "windows", "workstation");
-        var second = registry.RegisterIfAbsent("device-1", "MACHINE_A", "windows", "workstation");
-
-        Assert.False(string.IsNullOrEmpty(first.DeviceKey));
-        Assert.False(string.IsNullOrEmpty(second.DeviceKey));
-        Assert.Equal(1, registry.Count); // exactly one device, no duplicates
-        Assert.True(registry.IsValidDeviceKey(second.DeviceKey));
-        Assert.False(registry.IsValidDeviceKey(first.DeviceKey), "the previous key must be retired, not left working alongside the new one");
-    }
-
-    [Fact]
-    public void RegisterIfAbsent_SameDeviceTwice_WithinTheReplayWindow_ReturnsTheSameKey()
-    {
-        // The retry-safety property: a duplicate enrollment must not retire a key the caller may already be
-        // holding from a response it did save.
         using var temp = new TempStore();
         var registry = new DeviceRegistry(temp.Path);
 
         var first = registry.RegisterIfAbsent("device-1", "MACHINE_A", "windows", "workstation");
         var second = registry.RegisterIfAbsent("device-1", "MACHINE_A", "windows", "workstation");
 
-        Assert.Equal(first.DeviceKey, second.DeviceKey);
-        Assert.True(registry.IsValidDeviceKey(first.DeviceKey));
+        Assert.False(string.IsNullOrEmpty(first.DeviceKey));
+        Assert.False(string.IsNullOrEmpty(second.DeviceKey));
+        Assert.NotEqual(first.DeviceKey, second.DeviceKey); // a repeat enrollment rotates, never replays
+        Assert.Equal(1, registry.Count); // exactly one device, no duplicates
+        Assert.True(registry.IsValidDeviceKey(second.DeviceKey));
+        Assert.False(registry.IsValidDeviceKey(first.DeviceKey), "the previous key must be retired, not left working alongside the new one");
+    }
+
+    [Fact]
+    public void RegisterIfAbsent_SameDeviceTwice_RotatesAndNeverReplaysTheOldKey()
+    {
+        // The retry-safety property post-#1899: a repeat enrollment hands back a FRESH working key rather than
+        // re-revealing the old one from a plaintext cache. The client writes whichever key it receives, so a
+        // sequential retry always ends up holding a valid credential; no plaintext is retained to replay.
+        using var temp = new TempStore();
+        var registry = new DeviceRegistry(temp.Path);
+
+        var first = registry.RegisterIfAbsent("device-1", "MACHINE_A", "windows", "workstation");
+        var second = registry.RegisterIfAbsent("device-1", "MACHINE_A", "windows", "workstation");
+
+        Assert.NotEqual(first.DeviceKey, second.DeviceKey);
+        Assert.True(registry.IsValidDeviceKey(second.DeviceKey), "the freshly returned key must authenticate");
+        Assert.False(registry.IsValidDeviceKey(first.DeviceKey), "the superseded key must not keep working");
         Assert.Equal(1, registry.Count);
     }
 
@@ -117,10 +120,9 @@ public sealed class SignedInEnrollmentTests
     public void RegisterIfAbsent_ManyCalls_NeverAccumulateDevicesOrKeys()
     {
         // The poll loop is guarded to never call enroll repeatedly, but the server holds the line anyway:
-        // even ten calls yield one device and one working key (the #1136 guardrail). Run with a zero replay
-        // window so every call rotates - the accumulation guardrail is asserted on the branch that mints.
+        // even ten calls yield one device and one working key (the #1136 guardrail). Every call rotates.
         using var temp = new TempStore();
-        var registry = new DeviceRegistry(temp.Path, TimeSpan.Zero);
+        var registry = new DeviceRegistry(temp.Path);
 
         var issued = new List<string> { registry.RegisterIfAbsent("device-1", "MACHINE_A").DeviceKey };
         for (var i = 0; i < 10; i++)

--- a/src/CcDirector.Gateway.Tests/SignedInEnrollmentTests.cs
+++ b/src/CcDirector.Gateway.Tests/SignedInEnrollmentTests.cs
@@ -75,16 +75,17 @@ public sealed class SignedInEnrollmentTests
     // ---- One entry, exactly one valid key (DeviceRegistry.RegisterIfAbsent) --------------------
     //
     // Before issue #1878 the registry stored the plaintext key and handed the SAME key back on a repeat
-    // enrollment. It now stores only a hash, so there is no plaintext to return and a repeat enrollment
-    // re-issues the key in place. The #1136 property being defended is unchanged and is what these tests
-    // assert: enrollment can never ACCUMULATE credentials - one device identity, one registry entry, and
-    // exactly one key that validates at any moment.
+    // enrollment. It now stores only a hash, so a repeat enrollment is answered from a short in-memory
+    // replay window (same key, nothing rotated) and rotates in place once that window has closed. The #1136
+    // property being defended is unchanged across both branches and is what these tests assert: enrollment
+    // can never ACCUMULATE credentials - one device identity, one registry entry, and exactly one key that
+    // validates at any moment. A zero replay window is how a test reaches the rotate branch deterministically.
 
     [Fact]
     public void RegisterIfAbsent_SameDeviceTwice_LeavesOneEntryAndOneValidKey()
     {
         using var temp = new TempStore();
-        var registry = new DeviceRegistry(temp.Path);
+        var registry = new DeviceRegistry(temp.Path, TimeSpan.Zero);
 
         var first = registry.RegisterIfAbsent("device-1", "MACHINE_A", "windows", "workstation");
         var second = registry.RegisterIfAbsent("device-1", "MACHINE_A", "windows", "workstation");
@@ -97,12 +98,29 @@ public sealed class SignedInEnrollmentTests
     }
 
     [Fact]
+    public void RegisterIfAbsent_SameDeviceTwice_WithinTheReplayWindow_ReturnsTheSameKey()
+    {
+        // The retry-safety property: a duplicate enrollment must not retire a key the caller may already be
+        // holding from a response it did save.
+        using var temp = new TempStore();
+        var registry = new DeviceRegistry(temp.Path);
+
+        var first = registry.RegisterIfAbsent("device-1", "MACHINE_A", "windows", "workstation");
+        var second = registry.RegisterIfAbsent("device-1", "MACHINE_A", "windows", "workstation");
+
+        Assert.Equal(first.DeviceKey, second.DeviceKey);
+        Assert.True(registry.IsValidDeviceKey(first.DeviceKey));
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
     public void RegisterIfAbsent_ManyCalls_NeverAccumulateDevicesOrKeys()
     {
         // The poll loop is guarded to never call enroll repeatedly, but the server holds the line anyway:
-        // even ten calls yield one device and one working key (the #1136 guardrail).
+        // even ten calls yield one device and one working key (the #1136 guardrail). Run with a zero replay
+        // window so every call rotates - the accumulation guardrail is asserted on the branch that mints.
         using var temp = new TempStore();
-        var registry = new DeviceRegistry(temp.Path);
+        var registry = new DeviceRegistry(temp.Path, TimeSpan.Zero);
 
         var issued = new List<string> { registry.RegisterIfAbsent("device-1", "MACHINE_A").DeviceKey };
         for (var i = 0; i < 10; i++)

--- a/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
@@ -20,7 +20,7 @@ namespace CcDirector.Gateway.Api;
 ///   POST /devices/enroll-hosted
 ///     Authorization: Bearer &lt;the caller's Supabase access token&gt;
 ///     { deviceId, machineName, platform, deviceType }
-///   -&gt; 200 { deviceKey, ... }   mint (or return, if already present) this device's key, bound to the tenant
+///   -&gt; 200 { deviceKey, ... }   issue this device's key (a fresh one if it is already enrolled), bound to the tenant
 ///   -&gt; 400                       deviceId missing
 ///   -&gt; 401                       missing / invalid / expired account token (no verified subject to bind)
 ///
@@ -128,9 +128,9 @@ internal static class HostedEnrollmentEndpoint
         var tenant = tenants.MintOrLookupBySubject(validation.Subject, email);
 
         // The device id is CLIENT-supplied, so it must NEVER be the registry key on its own: two different
-        // accounts presenting the same deviceId would otherwise collide, and RegisterIfAbsent's idempotency
-        // would hand one account the OTHER's key (which SetAccountBinding then rebinds to the new tenant) -
-        // letting a pre-enroller keep a key that becomes bound to the victim's tenant. Namespacing the registry
+        // accounts presenting the same deviceId would otherwise collide on ONE registry entry, and enrolling
+        // would hand one account a working key on the OTHER's record (which SetAccountBinding then rebinds to
+        // the new tenant) - letting a pre-enroller take over the victim's device entry. Namespacing the registry
         // id with a ONE-WAY HASH of the resolved tenant makes cross-account collision impossible (different
         // accounts -> different tenants -> different hashes -> different device spaces) while staying
         // idempotent for one account (same tenant -> same hash). The hash - not the subject and not the raw

--- a/src/CcDirector.Gateway/Api/SignedInEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/SignedInEnrollmentEndpoint.cs
@@ -40,11 +40,13 @@ public enum EnrollGateDecision
 ///   2. Bound to the Gateway's current signed-in account identity (GatewaySignInService.GetIdentity).
 ///      Not signed in -> 409 with a "sign in first" the client maps to opening the browser sign-in.
 ///   3. One key per device (DeviceRegistry.RegisterIfAbsent): a device that already holds an active key
-///      is re-issued a key IN PLACE - one registry entry, exactly one valid key, and the previous key
-///      retired. Enrollment can therefore never ACCUMULATE valid credentials, which is what the #1136
-///      auto-mint key leak did. (Before issue #1878 the existing key was handed back byte-for-byte;
-///      the registry now stores only a hash of it, so there is no plaintext left to return.) Combined
-///      with the client only calling enroll once, never from its polling loop, this stays a one-time act.
+///      ends up with one registry entry, exactly one valid key, and any previous key retired. Enrollment
+///      can therefore never ACCUMULATE valid credentials, which is what the #1136 auto-mint key leak did.
+///      Combined with the client only calling enroll once, never from its polling loop, this stays a
+///      one-time act. (Before issue #1878 the existing key was handed back byte-for-byte; the registry
+///      now stores only a hash of it, so there is no plaintext left to return. Repeat calls are still
+///      SAFE TO RETRY - a duplicate within a short in-memory window gets the same key back rather than
+///      rotating one this endpoint has already returned to a caller that may not have saved it.)
 ///
 /// Every mint is logged with the account identity, device id, and timestamp (guardrail 5) so any leak
 /// is traceable. Remote/headless Directors (not on the Gateway's machine) enroll via the tailnet

--- a/src/CcDirector.Gateway/Api/SignedInEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/SignedInEnrollmentEndpoint.cs
@@ -31,18 +31,20 @@ public enum EnrollGateDecision
 /// This is the sign-in replacement for the pairing code: a device gets onto the Gateway by signing in
 /// to DevThrottle, not by reading a code off the Gateway host.
 ///
-///   POST /devices/enroll-signed-in -> mint (or, if this device already has one, RETURN) this
-///       same-machine Director's own per-device key. Gated by three guardrails, each enforced here:
+///   POST /devices/enroll-signed-in -> issue this same-machine Director's own per-device key (a fresh
+///       one if it is already enrolled). Gated by three guardrails, each enforced here:
 ///
 ///   1. Same-machine PROVEN at the transport layer: the caller's remote address must be loopback.
 ///      A null or non-loopback address is rejected (403). This is never a self-asserted header/flag,
 ///      so the endpoint cannot be used from the tailnet or the LAN.
 ///   2. Bound to the Gateway's current signed-in account identity (GatewaySignInService.GetIdentity).
 ///      Not signed in -> 409 with a "sign in first" the client maps to opening the browser sign-in.
-///   3. Idempotent mint (DeviceRegistry.RegisterIfAbsent): a device that already holds an active key
-///      gets the SAME key back - never a fresh key per call. This is the guardrail against the #1136
-///      auto-mint key leak; combined with the client only calling enroll once (never from its polling
-///      loop), a key is minted at most once per device identity.
+///   3. One key per device (DeviceRegistry.RegisterIfAbsent): a device that already holds an active key
+///      is re-issued a key IN PLACE - one registry entry, exactly one valid key, and the previous key
+///      retired. Enrollment can therefore never ACCUMULATE valid credentials, which is what the #1136
+///      auto-mint key leak did. (Before issue #1878 the existing key was handed back byte-for-byte;
+///      the registry now stores only a hash of it, so there is no plaintext left to return.) Combined
+///      with the client only calling enroll once, never from its polling loop, this stays a one-time act.
 ///
 /// Every mint is logged with the account identity, device id, and timestamp (guardrail 5) so any leak
 /// is traceable. Remote/headless Directors (not on the Gateway's machine) enroll via the tailnet
@@ -98,7 +100,7 @@ internal static class SignedInEnrollmentEndpoint
                         statusCode: StatusCodes.Status409Conflict);
             }
 
-            // Guardrail 3: idempotent - reuse the existing active key if present, mint at most once.
+            // Guardrail 3: one registry entry and exactly one valid key per device identity.
             var response = devices.RegisterIfAbsent(req.DeviceId, req.MachineName, req.Platform, req.DeviceType);
 
             // Guardrail 5: log the mint with the bound account identity, device id, and (via FileLog) time.

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2664,6 +2664,11 @@ public sealed class GatewayHost : IAsyncDisposable
         Registry.Dispose();
         Launchers.Dispose();
 
+        // Stops the device registry's replayable-key eviction pass and drops any issued key it is still
+        // holding in memory for enrollment retry-safety (issue #1878). The enrolled devices themselves are
+        // on disk as hashes and are unaffected; only the short-lived plaintext goes.
+        try { Devices.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] device registry dispose error: {ex.Message}"); }
+
         if (_app is not null)
         {
             try { await _app.StopAsync(TimeSpan.FromSeconds(2)); }

--- a/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
+++ b/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
@@ -15,9 +16,26 @@ namespace CcDirector.Gateway.Pairing;
 /// alongside its name, machine, issued-at, and status.
 ///
 /// Persisted to <c>%LOCALAPPDATA%\cc-director\config\director\devices.json</c> so the registry
-/// survives a Gateway restart (a per-device key must keep working across restarts). The file holds the
-/// issued keys, so it is the Gateway host's secret store - locked to the current user by living under
-/// the per-user config root.
+/// survives a Gateway restart (a per-device key must keep working across restarts).
+///
+/// The file stores each key ONLY as a one-way hash (issue #1878). A device key is a bearer secret that
+/// authenticates every Director-to-Gateway call, and on the hosted Gateway this one file holds every
+/// tenant's device binding on shared infrastructure - so anything that can read the file used to be able
+/// to impersonate every tenant's Director. The Gateway only ever needs to VERIFY a presented key, exactly
+/// like a password, so the plaintext is returned to its owner once at enrollment and never written down.
+/// A read of <c>devices.json</c> now yields no usable credential.
+///
+/// The hash is a plain SHA-256 of the key, deliberately NOT a slow password-stretching function: the
+/// secret is a 256-bit value this class generated with a cryptographic random number generator, not a
+/// human-chosen password, so there is no guessable search space for stretching to defend and a
+/// deliberate per-verification delay would be paid on the hot path of EVERY authenticated request.
+/// For the same reason there is no per-record salt - salts defend low-entropy secrets against
+/// precomputation, which does not apply to a 256-bit random value.
+///
+/// Migration: a registry file written before this change holds the plaintext key in <c>DeviceKey</c>.
+/// <see cref="Load"/> hashes any such record on the spot, drops the plaintext, and rewrites the file, so
+/// every device enrolled before the change keeps working with the key it already holds and the plaintext
+/// disappears from disk on the first load after the upgrade.
 ///
 /// Thread-safe: registration happens on request threads while GET /devices lists devices.
 /// </summary>
@@ -75,7 +93,7 @@ public sealed class DeviceRegistry
         {
             DeviceId = deviceId,
             MachineName = machineName ?? "",
-            DeviceKey = key,
+            DeviceKeyHash = HashKey(key),
             IssuedAtUtc = DateTime.UtcNow,
             Status = StatusActive,
             Platform = string.IsNullOrWhiteSpace(platform) ? UnknownPlatform : platform.Trim(),
@@ -96,11 +114,22 @@ public sealed class DeviceRegistry
     }
 
     /// <summary>
-    /// Idempotent enrollment for the account-sign-in path (issue #1069): if this device id already holds an
-    /// active per-device key, return that SAME key unchanged; otherwise mint one via <see cref="Register"/>.
-    /// This is the load-bearing guardrail against minting a fresh key on every call - the auto-mint key leak
-    /// that #1136 fixed. Unlike <see cref="Register"/> (which rotates the key so a re-pairing issues a fresh
-    /// one), this never rotates: one device identity gets exactly one key until it is revoked.
+    /// Enrollment for the account-sign-in path (issue #1069): this device identity ends up holding exactly
+    /// ONE valid per-device key, whether it is enrolling for the first time or re-enrolling.
+    ///
+    /// A device that is already enrolled keeps its one entry - its account and tenant binding, its cloud
+    /// mapping, and its display attributes are all preserved - and is issued a fresh key IN PLACE, which
+    /// immediately retires the previous one. It does not get a second entry and it does not end up with two
+    /// working keys. That is the guardrail against the #1136 auto-mint key leak, which was an enrollment
+    /// call ACCUMULATING valid credentials in the registry; the count of valid keys per device identity is
+    /// still capped at one.
+    ///
+    /// Before issue #1878 this returned the device's existing key byte-for-byte. It cannot any more, and
+    /// deliberately so: the registry stores only a one-way hash, so there is no stored plaintext to hand
+    /// back. Re-issuing in place is the behaviour that replaces it. Every caller writes the returned key
+    /// over whatever it held, so a re-enrolling device is left holding a working key either way. An
+    /// ALREADY-enrolled device that simply keeps using its existing key is untouched by this - it never
+    /// calls here, and its key keeps verifying against the stored hash.
     /// </summary>
     public DeviceRegistrationResponse RegisterIfAbsent(string deviceId, string machineName, string? platform = null, string? deviceType = null)
     {
@@ -109,12 +138,16 @@ public sealed class DeviceRegistry
 
         if (_byDeviceId.TryGetValue(deviceId, out var existing)
             && string.Equals(existing.Status, StatusActive, StringComparison.Ordinal)
-            && !string.IsNullOrEmpty(existing.DeviceKey))
+            && !string.IsNullOrEmpty(existing.DeviceKeyHash))
         {
-            FileLog.Write($"[DeviceRegistry] RegisterIfAbsent: device id={deviceId} already has an active key; returning it unchanged (no re-mint)");
+            var reissued = GenerateDeviceKey();
+            existing.DeviceKeyHash = HashKey(reissued);
+            existing.IssuedAtUtc = DateTime.UtcNow;
+            Save();
+            FileLog.Write($"[DeviceRegistry] RegisterIfAbsent: device id={deviceId} is already enrolled; re-issued its key in place (one entry, one valid key, binding preserved)");
             return new DeviceRegistrationResponse
             {
-                DeviceKey = existing.DeviceKey,
+                DeviceKey = reissued,
                 DeviceId = deviceId,
                 MachineName = existing.MachineName,
                 Status = existing.Status,
@@ -181,22 +214,35 @@ public sealed class DeviceRegistry
     }
 
     /// <summary>
-    /// True when the supplied key matches an active device's per-device key. The lookup is over
-    /// all active keys with a constant-time compare so a near-miss reveals nothing through timing.
+    /// True when the supplied key matches an active device's per-device key. The lookup hashes the
+    /// presented key once and compares that hash against every active device's STORED hash (issue #1878)
+    /// with a constant-time compare, so a near-miss reveals nothing through timing.
     /// </summary>
-    public bool IsValidDeviceKey(string? key)
+    public bool IsValidDeviceKey(string? key) => FindActiveByKey(key) is not null;
+
+    /// <summary>
+    /// The active device whose stored per-device key hash matches <paramref name="key"/>, or null when none
+    /// does. This is the single place a presented key is turned back into a device (issue #1878): the key is
+    /// hashed once, then compared against each active record's stored hash with a constant-time compare, so a
+    /// near-miss reveals nothing through timing. This is the hot path - it runs on every authenticated
+    /// request - which is why the stored form is a plain hash of a 256-bit random secret rather than a
+    /// deliberately slow password-stretching function.
+    /// </summary>
+    private DeviceRecord? FindActiveByKey(string? key)
     {
-        if (string.IsNullOrEmpty(key)) return false;
-        var supplied = System.Text.Encoding.ASCII.GetBytes(key);
+        if (string.IsNullOrEmpty(key)) return null;
+        var supplied = HashKeyBytes(key);
         foreach (var record in _byDeviceId.Values)
         {
             if (!string.Equals(record.Status, StatusActive, StringComparison.Ordinal)) continue;
-            var stored = System.Text.Encoding.ASCII.GetBytes(record.DeviceKey);
+            if (string.IsNullOrEmpty(record.DeviceKeyHash)) continue;
+            var stored = DecodeHash(record.DeviceKeyHash);
+            if (stored is null) continue;
             if (stored.Length == supplied.Length &&
                 CryptographicOperations.FixedTimeEquals(stored, supplied))
-                return true;
+                return record;
         }
-        return false;
+        return null;
     }
 
     /// <summary>
@@ -207,20 +253,7 @@ public sealed class DeviceRegistry
     /// compare is constant-time, mirroring <see cref="IsValidDeviceKey"/>, so a near-miss reveals nothing
     /// through timing.
     /// </summary>
-    public string? DeviceTypeForKey(string? key)
-    {
-        if (string.IsNullOrEmpty(key)) return null;
-        var supplied = System.Text.Encoding.ASCII.GetBytes(key);
-        foreach (var record in _byDeviceId.Values)
-        {
-            if (!string.Equals(record.Status, StatusActive, StringComparison.Ordinal)) continue;
-            var stored = System.Text.Encoding.ASCII.GetBytes(record.DeviceKey);
-            if (stored.Length == supplied.Length &&
-                CryptographicOperations.FixedTimeEquals(stored, supplied))
-                return record.DeviceType;
-        }
-        return null;
-    }
+    public string? DeviceTypeForKey(string? key) => FindActiveByKey(key)?.DeviceType;
 
     /// <summary>
     /// The tenant id of the active device whose per-device key matches <paramref name="key"/>, or null when
@@ -233,17 +266,9 @@ public sealed class DeviceRegistry
     /// </summary>
     public string? TenantForKey(string? key)
     {
-        if (string.IsNullOrEmpty(key)) return null;
-        var supplied = System.Text.Encoding.ASCII.GetBytes(key);
-        foreach (var record in _byDeviceId.Values)
-        {
-            if (!string.Equals(record.Status, StatusActive, StringComparison.Ordinal)) continue;
-            var stored = System.Text.Encoding.ASCII.GetBytes(record.DeviceKey);
-            if (stored.Length == supplied.Length &&
-                CryptographicOperations.FixedTimeEquals(stored, supplied))
-                return string.IsNullOrEmpty(record.TenantId) ? null : record.TenantId;
-        }
-        return null;
+        var record = FindActiveByKey(key);
+        if (record is null) return null;
+        return string.IsNullOrEmpty(record.TenantId) ? null : record.TenantId;
     }
 
     /// <summary>
@@ -344,6 +369,20 @@ public sealed class DeviceRegistry
             .TrimEnd('=');
     }
 
+    /// <summary>The stored form of a device key: the lower-case hexadecimal SHA-256 of the key (issue #1878).</summary>
+    private static string HashKey(string key) => Convert.ToHexString(HashKeyBytes(key)).ToLowerInvariant();
+
+    private static byte[] HashKeyBytes(string key) =>
+        SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(key));
+
+    /// <summary>The bytes of a stored hash, or null when the stored text is not valid hexadecimal (a
+    /// hand-edited or corrupt record, which then simply matches nothing).</summary>
+    private static byte[]? DecodeHash(string hex)
+    {
+        try { return Convert.FromHexString(hex); }
+        catch (FormatException) { return null; }
+    }
+
     private void Load()
     {
         if (!File.Exists(_storePath)) return;
@@ -355,12 +394,31 @@ public sealed class DeviceRegistry
             PropertyNameCaseInsensitive = true,
         });
         if (records is null) return;
+        var migrated = 0;
         foreach (var record in records)
         {
             if (string.IsNullOrEmpty(record.DeviceId)) continue;
+
+            // Migration (issue #1878): a file written before device keys were hashed carries the plaintext
+            // key. Hash it here and drop the plaintext, so the device keeps working with the key it already
+            // holds and the plaintext leaves the file on the first save after this load.
+            if (!string.IsNullOrEmpty(record.DeviceKey))
+            {
+                if (string.IsNullOrEmpty(record.DeviceKeyHash))
+                    record.DeviceKeyHash = HashKey(record.DeviceKey);
+                record.DeviceKey = null;
+                migrated++;
+            }
+
             _byDeviceId[record.DeviceId] = record;
         }
         FileLog.Write($"[DeviceRegistry] Loaded {_byDeviceId.Count} device(s) from {_storePath}");
+
+        if (migrated > 0)
+        {
+            Save();
+            FileLog.Write($"[DeviceRegistry] Migrated {migrated} device(s) from a plaintext key to a stored hash; the plaintext keys are no longer on disk and every migrated device keeps its existing key");
+        }
     }
 
     private void Save()
@@ -373,17 +431,29 @@ public sealed class DeviceRegistry
             var json = JsonSerializer.Serialize(_byDeviceId.Values.ToList(), new JsonSerializerOptions
             {
                 WriteIndented = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             });
             File.WriteAllText(_storePath, json);
         }
     }
 
-    /// <summary>One device's full record, including the issued key (persisted, never listed).</summary>
+    /// <summary>One device's full record. It carries the HASH of the issued key, never the key (issue #1878).</summary>
     private sealed class DeviceRecord
     {
         public string DeviceId { get; set; } = "";
         public string MachineName { get; set; } = "";
-        public string DeviceKey { get; set; } = "";
+
+        /// <summary>
+        /// The plaintext key as written by a registry file from BEFORE issue #1878. This property exists
+        /// only so <see cref="Load"/> can read such a file and migrate it; it is nulled the moment it is
+        /// hashed and is never written back out. Nothing else may read or set it.
+        /// </summary>
+        public string? DeviceKey { get; set; }
+
+        /// <summary>The lower-case hexadecimal SHA-256 of this device's key - the only form of the key that
+        /// is ever persisted. Verified against, never reversed.</summary>
+        public string DeviceKeyHash { get; set; } = "";
+
         public DateTime IssuedAtUtc { get; set; }
         public string Status { get; set; } = StatusActive;
 

--- a/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
+++ b/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
@@ -22,8 +22,13 @@ namespace CcDirector.Gateway.Pairing;
 /// authenticates every Director-to-Gateway call, and on the hosted Gateway this one file holds every
 /// tenant's device binding on shared infrastructure - so anything that can read the file used to be able
 /// to impersonate every tenant's Director. The Gateway only ever needs to VERIFY a presented key, exactly
-/// like a password, so the plaintext is returned to its owner once at enrollment and never written down.
+/// like a password, so the plaintext is returned to its owner at enrollment and never written to the file.
 /// A read of <c>devices.json</c> now yields no usable credential.
+///
+/// One deliberate exception, and it is memory-only: an issued key is held in this process for a short replay
+/// window so that a RETRIED enrollment gets the same key back rather than a rotated one (see
+/// <see cref="RegisterIfAbsent"/>). It is never serialized and does not survive a restart, so it does not
+/// weaken the at-rest property above.
 ///
 /// The hash is a plain SHA-256 of the key, deliberately NOT a slow password-stretching function: the
 /// secret is a 256-bit value this class generated with a cryptographic random number generator, not a
@@ -34,8 +39,15 @@ namespace CcDirector.Gateway.Pairing;
 ///
 /// Migration: a registry file written before this change holds the plaintext key in <c>DeviceKey</c>.
 /// <see cref="Load"/> hashes any such record on the spot, drops the plaintext, and rewrites the file, so
-/// every device enrolled before the change keeps working with the key it already holds and the plaintext
-/// disappears from disk on the first load after the upgrade.
+/// every device enrolled before the change keeps working with the key it already holds and the plaintext is
+/// gone from the LIVE registry file after the first load following the upgrade.
+///
+/// The scope of that claim is exactly the live file and no more. Rewriting a file cannot erase a copy of the
+/// old contents that something else already took: a share snapshot, a backup, a soft-delete retention window,
+/// or file-system history all hold whatever was there before, and this code has no reach into any of them.
+/// Where such retention exists on a deployment, purging it is separate operational work and must be tracked
+/// as such. Any key that a pre-change file may have exposed through a retained copy is only truly dealt with
+/// by rotating that key, not by this migration.
 ///
 /// Thread-safe: registration happens on request threads while GET /devices lists devices.
 /// </summary>
@@ -50,20 +62,48 @@ public sealed class DeviceRegistry
     /// <summary>The platform recorded when a child app enrolls without supplying one.</summary>
     public const string UnknownPlatform = "unknown";
 
+    /// <summary>
+    /// How long a key issued by <see cref="RegisterIfAbsent"/> stays replayable, so that a retried or
+    /// duplicated enrollment gets the SAME key back instead of rotating one the caller may not have saved
+    /// yet. See <see cref="RegisterIfAbsent"/> for why this exists.
+    /// </summary>
+    public static readonly TimeSpan DefaultEnrollmentReplayWindow = TimeSpan.FromMinutes(5);
+
     private readonly string _storePath;
     private readonly object _saveLock = new();
+    private readonly object _enrollLock = new();
+    private readonly TimeSpan _replayWindow;
     private readonly ConcurrentDictionary<string, DeviceRecord> _byDeviceId =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The key most recently issued by <see cref="RegisterIfAbsent"/> per device id, held IN MEMORY ONLY
+    /// for <see cref="_replayWindow"/> so a retry of the same enrollment can be answered with the same key.
+    /// Never serialized, never written to <see cref="_storePath"/>, and gone when the process exits.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, ReplayableIssue> _replayableIssues =
         new(StringComparer.Ordinal);
 
     public DeviceRegistry() : this(null) { }
 
     /// <param name="storePath">Override the registry file (tests pass an isolated temp path);
     /// production omits it for the shared default under the config root.</param>
-    public DeviceRegistry(string? storePath)
+    public DeviceRegistry(string? storePath) : this(storePath, DefaultEnrollmentReplayWindow) { }
+
+    /// <param name="storePath">Override the registry file (tests pass an isolated temp path);
+    /// production omits it for the shared default under the config root.</param>
+    /// <param name="enrollmentReplayWindow">How long a key issued by <see cref="RegisterIfAbsent"/> stays
+    /// replayable. Production uses <see cref="DefaultEnrollmentReplayWindow"/>; a test passes
+    /// <see cref="TimeSpan.Zero"/> to exercise the behaviour after the window has closed.</param>
+    public DeviceRegistry(string? storePath, TimeSpan enrollmentReplayWindow)
     {
+        if (enrollmentReplayWindow < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(enrollmentReplayWindow), "the replay window cannot be negative");
+
         _storePath = string.IsNullOrWhiteSpace(storePath)
             ? Path.Combine(CcStorage.Config(), "director", "devices.json")
             : storePath;
+        _replayWindow = enrollmentReplayWindow;
         Load();
     }
 
@@ -124,39 +164,129 @@ public sealed class DeviceRegistry
     /// call ACCUMULATING valid credentials in the registry; the count of valid keys per device identity is
     /// still capped at one.
     ///
-    /// Before issue #1878 this returned the device's existing key byte-for-byte. It cannot any more, and
-    /// deliberately so: the registry stores only a one-way hash, so there is no stored plaintext to hand
-    /// back. Re-issuing in place is the behaviour that replaces it. Every caller writes the returned key
-    /// over whatever it held, so a re-enrolling device is left holding a working key either way. An
-    /// ALREADY-enrolled device that simply keeps using its existing key is untouched by this - it never
-    /// calls here, and its key keeps verifying against the stored hash.
+    /// Before issue #1878 this returned the device's existing key byte-for-byte, so calling it twice was
+    /// harmless. It cannot return a stored key any more - the registry keeps only a one-way hash - so the
+    /// repeat-call safety is preserved a different way, by a short IN-MEMORY replay window
+    /// (<see cref="DefaultEnrollmentReplayWindow"/>).
+    ///
+    /// A repeat call inside that window returns the SAME key that the previous call issued and does not
+    /// rotate anything. This matters because the caller has not necessarily saved the first response yet:
+    /// a lost or delayed response, a double submit, or two enrollment calls in flight would otherwise leave
+    /// a caller holding a key that a later call had already retired, locking that device out until a human
+    /// re-enrolled it. That is a self-inflicted outage on a retry, which is exactly the failure that only
+    /// shows up on a flaky connection. The whole method is serialized, so two simultaneous calls resolve to
+    /// one issue rather than racing to rotate.
+    ///
+    /// After the window closes, a further call rotates the key in place: same single registry entry, same
+    /// account and tenant binding, same cloud mapping, and still exactly one key that validates, with the
+    /// previous one retired. That one-key-per-device cap is the #1136 auto-mint guardrail (the leak was
+    /// enrollment ACCUMULATING valid credentials) and it holds on both paths.
+    ///
+    /// The replayable key lives in this process's memory and nowhere else - it is never serialized and it
+    /// does not survive a restart - so the at-rest property this change exists for is untouched.
+    ///
+    /// An ALREADY-enrolled device that simply keeps using its existing key never calls here at all; its key
+    /// keeps verifying against the stored hash.
     /// </summary>
     public DeviceRegistrationResponse RegisterIfAbsent(string deviceId, string machineName, string? platform = null, string? deviceType = null)
     {
         if (string.IsNullOrWhiteSpace(deviceId))
             throw new ArgumentException("deviceId is required", nameof(deviceId));
 
-        if (_byDeviceId.TryGetValue(deviceId, out var existing)
-            && string.Equals(existing.Status, StatusActive, StringComparison.Ordinal)
-            && !string.IsNullOrEmpty(existing.DeviceKeyHash))
+        // Serialized so that two enrollment calls in flight for the same device cannot both rotate. The
+        // path runs at enrollment only, never on the per-request authentication hot path.
+        lock (_enrollLock)
         {
-            var reissued = GenerateDeviceKey();
-            existing.DeviceKeyHash = HashKey(reissued);
-            existing.IssuedAtUtc = DateTime.UtcNow;
-            Save();
-            FileLog.Write($"[DeviceRegistry] RegisterIfAbsent: device id={deviceId} is already enrolled; re-issued its key in place (one entry, one valid key, binding preserved)");
-            return new DeviceRegistrationResponse
+            if (_byDeviceId.TryGetValue(deviceId, out var existing)
+                && string.Equals(existing.Status, StatusActive, StringComparison.Ordinal)
+                && !string.IsNullOrEmpty(existing.DeviceKeyHash))
             {
-                DeviceKey = reissued,
-                DeviceId = deviceId,
-                MachineName = existing.MachineName,
-                Status = existing.Status,
-                DeviceCount = _byDeviceId.Count,
-            };
-        }
+                if (TryReplayIssuedKey(deviceId, existing, out var replayed))
+                {
+                    FileLog.Write($"[DeviceRegistry] RegisterIfAbsent: device id={deviceId} enrolled again within the replay window; returned the SAME key, nothing rotated");
+                    return new DeviceRegistrationResponse
+                    {
+                        DeviceKey = replayed,
+                        DeviceId = deviceId,
+                        MachineName = existing.MachineName,
+                        Status = existing.Status,
+                        DeviceCount = _byDeviceId.Count,
+                    };
+                }
 
-        return Register(deviceId, machineName, platform, deviceType);
+                var reissued = GenerateDeviceKey();
+                var reissuedHash = HashKey(reissued);
+                existing.DeviceKeyHash = reissuedHash;
+                existing.IssuedAtUtc = DateTime.UtcNow;
+                Save();
+                RecordReplayableIssue(deviceId, reissued, reissuedHash);
+                FileLog.Write($"[DeviceRegistry] RegisterIfAbsent: device id={deviceId} is already enrolled and past the replay window; re-issued its key in place (one entry, one valid key, binding preserved)");
+                return new DeviceRegistrationResponse
+                {
+                    DeviceKey = reissued,
+                    DeviceId = deviceId,
+                    MachineName = existing.MachineName,
+                    Status = existing.Status,
+                    DeviceCount = _byDeviceId.Count,
+                };
+            }
+
+            var fresh = Register(deviceId, machineName, platform, deviceType);
+            RecordReplayableIssue(deviceId, fresh.DeviceKey, HashKey(fresh.DeviceKey));
+            return fresh;
+        }
     }
+
+    /// <summary>
+    /// The key this registry last issued for <paramref name="deviceId"/> through
+    /// <see cref="RegisterIfAbsent"/>, when that issue is still inside the replay window AND is still the
+    /// key the stored record verifies against. Both conditions matter: an expired entry must not be handed
+    /// out, and neither must one that some other path (an explicit <see cref="Register"/> re-pairing, a
+    /// revoke-and-re-enroll) has already superseded.
+    /// </summary>
+    private bool TryReplayIssuedKey(string deviceId, DeviceRecord existing, out string key)
+    {
+        key = "";
+        PruneExpiredIssues();
+
+        if (!_replayableIssues.TryGetValue(deviceId, out var issue)) return false;
+        if (DateTime.UtcNow - issue.IssuedAtUtc >= _replayWindow) return false;
+        if (!string.Equals(issue.KeyHash, existing.DeviceKeyHash, StringComparison.Ordinal)) return false;
+
+        key = issue.Key;
+        return true;
+    }
+
+    /// <summary>
+    /// Remembers the key just issued so the next call inside the window can replay it. This deliberately
+    /// records unconditionally, including for a zero window: the window is enforced in exactly ONE place,
+    /// the expiry check in <see cref="TryReplayIssuedKey"/>. A second short-circuit here would mean a broken
+    /// expiry check could still look correct under a zero window, which is the guard that would hide it.
+    /// </summary>
+    private void RecordReplayableIssue(string deviceId, string key, string keyHash)
+    {
+        _replayableIssues[deviceId] = new ReplayableIssue(key, keyHash, DateTime.UtcNow);
+    }
+
+    /// <summary>Drops replayable keys whose window has closed, so a plaintext key is not held in memory any
+    /// longer than the retry it exists to absorb.</summary>
+    private void PruneExpiredIssues()
+    {
+        var now = DateTime.UtcNow;
+        foreach (var pair in _replayableIssues)
+        {
+            if (now - pair.Value.IssuedAtUtc >= _replayWindow)
+                _replayableIssues.TryRemove(pair.Key, out _);
+        }
+    }
+
+    /// <summary>A key handed out by <see cref="RegisterIfAbsent"/>, kept in memory only, so that a retry of
+    /// the same enrollment can be answered with the same key instead of rotating one the caller may not
+    /// have saved yet.</summary>
+    /// <param name="Key">The issued plaintext key. In memory for the replay window; never persisted.</param>
+    /// <param name="KeyHash">The stored form, used to confirm this issue is still the current one.</param>
+    /// <param name="IssuedAtUtc">When it was issued, for the window.</param>
+    private sealed record ReplayableIssue(string Key, string KeyHash, DateTime IssuedAtUtc);
 
     /// <summary>
     /// Records the cloud roster id assigned to a mirrored child (Path B, Diagram 2b) so a later
@@ -196,6 +326,7 @@ public sealed class DeviceRegistry
         if (!_byDeviceId.TryRemove(deviceId, out _))
             return false;
 
+        _replayableIssues.TryRemove(deviceId, out _);
         Save();
         FileLog.Write($"[DeviceRegistry] Removed device id={deviceId} (local key revoked), total={_byDeviceId.Count}");
         return true;
@@ -215,18 +346,34 @@ public sealed class DeviceRegistry
 
     /// <summary>
     /// True when the supplied key matches an active device's per-device key. The lookup hashes the
-    /// presented key once and compares that hash against every active device's STORED hash (issue #1878)
-    /// with a constant-time compare, so a near-miss reveals nothing through timing.
+    /// presented key once and compares that digest against each active device's STORED digest (issue #1878)
+    /// with a constant-time DIGEST comparison. See <see cref="FindActiveByKey"/> for what that does and does
+    /// not cover - the comparison is constant-time; the surrounding lookup is not.
     /// </summary>
     public bool IsValidDeviceKey(string? key) => FindActiveByKey(key) is not null;
 
     /// <summary>
     /// The active device whose stored per-device key hash matches <paramref name="key"/>, or null when none
     /// does. This is the single place a presented key is turned back into a device (issue #1878): the key is
-    /// hashed once, then compared against each active record's stored hash with a constant-time compare, so a
-    /// near-miss reveals nothing through timing. This is the hot path - it runs on every authenticated
-    /// request - which is why the stored form is a plain hash of a 256-bit random secret rather than a
-    /// deliberately slow password-stretching function.
+    /// hashed once, then that digest is compared against each active record's stored digest with
+    /// <see cref="CryptographicOperations.FixedTimeEquals"/>.
+    ///
+    /// Be precise about what that buys, because it is easy to overstate. The DIGEST COMPARISON is
+    /// constant-time: it always reads both digests in full, so it does not leak how many leading bytes of a
+    /// wrong digest happened to match, and it is that partial-match signal which would otherwise let an
+    /// attacker walk a guess towards a stored value byte by byte. The comparison is the part that has to be
+    /// constant-time and it is.
+    ///
+    /// The LOOKUP AROUND IT is not constant-time and does not claim to be. It walks the records, it skips
+    /// inactive and unhashed ones, and it returns as soon as it matches - so its running time varies with how
+    /// many devices are enrolled and with where in the walk a match falls. What that can leak is coarse
+    /// registry shape (roughly how many devices exist, and a matching key's rough position among them), not
+    /// any information about the SECRET, because the compared digest is the output of a hash of the presented
+    /// value and a wrong guess produces an unrelated digest whose position is meaningless. Making the walk
+    /// constant-time would defend nothing that matters here.
+    ///
+    /// This is the hot path - it runs on every authenticated request - which is why the stored form is a
+    /// plain hash of a 256-bit random secret rather than a deliberately slow password-stretching function.
     /// </summary>
     private DeviceRecord? FindActiveByKey(string? key)
     {
@@ -250,8 +397,8 @@ public sealed class DeviceRegistry
     /// per-device key matches <paramref name="key"/>, or null when no active device matches. Used by the
     /// DevThrottle Stats surface resolution to tag a remote prompt with the surface it came from, from the
     /// SAME verified key that already authenticated the call (no client change, no forgeable header). The
-    /// compare is constant-time, mirroring <see cref="IsValidDeviceKey"/>, so a near-miss reveals nothing
-    /// through timing.
+    /// digest comparison is constant-time, mirroring <see cref="IsValidDeviceKey"/>; see
+    /// <see cref="FindActiveByKey"/> for the exact scope of that.
     /// </summary>
     public string? DeviceTypeForKey(string? key) => FindActiveByKey(key)?.DeviceType;
 
@@ -260,9 +407,9 @@ public sealed class DeviceRegistry
     /// no active device matches OR the matched device has no tenant binding (Hosted Multi-Tenancy increment
     /// 1). The tunnel reads this at Hello from the SAME verified key that already authenticated the
     /// connection, so the resolved tenant comes from the AUTHENTICATED credential, never from anything the
-    /// client sent in its Hello payload. The compare is constant-time, mirroring <see cref="IsValidDeviceKey"/>,
-    /// so a near-miss reveals nothing through timing. A null return on hosted is a DENY, never a fall-back to
-    /// the local tenant.
+    /// client sent in its Hello payload. The digest comparison is constant-time, mirroring
+    /// <see cref="IsValidDeviceKey"/>; see <see cref="FindActiveByKey"/> for the exact scope of that. A null
+    /// return on hosted is a DENY, never a fall-back to the local tenant.
     /// </summary>
     public string? TenantForKey(string? key)
     {
@@ -401,7 +548,9 @@ public sealed class DeviceRegistry
 
             // Migration (issue #1878): a file written before device keys were hashed carries the plaintext
             // key. Hash it here and drop the plaintext, so the device keeps working with the key it already
-            // holds and the plaintext leaves the file on the first save after this load.
+            // holds and the plaintext is gone from the live file after the first save following this load.
+            // That is the whole of the claim: rewriting the live file cannot reach a snapshot, backup, or
+            // soft-delete copy of the old contents. See the type documentation.
             if (!string.IsNullOrEmpty(record.DeviceKey))
             {
                 if (string.IsNullOrEmpty(record.DeviceKeyHash))
@@ -417,7 +566,7 @@ public sealed class DeviceRegistry
         if (migrated > 0)
         {
             Save();
-            FileLog.Write($"[DeviceRegistry] Migrated {migrated} device(s) from a plaintext key to a stored hash; the plaintext keys are no longer on disk and every migrated device keeps its existing key");
+            FileLog.Write($"[DeviceRegistry] Migrated {migrated} device(s) from a plaintext key to a stored hash; every migrated device keeps its existing key and the plaintext is gone from the live registry file. Any snapshot, backup, or soft-delete copy of the pre-change file still holds those keys and is not reachable from here - purge it separately, or rotate the affected keys.");
         }
     }
 

--- a/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
+++ b/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
@@ -25,24 +25,23 @@ namespace CcDirector.Gateway.Pairing;
 /// like a password, so the plaintext is returned to its owner at enrollment and never written to the file.
 /// A read of <c>devices.json</c> now yields no usable credential.
 ///
-/// One deliberate exception, and it is memory-only: an issued key is held in this process for a short replay
-/// window so that a RETRIED enrollment gets the same key back rather than a rotated one (see
-/// <see cref="RegisterIfAbsent"/>). It is never serialized and does not survive a restart, so it does not
-/// weaken the at-rest property above.
+/// Plaintext is disclosed at exactly ONE point and never retained: the enrollment response. The key is
+/// generated, hashed into the record, and the plaintext is returned to the caller in that one response. It
+/// is never stored, never cached, and never held in this process past the return of the call that issued
+/// it - so a REPEAT enrollment cannot re-reveal a key that was already handed out (issue #1899). There is no
+/// path by which the current bearer credential can be read back out of the registry.
 ///
-/// What makes that exception acceptable is that it is SHORT-LIVED, so the short-livedness is enforced by a
-/// clock this type owns rather than merely asserted: a recurring eviction pass, started the moment the first
-/// key is retained, drops every issue whose window has closed - whether or not anything else ever calls in
-/// again. Plaintext is therefore held for at most one and a half replay windows (no more than seven and a
-/// half minutes by default), and <see cref="Dispose"/> ends it immediately.
-///
-/// That was got wrong once and the mistake is worth naming, because it is easy to make again. Checking an
-/// entry's age when somebody asks to replay it stops an expired key being RETURNED, and it looks like it
-/// bounds retention, but it does not: the ordinary case is a device that enrolls once under its own id and
-/// never comes back, and that device never reaches the check at all, so its plaintext key would sit in memory
-/// for the life of the process. Correctness of the reply and boundedness of the retention are two different
-/// jobs; only the second one needs a clock. Eviction has exactly ONE owner so a broken pass cannot be masked
-/// by some other path tidying up on its way past.
+/// Retry-safety without retaining plaintext (issue #1899): a repeat enrollment of an already-enrolled device
+/// ROTATES the key in place - it issues a fresh key, retires the previous one, and returns the fresh key in
+/// that response (see <see cref="RegisterIfAbsent"/>). Enrollment is a one-shot, deliberate act (the client
+/// calls it on a connect action, never from its polling loop), so the retry it actually produces is a
+/// SEQUENTIAL re-attempt after a failed or lost response: each such attempt returns a fresh, working key that
+/// the caller writes to its credential file, overwriting whatever it held. A caller that never received the
+/// first response never held the retired key, so rotating it locks nobody out; a caller that did receive and
+/// save a key does not then re-fire enrollment. The one-key-per-device cap is preserved - one registry entry,
+/// exactly one key that validates at any moment - which is the guardrail against the #1136 auto-mint leak
+/// (enrollment ACCUMULATING valid credentials). What rotation deliberately does NOT do is keep a plaintext
+/// copy around to hand back on a duplicate; that is precisely the property issue #1899 removed.
 ///
 /// The hash is a plain SHA-256 of the key, deliberately NOT a slow password-stretching function: the
 /// secret is a 256-bit value this class generated with a cryptographic random number generator, not a
@@ -51,10 +50,21 @@ namespace CcDirector.Gateway.Pairing;
 /// For the same reason there is no per-record salt - salts defend low-entropy secrets against
 /// precomputation, which does not apply to a 256-bit random value.
 ///
+/// The hash is also the INDEX key: a presented key is turned back into its device by a single hash-to-record
+/// dictionary lookup (issue #1899), not by walking every record, so authentication is O(1) in the number of
+/// enrolled devices. Each record carries its own tenant binding, so an indexed lookup resolves to a
+/// tenant-bound record exactly as the old walk did. See <see cref="FindActiveByKey"/>.
+///
+/// Each record also carries a NON-SECRET masked key identity - the key's first few characters and its last
+/// four (issue #1899) - so a host-readable listing can tell devices apart by key without ever holding or
+/// returning the raw key. The masked form reveals a handful of a 43-character (256-bit) key and leaves the
+/// overwhelming majority unknown, so it is not a credential and cannot be replayed.
+///
 /// Migration: a registry file written before this change holds the plaintext key in <c>DeviceKey</c>.
-/// <see cref="Load"/> hashes any such record on the spot, drops the plaintext, and rewrites the file, so
-/// every device enrolled before the change keeps working with the key it already holds and the plaintext is
-/// gone from the LIVE registry file after the first load following the upgrade.
+/// <see cref="Load"/> hashes any such record on the spot, records its masked key identity, drops the
+/// plaintext, and rewrites the file, so every device enrolled before the change keeps working with the key it
+/// already holds and the plaintext is gone from the LIVE registry file after the first load following the
+/// upgrade.
 ///
 /// The scope of that claim is exactly the live file and no more. Rewriting a file cannot erase a copy of the
 /// old contents that something else already took: a share snapshot, a backup, a soft-delete retention window,
@@ -76,73 +86,38 @@ public sealed class DeviceRegistry : IDisposable
     /// <summary>The platform recorded when a child app enrolls without supplying one.</summary>
     public const string UnknownPlatform = "unknown";
 
-    /// <summary>
-    /// How long a key issued by <see cref="RegisterIfAbsent"/> stays replayable, so that a retried or
-    /// duplicated enrollment gets the SAME key back instead of rotating one the caller may not have saved
-    /// yet. See <see cref="RegisterIfAbsent"/> for why this exists.
-    /// </summary>
-    public static readonly TimeSpan DefaultEnrollmentReplayWindow = TimeSpan.FromMinutes(5);
+    /// <summary>How many leading characters of a key make up its non-secret masked prefix (issue #1899).</summary>
+    private const int KeyPrefixLength = 8;
+
+    /// <summary>How many trailing characters of a key make up its non-secret masked suffix (issue #1899).</summary>
+    private const int KeyLast4Length = 4;
 
     private readonly string _storePath;
     private readonly object _saveLock = new();
     private readonly object _enrollLock = new();
-    private readonly TimeSpan _replayWindow;
     private readonly ConcurrentDictionary<string, DeviceRecord> _byDeviceId =
         new(StringComparer.Ordinal);
 
     /// <summary>
-    /// The key most recently issued by <see cref="RegisterIfAbsent"/> per device id, held IN MEMORY ONLY
-    /// for <see cref="_replayWindow"/> so a retry of the same enrollment can be answered with the same key.
-    /// Never serialized, never written to <see cref="_storePath"/>, and gone when the process exits.
+    /// The O(1) authentication index (issue #1899): the stored SHA-256 hash of a device's key mapped to that
+    /// device's record, so a presented key is verified by hashing it once and looking the digest up directly
+    /// rather than walking every device. Kept in lock-step with <see cref="_byDeviceId"/> by every path that
+    /// issues, rotates, or removes a key. The record it points at carries the tenant, so the lookup stays
+    /// tenant-bound. Holds no plaintext - the key is the digest, exactly what is on disk.
     /// </summary>
-    private readonly ConcurrentDictionary<string, ReplayableIssue> _replayableIssues =
+    private readonly ConcurrentDictionary<string, DeviceRecord> _byKeyHash =
         new(StringComparer.Ordinal);
-
-    /// <summary>The recurring pass that evicts expired replayable keys. Null until the first key is actually
-    /// retained, and again once disposed.</summary>
-    private Timer? _evictionTimer;
-
-    /// <summary>How the eviction pass gets driven; null means production's own <see cref="Timer"/>.</summary>
-    private readonly Action<TimeSpan, Action>? _scheduleEviction;
-
-    /// <summary>Whether the recurring eviction pass has been started. Only ever set under <see cref="_enrollLock"/>.</summary>
-    private bool _evictionStarted;
 
     public DeviceRegistry() : this(null) { }
 
     /// <param name="storePath">Override the registry file (tests pass an isolated temp path);
     /// production omits it for the shared default under the config root.</param>
-    public DeviceRegistry(string? storePath) : this(storePath, DefaultEnrollmentReplayWindow) { }
-
-    /// <param name="storePath">Override the registry file (tests pass an isolated temp path);
-    /// production omits it for the shared default under the config root.</param>
-    /// <param name="enrollmentReplayWindow">How long a key issued by <see cref="RegisterIfAbsent"/> stays
-    /// replayable. Production uses <see cref="DefaultEnrollmentReplayWindow"/>; a test passes
-    /// <see cref="TimeSpan.Zero"/> to exercise the behaviour after the window has closed.</param>
-    public DeviceRegistry(string? storePath, TimeSpan enrollmentReplayWindow)
-        : this(storePath, enrollmentReplayWindow, scheduleEviction: null) { }
-
-    /// <param name="storePath">Override the registry file (tests pass an isolated temp path);
-    /// production omits it for the shared default under the config root.</param>
-    /// <param name="enrollmentReplayWindow">How long a key issued by <see cref="RegisterIfAbsent"/> stays
-    /// replayable.</param>
-    /// <param name="scheduleEviction">How the recurring eviction pass gets driven. Null - production - starts
-    /// a <see cref="Timer"/> on the replay window. A test passes its own scheduler, captures the callback, and
-    /// fires it by hand, so that BOTH halves of eviction are proven without waiting on a clock: that this type
-    /// actually schedules a pass, and that the pass actually releases the plaintext. Waiting on a real timer
-    /// would make the proof a matter of how loaded the machine is, which is not a proof.</param>
-    internal DeviceRegistry(string? storePath, TimeSpan enrollmentReplayWindow, Action<TimeSpan, Action>? scheduleEviction)
+    public DeviceRegistry(string? storePath)
     {
-        if (enrollmentReplayWindow < TimeSpan.Zero)
-            throw new ArgumentOutOfRangeException(nameof(enrollmentReplayWindow), "the replay window cannot be negative");
-
         _storePath = string.IsNullOrWhiteSpace(storePath)
             ? Path.Combine(CcStorage.Config(), "director", "devices.json")
             : storePath;
-        _replayWindow = enrollmentReplayWindow;
         Load();
-
-        _scheduleEviction = scheduleEviction;
     }
 
     /// <summary>The on-disk registry file path.</summary>
@@ -172,13 +147,23 @@ public sealed class DeviceRegistry : IDisposable
             DeviceId = deviceId,
             MachineName = machineName ?? "",
             DeviceKeyHash = HashKey(key),
+            KeyPrefix = MaskPrefix(key),
+            KeyLast4 = MaskLast4(key),
             IssuedAtUtc = DateTime.UtcNow,
             Status = StatusActive,
             Platform = string.IsNullOrWhiteSpace(platform) ? UnknownPlatform : platform.Trim(),
             DeviceType = string.IsNullOrWhiteSpace(deviceType) ? DefaultDeviceType : deviceType.Trim(),
             CloudDeviceId = null,
         };
-        _byDeviceId[deviceId] = record;
+
+        // Replace any prior record for this device id and keep the hash index in lock-step: the prior
+        // record's stored hash must stop resolving the instant its key is superseded.
+        DeviceRecord? prior = null;
+        _byDeviceId.AddOrUpdate(deviceId, record, (_, existing) => { prior = existing; return record; });
+        if (prior is not null && !string.IsNullOrEmpty(prior.DeviceKeyHash))
+            _byKeyHash.TryRemove(prior.DeviceKeyHash, out _);
+        _byKeyHash[record.DeviceKeyHash] = record;
+
         Save();
         FileLog.Write($"[DeviceRegistry] Registered device id={deviceId}, machine={machineName}, type={record.DeviceType}, platform={record.Platform}, total={_byDeviceId.Count}");
         return new DeviceRegistrationResponse
@@ -202,26 +187,17 @@ public sealed class DeviceRegistry : IDisposable
     /// call ACCUMULATING valid credentials in the registry; the count of valid keys per device identity is
     /// still capped at one.
     ///
-    /// Before issue #1878 this returned the device's existing key byte-for-byte, so calling it twice was
-    /// harmless. It cannot return a stored key any more - the registry keeps only a one-way hash - so the
-    /// repeat-call safety is preserved a different way, by a short IN-MEMORY replay window
-    /// (<see cref="DefaultEnrollmentReplayWindow"/>).
+    /// Retry-safety (issue #1899): the registry keeps only a one-way hash of the key, so it has no plaintext
+    /// to hand back on a duplicate call, and it deliberately keeps none - retaining a plaintext copy just to
+    /// replay it is exactly what issue #1899 removed, because a retained-and-replayable key defeats hashing
+    /// at rest. A repeat call therefore ROTATES: it returns a FRESH working key and retires the previous one.
+    /// Enrollment is a one-shot, deliberate act (the client calls it on a connect action, never from its
+    /// polling loop), so the retry that actually occurs is a sequential re-attempt after a failed or lost
+    /// response - and each such attempt returns a fresh key the caller writes to its credential file. A caller
+    /// that never received the first response never held the retired key, so rotating it locks nobody out.
     ///
-    /// A repeat call inside that window returns the SAME key that the previous call issued and does not
-    /// rotate anything. This matters because the caller has not necessarily saved the first response yet:
-    /// a lost or delayed response, a double submit, or two enrollment calls in flight would otherwise leave
-    /// a caller holding a key that a later call had already retired, locking that device out until a human
-    /// re-enrolled it. That is a self-inflicted outage on a retry, which is exactly the failure that only
-    /// shows up on a flaky connection. The whole method is serialized, so two simultaneous calls resolve to
-    /// one issue rather than racing to rotate.
-    ///
-    /// After the window closes, a further call rotates the key in place: same single registry entry, same
-    /// account and tenant binding, same cloud mapping, and still exactly one key that validates, with the
-    /// previous one retired. That one-key-per-device cap is the #1136 auto-mint guardrail (the leak was
-    /// enrollment ACCUMULATING valid credentials) and it holds on both paths.
-    ///
-    /// The replayable key lives in this process's memory and nowhere else - it is never serialized and it
-    /// does not survive a restart - so the at-rest property this change exists for is untouched.
+    /// The whole method is serialized, so two simultaneous calls resolve one after the other rather than
+    /// racing; the later one wins and its key is the one that validates.
     ///
     /// An ALREADY-enrolled device that simply keeps using its existing key never calls here at all; its key
     /// keeps verifying against the stored hash.
@@ -231,34 +207,29 @@ public sealed class DeviceRegistry : IDisposable
         if (string.IsNullOrWhiteSpace(deviceId))
             throw new ArgumentException("deviceId is required", nameof(deviceId));
 
-        // Serialized so that two enrollment calls in flight for the same device cannot both rotate. The
-        // path runs at enrollment only, never on the per-request authentication hot path.
+        // Serialized so that two enrollment calls in flight for the same device cannot both rotate at once.
+        // The path runs at enrollment only, never on the per-request authentication hot path.
         lock (_enrollLock)
         {
             if (_byDeviceId.TryGetValue(deviceId, out var existing)
                 && string.Equals(existing.Status, StatusActive, StringComparison.Ordinal)
                 && !string.IsNullOrEmpty(existing.DeviceKeyHash))
             {
-                if (TryReplayIssuedKey(deviceId, existing, out var replayed))
-                {
-                    FileLog.Write($"[DeviceRegistry] RegisterIfAbsent: device id={deviceId} enrolled again within the replay window; returned the SAME key, nothing rotated");
-                    return new DeviceRegistrationResponse
-                    {
-                        DeviceKey = replayed,
-                        DeviceId = deviceId,
-                        MachineName = existing.MachineName,
-                        Status = existing.Status,
-                        DeviceCount = _byDeviceId.Count,
-                    };
-                }
-
                 var reissued = GenerateDeviceKey();
-                var reissuedHash = HashKey(reissued);
-                existing.DeviceKeyHash = reissuedHash;
+                var supersededHash = existing.DeviceKeyHash;
+                existing.DeviceKeyHash = HashKey(reissued);
+                existing.KeyPrefix = MaskPrefix(reissued);
+                existing.KeyLast4 = MaskLast4(reissued);
                 existing.IssuedAtUtc = DateTime.UtcNow;
+
+                // Keep the hash index in lock-step: the retired key must stop resolving, the fresh key must
+                // start resolving to the same (binding-preserving) record.
+                if (!string.IsNullOrEmpty(supersededHash))
+                    _byKeyHash.TryRemove(supersededHash, out _);
+                _byKeyHash[existing.DeviceKeyHash] = existing;
+
                 Save();
-                RecordReplayableIssue(deviceId, reissued, reissuedHash);
-                FileLog.Write($"[DeviceRegistry] RegisterIfAbsent: device id={deviceId} is already enrolled and past the replay window; re-issued its key in place (one entry, one valid key, binding preserved)");
+                FileLog.Write($"[DeviceRegistry] RegisterIfAbsent: device id={deviceId} is already enrolled; rotated to a fresh key in place (one entry, one valid key, binding preserved, previous key retired)");
                 return new DeviceRegistrationResponse
                 {
                     DeviceKey = reissued,
@@ -269,124 +240,17 @@ public sealed class DeviceRegistry : IDisposable
                 };
             }
 
-            var fresh = Register(deviceId, machineName, platform, deviceType);
-            RecordReplayableIssue(deviceId, fresh.DeviceKey, HashKey(fresh.DeviceKey));
-            return fresh;
+            return Register(deviceId, machineName, platform, deviceType);
         }
     }
 
-    /// <summary>
-    /// The key this registry last issued for <paramref name="deviceId"/> through
-    /// <see cref="RegisterIfAbsent"/>, when that issue is still inside the replay window AND is still the
-    /// key the stored record verifies against. Both conditions matter: an expired entry must not be handed
-    /// out, and neither must one that some other path (an explicit <see cref="Register"/> re-pairing, a
-    /// revoke-and-re-enroll) has already superseded.
-    /// </summary>
-    private bool TryReplayIssuedKey(string deviceId, DeviceRecord existing, out string key)
-    {
-        key = "";
-
-        if (!_replayableIssues.TryGetValue(deviceId, out var issue)) return false;
-        if (DateTime.UtcNow - issue.IssuedAtUtc >= _replayWindow) return false;
-        if (!string.Equals(issue.KeyHash, existing.DeviceKeyHash, StringComparison.Ordinal)) return false;
-
-        key = issue.Key;
-        return true;
-    }
-
-    /// <summary>
-    /// Remembers the key just issued so the next call inside the window can replay it. This deliberately
-    /// records unconditionally, including for a zero window: the window is enforced in exactly ONE place,
-    /// the expiry check in <see cref="TryReplayIssuedKey"/>. A second short-circuit here would mean a broken
-    /// expiry check could still look correct under a zero window, which is the guard that would hide it.
-    /// </summary>
-    private void RecordReplayableIssue(string deviceId, string key, string keyHash)
-    {
-        _replayableIssues[deviceId] = new ReplayableIssue(key, keyHash, DateTime.UtcNow);
-        StartEvictionPassOnce();
-    }
-
-    /// <summary>
-    /// Starts the recurring eviction pass the first time this registry actually retains a plaintext key.
-    /// Retention is what the pass exists to bound, so it begins when retention begins - a registry that never
-    /// issues a key never needs a clock and never starts one.
-    ///
-    /// The pass runs at HALF the window, which fixes the real retention bound. An entry recorded just after a
-    /// pass waits out its own window and then at most one further interval, so plaintext is held for at most
-    /// one and a half windows - under the default, no more than seven and a half minutes. Running the pass at
-    /// the full window length would have made the true bound TWICE the window, which is not what the
-    /// documentation on this type claims, and the claim is the thing that has to be true.
-    ///
-    /// Called only from <see cref="RecordReplayableIssue"/>, which runs under <see cref="_enrollLock"/>, so
-    /// the once-only start needs no lock of its own.
-    /// </summary>
-    private void StartEvictionPassOnce()
-    {
-        if (_evictionStarted) return;
-        _evictionStarted = true;
-
-        var interval = EvictionIntervalFor(_replayWindow);
-        if (_scheduleEviction is not null)
-            _scheduleEviction(interval, EvictExpiredReplayableIssues);
-        else
-            _evictionTimer = new Timer(_ => EvictExpiredReplayableIssues(), null, interval, interval);
-    }
-
-    /// <summary>
-    /// Drops every replayable key whose window has closed, releasing the last strong reference to that
-    /// plaintext. Driven by the recurring eviction pass this type schedules for itself - NOT by anyone
-    /// happening to call in.
-    ///
-    /// The distinction matters and is the whole point of this method existing separately from the age check
-    /// in <see cref="TryReplayIssuedKey"/>. That age check stops an expired key being RETURNED; it does not
-    /// bound how long the plaintext is RETAINED, because it only runs when an already-enrolled device asks to
-    /// replay. A device that enrolls once under its own id and never comes back - the ordinary fresh
-    /// enrollment - would never reach it, so its key would sit in memory for the life of the process. Two
-    /// different jobs: that one is correctness, this one is retention, and retention needs a clock of its own.
-    /// </summary>
-    internal void EvictExpiredReplayableIssues()
-    {
-        var now = DateTime.UtcNow;
-        foreach (var pair in _replayableIssues)
-        {
-            if (now - pair.Value.IssuedAtUtc >= _replayWindow)
-                _replayableIssues.TryRemove(pair.Key, out _);
-        }
-    }
-
-    /// <summary>
-    /// How many issued plaintext keys this registry is currently holding in memory. Exposed to the test
-    /// assembly so retention can be asserted directly, rather than inferred from behaviour that would still
-    /// look correct while the plaintext stayed resident.
-    /// </summary>
-    internal int RetainedReplayableKeyCount => _replayableIssues.Count;
-
-    /// <summary>
-    /// How often the eviction pass runs for a given replay window: half the window, floored at one second so
-    /// a tiny or zero window (which tests use to reach the post-window branch) cannot turn into a busy loop.
-    /// Half, not the full window, so that the worst-case retention is one and a half windows rather than two.
-    /// </summary>
-    internal static TimeSpan EvictionIntervalFor(TimeSpan replayWindow)
-    {
-        var half = TimeSpan.FromTicks(replayWindow.Ticks / 2);
-        return half < TimeSpan.FromSeconds(1) ? TimeSpan.FromSeconds(1) : half;
-    }
-
-    /// <summary>Stops the recurring eviction pass and drops every retained plaintext key immediately.</summary>
+    /// <summary>Nothing to release: the registry retains no plaintext and holds no OS handle. Present so the
+    /// host can dispose it uniformly; drops the in-memory maps so shutdown lets go of every reference.</summary>
     public void Dispose()
     {
-        _evictionTimer?.Dispose();
-        _evictionTimer = null;
-        _replayableIssues.Clear();
+        _byKeyHash.Clear();
+        _byDeviceId.Clear();
     }
-
-    /// <summary>A key handed out by <see cref="RegisterIfAbsent"/>, kept in memory only, so that a retry of
-    /// the same enrollment can be answered with the same key instead of rotating one the caller may not
-    /// have saved yet.</summary>
-    /// <param name="Key">The issued plaintext key. In memory for the replay window; never persisted.</param>
-    /// <param name="KeyHash">The stored form, used to confirm this issue is still the current one.</param>
-    /// <param name="IssuedAtUtc">When it was issued, for the window.</param>
-    private sealed record ReplayableIssue(string Key, string KeyHash, DateTime IssuedAtUtc);
 
     /// <summary>
     /// Records the cloud roster id assigned to a mirrored child (Path B, Diagram 2b) so a later
@@ -423,10 +287,11 @@ public sealed class DeviceRegistry : IDisposable
         if (string.IsNullOrWhiteSpace(deviceId))
             return false;
 
-        if (!_byDeviceId.TryRemove(deviceId, out _))
+        if (!_byDeviceId.TryRemove(deviceId, out var removed))
             return false;
 
-        _replayableIssues.TryRemove(deviceId, out _);
+        if (!string.IsNullOrEmpty(removed.DeviceKeyHash))
+            _byKeyHash.TryRemove(removed.DeviceKeyHash, out _);
         Save();
         FileLog.Write($"[DeviceRegistry] Removed device id={deviceId} (local key revoked), total={_byDeviceId.Count}");
         return true;
@@ -446,49 +311,52 @@ public sealed class DeviceRegistry : IDisposable
 
     /// <summary>
     /// True when the supplied key matches an active device's per-device key. The lookup hashes the
-    /// presented key once and compares that digest against each active device's STORED digest (issue #1878)
-    /// with a constant-time DIGEST comparison. See <see cref="FindActiveByKey"/> for what that does and does
-    /// not cover - the comparison is constant-time; the surrounding lookup is not.
+    /// presented key once and finds the matching record by its STORED digest in O(1) (issue #1878, #1899),
+    /// confirming with a constant-time DIGEST comparison. See <see cref="FindActiveByKey"/> for exactly what
+    /// that comparison does and does not cover.
     /// </summary>
     public bool IsValidDeviceKey(string? key) => FindActiveByKey(key) is not null;
 
     /// <summary>
     /// The active device whose stored per-device key hash matches <paramref name="key"/>, or null when none
     /// does. This is the single place a presented key is turned back into a device (issue #1878): the key is
-    /// hashed once, then that digest is compared against each active record's stored digest with
+    /// hashed once, that digest indexes straight to the one record whose stored digest could match (issue
+    /// #1899 - O(1), not a walk of every device), and the match is then confirmed with
     /// <see cref="CryptographicOperations.FixedTimeEquals"/>.
     ///
-    /// Be precise about what that buys, because it is easy to overstate. The DIGEST COMPARISON is
-    /// constant-time: it always reads both digests in full, so it does not leak how many leading bytes of a
-    /// wrong digest happened to match, and it is that partial-match signal which would otherwise let an
-    /// attacker walk a guess towards a stored value byte by byte. The comparison is the part that has to be
-    /// constant-time and it is.
+    /// Be precise about what the constant-time compare buys, because it is easy to overstate. The DIGEST
+    /// COMPARISON always reads both digests in full, so it does not leak how many leading bytes of a wrong
+    /// digest happened to match, and it is that partial-match signal which would otherwise let an attacker
+    /// walk a guess towards a stored value byte by byte. That is the part that has to be constant-time and it
+    /// is.
     ///
-    /// The LOOKUP AROUND IT is not constant-time and does not claim to be. It walks the records, it skips
-    /// inactive and unhashed ones, and it returns as soon as it matches - so its running time varies with how
-    /// many devices are enrolled and with where in the walk a match falls. What that can leak is coarse
-    /// registry shape (roughly how many devices exist, and a matching key's rough position among them), not
-    /// any information about the SECRET, because the compared digest is the output of a hash of the presented
-    /// value and a wrong guess produces an unrelated digest whose position is meaningless. Making the walk
-    /// constant-time would defend nothing that matters here.
+    /// The dictionary lookup around it is not constant-time and does not claim to be. What it can leak is
+    /// coarse - roughly, whether a digest is present - not any information about the SECRET, because the
+    /// looked-up value is the output of a hash of the presented key: a wrong guess produces an unrelated
+    /// digest that indexes nothing meaningful. Making the lookup constant-time would defend nothing that
+    /// matters here.
     ///
     /// This is the hot path - it runs on every authenticated request - which is why the stored form is a
-    /// plain hash of a 256-bit random secret rather than a deliberately slow password-stretching function.
+    /// plain hash of a 256-bit random secret rather than a deliberately slow password-stretching function,
+    /// and why the lookup is an index rather than a scan.
     /// </summary>
     private DeviceRecord? FindActiveByKey(string? key)
     {
         if (string.IsNullOrEmpty(key)) return null;
+
+        var suppliedHex = HashKey(key);
+        if (!_byKeyHash.TryGetValue(suppliedHex, out var record)) return null;
+        if (!string.Equals(record.Status, StatusActive, StringComparison.Ordinal)) return null;
+        if (string.IsNullOrEmpty(record.DeviceKeyHash)) return null;
+
+        // The index found the record by exact digest; confirm with the constant-time byte comparison so the
+        // verification path is the same one the pre-index code proved, not the dictionary's own compare.
+        var stored = DecodeHash(record.DeviceKeyHash);
+        if (stored is null) return null;
         var supplied = HashKeyBytes(key);
-        foreach (var record in _byDeviceId.Values)
-        {
-            if (!string.Equals(record.Status, StatusActive, StringComparison.Ordinal)) continue;
-            if (string.IsNullOrEmpty(record.DeviceKeyHash)) continue;
-            var stored = DecodeHash(record.DeviceKeyHash);
-            if (stored is null) continue;
-            if (stored.Length == supplied.Length &&
-                CryptographicOperations.FixedTimeEquals(stored, supplied))
-                return record;
-        }
+        if (stored.Length == supplied.Length &&
+            CryptographicOperations.FixedTimeEquals(stored, supplied))
+            return record;
         return null;
     }
 
@@ -599,6 +467,8 @@ public sealed class DeviceRegistry : IDisposable
             MachineName = record.MachineName,
             IssuedAtUtc = record.IssuedAtUtc,
             Status = record.Status,
+            KeyPrefix = record.KeyPrefix,
+            KeyLast4 = record.KeyLast4,
         };
 
     /// <summary>The number of registered devices.</summary>
@@ -621,6 +491,23 @@ public sealed class DeviceRegistry : IDisposable
 
     private static byte[] HashKeyBytes(string key) =>
         SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(key));
+
+    /// <summary>The NON-SECRET masked prefix of a key (issue #1899): its first few characters, for a
+    /// host-readable listing to tell devices apart by key without ever holding the raw key. Reveals a handful
+    /// of a 256-bit key and is not a credential.</summary>
+    private static string MaskPrefix(string key)
+    {
+        if (string.IsNullOrEmpty(key)) return "";
+        return key.Length <= KeyPrefixLength ? key : key.Substring(0, KeyPrefixLength);
+    }
+
+    /// <summary>The NON-SECRET last few characters of a key (issue #1899), the trailing half of the masked
+    /// key identity. Not a credential.</summary>
+    private static string MaskLast4(string key)
+    {
+        if (string.IsNullOrEmpty(key) || key.Length < KeyLast4Length) return "";
+        return key.Substring(key.Length - KeyLast4Length);
+    }
 
     /// <summary>The bytes of a stored hash, or null when the stored text is not valid hexadecimal (a
     /// hand-edited or corrupt record, which then simply matches nothing).</summary>
@@ -647,19 +534,26 @@ public sealed class DeviceRegistry : IDisposable
             if (string.IsNullOrEmpty(record.DeviceId)) continue;
 
             // Migration (issue #1878): a file written before device keys were hashed carries the plaintext
-            // key. Hash it here and drop the plaintext, so the device keeps working with the key it already
-            // holds and the plaintext is gone from the live file after the first save following this load.
-            // That is the whole of the claim: rewriting the live file cannot reach a snapshot, backup, or
-            // soft-delete copy of the old contents. See the type documentation.
+            // key. Hash it here, record its non-secret masked identity (issue #1899) while the plaintext is
+            // still in hand, drop the plaintext, and rely on the save below so the device keeps working with
+            // the key it already holds and the plaintext is gone from the live file. That is the whole of the
+            // claim: rewriting the live file cannot reach a snapshot, backup, or soft-delete copy of the old
+            // contents. See the type documentation.
             if (!string.IsNullOrEmpty(record.DeviceKey))
             {
                 if (string.IsNullOrEmpty(record.DeviceKeyHash))
                     record.DeviceKeyHash = HashKey(record.DeviceKey);
+                if (string.IsNullOrEmpty(record.KeyPrefix))
+                    record.KeyPrefix = MaskPrefix(record.DeviceKey);
+                if (string.IsNullOrEmpty(record.KeyLast4))
+                    record.KeyLast4 = MaskLast4(record.DeviceKey);
                 record.DeviceKey = null;
                 migrated++;
             }
 
             _byDeviceId[record.DeviceId] = record;
+            if (!string.IsNullOrEmpty(record.DeviceKeyHash))
+                _byKeyHash[record.DeviceKeyHash] = record;
         }
         FileLog.Write($"[DeviceRegistry] Loaded {_byDeviceId.Count} device(s) from {_storePath}");
 
@@ -686,7 +580,8 @@ public sealed class DeviceRegistry : IDisposable
         }
     }
 
-    /// <summary>One device's full record. It carries the HASH of the issued key, never the key (issue #1878).</summary>
+    /// <summary>One device's full record. It carries the HASH of the issued key, never the key (issue #1878),
+    /// plus a NON-SECRET masked prefix/last-four of the key for host-readable listings (issue #1899).</summary>
     private sealed class DeviceRecord
     {
         public string DeviceId { get; set; } = "";
@@ -702,6 +597,13 @@ public sealed class DeviceRegistry : IDisposable
         /// <summary>The lower-case hexadecimal SHA-256 of this device's key - the only form of the key that
         /// is ever persisted. Verified against, never reversed.</summary>
         public string DeviceKeyHash { get; set; } = "";
+
+        /// <summary>The NON-SECRET first few characters of the key (issue #1899): display metadata so a
+        /// host-readable listing can tell devices apart by key without holding the raw key. Not a credential.</summary>
+        public string KeyPrefix { get; set; } = "";
+
+        /// <summary>The NON-SECRET last few characters of the key (issue #1899). Display metadata, not a credential.</summary>
+        public string KeyLast4 { get; set; } = "";
 
         public DateTime IssuedAtUtc { get; set; }
         public string Status { get; set; } = StatusActive;

--- a/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
+++ b/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
@@ -30,6 +30,20 @@ namespace CcDirector.Gateway.Pairing;
 /// <see cref="RegisterIfAbsent"/>). It is never serialized and does not survive a restart, so it does not
 /// weaken the at-rest property above.
 ///
+/// What makes that exception acceptable is that it is SHORT-LIVED, so the short-livedness is enforced by a
+/// clock this type owns rather than merely asserted: a recurring eviction pass, started the moment the first
+/// key is retained, drops every issue whose window has closed - whether or not anything else ever calls in
+/// again. Plaintext is therefore held for at most one and a half replay windows (no more than seven and a
+/// half minutes by default), and <see cref="Dispose"/> ends it immediately.
+///
+/// That was got wrong once and the mistake is worth naming, because it is easy to make again. Checking an
+/// entry's age when somebody asks to replay it stops an expired key being RETURNED, and it looks like it
+/// bounds retention, but it does not: the ordinary case is a device that enrolls once under its own id and
+/// never comes back, and that device never reaches the check at all, so its plaintext key would sit in memory
+/// for the life of the process. Correctness of the reply and boundedness of the retention are two different
+/// jobs; only the second one needs a clock. Eviction has exactly ONE owner so a broken pass cannot be masked
+/// by some other path tidying up on its way past.
+///
 /// The hash is a plain SHA-256 of the key, deliberately NOT a slow password-stretching function: the
 /// secret is a 256-bit value this class generated with a cryptographic random number generator, not a
 /// human-chosen password, so there is no guessable search space for stretching to defend and a
@@ -51,7 +65,7 @@ namespace CcDirector.Gateway.Pairing;
 ///
 /// Thread-safe: registration happens on request threads while GET /devices lists devices.
 /// </summary>
-public sealed class DeviceRegistry
+public sealed class DeviceRegistry : IDisposable
 {
     /// <summary>The status of an actively-enrolled device.</summary>
     public const string StatusActive = "active";
@@ -84,6 +98,16 @@ public sealed class DeviceRegistry
     private readonly ConcurrentDictionary<string, ReplayableIssue> _replayableIssues =
         new(StringComparer.Ordinal);
 
+    /// <summary>The recurring pass that evicts expired replayable keys. Null until the first key is actually
+    /// retained, and again once disposed.</summary>
+    private Timer? _evictionTimer;
+
+    /// <summary>How the eviction pass gets driven; null means production's own <see cref="Timer"/>.</summary>
+    private readonly Action<TimeSpan, Action>? _scheduleEviction;
+
+    /// <summary>Whether the recurring eviction pass has been started. Only ever set under <see cref="_enrollLock"/>.</summary>
+    private bool _evictionStarted;
+
     public DeviceRegistry() : this(null) { }
 
     /// <param name="storePath">Override the registry file (tests pass an isolated temp path);
@@ -96,6 +120,18 @@ public sealed class DeviceRegistry
     /// replayable. Production uses <see cref="DefaultEnrollmentReplayWindow"/>; a test passes
     /// <see cref="TimeSpan.Zero"/> to exercise the behaviour after the window has closed.</param>
     public DeviceRegistry(string? storePath, TimeSpan enrollmentReplayWindow)
+        : this(storePath, enrollmentReplayWindow, scheduleEviction: null) { }
+
+    /// <param name="storePath">Override the registry file (tests pass an isolated temp path);
+    /// production omits it for the shared default under the config root.</param>
+    /// <param name="enrollmentReplayWindow">How long a key issued by <see cref="RegisterIfAbsent"/> stays
+    /// replayable.</param>
+    /// <param name="scheduleEviction">How the recurring eviction pass gets driven. Null - production - starts
+    /// a <see cref="Timer"/> on the replay window. A test passes its own scheduler, captures the callback, and
+    /// fires it by hand, so that BOTH halves of eviction are proven without waiting on a clock: that this type
+    /// actually schedules a pass, and that the pass actually releases the plaintext. Waiting on a real timer
+    /// would make the proof a matter of how loaded the machine is, which is not a proof.</param>
+    internal DeviceRegistry(string? storePath, TimeSpan enrollmentReplayWindow, Action<TimeSpan, Action>? scheduleEviction)
     {
         if (enrollmentReplayWindow < TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(enrollmentReplayWindow), "the replay window cannot be negative");
@@ -105,6 +141,8 @@ public sealed class DeviceRegistry
             : storePath;
         _replayWindow = enrollmentReplayWindow;
         Load();
+
+        _scheduleEviction = scheduleEviction;
     }
 
     /// <summary>The on-disk registry file path.</summary>
@@ -247,7 +285,6 @@ public sealed class DeviceRegistry
     private bool TryReplayIssuedKey(string deviceId, DeviceRecord existing, out string key)
     {
         key = "";
-        PruneExpiredIssues();
 
         if (!_replayableIssues.TryGetValue(deviceId, out var issue)) return false;
         if (DateTime.UtcNow - issue.IssuedAtUtc >= _replayWindow) return false;
@@ -266,11 +303,48 @@ public sealed class DeviceRegistry
     private void RecordReplayableIssue(string deviceId, string key, string keyHash)
     {
         _replayableIssues[deviceId] = new ReplayableIssue(key, keyHash, DateTime.UtcNow);
+        StartEvictionPassOnce();
     }
 
-    /// <summary>Drops replayable keys whose window has closed, so a plaintext key is not held in memory any
-    /// longer than the retry it exists to absorb.</summary>
-    private void PruneExpiredIssues()
+    /// <summary>
+    /// Starts the recurring eviction pass the first time this registry actually retains a plaintext key.
+    /// Retention is what the pass exists to bound, so it begins when retention begins - a registry that never
+    /// issues a key never needs a clock and never starts one.
+    ///
+    /// The pass runs at HALF the window, which fixes the real retention bound. An entry recorded just after a
+    /// pass waits out its own window and then at most one further interval, so plaintext is held for at most
+    /// one and a half windows - under the default, no more than seven and a half minutes. Running the pass at
+    /// the full window length would have made the true bound TWICE the window, which is not what the
+    /// documentation on this type claims, and the claim is the thing that has to be true.
+    ///
+    /// Called only from <see cref="RecordReplayableIssue"/>, which runs under <see cref="_enrollLock"/>, so
+    /// the once-only start needs no lock of its own.
+    /// </summary>
+    private void StartEvictionPassOnce()
+    {
+        if (_evictionStarted) return;
+        _evictionStarted = true;
+
+        var interval = EvictionIntervalFor(_replayWindow);
+        if (_scheduleEviction is not null)
+            _scheduleEviction(interval, EvictExpiredReplayableIssues);
+        else
+            _evictionTimer = new Timer(_ => EvictExpiredReplayableIssues(), null, interval, interval);
+    }
+
+    /// <summary>
+    /// Drops every replayable key whose window has closed, releasing the last strong reference to that
+    /// plaintext. Driven by the recurring eviction pass this type schedules for itself - NOT by anyone
+    /// happening to call in.
+    ///
+    /// The distinction matters and is the whole point of this method existing separately from the age check
+    /// in <see cref="TryReplayIssuedKey"/>. That age check stops an expired key being RETURNED; it does not
+    /// bound how long the plaintext is RETAINED, because it only runs when an already-enrolled device asks to
+    /// replay. A device that enrolls once under its own id and never comes back - the ordinary fresh
+    /// enrollment - would never reach it, so its key would sit in memory for the life of the process. Two
+    /// different jobs: that one is correctness, this one is retention, and retention needs a clock of its own.
+    /// </summary>
+    internal void EvictExpiredReplayableIssues()
     {
         var now = DateTime.UtcNow;
         foreach (var pair in _replayableIssues)
@@ -278,6 +352,32 @@ public sealed class DeviceRegistry
             if (now - pair.Value.IssuedAtUtc >= _replayWindow)
                 _replayableIssues.TryRemove(pair.Key, out _);
         }
+    }
+
+    /// <summary>
+    /// How many issued plaintext keys this registry is currently holding in memory. Exposed to the test
+    /// assembly so retention can be asserted directly, rather than inferred from behaviour that would still
+    /// look correct while the plaintext stayed resident.
+    /// </summary>
+    internal int RetainedReplayableKeyCount => _replayableIssues.Count;
+
+    /// <summary>
+    /// How often the eviction pass runs for a given replay window: half the window, floored at one second so
+    /// a tiny or zero window (which tests use to reach the post-window branch) cannot turn into a busy loop.
+    /// Half, not the full window, so that the worst-case retention is one and a half windows rather than two.
+    /// </summary>
+    internal static TimeSpan EvictionIntervalFor(TimeSpan replayWindow)
+    {
+        var half = TimeSpan.FromTicks(replayWindow.Ticks / 2);
+        return half < TimeSpan.FromSeconds(1) ? TimeSpan.FromSeconds(1) : half;
+    }
+
+    /// <summary>Stops the recurring eviction pass and drops every retained plaintext key immediately.</summary>
+    public void Dispose()
+    {
+        _evictionTimer?.Dispose();
+        _evictionTimer = null;
+        _replayableIssues.Clear();
     }
 
     /// <summary>A key handed out by <see cref="RegisterIfAbsent"/>, kept in memory only, so that a retry of


### PR DESCRIPTION
Closes #1878.

## The defect

`DeviceRegistry` wrote every enrolled device's per-device key into
`config/director/devices.json` in the clear, and `IsValidDeviceKey` /
`DeviceTypeForKey` / `TenantForKey` each compared a presented key against that
stored plaintext.

That key is a bearer secret: it authenticates every Director-to-Gateway call. On
the hosted Gateway the single file also holds the device-to-account-to-tenant
map for every tenant, on a mounted Azure Files share. So anything that could read
one file could impersonate every tenant's Director - which is also what turned a
process spawned with a working directory on that same share (#1863) from a
code-execution problem into a credential-exfiltration one.

## The fix

Each key is stored only as a one-way SHA-256 hash. The Gateway never needs the
key itself: it returns the plaintext to its owner at enrollment and thereafter
only VERIFIES a presented key, the same way a password store does. A read of
`devices.json` now yields no usable credential.

Two design choices, both deliberate and both written down in the code:

- **Plain SHA-256, not a slow password-stretching function.** The secret is a
  256-bit value the registry generated with a cryptographic random number
  generator, not a human-chosen password, so there is no guessable search space
  for stretching to defend - and this lookup is the hot path, running on every
  authenticated request. No per-record salt either: salts defend low-entropy
  secrets against precomputation, which does not apply here.
- **Key lookup is unchanged in shape.** The three public lookups now share one
  private resolver that hashes the presented key once and compares that digest
  against each active record's stored digest with
  `CryptographicOperations.FixedTimeEquals`.

### What the constant-time property does and does not cover

Stated precisely, because the first draft of this pull request overstated it.

The **digest comparison** is constant-time: it always reads both digests in
full, so it does not leak how many leading bytes of a wrong digest happened to
match. That partial-match signal is the one that would otherwise let an attacker
walk a guess toward a stored value, and it is the part that has to be
constant-time.

The **lookup around it is not** constant-time and no longer claims to be. It
walks the records, skips inactive and unhashed ones, and returns as soon as it
matches, so its running time varies with how many devices are enrolled and where
a match falls. What that can leak is coarse registry shape, not anything about
the secret: the compared value is the output of a hash of the presented key, so a
wrong guess yields an unrelated digest whose position carries no information.
Making the walk constant-time would defend nothing here. The code says all of
this at `FindActiveByKey`, and the three public lookups point at it rather than
repeating a shorter, looser version.

## Enrollment stays safe to retry

Hashing the stored key removed the registry's ability to hand a re-enrolling
device its existing key back, which turned every duplicate `RegisterIfAbsent`
call into a **rotation**. That was a real regression, and a serious one: a caller
that had not yet durably saved the first response - a lost or delayed response, a
double submit, two calls in flight - would be left holding a key that a later
call had already retired, locked out until a human re-enrolled it. An outage that
only happens on a retry is the kind that does not surface until real devices are
enrolling over a flaky mobile connection. The method's name and its prior
contract both promised idempotence, so the property is restored rather than
documented as a hazard.

An issued key now stays replayable for a short window held **in this process's
memory only**. A duplicate enrollment inside that window returns the same key and
rotates nothing. It is never serialized, never written to `devices.json`, and does
not survive a restart, so the at-rest property this change exists for is
untouched. The whole method is serialized, so two calls in flight converge on one
issue instead of racing to rotate.

Past the window a further enrollment rotates in place: same single registry entry,
same account and tenant binding, same cloud mapping, and still exactly one key
that validates, with the previous one retired. That one-valid-key-per-device cap
is what the #1136 auto-mint key leak guardrail actually defends (the leak was
enrollment ACCUMULATING valid credentials), and it holds on both branches.

Two details that exist to keep the mechanism provable rather than merely correct:

- The window is enforced in **exactly one place**, the expiry check. An earlier
  draft also short-circuited the recording path on a zero window; that second
  guard was removed because it would have let a broken expiry check still look
  correct under the zero-window setting the tests use - the guard would have
  hidden the defect it sat next to.
- A replay is checked against what the record **currently** verifies, so a key
  superseded by an explicit re-pairing is never handed back.

## The migration story for existing keys

Real machines are enrolled against the live hosted box right now and there is no
re-enrollment path that does not involve a human, so invalidating a stored key
would take the box down.

`Load` handles it: a record that carries a plaintext `DeviceKey` and no
`DeviceKeyHash` is hashed on the spot, the plaintext is nulled, and the file is
rewritten. The device keeps working with the key it already holds; its account
and tenant binding, cloud mirror id, platform, and device type all survive. From
then on the record has no `deviceKey` field at all.

Proven by `ADeviceEnrolledBeforeTheChange_StillAuthenticatesAfterIt` and four
sibling tests, which start from a hand-written pre-change `devices.json` in
exactly the shape the old code emitted - plaintext key, hosted account and tenant
binding, cloud id - and assert the old key still authenticates, still resolves to
its bound tenant, still works after a further restart, and that the plaintext is
gone from the file.

### What the migration does NOT do - the claim, narrowed

The migration rewrites the **live** registry file. That is the whole of what a
file write can prove, and the earlier wording here ("the plaintext leaves the
disk") overclaimed. Rewriting a file cannot reach a copy of the old contents that
something else already took: a storage-share snapshot, a backup, a soft-delete
retention window, or file-system history all retain whatever the file held
before, and no write from inside the Gateway touches any of them.

On hosted, the registry sits on a mounted Azure Files share. Snapshots and soft
delete there are account-level and share-level settings held **outside this
repository** - a search of the repository finds no configuration that enables,
disables, or references them - so whether pre-change copies are being retained is
a property of the deployed storage account and has to be checked there rather
than inferred from code. This pull request does not assert either way.

Where such retention is found, two things follow, both separate operational work
tracked separately from this change:

1. Purge the retained copies of the pre-change `devices.json`.
2. Treat every key that appeared in plaintext in those copies as exposed and
   **rotate it**. Rotation, not file cleanup, is what ends the exposure - a copy
   may already have been read.

`docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md` carries the same
narrowed statement, so the document and the code agree.

## Documentation

`docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md` gains a section
classifying the device registry explicitly as a high-value store - what it holds,
that it used to hold plaintext, the at-rest handling now, the retry-safety
window, the note that hashing removes the bearer secret from the file but not the
metadata, and the "what the migration does not do" limits above.

### Retention of that window is enforced, not asserted

The window holds an issued key in memory, and what makes that acceptable is that
it is short-lived - so short-livedness is enforced by a clock this type owns.

A first version got this wrong in a way that looked right, and it is recorded
here because the shape recurs: pruning ran only inside the replay lookup, which
is reached only when an ALREADY-ENROLLED device asks to replay. A device that
enrolls once under its own identifier and never comes back - the ordinary
fresh-enrollment path - never reached it, so its plaintext key stayed strongly
referenced for the life of the process, and the dictionary grew with every fresh
identifier. **The property that justified the design was the one nothing tested.**

Refusing to hand back an expired key and bounding how long the key is kept are
two different jobs, and only the second one needs a clock:

- The registry starts a recurring eviction pass **the moment it first retains a
  key**, so retention and the clock that bounds it begin together.
- The pass drops every expired issue whether or not anything ever enrolls again.
- It runs at **half** the window, so the real bound is one and a half windows
  rather than two - by default, at most seven and a half minutes. The documented
  bound has to be the true one.
- The registry is now `IDisposable`; disposal stops the pass and drops everything
  retained. `GatewayHost.StopAsync` disposes it with its other timers.
- The lazy prune is gone. Eviction has exactly one owner, so a broken pass cannot
  be masked by another path tidying up on its way past.

Coverage is deterministic - a hand-driven scheduler fires the pass, so nothing
waits on a clock - and asserts retention **directly** through an internal count
rather than inferring it from behaviour that would still look correct while the
plaintext sat in memory. The control is a key still inside its window, which must
SURVIVE a pass; without it every retention test is satisfied by a pass that
clears the dictionary unconditionally and silently destroys the retry safety the
window exists to provide.

### Why the exposure is bounded rather than removed

The alternative is to retain nothing and have the caller present the key it
already holds. It was considered and not chosen, because it does not cover the
concurrent case: two enrollment calls in flight for a device that has no key yet
cannot present anything, so the second must rotate and the caller can be left
holding the first. That is the lock-out this window exists to prevent, so
removing the retention would trade a bounded, now-enforced memory exposure for an
uncovered lock-out path. It would also change the request contract across both
enrollment endpoints and every client that calls them.

It is nonetheless the better end state - it would let the window shrink to near
zero and cover the common double submit without retaining anything - and is
raised as follow-up work on the enrollment contract rather than folded into this
change.

## The previous head went continuous-integration green while carrying this defect

Stated plainly, because it is the honest reason the new tests exist and the
answer to anyone who later asks why a retention window needed eleven mutation
runs.

Head `db531999` passed every check - the full .NET suite across all seven test
projects and the web suite - while the replay cache was retaining plaintext
device keys for the life of the process. The suite was not careless and it was
not lucky. **Nothing exercised the property, so nothing could go red.** No test
ever asked "after a device enrolls once and never comes back, is its key still in
memory?", and a suite cannot answer a question nobody asks.

The general form is worth keeping: a green suite tells you the head is not
BROKEN in the ways it already knows how to check. It never tells you the head is
PROVEN. The gap between those two is exactly the size of the properties nothing
tests - and the property most likely to go untested is the one that JUSTIFIED the
design, because it feels like a premise rather than a behaviour. Short-livedness
was the premise that made an in-memory plaintext window acceptable here, and it
was the one thing with no coverage.

That is why the new tests assert retention directly, through a count of retained
keys, rather than through behaviour. Behaviour was already green.

## Proof status

The revert-proof recipes were run and passed on an earlier head. The branch has
since been rebased onto current `origin/main` and reworked twice, so they are
**pending a re-run on the current head** together with the round-two mutation
set - eleven runs, pre-registered with predicted reds in a comment below. The
machine's single Gateway test lane is held by other work; this queues behind it
rather than running two suites at once.


The baseline will be taken fresh at this head and reconciled against itself -
never against a count quoted from an earlier head or from another unit. A run
with no summary line is not a result in either direction. M4, the enrollment
lock, remains a DECLARED GAP: its red depends on thread interleaving, so it is
reported as unproven rather than promoted on a single green.
