### PR TITLE
fix(docker): build the cockpit and mobile app into the hosted image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,28 +13,86 @@
 # the same no-user-interface process, with the managed self-update loop and autostart both off, which is
 # what a container wants (the container runtime keeps the process alive; no start-on-login, no self-update).
 #
-# The cockpit and mobile React apps are deliberately NOT built into this image (the npm build targets
-# are skipped with the three Run*=false properties below). Those static assets are not needed to prove
-# the warm brain spawns a Unix-pseudo-terminal agent, and the React build is already cross-platform, so
-# skipping it hides no port risk. A full-asset image is a later concern.
+# The cockpit and mobile React apps ARE built into this image. They used to be skipped (with three
+# Run*=false properties on the publish command) back when this image only had to prove the warm brain
+# spawns a Unix-pseudo-terminal agent. That is obsolete: the hosted Gateway is the product a customer
+# reaches through a browser, and without those assets it has no browser user interface at all - the
+# cockpit shell answers 404 ("React Cockpit not built into this Gateway") and the mobile app answers
+# 404 as well. So the publish below leaves the three properties alone; a Release configuration turns
+# the cockpit build, the mobile build and the strict workspace typecheck on by default (see
+# src/CcDirector.Gateway/CcDirector.Gateway.csproj), the built files are staged into the Gateway's
+# wwwroot/c and wwwroot/m, and they flow into /app/publish - which is where CockpitReactApp.WebRoot
+# (AppContext.BaseDirectory/wwwroot/c) and the mobile app's static files are read from at run time.
+# Because those npm targets now run, the BUILD stage needs Node.js; it is installed there.
+#
+# HOW TO BUILD THIS IMAGE (the commit argument is required, see COCKPIT_COMMIT below):
+#
+#   docker build --build-arg COCKPIT_COMMIT=$(git rev-parse --short HEAD) -t devthrottle-gateway .
+#
 
 # ---- build stage -------------------------------------------------------------------------------
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
+
+# Node.js is a BUILD-stage requirement now that the cockpit and mobile npm targets run: the MSBuild
+# targets BuildCockpitApp, BuildMobileApp and TypecheckWorkspaces all shell out to npm at the
+# workspace root. Node 20 matches what the repository builds with elsewhere. This is the build stage
+# only - it is discarded, and the runtime stage installs its own Node for its own reason.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && node --version && npm --version
 
 # Copy the whole repository; `dotnet publish` on the host csproj restores only the projects it
 # transitively references (CcDirector.Gateway and CcDirector.Gateway.Migrations.Postgres among them), so the
 # unrelated trees are ignored by the build (and pruned by .dockerignore).
 COPY . .
 
-# Framework-dependent publish for linux-x64. The three Run*=false properties skip the npm-driven
-# mobile build, cockpit build, and workspace typecheck, so the build stage needs no Node.js at all.
+# Framework-dependent, runtime-identifier-agnostic publish (the entry point is `dotnet <dll>`, so the
+# image never needs a native apphost, and the runtime resolves the linux-x64 native assets out of the
+# published runtimes/ folder). It used to pass `-r linux-x64 --no-self-contained`. Both had to go now
+# that the npm targets run: those flags set global properties that make MSBuild evaluate
+# CcDirector.Gateway as TWO project instances, and BuildCockpitApp then runs twice. The cockpit
+# stamps its build TIME into the bundle, so the second run deletes wwwroot/c and re-emits the asset
+# under a DIFFERENT content hash - after the publish has already recorded the first run's file names.
+# The build then dies with MSB3030 "could not copy ... because it was not found". Measured: with the
+# flags, two "[BuildCockpitApp] staged" lines and MSB3030; without them, one line and a clean publish.
+#
+# The three Run*=true properties run the npm-driven mobile build, cockpit build and workspace
+# typecheck. Release already turns them on by default; they are stated here so the image's intent is
+# readable at the publish command rather than inferred from a configuration name. They are what put
+# wwwroot/c and wwwroot/m into /app/publish.
+#
 # Publishing the host (not CcDirector.Gateway directly) is what pulls the Postgres migrations assembly
 # into /app/publish so Database.Migrate() can load it at runtime.
+#
+# -m:1 (one MSBuild worker) keeps the npm work serialized. Every npm target drives the ONE shared
+# node_modules at the workspace root, and two `npm ci` calls running at once delete and re-link the
+# same directory - observed here as "Cannot find module esbuild/install.js" and as "EEXIST symlink
+# @devthrottle/mobile" while the graph still evaluated the Gateway twice. Nothing about this build is
+# slow enough to be worth trading that risk for parallel workers.
+#
+# COCKPIT_COMMIT is required. The cockpit stamps the repository commit into its About page, and it
+# normally reads that from git - which cannot work in here: the build context excludes .git, and a
+# build started from a git worktree has only a pointer file there in any case. So the commit is
+# handed in. There is deliberately no default: a cockpit that reports a commit it does not actually
+# contain is worse than a build that stops and tells you to pass the argument.
+ARG COCKPIT_COMMIT
+ENV COCKPIT_COMMIT=${COCKPIT_COMMIT}
+RUN test -n "$COCKPIT_COMMIT" || { \
+      echo "COCKPIT_COMMIT is required. Build with:"; \
+      echo "  docker build --build-arg COCKPIT_COMMIT=\$(git rev-parse --short HEAD) -t devthrottle-gateway ."; \
+      exit 1; }
+
 RUN dotnet publish src/CcDirector.Gateway.Host/CcDirector.Gateway.Host.csproj \
-    -c Release -r linux-x64 --no-self-contained \
-    -p:RunMobileBuild=false -p:RunCockpitBuild=false -p:RunWorkspaceTypecheck=false \
-    -o /app/publish --nologo
+    -c Release -m:1 \
+    -p:RunMobileBuild=true -p:RunCockpitBuild=true -p:RunWorkspaceTypecheck=true \
+    -o /app/publish --nologo \
+    && test -f /app/publish/wwwroot/c/index.html \
+    && test -f /app/publish/wwwroot/m/index.html \
+    && echo "[image] cockpit and mobile assets are present in the published output"
 
 # ---- runtime stage -----------------------------------------------------------------------------
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime

--- a/apps/cockpit/vite.config.ts
+++ b/apps/cockpit/vite.config.ts
@@ -6,9 +6,21 @@ import react from "@vitejs/plugin-react";
 // cockpit is deployed, independently of the Gateway's version. The two can diverge when only the
 // static cockpit files are refreshed (a cockpit-only redeploy), so the Gateway version alone cannot
 // tell you which cockpit you are looking at. The commit is the repo HEAD at build time; the time is
-// the build time. git is present in every build path (dev and the release MSBuild), so this is not
-// wrapped in a fallback - if it cannot read the commit the build fails loudly.
-const cockpitCommit = execSync("git rev-parse --short HEAD").toString().trim();
+// the build time. git is present in a normal build path (dev and the release MSBuild), so that is
+// the default source and it is not wrapped in a fallback - if it cannot read the commit the build
+// fails loudly.
+//
+// One build path genuinely has no git repository to ask: the container image. Its build context
+// excludes .git, and a build run from a git worktree has only a pointer file there anyway, so
+// `git rev-parse` cannot answer inside the image. That path supplies the commit directly through
+// COCKPIT_COMMIT (the repo-root Dockerfile requires it as a build argument). This is a second
+// SOURCE for the same fact, not a fallback to a made-up value: if neither the environment nor git
+// yields a commit, the build still fails and no build is ever stamped "unknown".
+const commitFromEnvironment = process.env.COCKPIT_COMMIT?.trim();
+const cockpitCommit =
+  commitFromEnvironment && commitFromEnvironment.length > 0
+    ? commitFromEnvironment
+    : execSync("git rev-parse --short HEAD").toString().trim();
 const cockpitBuildTime = new Date().toISOString();
 
 // The desktop Cockpit is the Gateway's canonical front door: it is served at the site root "/"

--- a/docs/architecture/hosted-gateway-qa.md
+++ b/docs/architecture/hosted-gateway-qa.md
@@ -346,6 +346,11 @@ dotnet publish src/CcDirector.Gateway.Host/CcDirector.Gateway.Host.csproj \
   CcDirector.Gateway.Host.runtimeconfig.json targets Microsoft.AspNetCore.App
 ```
 
+Note (issue #1892): the publish command above is the one that was run for THIS piece of work, and it is
+no longer the command in the Dockerfile. The image now builds the cockpit and the mobile app into
+`wwwroot/c` and `wwwroot/m`, so the three `Run*` properties are `true` and the runtime-identifier flags
+are gone. Read the Dockerfile for the current command.
+
 Boot smoke test (`GatewayHostBootSmokeTests`):
 - `PostgresMigrationSet_ResolvesByAssemblyName_WithoutDatabase` (always runs, no database): loads the
   migration set by the assembly name the host wires (`GetMigrations()`, which does not connect) and asserts


### PR DESCRIPTION
Closes #1892.

## The problem

The hosted container image had no browser user interface at all. The repository-root `Dockerfile`
deliberately skipped the two npm build targets (`-p:RunMobileBuild=false -p:RunCockpitBuild=false
-p:RunWorkspaceTypecheck=false`), so `wwwroot/c` and `wwwroot/m` were never in the published output.
`GET /` answered 404 "React Cockpit not built into this Gateway (release build only)" and `GET /m`
answered 404. That was a reasonable trade when the image only had to prove the warm brain could spawn
an agent on Linux; it is not reasonable now that the image is the product a customer reaches through
a browser.

## The change

Build stage of the `Dockerfile` only (the runtime stage is untouched):

- The three properties are now `true`, so the cockpit build, the mobile build and the strict
  workspace typecheck all run during `dotnet publish`.
- Node.js 20 is installed in the build stage, which previously needed no Node at all.
- The publish no longer passes `-r linux-x64 --no-self-contained`. Those flags set global properties
  that made MSBuild evaluate `CcDirector.Gateway` as two project instances, so `BuildCockpitApp` ran
  twice; the cockpit stamps its build time into the bundle, so the second run deleted `wwwroot/c` and
  re-emitted the asset under a different content hash after the publish had recorded the first run's
  file names, and the build died with `MSB3030 could not copy ... because it was not found`. The
  entry point is `dotnet <dll>`, so the image never needed a native apphost anyway.
- `-m:1` keeps the npm work serialized. Every npm target drives the one shared `node_modules` at the
  workspace root; two concurrent `npm ci` calls were observed failing with
  `Cannot find module esbuild/install.js` and `EEXIST symlink @devthrottle/mobile`.
- The publish step now asserts `wwwroot/c/index.html` and `wwwroot/m/index.html` exist in
  `/app/publish`, so an image that silently loses the user interface again cannot be built.
- `COCKPIT_COMMIT` is a required build argument. The cockpit stamps the repository commit into its
  About page by running `git rev-parse`, which cannot work inside the image: the build context
  excludes `.git`, and a build started from a git worktree only has a pointer file there. So
  `apps/cockpit/vite.config.ts` now takes the commit from `COCKPIT_COMMIT` when it is set and asks
  git otherwise. That is a second source for the same fact, not a fallback to a made-up value - if
  neither answers, the build still fails and nothing is ever stamped "unknown".
- The stale comment that said the assets are "deliberately NOT built into this image" is replaced by
  one describing what the image does now, including where the files land and who reads them.

Build the image with:

```
docker build --build-arg COCKPIT_COMMIT=$(git rev-parse --short HEAD) -t devthrottle-gateway .
```

## Proof - the assets are served, not merely built

The image was built locally and run. A green build is not a served page, so both were checked.

Inside the built runtime image:

```
/app/wwwroot/c: index.html, sw.js, assets/
/app/wwwroot/m: index.html, manifest.webmanifest, sw.js, push-sw.js, icons, assets/
grep -c '<the commit>' /app/wwwroot/c/assets/*.js  ->  1
```

`/app` is the working directory and the assemblies sit there, so `/app/wwwroot/c` is exactly
`CockpitReactApp.WebRoot` (`AppContext.BaseDirectory/wwwroot/c`); the mobile app reads
`AppContext.BaseDirectory/wwwroot/m` the same way.

Running the container and requesting it from inside:

| Request | Before | Now |
|---|---|---|
| `GET /` with no credential | 401 | 401 (unchanged, auth still enforced) |
| `GET /` with a valid device-key cookie | 404 "not built into this Gateway" | **200**, `<title>DevThrottle Cockpit</title>` |
| `GET /m/` with a valid device-key cookie | 404 | **200**, `<title>DevThrottle Mobile</title>` |
| `GET /assets/<hashed cockpit bundle>` | n/a | **200** |
| `GET /healthz` | 200 | 200 |

`CcDirector.Gateway.Host.dll` and `CcDirector.Gateway.Migrations.Postgres.dll` are both still present
in the image, so dropping the runtime identifier did not disturb the Postgres migration path.

## Tests

All seven test projects, plus the web workspaces:

| Project | Result |
|---|---|
| CcDirector.Core.Tests | Passed - 3306 passed, 8 skipped, 3314 total |
| CcDirector.Engine.Tests | Passed - 62 passed, 0 skipped, 62 total |
| CcDirector.HostedAgent.Tests | Passed - 86 passed, 0 skipped, 86 total |
| CcDirector.Launcher.Tests | Passed - 27 passed, 0 skipped, 27 total |
| CcDirector.Avalonia.Tests | Passed - 247 passed, 0 skipped, 247 total |
| CcDirector.Terminal.Avalonia.Tests | Passed - 21 passed, 0 skipped, 21 total |
| CcDirector.Gateway.Tests | Passed - 2941 passed, 10 skipped, 2951 total |

Web workspaces (`npm test --workspaces`): 50 test files / 544 tests passed, and 14 test files / 150
tests passed. The strict workspace typecheck also ran inside the container build.
