### PR TITLE
fix(gateway): tenant-key the dictation upload and transcript store

### DIFF
--- a/src/CcDirector.Gateway.Tests/DictationOmittedTenantBoundaryTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationOmittedTenantBoundaryTests.cs
@@ -1,0 +1,395 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Transcription;
+using CcDirector.Gateway.Voice;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1884, the FAIL-OPEN case: a HOSTED Gateway whose dictation endpoint was wired with NO tenant
+/// boundary must REFUSE on all five legs, never quietly serve the shared self-host partition.
+///
+/// Why this is its own test class. The tenant boundary is a SECURITY argument, and it used to be declared
+/// optional and nullable (<c>HostedTenantBoundary? tenantBoundary = null</c>) with <c>ResolveTenant</c>
+/// answering <see cref="TenantId.Local"/> whenever it was absent - WITHOUT ever asking
+/// <see cref="GatewayHostedMode.IsHosted"/>. Correctness therefore rested on every present and future call
+/// site remembering a one-word argument. Any hosted call site, test, or rewire that omitted it sent
+/// register, chunk, complete, ack and abandon to the base shared root - reopening transcript disclosure,
+/// chunk overwrite, ack, abandon and completion-cache joining - and NOTHING failed loud to say so. An
+/// optional security argument is indistinguishable from a resolved one at the call site, which is exactly
+/// why that mistake survives review.
+///
+/// TWO DEFENCES, and this class proves the runtime one. The compile-time one is that
+/// <c>GatewayDictationEndpoint.Map</c> now takes the boundary as a REQUIRED parameter, so omitting it will
+/// not build; the tests below have to force a null through explicitly (<c>null!</c>) to reproduce the
+/// miswire at all, which is the point - the accident is now unrepresentable, and even the deliberate
+/// version is refused.
+///
+/// EVERY LEG, not one. A fix proven on one leg says nothing about the other four: each leg calls
+/// <c>ResolveTenant</c> itself, so each is its own opportunity to fall back to Local.
+///
+/// EVERY ABSENCE CLAIM HAS A POSITIVE COMPANION. Each leg asserts the concrete refusal STATUS (403), the
+/// exact refusal the deny path - and only the deny path - produces, and the response's property set as an
+/// ALLOW-LIST (a substring check cannot see an extra leaked field). On top of that, a secret is seeded in
+/// the LOCAL partition under the very same upload id, and each leg is checked to have left it alone: not
+/// disclosed, not overwritten, not retired, not abandoned. Before the fix, the register leg alone handed
+/// that secret transcript straight back in its terminal-register body.
+///
+/// AND THE ROUTES ARE PROVEN TO EXIST. A test that drives a verb or path production does not map gets a
+/// framework 405/404 BEFORE endpoint selection, so no handler runs and the test passes for the wrong
+/// reason. Every request here is replayed against an IDENTICAL harness differing ONLY in the boundary
+/// argument (<see cref="Wired"/>), which answers each of them successfully - so a 403 above is the guard
+/// refusing, never a route that does not exist.
+///
+/// REVERT-PROVE: restore <c>ResolveTenant</c> to <c>boundary is null ? TenantId.Local : ...</c> and all five
+/// tests below go RED - the unwired legs answer 200 and the register leg hands back the seeded secret.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED and the storage root
+/// here is safe; both are restored in DisposeAsync.
+/// </summary>
+public sealed class DictationOmittedTenantBoundaryTests : IAsyncLifetime
+{
+    private const string GatewayToken = "test-token";
+
+    /// <summary>The thing an unwired hosted leg must never read, overwrite, retire, or abandon.</summary>
+    private const string LocalSecretTranscript = "self-host-partition-secret-transcript";
+    private const string LocalSecretAudio = "self-host-partition-secret-audio";
+
+    /// <summary>The one message the deny path produces. Asserted exactly, so a 403 from anywhere else fails.</summary>
+    private const string DenyMessage = "no tenant is bound to this request";
+
+    private readonly string _storageRoot =
+        Path.Combine(Path.GetTempPath(), "cc-dictation-nobound-" + Guid.NewGuid().ToString("N"));
+
+    private string? _priorHosted;
+    private string? _priorRoot;
+
+    /// <summary>The miswired host: hosted mode ON, no tenant boundary. The subject of every test here.</summary>
+    private Harness _unwired = null!;
+
+    /// <summary>The identical host WITH the boundary. The control that proves the routes and harness work.</summary>
+    private Harness _wired = null!;
+
+    private TenantId _tenant;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
+
+        // A canonical lowercase minted GUID - the ONE tenant spelling the registry produces and the upload
+        // store accepts as a partition name.
+        _tenant = new TenantId(Guid.NewGuid().ToString("D"));
+
+        _unwired = await Harness.StartAsync(_storageRoot, "unwired", _tenant, wireBoundary: false);
+        _wired = await Harness.StartAsync(_storageRoot, "wired", _tenant, wireBoundary: true);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _unwired.DisposeAsync();
+        await _wired.DisposeAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_storageRoot)) Directory.Delete(_storageRoot, true); } catch { /* cleanup */ }
+    }
+
+    // ===== leg 1: register =========================================================================
+
+    [Fact]
+    public async Task Register_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // THE CONCRETE DISCLOSURE this class exists for. Seed a delivered upload in the LOCAL partition -
+        // the base shared root, where self-host's dictations live - and register that same id against the
+        // unwired hosted host. Before the fix the missing boundary resolved to Local, the terminal-register
+        // short-circuit fired, and the response body carried the seeded transcript verbatim.
+        var id = Guid.NewGuid().ToString();
+        LocalStore().MarkDelivered(id, submitted: true, movedOn: false, transcript: LocalSecretTranscript);
+
+        var (status, body) = await Read(await _unwired.RegisterAsync(id));
+        AssertRefusal(status, body);
+
+        // The local record is untouched: still delivered, still its own words.
+        var record = LocalStore().ReadRecord(id);
+        Assert.NotNull(record);
+        Assert.Equal(DictationDeliveryState.Delivered, record!.State);
+        Assert.Equal(LocalSecretTranscript, record.Transcript);
+
+        // Positive companion: the SAME request on the SAME harness WITH a boundary is served, so the 403
+        // above is the guard refusing and not a route that does not exist or a host that answers nothing.
+        var wired = await Read(await _wired.RegisterAsync(id));
+        Assert.Equal(HttpStatusCode.OK, wired.status);
+        Assert.DoesNotContain(LocalSecretTranscript, wired.body, StringComparison.Ordinal);
+        var wiredRegister = JsonDocument.Parse(wired.body).RootElement;
+        // The fresh-register shape, which ONLY the genuine handler produces: an upload id, and no terminal
+        // short-circuit - the local partition's delivered record was not this host's to see.
+        Assert.False(string.IsNullOrWhiteSpace(wiredRegister.GetProperty("upload_id").GetString()));
+        Assert.False(wiredRegister.TryGetProperty("terminal", out _));
+    }
+
+    // ===== leg 2: chunk ============================================================================
+
+    [Fact]
+    public async Task Chunk_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // Staged audio in the local partition. An unwired hosted chunk must not be able to overwrite it,
+        // extend it, or even confirm that the upload id exists.
+        var id = Guid.NewGuid().ToString();
+        var local = LocalStore();
+        local.Register(id);
+        await local.StoreChunkAsync(id, 0, Encoding.UTF8.GetBytes(LocalSecretAudio), null, default);
+        Assert.Equal(LocalSecretAudio, await StagedTextAsync(local, id));
+
+        var (status, body) = await Read(await _unwired.PutChunkAsync(id, 0, "overwritten-by-the-unwired-host"));
+        AssertRefusal(status, body);
+        Assert.Equal(LocalSecretAudio, await StagedTextAsync(local, id));
+
+        // Positive companion: PUT on this exact path is a real production route and the wired host stores
+        // the chunk - into its OWN tenant partition, leaving the local bytes alone.
+        await _wired.RegisterAsync(id);
+        var wired = await Read(await _wired.PutChunkAsync(id, 0, "wired-host-audio"));
+        Assert.Equal(HttpStatusCode.OK, wired.status);
+        Assert.True(JsonDocument.Parse(wired.body).RootElement.GetProperty("ok").GetBoolean());
+        Assert.Equal(LocalSecretAudio, await StagedTextAsync(local, id));
+    }
+
+    // ===== leg 3: complete =========================================================================
+
+    [Fact]
+    public async Task Complete_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // The other door onto the same disclosure: complete's cached-terminal-outcome short-circuit. It also
+        // reaches the STATIC single-flight cache, which an unwired host would key as "Local|<id>" - joining
+        // the self-host partition's in-flight run.
+        var id = Guid.NewGuid().ToString();
+        LocalStore().MarkDelivered(id, submitted: true, movedOn: false, transcript: LocalSecretTranscript);
+
+        var (status, body) = await Read(await _unwired.CompleteAsync(id));
+        AssertRefusal(status, body);
+
+        // Nothing of the local record was disclosed and nothing of it moved.
+        var record = LocalStore().ReadRecord(id);
+        Assert.NotNull(record);
+        Assert.Equal(DictationDeliveryState.Delivered, record!.State);
+        Assert.Equal(LocalSecretTranscript, record.Transcript);
+
+        // Positive companion: the wired host reaches its own handler on this exact verb and path. It is NOT
+        // refused, and it does not see the local partition's terminal outcome either.
+        var wired = await Read(await _wired.CompleteAsync(id));
+        Assert.NotEqual(HttpStatusCode.Forbidden, wired.status);
+        Assert.NotEqual(HttpStatusCode.MethodNotAllowed, wired.status);
+        Assert.DoesNotContain(LocalSecretTranscript, wired.body, StringComparison.Ordinal);
+    }
+
+    // ===== leg 4: ack ==============================================================================
+
+    [Fact]
+    public async Task Ack_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // An ack DELETES state - it retires the durable tombstone that stops a delivered turn being injected
+        // twice. An unwired hosted host must not be able to retire the self-host partition's tombstone.
+        var id = Guid.NewGuid().ToString();
+        LocalStore().MarkDelivered(id, submitted: true, movedOn: false, transcript: LocalSecretTranscript);
+
+        var (status, body) = await Read(await _unwired.AckAsync(id));
+        AssertRefusal(status, body);
+        Assert.NotNull(LocalStore().ReadRecord(id));
+        Assert.Equal(LocalSecretTranscript, LocalStore().ReadRecord(id)!.Transcript);
+
+        // Positive companion: the wired host's ack really does run - it answers the handler's own shape and
+        // reports retired=false for an id that is not in ITS partition, which is a refusal by partition, not
+        // a broken route. The local tombstone is still standing.
+        var wired = await Read(await _wired.AckAsync(id));
+        Assert.Equal(HttpStatusCode.OK, wired.status);
+        var wiredRoot = JsonDocument.Parse(wired.body).RootElement;
+        Assert.True(wiredRoot.GetProperty("ok").GetBoolean());
+        Assert.False(wiredRoot.GetProperty("retired").GetBoolean());
+        Assert.NotNull(LocalStore().ReadRecord(id));
+    }
+
+    // ===== leg 5: abandon ==========================================================================
+
+    [Fact]
+    public async Task Abandon_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // Abandon DISCARDS staged audio and clears the session lock. An unwired hosted host must not be able
+        // to resolve or discard the self-host partition's live dictation.
+        var sessionId = Guid.NewGuid().ToString();
+        var id = Guid.NewGuid().ToString();
+        var local = LocalStore();
+        local.Register(id);
+        local.MarkPending(id, sessionId);
+        await local.StoreChunkAsync(id, 0, Encoding.UTF8.GetBytes(LocalSecretAudio), null, default);
+        Assert.True(local.IsSessionLocked(sessionId));
+
+        var (status, body) = await Read(await _unwired.AbandonAsync(id));
+        AssertRefusal(status, body);
+        Assert.Equal(DictationDeliveryState.Pending, local.ReadRecord(id)!.State);
+        Assert.Equal(LocalSecretAudio, await StagedTextAsync(local, id));
+        Assert.True(local.IsSessionLocked(sessionId));
+
+        // Positive companion: the wired host's abandon really does run on this exact verb and path - it
+        // answers the handler's own shape, inside its own partition, and the local dictation is still live.
+        var wired = await Read(await _wired.AbandonAsync(id));
+        Assert.Equal(HttpStatusCode.OK, wired.status);
+        Assert.True(JsonDocument.Parse(wired.body).RootElement.GetProperty("abandoned").GetBoolean());
+        Assert.Equal(DictationDeliveryState.Pending, local.ReadRecord(id)!.State);
+        Assert.True(local.IsSessionLocked(sessionId));
+    }
+
+    // ===== the refusal itself ======================================================================
+
+    /// <summary>
+    /// The refusal, asserted positively: the concrete status, the exact message only the deny path emits,
+    /// and the response's property set as an ALLOW-LIST. The allow-list matters - a substring check for what
+    /// must be absent cannot see an EXTRA field that leaked, and the whole hazard here is a body that
+    /// carries another partition's state.
+    /// </summary>
+    private static void AssertRefusal(HttpStatusCode status, string body)
+    {
+        Assert.Equal(HttpStatusCode.Forbidden, status);
+        var root = JsonDocument.Parse(body).RootElement;
+        Assert.Equal(JsonValueKind.Object, root.ValueKind);
+        Assert.Equal(new[] { "error" }, root.EnumerateObject().Select(p => p.Name).ToArray());
+        Assert.Equal(DenyMessage, root.GetProperty("error").GetString());
+        Assert.DoesNotContain(LocalSecretTranscript, body, StringComparison.Ordinal);
+        Assert.DoesNotContain(LocalSecretAudio, body, StringComparison.Ordinal);
+    }
+
+    // ===== helpers =================================================================================
+
+    /// <summary>The LOCAL (base, shared, self-host) partition - the one an unwired hosted leg would take.</summary>
+    private VoiceUploadStore LocalStore() => new VoiceUploadStore(Harness.UploadRoot(_storageRoot));
+
+    private static async Task<string> StagedTextAsync(VoiceUploadStore store, string uploadId)
+    {
+        var assembled = await store.AssembleAsync(uploadId, 1);
+        return assembled.Audio is null ? "" : Encoding.UTF8.GetString(assembled.Audio);
+    }
+
+    private static async Task<(HttpStatusCode status, string body)> Read(HttpResponseMessage resp)
+    {
+        using (resp) return (resp.StatusCode, await resp.Content.ReadAsStringAsync());
+    }
+
+    /// <summary>
+    /// A minimal host that maps ONLY the dictation endpoint. The two instances are built by the same code
+    /// with the same dependencies and differ in EXACTLY ONE argument - whether the tenant boundary is
+    /// supplied - so a difference in behaviour between them can only be that argument.
+    /// </summary>
+    private sealed class Harness : IAsyncDisposable
+    {
+        private readonly WebApplication _app;
+        private readonly HttpClient _http;
+
+        private Harness(WebApplication app, HttpClient http)
+        {
+            _app = app;
+            _http = http;
+        }
+
+        internal static string UploadRoot(string storageRoot) => Path.Combine(storageRoot, "dictation-uploads");
+
+        internal static async Task<Harness> StartAsync(string storageRoot, string name, TenantId tenant, bool wireBoundary)
+        {
+            var devices = new DeviceRegistry(Path.Combine(storageRoot, name, "devices.json"));
+            var deviceKey = devices.Register("dev-" + name, "M-" + name).DeviceKey;
+            devices.SetAccountBinding("dev-" + name, "sub-" + name, tenant.Value);
+
+            // BOTH harnesses share ONE upload root, so "the unwired host did not touch the local partition"
+            // is a claim about the very bytes the wired host would have to reach through its own partition.
+            var uploads = new VoiceUploadStore(UploadRoot(storageRoot));
+
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0");
+
+            var transcription = new GatewayTranscriptionService(
+                new KeyVault(Path.Combine(storageRoot, name, "keyvault.json")));
+
+            // The ONE argument under test. The unwired case has to be forced through with null! because the
+            // parameter is REQUIRED - the compile-time half of the fix - so the accidental version of this
+            // miswire cannot be written at all.
+            HostedTenantBoundary? boundary = wireBoundary
+                ? new HostedTenantBoundary(new AsyncLocalTenantContext(), devices)
+                : null;
+
+            GatewayDictationEndpoint.Map(app,
+                new DirectorRegistry(Path.Combine(storageRoot, name, "instances")),
+                owners: null,
+                token: GatewayToken,
+                transcription,
+                new TranscribingSessions(),
+                uploads,
+                devices,
+                boundary!);
+
+            await app.StartAsync();
+            var http = new HttpClient
+            {
+                BaseAddress = new Uri(app.Urls.First()),
+                Timeout = TimeSpan.FromSeconds(30),
+            };
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+            return new Harness(app, http);
+        }
+
+        // The verbs and paths below are the production ones, and the wired harness answering each of them
+        // is what proves it: a verb or path production does not map is answered 405/404 by the framework
+        // BEFORE endpoint selection, so no handler would run on either harness.
+        internal async Task<HttpResponseMessage> RegisterAsync(string uploadId, string? sessionId = null)
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Post, "/dictation/upload")
+            {
+                Content = JsonContent.Create(new { sessionId = sessionId ?? Guid.NewGuid().ToString(), baselineBufferBytes = 0 }),
+            };
+            req.Headers.Add("Idempotency-Key", uploadId);
+            return await _http.SendAsync(req);
+        }
+
+        internal async Task<HttpResponseMessage> PutChunkAsync(string uploadId, int index, string text)
+        {
+            using var content = new ByteArrayContent(Encoding.UTF8.GetBytes(text));
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            return await _http.PutAsync($"/dictation/{uploadId}/chunk/{index}", content);
+        }
+
+        internal Task<HttpResponseMessage> CompleteAsync(string uploadId)
+            => _http.PostAsJsonAsync($"/dictation/{uploadId}/complete",
+                new { sessionId = Guid.NewGuid().ToString(), totalChunks = 1 });
+
+        internal Task<HttpResponseMessage> AckAsync(string uploadId)
+            => _http.PostAsync($"/dictation/{uploadId}/ack", content: null);
+
+        internal Task<HttpResponseMessage> AbandonAsync(string uploadId)
+            => _http.PostAsync($"/dictation/{uploadId}/abandon", content: null);
+
+        public async ValueTask DisposeAsync()
+        {
+            _http.Dispose();
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DictationOmittedTenantBoundaryTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationOmittedTenantBoundaryTests.cs
@@ -111,6 +111,26 @@ namespace CcDirector.Gateway.Tests;
 /// belt in PartitionRootFor (unreachable while IsMintedAccountTenant stays strict). Neither got a test
 /// invented for it, because the only test either could have is one that cannot fail.
 ///
+/// A SURVIVAL CLAIM NEEDS ITS PRECONDITION ESTABLISHED, NOT ASSUMED - the trap these tests fell into first.
+///
+/// Every leg here asserts that something SURVIVED a refused operation: the tombstone is still there, the
+/// record is still Pending, the audio is unchanged. That is only evidence of a refusal if the operation
+/// would OTHERWISE HAVE DESTROYED IT. The starting state a survival claim depends on is not "a record
+/// exists" - it is "a record exists THAT THIS OPERATION WOULD DESTROY", and the second half is the half
+/// that gets assumed.
+///
+/// As first written, these tests never established it. A no-op ack leg, a no-op abandon leg, or a chunk leg
+/// that stored nothing at all would have left everything standing exactly as a refusal does, and every
+/// assertion would still have passed - a test that cannot fail, wearing the shape of a strong one. Note the
+/// direction of the trap: a refusal test is ASSERTING that nothing happened, so "nothing happened" can
+/// never by itself distinguish the refusal from the operation being inert.
+///
+/// So each leg now closes with a DESTRUCTIBILITY CONTROL: the same operation, permitted, really does retire
+/// the tombstone / resolve the record / overwrite the bytes. They run last because they consume the
+/// fixture. Together with the deny fingerprint - the exact 403 and the exact refusal message, which prove
+/// the request reached the guard rather than a missing route - the pair says: the thing was destructible,
+/// something tried to destroy it, it was refused, and it survived.
+///
 /// EVERY RED MUST ARRIVE AS AN ASSERTION, NOT A CRASH. A NullReferenceException or an input/output error
 /// means the mutation broke something upstream before the test could ask its question - that is laundering
 /// and it does not prove the line it was aimed at. Hence MustStillExist instead of bare `!` dereferences,
@@ -180,6 +200,11 @@ public sealed class DictationOmittedTenantBoundaryTests : IAsyncLifetime
         var id = Guid.NewGuid().ToString();
         LocalStore().MarkDelivered(id, submitted: true, movedOn: false, transcript: LocalSecretTranscript);
 
+        // Establish the starting state: DELIVERED is precisely the state that arms the terminal-register
+        // short-circuit, and the disclosure claim below is meaningless if the record is not in it.
+        Assert.Equal(DictationDeliveryState.Delivered,
+            MustStillExist(LocalStore(), id, "the local record must be terminal before register is attempted").State);
+
         var (status, body) = await Read(await _unwired.RegisterAsync(id));
         AssertRefusal(status, body);
 
@@ -225,6 +250,12 @@ public sealed class DictationOmittedTenantBoundaryTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.OK, wired.status);
         Assert.True(JsonDocument.Parse(wired.body).RootElement.GetProperty("ok").GetBoolean());
         Assert.Equal(LocalSecretAudio, await StagedTextAsync(local, id));
+
+        // AND PROVE THE LOCAL STAGING WAS OVERWRITABLE ALL ALONG. "The bytes did not change" only means the
+        // write was refused if a write that IS permitted would have changed them - otherwise a chunk leg
+        // that stores nothing at all passes this test. Done last: it consumes the fixture.
+        await local.StoreChunkAsync(id, 0, Encoding.UTF8.GetBytes("rewritten-by-the-control"), null, default);
+        Assert.Equal("rewritten-by-the-control", await StagedTextAsync(local, id));
     }
 
     // ===== leg 3: complete =========================================================================
@@ -237,6 +268,11 @@ public sealed class DictationOmittedTenantBoundaryTests : IAsyncLifetime
         // the self-host partition's in-flight run.
         var id = Guid.NewGuid().ToString();
         LocalStore().MarkDelivered(id, submitted: true, movedOn: false, transcript: LocalSecretTranscript);
+
+        // Same armed starting state as the register leg: the cached-terminal-outcome short-circuit only
+        // fires on a terminal record, so assert it rather than assume the seeding worked.
+        Assert.Equal(DictationDeliveryState.Delivered,
+            MustStillExist(LocalStore(), id, "the local record must be terminal before complete is attempted").State);
 
         var (status, body) = await Read(await _unwired.CompleteAsync(id));
         AssertRefusal(status, body);
@@ -265,6 +301,11 @@ public sealed class DictationOmittedTenantBoundaryTests : IAsyncLifetime
         var id = Guid.NewGuid().ToString();
         LocalStore().MarkDelivered(id, submitted: true, movedOn: false, transcript: LocalSecretTranscript);
 
+        // ESTABLISH THE STARTING STATE, never assume it. The claim below is that the tombstone SURVIVED a
+        // refused ack, and "it is still there" is only evidence of a refusal if it was there to begin with.
+        Assert.Equal(DictationDeliveryState.Delivered,
+            MustStillExist(LocalStore(), id, "the local tombstone must exist before the ack is attempted").State);
+
         var (status, body) = await Read(await _unwired.AckAsync(id));
         AssertRefusal(status, body);
         Assert.NotNull(LocalStore().ReadRecord(id));
@@ -280,6 +321,15 @@ public sealed class DictationOmittedTenantBoundaryTests : IAsyncLifetime
         Assert.True(wiredRoot.GetProperty("ok").GetBoolean());
         Assert.False(wiredRoot.GetProperty("retired").GetBoolean());
         Assert.NotNull(LocalStore().ReadRecord(id));
+
+        // AND PROVE THE TOMBSTONE WAS DESTRUCTIBLE ALL ALONG - the precondition the survival claim above
+        // silently rests on. Without this the test cannot tell "the ack was refused" from "an ack retires
+        // nothing anyway": a no-op ack leg would leave the record standing too, and every assertion above
+        // would still pass. The handler's ack IS this call (store.Acknowledge on the request's partition),
+        // so retiring it here proves the refusal prevented exactly the operation that would have destroyed
+        // it. Done last, because it deliberately consumes the fixture.
+        Assert.True(LocalStore().Acknowledge(id));
+        Assert.Null(LocalStore().ReadRecord(id));
     }
 
     // ===== leg 5: abandon ==========================================================================
@@ -312,6 +362,15 @@ public sealed class DictationOmittedTenantBoundaryTests : IAsyncLifetime
         Assert.Equal(DictationDeliveryState.Pending,
             MustStillExist(local, id, "the wired abandon must have stayed inside its own partition").State);
         Assert.True(local.IsSessionLocked(sessionId));
+
+        // AND PROVE THE LIVE DICTATION WAS RESOLVABLE ALL ALONG - same reasoning as the ack leg. "Still
+        // Pending, still locked" only means the abandon was refused if an abandon that IS permitted would
+        // have resolved it; otherwise a no-op abandon leg passes this test unchanged. The handler's abandon
+        // IS this call on the request's own partition. Done last: it consumes the fixture.
+        local.MarkAbandoned(id, "destructibility_control");
+        Assert.Equal(DictationDeliveryState.Abandoned,
+            MustStillExist(local, id, "the local record must be resolvable by an abandon that is allowed").State);
+        Assert.False(local.IsSessionLocked(sessionId));
     }
 
     // ===== the refusal itself ======================================================================

--- a/src/CcDirector.Gateway.Tests/DictationOmittedTenantBoundaryTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationOmittedTenantBoundaryTests.cs
@@ -62,34 +62,44 @@ namespace CcDirector.Gateway.Tests;
 /// REVERT-PROVE: restore <c>ResolveTenant</c> to <c>boundary is null ? TenantId.Local : ...</c> and all five
 /// tests below go RED - the unwired legs answer 200 and the register leg hands back the seeded secret.
 ///
-/// HOW THE THIRTEEN LINES OF THIS CHANGE ARE ATTRIBUTED, because a reader must not infer more from the
-/// combined revert than it can carry. Each line was reverted ALONE, built, and run filtered, and that is
-/// what attributes it. The combined all-lines revert answers two DIFFERENT questions - did this break
-/// something else in the suite, and was any of it already covered elsewhere - and it answers those
-/// regardless of how many lines were pulled at once.
+/// WHAT IS PROVED SEPARATELY, AND WHY THERE ARE EIGHT THINGS RATHER THAN THIRTEEN.
 ///
-/// The combined run does NOT separately prove L1, L2, L4, L5, L8 and L10. Reverting
-/// <c>VoiceUploadStore.PartitionRootFor</c> (L7) collapses every tenant onto one root, which makes the
-/// per-leg <c>ForTenant</c> calls irrelevant and reddens those lines' tests by itself; three of its
-/// failures are NullReferenceException or IOException, which never reach the distinguishing assertion at
-/// all. Those six are attributed by their single-line filtered probes and by nothing else.
+/// The rule this change is held to: mutate every line whose INDIVIDUAL wrongness could break isolation
+/// while everything else stays correct. A line is exempt only when bypass is STRUCTURALLY IMPOSSIBLE -
+/// never merely because its test also reddens under some other primitive's global revert. A global collapse
+/// reddening a leg's test proves the test is sensitive to the collapse; it does not prove the test would
+/// catch THAT LEG ALONE being wrong, and the leg alone being wrong is the realistic defect.
 ///
-///   L1  register leg ForTenant   - register leaks the seeded transcript
-///   L2  chunk leg ForTenant      - local staged audio is overwritten
-///   L3  complete leg ForTenant   - complete leaks the seeded transcript
-///   L4  ack leg ForTenant        - a foreign ack retires the record
-///   L5  abandon leg ForTenant    - a foreign abandon resolves the record
-///   L6  CacheKey at GetOrAdd     - both tenants observe one identical cache key
-///   L7  PartitionRootFor         - 17 red, and the subsumer described above
-///   L8  IsMintedAccountTenant    - the uppercase casing alias is no longer refused
-///   L8b path containment         - NO CANARY, unreachable by construction (documented at the guard)
-///   L9  record stamp/BelongsHere - a foreign record is returned; the session lock crosses
-///   L10 SweepAbandoned skip      - the sweep eats another tenant's staging
-///   L10b pending-projection skip - NO CANARY, redundant with BelongsHere (documented at the guard)
-///   L11 ResolveTenant gate       - the five tests below
+/// The five per-leg scopings USED to be five independent chances to forget - two hand-written lines
+/// repeated per leg, with the raw un-partitioned store sitting in scope beside them. They are now ONE
+/// primitive, and not by argument: <see cref="GatewayDictationEndpoint.Map"/> does not take a
+/// <c>VoiceUploadStore</c> at all, so there is no unscoped store in that file to use, and
+/// <c>DictationTenantGate.TryOpen</c> is the only source of a store and cannot return an unscoped one. The
+/// same was done to the two static caches: the tenant is a required parameter of every cache operation and
+/// the key is composed inside <c>TenantKeyedCache</c>, so an un-tenanted key is not expressible at a call
+/// site. Fewer proof units because the design got safer, not because the proof was argued down.
 ///
-/// The two no-canary lines are recorded as such on purpose. Neither got a test invented for it, because the
-/// only test either could have is one that cannot fail.
+///   P1 DictationTenantGate.TryOpen   - partition selection for all five legs (absorbs the five)
+///   P2 ResolveTenant hosted gate      - whether a request has an owning tenant at all
+///   P3 PartitionRootFor               - which directory a tenant's staging lives in
+///   P4 IsMintedAccountTenant          - whether a tenant id may name a directory
+///   P5 WriteRecordMarker tenant stamp - the owner recorded ON the record
+///   P6 BelongsHere                    - whether a record found here belongs here
+///   P7 TenantKeyedCache key           - the process-wide cache key (absorbs both cache call-site families)
+///   P8 SweepAbandoned container skip  - whether the partition container is an upload
+///
+/// P5 and P6 are two, not one: the stamp can be dropped while the check stays right, and the check can be
+/// neutered while the stamp stays right, and each leaks on its own.
+///
+/// Settled exempt, with reasons recorded at the guards themselves: the pending-projection container skip
+/// (redundant - BelongsHere on the same line is the real boundary and it has canaries) and the containment
+/// belt in PartitionRootFor (unreachable while IsMintedAccountTenant stays strict). Neither got a test
+/// invented for it, because the only test either could have is one that cannot fail.
+///
+/// EVERY RED MUST ARRIVE AS AN ASSERTION, NOT A CRASH. A NullReferenceException or an input/output error
+/// means the mutation broke something upstream before the test could ask its question - that is laundering
+/// and it does not prove the line it was aimed at. Hence MustStillExist instead of bare `!` dereferences,
+/// and hence the cross-boundary question is asked BEFORE any setup step that could throw.
 ///
 /// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED and the storage root
 /// here is safe; both are restored in DisposeAsync.
@@ -243,7 +253,8 @@ public sealed class DictationOmittedTenantBoundaryTests : IAsyncLifetime
         var (status, body) = await Read(await _unwired.AckAsync(id));
         AssertRefusal(status, body);
         Assert.NotNull(LocalStore().ReadRecord(id));
-        Assert.Equal(LocalSecretTranscript, LocalStore().ReadRecord(id)!.Transcript);
+        Assert.Equal(LocalSecretTranscript,
+            MustStillExist(LocalStore(), id, "the unwired ack must not have retired the local tombstone").Transcript);
 
         // Positive companion: the wired host's ack really does run - it answers the handler's own shape and
         // reports retired=false for an id that is not in ITS partition, which is a refusal by partition, not
@@ -273,7 +284,8 @@ public sealed class DictationOmittedTenantBoundaryTests : IAsyncLifetime
 
         var (status, body) = await Read(await _unwired.AbandonAsync(id));
         AssertRefusal(status, body);
-        Assert.Equal(DictationDeliveryState.Pending, local.ReadRecord(id)!.State);
+        Assert.Equal(DictationDeliveryState.Pending,
+            MustStillExist(local, id, "the unwired abandon must not have resolved the local record").State);
         Assert.Equal(LocalSecretAudio, await StagedTextAsync(local, id));
         Assert.True(local.IsSessionLocked(sessionId));
 
@@ -282,7 +294,8 @@ public sealed class DictationOmittedTenantBoundaryTests : IAsyncLifetime
         var wired = await Read(await _wired.AbandonAsync(id));
         Assert.Equal(HttpStatusCode.OK, wired.status);
         Assert.True(JsonDocument.Parse(wired.body).RootElement.GetProperty("abandoned").GetBoolean());
-        Assert.Equal(DictationDeliveryState.Pending, local.ReadRecord(id)!.State);
+        Assert.Equal(DictationDeliveryState.Pending,
+            MustStillExist(local, id, "the wired abandon must have stayed inside its own partition").State);
         Assert.True(local.IsSessionLocked(sessionId));
     }
 
@@ -309,6 +322,20 @@ public sealed class DictationOmittedTenantBoundaryTests : IAsyncLifetime
 
     /// <summary>The LOCAL (base, shared, self-host) partition - the one an unwired hosted leg would take.</summary>
     private VoiceUploadStore LocalStore() => new VoiceUploadStore(Harness.UploadRoot(_storageRoot));
+
+
+    /// <summary>
+    /// Read a record the claim under test says MUST still be there, asserting its presence before touching
+    /// it. Dereferencing with <c>!</c> turns an absent record into a NullReferenceException, and a crash is
+    /// not evidence about the line the test was aimed at - it only says something upstream broke before the
+    /// test could ask its question. Every red must be able to name what it caught.
+    /// </summary>
+    private static DictationDeliveryRecord MustStillExist(VoiceUploadStore store, string uploadId, string claim)
+    {
+        var record = store.ReadRecord(uploadId);
+        Assert.True(record is not null, claim + " (the record was absent)");
+        return record!;
+    }
 
     private static async Task<string> StagedTextAsync(VoiceUploadStore store, string uploadId)
     {
@@ -370,9 +397,8 @@ public sealed class DictationOmittedTenantBoundaryTests : IAsyncLifetime
                 token: GatewayToken,
                 transcription,
                 new TranscribingSessions(),
-                uploads,
-                devices,
-                boundary!);
+                new DictationTenantGate(uploads, boundary!),
+                devices);
 
             await app.StartAsync();
             var http = new HttpClient

--- a/src/CcDirector.Gateway.Tests/DictationOmittedTenantBoundaryTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationOmittedTenantBoundaryTests.cs
@@ -62,6 +62,35 @@ namespace CcDirector.Gateway.Tests;
 /// REVERT-PROVE: restore <c>ResolveTenant</c> to <c>boundary is null ? TenantId.Local : ...</c> and all five
 /// tests below go RED - the unwired legs answer 200 and the register leg hands back the seeded secret.
 ///
+/// HOW THE THIRTEEN LINES OF THIS CHANGE ARE ATTRIBUTED, because a reader must not infer more from the
+/// combined revert than it can carry. Each line was reverted ALONE, built, and run filtered, and that is
+/// what attributes it. The combined all-lines revert answers two DIFFERENT questions - did this break
+/// something else in the suite, and was any of it already covered elsewhere - and it answers those
+/// regardless of how many lines were pulled at once.
+///
+/// The combined run does NOT separately prove L1, L2, L4, L5, L8 and L10. Reverting
+/// <c>VoiceUploadStore.PartitionRootFor</c> (L7) collapses every tenant onto one root, which makes the
+/// per-leg <c>ForTenant</c> calls irrelevant and reddens those lines' tests by itself; three of its
+/// failures are NullReferenceException or IOException, which never reach the distinguishing assertion at
+/// all. Those six are attributed by their single-line filtered probes and by nothing else.
+///
+///   L1  register leg ForTenant   - register leaks the seeded transcript
+///   L2  chunk leg ForTenant      - local staged audio is overwritten
+///   L3  complete leg ForTenant   - complete leaks the seeded transcript
+///   L4  ack leg ForTenant        - a foreign ack retires the record
+///   L5  abandon leg ForTenant    - a foreign abandon resolves the record
+///   L6  CacheKey at GetOrAdd     - both tenants observe one identical cache key
+///   L7  PartitionRootFor         - 17 red, and the subsumer described above
+///   L8  IsMintedAccountTenant    - the uppercase casing alias is no longer refused
+///   L8b path containment         - NO CANARY, unreachable by construction (documented at the guard)
+///   L9  record stamp/BelongsHere - a foreign record is returned; the session lock crosses
+///   L10 SweepAbandoned skip      - the sweep eats another tenant's staging
+///   L10b pending-projection skip - NO CANARY, redundant with BelongsHere (documented at the guard)
+///   L11 ResolveTenant gate       - the five tests below
+///
+/// The two no-canary lines are recorded as such on purpose. Neither got a test invented for it, because the
+/// only test either could have is one that cannot fail.
+///
 /// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED and the storage root
 /// here is safe; both are restored in DisposeAsync.
 /// </summary>

--- a/src/CcDirector.Gateway.Tests/DictationOmittedTenantBoundaryTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationOmittedTenantBoundaryTests.cs
@@ -79,6 +79,13 @@ namespace CcDirector.Gateway.Tests;
 /// the key is composed inside <c>TenantKeyedCache</c>, so an un-tenanted key is not expressible at a call
 /// site. Fewer proof units because the design got safer, not because the proof was argued down.
 ///
+/// Stated precisely, because "no unscoped store identifier exists" and "an unscoped store cannot be passed"
+/// are DIFFERENT claims and only the first was proved: two private helpers on the completion path still take
+/// a bare store in their signatures. They cannot be reached with an unscoped one today because the gate
+/// privately owns the sole raw store, so the guarantee rests on that encapsulation rather than on the type
+/// system at those two signatures. See the note on <c>DictationTenantGate</c> for the stronger form and why
+/// it is deliberately left to a follow-up.
+///
 ///   P1 DictationTenantGate.TryOpen   - partition selection for all five legs (absorbs the five)
 ///   P2 ResolveTenant hosted gate      - whether a request has an owning tenant at all
 ///   P3 PartitionRootFor               - which directory a tenant's staging lives in
@@ -88,8 +95,16 @@ namespace CcDirector.Gateway.Tests;
 ///   P7 TenantKeyedCache key           - the process-wide cache key (absorbs both cache call-site families)
 ///   P8 SweepAbandoned container skip  - whether the partition container is an upload
 ///
-/// P5 and P6 are two, not one: the stamp can be dropped while the check stays right, and the check can be
-/// neutered while the stamp stays right, and each leaks on its own.
+/// P5 and P6 are two, not one, because each is independently bypassable: the stamp can be dropped while the
+/// check stays right, and the check can be neutered while the stamp stays right.
+///
+/// THEIR FAILURE MODES ARE NOT THE SAME, and blurring them across two rows costs exactly the precision this
+/// separation was for. P6 is the DISCLOSURE guard - neuter it and a record sitting in the wrong partition is
+/// handed to the wrong account. P5 is not: with the primary partition intact, dropping the stamp makes
+/// account records unattributed and therefore UNREADABLE - a correctness and availability failure. P5 still
+/// earns its own proof because the accepted design requires the persisted ownership stamp, but a mutation
+/// showing a line is load-bearing does not show it is load-bearing FOR THE SECURITY PROPERTY. Two different
+/// claims; only the one actually observed is ours to make.
 ///
 /// Settled exempt, with reasons recorded at the guards themselves: the pending-projection container skip
 /// (redundant - BelongsHere on the same line is the real boundary and it has canaries) and the containment

--- a/src/CcDirector.Gateway.Tests/DictationTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationTenantIsolationTests.cs
@@ -1,0 +1,422 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1884: the dictation front door is TENANT-KEYED on the hosted Gateway, proven over real HTTP with
+/// two accounts posting THE SAME UPLOAD ID.
+///
+/// This is an AUDIO and TRANSCRIPT disclosure surface. Before this, <c>VoiceUploadStore</c> had one global
+/// root and keyed every directory, chunk and record solely by the caller-supplied upload id; the delivery
+/// record carried no tenant; the upload / chunk / ack / abandon legs authenticated a DEVICE and never asked
+/// whose upload it was; and the static single-flight completion cache was keyed by upload id alone. So after
+/// account A completed upload id X, account B posting <c>Idempotency-Key: X</c> read A's terminal record and
+/// was handed A's TRANSCRIPT - and before A reached a terminal state, B could overwrite A's chunks, ack or
+/// abandon A's record, or race its completion. A GUID is not a tenant boundary: secrecy of an identifier is
+/// not authorization, and upload ids travel in client logs, retries and store-and-forward queues.
+///
+/// Every canary here is BIDIRECTIONAL and every absence claim has a POSITIVE CONTROL in front of it - the
+/// same account's own operation on the same id succeeding - so no assertion can pass merely because nothing
+/// happened at all.
+///
+/// Dictation is still DEAD on hosted and this does not revive it: the session locate inside the completion
+/// deliberately stays in the local partition (issue #1884 part (a), held). What is proven here is that the
+/// STATE is safe, so re-enabling the route later is not the thing that arms a leak.
+///
+/// THE PRODUCTION LINES THESE TESTS PROTECT (each revert-provable - revert it, watch these go red):
+///   - The <c>ResolveTenant</c> + <c>uploads.ForTenant(tenant)</c> pair at the head of each of the five legs
+///     in <c>GatewayDictationEndpoint</c>. Put any leg back on the shared <c>uploads</c> store and that leg's
+///     canary goes RED.
+///   - <c>GatewayDictationEndpoint.CacheKey</c> at the <c>_completes.GetOrAdd</c> call site. Key that call on
+///     the upload id alone and the single-flight canary goes RED.
+///   - <c>VoiceUploadStore.PartitionRootFor</c>, which is what makes all of the above structural rather than
+///     conventional.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED and the storage root
+/// here is safe; both are restored in DisposeAsync.
+/// </summary>
+public sealed class DictationTenantIsolationTests : IAsyncLifetime
+{
+    private const string GatewayToken = "test-token";
+
+    // The things one account must never be able to read, overwrite, or resolve out of the other.
+    private const string SecretTranscriptA = "alpha-account-secret-transcript";
+    private const string SecretTranscriptB = "bravo-account-secret-transcript";
+    private const string SecretAudioA = "alpha-account-secret-audio-bytes";
+    private const string SecretAudioB = "bravo-account-secret-audio-bytes";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _httpA = null!;
+    private HttpClient _httpB = null!;
+    private HttpClient _httpUnbound = null!;
+
+    private TenantId _tenantA;
+    private TenantId _tenantB;
+
+    private string? _priorHosted;
+    private string? _priorRoot;
+
+    private readonly string _storageRoot =
+        Path.Combine(Path.GetTempPath(), "cc-dictation-iso-storage-" + Guid.NewGuid().ToString("N"));
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-dictation-iso-instances-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        // Isolate the storage root BEFORE the Gateway starts so its dictation upload store binds the temp
+        // root, never the developer's real one.
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
+
+        _gateway = new GatewayHost(port: FreePort(), token: GatewayToken, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            promptLogPath: Path.Combine(_instancesDir, "prompt-log"));
+        await _gateway.StartAsync();
+
+        // Two accounts: two device keys, each bound to its OWN tenant, plus one registered-but-unbound key.
+        // The tenants are MINTED BY THE REAL REGISTRY, exactly as the hosted enrollment route does, because
+        // the upload store turns a tenant id into a DIRECTORY NAME and enforces the real minted shape - a
+        // test binding a made-up id would be testing a partition production can never create.
+        var keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        var keyUnbound = _gateway.Devices.Register("dev-x", "MX").DeviceKey;
+        _tenantA = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        _tenantB = _gateway.TenantRegistry.MintOrLookupBySubject("sub-bob", "bob@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", _tenantA.Value);
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", _tenantB.Value);
+
+        _httpA = NewClient(keyA);
+        _httpB = NewClient(keyB);
+        _httpUnbound = NewClient(keyUnbound);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _httpA.Dispose();
+        _httpB.Dispose();
+        _httpUnbound.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* cleanup */ }
+        try { if (Directory.Exists(_storageRoot)) Directory.Delete(_storageRoot, true); } catch { /* cleanup */ }
+    }
+
+    // ===== leg 1: chunks ===========================================================================
+
+    [Fact]
+    public async Task Chunks_cannot_cross_between_accounts_on_the_same_upload_id()
+    {
+        var id = Guid.NewGuid().ToString();
+
+        // Positive control: A registers the id and stages a chunk under it, successfully.
+        Assert.Equal(HttpStatusCode.OK, (await RegisterAsync(_httpA, id)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await PutChunkAsync(_httpA, id, 0, SecretAudioA)).StatusCode);
+        Assert.Equal(SecretAudioA, await StagedTextAsync(_tenantA, id));
+
+        // B cannot write into it. The upload id does not exist in B's partition, so B cannot overwrite A's
+        // audio, extend it, or even confirm that it exists.
+        Assert.Equal(HttpStatusCode.NotFound, (await PutChunkAsync(_httpB, id, 0, SecretAudioB)).StatusCode);
+        Assert.Equal(SecretAudioA, await StagedTextAsync(_tenantA, id));
+
+        // The other direction, on the same id - which is now legally B's id too, and that is the point: an
+        // upload id is only meaningful inside its own tenant.
+        Assert.Equal(HttpStatusCode.OK, (await RegisterAsync(_httpB, id)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await PutChunkAsync(_httpB, id, 0, SecretAudioB)).StatusCode);
+        Assert.Equal(SecretAudioB, await StagedTextAsync(_tenantB, id));
+        Assert.Equal(SecretAudioA, await StagedTextAsync(_tenantA, id));
+    }
+
+    // ===== leg 2: the terminal transcript, at register =============================================
+
+    [Fact]
+    public async Task A_terminal_transcript_is_never_handed_to_another_account_at_register()
+    {
+        // THE CONCRETE DISCLOSURE from the issue, driven over HTTP: after A completes upload id X, B posts
+        // /dictation/upload with Idempotency-Key: X and the terminal-register result hands B A's transcript.
+        var id = Guid.NewGuid().ToString();
+        Store(_tenantA).MarkDelivered(id, submitted: true, movedOn: false, transcript: SecretTranscriptA);
+
+        // Positive control: A re-registering its OWN delivered id really does get the cached terminal outcome
+        // back, so "B does not get it" cannot pass because the short-circuit never fires.
+        var (statusA, bodyA) = await ReadAsync(await RegisterAsync(_httpA, id));
+        Assert.Equal(HttpStatusCode.OK, statusA);
+        Assert.Contains(SecretTranscriptA, bodyA);
+
+        // The absence claim: B's register of the same id is an ordinary fresh register - no terminal flag, no
+        // transcript, nothing of A's in any form.
+        var (statusB, bodyB) = await ReadAsync(await RegisterAsync(_httpB, id));
+        Assert.Equal(HttpStatusCode.OK, statusB);
+        Assert.DoesNotContain(SecretTranscriptA, bodyB);
+        Assert.False(JsonDocument.Parse(bodyB).RootElement.TryGetProperty("terminal", out var terminal)
+                     && terminal.GetBoolean());
+        // A's record is untouched by B's register - still delivered, still A's words.
+        Assert.Equal(DictationDeliveryState.Delivered, Store(_tenantA).ReadRecord(id)!.State);
+        Assert.Equal(SecretTranscriptA, Store(_tenantA).ReadRecord(id)!.Transcript);
+
+        // The mirror direction on a second id owned by B.
+        var idB = Guid.NewGuid().ToString();
+        Store(_tenantB).MarkDelivered(idB, submitted: true, movedOn: false, transcript: SecretTranscriptB);
+        Assert.Contains(SecretTranscriptB, (await ReadAsync(await RegisterAsync(_httpB, idB))).body);
+        Assert.DoesNotContain(SecretTranscriptB, (await ReadAsync(await RegisterAsync(_httpA, idB))).body);
+    }
+
+    [Fact]
+    public async Task A_terminal_transcript_is_never_handed_to_another_account_at_complete()
+    {
+        // The same disclosure through the OTHER door: the cached-terminal-outcome short-circuit in complete.
+        var id = Guid.NewGuid().ToString();
+        Store(_tenantA).MarkDelivered(id, submitted: true, movedOn: false, transcript: SecretTranscriptA);
+
+        // Positive control: A's own re-complete returns its cached submitted outcome.
+        var (statusA, bodyA) = await ReadAsync(await CompleteAsync(_httpA, id));
+        Assert.Equal(HttpStatusCode.OK, statusA);
+        Assert.Contains(SecretTranscriptA, bodyA);
+
+        // B completing the same id gets nothing of A's: no 200, and no transcript in any form.
+        var (statusB, bodyB) = await ReadAsync(await CompleteAsync(_httpB, id));
+        Assert.NotEqual(HttpStatusCode.OK, statusB);
+        Assert.DoesNotContain(SecretTranscriptA, bodyB);
+
+        // Mirror.
+        var idB = Guid.NewGuid().ToString();
+        Store(_tenantB).MarkDelivered(idB, submitted: true, movedOn: false, transcript: SecretTranscriptB);
+        Assert.Contains(SecretTranscriptB, (await ReadAsync(await CompleteAsync(_httpB, idB))).body);
+        var crossing = await ReadAsync(await CompleteAsync(_httpA, idB));
+        Assert.NotEqual(HttpStatusCode.OK, crossing.status);
+        Assert.DoesNotContain(SecretTranscriptB, crossing.body);
+    }
+
+    // ===== leg 3: the in-flight completion cache ===================================================
+
+    [Fact]
+    public async Task The_static_single_flight_completion_cache_is_keyed_by_tenant()
+    {
+        // The cache is STATIC and used to be keyed by upload id alone, so whichever account's complete
+        // arrived first supplied the cached run to every other account posting that id - a purely in-memory
+        // cross-serve that no on-disk partition can guard.
+        //
+        // Bound to the REAL GetOrAdd call site through its seam, not to the key helper: a unit test of the
+        // helper alone would stay green if that call went back to keying on the upload id.
+        var id = Guid.NewGuid().ToString();
+        var observed = new List<string>();
+        GatewayDictationEndpoint.OnCompleteEntryCreatedForTests = key => { lock (observed) observed.Add(key); };
+        try
+        {
+            await RegisterAsync(_httpA, id);
+            await PutChunkAsync(_httpA, id, 0, SecretAudioA);
+            await CompleteAsync(_httpA, id);
+
+            await RegisterAsync(_httpB, id);
+            await PutChunkAsync(_httpB, id, 0, SecretAudioB);
+            await CompleteAsync(_httpB, id);
+        }
+        finally
+        {
+            GatewayDictationEndpoint.OnCompleteEntryCreatedForTests = null;
+        }
+
+        // Positive control: both completes really did create an entry, so "the two entries are different"
+        // cannot pass because the cache was never reached.
+        Assert.Contains(observed, k => k.Contains(_tenantA.Value, StringComparison.Ordinal));
+        Assert.Contains(observed, k => k.Contains(_tenantB.Value, StringComparison.Ordinal));
+
+        // Both directions: neither account's key can be read as the other's, so neither can join the other's
+        // in-flight run for the same upload id.
+        var keyA = GatewayDictationEndpoint.CacheKey(_tenantA, id);
+        var keyB = GatewayDictationEndpoint.CacheKey(_tenantB, id);
+        Assert.NotEqual(keyA, keyB);
+        Assert.DoesNotContain(_tenantB.Value, keyA, StringComparison.Ordinal);
+        Assert.DoesNotContain(_tenantA.Value, keyB, StringComparison.Ordinal);
+        Assert.Contains(keyA, observed);
+        Assert.Contains(keyB, observed);
+    }
+
+    // ===== leg 4: ack ==============================================================================
+
+    [Fact]
+    public async Task An_ack_never_retires_another_accounts_record()
+    {
+        // Positive control on a separate id first: an ack really does retire this account's own tombstone in
+        // this setup, so the "retired=false" claim below is a refusal and not a broken route.
+        var control = Guid.NewGuid().ToString();
+        Store(_tenantA).MarkDelivered(control, submitted: true, movedOn: false, transcript: SecretTranscriptA);
+        Assert.True(await AckRetiredAsync(_httpA, control));
+
+        var id = Guid.NewGuid().ToString();
+        Store(_tenantA).MarkDelivered(id, submitted: true, movedOn: false, transcript: SecretTranscriptA);
+
+        // B acking A's id retires nothing, and A's tombstone - the durable de-dupe that stops A's turn being
+        // injected a second time - is still standing afterwards.
+        Assert.False(await AckRetiredAsync(_httpB, id));
+        Assert.NotNull(Store(_tenantA).ReadRecord(id));
+        Assert.Equal(SecretTranscriptA, Store(_tenantA).ReadRecord(id)!.Transcript);
+
+        // And A can still retire its own, on the very id B just tried to.
+        Assert.True(await AckRetiredAsync(_httpA, id));
+        Assert.Null(Store(_tenantA).ReadRecord(id));
+
+        // Mirror.
+        var idB = Guid.NewGuid().ToString();
+        Store(_tenantB).MarkDelivered(idB, submitted: true, movedOn: false, transcript: SecretTranscriptB);
+        Assert.False(await AckRetiredAsync(_httpA, idB));
+        Assert.NotNull(Store(_tenantB).ReadRecord(idB));
+        Assert.True(await AckRetiredAsync(_httpB, idB));
+    }
+
+    // ===== leg 5: abandon ==========================================================================
+
+    [Fact]
+    public async Task An_abandon_never_resolves_or_discards_another_accounts_dictation()
+    {
+        var sessionA = Guid.NewGuid().ToString();
+
+        // Positive control on a separate id first: abandon really does work for this account.
+        var control = Guid.NewGuid().ToString();
+        await RegisterAsync(_httpA, control, sessionA);
+        Assert.True(await AbandonedAsync(_httpA, control));
+        Assert.Equal(DictationDeliveryState.Abandoned, Store(_tenantA).ReadRecord(control)!.State);
+
+        // A has a live pending dictation, with staged audio, holding its session lock.
+        var id = Guid.NewGuid().ToString();
+        await RegisterAsync(_httpA, id, sessionA);
+        await PutChunkAsync(_httpA, id, 0, SecretAudioA);
+        Assert.True(Store(_tenantA).IsSessionLocked(sessionA));
+
+        // B abandoning that id resolves nothing of A's: A's record is still PENDING, its audio is still
+        // staged, and its session is still locked. (B's own partition gets B's own tombstone, which is B's
+        // business and nobody else's.)
+        await AbandonedAsync(_httpB, id);
+        Assert.Equal(DictationDeliveryState.Pending, Store(_tenantA).ReadRecord(id)!.State);
+        Assert.Equal(SecretAudioA, await StagedTextAsync(_tenantA, id));
+        Assert.True(Store(_tenantA).IsSessionLocked(sessionA));
+
+        // Mirror: A cannot abandon B's live dictation either.
+        var sessionB = Guid.NewGuid().ToString();
+        var idB = Guid.NewGuid().ToString();
+        await RegisterAsync(_httpB, idB, sessionB);
+        await PutChunkAsync(_httpB, idB, 0, SecretAudioB);
+        await AbandonedAsync(_httpA, idB);
+        Assert.Equal(DictationDeliveryState.Pending, Store(_tenantB).ReadRecord(idB)!.State);
+        Assert.Equal(SecretAudioB, await StagedTextAsync(_tenantB, idB));
+        Assert.True(Store(_tenantB).IsSessionLocked(sessionB));
+    }
+
+    // ===== deny by default =========================================================================
+
+    [Fact]
+    public async Task Every_leg_denies_an_authenticated_key_with_no_bound_tenant()
+    {
+        // Deny-by-default: on hosted, an authenticated device whose key has no bound tenant is refused
+        // outright - it is never quietly served the LOCAL partition, which is where self-host's uploads live.
+        var id = Guid.NewGuid().ToString();
+        Store(_tenantA).MarkDelivered(id, submitted: true, movedOn: false, transcript: SecretTranscriptA);
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await RegisterAsync(_httpUnbound, id)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await PutChunkAsync(_httpUnbound, id, 0, SecretAudioB)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await CompleteAsync(_httpUnbound, id)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden,
+            (await _httpUnbound.PostAsync($"/dictation/{id}/ack", content: null)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden,
+            (await _httpUnbound.PostAsync($"/dictation/{id}/abandon", content: null)).StatusCode);
+
+        // Positive control: the same five calls from a BOUND key are not refused, so the 403s above are the
+        // tenant deny and not a route that is simply broken for everyone.
+        Assert.NotEqual(HttpStatusCode.Forbidden, (await RegisterAsync(_httpA, id)).StatusCode);
+        Assert.NotEqual(HttpStatusCode.Forbidden, (await PutChunkAsync(_httpA, id, 0, SecretAudioA)).StatusCode);
+        Assert.NotEqual(HttpStatusCode.Forbidden, (await CompleteAsync(_httpA, id)).StatusCode);
+        Assert.NotEqual(HttpStatusCode.Forbidden,
+            (await _httpA.PostAsync($"/dictation/{id}/abandon", content: null)).StatusCode);
+        Assert.NotEqual(HttpStatusCode.Forbidden,
+            (await _httpA.PostAsync($"/dictation/{id}/ack", content: null)).StatusCode);
+    }
+
+    // ===== helpers =================================================================================
+
+    // A store bound to ONE tenant's partition of the SAME on-disk dictation root the running Gateway reads
+    // (both resolve CcStorage.DictationUploads() under the isolated CC_DIRECTOR_ROOT), so a record written
+    // here is the one that tenant's handlers see - and one no other tenant's handlers can.
+    private static VoiceUploadStore Store(TenantId tenant)
+        => new VoiceUploadStore(CcStorage.DictationUploads()).ForTenant(tenant);
+
+    private static async Task<string> StagedTextAsync(TenantId tenant, string uploadId)
+    {
+        var assembled = await Store(tenant).AssembleAsync(uploadId, 1);
+        return assembled.Audio is null ? "" : Encoding.UTF8.GetString(assembled.Audio);
+    }
+
+    private static async Task<HttpResponseMessage> RegisterAsync(HttpClient http, string uploadId, string? sessionId = null)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/dictation/upload")
+        {
+            Content = JsonContent.Create(new { sessionId = sessionId ?? Guid.NewGuid().ToString(), baselineBufferBytes = 0 }),
+        };
+        req.Headers.Add("Idempotency-Key", uploadId);
+        return await http.SendAsync(req);
+    }
+
+    private static async Task<HttpResponseMessage> PutChunkAsync(HttpClient http, string uploadId, int index, string text)
+    {
+        using var content = new ByteArrayContent(Encoding.UTF8.GetBytes(text));
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        return await http.PutAsync($"/dictation/{uploadId}/chunk/{index}", content);
+    }
+
+    private static Task<HttpResponseMessage> CompleteAsync(HttpClient http, string uploadId)
+        => http.PostAsJsonAsync($"/dictation/{uploadId}/complete",
+            new { sessionId = Guid.NewGuid().ToString(), totalChunks = 1 });
+
+    private static async Task<bool> AckRetiredAsync(HttpClient http, string uploadId)
+    {
+        var resp = await http.PostAsync($"/dictation/{uploadId}/ack", content: null);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        return (await resp.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("retired").GetBoolean();
+    }
+
+    private static async Task<bool> AbandonedAsync(HttpClient http, string uploadId)
+    {
+        var resp = await http.PostAsync($"/dictation/{uploadId}/abandon", content: null);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        return (await resp.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("abandoned").GetBoolean();
+    }
+
+    private static async Task<(HttpStatusCode status, string body)> ReadAsync(HttpResponseMessage resp)
+        => (resp.StatusCode, await resp.Content.ReadAsStringAsync());
+
+    private HttpClient NewClient(string deviceKey)
+    {
+        var http = new HttpClient
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/"),
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return http;
+    }
+
+    private static int FreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DictationTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationTenantIsolationTests.cs
@@ -169,8 +169,9 @@ public sealed class DictationTenantIsolationTests : IAsyncLifetime
         Assert.False(JsonDocument.Parse(bodyB).RootElement.TryGetProperty("terminal", out var terminal)
                      && terminal.GetBoolean());
         // A's record is untouched by B's register - still delivered, still A's words.
-        Assert.Equal(DictationDeliveryState.Delivered, Store(_tenantA).ReadRecord(id)!.State);
-        Assert.Equal(SecretTranscriptA, Store(_tenantA).ReadRecord(id)!.Transcript);
+        var afterB = MustStillExist(_tenantA, id, "A's delivered record must survive B registering the same upload id");
+        Assert.Equal(DictationDeliveryState.Delivered, afterB.State);
+        Assert.Equal(SecretTranscriptA, afterB.Transcript);
 
         // The mirror direction on a second id owned by B.
         var idB = Guid.NewGuid().ToString();
@@ -268,7 +269,8 @@ public sealed class DictationTenantIsolationTests : IAsyncLifetime
         // injected a second time - is still standing afterwards.
         Assert.False(await AckRetiredAsync(_httpB, id));
         Assert.NotNull(Store(_tenantA).ReadRecord(id));
-        Assert.Equal(SecretTranscriptA, Store(_tenantA).ReadRecord(id)!.Transcript);
+        Assert.Equal(SecretTranscriptA,
+            MustStillExist(_tenantA, id, "B's ack must not have retired A's tombstone").Transcript);
 
         // And A can still retire its own, on the very id B just tried to.
         Assert.True(await AckRetiredAsync(_httpA, id));
@@ -293,7 +295,8 @@ public sealed class DictationTenantIsolationTests : IAsyncLifetime
         var control = Guid.NewGuid().ToString();
         await RegisterAsync(_httpA, control, sessionA);
         Assert.True(await AbandonedAsync(_httpA, control));
-        Assert.Equal(DictationDeliveryState.Abandoned, Store(_tenantA).ReadRecord(control)!.State);
+        Assert.Equal(DictationDeliveryState.Abandoned,
+            MustStillExist(_tenantA, control, "A's own abandon must have written A's tombstone").State);
 
         // A has a live pending dictation, with staged audio, holding its session lock.
         var id = Guid.NewGuid().ToString();
@@ -305,7 +308,8 @@ public sealed class DictationTenantIsolationTests : IAsyncLifetime
         // staged, and its session is still locked. (B's own partition gets B's own tombstone, which is B's
         // business and nobody else's.)
         await AbandonedAsync(_httpB, id);
-        Assert.Equal(DictationDeliveryState.Pending, Store(_tenantA).ReadRecord(id)!.State);
+        Assert.Equal(DictationDeliveryState.Pending,
+            MustStillExist(_tenantA, id, "B's abandon must not have resolved A's pending record").State);
         Assert.Equal(SecretAudioA, await StagedTextAsync(_tenantA, id));
         Assert.True(Store(_tenantA).IsSessionLocked(sessionA));
 
@@ -315,7 +319,8 @@ public sealed class DictationTenantIsolationTests : IAsyncLifetime
         await RegisterAsync(_httpB, idB, sessionB);
         await PutChunkAsync(_httpB, idB, 0, SecretAudioB);
         await AbandonedAsync(_httpA, idB);
-        Assert.Equal(DictationDeliveryState.Pending, Store(_tenantB).ReadRecord(idB)!.State);
+        Assert.Equal(DictationDeliveryState.Pending,
+            MustStillExist(_tenantB, idB, "A's abandon must not have resolved B's pending record").State);
         Assert.Equal(SecretAudioB, await StagedTextAsync(_tenantB, idB));
         Assert.True(Store(_tenantB).IsSessionLocked(sessionB));
     }
@@ -354,6 +359,20 @@ public sealed class DictationTenantIsolationTests : IAsyncLifetime
     // A store bound to ONE tenant's partition of the SAME on-disk dictation root the running Gateway reads
     // (both resolve CcStorage.DictationUploads() under the isolated CC_DIRECTOR_ROOT), so a record written
     // here is the one that tenant's handlers see - and one no other tenant's handlers can.
+
+    /// <summary>
+    /// Read a record the claim under test says MUST still be there, asserting its presence before touching
+    /// it. Dereferencing with <c>!</c> turns an absent record into a NullReferenceException, and a crash is
+    /// not evidence about the line the test was aimed at - it only says something upstream broke before the
+    /// test could ask its question. Every red must be able to name what it caught.
+    /// </summary>
+    private static DictationDeliveryRecord MustStillExist(TenantId tenant, string uploadId, string claim)
+    {
+        var record = Store(tenant).ReadRecord(uploadId);
+        Assert.True(record is not null, claim + " (the record was absent)");
+        return record!;
+    }
+
     private static VoiceUploadStore Store(TenantId tenant)
         => new VoiceUploadStore(CcStorage.DictationUploads()).ForTenant(tenant);
 

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTenantPartitionTests.cs
@@ -116,9 +116,17 @@ public sealed class VoiceUploadStoreTenantPartitionTests : IDisposable
         Assert.Null(_base.ReadRecord(id));
 
         // The mirror direction, on the same id: B's own terminal record is equally invisible to A.
+        //
+        // Read through MustStillExist rather than dereferencing with `!`. Under a mutation that collapses the
+        // partitions, B's write lands on A's record and A's read then returns null - and a bare `!` turns that
+        // into a NullReferenceException, which is a CRASH, not a proof. A crash says "something upstream
+        // broke"; it does not say "A's transcript survived B writing", which is the claim on this line. Asked
+        // by assertion, the same mutation reddens here with that sentence.
         b.MarkDelivered(id, submitted: true, movedOn: false, transcript: "bravo-secret-transcript");
-        Assert.Equal("bravo-secret-transcript", b.ReadRecord(id)!.Transcript);
-        Assert.Equal("alpha-secret-transcript", a.ReadRecord(id)!.Transcript);
+        Assert.Equal("bravo-secret-transcript",
+            MustStillExist(b, id, "B's own terminal record must be readable in B's partition").Transcript);
+        Assert.Equal("alpha-secret-transcript",
+            MustStillExist(a, id, "A's transcript must survive B writing the same upload id").Transcript);
     }
 
     [Fact]
@@ -137,6 +145,13 @@ public sealed class VoiceUploadStoreTenantPartitionTests : IDisposable
         // Physically place A's record file inside B's partition - the mis-computed-root scenario.
         var aFile = Path.Combine(a.Root, Guid.Parse(id).ToString("N"), "record.json");
         var bFile = Path.Combine(b.Root, Guid.Parse(id).ToString("N"), "record.json");
+
+        // ASK THE CROSS-BOUNDARY QUESTION FIRST, before any setup that could throw. If a mutation collapses
+        // the two partitions onto one root these are the SAME path, and File.Copy of a file onto itself
+        // throws an input/output error - a CRASH during setup, which proves nothing about the record check
+        // this test exists for and merely launders the mutation into a red. Asserting the paths differ turns
+        // that same mutation into a plain assertion failure that names what actually went wrong.
+        Assert.NotEqual(aFile, bFile);
         File.Copy(aFile, bFile, overwrite: true);
 
         // Positive control: the file really is there and really is A's, so the refusal below is a refusal and
@@ -153,10 +168,10 @@ public sealed class VoiceUploadStoreTenantPartitionTests : IDisposable
         a.MarkPending(pendingId, sessionA);
         Assert.True(a.IsSessionLocked(sessionA));  // positive control
         b.Register(pendingId);
-        File.Copy(
-            Path.Combine(a.Root, Guid.Parse(pendingId).ToString("N"), "record.json"),
-            Path.Combine(b.Root, Guid.Parse(pendingId).ToString("N"), "record.json"),
-            overwrite: true);
+        var aPending = Path.Combine(a.Root, Guid.Parse(pendingId).ToString("N"), "record.json");
+        var bPending = Path.Combine(b.Root, Guid.Parse(pendingId).ToString("N"), "record.json");
+        Assert.NotEqual(aPending, bPending);   // same reason as above: never let a collapse crash the setup
+        File.Copy(aPending, bPending, overwrite: true);
         Assert.False(b.IsSessionLocked(sessionA));
     }
 
@@ -239,6 +254,23 @@ public sealed class VoiceUploadStoreTenantPartitionTests : IDisposable
         Assert.False(_base.Exists(localId));
 
         Assert.True(a.Exists(id));
-        Assert.Equal(DictationDeliveryState.Pending, a.ReadRecord(id)!.State);
+        Assert.Equal(DictationDeliveryState.Pending,
+            MustStillExist(a, id, "the sweep must not have destroyed another tenant's pending record").State);
+    }
+
+    /// <summary>
+    /// Read a record that the claim under test says MUST still be there, asserting its presence before
+    /// touching it.
+    ///
+    /// This exists so a mutation reddens by ASSERTION rather than by CRASH. Dereferencing with <c>!</c> turns
+    /// an absent record into a NullReferenceException, and a NullReferenceException is not evidence about the
+    /// line the test was aimed at - it only says something upstream broke before the test could ask its
+    /// question. Every red has to be able to name what it caught.
+    /// </summary>
+    private static DictationDeliveryRecord MustStillExist(VoiceUploadStore store, string uploadId, string claim)
+    {
+        var record = store.ReadRecord(uploadId);
+        Assert.True(record is not null, claim + " (the record was absent)");
+        return record!;
     }
 }

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTenantPartitionTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1884: <see cref="VoiceUploadStore"/> is PARTITIONED BY TENANT - the on-disk root and the record -
+/// so a caller-supplied upload id is only meaningful inside its own tenant.
+///
+/// This is the store half. The end-to-end proof that no LEG of the dictation front door can cross an account
+/// boundary lives in <c>DictationTenantIsolationTests</c>; what is pinned here is the partition those legs
+/// stand on: the directory that makes a cross-tenant read physically impossible, the second (record-borne)
+/// check behind it, and the two path aliases that would quietly re-merge two accounts into one folder.
+///
+/// THE PRODUCTION LINES THESE TESTS PROTECT (each revert-provable - revert it, watch these go red):
+///   - <c>VoiceUploadStore.PartitionRootFor</c> - return <c>_partitionBase</c> for every tenant and the
+///     isolation assertions go RED (two accounts share one folder again).
+///   - <c>VoiceUploadStore.IsMintedAccountTenant</c> - loosen it to a character allow-list and the
+///     traversal / casing-alias refusals go RED.
+///   - <c>VoiceUploadStore.WriteRecordMarker</c>'s tenant stamp and <c>BelongsHere</c> - drop either and the
+///     foreign-record refusal goes RED.
+///   - The partition-container skip in <c>SweepAbandoned</c> - remove it and the sweep deletes every other
+///     tenant's staging in one pass, which that test goes RED on.
+/// </summary>
+public sealed class VoiceUploadStoreTenantPartitionTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "cc-upload-partition-" + Guid.NewGuid().ToString("N"));
+
+    private readonly VoiceUploadStore _base;
+
+    // Two tenants in exactly the form the real registry mints (a canonical lowercase GUID), because the
+    // store now enforces that shape - a made-up id would be testing a partition production cannot create.
+    private readonly TenantId _tenantA = new(Guid.NewGuid().ToString());
+    private readonly TenantId _tenantB = new(Guid.NewGuid().ToString());
+
+    public VoiceUploadStoreTenantPartitionTests() => _base = new VoiceUploadStore(_root);
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public void Self_host_keeps_the_exact_root_it_has_always_used()
+    {
+        // Self-host is the CONTROL for this whole change: the local tenant must resolve to the same directory
+        // as before, so nothing migrates and no upload moves.
+        Assert.Equal(_root, _base.Root);
+        Assert.Equal(_root, _base.ForTenant(TenantId.Local).Root);
+        Assert.True(_base.ForTenant(TenantId.Local).Tenant.IsLocal);
+
+        var id = Guid.NewGuid().ToString();
+        _base.Register(id);
+        Assert.True(Directory.Exists(Path.Combine(_root, Guid.Parse(id).ToString("N"))));
+        // And the local partition does not sprout a container it never had.
+        Assert.False(Directory.Exists(Path.Combine(_root, VoiceUploadStore.TenantPartitionDirectoryName)));
+    }
+
+    [Fact]
+    public async Task The_same_upload_id_is_two_different_uploads_in_two_tenants()
+    {
+        // The heart of the fix: an upload id is only meaningful INSIDE its tenant, so the SAME id is legal in
+        // both accounts at once and neither can see the other's staging.
+        var id = Guid.NewGuid().ToString();
+        var a = _base.ForTenant(_tenantA);
+        var b = _base.ForTenant(_tenantB);
+
+        a.Register(id);
+        await a.StoreChunkAsync(id, 0, Encoding.UTF8.GetBytes("alpha-audio"), null);
+
+        // Positive control in front of the absence claim: A really did stage bytes under this id.
+        Assert.True(a.Exists(id));
+        Assert.True(a.StagedBytes(id) > 0);
+
+        // Both directions. B does not see A's upload at all - not its bytes, not even its existence.
+        Assert.False(b.Exists(id));
+        Assert.Equal(0, b.StagedBytes(id));
+
+        b.Register(id);
+        await b.StoreChunkAsync(id, 0, Encoding.UTF8.GetBytes("bravo-audio"), null);
+
+        var assembledA = await a.AssembleAsync(id, 1);
+        var assembledB = await b.AssembleAsync(id, 1);
+        Assert.Equal("alpha-audio", Encoding.UTF8.GetString(assembledA.Audio!));
+        Assert.Equal("bravo-audio", Encoding.UTF8.GetString(assembledB.Audio!));
+
+        // ...and neither is the LOCAL partition's, which stays empty of this id entirely.
+        Assert.False(_base.Exists(id));
+    }
+
+    [Fact]
+    public void A_terminal_record_is_invisible_and_unresolvable_from_another_tenant()
+    {
+        // The concrete disclosure from the issue: after A completes upload id X, B posting the same id was
+        // handed A's terminal record - and therefore A's TRANSCRIPT.
+        var id = Guid.NewGuid().ToString();
+        var a = _base.ForTenant(_tenantA);
+        var b = _base.ForTenant(_tenantB);
+
+        a.MarkDelivered(id, submitted: true, movedOn: false, transcript: "alpha-secret-transcript");
+
+        // Positive control: A reads its own terminal record back, so the absence claim below is not passing
+        // because nothing was ever written.
+        var mine = a.ReadRecord(id);
+        Assert.NotNull(mine);
+        Assert.Equal("alpha-secret-transcript", mine!.Transcript);
+        Assert.Equal(_tenantA.Value, mine.Tenant);
+
+        Assert.Null(b.ReadRecord(id));
+        Assert.Null(_base.ReadRecord(id));
+
+        // The mirror direction, on the same id: B's own terminal record is equally invisible to A.
+        b.MarkDelivered(id, submitted: true, movedOn: false, transcript: "bravo-secret-transcript");
+        Assert.Equal("bravo-secret-transcript", b.ReadRecord(id)!.Transcript);
+        Assert.Equal("alpha-secret-transcript", a.ReadRecord(id)!.Transcript);
+    }
+
+    [Fact]
+    public void A_record_carrying_another_tenant_is_refused_even_inside_this_partition()
+    {
+        // The second, independent check. The directory already makes this unreachable, which is exactly why
+        // it must be tested directly: if a partition root were ever mis-computed, the record itself still
+        // refuses to be handed to the wrong account rather than silently disclosing a transcript.
+        var id = Guid.NewGuid().ToString();
+        var a = _base.ForTenant(_tenantA);
+        var b = _base.ForTenant(_tenantB);
+
+        a.MarkDelivered(id, submitted: true, movedOn: false, transcript: "alpha-secret-transcript");
+        b.Register(id);
+
+        // Physically place A's record file inside B's partition - the mis-computed-root scenario.
+        var aFile = Path.Combine(a.Root, Guid.Parse(id).ToString("N"), "record.json");
+        var bFile = Path.Combine(b.Root, Guid.Parse(id).ToString("N"), "record.json");
+        File.Copy(aFile, bFile, overwrite: true);
+
+        // Positive control: the file really is there and really is A's, so the refusal below is a refusal and
+        // not a missing file.
+        Assert.Contains("alpha-secret-transcript", File.ReadAllText(bFile));
+
+        Assert.Null(b.ReadRecord(id));
+
+        // The same check on the PENDING projection, which reads records by enumeration rather than by id: a
+        // foreign pending record planted in this partition must not lock a session here either.
+        var pendingId = Guid.NewGuid().ToString();
+        var sessionA = Guid.NewGuid().ToString();
+        a.Register(pendingId);
+        a.MarkPending(pendingId, sessionA);
+        Assert.True(a.IsSessionLocked(sessionA));  // positive control
+        b.Register(pendingId);
+        File.Copy(
+            Path.Combine(a.Root, Guid.Parse(pendingId).ToString("N"), "record.json"),
+            Path.Combine(b.Root, Guid.Parse(pendingId).ToString("N"), "record.json"),
+            overwrite: true);
+        Assert.False(b.IsSessionLocked(sessionA));
+    }
+
+    [Fact]
+    public void The_session_lock_projection_never_crosses_tenants()
+    {
+        var idA = Guid.NewGuid().ToString();
+        var idB = Guid.NewGuid().ToString();
+        var sessionA = Guid.NewGuid().ToString();
+        var sessionB = Guid.NewGuid().ToString();
+        var a = _base.ForTenant(_tenantA);
+        var b = _base.ForTenant(_tenantB);
+
+        a.Register(idA);
+        a.MarkPending(idA, sessionA);
+        b.Register(idB);
+        b.MarkPending(idB, sessionB);
+
+        // Positive controls first: each account's own pending upload does lock its own session.
+        Assert.True(a.IsSessionLocked(sessionA));
+        Assert.True(b.IsSessionLocked(sessionB));
+
+        // Both directions: neither account's pending upload can lock (or be seen by) the other.
+        Assert.False(a.IsSessionLocked(sessionB));
+        Assert.False(b.IsSessionLocked(sessionA));
+        Assert.DoesNotContain(sessionB, a.LockedSessionIds());
+        Assert.DoesNotContain(sessionA, b.LockedSessionIds());
+        // The local partition sees neither, which is the self-host control.
+        Assert.Empty(_base.LockedSessionIds());
+    }
+
+    [Theory]
+    // The traversal alias: combining the base root with "tenants" and ".." canonicalizes to exactly the base
+    // root - the LOCAL partition - so a character allow-list that accepts ".." merges an account into it.
+    [InlineData("..")]
+    [InlineData("../..")]
+    [InlineData("a/b")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-guid")]
+    // The reserved system identity: no recorded audio belongs to it, so the safe answer is no partition.
+    [InlineData("system")]
+    public void A_tenant_id_that_is_not_a_minted_account_is_refused_not_normalised(string value)
+    {
+        // A blank value cannot even construct a TenantId, which is the same refusal one layer earlier.
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            Assert.Throws<ArgumentException>(() => new TenantId(value));
+            return;
+        }
+        Assert.Throws<ArgumentException>(() => _base.ForTenant(new TenantId(value)));
+    }
+
+    [Fact]
+    public void An_uppercase_spelling_of_a_minted_tenant_is_refused_rather_than_folded()
+    {
+        // The casing alias, and the reason refusing beats normalising: Windows and Azure Files name the SAME
+        // directory for both spellings, while the tenants table treats them as DIFFERENT identities. Folding
+        // the case would hand two identities one folder full of audio; refusing keeps them apart.
+        var upper = new TenantId(_tenantA.Value.ToUpperInvariant());
+        Assert.Throws<ArgumentException>(() => _base.ForTenant(upper));
+    }
+
+    [Fact]
+    public void Sweeping_the_local_partition_never_touches_another_tenants_staging()
+    {
+        // The container holding the other partitions is not an upload. Age-sweeping it would delete every
+        // other account's staged audio in one pass - the loudest possible cross-tenant write.
+        var id = Guid.NewGuid().ToString();
+        var a = _base.ForTenant(_tenantA);
+        a.Register(id);
+        a.MarkPending(id, Guid.NewGuid().ToString());
+
+        // Positive control: the sweep really does run and really does remove an aged LOCAL upload, so the
+        // survival assertion below is not passing because the sweep did nothing at all.
+        // A cutoff in the FUTURE (a negative max age), so "aged out" is deterministic without sleeping.
+        var localId = Guid.NewGuid().ToString();
+        _base.Register(localId);
+        Assert.Equal(1, _base.SweepAbandoned(TimeSpan.FromDays(-1)));
+        Assert.False(_base.Exists(localId));
+
+        Assert.True(a.Exists(id));
+        Assert.Equal(DictationDeliveryState.Pending, a.ReadRecord(id)!.State);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTenantPartitionTests.cs
@@ -26,6 +26,34 @@ namespace CcDirector.Gateway.Tests;
 ///     foreign-record refusal goes RED.
 ///   - The partition-container skip in <c>SweepAbandoned</c> - remove it and the sweep deletes every other
 ///     tenant's staging in one pass, which that test goes RED on.
+///
+/// IF YOU ARE ADDING A PARTITION TEST HERE, READ THIS FIRST: A RED MUST BE AN ASSERTION, NEVER A CRASH.
+///
+/// Every test in this file is a canary for a specific mutation, and a canary only pays for itself if its
+/// red can NAME what it caught. A NullReferenceException or an input/output error means the mutation broke
+/// something before the test could ask its question. It still shows up as a red, which is why it is so
+/// easy to accept - but it is evidence that SOMETHING is wrong, not evidence about the line the mutation
+/// was aimed at. Counting it launders the mutation into a proof it did not earn.
+///
+/// Two ways that happens in a PARTITION test specifically, both of which have already bitten this file:
+///
+///  1. DEREFERENCING A RECORD THAT THE MUTATION DELETED. <c>store.ReadRecord(id)!.State</c> reads fine
+///     until a mutation makes the read return null, and then the test dies on the <c>!</c> instead of
+///     failing on the claim. Use <see cref="MustStillExist"/>: it asserts presence, with the sentence the
+///     test is actually making, before anything touches the record.
+///
+///  2. THE SETUP ITSELF THROWING - the subtler one, and the one that looks like an environment fault.
+///     Several tests here copy one tenant's record file into another tenant's partition to stage the
+///     mis-computed-root scenario. When a mutation COLLAPSES the partitions, those two paths become THE
+///     SAME PATH, and copying a file onto itself throws a file-in-use error. The test crashes during
+///     ARRANGE, before a single assertion runs, and the crash tells you nothing about the record check the
+///     test exists for. So ASK THE CROSS-BOUNDARY QUESTION FIRST: assert the two partition paths differ
+///     BEFORE the copy. The same mutation then reddens as a plain assertion that says the partitions
+///     collapsed - which is exactly what happened. That is why those <c>Assert.NotEqual</c> calls are
+///     ordered ahead of the <c>File.Copy</c> calls, and they must stay ahead of them.
+///
+/// The general rule both cases are instances of: put the assertion that states the boundary claim BEFORE
+/// any control, setup, or dereference that a broken boundary could make throw.
 /// </summary>
 public sealed class VoiceUploadStoreTenantPartitionTests : IDisposable
 {
@@ -146,11 +174,11 @@ public sealed class VoiceUploadStoreTenantPartitionTests : IDisposable
         var aFile = Path.Combine(a.Root, Guid.Parse(id).ToString("N"), "record.json");
         var bFile = Path.Combine(b.Root, Guid.Parse(id).ToString("N"), "record.json");
 
-        // ASK THE CROSS-BOUNDARY QUESTION FIRST, before any setup that could throw. If a mutation collapses
-        // the two partitions onto one root these are the SAME path, and File.Copy of a file onto itself
-        // throws an input/output error - a CRASH during setup, which proves nothing about the record check
-        // this test exists for and merely launders the mutation into a red. Asserting the paths differ turns
-        // that same mutation into a plain assertion failure that names what actually went wrong.
+        // ASK THE CROSS-BOUNDARY QUESTION FIRST - see the class comment. Under a mutation that collapses
+        // the partitions these are the SAME path, and File.Copy of a file onto itself throws during ARRANGE,
+        // before any assertion runs, which proves nothing about the record check this test exists for.
+        // Asserting the paths differ turns that mutation into a red that says the partitions collapsed.
+        // This line must stay AHEAD of the copy.
         Assert.NotEqual(aFile, bFile);
         File.Copy(aFile, bFile, overwrite: true);
 
@@ -170,7 +198,9 @@ public sealed class VoiceUploadStoreTenantPartitionTests : IDisposable
         b.Register(pendingId);
         var aPending = Path.Combine(a.Root, Guid.Parse(pendingId).ToString("N"), "record.json");
         var bPending = Path.Combine(b.Root, Guid.Parse(pendingId).ToString("N"), "record.json");
-        Assert.NotEqual(aPending, bPending);   // same reason as above: never let a collapse crash the setup
+        // Ahead of the copy for the reason in the class comment: under a collapse these are the same path
+        // and File.Copy would throw during setup, laundering the mutation into a crash-red.
+        Assert.NotEqual(aPending, bPending);
         File.Copy(aPending, bPending, overwrite: true);
         Assert.False(b.IsSessionLocked(sessionA));
     }

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTenantPartitionTests.cs
@@ -22,8 +22,15 @@ namespace CcDirector.Gateway.Tests;
 ///     isolation assertions go RED (two accounts share one folder again).
 ///   - <c>VoiceUploadStore.IsMintedAccountTenant</c> - loosen it to a character allow-list and the
 ///     traversal / casing-alias refusals go RED.
-///   - <c>VoiceUploadStore.WriteRecordMarker</c>'s tenant stamp and <c>BelongsHere</c> - drop either and the
-///     foreign-record refusal goes RED.
+///   - <c>VoiceUploadStore.BelongsHere</c> - the independent DISCLOSURE guard. Neuter it (<c>=&gt; true</c>)
+///     and a record physically present in the wrong partition is handed over; the foreign-record refusal
+///     goes RED.
+///   - <c>VoiceUploadStore.WriteRecordMarker</c>'s tenant stamp - a separate line with a DIFFERENT failure
+///     mode, and the distinction is worth keeping crisp. Drop the stamp while <c>BelongsHere</c> stays
+///     strict and nothing is disclosed: with the primary partition intact, account records simply become
+///     unattributed and are therefore REFUSED - a correctness and availability failure, not a disclosure
+///     one. It still earns its own proof, because the accepted design requires the persisted ownership
+///     stamp; it just must not be described as demonstrating cross-tenant disclosure.
 ///   - The partition-container skip in <c>SweepAbandoned</c> - remove it and the sweep deletes every other
 ///     tenant's staging in one pass, which that test goes RED on.
 ///

--- a/src/CcDirector.Gateway/Api/DictationTenantGate.cs
+++ b/src/CcDirector.Gateway/Api/DictationTenantGate.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics.CodeAnalysis;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Voice;
+using Microsoft.AspNetCore.Http;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The ONE door onto the dictation upload staging, and the reason a dictation leg can no longer be written
+/// unscoped (issue #1884).
+///
+/// THE DEFECT SHAPE THIS REMOVES. Every dictation leg used to be scoped by hand:
+///
+///   <code>
+///   if (ResolveTenant(ctx, tenantBoundary) is not { } tenant) return NoTenantResult();
+///   var store = uploads.ForTenant(tenant);
+///   </code>
+///
+/// Two lines, repeated five times, with the raw un-partitioned <see cref="VoiceUploadStore"/> sitting in
+/// scope beside them. That is not one safeguard used five times - it is FIVE INDEPENDENT CHANCES TO FORGET.
+/// Any one leg could drop its <c>ForTenant</c> while the tenant boundary and the partition computation both
+/// stayed perfectly correct, and that leg alone would then read, overwrite, retire or discard another
+/// account's recorded audio and its transcript. Nothing would fail to compile and nothing would fail loud.
+/// The realistic version of that defect is not someone editing an existing leg: it is the SIXTH leg somebody
+/// adds next month, who will never read any of the reasoning that surrounds these five.
+///
+/// So the fix is not to prove the five legs correct today. It is to make the mistake INEXPRESSIBLE:
+/// <see cref="GatewayDictationEndpoint.Map"/> does not take a <see cref="VoiceUploadStore"/> at all. It takes
+/// this gate. There is no unscoped store in scope anywhere in that file, so "forget to scope this leg" stops
+/// being something a person can type - a new leg has nothing to call except <see cref="TryOpen"/>, and
+/// <see cref="TryOpen"/> cannot hand back an unscoped store. A guarantee held by the type system does not
+/// depend on the next author knowing why it matters.
+///
+/// It also folds the DENY into the same call. Resolving a tenant and refusing when there is none are one
+/// decision, and splitting them across two statements is what let a leg keep the resolve and lose the scope.
+/// Here a caller that does not check the return value has no store to use.
+/// </summary>
+internal sealed class DictationTenantGate
+{
+    private readonly VoiceUploadStore _uploads;
+    private readonly Tenancy.HostedTenantBoundary? _boundary;
+
+    /// <param name="uploads">
+    /// The base staging store. Held PRIVATELY and never handed out un-partitioned - that is the whole point
+    /// of this type, and it is why the endpoint takes the gate rather than the store.
+    /// </param>
+    /// <param name="boundary">
+    /// The hosted tenant boundary. Required, so omitting it is a compile error rather than a silent runtime
+    /// downgrade to the shared self-host root. It is still checked for null at the moment of use, because a
+    /// test can force one through to reproduce the miswire and must be refused on hosted even so.
+    /// </param>
+    internal DictationTenantGate(VoiceUploadStore uploads, Tenancy.HostedTenantBoundary boundary)
+    {
+        _uploads = uploads ?? throw new ArgumentNullException(nameof(uploads));
+        _boundary = boundary;
+    }
+
+    /// <summary>
+    /// Open this request's own partition of the dictation staging, or refuse.
+    ///
+    /// Returns true with a store bound to the caller's tenant, or false with the 403 the caller must return.
+    /// On the hosted Gateway a missing boundary, a boundary that is not hosted-wired, and an authenticated key
+    /// with no bound tenant are ALL refusals - never the local partition, never the reserved system tenant.
+    /// Off hosted mode every authenticated caller is the single local tenant, exactly as before.
+    ///
+    /// The out-parameter shape is deliberate: there is no way to obtain the store except through the branch
+    /// that has already proven a tenant, so the check cannot be separated from the use.
+    /// </summary>
+    internal bool TryOpen(
+        HttpContext ctx,
+        [NotNullWhen(true)] out VoiceUploadStore? store,
+        out TenantId tenant,
+        [NotNullWhen(false)] out IResult? deny)
+    {
+        if (GatewayDictationEndpoint.ResolveTenant(ctx, _boundary) is not { } resolved)
+        {
+            store = null;
+            tenant = default;
+            deny = GatewayDictationEndpoint.NoTenantResult();
+            return false;
+        }
+
+        store = _uploads.ForTenant(resolved);
+        tenant = resolved;
+        deny = null;
+        return true;
+    }
+}

--- a/src/CcDirector.Gateway/Api/DictationTenantGate.cs
+++ b/src/CcDirector.Gateway/Api/DictationTenantGate.cs
@@ -34,6 +34,28 @@ namespace CcDirector.Gateway.Api;
 /// It also folds the DENY into the same call. Resolving a tenant and refusing when there is none are one
 /// decision, and splitting them across two statements is what let a leg keep the resolve and lose the scope.
 /// Here a caller that does not check the return value has no store to use.
+///
+/// EXACTLY WHAT CARRIES THE GUARANTEE, stated precisely because the exemption from per-leg proof was granted
+/// on structural impossibility and a reader who finds a looser signature will rightly doubt the rest.
+///
+/// What is shown: <see cref="GatewayDictationEndpoint.Map"/> does not accept or capture a
+/// <see cref="VoiceUploadStore"/>, no unscoped store IDENTIFIER exists anywhere in that file, and the five
+/// legs can obtain a store only from <see cref="TryOpen"/>, which cannot return an unscoped one.
+///
+/// What is NOT shown: that an unscoped store could not be PASSED. Two private helpers on the completion path
+/// (<c>RunCompleteCoreAsync</c> and <c>MapNonOkTranscription</c>) still take a bare
+/// <see cref="VoiceUploadStore"/> in their signatures and would accept an unscoped one if such a store were
+/// ever in reach. Today none can be: this gate PRIVATELY OWNS the only raw store and hands out nothing but
+/// partitioned views. So the property holds by THIS TYPE'S ENCAPSULATION, not by the type system at those two
+/// signatures. Both statements are true; only the first was proved by inspection, and they are different
+/// claims.
+///
+/// The stronger form - give <see cref="TryOpen"/> a distinct scoped-handle type, constructible only here, and
+/// take THAT in the two helpers - would move the guarantee into the type system, where it would survive
+/// someone later making a raw store reachable for an unrelated reason. It is deliberately NOT done in this
+/// change: the structure above has been independently inspected and is what the mutation proof runs against,
+/// and altering it now would mean proving something other than what was validated. Worth doing next, when it
+/// is not racing a proof.
 /// </summary>
 internal sealed class DictationTenantGate
 {

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -39,6 +39,20 @@ namespace CcDirector.Gateway.Api;
 /// the tombstone is retired only by the client ack. Every route is token-gated via
 /// <see cref="AuthMiddleware.HasValidToken"/> so it holds even when the production tray Gateway runs with
 /// the global auth middleware off.
+///
+/// TENANT-KEYED (issue #1884). Authenticating a DEVICE is not the same as authorizing an UPLOAD. Every leg -
+/// upload, chunk, complete, ack, abandon - now resolves the request's tenant from the authenticated device
+/// key and works ONLY inside that tenant's partition of <see cref="VoiceUploadStore"/>, and the two static
+/// in-memory caches below are keyed by tenant as well as upload id. Before this, an upload id was the whole
+/// key: after account A completed upload id X, account B posting with <c>Idempotency-Key: X</c> was handed
+/// A's terminal record - and A's TRANSCRIPT - and before A reached a terminal state B could overwrite A's
+/// chunks, ack or abandon A's record, or race its completion. A GUID is not a tenant boundary; upload ids
+/// travel in client logs, retries and store-and-forward queues.
+///
+/// NOTE, deliberately: this makes the STATE safe, it does not make dictation work on hosted. The session
+/// locate inside the completion still resolves in the LOCAL partition, so a hosted session is not found and
+/// dictation stays dead there exactly as it is today (issue #1884 part (a), held pending a separate ruling).
+/// Partitioning first is the point: converting the route first would ARM this store rather than close it.
 /// </summary>
 internal static class GatewayDictationEndpoint
 {
@@ -47,26 +61,65 @@ internal static class GatewayDictationEndpoint
     // (non-resumed) sends always inject; the 1-hour staging sweep is the hard backstop for staleness.
     private const long MovedOnBufferGrowthBytes = 512;
 
-    // In-memory single-flight for complete, keyed by uploadId: concurrent or retried completes await the
-    // SAME in-flight work so the turn is submitted at most once WHILE this instance holds the entry. The
-    // entry is dropped as soon as the work settles - the DURABLE de-dupe (a delivered/abandoned upload id
-    // never re-injecting, past any age and across a restart) is owned by the on-disk delivery record
-    // (issue #1183), not by this cache, so there is no age-swept idempotency window to reopen the hole.
+    // In-memory single-flight for complete, keyed by TENANT AND uploadId: concurrent or retried completes
+    // await the SAME in-flight work so the turn is submitted at most once WHILE this instance holds the
+    // entry. The entry is dropped as soon as the work settles - the DURABLE de-dupe (a delivered/abandoned
+    // upload id never re-injecting, past any age and across a restart) is owned by the on-disk delivery
+    // record (issue #1183), not by this cache, so there is no age-swept idempotency window to reopen the
+    // hole.
+    //
+    // The TENANT in the key is issue #1884. This dictionary is static (process-wide) and used to be keyed by
+    // upload id alone, so whichever account's complete arrived first supplied the cached run to every other
+    // account posting that id - handing one account's transcript to another through a purely in-memory path
+    // that no on-disk partition can guard. The store partition and this key are two separate defences and
+    // both are needed: the same upload id is now perfectly legal in two tenants at once.
     private sealed record CompleteEntry(Lazy<Task<DictationOutcome>> Task);
     private static readonly ConcurrentDictionary<string, CompleteEntry> _completes = new();
 
-    // uploadId -> sessionId, captured at register so the chunk handler (which only has the uploadId)
-    // can refresh the session's orange "Transcribing..." heartbeat as chunks stream in (issue #1126).
-    // Pruned when the upload reaches a terminal completion; a leaked entry for a never-completed upload
-    // is a single guid-pair and is bounded by real abandoned-upload volume.
+    // (tenant, uploadId) -> sessionId, captured at register so the chunk handler (which only has the
+    // uploadId) can refresh the session's orange "Transcribing..." heartbeat as chunks stream in (issue
+    // #1126). Pruned when the upload reaches a terminal completion; a leaked entry for a never-completed
+    // upload is a single guid-pair and is bounded by real abandoned-upload volume. Tenant-keyed for the same
+    // reason as _completes: it is static, and a session id is not one account's to hand to another.
     private static readonly ConcurrentDictionary<string, string> _uploadSids = new();
+
+    /// <summary>
+    /// The key both static caches use: the owning tenant AND the canonical staging spelling of the upload id.
+    /// The id is canonicalized through the store's own normalizer so two spellings of one GUID cannot become
+    /// two cache entries for one staging directory, and the tenant is first so a key can never be read as
+    /// belonging to a different account by accident.
+    /// </summary>
+    internal static string CacheKey(TenantId tenant, string uploadId)
+        => tenant.Value + "|" + (VoiceUploadStore.NormalizeUploadId(uploadId) ?? "invalid");
+
+    /// <summary>
+    /// Test seam: invoked with the cache key at the moment a single-flight completion entry is CREATED, so a
+    /// test can bind the real call site rather than a helper. Null in production, never assigned outside
+    /// tests. It exists because "the cache is tenant-keyed" is a claim about the GetOrAdd call, and a unit
+    /// test of the key function alone would stay green if that call went back to keying on the upload id.
+    /// </summary>
+    internal static Action<string>? OnCompleteEntryCreatedForTests;
+
+    /// <summary>
+    /// Resolve the request's tenant from the AUTHENTICATED device key the auth layer stashed - the same seam
+    /// the prompt log and the cockpit read path use. Null means DENY: on hosted, an authenticated request
+    /// whose key has no bound tenant is refused, never served the local partition. Self-host, or no boundary
+    /// (older callers and tests), is always Local.
+    /// </summary>
+    private static TenantId? ResolveTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
+        => boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+
+    private static IResult NoTenantResult()
+        => Results.Json(new { error = "no tenant is bound to this request" },
+            statusCode: StatusCodes.Status403Forbidden);
 
     public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry,
         SessionOwnerCache? owners, string token, GatewayTranscriptionService transcription,
         TranscribingSessions transcribingSessions, VoiceUploadStore uploads, Pairing.DeviceRegistry devices,
         Streaming.PushedSessionStore? pushedSessions = null,
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = null,
-        TimeSpan? streamStale = null)
+        TimeSpan? streamStale = null,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null)
     {
         // Gateway Cleanup mission, Phase 2 (PR E-B): resolve the owning Director push-store-first and inject
         // the dictation through the tunnel-first SessionVerbClient (the delivery marker rides the PromptRequest
@@ -76,6 +129,10 @@ internal static class GatewayDictationEndpoint
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
+            // Authorize the UPLOAD, not just the device (issue #1884): everything below runs inside this
+            // request's own tenant partition, so an upload id from another account is simply not present.
+            if (ResolveTenant(ctx, tenantBoundary) is not { } tenant) return NoTenantResult();
+            var store = uploads.ForTenant(tenant);
             var sid = body?.SessionId ?? "";
             if (!Guid.TryParse(sid, out _))
                 return Results.Json(new { error = "sessionId (guid) is required" }, statusCode: StatusCodes.Status400BadRequest);
@@ -88,11 +145,11 @@ internal static class GatewayDictationEndpoint
             // (delivered or abandoned), do NOT re-open it as a fresh PENDING upload - return the cached
             // outcome so a re-registering client (whose earlier response was lost) drops its on-device copy
             // and acknowledges instead of re-uploading and re-injecting. Survives a restart (on disk).
-            var existing = string.IsNullOrWhiteSpace(key) ? null : uploads.ReadRecord(key);
+            var existing = string.IsNullOrWhiteSpace(key) ? null : store.ReadRecord(key);
             if (existing is { State: DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned })
             {
                 FileLog.Write($"[GatewayDictation] upload re-register of terminal uploadId={key} state={existing.State}");
-                return TerminalRegisterResult(uploads.Register(key), existing);
+                return TerminalRegisterResult(store.Register(key), existing);
             }
             // A PENDING or FAILED record (or none) is (re-)opened as a fresh PENDING upload. Register
             // (re-)opens the staging dir; MarkPending writes the explicit durable PENDING marker carrying the
@@ -101,9 +158,9 @@ internal static class GatewayDictationEndpoint
             // to PENDING - overwriting the FAILED marker while keeping the staged chunks (issue #1185).
             if (existing is { State: DictationDeliveryState.Failed })
                 FileLog.Write($"[GatewayDictation] upload re-register clears FAILED uploadId={key}, retrying");
-            var uploadId = uploads.Register(string.IsNullOrWhiteSpace(key) ? null : key);
-            uploads.MarkPending(uploadId, sid);
-            _uploadSids[uploadId] = sid;
+            var uploadId = store.Register(string.IsNullOrWhiteSpace(key) ? null : key);
+            store.MarkPending(uploadId, sid);
+            _uploadSids[CacheKey(tenant, uploadId)] = sid;
             try { transcribingSessions.Begin(sid); } catch { /* the orange mark is a nicety */ }
             FileLog.Write($"[GatewayDictation] upload registered sid={sid} uploadId={uploadId}");
             return Results.Json(new { upload_id = uploadId });
@@ -113,7 +170,12 @@ internal static class GatewayDictationEndpoint
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
-            if (!uploads.Exists(uploadId))
+            // Issue #1884: an upload id that belongs to another account does not exist in this partition, so
+            // the existing unknown-id guard becomes the authorization - the caller cannot overwrite, extend,
+            // or even confirm the existence of another account's staged audio.
+            if (ResolveTenant(ctx, tenantBoundary) is not { } tenant) return NoTenantResult();
+            var store = uploads.ForTenant(tenant);
+            if (!store.Exists(uploadId))
                 return Results.Json(new { error = "unknown upload id (register it first)" }, statusCode: StatusCodes.Status404NotFound);
 
             var sha = ctx.Request.Headers["X-Chunk-Sha256"].ToString();
@@ -121,10 +183,10 @@ internal static class GatewayDictationEndpoint
             await ctx.Request.Body.CopyToAsync(ms, ctx.RequestAborted);
             try
             {
-                await uploads.StoreChunkAsync(uploadId, index, ms.ToArray(), string.IsNullOrEmpty(sha) ? null : sha, ctx.RequestAborted);
+                await store.StoreChunkAsync(uploadId, index, ms.ToArray(), string.IsNullOrEmpty(sha) ? null : sha, ctx.RequestAborted);
                 // Heartbeat: a stored chunk is progress, so keep the orange mark alive past its idle
                 // backstop for a slow upload that streams over more than the idle window (issue #1126).
-                if (_uploadSids.TryGetValue(uploadId, out var chunkSid))
+                if (_uploadSids.TryGetValue(CacheKey(tenant, uploadId), out var chunkSid))
                     transcribingSessions.Refresh(chunkSid);
                 return Results.Json(new { ok = true, index });
             }
@@ -139,6 +201,11 @@ internal static class GatewayDictationEndpoint
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
+            // Issue #1884: resolve and authorize the tenant BEFORE anything touches the store or the static
+            // single-flight cache, so a caller who does not own this upload id can neither read its record
+            // nor join its in-flight completion run.
+            if (ResolveTenant(ctx, tenantBoundary) is not { } tenant) return NoTenantResult();
+            var store = uploads.ForTenant(tenant);
             if (req is null || req.TotalChunks <= 0 || !Guid.TryParse(req.SessionId ?? "", out _))
                 return Results.Json(new { error = "sessionId (guid) and totalChunks (>0) are required" },
                     statusCode: StatusCodes.Status400BadRequest);
@@ -159,11 +226,11 @@ internal static class GatewayDictationEndpoint
             // window and even after a Gateway restart (the record and this check both live on disk). This
             // handles the SEQUENTIAL/after-restart retry; the in-memory single-flight below handles two
             // CONCURRENT completes racing before the first tombstone is written (they share one run).
-            var settled = uploads.ReadRecord(uploadId);
+            var settled = store.ReadRecord(uploadId);
             if (settled is { State: DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned })
             {
                 EndTranscribing(transcribingSessions, req.SessionId!);
-                _uploadSids.TryRemove(uploadId, out _);
+                _uploadSids.TryRemove(CacheKey(tenant, uploadId), out _);
                 FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: cached terminal outcome " +
                     $"state={settled.State} (no re-injection)");
                 return TerminalOutcome(settled).ToResult();
@@ -173,7 +240,7 @@ internal static class GatewayDictationEndpoint
             // chunks) and re-drive the real work below.
             if (settled is { State: DictationDeliveryState.Failed })
             {
-                uploads.ClearFailed(uploadId);
+                store.ClearFailed(uploadId);
                 FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: cleared FAILED, retrying");
             }
 
@@ -181,10 +248,14 @@ internal static class GatewayDictationEndpoint
             // still-PENDING id is assembled + transcribed + injected at most once even under a concurrent
             // race. The entry is dropped once the run settles (below); the durable tombstone owns de-dupe
             // from then on, so there is no age-swept cache window.
-            var entry = _completes.GetOrAdd(uploadId, id => new CompleteEntry(
-                new Lazy<Task<DictationOutcome>>(() => RunCompleteCoreAsync(
-                    id, req, uploads, registry, owners, transcription, transcribingSessions, deliverySurface,
-                    pushedSessions, sendCommand, stale))));
+            var completeKey = CacheKey(tenant, uploadId);
+            var entry = _completes.GetOrAdd(completeKey, _ =>
+            {
+                OnCompleteEntryCreatedForTests?.Invoke(completeKey);
+                return new CompleteEntry(new Lazy<Task<DictationOutcome>>(() => RunCompleteCoreAsync(
+                    uploadId, req, store, registry, owners, transcription, transcribingSessions, deliverySurface,
+                    pushedSessions, sendCommand, stale)));
+            });
 
             DictationOutcome outcome;
             try
@@ -193,7 +264,7 @@ internal static class GatewayDictationEndpoint
             }
             catch (Exception ex)
             {
-                _completes.TryRemove(uploadId, out _); // transient: let a retry re-run
+                _completes.TryRemove(completeKey, out _); // transient: let a retry re-run
                 return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status502BadGateway);
             }
 
@@ -207,13 +278,13 @@ internal static class GatewayDictationEndpoint
             if (!outcome.IsIncomplete)
             {
                 EndTranscribing(transcribingSessions, req.SessionId!);
-                _uploadSids.TryRemove(uploadId, out _);
+                _uploadSids.TryRemove(completeKey, out _);
             }
             // Drop the in-memory single-flight entry once the run settles. A terminal run has already
             // written the durable tombstone (inside the core), so a later retry short-circuits on the
             // ReadRecord check above; a non-terminal run (transient error, incomplete upload, out-of-credits)
             // leaves no tombstone, so the next complete re-runs the real work (issue #1183).
-            _completes.TryRemove(uploadId, out _);
+            _completes.TryRemove(completeKey, out _);
             return outcome.ToResult();
         });
 
@@ -227,7 +298,11 @@ internal static class GatewayDictationEndpoint
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
-            var retired = uploads.Acknowledge(uploadId);
+            // Issue #1884: an ack RETIRES a record - it deletes state. Scoped to the caller's own partition,
+            // so acking an id another account owns finds nothing and reports retired=false, leaving that
+            // account's tombstone (and therefore its de-dupe guarantee) untouched.
+            if (ResolveTenant(ctx, tenantBoundary) is not { } tenant) return NoTenantResult();
+            var retired = uploads.ForTenant(tenant).Acknowledge(uploadId);
             FileLog.Write($"[GatewayDictation] ack uploadId={uploadId} retired={retired}");
             return Results.Json(new { ok = true, retired });
         });
@@ -238,21 +313,26 @@ internal static class GatewayDictationEndpoint
         // Idempotent and safe against a race with delivery: if the turn already DELIVERED we do NOT abandon
         // (it landed) and say so; otherwise the id becomes ABANDONED. The client that still holds the audio
         // reconciles on its next contact - a re-register / re-complete of an abandoned id returns dropped, so
-        // it drops its on-device copy with no resurrection and no duplicate. Abandon may target ANY surface's
-        // dictation because it addresses the durable upload id, not the caller.
+        // it drops its on-device copy with no resurrection and no duplicate. Abandon may target ANY SURFACE'S
+        // dictation - phone, cockpit, desktop - because it addresses the durable upload id rather than the
+        // device that recorded it. Issue #1884 draws the line that "any surface" always meant: any surface OF
+        // THE SAME ACCOUNT. It is scoped to the caller's own partition, so it can no longer discard another
+        // account's staged audio or resolve its pending record.
         app.MapPost("/dictation/{uploadId}/abandon", (string uploadId, HttpContext ctx) =>
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
+            if (ResolveTenant(ctx, tenantBoundary) is not { } tenant) return NoTenantResult();
+            var store = uploads.ForTenant(tenant);
 
-            var existing = uploads.ReadRecord(uploadId);
+            var existing = store.ReadRecord(uploadId);
             if (existing is { State: DictationDeliveryState.Delivered })
             {
                 FileLog.Write($"[GatewayDictation] abandon uploadId={uploadId}: already DELIVERED, not abandoning");
                 return Results.Json(new { ok = true, upload_id = uploadId, abandoned = false, already_delivered = true });
             }
 
-            uploads.MarkAbandoned(uploadId, "user_abandoned");
+            store.MarkAbandoned(uploadId, "user_abandoned");
             // Clear the in-memory transcribing marks so the roster un-oranges at once (the durable PENDING
             // marker - the "Uploading from phone" source - is already gone via MarkAbandoned).
             var sid = existing?.SessionId;
@@ -407,6 +487,12 @@ internal static class GatewayDictationEndpoint
 
             // Gateway Cleanup mission, Phase 2: resolve the owner push-store-first (no HTTP fan-out) and gate
             // on an exited session, exactly as the old LocateAsync did, then reach it through the tunnel.
+            //
+            // DELIBERATELY STILL TenantId.Local (issue #1884). Scoping this locate to the request's tenant is
+            // what would make dictation work on the hosted Gateway, and that is held pending a separate
+            // ruling - so it stays local and a hosted session is not found, exactly as today. This pull
+            // request makes the STATE safe so that re-enabling the route later is not the thing that arms a
+            // leak; it does not re-enable the route.
             var (director, session) = await GatewayEndpoints.LocateSessionAsync(
                 registry, sid, pushedSessions, streamStale, TenantId.Local, owners);
             if (director is null || session is null)

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -102,24 +102,53 @@ internal static class GatewayDictationEndpoint
 
     /// <summary>
     /// Resolve the request's tenant from the AUTHENTICATED device key the auth layer stashed - the same seam
-    /// the prompt log and the cockpit read path use. Null means DENY: on hosted, an authenticated request
-    /// whose key has no bound tenant is refused, never served the local partition. Self-host, or no boundary
-    /// (older callers and tests), is always Local.
+    /// the prompt log and the cockpit read path use. Null means DENY.
+    ///
+    /// GATED ON <see cref="GatewayHostedMode.IsHosted"/> ITSELF, never on whether a boundary was passed in.
+    /// Deciding on the argument fails OPEN, and this is the fail-open that matters most on this endpoint: the
+    /// boundary is a SECURITY argument, so a hosted call site, test, or future rewire that does not supply one
+    /// would be answered <see cref="TenantId.Local"/>, and every leg below would then operate on the shared
+    /// self-host root - reopening transcript reads, chunk overwrite, ack, abandon, and completion-cache
+    /// joining, silently, with nothing failing loud to say so. An optional security argument is
+    /// indistinguishable from a resolved one at the call site, which is exactly why that mistake survives.
+    ///
+    /// So on hosted this NEVER substitutes a tenant. A missing boundary, a boundary that is not hosted-wired
+    /// (its ambient context is the single-tenant one, so it can only ever answer Local), and a key with no
+    /// bound tenant all resolve to null, and null is a REFUSAL - never Local, never SYSTEM. Off hosted mode
+    /// the answer is Local exactly as it has always been, so self-host behaviour is byte-identical.
+    ///
+    /// The second defence is that <see cref="Map"/> takes the boundary as a REQUIRED argument, so omitting it
+    /// is a compile error rather than a runtime downgrade. Belt and braces is deliberate: this makes the
+    /// runtime safe, the required argument makes the mistake unrepresentable.
     /// </summary>
     private static TenantId? ResolveTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
-        => boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+    {
+        if (!GatewayHostedMode.IsHosted)
+            return boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+        if (boundary is null || !boundary.IsHosted)
+            return null;
+        return boundary.ResolveRequestTenant(ctx);
+    }
 
     private static IResult NoTenantResult()
         => Results.Json(new { error = "no tenant is bound to this request" },
             statusCode: StatusCodes.Status403Forbidden);
 
+    /// <param name="tenantBoundary">
+    /// The hosted tenant boundary - the ONE seam that turns this request's AUTHENTICATED device key into the
+    /// tenant whose partition these five legs work in. REQUIRED, deliberately: it used to be an optional
+    /// nullable argument, which made forgetting it a one-word mistake that silently sent every leg to the
+    /// shared self-host root. It is non-optional so that omission is a COMPILE error, and
+    /// <see cref="ResolveTenant"/> refuses at runtime on hosted regardless, so a caller that forces a null
+    /// through still cannot be served another account's audio.
+    /// </param>
     public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry,
         SessionOwnerCache? owners, string token, GatewayTranscriptionService transcription,
         TranscribingSessions transcribingSessions, VoiceUploadStore uploads, Pairing.DeviceRegistry devices,
+        Tenancy.HostedTenantBoundary tenantBoundary,
         Streaming.PushedSessionStore? pushedSessions = null,
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = null,
-        TimeSpan? streamStale = null,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null)
+        TimeSpan? streamStale = null)
     {
         // Gateway Cleanup mission, Phase 2 (PR E-B): resolve the owning Director push-store-first and inject
         // the dictation through the tunnel-first SessionVerbClient (the delivery marker rides the PromptRequest

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -74,14 +74,42 @@ internal static class GatewayDictationEndpoint
     // that no on-disk partition can guard. The store partition and this key are two separate defences and
     // both are needed: the same upload id is now perfectly legal in two tenants at once.
     private sealed record CompleteEntry(Lazy<Task<DictationOutcome>> Task);
-    private static readonly ConcurrentDictionary<string, CompleteEntry> _completes = new();
+    private static readonly TenantKeyedCache<CompleteEntry> _completes = new();
 
     // (tenant, uploadId) -> sessionId, captured at register so the chunk handler (which only has the
     // uploadId) can refresh the session's orange "Transcribing..." heartbeat as chunks stream in (issue
     // #1126). Pruned when the upload reaches a terminal completion; a leaked entry for a never-completed
     // upload is a single guid-pair and is bounded by real abandoned-upload volume. Tenant-keyed for the same
     // reason as _completes: it is static, and a session id is not one account's to hand to another.
-    private static readonly ConcurrentDictionary<string, string> _uploadSids = new();
+    private static readonly TenantKeyedCache<string> _uploadSids = new();
+
+    /// <summary>
+    /// A process-wide cache whose key CANNOT be composed without a tenant.
+    ///
+    /// Same reasoning as <see cref="DictationTenantGate"/>, applied to the in-memory half. These two caches
+    /// are static, so a key that omits the tenant hands one account's in-flight completion - and its
+    /// transcript - to another through a path no on-disk partition can guard. When they were raw
+    /// dictionaries keyed by a string the caller built, every use site was another chance to build that
+    /// string without the tenant. Here the tenant is a required PARAMETER of every operation and the key is
+    /// composed inside, so an un-tenanted key is not something a call site can express - including the call
+    /// site somebody adds next month.
+    /// </summary>
+    private sealed class TenantKeyedCache<T>
+    {
+        private readonly ConcurrentDictionary<string, T> _map = new();
+
+        internal T GetOrAdd(TenantId tenant, string uploadId, Func<string, T> create)
+            => _map.GetOrAdd(CacheKey(tenant, uploadId), create);
+
+        internal bool TryGet(TenantId tenant, string uploadId, out T value)
+            => _map.TryGetValue(CacheKey(tenant, uploadId), out value!);
+
+        internal void Set(TenantId tenant, string uploadId, T value)
+            => _map[CacheKey(tenant, uploadId)] = value;
+
+        internal void Remove(TenantId tenant, string uploadId)
+            => _map.TryRemove(CacheKey(tenant, uploadId), out _);
+    }
 
     /// <summary>
     /// The key both static caches use: the owning tenant AND the canonical staging spelling of the upload id.
@@ -121,7 +149,7 @@ internal static class GatewayDictationEndpoint
     /// is a compile error rather than a runtime downgrade. Belt and braces is deliberate: this makes the
     /// runtime safe, the required argument makes the mistake unrepresentable.
     /// </summary>
-    private static TenantId? ResolveTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
+    internal static TenantId? ResolveTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
     {
         if (!GatewayHostedMode.IsHosted)
             return boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
@@ -130,22 +158,19 @@ internal static class GatewayDictationEndpoint
         return boundary.ResolveRequestTenant(ctx);
     }
 
-    private static IResult NoTenantResult()
+    internal static IResult NoTenantResult()
         => Results.Json(new { error = "no tenant is bound to this request" },
             statusCode: StatusCodes.Status403Forbidden);
 
-    /// <param name="tenantBoundary">
-    /// The hosted tenant boundary - the ONE seam that turns this request's AUTHENTICATED device key into the
-    /// tenant whose partition these five legs work in. REQUIRED, deliberately: it used to be an optional
-    /// nullable argument, which made forgetting it a one-word mistake that silently sent every leg to the
-    /// shared self-host root. It is non-optional so that omission is a COMPILE error, and
-    /// <see cref="ResolveTenant"/> refuses at runtime on hosted regardless, so a caller that forces a null
-    /// through still cannot be served another account's audio.
+    /// <param name="gate">
+    /// The ONLY way any leg below can obtain an upload store, and the reason a leg can no longer be written
+    /// unscoped. See <see cref="DictationTenantGate"/>: this method deliberately does NOT take a
+    /// <see cref="VoiceUploadStore"/>, so there is no unscoped store in scope anywhere in this file to
+    /// accidentally use.
     /// </param>
     public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry,
         SessionOwnerCache? owners, string token, GatewayTranscriptionService transcription,
-        TranscribingSessions transcribingSessions, VoiceUploadStore uploads, Pairing.DeviceRegistry devices,
-        Tenancy.HostedTenantBoundary tenantBoundary,
+        TranscribingSessions transcribingSessions, DictationTenantGate gate, Pairing.DeviceRegistry devices,
         Streaming.PushedSessionStore? pushedSessions = null,
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = null,
         TimeSpan? streamStale = null)
@@ -160,8 +185,7 @@ internal static class GatewayDictationEndpoint
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
             // Authorize the UPLOAD, not just the device (issue #1884): everything below runs inside this
             // request's own tenant partition, so an upload id from another account is simply not present.
-            if (ResolveTenant(ctx, tenantBoundary) is not { } tenant) return NoTenantResult();
-            var store = uploads.ForTenant(tenant);
+            if (!gate.TryOpen(ctx, out var store, out var tenant, out var deny)) return deny;
             var sid = body?.SessionId ?? "";
             if (!Guid.TryParse(sid, out _))
                 return Results.Json(new { error = "sessionId (guid) is required" }, statusCode: StatusCodes.Status400BadRequest);
@@ -189,7 +213,7 @@ internal static class GatewayDictationEndpoint
                 FileLog.Write($"[GatewayDictation] upload re-register clears FAILED uploadId={key}, retrying");
             var uploadId = store.Register(string.IsNullOrWhiteSpace(key) ? null : key);
             store.MarkPending(uploadId, sid);
-            _uploadSids[CacheKey(tenant, uploadId)] = sid;
+            _uploadSids.Set(tenant, uploadId, sid);
             try { transcribingSessions.Begin(sid); } catch { /* the orange mark is a nicety */ }
             FileLog.Write($"[GatewayDictation] upload registered sid={sid} uploadId={uploadId}");
             return Results.Json(new { upload_id = uploadId });
@@ -202,8 +226,7 @@ internal static class GatewayDictationEndpoint
             // Issue #1884: an upload id that belongs to another account does not exist in this partition, so
             // the existing unknown-id guard becomes the authorization - the caller cannot overwrite, extend,
             // or even confirm the existence of another account's staged audio.
-            if (ResolveTenant(ctx, tenantBoundary) is not { } tenant) return NoTenantResult();
-            var store = uploads.ForTenant(tenant);
+            if (!gate.TryOpen(ctx, out var store, out var tenant, out var deny)) return deny;
             if (!store.Exists(uploadId))
                 return Results.Json(new { error = "unknown upload id (register it first)" }, statusCode: StatusCodes.Status404NotFound);
 
@@ -215,7 +238,7 @@ internal static class GatewayDictationEndpoint
                 await store.StoreChunkAsync(uploadId, index, ms.ToArray(), string.IsNullOrEmpty(sha) ? null : sha, ctx.RequestAborted);
                 // Heartbeat: a stored chunk is progress, so keep the orange mark alive past its idle
                 // backstop for a slow upload that streams over more than the idle window (issue #1126).
-                if (_uploadSids.TryGetValue(CacheKey(tenant, uploadId), out var chunkSid))
+                if (_uploadSids.TryGet(tenant, uploadId, out var chunkSid))
                     transcribingSessions.Refresh(chunkSid);
                 return Results.Json(new { ok = true, index });
             }
@@ -233,8 +256,7 @@ internal static class GatewayDictationEndpoint
             // Issue #1884: resolve and authorize the tenant BEFORE anything touches the store or the static
             // single-flight cache, so a caller who does not own this upload id can neither read its record
             // nor join its in-flight completion run.
-            if (ResolveTenant(ctx, tenantBoundary) is not { } tenant) return NoTenantResult();
-            var store = uploads.ForTenant(tenant);
+            if (!gate.TryOpen(ctx, out var store, out var tenant, out var deny)) return deny;
             if (req is null || req.TotalChunks <= 0 || !Guid.TryParse(req.SessionId ?? "", out _))
                 return Results.Json(new { error = "sessionId (guid) and totalChunks (>0) are required" },
                     statusCode: StatusCodes.Status400BadRequest);
@@ -259,7 +281,7 @@ internal static class GatewayDictationEndpoint
             if (settled is { State: DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned })
             {
                 EndTranscribing(transcribingSessions, req.SessionId!);
-                _uploadSids.TryRemove(CacheKey(tenant, uploadId), out _);
+                _uploadSids.Remove(tenant, uploadId);
                 FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: cached terminal outcome " +
                     $"state={settled.State} (no re-injection)");
                 return TerminalOutcome(settled).ToResult();
@@ -277,8 +299,7 @@ internal static class GatewayDictationEndpoint
             // still-PENDING id is assembled + transcribed + injected at most once even under a concurrent
             // race. The entry is dropped once the run settles (below); the durable tombstone owns de-dupe
             // from then on, so there is no age-swept cache window.
-            var completeKey = CacheKey(tenant, uploadId);
-            var entry = _completes.GetOrAdd(completeKey, _ =>
+            var entry = _completes.GetOrAdd(tenant, uploadId, completeKey =>
             {
                 OnCompleteEntryCreatedForTests?.Invoke(completeKey);
                 return new CompleteEntry(new Lazy<Task<DictationOutcome>>(() => RunCompleteCoreAsync(
@@ -293,7 +314,7 @@ internal static class GatewayDictationEndpoint
             }
             catch (Exception ex)
             {
-                _completes.TryRemove(completeKey, out _); // transient: let a retry re-run
+                _completes.Remove(tenant, uploadId); // transient: let a retry re-run
                 return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status502BadGateway);
             }
 
@@ -307,13 +328,13 @@ internal static class GatewayDictationEndpoint
             if (!outcome.IsIncomplete)
             {
                 EndTranscribing(transcribingSessions, req.SessionId!);
-                _uploadSids.TryRemove(completeKey, out _);
+                _uploadSids.Remove(tenant, uploadId);
             }
             // Drop the in-memory single-flight entry once the run settles. A terminal run has already
             // written the durable tombstone (inside the core), so a later retry short-circuits on the
             // ReadRecord check above; a non-terminal run (transient error, incomplete upload, out-of-credits)
             // leaves no tombstone, so the next complete re-runs the real work (issue #1183).
-            _completes.TryRemove(completeKey, out _);
+            _completes.Remove(tenant, uploadId);
             return outcome.ToResult();
         });
 
@@ -330,8 +351,8 @@ internal static class GatewayDictationEndpoint
             // Issue #1884: an ack RETIRES a record - it deletes state. Scoped to the caller's own partition,
             // so acking an id another account owns finds nothing and reports retired=false, leaving that
             // account's tombstone (and therefore its de-dupe guarantee) untouched.
-            if (ResolveTenant(ctx, tenantBoundary) is not { } tenant) return NoTenantResult();
-            var retired = uploads.ForTenant(tenant).Acknowledge(uploadId);
+            if (!gate.TryOpen(ctx, out var store, out _, out var deny)) return deny;
+            var retired = store.Acknowledge(uploadId);
             FileLog.Write($"[GatewayDictation] ack uploadId={uploadId} retired={retired}");
             return Results.Json(new { ok = true, retired });
         });
@@ -351,8 +372,7 @@ internal static class GatewayDictationEndpoint
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
-            if (ResolveTenant(ctx, tenantBoundary) is not { } tenant) return NoTenantResult();
-            var store = uploads.ForTenant(tenant);
+            if (!gate.TryOpen(ctx, out var store, out _, out var deny)) return deny;
 
             var existing = store.ReadRecord(uploadId);
             if (existing is { State: DictationDeliveryState.Delivered })
@@ -401,7 +421,7 @@ internal static class GatewayDictationEndpoint
     // The retryable arm used to return silently, which is why the log could say WHEN it wedged but never
     // WHY. It logs now.
     internal static DictationOutcome? MapNonOkTranscription(
-        GatewayTranscriptionResult result, string uploadId, VoiceUploadStore uploads)
+        GatewayTranscriptionResult result, string uploadId, VoiceUploadStore store)
     {
         if (result.Outcome == TranscriptionOutcome.Ok) return null;
         if (result.Outcome == TranscriptionOutcome.OutOfCredits)
@@ -410,7 +430,7 @@ internal static class GatewayDictationEndpoint
             // to transcribe it with; the client still gets 402, and adding credit + retrying re-enters
             // PENDING and delivers. NOTE: never once observed to fire - zero OutOfCredits in any log on this
             // machine, ever, across 846 terminal outcomes. The mechanism is real; the cause is not this.
-            uploads.MarkFailed(uploadId, "out_of_credits");
+            store.MarkFailed(uploadId, "out_of_credits");
             FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: out of credits " +
                 $"code={result.Code}; parked FAILED (chunks retained, retryable)");
             return DictationOutcome.OutOfCredits(HostedAiErrorMapper.MapCode(result.Code));
@@ -421,14 +441,14 @@ internal static class GatewayDictationEndpoint
         // explicit user retry can re-complete) and return the client's stop contract.
         if (result.Outcome == TranscriptionOutcome.PermanentError)
         {
-            uploads.MarkFailed(uploadId, result.Code ?? "");
+            store.MarkFailed(uploadId, result.Code ?? "");
             FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: permanent failure " +
                 $"code={result.Code}; parked FAILED");
             return DictationOutcome.Permanent(TranslatePermanentReason(result.Code));
         }
         // The retryable arm - THE ONE THAT ACTUALLY WEDGED (see f13cb4b6d9d0 above). Still a 502 the client
         // re-drives; now it parks the record so the colour tells the truth between attempts.
-        uploads.MarkFailed(uploadId, result.Code ?? "transcription_error");
+        store.MarkFailed(uploadId, result.Code ?? "transcription_error");
         FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: retryable transcription failure " +
             $"code={result.Code} error={result.Error}; parked FAILED (chunks retained, retryable)");
         return DictationOutcome.Error(StatusCodes.Status502BadGateway, result.Error ?? "transcription failed");
@@ -461,7 +481,7 @@ internal static class GatewayDictationEndpoint
             : Results.Json(new { upload_id = uploadId, terminal = true, submitted = record.Submitted, movedOn = record.MovedOn, dropped = false, transcript = record.Transcript });
 
     private static async Task<DictationOutcome> RunCompleteCoreAsync(
-        string uploadId, DictationCompleteRequest req, VoiceUploadStore uploads, DirectorRegistry registry,
+        string uploadId, DictationCompleteRequest req, VoiceUploadStore store, DirectorRegistry registry,
         SessionOwnerCache? owners, GatewayTranscriptionService transcription,
         TranscribingSessions transcribingSessions, string? deliverySurface,
         Streaming.PushedSessionStore? pushedSessions, DirectorCommandRouter.SendDirectorCommandAsync? sendCommand,
@@ -480,7 +500,7 @@ internal static class GatewayDictationEndpoint
                 return DictationOutcome.Error(StatusCodes.Status503ServiceUnavailable,
                     $"no key configured for transcription mode {routing.Mode}");
 
-            var assembled = await uploads.AssembleAsync(uploadId, req.TotalChunks);
+            var assembled = await store.AssembleAsync(uploadId, req.TotalChunks);
             if (assembled.Status == "unknown_upload")
                 return DictationOutcome.Error(StatusCodes.Status404NotFound, "unknown upload id");
             if (assembled.Status == "incomplete")
@@ -488,13 +508,13 @@ internal static class GatewayDictationEndpoint
             var audio = assembled.Audio;
             if (audio is null || audio.Length == 0)
             {
-                uploads.Delete(uploadId);
+                store.Delete(uploadId);
                 return DictationOutcome.Error(StatusCodes.Status502BadGateway, "assembled recording was empty");
             }
 
             var result = await transcription.TranscribeAsync(
                 audio, "audio." + (req.Ext ?? "wav"), req.Mime ?? "audio/wav", applyCorrection: true, CancellationToken.None);
-            if (MapNonOkTranscription(result, uploadId, uploads) is { } nonOk)
+            if (MapNonOkTranscription(result, uploadId, store) is { } nonOk)
                 return nonOk;
 
             var transcript = (result.Text ?? "").Trim();
@@ -510,7 +530,7 @@ internal static class GatewayDictationEndpoint
                 // Silent/empty clip with no typed text: nothing to submit, but the turn is genuinely done -
                 // record it as a durable DELIVERED tombstone so a re-complete returns the same no-op outcome
                 // instead of re-running (issue #1183). Discards the retained chunks, keeps the marker.
-                uploads.MarkDelivered(uploadId, submitted: false, movedOn: false, transcript);
+                store.MarkDelivered(uploadId, submitted: false, movedOn: false, transcript);
                 return DictationOutcome.Submitted(false, false, transcript);
             }
 
@@ -542,14 +562,14 @@ internal static class GatewayDictationEndpoint
             // larger of the two costs nothing when no attempt failed (the stored value is absent) and is what
             // stops the observed drop when one did.
             var effectiveBaseline = Math.Max(
-                req.BaselineBufferBytes, uploads.ReadRecord(uploadId)?.RebaselineBufferBytes ?? 0);
+                req.BaselineBufferBytes, store.ReadRecord(uploadId)?.RebaselineBufferBytes ?? 0);
             if (req.Resumed && session is not null && req.BaselineBufferBytes > 0 &&
                 session.TotalBufferBytes > effectiveBaseline + MovedOnBufferGrowthBytes)
             {
                 // The turn is resolved (deliberately dropped as stale): a durable DELIVERED tombstone with
                 // movedOn set, so a re-complete returns the same moved-on outcome and never injects the stale
                 // clip (issue #1183). Discards the retained chunks, keeps the marker.
-                uploads.MarkDelivered(uploadId, submitted: false, movedOn: true, transcript);
+                store.MarkDelivered(uploadId, submitted: false, movedOn: true, transcript);
                 FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: session moved on " +
                     $"(buffer {req.BaselineBufferBytes}/effective {effectiveBaseline}->{session.TotalBufferBytes}); dropped");
                 return DictationOutcome.Submitted(false, true, transcript);
@@ -591,7 +611,7 @@ internal static class GatewayDictationEndpoint
                 var (_, freshSession) = await GatewayEndpoints.LocateSessionAsync(
                     registry, sid, pushedSessions, streamStale, TenantId.Local, owners);
                 if (freshSession is not null)
-                    uploads.RecordFailedDeliveryBaseline(uploadId, freshSession.TotalBufferBytes);
+                    store.RecordFailedDeliveryBaseline(uploadId, freshSession.TotalBufferBytes);
                 FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: submit FAILED ({err}); " +
                     $"re-baselined to {freshSession?.TotalBufferBytes.ToString() ?? "unavailable"} " +
                     $"(was {req.BaselineBufferBytes}) so the retry is not dropped as stale");
@@ -604,7 +624,7 @@ internal static class GatewayDictationEndpoint
             // milliseconds between PostPromptAsync returning and this marker landing on disk would let a
             // later re-complete inject the turn a second time. We minimize and document it rather than paper
             // over it with a fallback. MarkDelivered discards the retained chunks and keeps the marker.
-            uploads.MarkDelivered(uploadId, submitted: true, movedOn: false, transcript);
+            store.MarkDelivered(uploadId, submitted: true, movedOn: false, transcript);
             FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: submitted chars={message.Length}");
             return DictationOutcome.Submitted(true, false, transcript);
         }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1846,7 +1846,8 @@ public sealed class GatewayHost : IAsyncDisposable
         GatewayDictationEndpoint.Map(_app, Registry, SessionOwners, Token,
             _dictationTranscription ?? new Transcription.GatewayTranscriptionService(_keyVault, telemetry: _transcriptionTelemetry, audioArchive: _transcriptionAudioArchive), _transcribingSessions, _dictationUploads, Devices,
             pushedSessions: PushedSessions,
-            sendCommand: SendCommandAsync);
+            sendCommand: SendCommandAsync,
+            tenantBoundary: _tenantBoundary);
         // Durable per-upload-id dictation record (issue #1183): a PENDING upload's chunks are retained
         // until it becomes DELIVERED or ABANDONED, and the delivered/abandoned tombstone (the durable
         // de-dupe marker) is retained until the client acknowledges it - so an undelivered dictation

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1844,10 +1844,9 @@ public sealed class GatewayHost : IAsyncDisposable
         // in resumable chunks and the Gateway assembles → transcribes → injects the turn into the
         // owning session itself, so a refresh / dropped connection cannot lose a recorded utterance.
         GatewayDictationEndpoint.Map(_app, Registry, SessionOwners, Token,
-            _dictationTranscription ?? new Transcription.GatewayTranscriptionService(_keyVault, telemetry: _transcriptionTelemetry, audioArchive: _transcriptionAudioArchive), _transcribingSessions, _dictationUploads, Devices,
+            _dictationTranscription ?? new Transcription.GatewayTranscriptionService(_keyVault, telemetry: _transcriptionTelemetry, audioArchive: _transcriptionAudioArchive), _transcribingSessions, _dictationUploads, Devices, _tenantBoundary,
             pushedSessions: PushedSessions,
-            sendCommand: SendCommandAsync,
-            tenantBoundary: _tenantBoundary);
+            sendCommand: SendCommandAsync);
         // Durable per-upload-id dictation record (issue #1183): a PENDING upload's chunks are retained
         // until it becomes DELIVERED or ABANDONED, and the delivered/abandoned tombstone (the durable
         // de-dupe marker) is retained until the client acknowledges it - so an undelivered dictation

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1844,7 +1844,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // in resumable chunks and the Gateway assembles → transcribes → injects the turn into the
         // owning session itself, so a refresh / dropped connection cannot lose a recorded utterance.
         GatewayDictationEndpoint.Map(_app, Registry, SessionOwners, Token,
-            _dictationTranscription ?? new Transcription.GatewayTranscriptionService(_keyVault, telemetry: _transcriptionTelemetry, audioArchive: _transcriptionAudioArchive), _transcribingSessions, _dictationUploads, Devices, _tenantBoundary,
+            _dictationTranscription ?? new Transcription.GatewayTranscriptionService(_keyVault, telemetry: _transcriptionTelemetry, audioArchive: _transcriptionAudioArchive), _transcribingSessions, new Api.DictationTenantGate(_dictationUploads, _tenantBoundary), Devices,
             pushedSessions: PushedSessions,
             sendCommand: SendCommandAsync);
         // Durable per-upload-id dictation record (issue #1183): a PENDING upload's chunks are retained

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -137,6 +137,19 @@ public sealed class VoiceUploadStore
         // Belt and braces, because the cost of being wrong here is one account reading another's dictation:
         // the result must actually LIE INSIDE the partition container. The rule above already excludes
         // traversal, so this can only fire if that rule is ever loosened - which is exactly when it is wanted.
+        //
+        // THIS GUARD HAS NO CANARY, DELIBERATELY, AND THAT IS NOT A COVERAGE GAP TO FILL. Measured, not
+        // assumed: deleting these three lines and running the tenant-partition and dictation suites reddens
+        // NOTHING. It cannot redden, because IsMintedAccountTenant above already refuses every value that
+        // could escape the root - ".." and "../.." and "a/b" and any non-GUID - so no input this method can
+        // legally receive reaches here with a combined path outside the container. It is unreachable by
+        // construction, which is the whole reason it is belt and braces rather than the primary defence.
+        //
+        // So do NOT write a test for it: the only test that could exist here is one that cannot fail, and a
+        // test that cannot fail is worse than no test - it reads as coverage. The condition under which this
+        // guard becomes reachable, and therefore the condition under which it becomes testable and MUST be
+        // given a canary, is precisely the moment someone loosens IsMintedAccountTenant. If you are here
+        // because you just did that, this guard is now live and needs a test that fails when you remove it.
         var expectedRoot =
             Path.GetFullPath(Path.Combine(_partitionBase, TenantPartitionDirectoryName)) + Path.DirectorySeparatorChar;
         if (!Path.GetFullPath(combined).StartsWith(expectedRoot, StringComparison.OrdinalIgnoreCase))
@@ -455,6 +468,18 @@ public sealed class VoiceUploadStore
         }
         foreach (var dir in dirs)
         {
+            // The partition container is not an upload, so skip it rather than probing it for a record.
+            //
+            // NO CANARY HERE EITHER, and for a different reason than the containment guard in
+            // PartitionRootFor - this one is REDUNDANT rather than unreachable. Measured: removing this line
+            // reddens nothing. It cannot, because the container directory holds other tenants' partitions and
+            // no record.json of its own, so ReadRecordFile returns null and the pattern match already declines
+            // it; and even if a record were somehow found there, BelongsHere on the same line refuses a record
+            // belonging to another tenant. Two independent things downstream already give the right answer.
+            //
+            // It stays because it says what is true - a partition container is not an upload - and because it
+            // stops a pointless file probe per partition on every projection. It is clarity and cost, not a
+            // security boundary; the security boundary on this line is BelongsHere, and THAT one has canaries.
             if (IsPartitionContainer(dir)) continue;
             if (ReadRecordFile(RecordPath(dir)) is { State: DictationDeliveryState.Pending } rec && BelongsHere(rec))
                 yield return rec;

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Gateway.Voice;
@@ -32,19 +33,133 @@ namespace CcDirector.Gateway.Voice;
 /// keeps the outcome marker, so a delivered upload id is de-duplicated forever - across time and a
 /// Gateway restart - until the client acknowledges it (<see cref="Acknowledge"/>). See
 /// <see cref="DictationDeliveryRecord"/> for the model.
+///
+/// PARTITIONED BY TENANT (issue #1884). Every directory, chunk and record used to be keyed SOLELY by the
+/// caller-supplied upload id, on one global root. A GUID is not a tenant boundary: secrecy of an identifier
+/// is not authorization, and upload ids travel in client logs, retries and store-and-forward queues - so on
+/// the hosted Gateway one account holding another's upload id could read its transcript, overwrite its
+/// chunks, or resolve its record. An upload id is now only meaningful INSIDE its own tenant: the partition is
+/// the DIRECTORY (<see cref="ForTenant"/>), so a read physically cannot open another tenant's staging, and
+/// the record itself carries its tenant as a second, independent check. <see cref="TenantId.Local"/> keeps
+/// today's path exactly - self-host is unchanged and nothing migrates - and a hosted account tenant lands
+/// under tenants/&lt;id&gt;/. The tenant is always supplied by the caller, which resolved it from the
+/// authenticated device key at the boundary; this type never guesses one.
 /// </summary>
 public sealed class VoiceUploadStore
 {
+    /// <summary>The container directory hosting the non-local partitions, directly under the base root.</summary>
+    public const string TenantPartitionDirectoryName = "tenants";
+
+    // This partition's staging root: the base root for the local tenant, base/tenants/<id> otherwise.
     private readonly string _root;
+    // The base root every partition is computed from, so ForTenant on an already-partitioned store still
+    // resolves against the base rather than nesting a partition inside a partition.
+    private readonly string _partitionBase;
+    // The tenant this instance is bound to. Stamped onto every record written and required to match on
+    // every record read.
+    private readonly TenantId _tenant;
 
     public VoiceUploadStore() : this(CcStorage.VoiceTurnUploads()) { }
 
     /// <summary>Test seam: stage under an explicit root instead of the shared storage dir.</summary>
-    public VoiceUploadStore(string root)
+    public VoiceUploadStore(string root) : this(root, TenantId.Local, root) { }
+
+    private VoiceUploadStore(string root, TenantId tenant, string partitionBase)
     {
         _root = root;
+        _tenant = tenant;
+        _partitionBase = partitionBase;
         Directory.CreateDirectory(_root);
     }
+
+    /// <summary>The tenant this store instance is bound to.</summary>
+    public TenantId Tenant => _tenant;
+
+    /// <summary>This partition's staging root on disk.</summary>
+    public string Root => _root;
+
+    /// <summary>
+    /// A view of this staging bound to ONE tenant. Every path, gate, chunk and record of the returned store
+    /// lives inside that tenant's partition, so an upload id from another tenant simply does not exist here -
+    /// the isolation is the directory, not a predicate a later edit could forget to apply.
+    /// </summary>
+    public VoiceUploadStore ForTenant(TenantId tenant)
+    {
+        if (!tenant.IsValid)
+            throw new ArgumentException(
+                "An upload partition needs a valid tenant; an unresolved tenant is denied, never defaulted.",
+                nameof(tenant));
+        return tenant.IsLocal && string.Equals(_root, _partitionBase, StringComparison.Ordinal) && _tenant.IsLocal
+            ? this
+            : new VoiceUploadStore(PartitionRootFor(tenant), tenant, _partitionBase);
+    }
+
+    /// <summary>
+    /// True only for the EXACT form <see cref="Tenancy.TenantRegistry"/> mints: a canonical lowercase GUID.
+    ///
+    /// A tenant id becomes a DIRECTORY NAME here, so it must be a shape this system actually produces - not
+    /// merely "characters that look harmless". Both structural aliases already found on the prompt-log
+    /// partition (<c>GatewayPromptLog</c>) apply verbatim to this one:
+    ///
+    ///  - A character allow-list such as <c>^[A-Za-z0-9._-]{1,64}$</c> accepts <c>".."</c>, and combining the
+    ///    base root with <c>tenants</c> and <c>".."</c> canonicalizes to exactly the base root - the LOCAL
+    ///    partition.
+    ///  - An allow-list accepting <c>A-F</c> as well as <c>a-f</c> lets two ids that differ only in case name
+    ///    the SAME directory on Windows and Azure Files while being DIFFERENT identities to the
+    ///    case-sensitive tenants table. That is one tenant reading another's audio through a casing alias.
+    ///
+    /// So this accepts ONE spelling: parse strictly, then require the value to equal its own canonical
+    /// round-trip. Anything else is REFUSED rather than normalised - normalising is how two identities
+    /// quietly share a folder, and this folder holds recorded AUDIO and its TRANSCRIPT.
+    /// </summary>
+    private static bool IsMintedAccountTenant(string value)
+        => Guid.TryParseExact(value, "D", out var parsed)
+           && string.Equals(value, parsed.ToString("D"), StringComparison.Ordinal);
+
+    /// <summary>
+    /// The staging root one tenant's uploads live in. The local tenant keeps the root it has always used -
+    /// self-host unchanged, nothing migrates - and every other tenant gets its own folder beneath it.
+    /// </summary>
+    private string PartitionRootFor(TenantId tenant)
+    {
+        if (tenant.IsLocal) return _partitionBase;
+
+        // Every other partition must be a minted account tenant - including the reserved SYSTEM tenant, which
+        // is deliberately REFUSED rather than given a folder: no recorded audio belongs to it, so the safe
+        // answer is that it has no partition at all.
+        if (!IsMintedAccountTenant(tenant.Value))
+            throw new ArgumentException(
+                $"Tenant '{tenant.ToLogString()}' is not a minted account tenant and cannot name an upload partition.",
+                nameof(tenant));
+
+        var combined = Path.Combine(_partitionBase, TenantPartitionDirectoryName, tenant.Value);
+
+        // Belt and braces, because the cost of being wrong here is one account reading another's dictation:
+        // the result must actually LIE INSIDE the partition container. The rule above already excludes
+        // traversal, so this can only fire if that rule is ever loosened - which is exactly when it is wanted.
+        var expectedRoot =
+            Path.GetFullPath(Path.Combine(_partitionBase, TenantPartitionDirectoryName)) + Path.DirectorySeparatorChar;
+        if (!Path.GetFullPath(combined).StartsWith(expectedRoot, StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException(
+                $"Tenant '{tenant.ToLogString()}' resolves outside the upload partition root.", nameof(tenant));
+
+        return combined;
+    }
+
+    /// <summary>
+    /// The SECOND, independent check on a record: does the record on disk claim this partition's tenant?
+    /// The directory already makes a cross-tenant read impossible, so this can only fire if a partition root
+    /// is ever mis-computed - which is precisely the failure that must not silently hand over a transcript.
+    ///
+    /// An ABSENT tenant on the record is accepted ONLY for the local partition. That is not a fallback: it is
+    /// the exact reading of records written before this field existed, all of which are self-host records in
+    /// the local partition. In an account partition an absent tenant is refused, so a missing value can never
+    /// become a way in.
+    /// </summary>
+    private bool BelongsHere(DictationDeliveryRecord record)
+        => string.IsNullOrEmpty(record.Tenant)
+            ? _tenant.IsLocal
+            : string.Equals(record.Tenant, _tenant.Value, StringComparison.Ordinal);
 
     /// <summary>
     /// Begin (or re-open) an upload. The caller supplies a GUID id (it is also the
@@ -189,6 +304,10 @@ public sealed class VoiceUploadStore
         {
             foreach (var dir in Directory.EnumerateDirectories(_root))
             {
+                // The partition container is not an upload; sweeping it by age would delete every other
+                // tenant's staging in one go (issue #1884). An upload directory is a 32-hex id, so this
+                // name can only ever be the container.
+                if (IsPartitionContainer(dir)) continue;
                 try
                 {
                     if (Directory.GetLastWriteTimeUtc(dir) < cutoff)
@@ -242,7 +361,19 @@ public sealed class VoiceUploadStore
     public DictationDeliveryRecord? ReadRecord(string uploadId)
     {
         var uid = NormalizeId(uploadId);
-        return uid is null ? null : ReadRecordFile(RecordPath(DirFor(uid)));
+        if (uid is null) return null;
+        var record = ReadRecordFile(RecordPath(DirFor(uid)));
+        if (record is null) return null;
+        // Tenant-checked as well as partitioned (issue #1884). See BelongsHere: the directory is the boundary,
+        // this is the independent second opinion, and a record that fails it is treated as absent rather than
+        // handed to a caller it does not belong to.
+        if (!BelongsHere(record))
+        {
+            FileLog.Write($"[VoiceUploadStore] ReadRecord: uploadId={uid} record belongs to another tenant " +
+                $"(partition={_tenant.ToLogString()}); refused");
+            return null;
+        }
+        return record;
     }
 
     private static DictationDeliveryRecord? ReadRecordFile(string path)
@@ -323,8 +454,11 @@ public sealed class VoiceUploadStore
             dirs = Array.Empty<string>();
         }
         foreach (var dir in dirs)
-            if (ReadRecordFile(RecordPath(dir)) is { State: DictationDeliveryState.Pending } rec)
+        {
+            if (IsPartitionContainer(dir)) continue;
+            if (ReadRecordFile(RecordPath(dir)) is { State: DictationDeliveryState.Pending } rec && BelongsHere(rec))
                 yield return rec;
+        }
     }
 
     /// <summary>
@@ -528,11 +662,15 @@ public sealed class VoiceUploadStore
     }
 
     // Persist the record.json marker atomically (temp + move), leaving any staged chunks untouched.
-    private static void WriteRecordMarker(string dir, DictationDeliveryRecord record)
+    //
+    // THE ONE PLACE a record is written, so it is the one place the owning tenant is stamped (issue #1884).
+    // Stamped here rather than by each composer on purpose: a composer that forgot would write an
+    // unattributed record, and the whole point of the field is that it cannot be forgotten.
+    private void WriteRecordMarker(string dir, DictationDeliveryRecord record)
     {
         var path = RecordPath(dir);
         var tmp = path + ".tmp";
-        File.WriteAllText(tmp, JsonSerializer.Serialize(record, RecordJson));
+        File.WriteAllText(tmp, JsonSerializer.Serialize(record with { Tenant = _tenant.Value }, RecordJson));
         File.Move(tmp, path, overwrite: true);
     }
 
@@ -625,6 +763,12 @@ public sealed class VoiceUploadStore
     private string GateKey(string uid) => Path.GetFullPath(DirFor(uid));
 
     private string DirFor(string uid) => Path.Combine(_root, uid);
+
+    // True for the directory that HOLDS the other tenants' partitions, which is never itself an upload.
+    private static bool IsPartitionContainer(string dir)
+        => string.Equals(Path.GetFileName(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)),
+            TenantPartitionDirectoryName, StringComparison.OrdinalIgnoreCase);
+
     private static string ChunkPath(string dir, int index) => Path.Combine(dir, $"{index:D5}.part");
     private static string RecordPath(string dir) => Path.Combine(dir, "record.json");
 
@@ -640,6 +784,13 @@ public sealed class VoiceUploadStore
         if (string.IsNullOrWhiteSpace(id)) return null;
         return Guid.TryParse(id, out var g) ? g.ToString("N") : null;
     }
+
+    /// <summary>
+    /// The canonical staging form of a caller-supplied upload id, or null when it is not a GUID. Exposed so
+    /// the endpoint's in-memory caches key on the SAME single spelling this store keys its directories by:
+    /// two spellings of one GUID must not become two cache entries for one staging directory.
+    /// </summary>
+    internal static string? NormalizeUploadId(string? id) => NormalizeId(id);
 
     private static string Sha256Hex(byte[] bytes)
         => Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
@@ -683,6 +834,14 @@ public enum DictationDeliveryState { Pending, Delivered, Abandoned, Failed }
 /// that never saw the 502 still retries against the honest baseline. Null (absent) in every record written
 /// before this field existed, which reads back as "no attempt has failed" - the correct meaning.
 /// </param>
+/// <param name="Tenant">
+/// The tenant that owns this upload (issue #1884). Stamped by <see cref="VoiceUploadStore"/> on every write
+/// from the partition the record is written into - callers never supply it - and required to match on every
+/// read. The directory partition is the boundary; this field is the independent second check, so a
+/// mis-computed partition root cannot silently hand one account another's audio or transcript. Empty in
+/// records written before the field existed, which are self-host records and are accepted only in the local
+/// partition.
+/// </param>
 public sealed record DictationDeliveryRecord(
     DictationDeliveryState State,
     bool Submitted,
@@ -690,4 +849,5 @@ public sealed record DictationDeliveryRecord(
     string Transcript,
     string? Reason,
     string SessionId = "",
-    long? RebaselineBufferBytes = null);
+    long? RebaselineBufferBytes = null,
+    string Tenant = "");


### PR DESCRIPTION
Closes the store half of thefrederiksen/devthrottle_internal#889: tenant-key the dictation upload and transcript store so a caller cannot claim another account's upload id.

This does NOT re-enable dictation on hosted. That is thefrederiksen/devthrottle_internal#889 part (a) and is held: the session locate inside the completion deliberately still resolves in the local partition, so a hosted session is still not found and the route stays as dead as it is today. Partitioning first is the whole point - converting the route first would arm this store rather than close it.

## The defect

`VoiceUploadStore` had ONE GLOBAL ROOT and keyed every directory, chunk and record solely by the caller-supplied upload id. `DictationDeliveryRecord` carried no tenant. The upload, chunk, ack and abandon legs authenticated a DEVICE and never asked whose upload it was. The in-flight completion cache was static and keyed by upload id alone.

So after account A completed upload id X, account B posting `Idempotency-Key: X` read A's terminal record and was handed A's TRANSCRIPT; and before X reached a terminal state, B could overwrite A's chunks, ack or abandon A's record, or race its completion. A GUID is not a tenant boundary - secrecy of an identifier is not authorization, and upload ids travel in client logs, retries and store-and-forward queues.

## What changed

1. **The store is partitioned by tenant** - the on-disk root and the record. `ForTenant(tenant)` returns a store whose every path, gate, chunk and record lives inside that tenant's partition, so the isolation is the DIRECTORY, not a predicate a later edit could forget. The same upload id is now legally two different uploads in two accounts.
2. **The record carries its tenant**, stamped in the one place a record is written and required to match on every read - an independent second check behind the directory, so a mis-computed partition root cannot silently hand over a transcript.
3. **The static single-flight completion cache and the upload-to-session map are keyed by tenant and upload id.** Those are in-memory and no on-disk partition can guard them.
4. **All five legs - upload, chunk, complete, ack, abandon - resolve and authorize the tenant** from the authenticated device key, using the same seam the prompt log and the cockpit read path use. Deny-by-default: on hosted, an authenticated key with no bound tenant gets 403, never the local partition.
5. **An unscoped leg is no longer something a person can write.** `GatewayDictationEndpoint.Map` does not accept or capture a `VoiceUploadStore` at all - it takes a `DictationTenantGate`, which privately owns the only raw store and whose `TryOpen` cannot return an unscoped one, with the refusal folded into the same call so a caller who skips the check gets no store rather than an unchecked one. The two static caches got the same treatment: the tenant is a required parameter and the key is composed inside the cache type. The realistic defect was never an edit to one of these five legs - it was the sixth leg added later by someone who never read the reasoning around them.

The tenant id becomes a PATH COMPONENT here, so only the one canonical lowercase form the registry mints is accepted. A traversal spelling (`..` resolves to the parent partition) and an uppercase alias (same directory on Windows and Azure Files, different identity to the case-sensitive tenants table) are REFUSED rather than normalised, and the combined path is asserted to resolve inside the partition root. Worked example followed: `GatewayPromptLog`.

**Self-host is unchanged and is the control**: the local tenant keeps the exact root it has always used, nothing migrates, and no upload moves.

## Why this is being re-proved on current main

> thefrederiksen/devthrottle#1915 partitions voice state per tenant and this partitions dictation state per tenant - two partitions of the same storage root, landed independently, **never once executed in the same suite.**

That is the case for re-proving this change against current main rather than merging evidence gathered on an older base, and it is checkable by anyone in a minute.

Main has moved seven commits since the base the first full proof ran on, four of them merges touching adjacent surface: the stats deny (#1888), the voice partition (#1915), the entitlement gate (#1901), and pinned-root storage behaviour (#1891). They bring three brand-new Gateway test classes - `WingmanVoiceTenantPartitionTests`, `HostedStatsDenyTests`, `HostedEntitlementGateTests` - plus changes to six existing ones. A full-suite revert exists to answer "did this break something else"; asked against a suite that does not contain the code this change now sits beside, that question was unanswerable.

**Pre-registered suspect, written down before the run rather than assembled after it:** thefrederiksen/devthrottle#1891 changed legacy-data migration behaviour for an explicitly pinned root, and the tenant tests here pin `CC_DIRECTOR_ROOT` to a temporary directory - the same mechanism from opposite sides. If the baseline surprises us, that is the first place to look. If it turns out to be something else entirely, that will be said plainly; a wrong pre-registered suspect is still worth more than a right retrospective one.

## Proof

The evidence for this change is the full-suite mutation proof in the pull request comments, not this section. **Eight one-primitive mutations, each a full Gateway suite, plus a restored run at the exact pushed head**, with every red named, its kind (assertion or crash) reported, its actual assertion text quoted, and each arm reconciled arithmetically against the restored count.

Two results worth stating here because they are easy to overstate elsewhere:

- **The record tenant stamp is not a disclosure guard.** Dropping it while the ownership check stays strict makes account records unattributed and therefore **unreadable** - a correctness and availability failure. Its reds are all "the record was absent", including account A failing to read account A's own transcript. It earns its own proof because the design requires the persisted ownership marker; it does not demonstrate cross-tenant disclosure.
- **`BelongsHere` is the disclosure guard**, and its red says so concretely: account B's partition returning account A's record with A's transcript in it.

Two defences are deliberately left without canaries, documented at the guards themselves: the path-containment belt in `PartitionRootFor` (unreachable while `IsMintedAccountTenant` admits only canonical lowercase minted identifiers - the comment names predicate loosening as the point it becomes live and must gain one) and the partition-container skip in the pending-record projection (a clarity and cost skip; the real boundary on that line is `BelongsHere`, which is separately canaried). Neither got a test invented for it, because the only test either could have is one that cannot fail.

## Test counts

Reported with the full-suite proof at the head being merged, across all seven test projects. The earlier counts in this body's history referred to an older base and an older suite composition and are superseded - including a `HostedAccountStatusTests` failure that was genuinely pre-existing at the time and has since been fixed on main by thefrederiksen/devthrottle#1916.

No web workspace is touched (no TypeScript or contract change).
