### PR TITLE
fix(gateway): deny four cross-tenant content read families on the hosted gateway

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedContentDenyGroupFilterTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentDenyGroupFilterTests.cs
@@ -1,0 +1,264 @@
+using System.Net;
+using System.Text.Json;
+using CcDirector.AgentBrain;
+using CcDirector.Core;
+using CcDirector.Core.Configuration;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Transcription;
+using CcDirector.Gateway.Voice;
+using CcDirector.Gateway.Wingman;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// PROVES THE PROPERTY THAT MADE THE GROUP FILTER THE RIGHT SHAPE, WHICH NOTHING ELSE HERE CAN SEE.
+///
+/// Each of the four denied families is guarded by ONE <c>AddEndpointFilter</c> on the route group rather
+/// than a <c>DenyOnHosted()</c> call repeated in every handler. The stated reason is that a per-route
+/// guard ROTS - the moment someone adds a route to that file it is undefended and nothing fails - whereas
+/// a group filter runs before every route in the group INCLUDING ROUTES THAT DO NOT EXIST YET.
+///
+/// That difference is completely invisible to any test that only drives the routes existing today: a
+/// per-route guard and a group filter behave identically on those. Which is exactly what makes the
+/// per-route shape dangerous, and exactly why the claim needs its own proof rather than an assurance in a
+/// pull request body. Until this file existed, the pull request asserted the future-route property and
+/// nothing tested it.
+///
+/// So each family maps a BRAND-NEW route onto its returned group, with NO deny written for it anywhere,
+/// and asserts:
+///
+///   1. HOSTED           - the probe route is refused, carrying that family's refusal and nothing else.
+///   2. SELF-HOST        - the SAME probe route is SERVED, over BOTH non-hosted forms that occur in
+///                         practice (the variable absent, and the variable present but "0").
+///   3. SCOPING CONTROL  - a route mapped OUTSIDE the group still SERVES on hosted.
+///
+/// All three are needed and none is redundant. Without (2) a filter that refused everything
+/// unconditionally would pass every hosted assertion in this file while having silently killed the route
+/// for self-host too - a brick is indistinguishable from a working gate if you only push on it from one
+/// side. Without (3) the hosted passes could be the host refusing everything rather than the filter doing
+/// its job.
+///
+/// The self-host legs also assert <see cref="GatewayHostedMode.IsHosted"/> is genuinely false rather than
+/// trusting the environment variable to have taken effect, so no leg can silently run in the mode it
+/// believes it is not in.
+/// </summary>
+[Collection("DirectorRoot")]   // serialized: every leg mutates the process-wide CC_GATEWAY_HOSTED and
+                              // CC_DIRECTOR_ROOT, so running beside another collection would let one
+                              // test's mode leak into another's - the exact silent-wrong-mode failure
+                              // the IsHosted assertions above exist to catch.
+public sealed class HostedContentDenyGroupFilterTests
+{
+    private const string ProbeBody = "probe-served-zqxjv";
+
+    private const string TranscriptionRefusal = "transcription analysis is not available on the hosted gateway";
+    private const string InstructionsRefusal = "the wingman instructions surface is not available on the hosted gateway";
+    private const string UtteranceRefusal = "the wingman utterance upload is not available on the hosted gateway";
+    private const string DictationRefusal = "dictation upload is not available on the hosted gateway";
+
+    /// <summary>Which family, its group-mapper, and the refusal its filter must produce.</summary>
+    public static TheoryData<string> Families() => new() { "transcription", "instructions", "utterance", "dictation" };
+
+    private static string RefusalFor(string family) => family switch
+    {
+        "transcription" => TranscriptionRefusal,
+        "instructions" => InstructionsRefusal,
+        "utterance" => UtteranceRefusal,
+        "dictation" => DictationRefusal,
+        _ => throw new ArgumentOutOfRangeException(nameof(family)),
+    };
+
+    // ===== 1. HOSTED: a route added to the group later is refused, with no deny of its own =====
+
+    [Theory]
+    [MemberData(nameof(Families))]
+    public async Task A_route_added_to_the_group_later_is_refused_on_hosted(string family)
+    {
+        using var env = new HostedEnv("1");
+        Assert.True(GatewayHostedMode.IsHosted, "the hosted leg must actually be in hosted mode");
+
+        await using var rig = await Rig.StartAsync(family);
+
+        var resp = await rig.Http.GetAsync("probe-added-later");
+
+        var root = await ContentFingerprint.AsJsonObjectAsync(resp, $"{family} probe on hosted");
+        Assert.Equal(new[] { "error" }, root.EnumerateObject().Select(p => p.Name).ToArray());
+        Assert.Equal(RefusalFor(family), ContentFingerprint.Text(root, "error", family));
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    // ===== 2. SELF-HOST: the same probe route still serves, over BOTH non-hosted forms =====
+
+    [Theory]
+    [InlineData("transcription", null)]
+    [InlineData("transcription", "0")]
+    [InlineData("instructions", null)]
+    [InlineData("instructions", "0")]
+    [InlineData("utterance", null)]
+    [InlineData("utterance", "0")]
+    [InlineData("dictation", null)]
+    [InlineData("dictation", "0")]
+    public async Task A_route_added_to_the_group_still_serves_on_self_host(string family, string? hostedValue)
+    {
+        using var env = new HostedEnv(hostedValue);
+        Assert.False(GatewayHostedMode.IsHosted,
+            $"the self-host leg must actually be in self-host mode (CC_GATEWAY_HOSTED={hostedValue ?? "absent"})");
+
+        await using var rig = await Rig.StartAsync(family);
+
+        var resp = await rig.Http.GetAsync("probe-added-later");
+        var body = await resp.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal(ProbeBody, body);
+    }
+
+    // ===== 3. SCOPING CONTROL: a route OUTSIDE the group still serves on hosted =====
+
+    [Theory]
+    [MemberData(nameof(Families))]
+    public async Task A_route_outside_the_group_still_serves_on_hosted(string family)
+    {
+        using var env = new HostedEnv("1");
+        Assert.True(GatewayHostedMode.IsHosted, "the hosted leg must actually be in hosted mode");
+
+        await using var rig = await Rig.StartAsync(family);
+
+        // Mapped on the application, NOT on the guarded group. If this were refused, the hosted passes
+        // above would be the host refusing everything rather than the filter being correctly scoped.
+        var resp = await rig.Http.GetAsync("outside-the-group");
+        var body = await resp.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal(ProbeBody, body);
+    }
+
+    /// <summary>Sets CC_GATEWAY_HOSTED for one test and restores whatever was there before.</summary>
+    private sealed class HostedEnv : IDisposable
+    {
+        private readonly string? _prior;
+
+        public HostedEnv(string? value)
+        {
+            _prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", value);
+        }
+
+        public void Dispose() => Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _prior);
+    }
+
+    /// <summary>
+    /// A minimal application carrying ONE family's guarded group, plus a probe route mapped onto that
+    /// group and a control route mapped outside it. Deliberately not a whole GatewayHost: the point is to
+    /// hold the returned group and map onto it, which only the endpoint's own Map can hand back.
+    /// </summary>
+    private sealed class Rig : IAsyncDisposable
+    {
+        private readonly WebApplication _app;
+        private readonly string _root;
+        private readonly string? _priorRoot;
+        private readonly GatewayDbTestHarness? _db;
+        public HttpClient Http { get; }
+
+        private Rig(WebApplication app, HttpClient http, string root, string? priorRoot,
+            GatewayDbTestHarness? db)
+        {
+            _app = app;
+            Http = http;
+            _root = root;
+            _priorRoot = priorRoot;
+            _db = db;
+        }
+
+        public static async Task<Rig> StartAsync(string family)
+        {
+            var priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+            var root = Path.Combine(Path.GetTempPath(), "ccd-probe-" + Guid.NewGuid().ToString("N"));
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", root);
+
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0");
+
+            GatewayDbTestHarness? db = null;
+            var group = MapFamily(app, family, root, ref db);
+
+            // The brand-new route, on the guarded group, with NO deny of its own.
+            group.MapGet("/probe-added-later", () => Results.Text(ProbeBody));
+            // The control, deliberately OUTSIDE the group.
+            app.MapGet("/outside-the-group", () => Results.Text(ProbeBody));
+
+            await app.StartAsync();
+            return new Rig(app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) },
+                root, priorRoot, db);
+        }
+
+        private static RouteGroupBuilder MapFamily(WebApplication app, string family, string root,
+            ref GatewayDbTestHarness? db)
+        {
+            var brain = (WingmanModelRole _, CancellationToken _) =>
+                Task.FromException<IAgentBrain>(
+                    new InvalidOperationException("the brain must not be reached by a routing probe"));
+
+            switch (family)
+            {
+                case "transcription":
+                    return TranscriptionAnalysisEndpoint.Map(app);
+
+                case "instructions":
+                    db = new GatewayDbTestHarness();
+                    return WingmanInstructionsEndpoint.Map(
+                        app,
+                        new WingmanInstructionsStore(db.Open(), db.LegacyPath("probe-legacy.json")),
+                        new WingmanTrainingStore(() => false, Path.Combine(root, "training")),
+                        brain);
+
+                case "utterance":
+                {
+                    var vault = new KeyVault(Path.Combine(root, "probe.vault"));
+                    var voice = new WingmanVoiceService(brain, vault, Path.Combine(root, "voice.json"));
+                    return GatewayWingmanVoiceEndpoint.Map(
+                        app,
+                        new DirectorRegistry(Path.Combine(root, "instances")),
+                        brain,
+                        vault,
+                        voice);
+                }
+
+                case "dictation":
+                {
+                    var vault = new KeyVault(Path.Combine(root, "probe.vault"));
+                    return GatewayDictationEndpoint.Map(
+                        app,
+                        new DirectorRegistry(Path.Combine(root, "instances")),
+                        owners: null,
+                        token: "probe-token",
+                        transcription: new GatewayTranscriptionService(vault),
+                        transcribingSessions: new TranscribingSessions(),
+                        uploads: new VoiceUploadStore(Path.Combine(root, "uploads")),
+                        devices: new Pairing.DeviceRegistry(Path.Combine(root, "devices.json")));
+                }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(family), family, "unknown family");
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Http.Dispose();
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+            _db?.Dispose();
+            try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedContentDenyGroupFilterTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentDenyGroupFilterTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text;
 using System.Text.Json;
 using CcDirector.AgentBrain;
 using CcDirector.Core;
@@ -37,18 +38,28 @@ namespace CcDirector.Gateway.Tests;
 /// nothing tested it.
 ///
 /// So each family maps a BRAND-NEW route onto its returned group handle, with NO deny written for it
-/// anywhere, and asserts:
+/// anywhere. The probe route is a BODY-BOUND POST, not a parameterless GET, because a parameterless GET is
+/// the ONE shape the underlying endpoint-filter defect could never be seen through: a filter that answered
+/// AFTER model binding still refused a GET correctly while leaking every bound body, a malformed body to the
+/// framework's own 400, and a wrong media type to its own 415. The GET probe this file first shipped proved
+/// the future-route property but was blind to a regression back to that defect. A body-bound POST is not, so
+/// each family asserts:
 ///
-///   1. HOSTED           - the probe route is refused, carrying that family's refusal and nothing else.
-///   2. SELF-HOST        - the SAME probe route is SERVED, over BOTH non-hosted forms that occur in
-///                         practice (the variable absent, and the variable present but "0").
+///   1. HOSTED           - the future route is refused across the shapes that regression hides in: a
+///                         MALFORMED body (answered by the framework's own 400 under the old defect), a
+///                         WRONG MEDIA TYPE (answered by its own 415), and - the load-bearing one - a
+///                         NO-BINDING sentinel proving NO handler-bound code ran behind the refusal on any
+///                         shape. Each carries that family's refusal and nothing else.
+///   2. SELF-HOST        - the SAME body-bound route still BINDS and SERVES, over BOTH non-hosted forms that
+///                         occur in practice (the variable absent, and the variable present but "0"), and the
+///                         custom binder is proven to have actually run.
 ///   3. SCOPING CONTROL  - a route mapped OUTSIDE the group still SERVES on hosted.
 ///
-/// All three are needed and none is redundant. Without (2) a filter that refused everything
-/// unconditionally would pass every hosted assertion in this file while having silently killed the route
-/// for self-host too - a brick is indistinguishable from a working gate if you only push on it from one
-/// side. Without (3) the hosted passes could be the host refusing everything rather than the primitive
-/// doing its job.
+/// All three are needed and none is redundant. Without (2) a filter that refused everything unconditionally -
+/// or one that bricked binding on every deployment - would pass every hosted assertion in this file while
+/// having silently killed the route for self-host too; a brick is indistinguishable from a working gate if
+/// you only push on it from one side. Without (3) the hosted passes could be the host refusing everything
+/// rather than the primitive doing its job.
 ///
 /// The self-host legs also assert <see cref="GatewayHostedMode.IsHosted"/> is genuinely false rather than
 /// trusting the environment variable to have taken effect, so no leg can silently run in the mode it
@@ -83,6 +94,9 @@ public sealed class HostedContentDenyGroupFilterTests
 
     private static string ProbePath(string family) => PrefixFor(family) + "probe-added-later";
 
+    /// <summary>The second future route, whose parameter is a custom binder we can watch run (or not run).</summary>
+    private static string BindingProbePath(string family) => PrefixFor(family) + "probe-binding";
+
     private const string TranscriptionRefusal = "transcription analysis is not available on the hosted gateway";
     private const string InstructionsRefusal = "the wingman instructions surface is not available on the hosted gateway";
     private const string UtteranceRefusal = "the wingman utterance upload is not available on the hosted gateway";
@@ -100,26 +114,79 @@ public sealed class HostedContentDenyGroupFilterTests
         _ => throw new ArgumentOutOfRangeException(nameof(family)),
     };
 
-    // ===== 1. HOSTED: a route added to the group later is refused, with no deny of its own =====
-
-    [Theory]
-    [MemberData(nameof(Families))]
-    public async Task A_route_added_to_the_group_later_is_refused_on_hosted(string family)
+    /// <summary>
+    /// Asserts the response is EXACTLY this family's refusal and nothing else - the family's error string, a
+    /// one-name property set, application/json, and a 404. The media type and property set are checked
+    /// through <see cref="ContentFingerprint"/>, so a masking route (the Cockpit single-page-app fallback, or
+    /// any other handler) reddens as "expected application/json, got &lt;that&gt;" rather than as a parser
+    /// crash - a red that arrives as a crash proves a route moved, not that the guard held.
+    /// </summary>
+    private static async Task AssertIsExactlyTheRefusal(HttpResponseMessage resp, string family)
     {
-        using var env = new HostedEnv("1");
-        Assert.True(GatewayHostedMode.IsHosted, "the hosted leg must actually be in hosted mode");
-
-        await using var rig = await Rig.StartAsync(family);
-
-        var resp = await rig.Http.GetAsync(ProbePath(family));
-
         var root = await ContentFingerprint.AsJsonObjectAsync(resp, $"{family} probe on hosted");
         Assert.Equal(new[] { "error" }, root.EnumerateObject().Select(p => p.Name).ToArray());
         Assert.Equal(RefusalFor(family), ContentFingerprint.Text(root, "error", family));
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
-    // ===== 2. SELF-HOST: the same probe route still serves, over BOTH non-hosted forms =====
+    // ===== 1. HOSTED: a BODY-BOUND route added to the group later is refused across the shapes a =====
+    // =====    parameterless GET is blind to, and NO handler-bound code runs behind the refusal. =====
+
+    [Theory]
+    [MemberData(nameof(Families))]
+    public async Task A_malformed_body_on_a_route_added_later_meets_the_refusal_on_hosted(string family)
+    {
+        using var env = new HostedEnv("1");
+        Assert.True(GatewayHostedMode.IsHosted, "the hosted leg must actually be in hosted mode");
+
+        await using var rig = await Rig.StartAsync(family);
+
+        // Malformed JSON is a shape an earlier boundary let the framework answer with its own 400 instead of
+        // the refusal - and a parameterless GET, having no body to be malformed, could never surface it.
+        var resp = await rig.PostAsync(ProbePath(family), "{ not json", "application/json");
+
+        await AssertIsExactlyTheRefusal(resp, family);
+    }
+
+    [Theory]
+    [MemberData(nameof(Families))]
+    public async Task A_wrong_media_type_on_a_route_added_later_meets_the_refusal_on_hosted(string family)
+    {
+        using var env = new HostedEnv("1");
+        Assert.True(GatewayHostedMode.IsHosted, "the hosted leg must actually be in hosted mode");
+
+        await using var rig = await Rig.StartAsync(family);
+
+        // A body parameter makes the framework infer a media-type constraint that endpoint SELECTION enforces
+        // ahead of any handler; mapping no handler at all on hosted is what strips the constraint with it.
+        // The shape that survived longest across candidate designs, and one a GET cannot exercise.
+        var resp = await rig.PostAsync(ProbePath(family), "hello", "text/plain");
+
+        await AssertIsExactlyTheRefusal(resp, family);
+    }
+
+    [Theory]
+    [MemberData(nameof(Families))]
+    public async Task No_argument_binder_runs_behind_the_refusal_on_hosted(string family)
+    {
+        using var env = new HostedEnv("1");
+        Assert.True(GatewayHostedMode.IsHosted, "the hosted leg must actually be in hosted mode");
+
+        ProbeBinding.Reset();
+        await using var rig = await Rig.StartAsync(family);
+
+        // The claim the GET probe could not make: not that the answer was right, but that NO handler-bound
+        // code executed - the property that separates a refusal placed BEFORE binding from one placed after
+        // it, and the one that was false under the original endpoint-filter defect on every shape, a valid
+        // body included.
+        await rig.PostAsync(BindingProbePath(family), "{\"value\":\"x\"}", "application/json");
+        await rig.PostAsync(BindingProbePath(family), "{ not json", "application/json");
+        await rig.PostAsync(BindingProbePath(family), "hello", "text/plain");
+
+        Assert.Equal(0, ProbeBinding.Count);
+    }
+
+    // ===== 2. SELF-HOST: the same body-bound route still BINDS and SERVES, over BOTH non-hosted forms =====
 
     [Theory]
     [InlineData("transcription", null)]
@@ -130,19 +197,26 @@ public sealed class HostedContentDenyGroupFilterTests
     [InlineData("utterance", "0")]
     [InlineData("dictation", null)]
     [InlineData("dictation", "0")]
-    public async Task A_route_added_to_the_group_still_serves_on_self_host(string family, string? hostedValue)
+    public async Task A_route_added_to_the_group_still_binds_and_serves_on_self_host(string family, string? hostedValue)
     {
         using var env = new HostedEnv(hostedValue);
         Assert.False(GatewayHostedMode.IsHosted,
             $"the self-host leg must actually be in self-host mode (CC_GATEWAY_HOSTED={hostedValue ?? "absent"})");
 
+        ProbeBinding.Reset();
         await using var rig = await Rig.StartAsync(family);
 
-        var resp = await rig.Http.GetAsync(ProbePath(family));
-        var body = await resp.Content.ReadAsStringAsync();
+        // The JSON body binds and the handler serves it back: the positive twin of the hosted no-binding
+        // claim, and proof the substitution did not brick the route for self-host.
+        var echo = await rig.PostAsync(ProbePath(family), $"{{\"text\":\"{ProbeBody}\"}}", "application/json");
+        Assert.Equal(HttpStatusCode.OK, echo.StatusCode);
+        Assert.Equal(ProbeBody, await echo.Content.ReadAsStringAsync());
 
-        Assert.Equal(ProbeBody, body);
-        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        // And the custom binder ACTUALLY RAN. Without this a primitive that broke binding on every deployment
+        // would satisfy the hosted no-binding assertion and nothing here would notice.
+        var bound = await rig.PostAsync(BindingProbePath(family), "{\"value\":\"x\"}", "application/json");
+        Assert.Equal(HttpStatusCode.OK, bound.StatusCode);
+        Assert.Equal(1, ProbeBinding.Count);
     }
 
     // ===== 3. SCOPING CONTROL: a route OUTSIDE the group still serves on hosted =====
@@ -202,6 +276,10 @@ public sealed class HostedContentDenyGroupFilterTests
             _db = db;
         }
 
+        /// <summary>A POST with an explicit body and media type - the shapes the body-bound probes exercise.</summary>
+        public Task<HttpResponseMessage> PostAsync(string path, string content, string mediaType)
+            => Http.PostAsync(path, new StringContent(content, Encoding.UTF8, mediaType));
+
         public static async Task<Rig> StartAsync(string family)
         {
             var priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
@@ -216,8 +294,12 @@ public sealed class HostedContentDenyGroupFilterTests
             GatewayDbTestHarness? db = null;
             var group = MapFamily(app, family, root, ref db);
 
-            // The brand-new route, on the guarded group, with NO deny of its own.
-            group.MapGet("/probe-added-later", () => Results.Text(ProbeBody));
+            // The brand-new routes, on the guarded group, with NO deny of their own - and BODY-BOUND, so they
+            // exercise the shape a parameterless GET is blind to. One carries a JSON body (a malformed body
+            // and a wrong media type are answerable here); the other a custom binder whose execution is
+            // observable, so "no handler-bound code ran" is a fact and not an inference.
+            group.MapPost("/probe-added-later", (EchoBody body) => Results.Text(body.Text));
+            group.MapPost("/probe-binding", (ProbeBinding probe) => Results.Text(probe.Value));
             // The control, deliberately OUTSIDE the group.
             app.MapGet("/outside-the-group", () => Results.Text(ProbeBody));
 
@@ -285,6 +367,34 @@ public sealed class HostedContentDenyGroupFilterTests
             Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
             _db?.Dispose();
             try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>The JSON body the echo probe binds. A malformed body and a wrong media type are shapes that
+    /// only exist because this parameter does - which is the whole reason the probe is no longer a GET.</summary>
+    private sealed record EchoBody(string Text);
+
+    /// <summary>
+    /// A parameter whose BINDING IS OBSERVABLE. Argument binding leaves no trace of its own, so proving that
+    /// nothing bound on hosted requires a parameter that records the fact it was bound. This is the instrument
+    /// for the load-bearing claim - not that the response was right, but that no handler-bound code ran at all.
+    /// Its counter is private to this class and its tests are serialized by the collection, so a Reset-then-
+    /// assert cannot be contaminated by another class.
+    /// </summary>
+    private sealed class ProbeBinding
+    {
+        private static int _count;
+
+        public string Value { get; init; } = "";
+
+        public static int Count => Volatile.Read(ref _count);
+
+        public static void Reset() => Interlocked.Exchange(ref _count, 0);
+
+        public static ValueTask<ProbeBinding?> BindAsync(HttpContext context)
+        {
+            Interlocked.Increment(ref _count);
+            return ValueTask.FromResult<ProbeBinding?>(new ProbeBinding { Value = ProbeBody });
         }
     }
 }

--- a/src/CcDirector.Gateway.Tests/HostedContentDenyGroupFilterTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentDenyGroupFilterTests.cs
@@ -6,6 +6,7 @@ using CcDirector.Core.Configuration;
 using CcDirector.Gateway.Tests.Data;
 using CcDirector.Gateway.Api;
 using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.Transcription;
 using CcDirector.Gateway.Voice;
 using CcDirector.Gateway.Wingman;
@@ -20,19 +21,23 @@ namespace CcDirector.Gateway.Tests;
 /// <summary>
 /// PROVES THE PROPERTY THAT MADE THE GROUP FILTER THE RIGHT SHAPE, WHICH NOTHING ELSE HERE CAN SEE.
 ///
-/// Each of the four denied families is guarded by ONE <c>AddEndpointFilter</c> on the route group rather
-/// than a <c>DenyOnHosted()</c> call repeated in every handler. The stated reason is that a per-route
-/// guard ROTS - the moment someone adds a route to that file it is undefended and nothing fails - whereas
-/// a group filter runs before every route in the group INCLUDING ROUTES THAT DO NOT EXIST YET.
+/// Each of the four denied families is denied through the shared refusal primitive
+/// <see cref="CcDirector.Gateway.Tenancy.HostedRouteDeny"/> - three via <c>ExclusiveGroup</c> (one catch-all
+/// refusal claims the whole prefix) and transcription via the per-route <c>Group</c> (a refusal mirrors each
+/// route mapped through the returned handle) - rather than a <c>DenyOnHosted()</c> call repeated in every
+/// handler. The stated reason is that a per-handler guard ROTS - the moment someone adds a route to that
+/// file it is undefended and nothing fails - whereas mapping through the primitive's group handle covers
+/// every route mapped through it INCLUDING ROUTES THAT DO NOT EXIST YET (an exclusive family's catch-all
+/// covers even paths never declared; a per-route family covers every route it maps through the handle).
 ///
 /// That difference is completely invisible to any test that only drives the routes existing today: a
-/// per-route guard and a group filter behave identically on those. Which is exactly what makes the
-/// per-route shape dangerous, and exactly why the claim needs its own proof rather than an assurance in a
+/// per-handler guard and the primitive behave identically on those. Which is exactly what makes the
+/// per-handler shape dangerous, and exactly why the claim needs its own proof rather than an assurance in a
 /// pull request body. Until this file existed, the pull request asserted the future-route property and
 /// nothing tested it.
 ///
-/// So each family maps a BRAND-NEW route onto its returned group, with NO deny written for it anywhere,
-/// and asserts:
+/// So each family maps a BRAND-NEW route onto its returned group handle, with NO deny written for it
+/// anywhere, and asserts:
 ///
 ///   1. HOSTED           - the probe route is refused, carrying that family's refusal and nothing else.
 ///   2. SELF-HOST        - the SAME probe route is SERVED, over BOTH non-hosted forms that occur in
@@ -42,8 +47,8 @@ namespace CcDirector.Gateway.Tests;
 /// All three are needed and none is redundant. Without (2) a filter that refused everything
 /// unconditionally would pass every hosted assertion in this file while having silently killed the route
 /// for self-host too - a brick is indistinguishable from a working gate if you only push on it from one
-/// side. Without (3) the hosted passes could be the host refusing everything rather than the filter doing
-/// its job.
+/// side. Without (3) the hosted passes could be the host refusing everything rather than the primitive
+/// doing its job.
 ///
 /// The self-host legs also assert <see cref="GatewayHostedMode.IsHosted"/> is genuinely false rather than
 /// trusting the environment variable to have taken effect, so no leg can silently run in the mode it
@@ -58,19 +63,21 @@ public sealed class HostedContentDenyGroupFilterTests
     private const string ProbeBody = "probe-served-zqxjv";
 
     /// <summary>
-    /// The URL prefix of each family's guarded group, because they are NOT all the same and assuming they
-    /// were is what broke this rig on its first run. Three families map their group with an EMPTY prefix
-    /// (the route paths are written out in full inside the group, so the self-host surface stays
-    /// byte-identical); the utterance family maps its group at "/wingman/utterance" and writes its routes
-    /// relative to that. A probe mapped onto a group is reachable only under that group's prefix, so the
-    /// prefix has to come from the production code rather than from an assumption about it.
+    /// The URL prefix of each family's denied group, because they are NOT all the same and assuming they
+    /// were is what broke this rig on its first run. After the move to the shared refusal primitive every
+    /// family maps its group at its OWN real prefix and writes its routes relative to that, so a probe mapped
+    /// onto the group is reachable only under that prefix - and the prefix has to come from the production
+    /// code rather than from an assumption about it. Three families claim their prefix EXCLUSIVELY
+    /// (instructions, utterance, dictation); transcription uses the PER-ROUTE group because <c>/transcription</c>
+    /// also carries the live batch + cleanup routes, but its group prefix is <c>/transcription</c> all the
+    /// same, so its probe sits one segment deeper than before.
     /// </summary>
     private static string PrefixFor(string family) => family switch
     {
-        "transcription" => "",
-        "instructions" => "",
+        "transcription" => "transcription/",
+        "instructions" => "gateway/wingman/instructions/",
         "utterance" => "wingman/utterance/",
-        "dictation" => "",
+        "dictation" => "dictation/",
         _ => throw new ArgumentOutOfRangeException(nameof(family)),
     };
 
@@ -150,7 +157,7 @@ public sealed class HostedContentDenyGroupFilterTests
         await using var rig = await Rig.StartAsync(family);
 
         // Mapped on the application, NOT on the guarded group. If this were refused, the hosted passes
-        // above would be the host refusing everything rather than the filter being correctly scoped.
+        // above would be the host refusing everything rather than the primitive being correctly scoped.
         var resp = await rig.Http.GetAsync("outside-the-group");
         var body = await resp.Content.ReadAsStringAsync();
 
@@ -219,7 +226,7 @@ public sealed class HostedContentDenyGroupFilterTests
                 root, priorRoot, db);
         }
 
-        private static RouteGroupBuilder MapFamily(WebApplication app, string family, string root,
+        private static HostedDenyGroup MapFamily(WebApplication app, string family, string root,
             ref GatewayDbTestHarness? db)
         {
             var brain = (WingmanModelRole _, CancellationToken _) =>

--- a/src/CcDirector.Gateway.Tests/HostedContentDenyGroupFilterTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentDenyGroupFilterTests.cs
@@ -57,6 +57,25 @@ public sealed class HostedContentDenyGroupFilterTests
 {
     private const string ProbeBody = "probe-served-zqxjv";
 
+    /// <summary>
+    /// The URL prefix of each family's guarded group, because they are NOT all the same and assuming they
+    /// were is what broke this rig on its first run. Three families map their group with an EMPTY prefix
+    /// (the route paths are written out in full inside the group, so the self-host surface stays
+    /// byte-identical); the utterance family maps its group at "/wingman/utterance" and writes its routes
+    /// relative to that. A probe mapped onto a group is reachable only under that group's prefix, so the
+    /// prefix has to come from the production code rather than from an assumption about it.
+    /// </summary>
+    private static string PrefixFor(string family) => family switch
+    {
+        "transcription" => "",
+        "instructions" => "",
+        "utterance" => "wingman/utterance/",
+        "dictation" => "",
+        _ => throw new ArgumentOutOfRangeException(nameof(family)),
+    };
+
+    private static string ProbePath(string family) => PrefixFor(family) + "probe-added-later";
+
     private const string TranscriptionRefusal = "transcription analysis is not available on the hosted gateway";
     private const string InstructionsRefusal = "the wingman instructions surface is not available on the hosted gateway";
     private const string UtteranceRefusal = "the wingman utterance upload is not available on the hosted gateway";
@@ -85,7 +104,7 @@ public sealed class HostedContentDenyGroupFilterTests
 
         await using var rig = await Rig.StartAsync(family);
 
-        var resp = await rig.Http.GetAsync("probe-added-later");
+        var resp = await rig.Http.GetAsync(ProbePath(family));
 
         var root = await ContentFingerprint.AsJsonObjectAsync(resp, $"{family} probe on hosted");
         Assert.Equal(new[] { "error" }, root.EnumerateObject().Select(p => p.Name).ToArray());
@@ -112,11 +131,11 @@ public sealed class HostedContentDenyGroupFilterTests
 
         await using var rig = await Rig.StartAsync(family);
 
-        var resp = await rig.Http.GetAsync("probe-added-later");
+        var resp = await rig.Http.GetAsync(ProbePath(family));
         var body = await resp.Content.ReadAsStringAsync();
 
-        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.Equal(ProbeBody, body);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
     }
 
     // ===== 3. SCOPING CONTROL: a route OUTSIDE the group still serves on hosted =====

--- a/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
@@ -540,6 +540,12 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     /// <summary>Planted in the seeded wingman training record and asserted back out of /records.</summary>
     private const string SeededReply = "seeded agent reply zqxjv";
 
+    /// <summary>
+    /// The name of the daily training file this test planted, so a test can build the POSITIONAL
+    /// "&lt;filename&gt;#&lt;lineindex&gt;" id of a record it planted itself rather than guessing one.
+    /// </summary>
+    private string _trainingFileName = "";
+
     private static readonly string[] Refusals =
     {
         "transcription analysis is not available on the hosted gateway",
@@ -613,16 +619,23 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// Plant ONE wingman training record, in the exact append-only JSON-lines shape the production writer
-    /// emits, so /records must hand back its positional "&lt;filename&gt;#&lt;lineindex&gt;" id. Written directly
-    /// rather than through the capture path because capture is gated on a setting and needs a live session
-    /// with a terminal - neither of which this control is about.
+    /// Plant TWO wingman training records, in the exact append-only JSON-lines shape the production writer
+    /// emits, so /records must hand back their positional "&lt;filename&gt;#&lt;lineindex&gt;" ids. Written
+    /// directly rather than through the capture path because capture is gated on a setting and needs a live
+    /// session with a terminal - neither of which this control is about.
+    ///
+    /// Line 0 carries an agent reply and is what /records is asserted against. LINE 1 CARRIES NO REPLY ON
+    /// PURPOSE: it is what gives the A/B test route a served-side proof that costs no model call. That route
+    /// distinguishes "this positional id resolved to a record which happens to have no reply" from "no such
+    /// record", and only a handler that actually read THIS file can tell those apart - so an empty reply is
+    /// a seeded fact, not an omission.
     /// </summary>
-    private static void SeedWingmanTrainingRecord()
+    private void SeedWingmanTrainingRecord()
     {
         var dir = CcStorage.WingmanTrainingData();
         Directory.CreateDirectory(dir);
-        var line = JsonSerializer.Serialize(new
+
+        string Line(string reply) => JsonSerializer.Serialize(new
         {
             atUtc = DateTime.UtcNow,
             sessionId = "11111111-1111-1111-1111-111111111111",
@@ -631,14 +644,16 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
             terminalChars = 5,
             terminalTruncated = false,
             terminal = "lines",
-            reply = SeededReply,
+            reply,
             recentContext = "context",
             spoken = "spoken summary",
             replySeconds = 1.5,
         });
+
+        _trainingFileName = $"wingman-training-{DateTime.UtcNow:yyyy-MM-dd}.jsonl";
         File.AppendAllText(
-            Path.Combine(dir, $"wingman-training-{DateTime.UtcNow:yyyy-MM-dd}.jsonl"),
-            line + "\n");
+            Path.Combine(dir, _trainingFileName),
+            Line(SeededReply) + "\n" + Line("") + "\n");
     }
 
     public async Task DisposeAsync()
@@ -769,6 +784,142 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
             root.EnumerateObject().Select(p => p.Name).ToArray());
         Assert.False(string.IsNullOrWhiteSpace(
             ContentFingerprint.Text(root, "content", "GET gateway/wingman/instructions/default")));
+    }
+
+    /// <summary>
+    /// THE REVERT ROUTE, which the hosted deny refuses and which nothing here served-proved until now.
+    ///
+    /// A deny that answers 404 is indistinguishable from a route that was deleted, so every denied path and
+    /// verb needs a self-host fact showing THIS handler answers it. Revert gets the strongest kind: two
+    /// versions are saved through the public surface, the FIRST is made active again by id, and the active
+    /// content is read back through a DIFFERENT route than the one that changed it. Both values were
+    /// planted by this test, so no catch-all and no shipped default can produce them.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_wingman_revert_makes_an_earlier_version_active_again()
+    {
+        var first = "seeded wingman version one zqxjv " + Guid.NewGuid().ToString("N");
+        var second = "seeded wingman version two zqxjv " + Guid.NewGuid().ToString("N");
+
+        var firstId = await SaveInstructionsAsync(first);
+        await SaveInstructionsAsync(second);
+
+        // PRECONDITION, asserted not assumed: the SECOND version is the active one, so the revert below is
+        // load bearing. Without this the test would pass even if revert did nothing at all.
+        var beforeRevert = await GetJsonAsync("gateway/wingman/instructions");
+        Assert.Equal(second, ContentFingerprint.Text(
+            ContentFingerprint.Prop(beforeRevert, "active", "GET gateway/wingman/instructions (before revert)"),
+            "content", "GET gateway/wingman/instructions (before revert)"));
+
+        var reverted = await Send(HttpMethod.Post, "gateway/wingman/instructions/revert",
+            JsonSerializer.Serialize(new { id = firstId }));
+        var revertedBody = await JsonAsync(reverted, "POST gateway/wingman/instructions/revert");
+        Assert.Equal(first, ContentFingerprint.Text(
+            ContentFingerprint.Prop(revertedBody, "active", "POST gateway/wingman/instructions/revert"),
+            "content", "POST gateway/wingman/instructions/revert"));
+
+        // Read back through a different route: the change was durable in the store, not a returned value.
+        var afterRevert = await GetJsonAsync("gateway/wingman/instructions");
+        Assert.Equal(first, ContentFingerprint.Text(
+            ContentFingerprint.Prop(afterRevert, "active", "GET gateway/wingman/instructions (after revert)"),
+            "content", "GET gateway/wingman/instructions (after revert)"));
+    }
+
+    /// <summary>
+    /// THE SWITCH-TO-DEFAULT ROUTE, served-proved the same way: a real state transition, with the
+    /// precondition asserted so the transition cannot be vacuous.
+    ///
+    /// A custom version is saved (so the box is genuinely customized - asserted), the route is called, and
+    /// the box is read back through a DIFFERENT route as no longer customized AND serving the deployed
+    /// default's content rather than the planted one. A handler that did nothing, and a catch-all answering
+    /// both calls identically, both fail that.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_wingman_switch_to_default_drops_the_custom_version()
+    {
+        var custom = "seeded wingman custom zqxjv " + Guid.NewGuid().ToString("N");
+        await SaveInstructionsAsync(custom);
+
+        var deployedDefault = ContentFingerprint.Text(
+            await GetJsonAsync("gateway/wingman/instructions/default"),
+            "content", "GET gateway/wingman/instructions/default");
+        Assert.False(string.IsNullOrWhiteSpace(deployedDefault));
+        Assert.NotEqual(deployedDefault, custom);
+
+        // PRECONDITION: the box really is customized right now, so the switch below has something to undo.
+        var before = await GetJsonAsync("gateway/wingman/instructions");
+        Assert.True(ContentFingerprint.Flag(before, "isCustomized",
+            "GET gateway/wingman/instructions (before switch-to-default)"));
+
+        var switched = await Send(HttpMethod.Post, "gateway/wingman/instructions/switch-to-default", "");
+        var switchedBody = await JsonAsync(switched, "POST gateway/wingman/instructions/switch-to-default");
+        Assert.False(ContentFingerprint.Flag(switchedBody, "isCustomized",
+            "POST gateway/wingman/instructions/switch-to-default"));
+
+        var after = await GetJsonAsync("gateway/wingman/instructions");
+        Assert.False(ContentFingerprint.Flag(after, "isCustomized",
+            "GET gateway/wingman/instructions (after switch-to-default)"));
+        Assert.Equal(deployedDefault, ContentFingerprint.Text(
+            ContentFingerprint.Prop(after, "active", "GET gateway/wingman/instructions (after switch-to-default)"),
+            "content", "GET gateway/wingman/instructions (after switch-to-default)"));
+    }
+
+    /// <summary>
+    /// THE A/B TEST ROUTE, served-proved WITHOUT spending a single model call.
+    ///
+    /// This is the last denied path in the instructions family with no served-side fact, and it is the
+    /// awkward one: its normal success path ends in real brain calls, which this suite stands up no provider
+    /// for and which would make the row depend on a network. It does not need them. The handler resolves
+    /// every requested record against the training store BEFORE any translation, and it reports three
+    /// distinguishable outcomes. Two of them are reachable with no provider at all:
+    ///
+    ///   - a positional id this test PLANTED, on a line deliberately written with no agent reply
+    ///     -> "record has no agent reply to translate". Only a handler that read THIS file can say that;
+    ///        a handler that read nothing would call the record missing.
+    ///   - an id that resolves to nothing -> "record not found".
+    ///
+    /// Telling those two apart is the seeded fact. The exact top-level property set is pinned as well,
+    /// because it is this handler's contract and no other handler on the Gateway emits it.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_wingman_test_resolves_the_seeded_record_without_a_model_call()
+    {
+        const string what = "POST gateway/wingman/instructions/test";
+
+        // Line 1 is the record planted with an empty reply; the second id resolves to no file at all.
+        var seededId = _trainingFileName + "#1";
+        const string missingId = "wingman-training-1970-01-01.jsonl#7";
+
+        var resp = await Send(HttpMethod.Post, "gateway/wingman/instructions/test",
+            JsonSerializer.Serialize(new { content = "draft instructions zqxjv", recordIds = new[] { seededId, missingId } }));
+        var root = await JsonAsync(resp, what);
+
+        Assert.Equal(new[] { "results", "ranCount", "capped" },
+            root.EnumerateObject().Select(p => p.Name).ToArray());
+
+        var results = ContentFingerprint.Arr(root, "results", what).EnumerateArray().ToArray();
+        Assert.Equal(2, results.Length);
+        Assert.Equal(2, ContentFingerprint.Num(root, "ranCount", what));
+        Assert.False(ContentFingerprint.Flag(root, "capped", what));
+
+        var seeded = Assert.Single(results, r => ContentFingerprint.Str(r, "id") == seededId);
+        Assert.Equal("record has no agent reply to translate", ContentFingerprint.Str(seeded, "error"));
+
+        var missing = Assert.Single(results, r => ContentFingerprint.Str(r, "id") == missingId);
+        Assert.Equal("record not found", ContentFingerprint.Str(missing, "error"));
+    }
+
+    /// <summary>Saves a version through the real route and returns its id, asserting the save answered.</summary>
+    private async Task<string> SaveInstructionsAsync(string content)
+    {
+        var resp = await Send(HttpMethod.Put, "gateway/wingman/instructions",
+            JsonSerializer.Serialize(new { content }));
+        var body = await JsonAsync(resp, "PUT gateway/wingman/instructions");
+        var active = ContentFingerprint.Prop(body, "active", "PUT gateway/wingman/instructions");
+        Assert.Equal(content, ContentFingerprint.Text(active, "content", "PUT gateway/wingman/instructions"));
+        var id = ContentFingerprint.Text(active, "id", "PUT gateway/wingman/instructions");
+        Assert.False(string.IsNullOrWhiteSpace(id));
+        return id!;
     }
 
     // ===== The two upload families: every leg leaves a receipt =====

--- a/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
@@ -2,7 +2,9 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using CcDirector.Core.Storage;
 using CcDirector.Gateway;
+using CcDirector.Gateway.Transcription;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
@@ -54,6 +56,18 @@ namespace CcDirector.Gateway.Tests;
 ///   src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs     DenyOnHosted
 ///   src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs     DenyUtteranceOnHosted
 ///   src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs        DenyOnHosted
+///
+/// MUTATION-RED, AND WHY IT IS NOT OPTIONAL HERE. Removing the guard is only half the proof: it shows the
+/// refusal is what produces the refusal. It does NOT show the test could notice the route going missing.
+/// The Cockpit <c>MapFallback("{*path}")</c> answers ANY unclaimed path and verb - 404 in a Debug test
+/// host, 200 with the HTML shell on a release host - and no 405 is ever raised here. So the second half of
+/// the proof is to RENAME or RE-VERB each route and confirm the matching test goes RED. Both halves are
+/// recorded in the pull request.
+///
+/// The assertions in THIS class survive that fallback by construction: each parses the body and requires
+/// the property set to be exactly one <c>error</c> field with an exact message, so an HTML shell fails to
+/// parse and any other JSON fails the property-set check. The receipts in the self-host class are what
+/// needed rebuilding - they rested on a bare 200.
 ///
 /// The SELF-HOST CONTROLS are <see cref="HostedContentReadSelfHostControlTests"/> in this file, plus the
 /// pre-existing <see cref="VoiceUploadLimitsTests"/> (which drives the real utterance upload family with
@@ -301,16 +315,68 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
 /// the two upload families are the phone's voice and dictation lanes. A deny scoped to the wrong signal
 /// would break the shipped product in order to protect the unshipped one, and it would do so silently.
 ///
-/// What is asserted is NOT that a particular payload comes back - these routes legitimately answer many
-/// ways on an empty box (an empty log, an unknown upload id, a missing key) and pinning the exact shape
-/// would make this a change-detector. What is asserted is that the HOSTED REFUSAL IS ABSENT: the route is
-/// still routable (never 404-with-the-refusal-body) and, where it answers, the body is not the refusal.
-/// That is exactly the property the deny must not leak into self-host, and nothing more.
+/// EVERY ASSERTION HERE IS A HANDLER RECEIPT, AND THAT IS NOT A STYLE CHOICE - IT IS THE ONLY THING THAT
+/// WORKS ON THIS GATEWAY. Two route-masking catch-alls exist, and both were read on this branch rather
+/// than assumed:
+///
+///   1. THE ONE THAT APPLIES TO EVERY ROUTE BELOW - the single-page-app fallback.
+///      <c>CockpitReactApp</c> maps <c>MapFallback("{*path}")</c> (CockpitReactApp.cs:125), which matches
+///      ANY path and ANY verb that nothing else claimed, and its own not-found text says
+///      "React Cockpit not built into this Gateway (release build only)". So a deleted, renamed or
+///      re-verbed route answers 404 in a Debug test host but 200 WITH THE HTML SHELL on a release host.
+///      Any assertion resting on "I got a 200" passes on a route that no longer exists.
+///   2. The all-verb session catch-all. <c>SessionWsProxyEndpoints</c> maps
+///      <c>app.Map("/sessions/{sid}/{**rest}")</c> (SessionWsProxyEndpoints.cs:153) - least-specific,
+///      every verb - which swallows a deleted or re-verbed route on any <c>/sessions/{sid}/...</c> path
+///      and answers 503 as <c>application/json</c>, never reaching the fallback, so a <c>text/html</c>
+///      check sails straight past it. NONE of the four families denied here lives under
+///      <c>/sessions/{sid}/</c>, so this one cannot mask THESE routes - it is recorded because it is why
+///      "check the content type" is not a general defence on this Gateway, and the next route added to
+///      this file might well sit under that prefix.
+///
+/// A 405 never occurs on these paths in either condition, so "the verb is wrong" does not announce itself
+/// either. That is why the previous version of this class was unsound: it asserted status 200 plus the
+/// ABSENCE of the refusal strings, and a built Cockpit shell satisfies both. It also drove <c>POST</c> at
+/// the dictation chunk route, which production maps as <c>MapPut</c> ONLY
+/// (GatewayDictationEndpoint.cs:176) - a request that never reached the handler at all, and nothing in the
+/// assertion could notice.
+///
+/// So: every read asserts SEEDED or ROUTE-SPECIFIC JSON that only that handler could have produced, and
+/// every write asserts its own STORE RECEIPT - a state change read back - rather than a status code.
+/// Neither catch-all can fake those.
+///
+/// These are still not change-detectors: what is pinned is the one value this test itself planted, or the
+/// exact top-level property set of a handler whose payload is a stable contract, never an incidental
+/// field a later feature would legitimately move.
+///
+/// Three untouched pre-existing suites are controls too, and they exercise these families with real
+/// payloads: <see cref="VoiceUploadLimitsTests"/> (the real utterance upload family end to end),
+/// <see cref="DictationSessionLockTests"/> and <see cref="DurableDictationDedupeTests"/>.
+///
+/// MUTATION-RED RECIPE (run verbatim; this is the only check that catches both catch-alls, because it
+/// does not depend on predicting what the framework returns):
+///   For each route below, in the production file, either RENAME the path (add "-x") or RE-VERB it
+///   (MapGet -> MapPost, MapPut -> MapPost). Rebuild, check the build line, run this class. The test for
+///   that route must go RED. If it stays GREEN the canary cannot fail and the assertion is worthless -
+///   fix the assertion, not the route. Restore, and confirm green.
 /// </summary>
 [Collection("DirectorRoot")]
 public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
 {
     private const string Token = "test-token";
+
+    /// <summary>Planted in the seeded telemetry record and asserted back out of /transcription/turns.</summary>
+    private const string SeededRawText = "seeded raw utterance zqxjv";
+
+    /// <summary>Planted as the cleaned text, so /transcription/words must count this word.</summary>
+    private const string SeededWord = "zqxjvword";
+
+    /// <summary>Planted as a dictionary correction, so /transcription/terms must report this pair.</summary>
+    private const string SeededFind = "zqxjvfind";
+    private const string SeededReplace = "zqxjvreplace";
+
+    /// <summary>Planted in the seeded wingman training record and asserted back out of /records.</summary>
+    private const string SeededReply = "seeded agent reply zqxjv";
 
     private static readonly string[] Refusals =
     {
@@ -352,6 +418,65 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         await _gateway.StartAsync();
         _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
         _key = _gateway.Devices.Register("dev-owner", "MA").DeviceKey;
+
+        SeedTranscriptionTelemetry();
+        SeedWingmanTrainingRecord();
+    }
+
+    /// <summary>
+    /// Plant ONE transcription turn in the real on-disk telemetry log, under this test's isolated storage
+    /// root, using the production writer. All four /transcription reads derive from this one record, so
+    /// each of them has something only that handler could return.
+    /// </summary>
+    private static void SeedTranscriptionTelemetry()
+    {
+        new TranscriptionTelemetryLog().Record(new TranscriptionTelemetryRecord
+        {
+            TimestampUtc = DateTime.UtcNow,
+            TurnId = "seed-turn",
+            Outcome = "ok",
+            Mode = "devthrottle",
+            AudioBytes = 4096,
+            TranscriptionMs = 120,
+            CleanupMs = 30,
+            Corrected = true,
+            CleanupApplied = true,
+            ChangedWordCount = 1,
+            Changes = new[] { new TelemetryEdit { Find = SeededFind, Replace = SeededReplace } },
+            CharCount = SeededRawText.Length,
+            WordCount = 4,
+            RawText = SeededRawText,
+            CleanedText = SeededWord,
+        });
+    }
+
+    /// <summary>
+    /// Plant ONE wingman training record, in the exact append-only JSON-lines shape the production writer
+    /// emits, so /records must hand back its positional "&lt;filename&gt;#&lt;lineindex&gt;" id. Written directly
+    /// rather than through the capture path because capture is gated on a setting and needs a live session
+    /// with a terminal - neither of which this control is about.
+    /// </summary>
+    private static void SeedWingmanTrainingRecord()
+    {
+        var dir = CcStorage.WingmanTrainingData();
+        Directory.CreateDirectory(dir);
+        var line = JsonSerializer.Serialize(new
+        {
+            atUtc = DateTime.UtcNow,
+            sessionId = "11111111-1111-1111-1111-111111111111",
+            source = "voice-turn",
+            model = "test-model",
+            terminalChars = 5,
+            terminalTruncated = false,
+            terminal = "lines",
+            reply = SeededReply,
+            recentContext = "context",
+            spoken = "spoken summary",
+            replySeconds = 1.5,
+        });
+        File.AppendAllText(
+            Path.Combine(dir, $"wingman-training-{DateTime.UtcNow:yyyy-MM-dd}.jsonl"),
+            line + "\n");
     }
 
     public async Task DisposeAsync()
@@ -364,74 +489,254 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
     }
 
-    [Theory]
-    [InlineData("transcription/turns")]
-    [InlineData("transcription/stats")]
-    [InlineData("transcription/terms")]
-    [InlineData("transcription/words")]
-    [InlineData("gateway/wingman/instructions")]
-    [InlineData("gateway/wingman/instructions/records")]
-    [InlineData("gateway/wingman/instructions/versions")]
-    [InlineData("gateway/wingman/instructions/default")]
-    [InlineData("gateway/wingman/instructions/update")]
-    public async Task Self_host_still_serves_every_denied_read(string path)
+    // ===== The transcription analysis reads: each asserts the SEEDED record back out =====
+
+    [Fact]
+    public async Task Self_host_transcription_turns_returns_the_seeded_turn()
+    {
+        var root = await GetJsonAsync("transcription/turns");
+
+        var texts = root.GetProperty("turns").EnumerateArray()
+            .Select(t => t.TryGetProperty("rawText", out var r) ? r.GetString() : null)
+            .ToArray();
+        Assert.Contains(SeededRawText, texts);
+    }
+
+    [Fact]
+    public async Task Self_host_transcription_stats_counts_the_seeded_turn()
+    {
+        var root = await GetJsonAsync("transcription/stats");
+
+        // Exactly one turn was planted into an isolated, otherwise-empty log, so this is an exact figure
+        // rather than a "greater than zero" that an accidental extra record could satisfy.
+        Assert.Equal(1, root.GetProperty("totalTurns").GetInt32());
+        Assert.Equal(1, root.GetProperty("successfulTurns").GetInt32());
+    }
+
+    [Fact]
+    public async Task Self_host_transcription_terms_returns_the_seeded_correction()
+    {
+        var root = await GetJsonAsync("transcription/terms");
+
+        var pairs = root.GetProperty("terms").EnumerateArray()
+            .Select(t => (t.GetProperty("find").GetString(), t.GetProperty("replace").GetString()))
+            .ToArray();
+        Assert.Contains((SeededFind, SeededReplace), pairs);
+    }
+
+    [Fact]
+    public async Task Self_host_transcription_words_counts_the_seeded_word()
+    {
+        var root = await GetJsonAsync("transcription/words");
+
+        var words = root.GetProperty("words").EnumerateArray()
+            .Select(w => w.GetProperty("word").GetString())
+            .ToArray();
+        Assert.Contains(SeededWord, words);
+    }
+
+    // ===== The wingman instructions reads =====
+
+    /// <summary>
+    /// The training-records read - the actual content leak the hosted deny closes - proven still open on
+    /// self-host by returning the seeded record's POSITIONAL id and its reply preview. Nothing but this
+    /// handler reading this store can produce that id.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_wingman_records_returns_the_seeded_training_record()
+    {
+        var root = await GetJsonAsync("gateway/wingman/instructions/records");
+
+        var records = root.GetProperty("records").EnumerateArray().ToArray();
+        var seeded = Assert.Single(records,
+            r => r.GetProperty("id").GetString()!.EndsWith("#0", StringComparison.Ordinal));
+        Assert.StartsWith("wingman-training-", seeded.GetProperty("id").GetString());
+        Assert.Contains(SeededReply, seeded.GetProperty("replyPreview").GetString());
+    }
+
+    /// <summary>
+    /// Saving a version and reading it back is the strongest available receipt for the instructions
+    /// routes: the value asserted is one this test itself planted through the public surface, so no
+    /// catch-all and no shipped default can produce it.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_wingman_instructions_round_trips_a_saved_version()
+    {
+        var content = "seeded wingman instructions zqxjv " + Guid.NewGuid().ToString("N");
+
+        var saved = await Send(HttpMethod.Put, "gateway/wingman/instructions",
+            JsonSerializer.Serialize(new { content }));
+        Assert.Equal(HttpStatusCode.OK, saved.StatusCode);
+
+        var active = await GetJsonAsync("gateway/wingman/instructions");
+        Assert.Equal(content, active.GetProperty("active").GetProperty("content").GetString());
+        Assert.True(active.GetProperty("isCustomized").GetBoolean());
+
+        var versions = await GetJsonAsync("gateway/wingman/instructions/versions");
+        Assert.Contains(versions.GetProperty("versions").EnumerateArray(),
+            v => v.GetProperty("content").GetString() == content);
+
+        // The managed-default review must now report the box as customized - a state change this test
+        // caused, read back through a DIFFERENT route than the one that caused it.
+        var update = await GetJsonAsync("gateway/wingman/instructions/update");
+        Assert.True(update.GetProperty("isCustomized").GetBoolean());
+    }
+
+    /// <summary>
+    /// The deployed default has no seedable value - it ships with the build - so this pins the one thing
+    /// that is genuinely route-specific and contractual: the exact top-level property set, plus non-empty
+    /// content. The Cockpit HTML shell is not JSON at all, and the /sessions catch-all's 503 body has a
+    /// different property set, so neither can satisfy this.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_wingman_default_returns_the_deployed_default_prompt()
+    {
+        var root = await GetJsonAsync("gateway/wingman/instructions/default");
+
+        Assert.Equal(
+            new[] { "version", "hash", "content" },
+            root.EnumerateObject().Select(p => p.Name).ToArray());
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("content").GetString()));
+    }
+
+    // ===== The two upload families: every leg leaves a receipt =====
+
+    /// <summary>
+    /// The owner's phone still registers an utterance upload AND the bytes it sends are staged. The chunk
+    /// leg has no read route, so the receipt is the staged file itself: the whole isolated storage root is
+    /// searched for a file whose CONTENT is the exact payload sent. Searching by content rather than by an
+    /// expected path means the assertion cannot pass by looking in the wrong place, and cannot fail merely
+    /// because the store renames its layout.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_utterance_upload_registers_and_stages_the_chunk_bytes()
+    {
+        var register = await Send(HttpMethod.Post, "wingman/utterance/upload", "");
+        Assert.Equal(HttpStatusCode.OK, register.StatusCode);
+        var id = (await JsonAsync(register)).GetProperty("upload_id").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(id));
+
+        var payload = Encoding.UTF8.GetBytes("utterance-bytes-zqxjv-" + Guid.NewGuid().ToString("N"));
+        var chunk = await SendBytes(HttpMethod.Put, $"wingman/utterance/{id}/chunk/0", payload);
+        Assert.Equal(HttpStatusCode.OK, chunk.StatusCode);
+        Assert.Equal(0, (await JsonAsync(chunk)).GetProperty("index").GetInt32());
+
+        AssertStagedOnDisk(payload);
+    }
+
+    /// <summary>
+    /// The same for the dictation lane. NOTE THE VERB: production maps this chunk route with
+    /// <c>MapPut</c> and nothing else. An earlier version of this test drove <c>POST</c>, which never
+    /// reached the handler - and because no 405 occurs on this path, nothing in a status-based assertion
+    /// could notice. The staged-bytes receipt is what makes the verb matter.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_dictation_upload_registers_and_stages_the_chunk_bytes()
+    {
+        var id = await RegisterDictationAsync(Guid.NewGuid().ToString("N"));
+
+        var payload = Encoding.UTF8.GetBytes("dictation-bytes-zqxjv-" + Guid.NewGuid().ToString("N"));
+        var chunk = await SendBytes(HttpMethod.Put, $"dictation/{id}/chunk/0", payload);
+        Assert.Equal(HttpStatusCode.OK, chunk.StatusCode);
+        Assert.Equal(0, (await JsonAsync(chunk)).GetProperty("index").GetInt32());
+
+        AssertStagedOnDisk(payload);
+    }
+
+    /// <summary>
+    /// The abandon leg gets its own receipt, and it is a durable state change rather than a status:
+    /// abandoning writes a terminal tombstone, so RE-REGISTERING the same upload id afterwards reports it
+    /// dropped. Read back through a different route than the one that caused it, which no catch-all can
+    /// fake.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_dictation_abandon_writes_a_tombstone_read_back_at_register()
+    {
+        var key = Guid.NewGuid().ToString("N");
+        var id = await RegisterDictationAsync(key);
+
+        var abandon = await Send(HttpMethod.Post, $"dictation/{id}/abandon", "");
+        Assert.Equal(HttpStatusCode.OK, abandon.StatusCode);
+        Assert.True((await JsonAsync(abandon)).GetProperty("abandoned").GetBoolean());
+
+        var reRegister = await Send(HttpMethod.Post, "dictation/upload",
+            "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}", key);
+        Assert.Equal(HttpStatusCode.OK, reRegister.StatusCode);
+        var again = await JsonAsync(reRegister);
+        Assert.True(again.GetProperty("terminal").GetBoolean());
+        Assert.True(again.GetProperty("dropped").GetBoolean());
+    }
+
+    /// <summary>
+    /// The ack leg gets its own receipt too, and it is a state TRANSITION rather than a single value:
+    /// acking a tombstone retires it, so the first ack reports retired and a second ack on the same id
+    /// reports not-retired. A catch-all answering both calls identically cannot produce that difference.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_dictation_ack_retires_the_tombstone_exactly_once()
+    {
+        var id = await RegisterDictationAsync(Guid.NewGuid().ToString("N"));
+        await Send(HttpMethod.Post, $"dictation/{id}/abandon", "");
+
+        var first = await Send(HttpMethod.Post, $"dictation/{id}/ack", "");
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        Assert.True((await JsonAsync(first)).GetProperty("retired").GetBoolean());
+
+        var second = await Send(HttpMethod.Post, $"dictation/{id}/ack", "");
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.False((await JsonAsync(second)).GetProperty("retired").GetBoolean());
+    }
+
+    // ===== Helpers =====
+
+    /// <summary>
+    /// GET a route and return its parsed JSON body, refusing anything that is not a real JSON object from
+    /// that handler. Parsing is itself part of the check: the Cockpit single-page-app fallback answers a
+    /// deleted GET route with the HTML shell on a release host, and HTML does not parse.
+    /// </summary>
+    private async Task<JsonElement> GetJsonAsync(string path)
     {
         var resp = await Send(HttpMethod.Get, path);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         await AssertNotTheHostedRefusal(resp);
+        return await JsonAsync(resp);
     }
 
-    /// <summary>
-    /// The owner's phone still registers an utterance upload and gets an id back - the leg the hosted deny
-    /// closes, proven open here. The chunk and complete legs are covered end to end, with real audio, by
-    /// the untouched <see cref="VoiceUploadLimitsTests"/>.
-    /// </summary>
-    [Fact]
-    public async Task Self_host_still_registers_a_wingman_utterance_upload()
+    private static async Task<JsonElement> JsonAsync(HttpResponseMessage resp)
     {
-        var resp = await Send(HttpMethod.Post, "wingman/utterance/upload", "");
-        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-
-        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
-        Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("upload_id").GetString()));
+        var body = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+        return doc.RootElement.Clone();
     }
 
-    /// <summary>
-    /// The owner's phone still registers a dictation upload. Same shape as the utterance control; the
-    /// chunk/complete/ack/abandon legs are covered by the untouched
-    /// <see cref="DictationSessionLockTests"/> and <see cref="DurableDictationDedupeTests"/>.
-    /// </summary>
-    [Fact]
-    public async Task Self_host_still_registers_a_dictation_upload()
+    private async Task<string> RegisterDictationAsync(string idempotencyKey)
     {
         var resp = await Send(HttpMethod.Post, "dictation/upload",
-            "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}");
+            "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}", idempotencyKey);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-
-        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
-        Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("upload_id").GetString()));
+        var id = (await JsonAsync(resp)).GetProperty("upload_id").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(id));
+        return id!;
     }
 
-    /// <summary>
-    /// The unknown-id answers on self-host must still be the STORE's own answers, not the hosted refusal.
-    /// This is the case a wrongly-scoped deny would most easily hide behind, because both are a 404.
-    /// </summary>
-    [Theory]
-    [InlineData("PUT", "wingman/utterance/no-such-id/chunk/0", "bytes")]
-    [InlineData("POST", "dictation/no-such-id/chunk/0", "bytes")]
-    [InlineData("POST", "dictation/no-such-id/ack", "")]
-    [InlineData("POST", "dictation/no-such-id/abandon", "")]
-    public async Task Self_host_answers_an_unknown_upload_id_itself_not_with_the_hosted_refusal(
-        string method, string path, string body)
+    /// <summary>The staged-bytes receipt: some file under the isolated root holds exactly these bytes.</summary>
+    private void AssertStagedOnDisk(byte[] payload)
     {
-        var resp = await Send(new HttpMethod(method), path, body);
-        await AssertNotTheHostedRefusal(resp);
+        var found = Directory.EnumerateFiles(_root, "*", SearchOption.AllDirectories)
+            .Any(f =>
+            {
+                try { return File.ReadAllBytes(f).AsSpan().SequenceEqual(payload); }
+                catch { return false; }
+            });
+        Assert.True(found, "the chunk handler did not stage the uploaded bytes anywhere under the storage root");
     }
 
     /// <summary>
     /// Reads the body and fails if it carries ANY of the four hosted refusal messages. Deliberately checks
     /// all four in every case rather than the one belonging to that route: a copy-paste that wired the
-    /// wrong helper onto a group would still be caught.
+    /// wrong helper onto a group would still be caught. This is a floor, not the assertion - every test
+    /// above also proves a handler receipt.
     /// </summary>
     private static async Task AssertNotTheHostedRefusal(HttpResponseMessage resp)
     {
@@ -440,12 +745,23 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
             Assert.DoesNotContain(refusal, body, StringComparison.Ordinal);
     }
 
-    private Task<HttpResponseMessage> Send(HttpMethod method, string path, string? body = null)
+    private Task<HttpResponseMessage> Send(HttpMethod method, string path, string? body = null,
+        string? idempotencyKey = null)
     {
         var req = new HttpRequestMessage(method, path);
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        if (idempotencyKey is not null) req.Headers.Add("Idempotency-Key", idempotencyKey);
         if (body is not null)
             req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return _http.SendAsync(req);
+    }
+
+    private Task<HttpResponseMessage> SendBytes(HttpMethod method, string path, byte[] payload)
+    {
+        var req = new HttpRequestMessage(method, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        req.Content = new ByteArrayContent(payload);
+        req.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
         return _http.SendAsync(req);
     }
 
@@ -457,3 +773,4 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         finally { listener.Stop(); }
     }
 }
+

--- a/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
@@ -1,0 +1,459 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Four route families that serve one account's CONTENT to any other account's authenticated device key
+/// are refused on the hosted Gateway. Issues #1897, #1853 (read side), #1896 and #1884.
+///
+/// All four share one defect: the store behind them has a single on-disk root with no tenant anywhere in
+/// the path, the file name, or the record, and the route addresses it by something that is not a tenant
+/// boundary - a positional index, a turn id, or an identifier the CALLER supplies. Public signup on the
+/// backing account project is open, so "any authenticated caller" means the public.
+///
+///   /transcription/*                     one shared daily telemetry log; /turns returns up to 2000
+///                                        records including rawText and cleanedText and needs NO
+///                                        identifier at all - one request returns everyone's speech.
+///   /gateway/wingman/instructions/*       training records holding up to 20,000 characters of raw session
+///                                        TERMINAL output, addressable by a POSITIONAL
+///                                        "&lt;filename&gt;#&lt;lineindex&gt;" id; plus the single-owner wingman
+///                                        prompt, which has no per-tenant version to serve.
+///   /wingman/utterance/*                  staged audio and the assembled transcript, keyed solely by a
+///                                        caller-supplied Idempotency-Key under a shared root.
+///   /dictation/*                          the same VoiceUploadStore shape: re-registering another
+///                                        account's upload id returns ITS transcript from the terminal
+///                                        tombstone, with no session lookup in the way.
+///
+/// WHY A DENY AND NOT A PARTITION. The tenant is not missing from the query, it is missing from the DATA.
+/// These records were written with no tenant on them, so there is nothing to filter by; attributing them
+/// after the fact would be a guess presented as a boundary. Partitioning each store is the job of the
+/// issue named beside it, and un-denying is gated on that work - see the debt table in the pull request.
+///
+/// WHY A REFUSAL AND NOT AN EMPTY RESULT. An empty stats block, an empty record list or an empty
+/// transcript is a FALSE statement about a box that is transcribing and capturing; a refusal is merely an
+/// absent one.
+///
+/// THE GATE IS ON THE DEPLOYMENT SIGNAL. Every one reads <see cref="GatewayHostedMode.IsHosted"/> directly,
+/// not an optional boundary or tenant argument. A security branch that depends on an optional argument
+/// fails OPEN the moment a caller omits it.
+///
+/// REVERT-PROOF RECIPE (run verbatim, per family):
+///   1. In the named file, delete the <c>AddEndpointFilter</c> block that calls the deny helper.
+///   2. Run this class. The theory cases for that family go RED (200/400/404-without-the-refusal-body
+///      instead of the refusal), while every other family stays green.
+///   3. Run the self-host controls named below. They stay GREEN throughout - the guard is invisible to
+///      self-host in both directions, which is the point.
+///   4. Restore the block. Everything goes green again.
+/// The files and blocks are:
+///   src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs   DenyOnHosted
+///   src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs     DenyOnHosted
+///   src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs     DenyUtteranceOnHosted
+///   src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs        DenyOnHosted
+///
+/// The SELF-HOST CONTROLS are <see cref="HostedContentReadSelfHostControlTests"/> in this file, plus the
+/// pre-existing <see cref="VoiceUploadLimitsTests"/> (which drives the real utterance upload family with
+/// hosted off and would red immediately if the route paths shifted), <see cref="DictationSessionLockTests"/>
+/// and <see cref="DurableDictationDedupeTests"/> (the real dictation family, hosted off). None of them was
+/// touched by this change.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class HostedContentReadDenyTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    private const string TranscriptionRefusal = "transcription analysis is not available on the hosted gateway";
+    private const string InstructionsRefusal = "the wingman instructions surface is not available on the hosted gateway";
+    private const string UtteranceRefusal = "the wingman utterance upload is not available on the hosted gateway";
+    private const string DictationRefusal = "dictation upload is not available on the hosted gateway";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _key = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-hosted-content-" + Guid.NewGuid().ToString("N"));
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private string? _priorHosted;
+
+    public HostedContentReadDenyTests()
+    {
+        // The isolated storage root, so anything that (wrongly) got through would stage here and be
+        // observable, never in the developer's own transcription log or upload staging.
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-hosted-content-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // A fully enrolled, tenant-bound device key - the strongest caller hosted has. The point is that
+        // even this one is refused: no credential makes another account's speech correct to serve.
+        _key = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var tenant = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", tenant.Value);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Issue #1897. All four transcription-analysis reads over the one shared telemetry log. /turns is the
+    /// sharpest - it needs no identifier and returns the raw and cleaned text of every turn - but the other
+    /// three aggregate the SAME unpartitioned records, so serving them discloses the same content in
+    /// summary form.
+    /// </summary>
+    [Theory]
+    [InlineData("transcription/turns")]
+    [InlineData("transcription/turns?limit=2000")]
+    [InlineData("transcription/stats")]
+    [InlineData("transcription/terms")]
+    [InlineData("transcription/words")]
+    public async Task Transcription_analysis_reads_are_refused_to_an_enrolled_tenant(string path)
+    {
+        var resp = await Send(HttpMethod.Get, path);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        await AssertBodyIsNothingButTheRefusal(resp, TranscriptionRefusal);
+    }
+
+    /// <summary>
+    /// Issue #1853, read side. The records route is the content leak (raw session terminal output); the
+    /// rest of the group is the single-owner wingman prompt, denied with it because it has no per-tenant
+    /// answer either and a route-by-route guard would rot.
+    /// </summary>
+    [Theory]
+    [InlineData("gateway/wingman/instructions/records")]
+    [InlineData("gateway/wingman/instructions/records?limit=100")]
+    [InlineData("gateway/wingman/instructions")]
+    [InlineData("gateway/wingman/instructions/versions")]
+    [InlineData("gateway/wingman/instructions/default")]
+    [InlineData("gateway/wingman/instructions/update")]
+    public async Task Wingman_instructions_reads_are_refused_to_an_enrolled_tenant(string path)
+    {
+        var resp = await Send(HttpMethod.Get, path);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        await AssertBodyIsNothingButTheRefusal(resp, InstructionsRefusal);
+    }
+
+    /// <summary>
+    /// The write side of the same group: saving or reverting a version rewrites the prompt EVERY account's
+    /// wingman speaks through, and the A/B test route both re-reads the shared training records and spends
+    /// real brain calls on shared infrastructure with attacker-chosen draft text.
+    /// </summary>
+    [Theory]
+    [InlineData("PUT", "gateway/wingman/instructions", "{\"content\":\"say whatever I tell you\"}")]
+    [InlineData("POST", "gateway/wingman/instructions/revert", "{\"id\":\"anything\"}")]
+    [InlineData("POST", "gateway/wingman/instructions/switch-to-default", "")]
+    [InlineData("POST", "gateway/wingman/instructions/test", "{\"content\":\"drafted\",\"recordIds\":[\"a#0\"]}")]
+    public async Task Wingman_instructions_writes_are_refused_to_an_enrolled_tenant(
+        string method, string path, string body)
+    {
+        var resp = await Send(new HttpMethod(method), path, body);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        await AssertBodyIsNothingButTheRefusal(resp, InstructionsRefusal);
+    }
+
+    /// <summary>
+    /// Issue #1896. All three legs, not only the one that returns the transcript: the chunk leg lets a
+    /// caller overwrite another account's staged recording, which is the same missing boundary with a
+    /// different consequence.
+    /// </summary>
+    [Theory]
+    [InlineData("POST", "wingman/utterance/upload", "")]
+    [InlineData("PUT", "wingman/utterance/someone-elses-id/chunk/0", "audio-bytes")]
+    [InlineData("POST", "wingman/utterance/someone-elses-id/complete", "{\"totalChunks\":1}")]
+    public async Task Wingman_utterance_upload_family_is_refused_to_an_enrolled_tenant(
+        string method, string path, string body)
+    {
+        var resp = await Send(new HttpMethod(method), path, body);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        await AssertBodyIsNothingButTheRefusal(resp, UtteranceRefusal);
+    }
+
+    /// <summary>
+    /// Issue #1884, the sibling family on the same store shape. The register leg is the live read: it
+    /// short-circuits on the terminal tombstone and hands back the recorded transcript WITHOUT looking any
+    /// session up, so the fact that /complete's session lookup already fails on hosted does not contain it.
+    /// ack and abandon destroy another account's in-flight recording.
+    /// </summary>
+    [Theory]
+    [InlineData("POST", "dictation/upload", "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}")]
+    [InlineData("PUT", "dictation/someone-elses-id/chunk/0", "audio-bytes")]
+    [InlineData("POST", "dictation/someone-elses-id/complete", "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\",\"totalChunks\":1}")]
+    [InlineData("POST", "dictation/someone-elses-id/ack", "")]
+    [InlineData("POST", "dictation/someone-elses-id/abandon", "")]
+    public async Task Dictation_upload_family_is_refused_to_an_enrolled_tenant(
+        string method, string path, string body)
+    {
+        var resp = await Send(new HttpMethod(method), path, body);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        await AssertBodyIsNothingButTheRefusal(resp, DictationRefusal);
+    }
+
+    /// <summary>
+    /// The refusal must PREVENT the work, not merely relabel it. A handler that ran and then reported 404
+    /// would pass a status-code-only assertion, so this proves the two upload families staged nothing: the
+    /// idempotency key was never registered, so no directory for it exists under the isolated root.
+    /// </summary>
+    [Fact]
+    public async Task A_refused_upload_registration_staged_nothing_on_disk()
+    {
+        var key = "claimed-" + Guid.NewGuid().ToString("N");
+
+        var utterance = await Send(HttpMethod.Post, "wingman/utterance/upload", "", key);
+        Assert.Equal(HttpStatusCode.NotFound, utterance.StatusCode);
+
+        var dictation = await Send(HttpMethod.Post, "dictation/upload",
+            "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}", key);
+        Assert.Equal(HttpStatusCode.NotFound, dictation.StatusCode);
+
+        // Nothing named for that key anywhere under the isolated storage root. Searching the whole root
+        // rather than one expected directory is deliberate: it does not depend on knowing which staging
+        // path the store would have chosen, so it cannot pass by looking in the wrong place.
+        var staged = Directory.Exists(_root)
+            ? Directory.EnumerateFileSystemEntries(_root, "*" + key + "*", SearchOption.AllDirectories).ToArray()
+            : Array.Empty<string>();
+        Assert.Empty(staged);
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_caller_is_still_rejected()
+    {
+        // Control: the deny must not have opened these groups up as a side effect of running before the
+        // host-wide auth gate. Without a key the auth middleware still refuses first.
+        Assert.Equal(HttpStatusCode.Unauthorized, (await _http.GetAsync("transcription/turns")).StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized,
+            (await _http.GetAsync("gateway/wingman/instructions/records")).StatusCode);
+    }
+
+    /// <summary>
+    /// AN ALLOW-LIST, NOT A DENY-LIST, and the difference is the whole assertion.
+    ///
+    /// Asserting that a handful of known payload keys are ABSENT rots by construction: it protects against
+    /// the payload as it is today, every field added later is unprotected until someone remembers this
+    /// file, and a substring check silently misses siblings (checking for "turns" would not catch a key
+    /// named "turnsTotal"). Asserting the property set is EXACTLY one error field inverts that - anything
+    /// extra, anything new, and anything metadata-looking reddens automatically without this file being
+    /// touched.
+    /// </summary>
+    private static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp, string expected)
+    {
+        var body = await resp.Content.ReadAsStringAsync();
+
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+
+        var properties = doc.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Equal(new[] { "error" }, properties);
+        Assert.Equal(expected, doc.RootElement.GetProperty("error").GetString());
+    }
+
+    private Task<HttpResponseMessage> Send(HttpMethod method, string path, string? body = null,
+        string? idempotencyKey = null)
+    {
+        var req = new HttpRequestMessage(method, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        if (idempotencyKey is not null) req.Headers.Add("Idempotency-Key", idempotencyKey);
+        if (body is not null)
+            req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return _http.SendAsync(req);
+    }
+
+    private static int FreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}
+
+/// <summary>
+/// THE SELF-HOST CONTROL, and the reason it is a separate class: it boots the SAME GatewayHost with hosted
+/// mode OFF and drives the SAME routes.
+///
+/// This is the condition the deny has to meet to be correct rather than merely safe. Self-host is
+/// single-tenant, these features WORK there, and the owner uses them - the transcription analysis is how
+/// an agent measures dictation quality, the training records are how the wingman prompt gets improved, and
+/// the two upload families are the phone's voice and dictation lanes. A deny scoped to the wrong signal
+/// would break the shipped product in order to protect the unshipped one, and it would do so silently.
+///
+/// What is asserted is NOT that a particular payload comes back - these routes legitimately answer many
+/// ways on an empty box (an empty log, an unknown upload id, a missing key) and pinning the exact shape
+/// would make this a change-detector. What is asserted is that the HOSTED REFUSAL IS ABSENT: the route is
+/// still routable (never 404-with-the-refusal-body) and, where it answers, the body is not the refusal.
+/// That is exactly the property the deny must not leak into self-host, and nothing more.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    private static readonly string[] Refusals =
+    {
+        "transcription analysis is not available on the hosted gateway",
+        "the wingman instructions surface is not available on the hosted gateway",
+        "the wingman utterance upload is not available on the hosted gateway",
+        "dictation upload is not available on the hosted gateway",
+    };
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _key = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-selfhost-content-" + Guid.NewGuid().ToString("N"));
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private string? _priorHosted;
+
+    public HostedContentReadSelfHostControlTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-selfhost-content-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Hosted mode explicitly OFF - the whole point of this class. Cleared rather than set to "0" so it
+        // is the same absence a real self-host install has.
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _key = _gateway.Devices.Register("dev-owner", "MA").DeviceKey;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    [Theory]
+    [InlineData("transcription/turns")]
+    [InlineData("transcription/stats")]
+    [InlineData("transcription/terms")]
+    [InlineData("transcription/words")]
+    [InlineData("gateway/wingman/instructions")]
+    [InlineData("gateway/wingman/instructions/records")]
+    [InlineData("gateway/wingman/instructions/versions")]
+    [InlineData("gateway/wingman/instructions/default")]
+    [InlineData("gateway/wingman/instructions/update")]
+    public async Task Self_host_still_serves_every_denied_read(string path)
+    {
+        var resp = await Send(HttpMethod.Get, path);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        await AssertNotTheHostedRefusal(resp);
+    }
+
+    /// <summary>
+    /// The owner's phone still registers an utterance upload and gets an id back - the leg the hosted deny
+    /// closes, proven open here. The chunk and complete legs are covered end to end, with real audio, by
+    /// the untouched <see cref="VoiceUploadLimitsTests"/>.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_still_registers_a_wingman_utterance_upload()
+    {
+        var resp = await Send(HttpMethod.Post, "wingman/utterance/upload", "");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("upload_id").GetString()));
+    }
+
+    /// <summary>
+    /// The owner's phone still registers a dictation upload. Same shape as the utterance control; the
+    /// chunk/complete/ack/abandon legs are covered by the untouched
+    /// <see cref="DictationSessionLockTests"/> and <see cref="DurableDictationDedupeTests"/>.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_still_registers_a_dictation_upload()
+    {
+        var resp = await Send(HttpMethod.Post, "dictation/upload",
+            "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("upload_id").GetString()));
+    }
+
+    /// <summary>
+    /// The unknown-id answers on self-host must still be the STORE's own answers, not the hosted refusal.
+    /// This is the case a wrongly-scoped deny would most easily hide behind, because both are a 404.
+    /// </summary>
+    [Theory]
+    [InlineData("PUT", "wingman/utterance/no-such-id/chunk/0", "bytes")]
+    [InlineData("POST", "dictation/no-such-id/chunk/0", "bytes")]
+    [InlineData("POST", "dictation/no-such-id/ack", "")]
+    [InlineData("POST", "dictation/no-such-id/abandon", "")]
+    public async Task Self_host_answers_an_unknown_upload_id_itself_not_with_the_hosted_refusal(
+        string method, string path, string body)
+    {
+        var resp = await Send(new HttpMethod(method), path, body);
+        await AssertNotTheHostedRefusal(resp);
+    }
+
+    /// <summary>
+    /// Reads the body and fails if it carries ANY of the four hosted refusal messages. Deliberately checks
+    /// all four in every case rather than the one belonging to that route: a copy-paste that wired the
+    /// wrong helper onto a group would still be caught.
+    /// </summary>
+    private static async Task AssertNotTheHostedRefusal(HttpResponseMessage resp)
+    {
+        var body = await resp.Content.ReadAsStringAsync();
+        foreach (var refusal in Refusals)
+            Assert.DoesNotContain(refusal, body, StringComparison.Ordinal);
+    }
+
+    private Task<HttpResponseMessage> Send(HttpMethod method, string path, string? body = null)
+    {
+        var req = new HttpRequestMessage(method, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        if (body is not null)
+            req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return _http.SendAsync(req);
+    }
+
+    private static int FreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
@@ -898,6 +898,50 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
             ContentFingerprint.Text(afterAck, "upload_id", "POST dictation/upload (after ack)")));
     }
 
+    /// <summary>
+    /// THE TWO COMPLETE LEGS GET A SERVED-SIDE PROOF TOO, AND THEY NEEDED ONE.
+    ///
+    /// A deny that answers 404 is indistinguishable from a route that does not exist. So a hosted
+    /// refusal, on its own, is satisfied just as well by the route having been deleted - which means
+    /// every denied path needs a self-host proof that THIS handler answers it. The other legs get that
+    /// from their store receipts. These two had nothing, because completing an upload ends in a
+    /// transcription call and this suite stands up no provider.
+    ///
+    /// It turns out not to need one. Both handlers validate their body BEFORE resolving any provider,
+    /// and each rejects with a message no other handler in the Gateway emits. That message is a
+    /// handler-positive fingerprint on exactly the path and verb that is denied on hosted, and it is
+    /// deterministic: it depends on no key, no vault state and no network.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_utterance_complete_answers_from_its_own_handler()
+    {
+        // Body check first, before the upload is even looked up - so this needs no registration.
+        var badBody = await Send(HttpMethod.Post, "wingman/utterance/any-id/complete", "{}");
+        var badBodyJson = await JsonAsync(badBody, "POST wingman/utterance/{uploadId}/complete (bad body)");
+        Assert.Equal("totalChunks (>0) is required",
+            ContentFingerprint.Text(badBodyJson, "error", "POST wingman/utterance/{uploadId}/complete"));
+
+        // And a second message from the same handler, one step further in, proving the upload lookup runs.
+        var unknown = await Send(HttpMethod.Post, "wingman/utterance/not-a-real-upload/complete",
+            "{\"totalChunks\":1}");
+        var unknownJson = await JsonAsync(unknown, "POST wingman/utterance/{uploadId}/complete (unknown id)");
+        Assert.Equal("unknown upload id (register it first)",
+            ContentFingerprint.Text(unknownJson, "error", "POST wingman/utterance/{uploadId}/complete"));
+    }
+
+    /// <summary>
+    /// The same served-side proof for the dictation completion leg, for the same reason: its hosted
+    /// refusal is a 404, and without this nothing distinguishes that refusal from an absent route.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_dictation_complete_answers_from_its_own_handler()
+    {
+        var badBody = await Send(HttpMethod.Post, "dictation/any-id/complete", "{}");
+        var badBodyJson = await JsonAsync(badBody, "POST dictation/{uploadId}/complete (bad body)");
+        Assert.Equal("sessionId (guid) and totalChunks (>0) are required",
+            ContentFingerprint.Text(badBodyJson, "error", "POST dictation/{uploadId}/complete"));
+    }
+
     // ===== Helpers =====
 
     /// <summary>

--- a/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
@@ -166,18 +166,27 @@ internal static class ContentFingerprint
 /// not an optional boundary or tenant argument. A security branch that depends on an optional argument
 /// fails OPEN the moment a caller omits it.
 ///
-/// REVERT-PROOF RECIPE (run verbatim, per family):
-///   1. In the named file, delete the <c>AddEndpointFilter</c> block that calls the deny helper.
-///   2. Run this class. The theory cases for that family go RED (200/400/404-without-the-refusal-body
-///      instead of the refusal), while every other family stays green.
-///   3. Run the self-host controls named below. They stay GREEN throughout - the guard is invisible to
+/// REVERT-PROOF RECIPE (each family is denied through the shared refusal primitive
+/// <c>HostedRouteDeny</c>, not a bespoke filter - the revert is RE-ENABLING THE REAL HANDLER ON HOSTED):
+///   1. In the named file, change the family's routes so their real handlers map on hosted - e.g. replace
+///      the <c>HostedRouteDeny.ExclusiveGroup</c> / <c>HostedRouteDeny.Group</c> call in <c>Map</c> with a
+///      plain group that maps the handlers, OR flip the primitive's hosted branch so
+///      <c>HostedDenyGroup.Map</c> maps the handler instead of the refusal.
+///   2. Run this class. The theory cases for that family go RED - the real handler answers (a 200 payload,
+///      a 400/401/404 from the handler's own body checks, or a startup failure when an exclusive family's
+///      real route now serves under its own claimed prefix) instead of the exact refusal body - while every
+///      other family stays green.
+///   3. Run the self-host controls named below. They stay GREEN throughout - the deny is invisible to
 ///      self-host in both directions, which is the point.
-///   4. Restore the block. Everything goes green again.
-/// The files and blocks are:
-///   src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs   DenyOnHosted
-///   src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs     DenyOnHosted
-///   src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs     DenyUtteranceOnHosted
-///   src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs        DenyOnHosted
+///   4. Restore. Everything goes green again. (Proven for this branch: flipping the primitive's hosted
+///      branch to map handlers reddened all four families' hosted theories - transcription, instructions
+///      reads+writes, utterance, dictation - plus the unbound-caller and future-route probes; restoring
+///      returned all green.)
+/// The files and their deny call in <c>Map</c> are:
+///   src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs   HostedRouteDeny.Group (per-route)
+///   src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs     HostedRouteDeny.ExclusiveGroup
+///   src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs     HostedRouteDeny.ExclusiveGroup (utterance)
+///   src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs        HostedRouteDeny.ExclusiveGroup
 ///
 /// MUTATION-RED, AND WHY IT IS NOT OPTIONAL HERE. Removing the guard is only half the proof: it shows the
 /// refusal is what produces the refusal. It does NOT show the test could notice the route going missing.
@@ -500,8 +509,8 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
 /// either. That is why the previous version of this class was unsound: it asserted status 200 plus the
 /// ABSENCE of the refusal strings, and a built Cockpit shell satisfies both. It also drove <c>POST</c> at
 /// the dictation chunk route, which production maps as <c>MapPut</c> ONLY
-/// (GatewayDictationEndpoint.cs:176) - a request that never reached the handler at all, and nothing in the
-/// assertion could notice.
+/// (GatewayDictationEndpoint, the <c>/{uploadId}/chunk/{index:int}</c> leg) - a request that never reached
+/// the handler at all, and nothing in the assertion could notice.
 ///
 /// So: every read asserts SEEDED or ROUTE-SPECIFIC JSON that only that handler could have produced, and
 /// every write asserts its own STORE RECEIPT - a state change read back - rather than a status code.

--- a/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
@@ -36,6 +36,17 @@ internal static class ContentFingerprint
     {
         var body = await resp.Content.ReadAsStringAsync();
 
+        // FORMAT FACT FIRST. The media type is asserted before anything reads the body, because it is
+        // the fact that NAMES what was served: "got text/html" identifies the Cockpit shell exactly,
+        // where a bare status assertion would only say a number changed. Status is deliberately NOT
+        // asserted here - on the hosted rows 404 is the expected value either way, so it distinguishes
+        // nothing, and making it the first failure would prove a route moved rather than proving this
+        // canary can name what answered.
+        var mediaType = resp.Content.Headers.ContentType?.MediaType;
+        Assert.True(mediaType == "application/json",
+            $"{what}: expected application/json from this handler, got {mediaType ?? "no media type"} " +
+            $"(HTTP {(int)resp.StatusCode}). A masking route answered. Body: {Preview(body)}");
+
         JsonDocument? doc = null;
         try { doc = JsonDocument.Parse(body); }
         catch (JsonException) { /* asserted below, never thrown */ }
@@ -76,6 +87,42 @@ internal static class ContentFingerprint
             && v.ValueKind == JsonValueKind.String
             ? v.GetString()
             : null;
+
+    /// <summary>An ARRAY property, kind asserted before <c>EnumerateArray</c>, which would throw.</summary>
+    public static JsonElement Arr(JsonElement root, string name, string what)
+    {
+        var v = Prop(root, name, what);
+        Assert.True(v.ValueKind == JsonValueKind.Array,
+            $"{what}: '{name}' is {v.ValueKind}, not an array, so this is not this handler's payload.");
+        return v;
+    }
+
+    /// <summary>A NUMBER property, kind asserted before <c>GetInt32</c>, which would throw.</summary>
+    public static int Num(JsonElement root, string name, string what)
+    {
+        var v = Prop(root, name, what);
+        Assert.True(v.ValueKind == JsonValueKind.Number,
+            $"{what}: '{name}' is {v.ValueKind}, not a number, so this is not this handler's payload.");
+        return v.GetInt32();
+    }
+
+    /// <summary>A BOOLEAN property, kind asserted before <c>GetBoolean</c>, which would throw.</summary>
+    public static bool Flag(JsonElement root, string name, string what)
+    {
+        var v = Prop(root, name, what);
+        Assert.True(v.ValueKind is JsonValueKind.True or JsonValueKind.False,
+            $"{what}: '{name}' is {v.ValueKind}, not a boolean, so this is not this handler's payload.");
+        return v.GetBoolean();
+    }
+
+    /// <summary>A STRING property, kind asserted before <c>GetString</c>, which would throw.</summary>
+    public static string? Text(JsonElement root, string name, string what)
+    {
+        var v = Prop(root, name, what);
+        Assert.True(v.ValueKind is JsonValueKind.String or JsonValueKind.Null,
+            $"{what}: '{name}' is {v.ValueKind}, not a string, so this is not this handler's payload.");
+        return v.ValueKind == JsonValueKind.Null ? null : v.GetString();
+    }
 
     private static string Preview(string body)
     {
@@ -357,7 +404,7 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
 
         var properties = root.EnumerateObject().Select(p => p.Name).ToArray();
         Assert.Equal(new[] { "error" }, properties);
-        Assert.Equal(expected, ContentFingerprint.Prop(root, "error", what).GetString());
+        Assert.Equal(expected, ContentFingerprint.Text(root, "error", what));
     }
 
     private Task<HttpResponseMessage> Send(HttpMethod method, string path, string? body = null,
@@ -571,8 +618,8 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     {
         var root = await GetJsonAsync("transcription/turns");
 
-        var texts = ContentFingerprint.Prop(root, "turns", "GET transcription/turns").EnumerateArray()
-            .Select(t => t.TryGetProperty("rawText", out var r) ? r.GetString() : null)
+        var texts = ContentFingerprint.Arr(root, "turns", "GET transcription/turns").EnumerateArray()
+            .Select(t => ContentFingerprint.Str(t, "rawText"))
             .ToArray();
         Assert.Contains(SeededRawText, texts);
     }
@@ -584,8 +631,8 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
 
         // Exactly one turn was planted into an isolated, otherwise-empty log, so this is an exact figure
         // rather than a "greater than zero" that an accidental extra record could satisfy.
-        Assert.Equal(1, ContentFingerprint.Prop(root, "totalTurns", "GET transcription/stats").GetInt32());
-        Assert.Equal(1, ContentFingerprint.Prop(root, "successfulTurns", "GET transcription/stats").GetInt32());
+        Assert.Equal(1, ContentFingerprint.Num(root, "totalTurns", "GET transcription/stats"));
+        Assert.Equal(1, ContentFingerprint.Num(root, "successfulTurns", "GET transcription/stats"));
     }
 
     [Fact]
@@ -593,7 +640,7 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     {
         var root = await GetJsonAsync("transcription/terms");
 
-        var pairs = ContentFingerprint.Prop(root, "terms", "GET transcription/terms").EnumerateArray()
+        var pairs = ContentFingerprint.Arr(root, "terms", "GET transcription/terms").EnumerateArray()
             .Select(t => (ContentFingerprint.Str(t, "find"), ContentFingerprint.Str(t, "replace")))
             .ToArray();
         Assert.Contains((SeededFind, SeededReplace), pairs);
@@ -604,7 +651,7 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     {
         var root = await GetJsonAsync("transcription/words");
 
-        var words = ContentFingerprint.Prop(root, "words", "GET transcription/words").EnumerateArray()
+        var words = ContentFingerprint.Arr(root, "words", "GET transcription/words").EnumerateArray()
             .Select(w => ContentFingerprint.Str(w, "word"))
             .ToArray();
         Assert.Contains(SeededWord, words);
@@ -622,7 +669,7 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     {
         var root = await GetJsonAsync("gateway/wingman/instructions/records");
 
-        var records = ContentFingerprint.Prop(root, "records", "GET gateway/wingman/instructions/records")
+        var records = ContentFingerprint.Arr(root, "records", "GET gateway/wingman/instructions/records")
             .EnumerateArray().ToArray();
         var seeded = Assert.Single(records,
             r => (ContentFingerprint.Str(r, "id") ?? "").EndsWith("#0", StringComparison.Ordinal));
@@ -645,25 +692,25 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         // Fingerprint, not status: re-verbing this route sends the request to the Cockpit fallback, and a
         // status check would redden on 404 rather than on "that was not the save handler answering".
         var savedBody = await JsonAsync(saved, "PUT gateway/wingman/instructions");
-        Assert.Equal(content, ContentFingerprint.Str(
-            ContentFingerprint.Prop(savedBody, "active", "PUT gateway/wingman/instructions"), "content"));
+        Assert.Equal(content, ContentFingerprint.Text(
+            ContentFingerprint.Prop(savedBody, "active", "PUT gateway/wingman/instructions"),
+            "content", "PUT gateway/wingman/instructions"));
 
         var active = await GetJsonAsync("gateway/wingman/instructions");
         var activeVersion = ContentFingerprint.Prop(active, "active", "GET gateway/wingman/instructions");
         Assert.Equal(content,
-            ContentFingerprint.Prop(activeVersion, "content", "GET gateway/wingman/instructions").GetString());
-        Assert.True(ContentFingerprint.Prop(active, "isCustomized", "GET gateway/wingman/instructions").GetBoolean());
+            ContentFingerprint.Text(activeVersion, "content", "GET gateway/wingman/instructions"));
+        Assert.True(ContentFingerprint.Flag(active, "isCustomized", "GET gateway/wingman/instructions"));
 
         var versions = await GetJsonAsync("gateway/wingman/instructions/versions");
         Assert.Contains(
-            ContentFingerprint.Prop(versions, "versions", "GET gateway/wingman/instructions/versions").EnumerateArray(),
-            v => v.TryGetProperty("content", out var c) && c.GetString() == content);
+            ContentFingerprint.Arr(versions, "versions", "GET gateway/wingman/instructions/versions").EnumerateArray(),
+            v => ContentFingerprint.Str(v, "content") == content);
 
         // The managed-default review must now report the box as customized - a state change this test
         // caused, read back through a DIFFERENT route than the one that caused it.
         var update = await GetJsonAsync("gateway/wingman/instructions/update");
-        Assert.True(ContentFingerprint.Prop(update, "isCustomized", "GET gateway/wingman/instructions/update")
-            .GetBoolean());
+        Assert.True(ContentFingerprint.Flag(update, "isCustomized", "GET gateway/wingman/instructions/update"));
     }
 
     /// <summary>
@@ -681,7 +728,7 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
             new[] { "version", "hash", "content" },
             root.EnumerateObject().Select(p => p.Name).ToArray());
         Assert.False(string.IsNullOrWhiteSpace(
-            ContentFingerprint.Prop(root, "content", "GET gateway/wingman/instructions/default").GetString()));
+            ContentFingerprint.Text(root, "content", "GET gateway/wingman/instructions/default")));
     }
 
     // ===== The two upload families: every leg leaves a receipt =====
@@ -698,14 +745,14 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     {
         var register = await Send(HttpMethod.Post, "wingman/utterance/upload", "");
         var registerBody = await JsonAsync(register, "POST wingman/utterance/upload");
-        var id = ContentFingerprint.Prop(registerBody, "upload_id", "POST wingman/utterance/upload").GetString();
+        var id = ContentFingerprint.Text(registerBody, "upload_id", "POST wingman/utterance/upload");
         Assert.False(string.IsNullOrWhiteSpace(id));
 
         var payload = Encoding.UTF8.GetBytes("utterance-bytes-zqxjv-" + Guid.NewGuid().ToString("N"));
         var chunk = await SendBytes(HttpMethod.Put, $"wingman/utterance/{id}/chunk/0", payload);
         var chunkBody = await JsonAsync(chunk, "PUT wingman/utterance/{uploadId}/chunk/0");
         Assert.Equal(0,
-            ContentFingerprint.Prop(chunkBody, "index", "PUT wingman/utterance/{uploadId}/chunk/0").GetInt32());
+            ContentFingerprint.Num(chunkBody, "index", "PUT wingman/utterance/{uploadId}/chunk/0"));
 
         AssertStagedOnDisk(payload);
     }
@@ -725,7 +772,7 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         var chunk = await SendBytes(HttpMethod.Put, $"dictation/{id}/chunk/0", payload);
         var chunkBody = await JsonAsync(chunk, "PUT dictation/{uploadId}/chunk/0");
         Assert.Equal(0,
-            ContentFingerprint.Prop(chunkBody, "index", "PUT dictation/{uploadId}/chunk/0").GetInt32());
+            ContentFingerprint.Num(chunkBody, "index", "PUT dictation/{uploadId}/chunk/0"));
 
         AssertStagedOnDisk(payload);
     }
@@ -745,13 +792,13 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         var abandon = await Send(HttpMethod.Post, $"dictation/{id}/abandon", "");
         var abandonBody = await JsonAsync(abandon, "POST dictation/{uploadId}/abandon");
         Assert.True(
-            ContentFingerprint.Prop(abandonBody, "abandoned", "POST dictation/{uploadId}/abandon").GetBoolean());
+            ContentFingerprint.Flag(abandonBody, "abandoned", "POST dictation/{uploadId}/abandon"));
 
         var reRegister = await Send(HttpMethod.Post, "dictation/upload",
             "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}", key);
         var again = await JsonAsync(reRegister, "POST dictation/upload (re-register)");
-        Assert.True(ContentFingerprint.Prop(again, "terminal", "POST dictation/upload (re-register)").GetBoolean());
-        Assert.True(ContentFingerprint.Prop(again, "dropped", "POST dictation/upload (re-register)").GetBoolean());
+        Assert.True(ContentFingerprint.Flag(again, "terminal", "POST dictation/upload (re-register)"));
+        Assert.True(ContentFingerprint.Flag(again, "dropped", "POST dictation/upload (re-register)"));
     }
 
     /// <summary>
@@ -768,12 +815,12 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         var first = await Send(HttpMethod.Post, $"dictation/{id}/ack", "");
         var firstBody = await JsonAsync(first, "POST dictation/{uploadId}/ack (first)");
         Assert.True(
-            ContentFingerprint.Prop(firstBody, "retired", "POST dictation/{uploadId}/ack (first)").GetBoolean());
+            ContentFingerprint.Flag(firstBody, "retired", "POST dictation/{uploadId}/ack (first)"));
 
         var second = await Send(HttpMethod.Post, $"dictation/{id}/ack", "");
         var secondBody = await JsonAsync(second, "POST dictation/{uploadId}/ack (second)");
         Assert.False(
-            ContentFingerprint.Prop(secondBody, "retired", "POST dictation/{uploadId}/ack (second)").GetBoolean());
+            ContentFingerprint.Flag(secondBody, "retired", "POST dictation/{uploadId}/ack (second)"));
     }
 
     // ===== Helpers =====
@@ -802,7 +849,7 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         var resp = await Send(HttpMethod.Post, "dictation/upload",
             "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}", idempotencyKey);
         var body = await JsonAsync(resp, "POST dictation/upload");
-        var id = ContentFingerprint.Prop(body, "upload_id", "POST dictation/upload").GetString();
+        var id = ContentFingerprint.Text(body, "upload_id", "POST dictation/upload");
         Assert.False(string.IsNullOrWhiteSpace(id));
         return id!;
     }
@@ -810,6 +857,10 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     /// <summary>The staged-bytes receipt: some file under the isolated root holds exactly these bytes.</summary>
     private void AssertStagedOnDisk(byte[] payload)
     {
+        // Assert the directory exists before enumerating it: EnumerateFiles throws on a missing root,
+        // and a throw here would be a crash rather than a statement about what the handler staged.
+        Assert.True(Directory.Exists(_root), $"the storage root {_root} does not exist, so nothing could stage");
+
         var found = Directory.EnumerateFiles(_root, "*", SearchOption.AllDirectories)
             .Any(f =>
             {

--- a/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
@@ -10,6 +10,81 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
+/// Turns every way a MASKING ROUTE can answer into an xUnit ASSERTION, never an exception.
+///
+/// This exists because of how these rows are proven. The mutation sweep renames or re-verbs a route and
+/// requires the matching test to redden - but a red only proves the row if it arrives as an assertion
+/// about the thing under test. A red that arrives as a <see cref="JsonException"/> from parsing the
+/// Cockpit HTML shell, or a <see cref="KeyNotFoundException"/> from reading a property off some other
+/// handler's payload, is a CRASH: it says the request went somewhere unexpected, which is laundering, not
+/// proof that this canary detects it.
+///
+/// It also exists because of WHICH assertion must fail first. Checking the status code before the body
+/// would make a renamed route redden on "404 != 200" - which proves a route changed, not that the test
+/// can tell the handler's answer from a masking route's. The fingerprint has to be the first thing that
+/// can fail, so status is never asserted ahead of it.
+/// </summary>
+internal static class ContentFingerprint
+{
+    /// <summary>
+    /// The response body as a JSON object, or an assertion failure naming what was expected and showing
+    /// what actually came back. Handles both masking paths on this Gateway: the Cockpit
+    /// <c>MapFallback("{*path}")</c> shell (HTML - does not parse) and any other handler's JSON (parses,
+    /// but carries different properties, caught by the caller's property checks).
+    /// </summary>
+    public static async Task<JsonElement> AsJsonObjectAsync(HttpResponseMessage resp, string what)
+    {
+        var body = await resp.Content.ReadAsStringAsync();
+
+        JsonDocument? doc = null;
+        try { doc = JsonDocument.Parse(body); }
+        catch (JsonException) { /* asserted below, never thrown */ }
+
+        Assert.True(doc is not null,
+            $"{what}: expected this handler's JSON, but the body does not parse as JSON at all " +
+            $"(HTTP {(int)resp.StatusCode}). A masking route answered - most likely the Cockpit " +
+            $"single-page-app fallback. Body: {Preview(body)}");
+
+        using (doc)
+        {
+            Assert.True(doc!.RootElement.ValueKind == JsonValueKind.Object,
+                $"{what}: expected a JSON object from this handler, got {doc.RootElement.ValueKind}. " +
+                $"Body: {Preview(body)}");
+            return doc.RootElement.Clone();
+        }
+    }
+
+    /// <summary>
+    /// One property of the handler's answer, or an assertion failure listing what the body DID carry.
+    /// Reading it with the indexer instead would throw, and a throw does not prove the row.
+    /// </summary>
+    public static JsonElement Prop(JsonElement root, string name, string what)
+    {
+        Assert.True(root.TryGetProperty(name, out var value),
+            $"{what}: the response has no '{name}' property, so it did not come from this handler. " +
+            $"It carried: [{string.Join(", ", root.EnumerateObject().Select(p => p.Name))}]");
+        return value;
+    }
+
+    /// <summary>
+    /// A string property of one ARRAY ELEMENT, or null. Never throws: an element that lacks the property
+    /// must reach the caller's Assert as a value, not as a KeyNotFoundException, or the resulting red
+    /// would be a crash and would not prove the row.
+    /// </summary>
+    public static string? Str(JsonElement element, string name)
+        => element.ValueKind == JsonValueKind.Object && element.TryGetProperty(name, out var v)
+            && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+
+    private static string Preview(string body)
+    {
+        var flat = body.Replace('\r', ' ').Replace('\n', ' ').Trim();
+        return flat.Length <= 200 ? flat : flat[..200] + "...";
+    }
+}
+
+/// <summary>
 /// Four route families that serve one account's CONTENT to any other account's authenticated device key
 /// are refused on the hosted Gateway. Issues #1897, #1853 (read side), #1896 and #1884.
 ///
@@ -149,8 +224,10 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
     public async Task Transcription_analysis_reads_are_refused_to_an_enrolled_tenant(string path)
     {
         var resp = await Send(HttpMethod.Get, path);
+        // Fingerprint FIRST, status second: a renamed route must redden on "this is not the refusal
+        // body", not on "404 != 404". Asserting status ahead of the body would prove a route changed.
+        await AssertBodyIsNothingButTheRefusal(resp, TranscriptionRefusal, $"GET {path}");
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
-        await AssertBodyIsNothingButTheRefusal(resp, TranscriptionRefusal);
     }
 
     /// <summary>
@@ -168,8 +245,8 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
     public async Task Wingman_instructions_reads_are_refused_to_an_enrolled_tenant(string path)
     {
         var resp = await Send(HttpMethod.Get, path);
+        await AssertBodyIsNothingButTheRefusal(resp, InstructionsRefusal, $"GET {path}");
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
-        await AssertBodyIsNothingButTheRefusal(resp, InstructionsRefusal);
     }
 
     /// <summary>
@@ -186,8 +263,8 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
         string method, string path, string body)
     {
         var resp = await Send(new HttpMethod(method), path, body);
+        await AssertBodyIsNothingButTheRefusal(resp, InstructionsRefusal, $"{method} {path}");
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
-        await AssertBodyIsNothingButTheRefusal(resp, InstructionsRefusal);
     }
 
     /// <summary>
@@ -203,8 +280,8 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
         string method, string path, string body)
     {
         var resp = await Send(new HttpMethod(method), path, body);
+        await AssertBodyIsNothingButTheRefusal(resp, UtteranceRefusal, $"{method} {path}");
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
-        await AssertBodyIsNothingButTheRefusal(resp, UtteranceRefusal);
     }
 
     /// <summary>
@@ -223,8 +300,8 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
         string method, string path, string body)
     {
         var resp = await Send(new HttpMethod(method), path, body);
+        await AssertBodyIsNothingButTheRefusal(resp, DictationRefusal, $"{method} {path}");
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
-        await AssertBodyIsNothingButTheRefusal(resp, DictationRefusal);
     }
 
     /// <summary>
@@ -273,16 +350,14 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
     /// extra, anything new, and anything metadata-looking reddens automatically without this file being
     /// touched.
     /// </summary>
-    private static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp, string expected)
+    private static async Task AssertBodyIsNothingButTheRefusal(
+        HttpResponseMessage resp, string expected, string what)
     {
-        var body = await resp.Content.ReadAsStringAsync();
+        var root = await ContentFingerprint.AsJsonObjectAsync(resp, what);
 
-        using var doc = JsonDocument.Parse(body);
-        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
-
-        var properties = doc.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+        var properties = root.EnumerateObject().Select(p => p.Name).ToArray();
         Assert.Equal(new[] { "error" }, properties);
-        Assert.Equal(expected, doc.RootElement.GetProperty("error").GetString());
+        Assert.Equal(expected, ContentFingerprint.Prop(root, "error", what).GetString());
     }
 
     private Task<HttpResponseMessage> Send(HttpMethod method, string path, string? body = null,
@@ -496,7 +571,7 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     {
         var root = await GetJsonAsync("transcription/turns");
 
-        var texts = root.GetProperty("turns").EnumerateArray()
+        var texts = ContentFingerprint.Prop(root, "turns", "GET transcription/turns").EnumerateArray()
             .Select(t => t.TryGetProperty("rawText", out var r) ? r.GetString() : null)
             .ToArray();
         Assert.Contains(SeededRawText, texts);
@@ -509,8 +584,8 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
 
         // Exactly one turn was planted into an isolated, otherwise-empty log, so this is an exact figure
         // rather than a "greater than zero" that an accidental extra record could satisfy.
-        Assert.Equal(1, root.GetProperty("totalTurns").GetInt32());
-        Assert.Equal(1, root.GetProperty("successfulTurns").GetInt32());
+        Assert.Equal(1, ContentFingerprint.Prop(root, "totalTurns", "GET transcription/stats").GetInt32());
+        Assert.Equal(1, ContentFingerprint.Prop(root, "successfulTurns", "GET transcription/stats").GetInt32());
     }
 
     [Fact]
@@ -518,8 +593,8 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     {
         var root = await GetJsonAsync("transcription/terms");
 
-        var pairs = root.GetProperty("terms").EnumerateArray()
-            .Select(t => (t.GetProperty("find").GetString(), t.GetProperty("replace").GetString()))
+        var pairs = ContentFingerprint.Prop(root, "terms", "GET transcription/terms").EnumerateArray()
+            .Select(t => (ContentFingerprint.Str(t, "find"), ContentFingerprint.Str(t, "replace")))
             .ToArray();
         Assert.Contains((SeededFind, SeededReplace), pairs);
     }
@@ -529,8 +604,8 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     {
         var root = await GetJsonAsync("transcription/words");
 
-        var words = root.GetProperty("words").EnumerateArray()
-            .Select(w => w.GetProperty("word").GetString())
+        var words = ContentFingerprint.Prop(root, "words", "GET transcription/words").EnumerateArray()
+            .Select(w => ContentFingerprint.Str(w, "word"))
             .ToArray();
         Assert.Contains(SeededWord, words);
     }
@@ -547,11 +622,12 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     {
         var root = await GetJsonAsync("gateway/wingman/instructions/records");
 
-        var records = root.GetProperty("records").EnumerateArray().ToArray();
+        var records = ContentFingerprint.Prop(root, "records", "GET gateway/wingman/instructions/records")
+            .EnumerateArray().ToArray();
         var seeded = Assert.Single(records,
-            r => r.GetProperty("id").GetString()!.EndsWith("#0", StringComparison.Ordinal));
-        Assert.StartsWith("wingman-training-", seeded.GetProperty("id").GetString());
-        Assert.Contains(SeededReply, seeded.GetProperty("replyPreview").GetString());
+            r => (ContentFingerprint.Str(r, "id") ?? "").EndsWith("#0", StringComparison.Ordinal));
+        Assert.StartsWith("wingman-training-", ContentFingerprint.Str(seeded, "id"));
+        Assert.Contains(SeededReply, ContentFingerprint.Str(seeded, "replyPreview") ?? "");
     }
 
     /// <summary>
@@ -566,20 +642,28 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
 
         var saved = await Send(HttpMethod.Put, "gateway/wingman/instructions",
             JsonSerializer.Serialize(new { content }));
-        Assert.Equal(HttpStatusCode.OK, saved.StatusCode);
+        // Fingerprint, not status: re-verbing this route sends the request to the Cockpit fallback, and a
+        // status check would redden on 404 rather than on "that was not the save handler answering".
+        var savedBody = await JsonAsync(saved, "PUT gateway/wingman/instructions");
+        Assert.Equal(content, ContentFingerprint.Str(
+            ContentFingerprint.Prop(savedBody, "active", "PUT gateway/wingman/instructions"), "content"));
 
         var active = await GetJsonAsync("gateway/wingman/instructions");
-        Assert.Equal(content, active.GetProperty("active").GetProperty("content").GetString());
-        Assert.True(active.GetProperty("isCustomized").GetBoolean());
+        var activeVersion = ContentFingerprint.Prop(active, "active", "GET gateway/wingman/instructions");
+        Assert.Equal(content,
+            ContentFingerprint.Prop(activeVersion, "content", "GET gateway/wingman/instructions").GetString());
+        Assert.True(ContentFingerprint.Prop(active, "isCustomized", "GET gateway/wingman/instructions").GetBoolean());
 
         var versions = await GetJsonAsync("gateway/wingman/instructions/versions");
-        Assert.Contains(versions.GetProperty("versions").EnumerateArray(),
-            v => v.GetProperty("content").GetString() == content);
+        Assert.Contains(
+            ContentFingerprint.Prop(versions, "versions", "GET gateway/wingman/instructions/versions").EnumerateArray(),
+            v => v.TryGetProperty("content", out var c) && c.GetString() == content);
 
         // The managed-default review must now report the box as customized - a state change this test
         // caused, read back through a DIFFERENT route than the one that caused it.
         var update = await GetJsonAsync("gateway/wingman/instructions/update");
-        Assert.True(update.GetProperty("isCustomized").GetBoolean());
+        Assert.True(ContentFingerprint.Prop(update, "isCustomized", "GET gateway/wingman/instructions/update")
+            .GetBoolean());
     }
 
     /// <summary>
@@ -596,7 +680,8 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         Assert.Equal(
             new[] { "version", "hash", "content" },
             root.EnumerateObject().Select(p => p.Name).ToArray());
-        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("content").GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(
+            ContentFingerprint.Prop(root, "content", "GET gateway/wingman/instructions/default").GetString()));
     }
 
     // ===== The two upload families: every leg leaves a receipt =====
@@ -612,14 +697,15 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     public async Task Self_host_utterance_upload_registers_and_stages_the_chunk_bytes()
     {
         var register = await Send(HttpMethod.Post, "wingman/utterance/upload", "");
-        Assert.Equal(HttpStatusCode.OK, register.StatusCode);
-        var id = (await JsonAsync(register)).GetProperty("upload_id").GetString();
+        var registerBody = await JsonAsync(register, "POST wingman/utterance/upload");
+        var id = ContentFingerprint.Prop(registerBody, "upload_id", "POST wingman/utterance/upload").GetString();
         Assert.False(string.IsNullOrWhiteSpace(id));
 
         var payload = Encoding.UTF8.GetBytes("utterance-bytes-zqxjv-" + Guid.NewGuid().ToString("N"));
         var chunk = await SendBytes(HttpMethod.Put, $"wingman/utterance/{id}/chunk/0", payload);
-        Assert.Equal(HttpStatusCode.OK, chunk.StatusCode);
-        Assert.Equal(0, (await JsonAsync(chunk)).GetProperty("index").GetInt32());
+        var chunkBody = await JsonAsync(chunk, "PUT wingman/utterance/{uploadId}/chunk/0");
+        Assert.Equal(0,
+            ContentFingerprint.Prop(chunkBody, "index", "PUT wingman/utterance/{uploadId}/chunk/0").GetInt32());
 
         AssertStagedOnDisk(payload);
     }
@@ -637,8 +723,9 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
 
         var payload = Encoding.UTF8.GetBytes("dictation-bytes-zqxjv-" + Guid.NewGuid().ToString("N"));
         var chunk = await SendBytes(HttpMethod.Put, $"dictation/{id}/chunk/0", payload);
-        Assert.Equal(HttpStatusCode.OK, chunk.StatusCode);
-        Assert.Equal(0, (await JsonAsync(chunk)).GetProperty("index").GetInt32());
+        var chunkBody = await JsonAsync(chunk, "PUT dictation/{uploadId}/chunk/0");
+        Assert.Equal(0,
+            ContentFingerprint.Prop(chunkBody, "index", "PUT dictation/{uploadId}/chunk/0").GetInt32());
 
         AssertStagedOnDisk(payload);
     }
@@ -656,15 +743,15 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         var id = await RegisterDictationAsync(key);
 
         var abandon = await Send(HttpMethod.Post, $"dictation/{id}/abandon", "");
-        Assert.Equal(HttpStatusCode.OK, abandon.StatusCode);
-        Assert.True((await JsonAsync(abandon)).GetProperty("abandoned").GetBoolean());
+        var abandonBody = await JsonAsync(abandon, "POST dictation/{uploadId}/abandon");
+        Assert.True(
+            ContentFingerprint.Prop(abandonBody, "abandoned", "POST dictation/{uploadId}/abandon").GetBoolean());
 
         var reRegister = await Send(HttpMethod.Post, "dictation/upload",
             "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}", key);
-        Assert.Equal(HttpStatusCode.OK, reRegister.StatusCode);
-        var again = await JsonAsync(reRegister);
-        Assert.True(again.GetProperty("terminal").GetBoolean());
-        Assert.True(again.GetProperty("dropped").GetBoolean());
+        var again = await JsonAsync(reRegister, "POST dictation/upload (re-register)");
+        Assert.True(ContentFingerprint.Prop(again, "terminal", "POST dictation/upload (re-register)").GetBoolean());
+        Assert.True(ContentFingerprint.Prop(again, "dropped", "POST dictation/upload (re-register)").GetBoolean());
     }
 
     /// <summary>
@@ -679,12 +766,14 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         await Send(HttpMethod.Post, $"dictation/{id}/abandon", "");
 
         var first = await Send(HttpMethod.Post, $"dictation/{id}/ack", "");
-        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
-        Assert.True((await JsonAsync(first)).GetProperty("retired").GetBoolean());
+        var firstBody = await JsonAsync(first, "POST dictation/{uploadId}/ack (first)");
+        Assert.True(
+            ContentFingerprint.Prop(firstBody, "retired", "POST dictation/{uploadId}/ack (first)").GetBoolean());
 
         var second = await Send(HttpMethod.Post, $"dictation/{id}/ack", "");
-        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
-        Assert.False((await JsonAsync(second)).GetProperty("retired").GetBoolean());
+        var secondBody = await JsonAsync(second, "POST dictation/{uploadId}/ack (second)");
+        Assert.False(
+            ContentFingerprint.Prop(secondBody, "retired", "POST dictation/{uploadId}/ack (second)").GetBoolean());
     }
 
     // ===== Helpers =====
@@ -697,25 +786,23 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     private async Task<JsonElement> GetJsonAsync(string path)
     {
         var resp = await Send(HttpMethod.Get, path);
-        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         await AssertNotTheHostedRefusal(resp);
-        return await JsonAsync(resp);
+        // NO status assertion here, deliberately. If this route is renamed the Cockpit fallback answers,
+        // and a status check would make the row redden on "404 != 200" - proving a route changed rather
+        // than proving this canary can tell the handler's answer from a masking route's. The caller's
+        // fingerprint assertion is the first thing allowed to fail.
+        return await ContentFingerprint.AsJsonObjectAsync(resp, "GET " + path);
     }
 
-    private static async Task<JsonElement> JsonAsync(HttpResponseMessage resp)
-    {
-        var body = await resp.Content.ReadAsStringAsync();
-        using var doc = JsonDocument.Parse(body);
-        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
-        return doc.RootElement.Clone();
-    }
+    private static Task<JsonElement> JsonAsync(HttpResponseMessage resp, string what)
+        => ContentFingerprint.AsJsonObjectAsync(resp, what);
 
     private async Task<string> RegisterDictationAsync(string idempotencyKey)
     {
         var resp = await Send(HttpMethod.Post, "dictation/upload",
             "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}", idempotencyKey);
-        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-        var id = (await JsonAsync(resp)).GetProperty("upload_id").GetString();
+        var body = await JsonAsync(resp, "POST dictation/upload");
+        var id = ContentFingerprint.Prop(body, "upload_id", "POST dictation/upload").GetString();
         Assert.False(string.IsNullOrWhiteSpace(id));
         return id!;
     }

--- a/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
@@ -210,6 +210,7 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
     private GatewayHost _gateway = null!;
     private HttpClient _http = null!;
     private string _key = "";
+    private string _unboundKey = "";
 
     private readonly string _instancesDir =
         Path.Combine(Path.GetTempPath(), "cc-hosted-content-" + Guid.NewGuid().ToString("N"));
@@ -244,6 +245,11 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
         _key = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
         var tenant = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
         _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", tenant.Value);
+
+        // A second, enrolled but DELIBERATELY UNBOUND device key: registered, so the host-wide auth gate
+        // lets it through, but tied to no account and therefore to no tenant. See
+        // Every_family_is_refused_to_a_caller_carrying_no_tenant_at_all for why this caller exists.
+        _unboundKey = _gateway.Devices.Register("dev-unbound", "MB").DeviceKey;
     }
 
     public async Task DisposeAsync()
@@ -375,6 +381,40 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
             ? Directory.EnumerateFileSystemEntries(_root, "*" + key + "*", SearchOption.AllDirectories).ToArray()
             : Array.Empty<string>();
         Assert.Empty(staged);
+    }
+
+    /// <summary>
+    /// THE GATE MUST NOT DEPEND ON RESOLVING A TENANT, AND THIS IS THE CASE THAT PROVES IT.
+    ///
+    /// The stated reason these denies read <see cref="GatewayHostedMode.IsHosted"/> directly, rather than
+    /// branching on a boundary or tenant argument, is that a security branch resting on an optional input
+    /// FAILS OPEN the moment a caller does not supply it. Every other hosted test here drives a fully
+    /// enrolled, tenant-BOUND device key - so all of them would still pass under a deny that quietly
+    /// depended on tenant resolution succeeding. The property that justifies the design choice is
+    /// invisible to them.
+    ///
+    /// This is that property's case: a device key that is registered (so the host-wide auth gate admits
+    /// it) but bound to NO account and therefore carrying NO tenant - the closest thing this surface has
+    /// to "the caller omitted the argument". It must be refused exactly as the bound caller is, with the
+    /// same body, because the refusal was never about who is asking.
+    /// </summary>
+    [Theory]
+    [InlineData("GET", "transcription/turns", null, TranscriptionRefusal)]
+    [InlineData("GET", "gateway/wingman/instructions/records", null, InstructionsRefusal)]
+    [InlineData("POST", "wingman/utterance/upload", "", UtteranceRefusal)]
+    [InlineData("POST", "dictation/upload", "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}", DictationRefusal)]
+    public async Task Every_family_is_refused_to_a_caller_carrying_no_tenant_at_all(
+        string method, string path, string? body, string refusal)
+    {
+        var req = new HttpRequestMessage(new HttpMethod(method), path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _unboundKey);
+        if (body is not null)
+            req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        var resp = await _http.SendAsync(req);
+
+        await AssertBodyIsNothingButTheRefusal(resp, refusal, $"{method} {path} (unbound caller)");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
@@ -845,12 +845,38 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
     /// The ack leg gets its own receipt too, and it is a state TRANSITION rather than a single value:
     /// acking a tombstone retires it, so the first ack reports retired and a second ack on the same id
     /// reports not-retired. A catch-all answering both calls identically cannot produce that difference.
+    ///
+    /// THE PRECONDITION IS ASSERTED, NOT ASSUMED, AND THAT IS THE WHOLE CORRECTION HERE. An earlier
+    /// version registered, abandoned, then acked twice - and passed IDENTICALLY when the abandon route was
+    /// renamed away, because <c>Acknowledge</c> only requires the staging DIRECTORY to exist and
+    /// registering alone creates it. So the transition it measured was directory-existence, not
+    /// tombstone-retirement: the test never established the tombstone it is named for. The route-mutation
+    /// sweep caught it - renaming POST /dictation/{id}/abandon left this row green when it was declared to
+    /// redden, which is precisely the canary-cannot-fail signal.
+    ///
+    /// It now reads the tombstone back through the register route BEFORE acking, so the abandon is load
+    /// bearing, and reads it back again AFTER to prove the retirement was real rather than a returned
+    /// boolean.
     /// </summary>
     [Fact]
     public async Task Self_host_dictation_ack_retires_the_tombstone_exactly_once()
     {
-        var id = await RegisterDictationAsync(Guid.NewGuid().ToString("N"));
-        await Send(HttpMethod.Post, $"dictation/{id}/abandon", "");
+        const string session = "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}";
+        var key = Guid.NewGuid().ToString("N");
+        var id = await RegisterDictationAsync(key);
+
+        var abandon = await Send(HttpMethod.Post, $"dictation/{id}/abandon", "");
+        var abandonBody = await JsonAsync(abandon, "POST dictation/{uploadId}/abandon");
+        Assert.True(
+            ContentFingerprint.Flag(abandonBody, "abandoned", "POST dictation/{uploadId}/abandon"));
+
+        // PRECONDITION: a terminal tombstone really exists now. If the abandon did not happen, this
+        // re-register is an ordinary fresh upload carrying no "terminal" property at all, and this
+        // assertion fails - which is what makes the rest of the test depend on the abandon.
+        var beforeAck = await JsonAsync(
+            await Send(HttpMethod.Post, "dictation/upload", session, key),
+            "POST dictation/upload (before ack)");
+        Assert.True(ContentFingerprint.Flag(beforeAck, "terminal", "POST dictation/upload (before ack)"));
 
         var first = await Send(HttpMethod.Post, $"dictation/{id}/ack", "");
         var firstBody = await JsonAsync(first, "POST dictation/{uploadId}/ack (first)");
@@ -861,6 +887,15 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         var secondBody = await JsonAsync(second, "POST dictation/{uploadId}/ack (second)");
         Assert.False(
             ContentFingerprint.Flag(secondBody, "retired", "POST dictation/{uploadId}/ack (second)"));
+
+        // AND the retirement was real: the same id now registers as a FRESH upload, with no terminal
+        // outcome to report. A returned "retired: true" alone would not have shown that.
+        var afterAck = await JsonAsync(
+            await Send(HttpMethod.Post, "dictation/upload", session, key),
+            "POST dictation/upload (after ack)");
+        Assert.False(afterAck.TryGetProperty("terminal", out _));
+        Assert.False(string.IsNullOrWhiteSpace(
+            ContentFingerprint.Text(afterAck, "upload_id", "POST dictation/upload (after ack)")));
     }
 
     // ===== Helpers =====

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -111,7 +111,11 @@ internal static class GatewayDictationEndpoint
             statusCode: StatusCodes.Status404NotFound);
     }
 
-    public static void Map(IEndpointRouteBuilder outer, DirectorRegistry registry,
+    /// Returns the guarded route group. That return value exists SOLELY so a test can map a brand-new
+    /// route onto the same group and prove it is refused on hosted with no deny written for it - the
+    /// property that distinguishes a group filter from a per-route guard, and which is otherwise
+    /// invisible to any test that only drives the routes existing today.
+    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, DirectorRegistry registry,
         SessionOwnerCache? owners, string token, GatewayTranscriptionService transcription,
         TranscribingSessions transcribingSessions, VoiceUploadStore uploads, Pairing.DeviceRegistry devices,
         Streaming.PushedSessionStore? pushedSessions = null,
@@ -328,6 +332,8 @@ internal static class GatewayDictationEndpoint
             FileLog.Write($"[GatewayDictation] abandon uploadId={uploadId} sid={sid}: marked ABANDONED, staging discarded");
             return Results.Json(new { ok = true, upload_id = uploadId, abandoned = true });
         });
+
+        return app;
     }
 
     // Map a NON-Ok transcription result to the dictation outcome, or null when the result is Ok and the

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -101,17 +101,28 @@ internal static class GatewayDictationEndpoint
     /// meaningless without a tenant to scope it to, and the store has none - so "not here" is the truthful
     /// answer. 403 would imply the right credential could reach it, and none can.
     ///
-    /// UN-DENY CONDITION - THE WRITE IS STOPPED. Nothing accumulates behind this refusal into the dictation
-    /// store, so lifting it does not expose a history built up while it stood. The five legs in this group
-    /// are the ONLY writers into the dictation <c>VoiceUploadStore</c>: the instance is constructed once in
-    /// <c>GatewayHost</c> against the dictation-uploads root and reaches this endpoint plus one read-only
-    /// status query, and every <c>uploads.</c> mutation in this file - register, mark pending, store chunk,
-    /// mark delivered, mark failed, acknowledge, mark abandoned - sits inside the guarded group. The static
-    /// <c>_completes</c> cache is filled only by the completion leg, which is refused too. NOTE THE
-    /// BOUNDARY OF THAT CLAIM: it is about THIS store. A completed dictation also used to write a turn into
-    /// the shared transcription telemetry log, and that log is the transcription-analysis family's problem,
-    /// not this one's - see the un-deny condition on <c>TranscriptionAnalysisEndpoint</c>, which is the
-    /// accumulating kind.
+    /// UN-DENY CONDITION. Two SEPARATE questions, because answering only the first is how a deny gets
+    /// mistaken for a clean slate.
+    ///
+    /// (a) DOES ANYTHING STILL WRITE IT? No - checked by enumerating WRITERS rather than by looking at the
+    /// denied routes, which is the question that actually matters. Every <c>VoiceUploadStore</c> construction
+    /// in the repository was listed: the only production one on the dictation-uploads root is the instance
+    /// <c>GatewayHost</c> holds as <c>_dictationUploads</c>, which reaches this endpoint plus one READ-only
+    /// status query (<c>DictationStatusFor</c>); <c>DictationLockReader</c> in Core also only reads.
+    /// Every <c>uploads.</c> mutation in this file - register, mark pending, store chunk, mark delivered,
+    /// mark failed, acknowledge, mark abandoned - is inside the guarded group, and the static
+    /// <c>_completes</c> cache is filled only by the completion leg, which is refused too.
+    /// <c>SweepAbandoned</c> has no production caller. The only residual write is the constructor ensuring
+    /// the directory exists: an empty directory, never content.
+    ///
+    /// (b) WHAT ALREADY EXISTS? Unknown, and presumed contaminated. The shared dictation-uploads root may
+    /// hold pre-deny cross-tenant staged audio, delivery records and transcripts. SO THE UN-DENY STILL
+    /// REQUIRES PURGING OR QUARANTINING THE LEGACY ROOT, on top of issue #1884's tenant-keying of the store,
+    /// the record and the <c>_completes</c> cache.
+    ///
+    /// NOTE THE BOUNDARY OF THE (a) CLAIM: it is about THIS store. A completed dictation also writes a turn
+    /// into the shared transcription telemetry log, and that log has live writers outside any deny - see the
+    /// un-deny condition on <c>TranscriptionAnalysisEndpoint</c>, which is the accumulating kind.
     /// </summary>
     private static IResult? DenyOnHosted()
     {
@@ -152,6 +163,36 @@ internal static class GatewayDictationEndpoint
         // the dictation through the tunnel-first SessionVerbClient (the delivery marker rides the PromptRequest
         // DeliveryUploadId field, not an HTTP header), so this path no longer HTTP-dials the Director.
         var stale = streamStale ?? TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
+
+        // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - deliberately, and that is the only reason
+        // MapRoutes exists as a separate method. Copied from the key-vault deny (pull request #1904), which
+        // is the reviewed instance of this pattern.
+        //
+        // Written inline here, beside both builders, each of these FIVE routes could INDIVIDUALLY be mapped
+        // onto `outer` instead of onto `app` - a one-word edit that compiles, passes every existing test,
+        // and opens exactly that route on hosted while the other four stay correctly denied. That is five
+        // independently bypassable primitives, and under the bypassability rule each would owe its own
+        // full-suite security run. Handing the guarded group to a method that never receives the ungrouped
+        // builder makes the mistake INEXPRESSIBLE rather than merely unlikely: inside MapRoutes there is
+        // nothing to map onto except the guarded group. The count falls by DESIGN, not by an argument about
+        // how careful the next author will be.
+        MapRoutes(app, registry, owners, token, transcription, transcribingSessions, uploads, devices,
+            pushedSessions, sendCommand, stale);
+        return app;
+    }
+
+    /// <summary>
+    /// The five dictation upload routes. Takes the GUARDED group and nothing else - see the note at the call
+    /// site: the ungrouped route builder is deliberately out of scope here, so no route in this family can be
+    /// mapped around the hosted filter.
+    /// </summary>
+    private static void MapRoutes(RouteGroupBuilder app, DirectorRegistry registry,
+        SessionOwnerCache? owners, string token, GatewayTranscriptionService transcription,
+        TranscribingSessions transcribingSessions, VoiceUploadStore uploads, Pairing.DeviceRegistry devices,
+        Streaming.PushedSessionStore? pushedSessions,
+        DirectorCommandRouter.SendDirectorCommandAsync? sendCommand,
+        TimeSpan stale)
+    {
         app.MapPost("/dictation/upload", (DictationUploadRequest? body, HttpContext ctx) =>
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
@@ -344,8 +385,6 @@ internal static class GatewayDictationEndpoint
             FileLog.Write($"[GatewayDictation] abandon uploadId={uploadId} sid={sid}: marked ABANDONED, staging discarded");
             return Results.Json(new { ok = true, upload_id = uploadId, abandoned = true });
         });
-
-        return app;
     }
 
     // Map a NON-Ok transcription result to the dictation outcome, or null when the result is Ok and the

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -100,6 +100,18 @@ internal static class GatewayDictationEndpoint
     /// 404 rather than 403: on hosted this upload family does not exist as a concept - an upload id is
     /// meaningless without a tenant to scope it to, and the store has none - so "not here" is the truthful
     /// answer. 403 would imply the right credential could reach it, and none can.
+    ///
+    /// UN-DENY CONDITION - THE WRITE IS STOPPED. Nothing accumulates behind this refusal into the dictation
+    /// store, so lifting it does not expose a history built up while it stood. The five legs in this group
+    /// are the ONLY writers into the dictation <c>VoiceUploadStore</c>: the instance is constructed once in
+    /// <c>GatewayHost</c> against the dictation-uploads root and reaches this endpoint plus one read-only
+    /// status query, and every <c>uploads.</c> mutation in this file - register, mark pending, store chunk,
+    /// mark delivered, mark failed, acknowledge, mark abandoned - sits inside the guarded group. The static
+    /// <c>_completes</c> cache is filled only by the completion leg, which is refused too. NOTE THE
+    /// BOUNDARY OF THAT CLAIM: it is about THIS store. A completed dictation also used to write a turn into
+    /// the shared transcription telemetry log, and that log is the transcription-analysis family's problem,
+    /// not this one's - see the un-deny condition on <c>TranscriptionAnalysisEndpoint</c>, which is the
+    /// accumulating kind.
     /// </summary>
     private static IResult? DenyOnHosted()
     {

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -104,21 +104,25 @@ internal static class GatewayDictationEndpoint
     /// UN-DENY CONDITION. Two SEPARATE questions, because answering only the first is how a deny gets
     /// mistaken for a clean slate.
     ///
-    /// (a) DOES ANYTHING STILL WRITE IT? No - checked by enumerating WRITERS rather than by looking at the
-    /// denied routes, which is the question that actually matters. Every <c>VoiceUploadStore</c> construction
-    /// in the repository was listed: the only production one on the dictation-uploads root is the instance
-    /// <c>GatewayHost</c> holds as <c>_dictationUploads</c>, which reaches this endpoint plus one READ-only
-    /// status query (<c>DictationStatusFor</c>); <c>DictationLockReader</c> in Core also only reads.
-    /// Every <c>uploads.</c> mutation in this file - register, mark pending, store chunk, mark delivered,
-    /// mark failed, acknowledge, mark abandoned - is inside the guarded group, and the static
-    /// <c>_completes</c> cache is filled only by the completion leg, which is refused too.
-    /// <c>SweepAbandoned</c> has no production caller. The only residual write is the constructor ensuring
-    /// the directory exists: an empty directory, never content.
+    /// (a) DOES ANYTHING STILL WRITE IT? No. Checked by sweeping the COMPLETE MUTATING SURFACE of the state
+    /// rather than the routes that touch it: every <c>VoiceUploadStore</c> construction in the repository,
+    /// then every production caller of every mutating method on the type, and finally any raw file writer
+    /// into the root that bypasses the type. The only production instance on the dictation-uploads root is
+    /// the one <c>GatewayHost</c> holds as <c>_dictationUploads</c>, which reaches this endpoint plus one
+    /// READ-only status query (<c>DictationStatusFor</c>); Core's <c>DictationLockReader</c> also only reads.
+    /// Every mutation - register, mark pending, store chunk, assemble, delete, mark delivered, mark failed,
+    /// clear failed, record baseline, acknowledge, mark abandoned - is inside the guarded group or inside a
+    /// private helper (<c>RunCompleteCoreAsync</c>, <c>MapNonOkTranscription</c>) whose only caller is the
+    /// completion leg, which is itself refused. The static <c>_completes</c> cache is filled only by that
+    /// same leg. <c>SweepAbandoned</c> has no production caller. Nothing writes the root outside the store.
+    /// The only residual write is the constructor ensuring the directory exists: an empty directory, never
+    /// content.
     ///
-    /// (b) WHAT ALREADY EXISTS? Unknown, and presumed contaminated. The shared dictation-uploads root may
-    /// hold pre-deny cross-tenant staged audio, delivery records and transcripts. SO THE UN-DENY STILL
-    /// REQUIRES PURGING OR QUARANTINING THE LEGACY ROOT, on top of issue #1884's tenant-keying of the store,
-    /// the record and the <c>_completes</c> cache.
+    /// (b) WHAT ALREADY EXISTS? A SEPARATE QUESTION, and it is not answered by (a). NO NEW WRITES IS A
+    /// STATEMENT ABOUT THE FUTURE, NOT EVIDENCE ABOUT THE PAST. The shared dictation-uploads root may hold
+    /// pre-deny cross-tenant staged audio, delivery records and transcripts. SO THE UN-DENY STILL REQUIRES
+    /// PURGING OR QUARANTINING THE LEGACY ROOT, on top of issue #1884's tenant-keying of the store, the
+    /// record and the <c>_completes</c> cache.
     ///
     /// NOTE THE BOUNDARY OF THE (a) CLAIM: it is about THIS store. A completed dictation also writes a turn
     /// into the shared transcription telemetry log, and that log has live writers outside any deny - see the
@@ -176,6 +180,13 @@ internal static class GatewayDictationEndpoint
         // builder makes the mistake INEXPRESSIBLE rather than merely unlikely: inside MapRoutes there is
         // nothing to map onto except the guarded group. The count falls by DESIGN, not by an argument about
         // how careful the next author will be.
+        //
+        // THE LIMIT OF THAT PROPERTY, STATED SO NOBODY OVER-CLAIMS IT: it holds WITHIN THIS MAPPING SITE.
+        // It does not reach across sites. This deny is one of FOUR families, each creating its own group,
+        // attaching its own filter and mapping from its own site, so any one site can be wrong while the
+        // other three stay correct and no compiler notices. That is exactly why the registered proof is
+        // four filter-removal arms and four gate-inversion arms rather than one of each: the split removes
+        // the per-ROUTE bypass inside a family, it does not merge the four families into one primitive.
         MapRoutes(app, registry, owners, token, transcription, transcribingSessions, uploads, devices,
             pushedSessions, sendCommand, stale);
         return app;

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -39,6 +39,32 @@ namespace CcDirector.Gateway.Api;
 /// the tombstone is retired only by the client ack. Every route is token-gated via
 /// <see cref="AuthMiddleware.HasValidToken"/> so it holds even when the production tray Gateway runs with
 /// the global auth middleware off.
+///
+/// DENIED IN WHOLE ON HOSTED (issue #1884). This is the SIBLING of the utterance upload family denied in
+/// <see cref="GatewayWingmanVoiceEndpoint"/> under issue #1896 - a different route family standing on the
+/// same <see cref="VoiceUploadStore"/> shape, with the same defect: one on-disk root shared across every
+/// account, every directory and record and chunk keyed SOLELY by the caller-supplied upload id, a
+/// <c>DictationDeliveryRecord</c> that carries no tenant, and a static <c>_completes</c> cache keyed solely
+/// by that same id.
+///
+/// The disclosure is live and needs no session: after account A completes upload id X, account B posts
+/// /dictation/upload with <c>Idempotency-Key: X</c>, the terminal-register short-circuit reads A's record,
+/// and B is handed A's TRANSCRIPT. That leg never looks a session up, so the fact that /complete's session
+/// lookup already fails on hosted does not contain it. Before A reaches a terminal state, B can also
+/// overwrite A's chunks, or ack or abandon A's record.
+///
+/// A caller-supplied identifier is not a tenant boundary. Secrecy of an identifier is not authorization,
+/// and upload ids travel through client logs, retries and store-and-forward queues.
+///
+/// The whole family, not only the leg that hands text back: ack and abandon destroy another account's
+/// in-flight recording, which is the same missing boundary with a different consequence. It is a deny
+/// rather than a partition because the records carry no tenant to partition BY - partitioning the store is
+/// issue #1884's job, and un-denying is gated on it. It refuses rather than reporting an empty or dropped
+/// upload, because "your dictation was dropped" is a FALSE statement where a refusal is merely absent.
+///
+/// Self-host is COMPLETELY unchanged, and that is the control. Self-host has one tenant, so the shared root
+/// is the owner's own root and the phone's durable store-and-forward dictation lane behaves exactly as it
+/// always has.
 /// </summary>
 internal static class GatewayDictationEndpoint
 {
@@ -61,13 +87,51 @@ internal static class GatewayDictationEndpoint
     // is a single guid-pair and is bounded by real abandoned-upload volume.
     private static readonly ConcurrentDictionary<string, string> _uploadSids = new();
 
-    public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry,
+    /// <summary>
+    /// The hosted refusal for the whole /dictation upload family (issue #1884), or null on self-host where
+    /// nothing changes.
+    ///
+    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> - the INDEPENDENT deployment signal - and NOT on a
+    /// boundary or tenant argument being passed in. A security branch that depends on an optional argument
+    /// fails OPEN when a caller omits it, which is exactly how the hosted account-status fix nearly shipped
+    /// a hole: omit the argument and a hosted Gateway silently takes the self-host path. Asking hosted mode
+    /// directly means this family cannot hand back another account's transcript however the host is wired.
+    ///
+    /// 404 rather than 403: on hosted this upload family does not exist as a concept - an upload id is
+    /// meaningless without a tenant to scope it to, and the store has none - so "not here" is the truthful
+    /// answer. 403 would imply the right credential could reach it, and none can.
+    /// </summary>
+    private static IResult? DenyOnHosted()
+    {
+        if (!GatewayHostedMode.IsHosted) return null;
+
+        FileLog.Write("[GatewayDictation] DENIED on hosted: the dictation upload store is keyed only by a caller-supplied id under one shared root, so an upload id is not a tenant boundary");
+        return Results.Json(
+            new { error = "dictation upload is not available on the hosted gateway" },
+            statusCode: StatusCodes.Status404NotFound);
+    }
+
+    public static void Map(IEndpointRouteBuilder outer, DirectorRegistry registry,
         SessionOwnerCache? owners, string token, GatewayTranscriptionService transcription,
         TranscribingSessions transcribingSessions, VoiceUploadStore uploads, Pairing.DeviceRegistry devices,
         Streaming.PushedSessionStore? pushedSessions = null,
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = null,
         TimeSpan? streamStale = null)
     {
+        FileLog.Write($"[GatewayDictation] mapping /dictation; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1884)");
+
+        // The whole group behind ONE filter, rather than a guard line repeated in every handler.
+        // A repeated guard is a thing to forget: the route added next year would be open by default and
+        // nobody would notice. A group filter runs before EVERY route mapped below, including routes that
+        // do not exist yet, so the refusal cannot rot as the group grows. The empty prefix keeps the route
+        // paths written out in full, exactly as before, so the self-host surface is byte-identical.
+        var app = outer.MapGroup("");
+        app.AddEndpointFilter(async (ctx, next) =>
+        {
+            if (DenyOnHosted() is { } denied) return denied;
+            return await next(ctx);
+        });
+
         // Gateway Cleanup mission, Phase 2 (PR E-B): resolve the owning Director push-store-first and inject
         // the dictation through the tunnel-first SessionVerbClient (the delivery marker rides the PromptRequest
         // DeliveryUploadId field, not an HTTP header), so this path no longer HTTP-dials the Director.

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -6,6 +6,7 @@ using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
 using CcDirector.Gateway.HostedAi;
+using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.Transcription;
 using CcDirector.Gateway.Util;
 using CcDirector.Gateway.Voice;
@@ -87,36 +88,41 @@ internal static class GatewayDictationEndpoint
     // is a single guid-pair and is bounded by real abandoned-upload volume.
     private static readonly ConcurrentDictionary<string, string> _uploadSids = new();
 
+    /// <summary>The exclusive prefix the dictation upload route group owns outright on hosted.</summary>
+    internal const string Prefix = "/dictation";
+
+    /// <summary>The single error string the hosted refusal serves. Held here so a test can assert against the
+    /// exact string that is served rather than a copy that could drift.</summary>
+    internal const string RefusalMessage = "dictation upload is not available on the hosted gateway";
+
     /// <summary>
-    /// The hosted refusal for the whole /dictation upload family (issue #1884), or null on self-host where
-    /// nothing changes.
-    ///
-    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> - the INDEPENDENT deployment signal - and NOT on a
-    /// boundary or tenant argument being passed in. A security branch that depends on an optional argument
-    /// fails OPEN when a caller omits it, which is exactly how the hosted account-status fix nearly shipped
-    /// a hole: omit the argument and a hosted Gateway silently takes the self-host path. Asking hosted mode
-    /// directly means this family cannot hand back another account's transcript however the host is wired.
-    ///
-    /// 404 rather than 403: on hosted this upload family does not exist as a concept - an upload id is
-    /// meaningless without a tenant to scope it to, and the store has none - so "not here" is the truthful
-    /// answer. 403 would imply the right credential could reach it, and none can.
+    /// The hosted refusal payload for the whole /dictation upload family (issue #1884). Validated on
+    /// construction, so a blank field fails the Gateway at startup rather than serving a refusal a caller
+    /// cannot act on. 404 rather than 403: on hosted this upload family does not exist as a concept - an
+    /// upload id is meaningless without a tenant to scope it to, and the store has none - so "not here" is
+    /// the truthful answer; 403 would imply the right credential could reach it, and none can. Driven off
+    /// <see cref="GatewayHostedMode.IsHosted"/> inside the primitive - the INDEPENDENT deployment signal, not
+    /// an optional argument a caller can omit and thereby fail OPEN.
     ///
     /// UN-DENY CONDITION. Two SEPARATE questions, because answering only the first is how a deny gets
     /// mistaken for a clean slate.
     ///
-    /// (a) DOES ANYTHING STILL WRITE IT? No. Checked by sweeping the COMPLETE MUTATING SURFACE of the state
-    /// rather than the routes that touch it: every <c>VoiceUploadStore</c> construction in the repository,
-    /// then every production caller of every mutating method on the type, and finally any raw file writer
-    /// into the root that bypasses the type. The only production instance on the dictation-uploads root is
-    /// the one <c>GatewayHost</c> holds as <c>_dictationUploads</c>, which reaches this endpoint plus one
-    /// READ-only status query (<c>DictationStatusFor</c>); Core's <c>DictationLockReader</c> also only reads.
-    /// Every mutation - register, mark pending, store chunk, assemble, delete, mark delivered, mark failed,
-    /// clear failed, record baseline, acknowledge, mark abandoned - is inside the guarded group or inside a
-    /// private helper (<c>RunCompleteCoreAsync</c>, <c>MapNonOkTranscription</c>) whose only caller is the
-    /// completion leg, which is itself refused. The static <c>_completes</c> cache is filled only by that
-    /// same leg. <c>SweepAbandoned</c> has no production caller. Nothing writes the root outside the store.
-    /// The only residual write is the constructor ensuring the directory exists: an empty directory, never
-    /// content.
+    /// (a) DOES ANYTHING STILL WRITE IT? No, and NO OFF-ROUTE WRITER NEEDS A HOST-GATE HERE. Checked by
+    /// sweeping the COMPLETE MUTATING SURFACE of the state rather than the routes that touch it: every
+    /// <c>VoiceUploadStore</c> construction in the repository, then every production caller of every mutating
+    /// method on the type, and finally any raw file writer into the root that bypasses the type. The only
+    /// production instance on the dictation-uploads root is the one <c>GatewayHost</c> holds as
+    /// <c>_dictationUploads</c>, which reaches this endpoint plus one READ-only status query
+    /// (<c>DictationStatusFor</c>); Core's <c>DictationLockReader</c> also only reads. Every mutation -
+    /// register, mark pending, store chunk, assemble, delete, mark delivered, mark failed, clear failed,
+    /// record baseline, acknowledge, mark abandoned - is inside this refused group or inside a private helper
+    /// (<c>RunCompleteCoreAsync</c>, <c>MapNonOkTranscription</c>) whose only caller is the completion leg,
+    /// which is itself refused. The static <c>_completes</c> cache is filled only by that same leg.
+    /// <c>SweepAbandoned</c> has no production caller. Nothing writes the root outside the store. The only
+    /// residual write is the constructor ensuring the directory exists: an empty directory, never content. So
+    /// with the routes refused, no writer to this store reaches it on hosted - there is no OFF-route writer
+    /// to gate (unlike the transcription-telemetry and wingman-training stores, whose writers fire from
+    /// undenied paths and are host-gated at the writer).
     ///
     /// (b) WHAT ALREADY EXISTS? A SEPARATE QUESTION, and it is not answered by (a). NO NEW WRITES IS A
     /// STATEMENT ABOUT THE FUTURE, NOT EVIDENCE ABOUT THE PAST. The shared dictation-uploads root may hold
@@ -125,86 +131,79 @@ internal static class GatewayDictationEndpoint
     /// record and the <c>_completes</c> cache.
     ///
     /// NOTE THE BOUNDARY OF THE (a) CLAIM: it is about THIS store. A completed dictation also writes a turn
-    /// into the shared transcription telemetry log, and that log has live writers outside any deny - see the
-    /// un-deny condition on <c>TranscriptionAnalysisEndpoint</c>, which is the accumulating kind.
+    /// into the shared transcription telemetry log - but that writer is now host-gated in
+    /// <c>GatewayTranscriptionService.RecordTelemetry</c>, so it too stops on hosted (see the un-deny
+    /// condition on <c>TranscriptionAnalysisEndpoint</c>).
+    ///
+    /// HOW THE DENY IS EXPRESSED - THE SHARED REFUSAL PRIMITIVE, NOT A BESPOKE FILTER. This group is denied
+    /// through <see cref="HostedRouteDeny.ExclusiveGroup"/>, the ONE hosted-refusal boundary every deny
+    /// family on this Gateway adopts (reference implementation: the key-vault deny in pull request #1904). An
+    /// earlier revision rolled its own <c>AddEndpointFilter</c> deny before the primitive existed; it has
+    /// been replaced. The family owns the <c>/dictation</c> prefix OUTRIGHT - nothing else serves beneath it
+    /// - so on hosted the five handlers are NEVER MAPPED and ONE verb-less catch-all refuses everything under
+    /// the prefix plus a root refusal at the prefix itself, covering every verb, every request shape, and
+    /// every future sub-path for free. The exclusivity claim is CHECKED at startup by
+    /// <see cref="HostedRefusalRouteSpace.ValidateBeforeStart"/>. Off hosted the primitive maps the five real
+    /// handlers exactly as an unguarded builder would - self-host unchanged.
     /// </summary>
-    private static IResult? DenyOnHosted()
-    {
-        if (!GatewayHostedMode.IsHosted) return null;
+    private static HostedDenial Denial() => new(
+        family: "dictation-upload",
+        message: RefusalMessage,
+        reason: "the dictation upload store keys every directory, record and chunk SOLELY by the caller-supplied " +
+                "upload id under one on-disk root shared across every account, and a re-register of another " +
+                "account's upload id short-circuits on its terminal tombstone and hands back that account's " +
+                "transcript with no session lookup in the way - so a caller-supplied id is not a tenant boundary",
+        unDenyInstruction: "do NOT simply remove this deny: tenant-key the store, the delivery record and the " +
+                "_completes cache, THEN purge or quarantine the pre-existing shared dictation-uploads root " +
+                "(pre-deny cross-tenant staged audio, records and transcripts are already in it and this change " +
+                "never touched them), and only then restore a tenant-scoped route",
+        statusCode: StatusCodes.Status404NotFound);
 
-        FileLog.Write("[GatewayDictation] DENIED on hosted: the dictation upload store is keyed only by a caller-supplied id under one shared root, so an upload id is not a tenant boundary");
-        return Results.Json(
-            new { error = "dictation upload is not available on the hosted gateway" },
-            statusCode: StatusCodes.Status404NotFound);
-    }
-
-    /// Returns the guarded route group. That return value exists SOLELY so a test can map a brand-new
-    /// route onto the same group and prove it is refused on hosted with no deny written for it - the
-    /// property that distinguishes a group filter from a per-route guard, and which is otherwise
-    /// invisible to any test that only drives the routes existing today.
-    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, DirectorRegistry registry,
+    /// <summary>
+    /// Maps the dictation routes and RETURNS the denied group they were mapped through. The routes are mapped
+    /// through the group HANDLE (<see cref="HostedDenyGroup"/>), never through the ungrouped builder: the
+    /// handle is obtainable only from <see cref="HostedRouteDeny"/>, so a route mapped around the refusal is
+    /// not expressible in <see cref="MapRoutes"/> without changing its signature - the bypass count is reduced
+    /// by design, not by care. On hosted the exclusive catch-all refuses the whole group and each handler is
+    /// DISCARDED; off hosted the handle maps each handler as an unguarded builder would. The return value
+    /// exists so a test can map a brand-new route through the returned handle and show the refusal already
+    /// covers routes nobody has written yet.
+    /// </summary>
+    public static HostedDenyGroup Map(IEndpointRouteBuilder outer, DirectorRegistry registry,
         SessionOwnerCache? owners, string token, GatewayTranscriptionService transcription,
         TranscribingSessions transcribingSessions, VoiceUploadStore uploads, Pairing.DeviceRegistry devices,
         Streaming.PushedSessionStore? pushedSessions = null,
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = null,
         TimeSpan? streamStale = null)
     {
-        FileLog.Write($"[GatewayDictation] mapping /dictation; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1884)");
+        FileLog.Write($"[GatewayDictation] mapping {Prefix}; hosted={GatewayHostedMode.IsHosted} - on hosted the whole group is refused via the shared refusal primitive (issue #1884)");
 
-        // The whole group behind ONE filter, rather than a guard line repeated in every handler.
-        // A repeated guard is a thing to forget: the route added next year would be open by default and
-        // nobody would notice. A group filter runs before EVERY route mapped below, including routes that
-        // do not exist yet, so the refusal cannot rot as the group grows. The empty prefix keeps the route
-        // paths written out in full, exactly as before, so the self-host surface is byte-identical.
-        var app = outer.MapGroup("");
-        app.AddEndpointFilter(async (ctx, next) =>
-        {
-            if (DenyOnHosted() is { } denied) return denied;
-            return await next(ctx);
-        });
+        var app = HostedRouteDeny.ExclusiveGroup(outer, Prefix, Denial());
 
         // Gateway Cleanup mission, Phase 2 (PR E-B): resolve the owning Director push-store-first and inject
         // the dictation through the tunnel-first SessionVerbClient (the delivery marker rides the PromptRequest
         // DeliveryUploadId field, not an HTTP header), so this path no longer HTTP-dials the Director.
         var stale = streamStale ?? TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
 
-        // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - deliberately, and that is the only reason
-        // MapRoutes exists as a separate method. Copied from the key-vault deny (pull request #1904), which
-        // is the reviewed instance of this pattern.
-        //
-        // Written inline here, beside both builders, each of these FIVE routes could INDIVIDUALLY be mapped
-        // onto `outer` instead of onto `app` - a one-word edit that compiles, passes every existing test,
-        // and opens exactly that route on hosted while the other four stay correctly denied. That is five
-        // independently bypassable primitives, and under the bypassability rule each would owe its own
-        // full-suite security run. Handing the guarded group to a method that never receives the ungrouped
-        // builder makes the mistake INEXPRESSIBLE rather than merely unlikely: inside MapRoutes there is
-        // nothing to map onto except the guarded group. The count falls by DESIGN, not by an argument about
-        // how careful the next author will be.
-        //
-        // THE LIMIT OF THAT PROPERTY, STATED SO NOBODY OVER-CLAIMS IT: it holds WITHIN THIS MAPPING SITE.
-        // It does not reach across sites. This deny is one of FOUR families, each creating its own group,
-        // attaching its own filter and mapping from its own site, so any one site can be wrong while the
-        // other three stay correct and no compiler notices. That is exactly why the registered proof is
-        // four filter-removal arms and four gate-inversion arms rather than one of each: the split removes
-        // the per-ROUTE bypass inside a family, it does not merge the four families into one primitive.
         MapRoutes(app, registry, owners, token, transcription, transcribingSessions, uploads, devices,
             pushedSessions, sendCommand, stale);
         return app;
     }
 
     /// <summary>
-    /// The five dictation upload routes. Takes the GUARDED group and nothing else - see the note at the call
-    /// site: the ungrouped route builder is deliberately out of scope here, so no route in this family can be
-    /// mapped around the hosted filter.
+    /// The five dictation upload routes, mapped relative to the <see cref="Prefix"/> so the full paths are
+    /// <c>/dictation/upload</c> and <c>/dictation/{uploadId}/...</c> exactly as before. Takes the denied GROUP
+    /// HANDLE and nothing else: the ungrouped route builder is deliberately out of scope here, so no route in
+    /// this family can be mapped around the hosted refusal.
     /// </summary>
-    private static void MapRoutes(RouteGroupBuilder app, DirectorRegistry registry,
+    private static void MapRoutes(HostedDenyGroup app, DirectorRegistry registry,
         SessionOwnerCache? owners, string token, GatewayTranscriptionService transcription,
         TranscribingSessions transcribingSessions, VoiceUploadStore uploads, Pairing.DeviceRegistry devices,
         Streaming.PushedSessionStore? pushedSessions,
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand,
         TimeSpan stale)
     {
-        app.MapPost("/dictation/upload", (DictationUploadRequest? body, HttpContext ctx) =>
+        app.MapPost("/upload", (DictationUploadRequest? body, HttpContext ctx) =>
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
@@ -241,7 +240,7 @@ internal static class GatewayDictationEndpoint
             return Results.Json(new { upload_id = uploadId });
         });
 
-        app.MapPut("/dictation/{uploadId}/chunk/{index:int}", async (string uploadId, int index, HttpContext ctx) =>
+        app.MapPut("/{uploadId}/chunk/{index:int}", async (string uploadId, int index, HttpContext ctx) =>
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
@@ -267,7 +266,7 @@ internal static class GatewayDictationEndpoint
             }
         });
 
-        app.MapPost("/dictation/{uploadId}/complete", async (string uploadId, DictationCompleteRequest? req, HttpContext ctx) =>
+        app.MapPost("/{uploadId}/complete", async (string uploadId, DictationCompleteRequest? req, HttpContext ctx) =>
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
@@ -355,7 +354,7 @@ internal static class GatewayDictationEndpoint
         // is a no-op returning retired=false. If the ack is lost the tombstone simply persists and a later
         // re-complete returns the same outcome and the client re-acks - so the tombstone is retired ONLY on
         // a real client ack, never by age.
-        app.MapPost("/dictation/{uploadId}/ack", (string uploadId, HttpContext ctx) =>
+        app.MapPost("/{uploadId}/ack", (string uploadId, HttpContext ctx) =>
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
@@ -372,7 +371,7 @@ internal static class GatewayDictationEndpoint
         // reconciles on its next contact - a re-register / re-complete of an abandoned id returns dropped, so
         // it drops its on-device copy with no resurrection and no duplicate. Abandon may target ANY surface's
         // dictation because it addresses the durable upload id, not the caller.
-        app.MapPost("/dictation/{uploadId}/abandon", (string uploadId, HttpContext ctx) =>
+        app.MapPost("/{uploadId}/abandon", (string uploadId, HttpContext ctx) =>
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -95,6 +95,14 @@ internal static class GatewayWingmanVoiceEndpoint
     /// 404 rather than 403: on hosted this upload family does not exist as a concept - an upload id is
     /// meaningless without a tenant to scope it to, and the store has none - so "not here" is the truthful
     /// answer. 403 would imply the right credential could reach it, and none can.
+    ///
+    /// UN-DENY CONDITION - THE WRITE IS STOPPED. Nothing accumulates behind this refusal, so lifting it does
+    /// not expose a history built up while it stood. The three legs in this group are the ONLY writers into
+    /// the voice-turn <c>VoiceUploadStore</c>: the store instance is constructed once in <c>GatewayHost</c>
+    /// and handed to this endpoint alone, and every <c>uploads.</c> call in this file sits inside the guarded
+    /// group. Registering, staging a chunk and assembling a transcript are all refused, so on hosted no
+    /// utterance bytes and no assembled transcript are written at all. (Whatever predates the deny is a
+    /// separate matter, and is covered by the partitioning gate in issue #1896.)
     /// </summary>
     private static IResult? DenyUtteranceOnHosted()
     {

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -13,6 +13,7 @@ using CcDirector.Core.Voice.Services;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
 using CcDirector.Gateway.HostedAi;
+using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.Voice;
 using CcDirector.Gateway.Wingman;
 using Microsoft.AspNetCore.Builder;
@@ -81,37 +82,41 @@ internal static class GatewayWingmanVoiceEndpoint
     private static IResult TooLarge(string error) =>
         Results.Json(new { error }, statusCode: StatusCodes.Status413PayloadTooLarge);
 
+    /// <summary>The exclusive prefix the /wingman/utterance upload route group owns outright on hosted.</summary>
+    internal const string UtterancePrefix = "/wingman/utterance";
+
+    /// <summary>The single error string the hosted utterance refusal serves. Held here so a test can assert
+    /// against the exact string that is served rather than a copy that could drift.</summary>
+    internal const string UtteranceRefusalMessage = "the wingman utterance upload is not available on the hosted gateway";
+
     /// <summary>
-    /// The hosted refusal for the whole /wingman/utterance upload family (issue #1896), or null on
-    /// self-host where nothing changes.
-    ///
-    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> - the INDEPENDENT deployment signal - and NOT on a
-    /// boundary or tenant argument being passed in. A security branch that depends on an optional argument
-    /// fails OPEN when a caller omits it, which is exactly how the hosted account-status fix nearly shipped
-    /// a hole: omit the argument and a hosted Gateway silently takes the self-host path. Asking hosted mode
-    /// directly means this family cannot serve another account's transcript on hosted however the host is
-    /// wired.
-    ///
-    /// 404 rather than 403: on hosted this upload family does not exist as a concept - an upload id is
-    /// meaningless without a tenant to scope it to, and the store has none - so "not here" is the truthful
-    /// answer. 403 would imply the right credential could reach it, and none can.
+    /// The hosted refusal payload for the whole /wingman/utterance upload family (issue #1896). Validated on
+    /// construction, so a blank field fails the Gateway at startup rather than serving a refusal a caller
+    /// cannot act on. 404 rather than 403: on hosted this upload family does not exist as a concept - an
+    /// upload id is meaningless without a tenant to scope it to, and the store has none - so "not here" is
+    /// the truthful answer; 403 would imply the right credential could reach it, and none can. Driven off
+    /// <see cref="GatewayHostedMode.IsHosted"/> inside the primitive - the INDEPENDENT deployment signal, not
+    /// an optional argument a caller can omit and thereby fail OPEN.
     ///
     /// UN-DENY CONDITION. Two SEPARATE questions, because answering only the first is how a deny gets
     /// mistaken for a clean slate. "Does anything still write this state" and "what is already sitting
     /// there" have different answers, and the second one does not improve while the deny stands.
     ///
-    /// (a) DOES ANYTHING STILL WRITE IT? No. Checked by sweeping the COMPLETE MUTATING SURFACE of the state
-    /// rather than the routes that touch it: every construction of a <c>VoiceUploadStore</c> in the
-    /// repository, then every production caller of every mutating method on the type (<c>Register</c>,
-    /// <c>StoreChunkAsync</c>, <c>AssembleAsync</c>, <c>Delete</c>, <c>MarkPending</c>,
-    /// <c>MarkDelivered</c>, <c>MarkAbandoned</c>, <c>MarkFailed</c>, <c>ClearFailed</c>,
-    /// <c>RecordFailedDeliveryBaseline</c>, <c>Acknowledge</c>, <c>SweepAbandoned</c>), and finally any raw
-    /// file writer into the root that bypasses the type entirely. The only production instance on this root
-    /// is the one <c>GatewayHost</c> holds as <c>_voiceTurnUploads</c> and hands to this endpoint alone;
-    /// every mutating call reached from this file is inside the guarded group; <c>SweepAbandoned</c> has NO
-    /// production caller at all, only a test; nothing writes the root outside the store. The one residual
-    /// write is the constructor calling <c>CcStorage.VoiceTurnUploads()</c>, which ENSURES the directory
-    /// exists: an empty directory, never content.
+    /// (a) DOES ANYTHING STILL WRITE IT? No, and NO OFF-ROUTE WRITER NEEDS A HOST-GATE HERE. Checked by
+    /// sweeping the COMPLETE MUTATING SURFACE of the state rather than the routes that touch it: every
+    /// construction of a <c>VoiceUploadStore</c> in the repository, then every production caller of every
+    /// mutating method on the type (<c>Register</c>, <c>StoreChunkAsync</c>, <c>AssembleAsync</c>,
+    /// <c>Delete</c>, <c>MarkPending</c>, <c>MarkDelivered</c>, <c>MarkAbandoned</c>, <c>MarkFailed</c>,
+    /// <c>ClearFailed</c>, <c>RecordFailedDeliveryBaseline</c>, <c>Acknowledge</c>, <c>SweepAbandoned</c>),
+    /// and finally any raw file writer into the root that bypasses the type entirely. The only production
+    /// instance on this root is the one <c>GatewayHost</c> holds as <c>_voiceTurnUploads</c> and hands to
+    /// this endpoint alone; every mutating call reached from this file is inside this refused group;
+    /// <c>SweepAbandoned</c> has NO production caller at all, only a test; nothing writes the root outside the
+    /// store. The one residual write is the constructor calling <c>CcStorage.VoiceTurnUploads()</c>, which
+    /// ENSURES the directory exists: an empty directory, never content. So with the routes refused, no writer
+    /// to this store reaches it on hosted - there is no OFF-route writer to gate (unlike the
+    /// transcription-telemetry and wingman-training stores, whose writers fire from undenied paths and are
+    /// host-gated at the writer).
     ///
     /// (b) WHAT ALREADY EXISTS? A SEPARATE QUESTION, and it is not answered by (a). NO NEW WRITES IS A
     /// STATEMENT ABOUT THE FUTURE, NOT EVIDENCE ABOUT THE PAST. The shared root may hold pre-deny
@@ -119,16 +124,30 @@ internal static class GatewayWingmanVoiceEndpoint
     /// untouched by it. SO THE UN-DENY STILL REQUIRES PURGING OR QUARANTINING THE LEGACY ROOT, on top of
     /// issue #1896's tenant-keying of the store - "the write is stopped" is not "the root is clean" and must
     /// never be read as the whole condition.
+    ///
+    /// HOW THE DENY IS EXPRESSED - THE SHARED REFUSAL PRIMITIVE, NOT A BESPOKE FILTER. This group is denied
+    /// through <see cref="HostedRouteDeny.ExclusiveGroup"/>, the ONE hosted-refusal boundary every deny
+    /// family on this Gateway adopts (reference implementation: the key-vault deny in pull request #1904). An
+    /// earlier revision rolled its own <c>AddEndpointFilter</c> deny before the primitive existed; it has
+    /// been replaced. The family owns the <c>/wingman/utterance</c> prefix OUTRIGHT - the rest of the voice
+    /// surface (voice-turn, tts, transcribe, explain, ask, menu) lives on OTHER paths and keeps serving on
+    /// hosted - so on hosted the three utterance handlers are NEVER MAPPED and ONE verb-less catch-all refuses
+    /// everything under the prefix plus a root refusal at the prefix itself, covering every verb, every
+    /// request shape, and every future sub-path for free. The exclusivity claim is CHECKED at startup by
+    /// <see cref="HostedRefusalRouteSpace.ValidateBeforeStart"/>. Off hosted the primitive maps the three real
+    /// handlers exactly as an unguarded builder would - self-host unchanged.
     /// </summary>
-    private static IResult? DenyUtteranceOnHosted()
-    {
-        if (!GatewayHostedMode.IsHosted) return null;
-
-        FileLog.Write("[GatewayWingmanVoice] DENIED on hosted: the utterance upload store is keyed only by a caller-supplied id under one shared root, so an upload id is not a tenant boundary");
-        return Results.Json(
-            new { error = "the wingman utterance upload is not available on the hosted gateway" },
-            statusCode: StatusCodes.Status404NotFound);
-    }
+    private static HostedDenial UtteranceDenial() => new(
+        family: "wingman-utterance",
+        message: UtteranceRefusalMessage,
+        reason: "the utterance upload store keys staged audio and the assembled transcript SOLELY by a " +
+                "caller-supplied Idempotency-Key under one on-disk root shared across every account, and complete " +
+                "returns the assembled transcript - so an account can claim another account's upload id and be " +
+                "handed the words it spoke, or overwrite its chunks before it completes",
+        unDenyInstruction: "do NOT simply remove this deny: tenant-key the utterance store, THEN purge or " +
+                "quarantine the pre-existing shared root (pre-deny cross-tenant staged audio and transcripts are " +
+                "already in it and this change never touched them), and only then restore a tenant-scoped route",
+        statusCode: StatusCodes.Status404NotFound);
 
     /// <summary>
     /// Read a request body into memory, giving up the moment it exceeds <paramref name="max"/>.
@@ -154,11 +173,12 @@ internal static class GatewayWingmanVoiceEndpoint
         }
     }
 
-    /// Returns the guarded route group. That return value exists SOLELY so a test can map a brand-new
+    /// Returns the DENIED utterance group. That return value exists SOLELY so a test can map a brand-new
     /// route onto the same group and prove it is refused on hosted with no deny written for it - the
-    /// property that distinguishes a group filter from a per-route guard, and which is otherwise
-    /// invisible to any test that only drives the routes existing today.
-    public static RouteGroupBuilder Map(
+    /// future-route property, which is otherwise invisible to any test that only drives the routes existing
+    /// today. Only the utterance family is denied; the rest of the voice surface stays on the ungrouped
+    /// builder and keeps serving on hosted.
+    public static HostedDenyGroup Map(
         IEndpointRouteBuilder app,
         DirectorRegistry registry,
         Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider,
@@ -376,19 +396,14 @@ internal static class GatewayWingmanVoiceEndpoint
         // Self-host is COMPLETELY unchanged: one tenant, so a shared root is the owner's own root, and the
         // phone's record-locally-and-keep-retrying path works exactly as it always has.
         //
-        // The group prefix reproduces the route paths character for character, so the self-host surface is
-        // byte-identical; the filter also covers legs added to this family later, which a per-route guard
-        // would not.
-        var utterance = app.MapGroup("/wingman/utterance");
-        utterance.AddEndpointFilter(async (ctx, next) =>
-        {
-            if (DenyUtteranceOnHosted() is { } denied) return denied;
-            return await next(ctx);
-        });
+        // The exclusive prefix reproduces the route paths character for character (the legs are written
+        // relative to it), so the self-host surface is byte-identical; on hosted the ONE catch-all under the
+        // prefix also covers legs added to this family later, which a per-route guard would not.
+        var utterance = HostedRouteDeny.ExclusiveGroup(app, UtterancePrefix, UtteranceDenial());
 
         // THE ROUTES ARE MAPPED WHERE THE UNFILTERED `app` IS NOT IN SCOPE - deliberately, and that is the
-        // only reason MapUtteranceRoutes exists as a separate method. Copied from the key-vault deny (pull
-        // request #1904), which is the reviewed instance of this pattern.
+        // only reason MapUtteranceRoutes exists as a separate method. It takes only the denied group handle
+        // (<see cref="HostedDenyGroup"/>), obtainable only from the refusal primitive.
         //
         // This file is the sharpest case of the problem, because unlike the other three families the
         // unfiltered builder is LEGITIMATELY here: the voice-turn, text-to-speech, transcribe, explain, ask
@@ -397,17 +412,17 @@ internal static class GatewayWingmanVoiceEndpoint
         // THREE utterance legs could INDIVIDUALLY be mapped onto `app` instead of onto `utterance`, a
         // one-word edit that compiles, passes every existing test, and opens that leg on hosted while the
         // other two stay correctly denied. Three independently bypassable primitives, each owing its own
-        // full-suite security run under the bypassability rule. Handing the guarded group to a method that
+        // full-suite security run under the bypassability rule. Handing the group handle to a method that
         // never receives `app` makes the mistake INEXPRESSIBLE rather than merely unlikely: inside
-        // MapUtteranceRoutes there is nothing to map onto except the guarded group. The count falls by
+        // MapUtteranceRoutes there is nothing to map onto except the group handle. The count falls by
         // DESIGN, not by an argument about how careful the next author will be.
         //
         // THE LIMIT OF THAT PROPERTY, STATED SO NOBODY OVER-CLAIMS IT: it holds WITHIN THIS MAPPING SITE.
-        // It does not reach across sites. This deny is one of FOUR families, each creating its own group,
-        // attaching its own filter and mapping from its own site, so any one site can be wrong while the
-        // other three stay correct and no compiler notices. That is exactly why the registered proof is
-        // four filter-removal arms and four gate-inversion arms rather than one of each: the split removes
-        // the per-ROUTE bypass inside a family, it does not merge the four families into one primitive.
+        // It does not reach across sites. This deny is one of FOUR families, each creating its own group and
+        // mapping from its own site, so any one site can be wrong while the other three stay correct and no
+        // compiler notices. That is exactly why the registered proof is four handler-restore arms rather than
+        // one: the group handle removes the per-ROUTE bypass inside a family, it does not merge the four
+        // families into one primitive.
         MapUtteranceRoutes(utterance, uploads, transcription);
 
         // Text-to-speech for the mobile Voice screen + Cockpit: turn the wingman's spoken summary into
@@ -821,11 +836,13 @@ internal static class GatewayWingmanVoiceEndpoint
     }
 
     /// <summary>
-    /// The three /wingman/utterance upload legs. Takes the GUARDED group and nothing else - see the note
-    /// at the call site: the unfiltered route builder that the rest of this file legitimately uses is
-    /// deliberately out of scope here, so no leg of this family can be mapped around the hosted filter.
+    /// The three /wingman/utterance upload legs, mapped relative to the <see cref="UtterancePrefix"/> so the
+    /// full paths are <c>/wingman/utterance/upload</c> and <c>/wingman/utterance/{uploadId}/...</c> exactly as
+    /// before. Takes the denied GROUP HANDLE and nothing else - see the note at the call site: the unfiltered
+    /// route builder that the rest of this file legitimately uses is deliberately out of scope here, so no leg
+    /// of this family can be mapped around the hosted refusal.
     /// </summary>
-    private static void MapUtteranceRoutes(RouteGroupBuilder utterance, VoiceUploadStore uploads,
+    private static void MapUtteranceRoutes(HostedDenyGroup utterance, VoiceUploadStore uploads,
         Transcription.GatewayTranscriptionService transcription)
     {
         utterance.MapPost("/upload", (HttpContext ctx) =>

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -96,13 +96,24 @@ internal static class GatewayWingmanVoiceEndpoint
     /// meaningless without a tenant to scope it to, and the store has none - so "not here" is the truthful
     /// answer. 403 would imply the right credential could reach it, and none can.
     ///
-    /// UN-DENY CONDITION - THE WRITE IS STOPPED. Nothing accumulates behind this refusal, so lifting it does
-    /// not expose a history built up while it stood. The three legs in this group are the ONLY writers into
-    /// the voice-turn <c>VoiceUploadStore</c>: the store instance is constructed once in <c>GatewayHost</c>
-    /// and handed to this endpoint alone, and every <c>uploads.</c> call in this file sits inside the guarded
-    /// group. Registering, staging a chunk and assembling a transcript are all refused, so on hosted no
-    /// utterance bytes and no assembled transcript are written at all. (Whatever predates the deny is a
-    /// separate matter, and is covered by the partitioning gate in issue #1896.)
+    /// UN-DENY CONDITION. Two SEPARATE questions, because answering only the first is how a deny gets
+    /// mistaken for a clean slate. "Does anything still write this state" and "what is already sitting
+    /// there" have different answers, and the second one does not improve while the deny stands.
+    ///
+    /// (a) DOES ANYTHING STILL WRITE IT? No - and this was checked by enumerating WRITERS, not by looking at
+    /// the denied routes. Every construction of a <c>VoiceUploadStore</c> in the repository was listed: the
+    /// only production one on this root is the instance <c>GatewayHost</c> holds as <c>_voiceTurnUploads</c>
+    /// and hands to this endpoint alone. Every <c>uploads.</c> call in this file is inside the guarded group.
+    /// <c>SweepAbandoned</c> - the one background-shaped mutator on the type - has NO production caller at
+    /// all, only a test. So on hosted no utterance bytes and no assembled transcript are written. The one
+    /// residual write is the store constructor calling <c>CcStorage.VoiceTurnUploads()</c>, which ENSURES the
+    /// directory exists: an empty directory, never content.
+    ///
+    /// (b) WHAT ALREADY EXISTS? Unknown, and presumed contaminated. Stopping the accumulation says nothing
+    /// about the shared root as it stands today, which may hold pre-deny cross-tenant staged audio and
+    /// assembled transcripts written before this refusal was hung. SO THE UN-DENY STILL REQUIRES PURGING OR
+    /// QUARANTINING THE LEGACY ROOT, on top of issue #1896's tenant-keying of the store - "the write is
+    /// stopped" is not "the root is clean" and must never be read as the whole condition.
     /// </summary>
     private static IResult? DenyUtteranceOnHosted()
     {
@@ -370,104 +381,22 @@ internal static class GatewayWingmanVoiceEndpoint
             return await next(ctx);
         });
 
-        utterance.MapPost("/upload", (HttpContext ctx) =>
-        {
-            var key = ctx.Request.Headers["Idempotency-Key"].ToString();
-            var id = uploads.Register(string.IsNullOrWhiteSpace(key) ? null : key);
-            return Results.Json(new { upload_id = id });
-        });
-
-        utterance.MapPut("/{uploadId}/chunk/{index:int}", async (string uploadId, int index, HttpContext ctx, CancellationToken ct) =>
-        {
-            if (!uploads.Exists(uploadId))
-                return Results.Json(new { error = "unknown upload id (register it first)" }, statusCode: StatusCodes.Status404NotFound);
-
-            // Refuse an oversized chunk BEFORE reading a byte of it, when the client declares its size.
-            // This is the cheap door: no allocation, no read, and the client learns immediately.
-            if (ctx.Request.ContentLength is { } declared && declared > VoiceUploadLimits.MaxChunkBytes)
-            {
-                FileLog.Write($"[GatewayWingmanVoice] chunk rejected: declared {declared} bytes > {VoiceUploadLimits.MaxChunkBytes} cap (upload={uploadId}, index={index})");
-                return TooLarge($"chunk is {declared} bytes; the limit is {VoiceUploadLimits.MaxChunkBytes}");
-            }
-
-            var sha = ctx.Request.Headers["X-Chunk-Sha256"].ToString();
-
-            // Content-Length is the client's CLAIM. It can be absent (chunked transfer-encoding) and it
-            // can be wrong, so the read itself is bounded too: this stops the moment the body exceeds
-            // the cap instead of faithfully buffering however much someone chooses to send.
-            var bytes = await ReadBoundedAsync(ctx.Request.Body, VoiceUploadLimits.MaxChunkBytes, ct);
-            if (bytes is null)
-            {
-                FileLog.Write($"[GatewayWingmanVoice] chunk rejected: body exceeded the {VoiceUploadLimits.MaxChunkBytes}-byte cap (upload={uploadId}, index={index})");
-                return TooLarge($"chunk exceeded the {VoiceUploadLimits.MaxChunkBytes}-byte limit");
-            }
-
-            // Total across the whole upload. Excluding THIS index is what keeps a resend free: the
-            // client's retry replaces chunk N, it does not add a second copy of it, and retrying is the
-            // normal case on this path.
-            var staged = uploads.StagedBytes(uploadId, excludeIndex: index);
-            if (staged + bytes.Length > VoiceUploadLimits.MaxTotalUploadBytes)
-            {
-                FileLog.Write($"[GatewayWingmanVoice] chunk rejected: upload total would be {staged + bytes.Length} > {VoiceUploadLimits.MaxTotalUploadBytes} cap (upload={uploadId})");
-                return TooLarge($"upload would exceed the {VoiceUploadLimits.MaxTotalUploadBytes}-byte total limit");
-            }
-
-            try { await uploads.StoreChunkAsync(uploadId, index, bytes, string.IsNullOrEmpty(sha) ? null : sha, ct); return Results.Json(new { ok = true, index }); }
-            catch (Exception ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status400BadRequest); }
-        });
-
-        utterance.MapPost("/{uploadId}/complete", async (string uploadId, UtteranceCompleteRequest? req, CancellationToken ct) =>
-        {
-            if (req is null || req.TotalChunks <= 0)
-                return Results.Json(new { error = "totalChunks (>0) is required" }, statusCode: StatusCodes.Status400BadRequest);
-            if (!uploads.Exists(uploadId))
-                return Results.Json(new { error = "unknown upload id (register it first)" }, statusCode: StatusCodes.Status404NotFound);
-
-            // The configured mode's key must be present (issue #887: both modes are key-bearing). The
-            // single transcription owner resolves this; check it BEFORE assembling so a no-key request
-            // does not pay the reassembly cost.
-            var routing = transcription.Resolve();
-            if (routing.Key is null)
-                return Results.Json(new { error = $"no key configured for transcription mode {routing.Mode.ToConfigString()}" }, statusCode: StatusCodes.Status503ServiceUnavailable);
-
-            AssembleResult assembled;
-            try { assembled = await uploads.AssembleAsync(uploadId, req.TotalChunks, ct); }
-            catch (Exception ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status400BadRequest); }
-
-            if (assembled.Status == "unknown_upload")
-                return Results.Json(new { error = "unknown upload id" }, statusCode: StatusCodes.Status404NotFound);
-            if (assembled.Status == "incomplete")
-                return Results.Json(new { status = "incomplete", missing = assembled.Missing }, statusCode: StatusCodes.Status409Conflict);
-
-            var assembledAudio = assembled.Audio;
-            if (assembledAudio is null || assembledAudio.Length == 0)
-            {
-                uploads.Delete(uploadId);
-                return Results.Json(new { error = "assembled recording was empty" }, statusCode: StatusCodes.Status502BadGateway);
-            }
-
-            // Transcribe through the single owner WITH the validated dictionary correction applied (the
-            // SAME engine every other surface uses; fails open to raw in local mode or on any error).
-            var result = await transcription.TranscribeAsync(
-                assembledAudio, "audio." + (req.Ext ?? "webm"), req.Mime ?? "audio/webm", applyCorrection: true, ct);
-            uploads.Delete(uploadId);
-            // Out of credits / monthly cap (issue #939): map to the shared 402 state (branch by code)
-            // instead of flattening it into a generic 502 - so the client shows the consistent
-            // add-credits message and keeps the recording, not "transcription failed".
-            if (result.Outcome == Transcription.TranscriptionOutcome.OutOfCredits)
-                return HostedAiHttp.PaymentRequiredResult(HostedAiErrorMapper.MapCode(result.Code));
-            if (result.Outcome != Transcription.TranscriptionOutcome.Ok)
-                return Results.Json(new { error = result.Error }, statusCode: StatusCodes.Status502BadGateway);
-            FileLog.Write($"[GatewayWingmanVoice] utterance complete {uploadId}: mode={result.Mode}, chars={result.Text?.Length ?? 0}");
-
-            // Capture-health persistence (issue #863): when the mobile dialog sent its measurements,
-            // record the audio-loss deficit (recording wall-clock vs decoded audio duration) into the
-            // same dictation session log the desktop and overlay write, tagged Source="mobile". The
-            // assembled WAV byte count is the audio the server actually transcribed. Fire-and-forget.
-            PersistMobileCaptureHealth(uploadId, req, assembledAudio.Length, result.Text);
-
-            return Results.Json(new { transcript = result.Text });
-        });
+        // THE ROUTES ARE MAPPED WHERE THE UNFILTERED `app` IS NOT IN SCOPE - deliberately, and that is the
+        // only reason MapUtteranceRoutes exists as a separate method. Copied from the key-vault deny (pull
+        // request #1904), which is the reviewed instance of this pattern.
+        //
+        // This file is the sharpest case of the problem, because unlike the other three families the
+        // unfiltered builder is LEGITIMATELY here: the voice-turn, text-to-speech, transcribe, explain, ask
+        // and menu routes below are not part of the denied family and must stay on `app`. That is exactly
+        // what made the bypass cheap - both builders in scope at the same mapping site, so each of these
+        // THREE utterance legs could INDIVIDUALLY be mapped onto `app` instead of onto `utterance`, a
+        // one-word edit that compiles, passes every existing test, and opens that leg on hosted while the
+        // other two stay correctly denied. Three independently bypassable primitives, each owing its own
+        // full-suite security run under the bypassability rule. Handing the guarded group to a method that
+        // never receives `app` makes the mistake INEXPRESSIBLE rather than merely unlikely: inside
+        // MapUtteranceRoutes there is nothing to map onto except the guarded group. The count falls by
+        // DESIGN, not by an argument about how careful the next author will be.
+        MapUtteranceRoutes(utterance, uploads, transcription);
 
         // Text-to-speech for the mobile Voice screen + Cockpit: turn the wingman's spoken summary into
         // natural-sounding audio (the browser's own voice is robotic). Returns audio/mpeg bytes the
@@ -877,6 +806,114 @@ internal static class GatewayWingmanVoiceEndpoint
         // The GUARDED group only - not the whole voice surface. Everything else mapped above is deliberately
         // outside it and must keep serving on hosted, which is itself asserted by a scoping control.
         return utterance;
+    }
+
+    /// <summary>
+    /// The three /wingman/utterance upload legs. Takes the GUARDED group and nothing else - see the note
+    /// at the call site: the unfiltered route builder that the rest of this file legitimately uses is
+    /// deliberately out of scope here, so no leg of this family can be mapped around the hosted filter.
+    /// </summary>
+    private static void MapUtteranceRoutes(RouteGroupBuilder utterance, VoiceUploadStore uploads,
+        Transcription.GatewayTranscriptionService transcription)
+    {
+        utterance.MapPost("/upload", (HttpContext ctx) =>
+        {
+            var key = ctx.Request.Headers["Idempotency-Key"].ToString();
+            var id = uploads.Register(string.IsNullOrWhiteSpace(key) ? null : key);
+            return Results.Json(new { upload_id = id });
+        });
+
+        utterance.MapPut("/{uploadId}/chunk/{index:int}", async (string uploadId, int index, HttpContext ctx, CancellationToken ct) =>
+        {
+            if (!uploads.Exists(uploadId))
+                return Results.Json(new { error = "unknown upload id (register it first)" }, statusCode: StatusCodes.Status404NotFound);
+
+            // Refuse an oversized chunk BEFORE reading a byte of it, when the client declares its size.
+            // This is the cheap door: no allocation, no read, and the client learns immediately.
+            if (ctx.Request.ContentLength is { } declared && declared > VoiceUploadLimits.MaxChunkBytes)
+            {
+                FileLog.Write($"[GatewayWingmanVoice] chunk rejected: declared {declared} bytes > {VoiceUploadLimits.MaxChunkBytes} cap (upload={uploadId}, index={index})");
+                return TooLarge($"chunk is {declared} bytes; the limit is {VoiceUploadLimits.MaxChunkBytes}");
+            }
+
+            var sha = ctx.Request.Headers["X-Chunk-Sha256"].ToString();
+
+            // Content-Length is the client's CLAIM. It can be absent (chunked transfer-encoding) and it
+            // can be wrong, so the read itself is bounded too: this stops the moment the body exceeds
+            // the cap instead of faithfully buffering however much someone chooses to send.
+            var bytes = await ReadBoundedAsync(ctx.Request.Body, VoiceUploadLimits.MaxChunkBytes, ct);
+            if (bytes is null)
+            {
+                FileLog.Write($"[GatewayWingmanVoice] chunk rejected: body exceeded the {VoiceUploadLimits.MaxChunkBytes}-byte cap (upload={uploadId}, index={index})");
+                return TooLarge($"chunk exceeded the {VoiceUploadLimits.MaxChunkBytes}-byte limit");
+            }
+
+            // Total across the whole upload. Excluding THIS index is what keeps a resend free: the
+            // client's retry replaces chunk N, it does not add a second copy of it, and retrying is the
+            // normal case on this path.
+            var staged = uploads.StagedBytes(uploadId, excludeIndex: index);
+            if (staged + bytes.Length > VoiceUploadLimits.MaxTotalUploadBytes)
+            {
+                FileLog.Write($"[GatewayWingmanVoice] chunk rejected: upload total would be {staged + bytes.Length} > {VoiceUploadLimits.MaxTotalUploadBytes} cap (upload={uploadId})");
+                return TooLarge($"upload would exceed the {VoiceUploadLimits.MaxTotalUploadBytes}-byte total limit");
+            }
+
+            try { await uploads.StoreChunkAsync(uploadId, index, bytes, string.IsNullOrEmpty(sha) ? null : sha, ct); return Results.Json(new { ok = true, index }); }
+            catch (Exception ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status400BadRequest); }
+        });
+
+        utterance.MapPost("/{uploadId}/complete", async (string uploadId, UtteranceCompleteRequest? req, CancellationToken ct) =>
+        {
+            if (req is null || req.TotalChunks <= 0)
+                return Results.Json(new { error = "totalChunks (>0) is required" }, statusCode: StatusCodes.Status400BadRequest);
+            if (!uploads.Exists(uploadId))
+                return Results.Json(new { error = "unknown upload id (register it first)" }, statusCode: StatusCodes.Status404NotFound);
+
+            // The configured mode's key must be present (issue #887: both modes are key-bearing). The
+            // single transcription owner resolves this; check it BEFORE assembling so a no-key request
+            // does not pay the reassembly cost.
+            var routing = transcription.Resolve();
+            if (routing.Key is null)
+                return Results.Json(new { error = $"no key configured for transcription mode {routing.Mode.ToConfigString()}" }, statusCode: StatusCodes.Status503ServiceUnavailable);
+
+            AssembleResult assembled;
+            try { assembled = await uploads.AssembleAsync(uploadId, req.TotalChunks, ct); }
+            catch (Exception ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status400BadRequest); }
+
+            if (assembled.Status == "unknown_upload")
+                return Results.Json(new { error = "unknown upload id" }, statusCode: StatusCodes.Status404NotFound);
+            if (assembled.Status == "incomplete")
+                return Results.Json(new { status = "incomplete", missing = assembled.Missing }, statusCode: StatusCodes.Status409Conflict);
+
+            var assembledAudio = assembled.Audio;
+            if (assembledAudio is null || assembledAudio.Length == 0)
+            {
+                uploads.Delete(uploadId);
+                return Results.Json(new { error = "assembled recording was empty" }, statusCode: StatusCodes.Status502BadGateway);
+            }
+
+            // Transcribe through the single owner WITH the validated dictionary correction applied (the
+            // SAME engine every other surface uses; fails open to raw in local mode or on any error).
+            var result = await transcription.TranscribeAsync(
+                assembledAudio, "audio." + (req.Ext ?? "webm"), req.Mime ?? "audio/webm", applyCorrection: true, ct);
+            uploads.Delete(uploadId);
+            // Out of credits / monthly cap (issue #939): map to the shared 402 state (branch by code)
+            // instead of flattening it into a generic 502 - so the client shows the consistent
+            // add-credits message and keeps the recording, not "transcription failed".
+            if (result.Outcome == Transcription.TranscriptionOutcome.OutOfCredits)
+                return HostedAiHttp.PaymentRequiredResult(HostedAiErrorMapper.MapCode(result.Code));
+            if (result.Outcome != Transcription.TranscriptionOutcome.Ok)
+                return Results.Json(new { error = result.Error }, statusCode: StatusCodes.Status502BadGateway);
+            FileLog.Write($"[GatewayWingmanVoice] utterance complete {uploadId}: mode={result.Mode}, chars={result.Text?.Length ?? 0}");
+
+            // Capture-health persistence (issue #863): when the mobile dialog sent its measurements,
+            // record the audio-loss deficit (recording wall-clock vs decoded audio duration) into the
+            // same dictation session log the desktop and overlay write, tagged Source="mobile". The
+            // assembled WAV byte count is the audio the server actually transcribed. Fire-and-forget.
+            PersistMobileCaptureHealth(uploadId, req, assembledAudio.Length, result.Text);
+
+            return Results.Json(new { transcript = result.Text });
+        });
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -82,6 +82,31 @@ internal static class GatewayWingmanVoiceEndpoint
         Results.Json(new { error }, statusCode: StatusCodes.Status413PayloadTooLarge);
 
     /// <summary>
+    /// The hosted refusal for the whole /wingman/utterance upload family (issue #1896), or null on
+    /// self-host where nothing changes.
+    ///
+    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> - the INDEPENDENT deployment signal - and NOT on a
+    /// boundary or tenant argument being passed in. A security branch that depends on an optional argument
+    /// fails OPEN when a caller omits it, which is exactly how the hosted account-status fix nearly shipped
+    /// a hole: omit the argument and a hosted Gateway silently takes the self-host path. Asking hosted mode
+    /// directly means this family cannot serve another account's transcript on hosted however the host is
+    /// wired.
+    ///
+    /// 404 rather than 403: on hosted this upload family does not exist as a concept - an upload id is
+    /// meaningless without a tenant to scope it to, and the store has none - so "not here" is the truthful
+    /// answer. 403 would imply the right credential could reach it, and none can.
+    /// </summary>
+    private static IResult? DenyUtteranceOnHosted()
+    {
+        if (!GatewayHostedMode.IsHosted) return null;
+
+        FileLog.Write("[GatewayWingmanVoice] DENIED on hosted: the utterance upload store is keyed only by a caller-supplied id under one shared root, so an upload id is not a tenant boundary");
+        return Results.Json(
+            new { error = "the wingman utterance upload is not available on the hosted gateway" },
+            statusCode: StatusCodes.Status404NotFound);
+    }
+
+    /// <summary>
     /// Read a request body into memory, giving up the moment it exceeds <paramref name="max"/>.
     ///
     /// The point is the giving up. <c>CopyToAsync(ms)</c> - what these routes used to do - is unbounded
@@ -304,14 +329,43 @@ internal static class GatewayWingmanVoiceEndpoint
         //   POST   /wingman/utterance/upload                  -> { upload_id }
         //   PUT    /wingman/utterance/{id}/chunk/{i}           -> { ok }   (idempotent)
         //   POST   /wingman/utterance/{id}/complete {total}    -> { transcript } | 409 { missing }
-        app.MapPost("/wingman/utterance/upload", (HttpContext ctx) =>
+        //
+        // DENIED IN WHOLE ON HOSTED (issue #1896). None of these three resolves a tenant at all, the upload
+        // id is CALLER-CHOSEN (it arrives as an Idempotency-Key header), the store behind them has one
+        // on-disk root shared across every account with no tenant segment in the path, and `complete`
+        // returns the assembled transcript. So an account can claim another account's upload id and be
+        // handed the words that account spoke - and, before the owner completes, overwrite its chunks.
+        // A caller-supplied identifier is not a tenant boundary: secrecy of an identifier is not
+        // authorization, and upload ids travel through client logs, retries and store-and-forward queues.
+        //
+        // The whole family, not just `complete`: denying only the leg that returns text would leave the
+        // chunk leg able to corrupt another account's recording, which is the same boundary failure with a
+        // different consequence. It is a deny rather than a partition because the staged records carry no
+        // tenant to partition BY - partitioning the store is issue #1896's job and un-denying is gated on
+        // it. It refuses rather than returning an empty transcript, because an empty transcript is a FALSE
+        // statement ("you said nothing") where a refusal is merely an absent one.
+        //
+        // Self-host is COMPLETELY unchanged: one tenant, so a shared root is the owner's own root, and the
+        // phone's record-locally-and-keep-retrying path works exactly as it always has.
+        //
+        // The group prefix reproduces the route paths character for character, so the self-host surface is
+        // byte-identical; the filter also covers legs added to this family later, which a per-route guard
+        // would not.
+        var utterance = app.MapGroup("/wingman/utterance");
+        utterance.AddEndpointFilter(async (ctx, next) =>
+        {
+            if (DenyUtteranceOnHosted() is { } denied) return denied;
+            return await next(ctx);
+        });
+
+        utterance.MapPost("/upload", (HttpContext ctx) =>
         {
             var key = ctx.Request.Headers["Idempotency-Key"].ToString();
             var id = uploads.Register(string.IsNullOrWhiteSpace(key) ? null : key);
             return Results.Json(new { upload_id = id });
         });
 
-        app.MapPut("/wingman/utterance/{uploadId}/chunk/{index:int}", async (string uploadId, int index, HttpContext ctx, CancellationToken ct) =>
+        utterance.MapPut("/{uploadId}/chunk/{index:int}", async (string uploadId, int index, HttpContext ctx, CancellationToken ct) =>
         {
             if (!uploads.Exists(uploadId))
                 return Results.Json(new { error = "unknown upload id (register it first)" }, statusCode: StatusCodes.Status404NotFound);
@@ -350,7 +404,7 @@ internal static class GatewayWingmanVoiceEndpoint
             catch (Exception ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status400BadRequest); }
         });
 
-        app.MapPost("/wingman/utterance/{uploadId}/complete", async (string uploadId, UtteranceCompleteRequest? req, CancellationToken ct) =>
+        utterance.MapPost("/{uploadId}/complete", async (string uploadId, UtteranceCompleteRequest? req, CancellationToken ct) =>
         {
             if (req is null || req.TotalChunks <= 0)
                 return Results.Json(new { error = "totalChunks (>0) is required" }, statusCode: StatusCodes.Status400BadRequest);

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -100,20 +100,25 @@ internal static class GatewayWingmanVoiceEndpoint
     /// mistaken for a clean slate. "Does anything still write this state" and "what is already sitting
     /// there" have different answers, and the second one does not improve while the deny stands.
     ///
-    /// (a) DOES ANYTHING STILL WRITE IT? No - and this was checked by enumerating WRITERS, not by looking at
-    /// the denied routes. Every construction of a <c>VoiceUploadStore</c> in the repository was listed: the
-    /// only production one on this root is the instance <c>GatewayHost</c> holds as <c>_voiceTurnUploads</c>
-    /// and hands to this endpoint alone. Every <c>uploads.</c> call in this file is inside the guarded group.
-    /// <c>SweepAbandoned</c> - the one background-shaped mutator on the type - has NO production caller at
-    /// all, only a test. So on hosted no utterance bytes and no assembled transcript are written. The one
-    /// residual write is the store constructor calling <c>CcStorage.VoiceTurnUploads()</c>, which ENSURES the
-    /// directory exists: an empty directory, never content.
+    /// (a) DOES ANYTHING STILL WRITE IT? No. Checked by sweeping the COMPLETE MUTATING SURFACE of the state
+    /// rather than the routes that touch it: every construction of a <c>VoiceUploadStore</c> in the
+    /// repository, then every production caller of every mutating method on the type (<c>Register</c>,
+    /// <c>StoreChunkAsync</c>, <c>AssembleAsync</c>, <c>Delete</c>, <c>MarkPending</c>,
+    /// <c>MarkDelivered</c>, <c>MarkAbandoned</c>, <c>MarkFailed</c>, <c>ClearFailed</c>,
+    /// <c>RecordFailedDeliveryBaseline</c>, <c>Acknowledge</c>, <c>SweepAbandoned</c>), and finally any raw
+    /// file writer into the root that bypasses the type entirely. The only production instance on this root
+    /// is the one <c>GatewayHost</c> holds as <c>_voiceTurnUploads</c> and hands to this endpoint alone;
+    /// every mutating call reached from this file is inside the guarded group; <c>SweepAbandoned</c> has NO
+    /// production caller at all, only a test; nothing writes the root outside the store. The one residual
+    /// write is the constructor calling <c>CcStorage.VoiceTurnUploads()</c>, which ENSURES the directory
+    /// exists: an empty directory, never content.
     ///
-    /// (b) WHAT ALREADY EXISTS? Unknown, and presumed contaminated. Stopping the accumulation says nothing
-    /// about the shared root as it stands today, which may hold pre-deny cross-tenant staged audio and
-    /// assembled transcripts written before this refusal was hung. SO THE UN-DENY STILL REQUIRES PURGING OR
-    /// QUARANTINING THE LEGACY ROOT, on top of issue #1896's tenant-keying of the store - "the write is
-    /// stopped" is not "the root is clean" and must never be read as the whole condition.
+    /// (b) WHAT ALREADY EXISTS? A SEPARATE QUESTION, and it is not answered by (a). NO NEW WRITES IS A
+    /// STATEMENT ABOUT THE FUTURE, NOT EVIDENCE ABOUT THE PAST. The shared root may hold pre-deny
+    /// cross-tenant staged audio and assembled transcripts, written before this refusal was hung and
+    /// untouched by it. SO THE UN-DENY STILL REQUIRES PURGING OR QUARANTINING THE LEGACY ROOT, on top of
+    /// issue #1896's tenant-keying of the store - "the write is stopped" is not "the root is clean" and must
+    /// never be read as the whole condition.
     /// </summary>
     private static IResult? DenyUtteranceOnHosted()
     {
@@ -396,6 +401,13 @@ internal static class GatewayWingmanVoiceEndpoint
         // never receives `app` makes the mistake INEXPRESSIBLE rather than merely unlikely: inside
         // MapUtteranceRoutes there is nothing to map onto except the guarded group. The count falls by
         // DESIGN, not by an argument about how careful the next author will be.
+        //
+        // THE LIMIT OF THAT PROPERTY, STATED SO NOBODY OVER-CLAIMS IT: it holds WITHIN THIS MAPPING SITE.
+        // It does not reach across sites. This deny is one of FOUR families, each creating its own group,
+        // attaching its own filter and mapping from its own site, so any one site can be wrong while the
+        // other three stay correct and no compiler notices. That is exactly why the registered proof is
+        // four filter-removal arms and four gate-inversion arms rather than one of each: the split removes
+        // the per-ROUTE bypass inside a family, it does not merge the four families into one primitive.
         MapUtteranceRoutes(utterance, uploads, transcription);
 
         // Text-to-speech for the mobile Voice screen + Cockpit: turn the wingman's spoken summary into

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -130,7 +130,11 @@ internal static class GatewayWingmanVoiceEndpoint
         }
     }
 
-    public static void Map(
+    /// Returns the guarded route group. That return value exists SOLELY so a test can map a brand-new
+    /// route onto the same group and prove it is refused on hosted with no deny written for it - the
+    /// property that distinguishes a group filter from a per-route guard, and which is otherwise
+    /// invisible to any test that only drives the routes existing today.
+    public static RouteGroupBuilder Map(
         IEndpointRouteBuilder app,
         DirectorRegistry registry,
         Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider,
@@ -861,6 +865,10 @@ internal static class GatewayWingmanVoiceEndpoint
         // Pressing menu options (fully hands-free voice-answering) is its own later issue, built with per-agent
         // picker profiles and a screen-version lock on every keypress. The GET /wingman/menu detection above
         // stays (read-only, for the announce step); it never leads to a keypress.
+
+        // The GUARDED group only - not the whole voice surface. Everything else mapped above is deliberately
+        // outside it and must keep serving on hosted, which is itself asserted by a scoping control.
+        return utterance;
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
@@ -1,4 +1,5 @@
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.Transcription;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -45,8 +46,32 @@ namespace CcDirector.Gateway.Api;
 /// "no transcription happened", which is not true on a box that is transcribing - whereas a refusal is
 /// merely an absent one.
 ///
+/// HOW THE DENY IS EXPRESSED - THE SHARED REFUSAL PRIMITIVE, NOT A BESPOKE FILTER. This group is denied
+/// through <see cref="HostedRouteDeny"/>, the ONE hosted-refusal boundary every deny family on this Gateway
+/// adopts (reference implementation: the key-vault deny in pull request #1904; primitive at
+/// <c>src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs</c>). An earlier revision rolled its own
+/// <c>AddEndpointFilter</c> deny before the primitive existed; it has been replaced so the release ships ONE
+/// refusal boundary, not one per family. On hosted the four handlers are NEVER MAPPED - in their place a
+/// verb-less refusal is mapped on each of the four route shapes, so EVERY request shape (a valid query, a
+/// wrong media type, a verb the group never mapped, and a route added LATER through the same group handle)
+/// meets the refusal rather than being answered by the framework ahead of it.
+///
+/// IT USES <see cref="HostedRouteDeny.Group"/> (PER-ROUTE), NOT <see cref="HostedRouteDeny.ExclusiveGroup"/>,
+/// and the reason is structural: the <c>/transcription</c> prefix is NOT owned exclusively by this analysis
+/// group. Two LIVE routes serve beneath it and must keep serving on hosted - <c>POST /transcription</c> (the
+/// batch transcribe endpoint) and <c>POST /transcription/cleanup</c> - so an exclusive catch-all under
+/// <c>/transcription</c> would take those undenied routes off the air, which the startup
+/// <see cref="HostedRefusalRouteSpace.ValidateBeforeStart"/> containment check would (correctly) refuse to
+/// start over. Per-route mode maps one verb-less refusal on each of the FOUR analysis paths and nothing
+/// else, leaving the two live writers untouched. The cost the primitive documents for this mode - a route
+/// added to the family gets no refusal unless it is mapped through the group handle - is covered here
+/// because every one of the four is mapped through that handle, and the future-route property is proven by a
+/// probe route mapped onto the returned handle (see <c>HostedContentDenyGroupFilterTests</c>).
+///
 /// Self-host is COMPLETELY unchanged, and that is the control. Self-host has exactly one tenant, so the
-/// shared log holds only the owner's own speech and these routes are exactly as correct as they ever were.
+/// shared log holds only the owner's own speech and these routes are exactly as correct as they ever were:
+/// off hosted the primitive maps the four real handlers exactly as an unguarded builder would, with no
+/// refusal created at all.
 /// </summary>
 internal static class TranscriptionAnalysisEndpoint
 {
@@ -55,108 +80,99 @@ internal static class TranscriptionAnalysisEndpoint
     private const int DefaultTermTop = 25;
     private const int DefaultWordTop = 50;
 
+    /// <summary>The prefix this analysis group's routes sit under. NOT claimed exclusively - see the class
+    /// note: <c>POST /transcription</c> and <c>POST /transcription/cleanup</c> are live routes beneath it.</summary>
+    internal const string Prefix = "/transcription";
+
+    /// <summary>The single error string the hosted refusal serves. Held here so a test can assert against the
+    /// exact string that is served rather than a copy that could drift.</summary>
+    internal const string RefusalMessage = "transcription analysis is not available on the hosted gateway";
+
     /// <summary>
-    /// The hosted refusal for the whole transcription-analysis group (issue #1897), or null on self-host
-    /// where nothing changes.
-    ///
-    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> - the INDEPENDENT deployment signal - and NOT on a
-    /// boundary or tenant argument being passed in. A security branch that depends on an optional argument
-    /// fails OPEN when a caller omits it, which is exactly how the hosted account-status fix nearly shipped
-    /// a hole: omit the argument and a hosted Gateway silently takes the self-host path. Asking hosted mode
-    /// directly means this group cannot serve the shared speech log on hosted however the host is wired.
-    ///
-    /// 404 rather than 403: on hosted this analysis surface does not exist as a concept - there is no
-    /// per-tenant log for it to read - so "not here" is the truthful answer. 403 would imply the right
-    /// credential could reach it, and none can.
+    /// The hosted refusal payload for the whole transcription-analysis group (issue #1897). Validated on
+    /// construction, so a blank field fails the Gateway at startup rather than serving a refusal a caller
+    /// cannot act on. 404 rather than 403: on hosted this analysis surface does not exist as a concept -
+    /// there is no per-tenant log for it to read - so "not here" is the truthful answer; 403 would imply the
+    /// right credential could reach it, and none can. The refusal is driven off
+    /// <see cref="GatewayHostedMode.IsHosted"/> inside the primitive - the INDEPENDENT deployment signal, not
+    /// an optional argument a caller can omit and thereby fail OPEN.
     ///
     /// UN-DENY CONDITION - REMOVING THIS DENY REQUIRES ALSO PURGING OR PARTITIONING WHAT ACCUMULATED BEHIND
     /// IT. Two SEPARATE questions, and here the first one fails outright.
     ///
-    /// (a) DOES ANYTHING STILL WRITE IT? YES, and unlike the wingman training store this one was checked
-    /// through its gate rather than at its call sites, because a call site proves code exists, not that it
-    /// runs. <c>GatewayTranscriptionService.RecordTelemetry</c> calls <c>TranscriptionTelemetryLog.Record</c>
-    /// on EVERY transcription, and <c>Record</c> is UNCONDITIONAL - it has no enabled-check of any kind. The
-    /// only flag near it is <c>TextEnabled</c>, which merely decides whether the spoken text is included,
-    /// defaults to TRUE, and has no configuration key wired to turn it off ("a future opt-out can gate it").
-    /// So every turn appends a record, WITH the raw and cleaned text in it. The surfaces reaching it - the
-    /// recording endpoints, the batch transcription endpoint and the wingman transcribe route - are all
-    /// outside this group. This is a READ deny only, the same shape as the merged stats deny #1888.
+    /// (a) DOES ANYTHING STILL WRITE IT? NO LONGER, on hosted. <c>GatewayTranscriptionService.RecordTelemetry</c>
+    /// calls <c>TranscriptionTelemetryLog.Record</c> on EVERY transcription, and that <c>Record</c> is
+    /// otherwise UNCONDITIONAL - it has no enabled-check of any kind (the only flag near it is
+    /// <c>TextEnabled</c>, which merely decides whether the spoken text is included and defaults to TRUE). An
+    /// earlier revision left that writer running and denied the READ only, the same shape as the merged stats
+    /// deny #1888. THIS PASS HOST-GATES THE WRITER TOO (defense in depth, deny-by-default, matching the
+    /// key-vault deny #1904): <c>RecordTelemetry</c> now NO-OPS on hosted, so no new speech accumulates in the
+    /// shared log while the deny stands. That gate is safe because the log's ONLY reader is this now-denied
+    /// analysis group - verified nothing billing / usage-metering / quota consumes it, so gating the write
+    /// undercounts nothing. #1888's read-only-deny decision predates this defense-in-depth pass; expanding it
+    /// here is deliberate.
     ///
-    /// (b) WHAT ALREADY EXISTS? A log of every account's speech from before the deny, growing the whole
-    /// time. Records written with no tenant on them cannot be attributed afterwards, so the choice is
-    /// deletion or quarantine, never a later migration. Un-denying on a partitioned WRITER alone would
-    /// expose the contaminated history underneath it.
+    /// (b) WHAT ALREADY EXISTS? A log of every account's speech from BEFORE the writer was gated. Gating the
+    /// write is a statement about the future, not evidence about the past. Records written with no tenant on
+    /// them cannot be attributed afterwards, so the choice is deletion or quarantine, never a later migration.
+    /// Un-denying on a partitioned WRITER alone would expose the contaminated history underneath it.
     /// </summary>
-    private static IResult? DenyOnHosted()
-    {
-        if (!GatewayHostedMode.IsHosted) return null;
+    private static HostedDenial Denial() => new(
+        family: "transcription-analysis",
+        message: RefusalMessage,
+        reason: "the transcription telemetry log is one shared daily file with no tenant in its path, its file " +
+                "name, or its records, so on a hosted box it holds what every account said out loud with nothing " +
+                "to tell them apart - and /turns returns the raw and cleaned text of up to 2000 of those records " +
+                "for one request carrying no identifier at all",
+        unDenyInstruction: "do NOT simply remove this deny: the writer is host-gated now (no new accumulation on " +
+                "hosted) but a shared, untenanted log predates the gate - so tenant-partition the telemetry log, " +
+                "purge or quarantine the pre-existing shared log (records written with no tenant cannot be " +
+                "attributed afterwards - the choice is deletion or quarantine, never a later migration), THEN " +
+                "un-gate the write, and only then restore a tenant-scoped read",
+        statusCode: StatusCodes.Status404NotFound);
 
-        FileLog.Write("[TranscriptionAnalysisEndpoint] DENIED on hosted: the transcription telemetry log is one shared file with no tenant in it, so there is no per-tenant answer to serve");
-        return Results.Json(
-            new { error = "transcription analysis is not available on the hosted gateway" },
-            statusCode: StatusCodes.Status404NotFound);
-    }
-
-    /// Returns the guarded route group. That return value exists SOLELY so a test can map a brand-new
-    /// route onto the same group and prove it is refused on hosted with no deny written for it - the
-    /// property that distinguishes a group filter from a per-route guard, and which is otherwise
-    /// invisible to any test that only drives the routes existing today.
-    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, TranscriptionTelemetryReader? reader = null)
+    /// <summary>
+    /// Maps the transcription-analysis routes and RETURNS the denied group they were mapped through.
+    ///
+    /// The routes are mapped through the group HANDLE (<see cref="HostedDenyGroup"/>), never through the
+    /// ungrouped builder: the handle is obtainable only from <see cref="HostedRouteDeny"/>, so a route mapped
+    /// around the refusal is not expressible in <see cref="MapRoutes"/> without changing its signature - the
+    /// bypass count is reduced by design, not by care. On hosted a per-route verb-less refusal replaces each
+    /// handler; off hosted the handle maps each handler as an unguarded builder would.
+    ///
+    /// PER-ROUTE, NOT EXCLUSIVE. See the class note: <c>/transcription</c> carries two live routes, so this
+    /// family cannot claim the prefix exclusively. The return value exists so the future-route property is
+    /// statable from outside this file: a test maps a brand-new route through the returned handle and shows
+    /// it is refused on hosted with no deny written for it.
+    /// </summary>
+    public static HostedDenyGroup Map(IEndpointRouteBuilder outer, TranscriptionTelemetryReader? reader = null)
     {
         var log = reader ?? new TranscriptionTelemetryReader();
 
-        FileLog.Write($"[TranscriptionAnalysisEndpoint] mapping /transcription analysis; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1897)");
+        FileLog.Write($"[TranscriptionAnalysisEndpoint] mapping {Prefix} analysis; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused via the shared refusal primitive (issue #1897)");
 
-        // The whole group behind ONE filter, rather than a guard line repeated in every handler.
-        // A repeated guard is a thing to forget: the route added next year would be open by default and
-        // nobody would notice. A group filter runs before EVERY route mapped below, including routes that
-        // do not exist yet, so the refusal cannot rot as the group grows. The empty prefix keeps the route
-        // paths written out in full, exactly as before, so the self-host surface is byte-identical.
-        var app = outer.MapGroup("");
-        app.AddEndpointFilter(async (ctx, next) =>
-        {
-            if (DenyOnHosted() is { } denied) return denied;
-            return await next(ctx);
-        });
-
-        // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - deliberately, and that is the only reason
-        // MapRoutes exists as a separate method. Copied from the key-vault deny (pull request #1904), which
-        // is the reviewed instance of this pattern.
-        //
-        // Written inline here, beside both builders, each of these four routes could INDIVIDUALLY be mapped
-        // onto `outer` instead of onto `app` - a one-word edit that compiles, passes every existing test,
-        // and opens exactly that route on hosted while the other three stay correctly denied. That is four
-        // independently bypassable primitives, and under the bypassability rule each would owe its own
-        // full-suite security run. Handing the guarded group to a method that never receives the ungrouped
-        // builder makes the mistake INEXPRESSIBLE rather than merely unlikely: inside MapRoutes there is
-        // nothing to map onto except the guarded group. The count falls by DESIGN, not by an argument about
-        // how careful the next author will be.
-        //
-        // THE LIMIT OF THAT PROPERTY, STATED SO NOBODY OVER-CLAIMS IT: it holds WITHIN THIS MAPPING SITE.
-        // It does not reach across sites. This deny is one of FOUR families, each creating its own group,
-        // attaching its own filter and mapping from its own site, so any one site can be wrong while the
-        // other three stay correct and no compiler notices. That is exactly why the registered proof is
-        // four filter-removal arms and four gate-inversion arms rather than one of each: the split removes
-        // the per-ROUTE bypass inside a family, it does not merge the four families into one primitive.
-        MapRoutes(app, log);
-        return app;
+        var group = HostedRouteDeny.Group(outer, Prefix, Denial());
+        MapRoutes(group, log);
+        return group;
     }
 
     /// <summary>
-    /// The four transcription-analysis routes. Takes the GUARDED group and nothing else - see the note at
-    /// the call site: the ungrouped route builder is deliberately out of scope here, so no route in this
-    /// family can be mapped around the hosted filter.
+    /// The four transcription-analysis routes, mapped relative to the <see cref="Prefix"/> so the full paths
+    /// are <c>/transcription/stats</c>, <c>/transcription/turns</c>, <c>/transcription/terms</c> and
+    /// <c>/transcription/words</c> exactly as before. Takes the denied GROUP HANDLE and nothing else: the
+    /// ungrouped route builder is deliberately out of scope here so no route can be mapped around the hosted
+    /// refusal.
     /// </summary>
-    private static void MapRoutes(RouteGroupBuilder app, TranscriptionTelemetryReader log)
+    private static void MapRoutes(HostedDenyGroup app, TranscriptionTelemetryReader log)
     {
-        app.MapGet("/transcription/stats", (HttpContext ctx) =>
+        app.MapGet("/stats", (HttpContext ctx) =>
         {
             var since = ResolveSince(ctx);
             FileLog.Write($"[TranscriptionAnalysisEndpoint] GET /transcription/stats since={since:o}");
             return Results.Json(log.ComputeStats(since));
         });
 
-        app.MapGet("/transcription/turns", (HttpContext ctx) =>
+        app.MapGet("/turns", (HttpContext ctx) =>
         {
             var since = ResolveSince(ctx);
             var limit = ClampInt(ctx.Request.Query["limit"], DefaultTurnLimit, 0, MaxTurnLimit);
@@ -164,14 +180,14 @@ internal static class TranscriptionAnalysisEndpoint
             return Results.Json(new { turns = log.Load(since, limit) });
         });
 
-        app.MapGet("/transcription/terms", (HttpContext ctx) =>
+        app.MapGet("/terms", (HttpContext ctx) =>
         {
             var since = ResolveSince(ctx);
             var top = ClampInt(ctx.Request.Query["top"], DefaultTermTop, 1, 1000);
             return Results.Json(new { terms = log.TopCorrections(top, since) });
         });
 
-        app.MapGet("/transcription/words", (HttpContext ctx) =>
+        app.MapGet("/words", (HttpContext ctx) =>
         {
             var since = ResolveSince(ctx);
             var top = ClampInt(ctx.Request.Query["top"], DefaultWordTop, 1, 5000);

--- a/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
@@ -19,6 +19,34 @@ namespace CcDirector.Gateway.Api;
 ///
 /// <c>days</c> takes precedence over <c>since</c>; with neither, the whole log is used. Inherits the
 /// host-wide token middleware like every other Gateway route.
+///
+/// DENIED IN WHOLE ON HOSTED (issue #1897). Every route in this file is refused on the hosted Gateway.
+/// All four read the SAME transcription telemetry log, which is one daily file in one shared directory
+/// with no tenant in its path, its file name, or its records. On a hosted box that log holds what every
+/// account on the machine said out loud, mixed together with nothing to tell them apart.
+///
+/// GET /transcription/turns is the sharpest of the four: it returns up to 2000 records including the
+/// full <c>rawText</c> and <c>cleanedText</c> of each turn, and it needs NO identifier of any kind - one
+/// request with any valid device key returns everybody's speech. The other three are aggregates computed
+/// over exactly the same unpartitioned records, so serving them would disclose the same content in
+/// summary form: /words is literally a frequency table of the words other accounts spoke.
+///
+/// It is a DENY OF THE WHOLE GROUP rather than a guard on the one obviously-bad route, because the four
+/// share one store and one shape - a fix aimed only at /turns would leave /words handing back the same
+/// speech a word at a time - and because a route-by-route guard rots: the next analysis route added to
+/// this file would be open again by default.
+///
+/// It is a deny rather than a per-tenant partition because the records were never written with a tenant.
+/// The tenant is not missing from the query, it is missing from the DATA, so there is nothing to filter
+/// by; inventing an attribution after the fact would be a guess presented as a boundary. Partitioning the
+/// store is issue #1897's job, and un-denying is gated on it.
+///
+/// It REFUSES rather than returning an empty result. An empty stats block is a FALSE statement - it says
+/// "no transcription happened", which is not true on a box that is transcribing - whereas a refusal is
+/// merely an absent one.
+///
+/// Self-host is COMPLETELY unchanged, and that is the control. Self-host has exactly one tenant, so the
+/// shared log holds only the owner's own speech and these routes are exactly as correct as they ever were.
 /// </summary>
 internal static class TranscriptionAnalysisEndpoint
 {
@@ -27,9 +55,47 @@ internal static class TranscriptionAnalysisEndpoint
     private const int DefaultTermTop = 25;
     private const int DefaultWordTop = 50;
 
-    public static void Map(IEndpointRouteBuilder app, TranscriptionTelemetryReader? reader = null)
+    /// <summary>
+    /// The hosted refusal for the whole transcription-analysis group (issue #1897), or null on self-host
+    /// where nothing changes.
+    ///
+    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> - the INDEPENDENT deployment signal - and NOT on a
+    /// boundary or tenant argument being passed in. A security branch that depends on an optional argument
+    /// fails OPEN when a caller omits it, which is exactly how the hosted account-status fix nearly shipped
+    /// a hole: omit the argument and a hosted Gateway silently takes the self-host path. Asking hosted mode
+    /// directly means this group cannot serve the shared speech log on hosted however the host is wired.
+    ///
+    /// 404 rather than 403: on hosted this analysis surface does not exist as a concept - there is no
+    /// per-tenant log for it to read - so "not here" is the truthful answer. 403 would imply the right
+    /// credential could reach it, and none can.
+    /// </summary>
+    private static IResult? DenyOnHosted()
+    {
+        if (!GatewayHostedMode.IsHosted) return null;
+
+        FileLog.Write("[TranscriptionAnalysisEndpoint] DENIED on hosted: the transcription telemetry log is one shared file with no tenant in it, so there is no per-tenant answer to serve");
+        return Results.Json(
+            new { error = "transcription analysis is not available on the hosted gateway" },
+            statusCode: StatusCodes.Status404NotFound);
+    }
+
+    public static void Map(IEndpointRouteBuilder outer, TranscriptionTelemetryReader? reader = null)
     {
         var log = reader ?? new TranscriptionTelemetryReader();
+
+        FileLog.Write($"[TranscriptionAnalysisEndpoint] mapping /transcription analysis; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1897)");
+
+        // The whole group behind ONE filter, rather than a guard line repeated in every handler.
+        // A repeated guard is a thing to forget: the route added next year would be open by default and
+        // nobody would notice. A group filter runs before EVERY route mapped below, including routes that
+        // do not exist yet, so the refusal cannot rot as the group grows. The empty prefix keeps the route
+        // paths written out in full, exactly as before, so the self-host surface is byte-identical.
+        var app = outer.MapGroup("");
+        app.AddEndpointFilter(async (ctx, next) =>
+        {
+            if (DenyOnHosted() is { } denied) return denied;
+            return await next(ctx);
+        });
 
         app.MapGet("/transcription/stats", (HttpContext ctx) =>
         {

--- a/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
@@ -69,13 +69,19 @@ internal static class TranscriptionAnalysisEndpoint
     /// per-tenant log for it to read - so "not here" is the truthful answer. 403 would imply the right
     /// credential could reach it, and none can.
     ///
-    /// UN-DENY CONDITION - THIS IS A READ DENY AND THE WRITE IS NOT STOPPED. Removing this deny requires
-    /// ALSO purging or partitioning what accumulated behind it. The telemetry log keeps being written on
-    /// hosted the whole time this refusal stands: <c>GatewayTranscriptionService</c> records a turn on every
-    /// transcription, and the routes that reach it are not in this group. So the file this deny hides goes
-    /// on mixing every account's raw and cleaned speech, and the day the refusal is lifted it would expose a
-    /// contaminated history rather than a clean start. Records written with no tenant on them cannot be
-    /// attributed afterwards - the choice is deletion or quarantine, not a later migration.
+    /// UN-DENY CONDITION - REMOVING THIS DENY REQUIRES ALSO PURGING OR PARTITIONING WHAT ACCUMULATED BEHIND
+    /// IT. Two SEPARATE questions, and here the first one fails outright.
+    ///
+    /// (a) DOES ANYTHING STILL WRITE IT? YES. <c>GatewayTranscriptionService</c> records a turn into the one
+    /// shared log on EVERY transcription, and the surfaces that reach it - the recording endpoints, the
+    /// batch transcription endpoint and the wingman transcribe route - are all outside this group. This is a
+    /// READ deny only, the same shape as the merged stats deny #1888. The file this refusal hides therefore
+    /// goes on mixing every account's raw and cleaned speech for as long as it stands.
+    ///
+    /// (b) WHAT ALREADY EXISTS? A log of every account's speech from before the deny, growing the whole
+    /// time. Records written with no tenant on them cannot be attributed afterwards, so the choice is
+    /// deletion or quarantine, never a later migration. Un-denying on a partitioned WRITER alone would
+    /// expose the contaminated history underneath it.
     /// </summary>
     private static IResult? DenyOnHosted()
     {
@@ -109,6 +115,29 @@ internal static class TranscriptionAnalysisEndpoint
             return await next(ctx);
         });
 
+        // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - deliberately, and that is the only reason
+        // MapRoutes exists as a separate method. Copied from the key-vault deny (pull request #1904), which
+        // is the reviewed instance of this pattern.
+        //
+        // Written inline here, beside both builders, each of these four routes could INDIVIDUALLY be mapped
+        // onto `outer` instead of onto `app` - a one-word edit that compiles, passes every existing test,
+        // and opens exactly that route on hosted while the other three stay correctly denied. That is four
+        // independently bypassable primitives, and under the bypassability rule each would owe its own
+        // full-suite security run. Handing the guarded group to a method that never receives the ungrouped
+        // builder makes the mistake INEXPRESSIBLE rather than merely unlikely: inside MapRoutes there is
+        // nothing to map onto except the guarded group. The count falls by DESIGN, not by an argument about
+        // how careful the next author will be.
+        MapRoutes(app, log);
+        return app;
+    }
+
+    /// <summary>
+    /// The four transcription-analysis routes. Takes the GUARDED group and nothing else - see the note at
+    /// the call site: the ungrouped route builder is deliberately out of scope here, so no route in this
+    /// family can be mapped around the hosted filter.
+    /// </summary>
+    private static void MapRoutes(RouteGroupBuilder app, TranscriptionTelemetryReader log)
+    {
         app.MapGet("/transcription/stats", (HttpContext ctx) =>
         {
             var since = ResolveSince(ctx);
@@ -137,8 +166,6 @@ internal static class TranscriptionAnalysisEndpoint
             var top = ClampInt(ctx.Request.Query["top"], DefaultWordTop, 1, 5000);
             return Results.Json(new { words = log.TopWords(top, since) });
         });
-
-        return app;
     }
 
     /// <summary>Resolve the time window: <c>days</c> (last N days) wins, else <c>since</c> (ISO), else null.</summary>

--- a/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
@@ -72,11 +72,15 @@ internal static class TranscriptionAnalysisEndpoint
     /// UN-DENY CONDITION - REMOVING THIS DENY REQUIRES ALSO PURGING OR PARTITIONING WHAT ACCUMULATED BEHIND
     /// IT. Two SEPARATE questions, and here the first one fails outright.
     ///
-    /// (a) DOES ANYTHING STILL WRITE IT? YES. <c>GatewayTranscriptionService</c> records a turn into the one
-    /// shared log on EVERY transcription, and the surfaces that reach it - the recording endpoints, the
-    /// batch transcription endpoint and the wingman transcribe route - are all outside this group. This is a
-    /// READ deny only, the same shape as the merged stats deny #1888. The file this refusal hides therefore
-    /// goes on mixing every account's raw and cleaned speech for as long as it stands.
+    /// (a) DOES ANYTHING STILL WRITE IT? YES, and unlike the wingman training store this one was checked
+    /// through its gate rather than at its call sites, because a call site proves code exists, not that it
+    /// runs. <c>GatewayTranscriptionService.RecordTelemetry</c> calls <c>TranscriptionTelemetryLog.Record</c>
+    /// on EVERY transcription, and <c>Record</c> is UNCONDITIONAL - it has no enabled-check of any kind. The
+    /// only flag near it is <c>TextEnabled</c>, which merely decides whether the spoken text is included,
+    /// defaults to TRUE, and has no configuration key wired to turn it off ("a future opt-out can gate it").
+    /// So every turn appends a record, WITH the raw and cleaned text in it. The surfaces reaching it - the
+    /// recording endpoints, the batch transcription endpoint and the wingman transcribe route - are all
+    /// outside this group. This is a READ deny only, the same shape as the merged stats deny #1888.
     ///
     /// (b) WHAT ALREADY EXISTS? A log of every account's speech from before the deny, growing the whole
     /// time. Records written with no tenant on them cannot be attributed afterwards, so the choice is
@@ -127,6 +131,13 @@ internal static class TranscriptionAnalysisEndpoint
         // builder makes the mistake INEXPRESSIBLE rather than merely unlikely: inside MapRoutes there is
         // nothing to map onto except the guarded group. The count falls by DESIGN, not by an argument about
         // how careful the next author will be.
+        //
+        // THE LIMIT OF THAT PROPERTY, STATED SO NOBODY OVER-CLAIMS IT: it holds WITHIN THIS MAPPING SITE.
+        // It does not reach across sites. This deny is one of FOUR families, each creating its own group,
+        // attaching its own filter and mapping from its own site, so any one site can be wrong while the
+        // other three stay correct and no compiler notices. That is exactly why the registered proof is
+        // four filter-removal arms and four gate-inversion arms rather than one of each: the split removes
+        // the per-ROUTE bypass inside a family, it does not merge the four families into one primitive.
         MapRoutes(app, log);
         return app;
     }

--- a/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
@@ -68,6 +68,14 @@ internal static class TranscriptionAnalysisEndpoint
     /// 404 rather than 403: on hosted this analysis surface does not exist as a concept - there is no
     /// per-tenant log for it to read - so "not here" is the truthful answer. 403 would imply the right
     /// credential could reach it, and none can.
+    ///
+    /// UN-DENY CONDITION - THIS IS A READ DENY AND THE WRITE IS NOT STOPPED. Removing this deny requires
+    /// ALSO purging or partitioning what accumulated behind it. The telemetry log keeps being written on
+    /// hosted the whole time this refusal stands: <c>GatewayTranscriptionService</c> records a turn on every
+    /// transcription, and the routes that reach it are not in this group. So the file this deny hides goes
+    /// on mixing every account's raw and cleaned speech, and the day the refusal is lifted it would expose a
+    /// contaminated history rather than a clean start. Records written with no tenant on them cannot be
+    /// attributed afterwards - the choice is deletion or quarantine, not a later migration.
     /// </summary>
     private static IResult? DenyOnHosted()
     {

--- a/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
@@ -79,7 +79,11 @@ internal static class TranscriptionAnalysisEndpoint
             statusCode: StatusCodes.Status404NotFound);
     }
 
-    public static void Map(IEndpointRouteBuilder outer, TranscriptionTelemetryReader? reader = null)
+    /// Returns the guarded route group. That return value exists SOLELY so a test can map a brand-new
+    /// route onto the same group and prove it is refused on hosted with no deny written for it - the
+    /// property that distinguishes a group filter from a per-route guard, and which is otherwise
+    /// invisible to any test that only drives the routes existing today.
+    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, TranscriptionTelemetryReader? reader = null)
     {
         var log = reader ?? new TranscriptionTelemetryReader();
 
@@ -125,6 +129,8 @@ internal static class TranscriptionAnalysisEndpoint
             var top = ClampInt(ctx.Request.Query["top"], DefaultWordTop, 1, 5000);
             return Results.Json(new { words = log.TopWords(top, since) });
         });
+
+        return app;
     }
 
     /// <summary>Resolve the time window: <c>days</c> (last N days) wins, else <c>since</c> (ISO), else null.</summary>

--- a/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
@@ -14,16 +14,85 @@ namespace CcDirector.Gateway.Api;
 /// this exposes viewing, editing (new version), version history + revert, and the managed-default
 /// flow (see the dev team's changes, switch to the latest default). Backed by
 /// <see cref="WingmanInstructionsStore"/>.
+///
+/// DENIED IN WHOLE ON HOSTED (issue #1853, read side). Every route in this file is refused on the hosted
+/// Gateway, for two independent reasons that both land on the same answer.
+///
+/// FIRST, THE CONTENT. GET /gateway/wingman/instructions/records pages the wingman training capture, and
+/// each of those records holds up to <see cref="WingmanTrainingStore.MaxTerminalChars"/> characters of raw
+/// session TERMINAL output plus the agent's reply, written to one shared directory with no tenant in it.
+/// A record is addressed by a POSITIONAL identifier - "&lt;filename&gt;#&lt;lineindex&gt;" - so a caller does not
+/// even have to guess: it can walk the index. POST /gateway/wingman/instructions/test then hands those same
+/// records back in full (<c>reply</c> and <c>oldSpoken</c> per record) to whoever asked. Issue #1853 set out
+/// to deny the training WRITE on hosted, but a write deny does nothing about records already on disk, and
+/// nothing about the read. This closes the read.
+///
+/// SECOND, THE OWNERSHIP. The instructions themselves are a single-owner control over the whole box, the
+/// same class as the /gateway settings group: a Gateway has ONE active wingman prompt, and it is the prompt
+/// every account's wingman speaks through. A tenant that saves a version, reverts a version or switches to
+/// default is not editing its own copy - there is no own copy - it is rewriting what the machine says to
+/// everybody. There is nothing to partition by, so a per-tenant answer would mean inventing state the
+/// schema does not have.
+///
+/// The A/B test route is a third strike on its own: it spends up to <see cref="MaxTestRecords"/> real brain
+/// calls per request on shared infrastructure, driven by attacker-chosen draft text.
+///
+/// It is a DENY OF THE WHOLE GROUP because the read and the write are equally damaging here and a
+/// route-by-route guard rots - the next route added to this file would be open by default.
+///
+/// It REFUSES rather than returning an empty record list. "You have no training records" is a FALSE
+/// statement on a box that has them; a refusal is merely an absent one.
+///
+/// Self-host is COMPLETELY unchanged, and that is the control. Self-host has one tenant and one owner, so
+/// the records are the owner's own terminal output and the prompt is the owner's own prompt.
 /// </summary>
 internal static class WingmanInstructionsEndpoint
 {
     /// <summary>Cap on records re-run per A/B test - each one is a (serial, sometimes slow) brain call.</summary>
     private const int MaxTestRecords = 5;
 
-    public static void Map(IEndpointRouteBuilder app, WingmanInstructionsStore store,
+    /// <summary>
+    /// The hosted refusal for the whole wingman-instructions group (issue #1853, read side), or null on
+    /// self-host where nothing changes.
+    ///
+    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> - the INDEPENDENT deployment signal - and NOT on a
+    /// boundary or tenant argument being passed in. A security branch that depends on an optional argument
+    /// fails OPEN when a caller omits it, which is exactly how the hosted account-status fix nearly shipped
+    /// a hole: omit the argument and a hosted Gateway silently takes the self-host path. Asking hosted mode
+    /// directly means this group cannot serve captured terminal output on hosted however the host is wired.
+    ///
+    /// 404 rather than 403: on hosted these routes do not exist as a concept - there is no per-tenant
+    /// training pool and no per-tenant wingman prompt - so "not here" is the truthful answer. 403 would
+    /// imply the right credential could reach them, and none can.
+    /// </summary>
+    private static IResult? DenyOnHosted()
+    {
+        if (!GatewayHostedMode.IsHosted) return null;
+
+        FileLog.Write("[WingmanInstructionsEndpoint] DENIED on hosted: the training records hold raw session terminal output in one shared store, and the wingman prompt is a single-owner control with no per-tenant answer");
+        return Results.Json(
+            new { error = "the wingman instructions surface is not available on the hosted gateway" },
+            statusCode: StatusCodes.Status404NotFound);
+    }
+
+    public static void Map(IEndpointRouteBuilder outer, WingmanInstructionsStore store,
         WingmanTrainingStore training, Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider)
     {
         var translator = new WingmanTranslator(brainProvider);
+
+        FileLog.Write($"[WingmanInstructionsEndpoint] mapping /gateway/wingman/instructions; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1853)");
+
+        // The whole group behind ONE filter, rather than a guard line repeated in every handler.
+        // A repeated guard is a thing to forget: the route added next year would be open by default and
+        // nobody would notice. A group filter runs before EVERY route mapped below, including routes that
+        // do not exist yet, so the refusal cannot rot as the group grows. The empty prefix keeps the route
+        // paths written out in full, exactly as before, so the self-host surface is byte-identical.
+        var app = outer.MapGroup("");
+        app.AddEndpointFilter(async (ctx, next) =>
+        {
+            if (DenyOnHosted() is { } denied) return denied;
+            return await next(ctx);
+        });
 
         // Current state: the active instructions, whether they are customized, whether the dev team
         // has shipped a newer default, and the deployed-default identity.

--- a/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
@@ -68,19 +68,29 @@ internal static class WingmanInstructionsEndpoint
     /// UN-DENY CONDITION - REMOVING THIS DENY REQUIRES ALSO PURGING OR PARTITIONING WHAT ACCUMULATED BEHIND
     /// IT. Two SEPARATE questions, and here the first one already fails.
     ///
-    /// (a) DOES ANYTHING STILL WRITE IT? YES, for the training records - and the writer is worse than a
-    /// route. The prompt half IS contained: every route that can rewrite the wingman instructions (save,
-    /// revert, switch-to-default) is in this group and refused with the reads. The RECORDS are written by
-    /// <c>WingmanVoiceService.GenerateOnceAsync</c> through <c>WingmanTrainingStore.CaptureAsync</c>, and
-    /// that path is reached by the Gateway's OWN voice sweep timer (<c>GatewayHost.SweepVoiceSessionsAsync</c>
-    /// pre-builds voice for idle sessions on an interval). So raw session terminal output keeps landing in
-    /// one untenanted store on hosted WITH NO REQUEST FROM ANYBODY - an unattended background writer, not
-    /// merely a route this deny happens not to cover. Issue #1853's separate interim write deny has not
-    /// landed. Looking only at the denied routes would have missed this entirely.
+    /// (a) DOES ANYTHING STILL WRITE IT? The prompt half IS contained: every route that can rewrite the
+    /// wingman instructions (save, revert, switch-to-default) is in this group and refused with the reads.
+    /// For the training RECORDS the honest answer is LATENT, NOT ACTIVE, and an earlier version of this note
+    /// got that wrong by reading call sites instead of following the gate.
     ///
-    /// (b) WHAT ALREADY EXISTS? Records from before the deny, plus everything the timer adds while it
-    /// stands. They carry no tenant, so they cannot be attributed after the fact: the choice is deletion or
-    /// quarantine, never a later migration.
+    /// There are three writers, none of them in this group: the voice-turn route, the explain route, and
+    /// <c>WingmanVoiceService.GenerateOnceAsync</c> - which is reached by the Gateway's OWN voice sweep
+    /// timer, so it needs no request from anybody. But ALL THREE funnel through
+    /// <c>WingmanTrainingStore.CaptureAsync</c>, whose first statement is <c>if (!Enabled) return;</c>, and
+    /// <c>Enabled</c> reads <c>WingmanTrainingCaptureConfig</c> - the <c>wingman_training_capture</c> key,
+    /// which is OPT-IN and DEFAULTS TO FALSE. On a hosted box that has never set it, nothing writes here at
+    /// all. A CALL SITE PROVES CODE EXISTS, NOT THAT IT RUNS.
+    ///
+    /// So the accurate statement is conditional: while that setting is off nothing accumulates, and the
+    /// moment it is turned on, three writers - one of them an unattended timer - begin appending raw session
+    /// terminal output to one untenanted store, and this deny covers none of them. Issue #1853's separate
+    /// interim write deny still has not landed.
+    ///
+    /// (b) WHAT ALREADY EXISTS? A SEPARATE QUESTION, and the one that decides the un-deny. "Nothing writes
+    /// today" is a statement about the future; it is not evidence about the past. Records may already be on
+    /// disk from any period when the setting was on, or carried in from a self-host box. They carry no
+    /// tenant, so they cannot be attributed after the fact: the choice is deletion or quarantine, never a
+    /// later migration. This is why the READ deny is worth having even while the writers are dormant.
     /// </summary>
     private static IResult? DenyOnHosted()
     {
@@ -127,6 +137,13 @@ internal static class WingmanInstructionsEndpoint
         // builder makes the mistake INEXPRESSIBLE rather than merely unlikely: inside MapRoutes there is
         // nothing to map onto except the guarded group. The count falls by DESIGN, not by an argument about
         // how careful the next author will be.
+        //
+        // THE LIMIT OF THAT PROPERTY, STATED SO NOBODY OVER-CLAIMS IT: it holds WITHIN THIS MAPPING SITE.
+        // It does not reach across sites. This deny is one of FOUR families, each creating its own group,
+        // attaching its own filter and mapping from its own site, so any one site can be wrong while the
+        // other three stay correct and no compiler notices. That is exactly why the registered proof is
+        // four filter-removal arms and four gate-inversion arms rather than one of each: the split removes
+        // the per-ROUTE bypass inside a family, it does not merge the four families into one primitive.
         MapRoutes(app, store, training, translator);
         return app;
     }

--- a/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
@@ -64,6 +64,15 @@ internal static class WingmanInstructionsEndpoint
     /// 404 rather than 403: on hosted these routes do not exist as a concept - there is no per-tenant
     /// training pool and no per-tenant wingman prompt - so "not here" is the truthful answer. 403 would
     /// imply the right credential could reach them, and none can.
+    ///
+    /// UN-DENY CONDITION - THE PROMPT WRITE IS STOPPED, THE RECORD WRITE IS NOT, SO THIS IS THE
+    /// ACCUMULATING KIND. Removing this deny requires ALSO purging or partitioning what accumulated behind
+    /// it. The prompt half is genuinely contained: every route that can rewrite the wingman instructions
+    /// (the save, the revert and the switch-to-default) is inside this group and refused with the reads. The
+    /// TRAINING RECORDS are not: they are written by the wingman voice-turn path through
+    /// <c>WingmanVoiceService</c> -> <c>WingmanTrainingStore.CaptureAsync</c>, which this group does not
+    /// touch and issue #1853's separate interim write deny has not landed. Raw session terminal output from
+    /// every account therefore keeps piling into one untenanted store while this refusal stands.
     /// </summary>
     private static IResult? DenyOnHosted()
     {

--- a/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
@@ -75,7 +75,11 @@ internal static class WingmanInstructionsEndpoint
             statusCode: StatusCodes.Status404NotFound);
     }
 
-    public static void Map(IEndpointRouteBuilder outer, WingmanInstructionsStore store,
+    /// Returns the guarded route group. That return value exists SOLELY so a test can map a brand-new
+    /// route onto the same group and prove it is refused on hosted with no deny written for it - the
+    /// property that distinguishes a group filter from a per-route guard, and which is otherwise
+    /// invisible to any test that only drives the routes existing today.
+    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, WingmanInstructionsStore store,
         WingmanTrainingStore training, Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider)
     {
         var translator = new WingmanTranslator(brainProvider);
@@ -220,6 +224,8 @@ internal static class WingmanInstructionsEndpoint
             }
             return Results.Json(new { results, ranCount = results.Count, capped = req.RecordIds.Length > MaxTestRecords });
         });
+
+        return app;
     }
 
     private static object Project(WingmanInstructionsStore.InstructionVersion v) => new

--- a/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
@@ -1,6 +1,7 @@
 using CcDirector.AgentBrain;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.Wingman;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -68,97 +69,102 @@ internal static class WingmanInstructionsEndpoint
     /// UN-DENY CONDITION - REMOVING THIS DENY REQUIRES ALSO PURGING OR PARTITIONING WHAT ACCUMULATED BEHIND
     /// IT. Two SEPARATE questions, and here the first one already fails.
     ///
-    /// (a) DOES ANYTHING STILL WRITE IT? The prompt half IS contained: every route that can rewrite the
-    /// wingman instructions (save, revert, switch-to-default) is in this group and refused with the reads.
-    /// For the training RECORDS the honest answer is LATENT, NOT ACTIVE, and an earlier version of this note
-    /// got that wrong by reading call sites instead of following the gate.
+    /// (a) DOES ANYTHING STILL WRITE IT? NOT ON HOSTED, in either half. The prompt half was always
+    /// contained: every route that can rewrite the wingman instructions (save, revert, switch-to-default) is
+    /// in this group and refused with the reads. For the training RECORDS there are three writers, none in
+    /// this group: the voice-turn route, the explain route, and <c>WingmanVoiceService.GenerateOnceAsync</c>
+    /// (reached by the Gateway's OWN voice sweep timer, so it needs no request from anybody). ALL THREE
+    /// funnel through <c>WingmanTrainingStore.CaptureAsync</c>, which was already OPT-IN and DEFAULTS TO
+    /// FALSE - but "off by default" is not "cannot be turned on", so THIS PASS HOST-GATES that capture too
+    /// (defense in depth, deny-by-default, matching the key-vault deny #1904): <c>CaptureAsync</c> and its
+    /// <c>WriteAsync</c> both NO-OP on hosted, so even with the setting on, no raw session terminal output
+    /// accumulates in the shared untenanted store while the deny stands. That gate is safe because the
+    /// store's ONLY reader is this now-denied group (the /records and /test routes) - verified nothing
+    /// billing / metering consumes it. #1853's separate interim write deny is subsumed by this gate.
     ///
-    /// There are three writers, none of them in this group: the voice-turn route, the explain route, and
-    /// <c>WingmanVoiceService.GenerateOnceAsync</c> - which is reached by the Gateway's OWN voice sweep
-    /// timer, so it needs no request from anybody. But ALL THREE funnel through
-    /// <c>WingmanTrainingStore.CaptureAsync</c>, whose first statement is <c>if (!Enabled) return;</c>, and
-    /// <c>Enabled</c> reads <c>WingmanTrainingCaptureConfig</c> - the <c>wingman_training_capture</c> key,
-    /// which is OPT-IN and DEFAULTS TO FALSE. On a hosted box that has never set it, nothing writes here at
-    /// all. A CALL SITE PROVES CODE EXISTS, NOT THAT IT RUNS.
+    /// (b) WHAT ALREADY EXISTS? A SEPARATE QUESTION, and the one that decides the un-deny. Gating the write
+    /// is a statement about the future; it is not evidence about the past. Records may already be on disk
+    /// from any period when the setting was on, or carried in from a self-host box. They carry no tenant, so
+    /// they cannot be attributed after the fact: the choice is deletion or quarantine, never a later
+    /// migration.
     ///
-    /// So the accurate statement is conditional: while that setting is off nothing accumulates, and the
-    /// moment it is turned on, three writers - one of them an unattended timer - begin appending raw session
-    /// terminal output to one untenanted store, and this deny covers none of them. Issue #1853's separate
-    /// interim write deny still has not landed.
-    ///
-    /// (b) WHAT ALREADY EXISTS? A SEPARATE QUESTION, and the one that decides the un-deny. "Nothing writes
-    /// today" is a statement about the future; it is not evidence about the past. Records may already be on
-    /// disk from any period when the setting was on, or carried in from a self-host box. They carry no
-    /// tenant, so they cannot be attributed after the fact: the choice is deletion or quarantine, never a
-    /// later migration. This is why the READ deny is worth having even while the writers are dormant.
+    /// HOW THE DENY IS EXPRESSED - THE SHARED REFUSAL PRIMITIVE, NOT A BESPOKE FILTER. This group is denied
+    /// through <see cref="HostedRouteDeny.ExclusiveGroup"/>, the ONE hosted-refusal boundary every deny
+    /// family on this Gateway adopts (reference implementation: the key-vault deny in pull request #1904).
+    /// An earlier revision rolled its own <c>AddEndpointFilter</c> deny before the primitive existed; it has
+    /// been replaced so the release ships ONE refusal boundary. The group owns the <c>/gateway/wingman/instructions</c>
+    /// prefix OUTRIGHT - nothing else serves beneath it - so the exclusive shape fits: on hosted the nine
+    /// handlers are NEVER MAPPED and ONE verb-less catch-all refuses everything under the prefix plus a root
+    /// refusal at the prefix itself, covering every verb, every request shape, and every future sub-path for
+    /// free. The exclusivity claim is CHECKED at startup by <see cref="HostedRefusalRouteSpace.ValidateBeforeStart"/>,
+    /// which fails the Gateway if any live route serves beneath the prefix. Off hosted the primitive maps the
+    /// nine real handlers exactly as an unguarded builder would, with no refusal at all - self-host unchanged.
     /// </summary>
-    private static IResult? DenyOnHosted()
-    {
-        if (!GatewayHostedMode.IsHosted) return null;
+    /// <summary>The exclusive prefix the wingman-instructions route group owns outright on hosted.</summary>
+    internal const string Prefix = "/gateway/wingman/instructions";
 
-        FileLog.Write("[WingmanInstructionsEndpoint] DENIED on hosted: the training records hold raw session terminal output in one shared store, and the wingman prompt is a single-owner control with no per-tenant answer");
-        return Results.Json(
-            new { error = "the wingman instructions surface is not available on the hosted gateway" },
-            statusCode: StatusCodes.Status404NotFound);
-    }
+    /// <summary>The single error string the hosted refusal serves. Held here so a test can assert against the
+    /// exact string that is served rather than a copy that could drift.</summary>
+    internal const string RefusalMessage = "the wingman instructions surface is not available on the hosted gateway";
 
-    /// Returns the guarded route group. That return value exists SOLELY so a test can map a brand-new
-    /// route onto the same group and prove it is refused on hosted with no deny written for it - the
-    /// property that distinguishes a group filter from a per-route guard, and which is otherwise
-    /// invisible to any test that only drives the routes existing today.
-    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, WingmanInstructionsStore store,
+    /// <summary>
+    /// The hosted refusal payload for the whole wingman-instructions group (issue #1853, read side).
+    /// Validated on construction, so a blank field fails the Gateway at startup rather than serving a refusal
+    /// a caller cannot act on. 404 rather than 403: on hosted these routes do not exist as a concept - there
+    /// is no per-tenant training pool and no per-tenant wingman prompt - so "not here" is the truthful
+    /// answer; 403 would imply the right credential could reach them, and none can. Driven off
+    /// <see cref="GatewayHostedMode.IsHosted"/> inside the primitive - the INDEPENDENT deployment signal, not
+    /// an optional argument a caller can omit and thereby fail OPEN.
+    /// </summary>
+    private static HostedDenial Denial() => new(
+        family: "wingman-instructions",
+        message: RefusalMessage,
+        reason: "the training records hold raw session terminal output in one shared, untenanted store addressable " +
+                "by a positional index, and the wingman prompt is a single-owner control over the whole box with no " +
+                "per-tenant version to serve",
+        unDenyInstruction: "do NOT simply remove this deny: the training capture is host-gated now (no new " +
+                "accumulation on hosted) but a shared, untenanted store predates the gate - so tenant-partition the " +
+                "training store, purge or quarantine the pre-existing records (records written with no tenant cannot " +
+                "be attributed afterwards - the choice is deletion or quarantine, never a later migration), and give " +
+                "the single-owner wingman prompt a per-tenant model before any of these routes come back",
+        statusCode: StatusCodes.Status404NotFound);
+
+    /// <summary>
+    /// Maps the wingman-instructions routes and RETURNS the denied group they were mapped through.
+    ///
+    /// The routes are mapped through the group HANDLE (<see cref="HostedDenyGroup"/>), never through the
+    /// ungrouped builder: the handle is obtainable only from <see cref="HostedRouteDeny"/>, so a route mapped
+    /// around the refusal is not expressible in <see cref="MapRoutes"/> without changing its signature - the
+    /// bypass count is reduced by design, not by care. On hosted the exclusive catch-all refuses the whole
+    /// group and each handler is DISCARDED; off hosted the handle maps each handler as an unguarded builder
+    /// would. The return value exists so the future-route property is statable from outside this file: a test
+    /// maps a brand-new route through the returned handle and shows the refusal already covers routes nobody
+    /// has written yet.
+    /// </summary>
+    public static HostedDenyGroup Map(IEndpointRouteBuilder outer, WingmanInstructionsStore store,
         WingmanTrainingStore training, Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider)
     {
         var translator = new WingmanTranslator(brainProvider);
 
-        FileLog.Write($"[WingmanInstructionsEndpoint] mapping /gateway/wingman/instructions; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1853)");
+        FileLog.Write($"[WingmanInstructionsEndpoint] mapping {Prefix}; hosted={GatewayHostedMode.IsHosted} - on hosted the whole group is refused via the shared refusal primitive (issue #1853)");
 
-        // The whole group behind ONE filter, rather than a guard line repeated in every handler.
-        // A repeated guard is a thing to forget: the route added next year would be open by default and
-        // nobody would notice. A group filter runs before EVERY route mapped below, including routes that
-        // do not exist yet, so the refusal cannot rot as the group grows. The empty prefix keeps the route
-        // paths written out in full, exactly as before, so the self-host surface is byte-identical.
-        var app = outer.MapGroup("");
-        app.AddEndpointFilter(async (ctx, next) =>
-        {
-            if (DenyOnHosted() is { } denied) return denied;
-            return await next(ctx);
-        });
-
-        // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - deliberately, and that is the only reason
-        // MapRoutes exists as a separate method. Copied from the key-vault deny (pull request #1904), which
-        // is the reviewed instance of this pattern.
-        //
-        // Written inline here, beside both builders, each of these NINE routes could INDIVIDUALLY be mapped
-        // onto `outer` instead of onto `app` - a one-word edit that compiles, passes every existing test,
-        // and opens exactly that route on hosted while the other eight stay correctly denied. That is nine
-        // independently bypassable primitives, and under the bypassability rule each would owe its own
-        // full-suite security run. Handing the guarded group to a method that never receives the ungrouped
-        // builder makes the mistake INEXPRESSIBLE rather than merely unlikely: inside MapRoutes there is
-        // nothing to map onto except the guarded group. The count falls by DESIGN, not by an argument about
-        // how careful the next author will be.
-        //
-        // THE LIMIT OF THAT PROPERTY, STATED SO NOBODY OVER-CLAIMS IT: it holds WITHIN THIS MAPPING SITE.
-        // It does not reach across sites. This deny is one of FOUR families, each creating its own group,
-        // attaching its own filter and mapping from its own site, so any one site can be wrong while the
-        // other three stay correct and no compiler notices. That is exactly why the registered proof is
-        // four filter-removal arms and four gate-inversion arms rather than one of each: the split removes
-        // the per-ROUTE bypass inside a family, it does not merge the four families into one primitive.
-        MapRoutes(app, store, training, translator);
-        return app;
+        var group = HostedRouteDeny.ExclusiveGroup(outer, Prefix, Denial());
+        MapRoutes(group, store, training, translator);
+        return group;
     }
 
     /// <summary>
-    /// The nine wingman-instructions routes. Takes the GUARDED group and nothing else - see the note at the
-    /// call site: the ungrouped route builder is deliberately out of scope here, so no route in this family
-    /// can be mapped around the hosted filter.
+    /// The nine wingman-instructions routes, mapped relative to the <see cref="Prefix"/> so the full paths
+    /// are <c>/gateway/wingman/instructions</c> and its sub-paths exactly as before. Takes the denied GROUP
+    /// HANDLE and nothing else: the ungrouped route builder is deliberately out of scope here so no route can
+    /// be mapped around the hosted refusal.
     /// </summary>
-    private static void MapRoutes(RouteGroupBuilder app, WingmanInstructionsStore store,
+    private static void MapRoutes(HostedDenyGroup app, WingmanInstructionsStore store,
         WingmanTrainingStore training, WingmanTranslator translator)
     {
         // Current state: the active instructions, whether they are customized, whether the dev team
         // has shipped a newer default, and the deployed-default identity.
-        app.MapGet("/gateway/wingman/instructions", () =>
+        app.MapGet("", () =>
         {
             var active = store.Active();
             return Results.Json(new
@@ -172,7 +178,7 @@ internal static class WingmanInstructionsEndpoint
         });
 
         // Save edited instructions as a new version and make them active.
-        app.MapPut("/gateway/wingman/instructions", (WingmanInstructionsBody? req) =>
+        app.MapPut("", (WingmanInstructionsBody? req) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.Content))
                 return Results.Json(new { error = "content is required" }, statusCode: StatusCodes.Status400BadRequest);
@@ -189,11 +195,11 @@ internal static class WingmanInstructionsEndpoint
         });
 
         // Version history, newest first.
-        app.MapGet("/gateway/wingman/instructions/versions", () =>
+        app.MapGet("/versions", () =>
             Results.Json(new { versions = store.Versions().Select(Project).ToList() }));
 
         // Make an existing version active again.
-        app.MapPost("/gateway/wingman/instructions/revert", (RevertBody? req) =>
+        app.MapPost("/revert", (RevertBody? req) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.Id))
                 return Results.Json(new { error = "id is required" }, statusCode: StatusCodes.Status400BadRequest);
@@ -203,7 +209,7 @@ internal static class WingmanInstructionsEndpoint
         });
 
         // The deployed default (the DevThrottle dev team's shipped instructions).
-        app.MapGet("/gateway/wingman/instructions/default", () =>
+        app.MapGet("/default", () =>
         {
             var d = store.DefaultAsVersion();
             return Results.Json(new { version = store.DefaultVersion, hash = store.DefaultHash, content = d.Content });
@@ -211,7 +217,7 @@ internal static class WingmanInstructionsEndpoint
 
         // The managed-default review: is a newer default available, and what did the dev team change
         // (the acknowledged/based-on default -> the new default), so the page can show the diff.
-        app.MapGet("/gateway/wingman/instructions/update", () =>
+        app.MapGet("/update", () =>
         {
             var (ackVersion, ackContent) = store.AcknowledgedDefault();
             return Results.Json(new
@@ -226,7 +232,7 @@ internal static class WingmanInstructionsEndpoint
         });
 
         // Adopt the deployed default (drop the custom version, acknowledge the latest default).
-        app.MapPost("/gateway/wingman/instructions/switch-to-default", () =>
+        app.MapPost("/switch-to-default", () =>
         {
             store.SwitchToDefault();
             return Results.Json(new { active = Project(store.Active()), isCustomized = store.IsCustomized, updateAvailable = store.UpdateAvailable });
@@ -234,7 +240,7 @@ internal static class WingmanInstructionsEndpoint
 
         // Recent captured training sessions (issue #537): the pool the user picks from to A/B-test a
         // draft prompt. Empty until the wingman_training_capture setting has been on for some turns.
-        app.MapGet("/gateway/wingman/instructions/records", (int? limit) =>
+        app.MapGet("/records", (int? limit) =>
         {
             var n = Math.Clamp(limit ?? 20, 1, 100);
             var records = training.ListRecords(n).Select(r => new
@@ -249,7 +255,7 @@ internal static class WingmanInstructionsEndpoint
         // return, per record, the agent reply, the wingman's ORIGINAL spoken output, and the NEW one
         // the draft produces - so the user sees the effect before saving. Does NOT change the live
         // instructions. Each record is a brain call, so the count is capped.
-        app.MapPost("/gateway/wingman/instructions/test", async (InstructionsTestBody? req, CancellationToken ct) =>
+        app.MapPost("/test", async (InstructionsTestBody? req, CancellationToken ct) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.Content))
                 return Results.Json(new { error = "content (the draft instructions) is required" }, statusCode: StatusCodes.Status400BadRequest);

--- a/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
@@ -65,14 +65,22 @@ internal static class WingmanInstructionsEndpoint
     /// training pool and no per-tenant wingman prompt - so "not here" is the truthful answer. 403 would
     /// imply the right credential could reach them, and none can.
     ///
-    /// UN-DENY CONDITION - THE PROMPT WRITE IS STOPPED, THE RECORD WRITE IS NOT, SO THIS IS THE
-    /// ACCUMULATING KIND. Removing this deny requires ALSO purging or partitioning what accumulated behind
-    /// it. The prompt half is genuinely contained: every route that can rewrite the wingman instructions
-    /// (the save, the revert and the switch-to-default) is inside this group and refused with the reads. The
-    /// TRAINING RECORDS are not: they are written by the wingman voice-turn path through
-    /// <c>WingmanVoiceService</c> -> <c>WingmanTrainingStore.CaptureAsync</c>, which this group does not
-    /// touch and issue #1853's separate interim write deny has not landed. Raw session terminal output from
-    /// every account therefore keeps piling into one untenanted store while this refusal stands.
+    /// UN-DENY CONDITION - REMOVING THIS DENY REQUIRES ALSO PURGING OR PARTITIONING WHAT ACCUMULATED BEHIND
+    /// IT. Two SEPARATE questions, and here the first one already fails.
+    ///
+    /// (a) DOES ANYTHING STILL WRITE IT? YES, for the training records - and the writer is worse than a
+    /// route. The prompt half IS contained: every route that can rewrite the wingman instructions (save,
+    /// revert, switch-to-default) is in this group and refused with the reads. The RECORDS are written by
+    /// <c>WingmanVoiceService.GenerateOnceAsync</c> through <c>WingmanTrainingStore.CaptureAsync</c>, and
+    /// that path is reached by the Gateway's OWN voice sweep timer (<c>GatewayHost.SweepVoiceSessionsAsync</c>
+    /// pre-builds voice for idle sessions on an interval). So raw session terminal output keeps landing in
+    /// one untenanted store on hosted WITH NO REQUEST FROM ANYBODY - an unattended background writer, not
+    /// merely a route this deny happens not to cover. Issue #1853's separate interim write deny has not
+    /// landed. Looking only at the denied routes would have missed this entirely.
+    ///
+    /// (b) WHAT ALREADY EXISTS? Records from before the deny, plus everything the timer adds while it
+    /// stands. They carry no tenant, so they cannot be attributed after the fact: the choice is deletion or
+    /// quarantine, never a later migration.
     /// </summary>
     private static IResult? DenyOnHosted()
     {
@@ -107,6 +115,30 @@ internal static class WingmanInstructionsEndpoint
             return await next(ctx);
         });
 
+        // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - deliberately, and that is the only reason
+        // MapRoutes exists as a separate method. Copied from the key-vault deny (pull request #1904), which
+        // is the reviewed instance of this pattern.
+        //
+        // Written inline here, beside both builders, each of these NINE routes could INDIVIDUALLY be mapped
+        // onto `outer` instead of onto `app` - a one-word edit that compiles, passes every existing test,
+        // and opens exactly that route on hosted while the other eight stay correctly denied. That is nine
+        // independently bypassable primitives, and under the bypassability rule each would owe its own
+        // full-suite security run. Handing the guarded group to a method that never receives the ungrouped
+        // builder makes the mistake INEXPRESSIBLE rather than merely unlikely: inside MapRoutes there is
+        // nothing to map onto except the guarded group. The count falls by DESIGN, not by an argument about
+        // how careful the next author will be.
+        MapRoutes(app, store, training, translator);
+        return app;
+    }
+
+    /// <summary>
+    /// The nine wingman-instructions routes. Takes the GUARDED group and nothing else - see the note at the
+    /// call site: the ungrouped route builder is deliberately out of scope here, so no route in this family
+    /// can be mapped around the hosted filter.
+    /// </summary>
+    private static void MapRoutes(RouteGroupBuilder app, WingmanInstructionsStore store,
+        WingmanTrainingStore training, WingmanTranslator translator)
+    {
         // Current state: the active instructions, whether they are customized, whether the dev team
         // has shipped a newer default, and the deployed-default identity.
         app.MapGet("/gateway/wingman/instructions", () =>
@@ -233,8 +265,6 @@ internal static class WingmanInstructionsEndpoint
             }
             return Results.Json(new { results, ranCount = results.Count, capped = req.RecordIds.Length > MaxTestRecords });
         });
-
-        return app;
     }
 
     private static object Project(WingmanInstructionsStore.InstructionVersion v) => new

--- a/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
+++ b/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
@@ -192,6 +192,18 @@ public sealed class GatewayTranscriptionService
         string turnId, string outcome, string mode, GatewayTranscriptionRouting routing, long audioBytes,
         long transcribeMs, long cleanupMs, bool corrected, string? raw, CleanupOutcome? cleanup, string? error)
     {
+        // HOSTED WRITE GATE (deny-by-default, defense in depth for the transcription-analysis read deny
+        // #1897). The shared telemetry log has no tenant in its path, file name, or records, and its ONLY
+        // reader is the now-denied analysis group (verified: nothing billing / usage-metering / quota
+        // consumes it, so gating undercounts nothing). Continuing to append every account's raw + cleaned
+        // speech to one shared file on hosted would keep accumulating cross-tenant data at rest that nothing
+        // on hosted can even read - so stop the write. Self-host is single-tenant and unchanged.
+        if (GatewayHostedMode.IsHosted)
+        {
+            FileLog.Write("[GatewayTranscriptionService] telemetry write SKIPPED on hosted: the shared transcription telemetry log has no tenant and its only reader is denied on hosted (issue #1897 defense in depth)");
+            return;
+        }
+
         var finalText = cleanup?.Text ?? raw;
         _telemetry.Record(new TranscriptionTelemetryRecord
         {

--- a/src/CcDirector.Gateway/Wingman/WingmanTrainingStore.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanTrainingStore.cs
@@ -57,6 +57,17 @@ public sealed class WingmanTrainingStore
         SessionVerbClient route, string sessionId, string source,
         string reply, string recentContext, string spoken, double replySeconds, CancellationToken ct = default)
     {
+        // HOSTED WRITE GATE (deny-by-default, defense in depth for the wingman-instructions read deny #1853).
+        // The training records hold raw session terminal output in one shared, untenanted store whose ONLY
+        // reader is the now-denied /records + /test routes (verified: nothing billing / metering consumes it).
+        // On hosted, stop capturing - do not fetch the terminal and do not accumulate cross-tenant terminal
+        // output nothing on hosted can read. Checked before the tunnel fetch so it costs nothing on hosted.
+        // Self-host (single tenant, opt-in) is unchanged.
+        if (GatewayHostedMode.IsHosted)
+        {
+            FileLog.Write($"[WingmanTrainingStore] capture SKIPPED on hosted: the shared training store is untenanted and its only reader is denied on hosted (issue #1853 defense in depth): sid={sessionId}");
+            return;
+        }
         if (!Enabled) return;
         string terminal = "";
         try
@@ -79,6 +90,9 @@ public sealed class WingmanTrainingStore
         string sessionId, string source, string terminal, string reply, string recentContext,
         string spoken, double replySeconds, CancellationToken ct = default)
     {
+        // The actual disk write - gated on hosted too (belt and suspenders behind CaptureAsync's gate), so a
+        // future direct caller of WriteAsync cannot reopen the accumulation the read deny #1853 exists to stop.
+        if (GatewayHostedMode.IsHosted) return;
         if (!Enabled) return;
         try
         {


### PR DESCRIPTION
Four route families on the hosted Gateway served one account's CONTENT to any other
account's authenticated device key. Public signup on the backing account project is open,
so "any authenticated caller" means the public. This refuses all four on hosted, and leaves
self-host completely unchanged.

## The defect they share

Every one of them stands on a store with a **single on-disk root and no tenant anywhere** -
not in the path, not in the file name, not in the record - addressed by something that is
**not a tenant boundary**: a positional index, a turn id, or an identifier the caller
supplies in a header.

A caller-supplied identifier is not authorization. Secrecy of an identifier is not
authorization either, and upload ids travel through client logs, retries and
store-and-forward queues.

## What is denied, and why

| Family | Routes | What it hands over | Tracked as |
|---|---|---|---|
| Transcription analysis | `GET /transcription/turns`, `/stats`, `/terms`, `/words` | Up to 2000 records including full `rawText` and `cleanedText` from one shared daily log. **Needs no identifier at all** - one request returns everybody's speech. The other three aggregate the same unpartitioned records. | thefrederiksen/devthrottle_internal#896 |
| Wingman instructions | `GET`/`PUT` `/gateway/wingman/instructions`, `GET /versions`, `POST /revert`, `GET /default`, `GET /update`, `POST /switch-to-default`, `GET /records`, `POST /test` | Training records holding up to 20,000 characters of raw session **terminal output** plus the agent reply, addressed by a positional `<filename>#<lineindex>` id a caller can simply walk. Plus the single-owner wingman prompt every account's wingman speaks through. `/test` also spends up to 5 real model calls per request on shared infrastructure. | thefrederiksen/devthrottle_internal#876 (read side) |
| Wingman utterance upload | `POST /wingman/utterance/upload`, `PUT /{uploadId}/chunk/{index}`, `POST /{uploadId}/complete` | Staged audio and the assembled transcript, keyed solely by a caller-supplied `Idempotency-Key` under a shared root. `complete` returns the transcript; `chunk` lets a caller overwrite another account's recording. | thefrederiksen/devthrottle_internal#895 |
| Dictation upload | `POST /dictation/upload`, `PUT /{uploadId}/chunk/{index}`, `POST /{uploadId}/complete`, `POST /{uploadId}/ack`, `POST /{uploadId}/abandon` | Same `VoiceUploadStore` shape. After account A completes upload id X, account B posts `/dictation/upload` with `Idempotency-Key: X` and the terminal-register short-circuit hands B **A's transcript**. That leg looks no session up, so the fact that `/complete`'s session lookup already fails on hosted does not contain it. `ack` and `abandon` destroy another account's in-flight recording. | thefrederiksen/devthrottle_internal#889 |

The dictation family was **found while doing the other three**: a different route family standing
on the same store shape with the identical defect, live on hosted today. Denied here rather than
left for later.

## The shape of the deny

- **One endpoint-group filter per family**, not a guard repeated in every handler. The filter runs
  before every route in the group **including routes that do not exist yet**, so the refusal cannot
  rot as the group grows.
- **The routes are mapped where the unfiltered builder is not in scope.** Each family's production
  routes live in a private method that receives ONLY the guarded `RouteGroupBuilder`, so mapping a
  route around the filter does not compile. Copied from the key-vault deny, thefrederiksen/devthrottle#1904.
- **Gated on `GatewayHostedMode.IsHosted`** - the independent deployment signal - never on an
  optional boundary or tenant argument, which **fails open** the moment a caller omits it.
- **Deny, not partition.** The tenant is missing from the DATA, not from the query.
- **Refuse, not serve empty.** An empty payload is a false statement; an absent one is merely absent.
- **The body is exactly one `error` property**, asserted as an ALLOW-LIST by enumerating the property
  set, never a deny-list of known keys.
- **404, not 403.** On hosted these surfaces do not exist as a concept.

## Self-host is explicitly unaffected

`HostedContentReadSelfHostControlTests` boots the **same** `GatewayHost` with hosted mode off and
drives the **same** routes. Self-host is single-tenant, these features work there and the owner uses
them. Three untouched pre-existing suites are controls too, with real payloads:
`VoiceUploadLimitsTests`, `DictationSessionLockTests`, `DurableDictationDedupeTests`.

## Why the self-host controls were rebuilt

The first version of those controls asserted **status 200 plus the absence of the refusal strings**.
Both are satisfied by a masking route, so they would have passed on routes that had been deleted:

- `CockpitReactApp` maps `MapFallback("{*path}")` (CockpitReactApp.cs:125), matching **any**
  unclaimed path and **any** verb, answering 404 in a Debug test host but **200 with the HTML shell
  on a release host**. Its own not-found text says "release build only".
- `SessionWsProxyEndpoints` maps `app.Map("/sessions/{sid}/{**rest}")`
  (SessionWsProxyEndpoints.cs:153) - least-specific, every verb - answering **503 as
  `application/json`**, so a content-type check does not catch it. **None of the four families here
  lives under `/sessions/{sid}/`**, so this one cannot mask these routes; it is recorded because it
  is why "check the content type" is not a general defence on this Gateway.
- **No 405 is ever raised on these paths**, so a wrong verb does not announce itself. The old
  control drove `POST` at the dictation chunk route, which production maps `MapPut` only
  (GatewayDictationEndpoint.cs:176) - the request never reached the handler and nothing noticed.

All three facts were read on this branch rather than assumed.

Every read now asserts **seeded or route-specific JSON that only that handler could produce**, and
every write asserts **its own store receipt** - a state change read back, never a status:

| Route | Receipt |
|---|---|
| `GET /transcription/turns` | one telemetry record planted via the production writer, its `rawText` read back |
| `GET /transcription/stats` | `totalTurns == 1` exactly, in an isolated otherwise-empty log |
| `GET /transcription/terms` | the planted find/replace pair |
| `GET /transcription/words` | the planted word counted |
| `GET /gateway/wingman/instructions/records` | a training record planted on disk, its positional id and reply preview read back |
| `GET`/`PUT` `/gateway/wingman/instructions`, `GET /versions`, `GET /update` | a version saved through the route and round-tripped; the customized flag read back through a **different** route than the one that set it |
| `GET /gateway/wingman/instructions/default` | exact top-level property set `{version, hash, content}` plus non-empty content |
| `PUT /wingman/utterance/{id}/chunk/{i}` | the uploaded bytes located on disk **by content** |
| `PUT /dictation/{id}/chunk/{i}` | same, and the verb is `PUT` |
| `POST /dictation/{id}/abandon` | the tombstone read back at re-register |
| `POST /dictation/{id}/ack` | retires exactly once: first `retired=true`, second `retired=false` |

Ordering matters as much as the assertion: **the fingerprint is the first thing allowed to fail**,
and status is only ever asserted after it. A status check first would make a renamed route redden on
"404 != 200", proving a route changed rather than proving the canary detects it.

Every failure path is also an **assertion, never an exception**. `JsonDocument.Parse` threw on the
HTML shell and `GetProperty` threw when another handler answered; both now assert, naming the route
and showing what came back. A red that arrives as a crash does not prove the row it was aimed at.

## Why a run with no summary line is not a result

The mutation driver originally scored any run with no failures as a passing canary check. A Gateway
test run refused by the suite lock - or killed - produces **no summary line at all**, and the driver
read that as a test-quality verdict. This is the artifact, printed verbatim by the old driver:

```
=== MUTATION: GET /transcription/turns [rename] ===

  *** NO RED - THE CANARY CANNOT FAIL FOR THIS ROUTE ***
```

A blank summary line, then a conclusion about test quality invented from a **scheduling** event -
precisely inverted, and in the exact category this work exists to find. The rule now: **a run that
produced no real `Passed!`/`Failed!` summary line is UNPROVEN and is re-run individually - never
scored as "no red", in either direction.**

The driver was rebuilt around that: it retries a non-summary run, records it as unproven if it never
completes, restores the mutation from an `atexit` hook and signal handlers rather than only
`finally`, **refuses to start on a dirty production tree**, aborts a row whose anchor is not unique,
treats a failed build under mutation as unproven rather than trusting stale binaries, and checks each
run's counts reconcile against baseline.

The start-check is the load-bearing part. `finally` does not run through a kill - a killed sweep left
a production endpoint **renamed** in the working tree, which would have presented as a route
mysteriously missing rather than as anything obviously wrong. Handlers are a better convention; the
dirty-tree check is the backstop that does not depend on having anticipated the escape route.

## What the second review demanded, and what changed

Two blockers, and the first one is about the SHAPE OF THE CODE rather than the proof - so it is
answered first, because it changes what the proof has to cover.

### 1. Every route was still individually bypassable

All four families kept the unfiltered builder in scope at the mapping site alongside the guarded
group. `TranscriptionAnalysisEndpoint`, `WingmanInstructionsEndpoint` and `GatewayDictationEndpoint`
had both `outer` and the filtered `app`; `GatewayWingmanVoiceEndpoint` had the unfiltered `app` beside
the filtered `utterance`. Changing one mapping receiver compiles, passes every existing test, and
opens exactly that route on hosted while its siblings stay correctly denied. Four, nine, three and
five independently bypassable primitives.

**And the twenty-one rename canaries did not test that.** Renaming or re-verbing a route proves the
route is reachable through the filter. The bypass substitutes the BUILDER, not the route. Those are
different mutations against different axes, and a lot of work on the wrong axis leaves the question
exactly as open as it was.

Every family's production routes now live in a private method that receives ONLY its filtered
`RouteGroupBuilder`. Inside it there is nothing to map onto except the guarded group, so mapping
around the filter DOES NOT COMPILE. The bypass is inexpressible rather than unlikely.

This copies **the key-vault deny, pull request thefrederiksen/devthrottle#1904**, which is the reviewed instance of the pattern
and the version to compare this against.

**THE LIMIT OF THE PROPERTY, STATED SO IT IS NOT OVER-CLAIMED.** The compile-time guarantee holds
WITHIN ONE MAPPING SITE. It does not reach across sites. This unit has FOUR families, each creating
its own group, attaching its own filter and mapping from its own site - so any one site can be wrong
while the other three stay correct, and no compiler notices. The split removes the per-ROUTE bypass
inside a family; it does NOT merge four families into one primitive, and it is not an argument for
fewer arms. That is precisely why the registration below is four filter removals and four gate
inversions rather than one of each.

`GatewayWingmanVoiceEndpoint` is the sharpest case and worth reading on its own: the unfiltered
builder is LEGITIMATELY in that file, because the voice-turn, text-to-speech, transcribe, explain, ask
and menu routes are not part of the denied family and must keep serving on hosted. That is exactly
what made the bypass cheap there. Only the three utterance legs moved.

### 2. The proof omitted the gate direction

Each family's deny is a CONJUNCTION of two independent facts: the filter must be ATTACHED, and its
`GatewayHostedMode.IsHosted` condition must FACE THE RIGHT WAY. A filter-removal arm leaves the
condition untouched, so it cannot detect a gate written backwards - and a backwards gate serves every
denied route to every account on hosted while breaking the owner's own features on self-host. Nothing
in the previous twenty-five-run registration would have gone red for it.

Four gate-inversion arms are now registered beside the four filter removals. Each inversion predicts
BOTH the hosted rows and the self-host rows, because a backwards gate breaks both directions at once,
and each predicts that the outside-the-group scoping control stays GREEN - a gate inversion cannot
reach a route mapped outside the group, so if that control reddens the arm hit something wider than
the gate.

## The proof, re-registered against the new structure

**Ten full-suite runs: a clean baseline, eight independent arms, an exact restored green.** No arm is
ever combined with another - a combined arm mis-attributes rows.

| Arm | What it breaks | Must redden |
|---|---|---|
| 4 x filter removal | the filter is not attached at all | that family's hosted refusal rows, the future-route probe, the no-tenant row |
| 4 x gate inversion | the hosted condition faces backwards | the same hosted rows AND that family's self-host receipts |

The anchor preflight passes: eight arms, each anchor appearing exactly once, zero bad anchors.

### How each run is believed, and what refuses it

**The baseline must be GREEN AND COMPLETE.** Green alone is not a reference: a truncated run is green
by construction, because the tests that would have failed never ran, and every arm measured against
that too-small number would then look like it reconciles. The driver requires the baseline's own
`passed + failed + skipped == total` before anything is compared to it.

**Reconciliation happens BEFORE scoring, not after.** For each arm, `passed + failed + skipped` must
equal the baseline TOTAL. A SHORT TOTAL IS TRUNCATION, NOT A MUTATION THAT REDDENED FEWER TESTS THAN
PREDICTED - the two are indistinguishable from the red list alone, which is exactly why the count has
to be believed before the reds are read. A short total now makes the arm UNPROVEN and skips scoring
entirely, so a truncated run can no longer report "expected but stayed green" about tests that never
executed.

Three defects were fixed to get there, and each could have laundered a truncated run into a clean
result: the sum left SKIPPED out (it balanced only because the skip count happened not to move); it
compared against baseline PASSED rather than baseline TOTAL (but tests move from passed to failed
under an arm - that is the point of an arm - so TOTAL is the quantity that must hold); and it scored
first and reconciled afterwards.

**The run refuses to start unless the work under test is COMMITTED.** The clean-tree check covers the
whole `src/` tree, not just the Gateway project: the test project is where the assertions live, and a
lost test edit falsifies an arm exactly as thoroughly as a lost production edit. The head under test
is stamped into the log so every number is attributed to an exact commit.

**The pushed-head enforcement is deliberately NOT here** - it belongs to the repository-wide guard
unit (#1937), which has taken it into its own mechanism. Two implementations of one guarantee drift
until neither can be shown to be the one doing the work.

**And the reason it is worth having is not the one an earlier version of this body gave**, so the
corrected version is recorded rather than the flattering one. That version claimed a pushed-head check
CLOSES the stash gap. It does not. Nothing can know what a head was SUPPOSED to contain - a commit
missing a repair is indistinguishable, from inside, from a commit that never needed one. What it buys
is that the claim becomes CHECKABLE BY SOMEONE ELSE: the commit every number is attributed to can be
fetched and read, so a missing repair is visible in the record instead of invisible on one machine.

**That distinction matters because this driver has both kinds and they are not the same thing.** Some
controls PREVENT a failure: the truncation check is one - a short total means the arm cannot be
scored, full stop. Others cannot prevent anything and only EXPOSE: the head stamp is one - it stops
nothing, it moves a potential failure somewhere a second person can see it. Conflating them is how a
log full of reassuring lines comes to feel like a guarantee.

### Labelling every control, and what that audit found

Classifying two controls led to classifying all of them, and the exercise was not bookkeeping - it
found two defects in the load-bearing scoring path, both of the same shape: **a control I described
as PREVENTING was implemented as merely EXPOSING.**

**1. A crash-red was credited to the prediction.** The rule at the top of the driver says "a red only
counts if it is an assertion" - a red arriving as a `JsonException` or a `KeyNotFoundException` means
the request went somewhere unexpected and something threw upstream of the assertion, which is
laundering. The implementation added *every* red to the credited set and merely appended the crash to
a list. So a crash-red satisfied the prediction, kept the row out of the not-reddened list, and the
arm read as PROVEN. That is precisely the laundering the rule exists to stop, sitting inside the
mechanism that enforces it. Now only assertion-reds are credited, so a crash leaves the row uncredited
and the arm unproven.

**2. The sweep returned zero no matter what it found.** Every check appends to a problems list - crash
reds, rows that stayed green, truncated arms, non-unique anchors, builds that failed under mutation -
and the final line printed that list and then `return 0`. The whole apparatus was an exposing control
wearing the costume of a preventing one: anything reading the exit code would be told the sweep passed
while the log said otherwise, and the log is exactly what nobody re-reads once the exit code is green.
**A finding that does not change the verdict is not a finding, it is a comment.** The verdict now
depends on the findings, and the restored re-check is held to the same green-AND-complete bar as the
baseline.

| Control | Kind |
|---|---|
| Clean `src/` tree before starting | PREVENTS - nothing runs |
| Baseline green AND complete | PREVENTS - aborts |
| Anchor not unique / build fails under an arm | PREVENTS - arm not scored |
| No summary line (retry, then unproven) | PREVENTS - a non-run is never scored |
| Arm total short of baseline total | PREVENTS - truncation, not scored |
| Crash-red not credited to a prediction | PREVENTS - **was exposing until this audit** |
| Restore-on-exit via `atexit` and signal handlers | PREVENTS - no mutation survives the process |
| Restored re-check green AND complete | PREVENTS - **was exposing until this audit** |
| Exit code reflects the problems list | PREVENTS - **was exposing until this audit** |
| Head stamped into the log | EXPOSES - stops nothing; makes numbers attributable |
| Unexpected-red reporting | EXPOSES the anomaly, and now also fails the verdict |

Before this audit I would have said the sweep had nine preventing controls. It had six, and three of
the most important - is this red real, did the tree come back, did anything go wrong at all - were
printouts.

**The test that matters is not "what kind is this" but "would removing it change any verdict the
system can produce".** Six of the labels above had been verified by execution; four had been assigned
by READING the code, which is the method that has been wrong three times on this unit already. So
each of those four was then executed against the condition it claims to catch - a non-unique anchor, a
build that fails under an arm, an arm run that yields no summary line - and each does fail the
verdict, with a positive control confirming a fully correct sweep still returns zero.

**The last label was the interesting one, and it was a third of a guarantee.** Restore-on-exit was
labelled as preventing a leftover mutation. Measured against three real process deaths: an uncaught
exception restores, a `sys.exit` through the signal path restores, and a **hard kill does not - the
mutation survives on disk**. So for the death mode that actually happened to this unit once, restore
prevents nothing; the only thing standing between it and a later run measuring mutated source is the
clean-tree precondition, which was then confirmed to see exactly the leftover such a kill produces.
The driver's own note now records the measured split rather than the comfortable summary. All three harnesses were re-run after the change, and the run count re-measured, because
the fix altered control flow that every earlier check depended on.

**Every one of these guards was watched refusing, each with a positive control**, rather than being
trusted because it was written: clean-and-matching admits while dirty, untracked-in-`src` and
head-not-pushed all refuse; a green-and-complete baseline proceeds while a green-but-truncated one and
a complete-but-red one both abort; a short arm total is marked truncated and NOT scored while a
complete one is scored normally. A guard nobody has seen refuse is not a guard.

One correction found while doing this: the canary gate sat AFTER the slice baseline, so the default
path ran a baseline it never used and would have handed the lane an ELEVENTH run while the
registration said ten. A registered count the driver does not honour is worth nothing, and the error
was in the direction of quietly consuming more of a contended box.

**The registered count is now MEASURED, not counted by reading.** The driver's default path was
executed with its runners instrumented: **exactly ten full-suite runs and zero slice runs** - one
baseline, eight arms, one restored re-check. Measuring it also corrected an arithmetic claim of my
own about the opt-in canary path: I expected twenty-two slice runs (one baseline plus twenty-one
mutations) and it actually takes twenty-three, because that path has its own restored re-check at the
end. The driver was right and my arithmetic was wrong - which is the whole argument for executing the
path rather than counting it in your head. That path stays opt-in and is no part of the registration.

**What is NOT in the registration, and why that is the point.** The per-route builder-substitution
bypass has no arm, because it no longer compiles - twenty-one route-level primitives removed by
design. The twenty-one rename canaries are no longer part of the security proof either: they are
positive-handler canaries, a test-quality check on the filtered slice, now off by default behind a
flag. What did NOT shrink is the per-family work: eight arms for four families, because four mapping
sites and four gates are four independent things that can each be wrong on their own.

## WHICH failures this deny prevents, and which it does not

The per-failure-mode question was applied to the driver first and then, more usefully, to the thing
that actually ships. Every sentence anyone would write about this deny is true - "the four content
read families are refused on hosted" - and, like every comfortable summary, it is not exhaustive. The
coverage is stated here so nobody reads it as "this state is protected".

| Failure mode | Covered? | By what |
|---|---|---|
| An existing route in a guarded family serves cross-tenant content on hosted | YES | the group filter; proven by the hosted refusal rows |
| A NEW route added to a guarded family later | YES | the group filter runs before routes that do not exist yet; proven by the four future-route probes |
| An existing route mapped onto the ungrouped builder to escape the filter | YES | does not compile - the routes are mapped where the unfiltered builder is out of scope |
| The hosted gate written backwards | YES | the four gate-inversion arms |
| The deny accidentally reaching self-host | YES | the self-host control class, plus the outside-the-group scoping control |
| **A NEW ENDPOINT FILE reading the same store with no filter of its own** | **NO** | **nothing. No test fails.** |
| **Writes into these stores** | **NO for two families** | see the un-deny ledger below |

**The uncovered mode is not hypothetical, and one store makes it cheap.** Today each state has exactly
one reader and each sits inside a guarded group - that was checked, not assumed. But nothing prevents
a fifth surface: a new endpoint file that constructs the store and serves it, with no group and no
filter, would be cross-tenant on hosted and **no test in the repository would go red**. The group
filter defends the family it is attached to; it cannot defend a family nobody has written yet.

`VoiceUploadStore` sharpens it. Its PARAMETERLESS constructor binds the shared cross-tenant voice-turn
root (`VoiceUploadStore() : this(CcStorage.VoiceTurnUploads())`), so `new VoiceUploadStore()` written
in a new endpoint tomorrow silently reaches every account's staged audio - no argument, no warning,
nothing to notice in review. That constructor belongs to the tenant-keying unit for that store
(#1900), so it is reported rather than edited here: two units changing one file is how the drift this
mission keeps finding gets started.

The durable fix for this mode is not another deny - it is tenant-keying the stores, which is exactly
what the issues in the un-deny ledger below are for. Recorded here so the gap is visible in the
record rather than resting on my having noticed it once.

## The un-deny ledger: two questions, not one

A read-only deny is a DEFERRED LEAK - content keeps accumulating behind it, and the day it is lifted
it exposes a contaminated history rather than a clean start. The first version of this ledger asked
whether the DENIED ROUTES write. That is the wrong question, and it is the question all four denies
tonight got wrong. The right ones are two, asked separately:

**(a) Does ANYTHING still write this state?** Not "do the denied routes write it" - a deny closes one
door and says nothing about the others.
**(b) What is ALREADY SITTING THERE from before the deny?** That does not improve while the refusal
stands, and stopping accumulation never cleans a root.

**A CALL SITE PROVES CODE EXISTS, NOT THAT IT RUNS**, and **NO NEW WRITES IS A STATEMENT ABOUT THE
FUTURE, NOT EVIDENCE ABOUT THE PAST**. Both of those cost me a claim below.

Re-asking (a) properly changed an answer twice - once in each direction. I first wrote that the
wingman training records are written by the Gateway's own voice sweep timer with no request from
anybody. That came from reading call sites. The writers are real but LATENT: every one of them is
behind an opt-in setting that defaults to off. The claim is corrected in the table below rather than
quietly softened. The transcription claim was put through the same check and survived, and is now
recorded with the evidence instead of the inference.

The two upload families were re-swept at METHOD level: every store construction, every production
caller of every mutating method on the type, and any raw file writer into the root that bypasses the
type - not the routes that happen to touch the state.

| Family | (a) Anything still writing? | (b) What already exists | Un-deny condition |
|---|---|---|---|
| Transcription analysis (#1897) | **YES - re-checked through the gate, not the call sites, and it survives.** `TranscriptionTelemetryLog.Record` is UNCONDITIONAL: no enabled-check of any kind. The only flag near it decides whether the spoken text is included, defaults to TRUE, and has no configuration key wired to turn it off. So every turn appends a record with the text in it. The recording endpoints, the batch transcription endpoint and the wingman transcribe route all reach it and none is in this group. Read-only deny, same shape as the merged stats deny thefrederiksen/devthrottle#1888. | Every account's speech, from before the deny and growing the whole time. | **Removing the deny requires ALSO purging or partitioning what accumulated behind it.** Records carry no tenant, so they cannot be attributed afterwards: deletion or quarantine, never a later migration. |
| Wingman instructions (#1853) | **LATENT, not active - I had this wrong and corrected it.** The prompt half IS contained (save, revert, switch-to-default are all in this group). For the records I first said the voice sweep timer writes them, having read call sites. Following the gate instead: all three writers - the voice-turn route, the explain route, and the timer-driven `GenerateOnceAsync` - funnel through `WingmanTrainingStore.CaptureAsync`, whose first statement checks `wingman_training_capture`, which is opt-in and defaults to FALSE. On a box that never set it, nothing writes. Turn it on and three writers, one unattended, start appending - none covered by this deny. | Records from any period the setting was on, or carried in from a self-host box. | **Removing the deny requires ALSO purging or partitioning what accumulated behind it.** Plus the interim training-write deny, still not merged. The read deny is worth having even while the writers are dormant. |
| Wingman utterance upload (#1896) | **No.** Writers enumerated exhaustively, not inferred: every `VoiceUploadStore` construction in the repository; the only production one on this root is `GatewayHost._voiceTurnUploads`, handed to this endpoint alone, and every `uploads.` call in the file is inside the guarded group. `SweepAbandoned` has NO production caller, only a test. The one residual write is the constructor ensuring an empty directory. | Unknown, presumed contaminated: the shared root may hold pre-deny cross-tenant staged audio and assembled transcripts. | **The write is stopped - AND the un-deny still requires purging or quarantining the legacy root**, on top of tenant-keying the store. "The write is stopped" is not "the root is clean". |
| Dictation upload (#1884) | **No.** Same exhaustive enumeration: the only production writer on the dictation-uploads root is `GatewayHost._dictationUploads` into this endpoint, plus one read-only status query and Core's read-only `DictationLockReader`. Every mutation in the file is inside the group; the static `_completes` cache is filled only by the completion leg, refused too. | Unknown, presumed contaminated: pre-deny staged audio, delivery records and transcripts. | **The write is stopped - AND the un-deny still requires purging or quarantining the legacy root**, on top of tenant-keying the store, the record and the `_completes` cache. |

The boundary of the two "no" answers is deliberately narrow: they are about THAT STORE. A completed
dictation also writes a turn into the shared transcription telemetry log, which is the first row's
problem and is the accumulating kind.

Note what is deliberately NOT written anywhere: "blocked on partitioning" as a standalone phrase.
Someone reading a ticket later ticks that off in good faith and re-enables the route. Every row names
the specific store and the specific thing that has to be true first.

## The un-deny debt

**A deny is a tracked promise to come back, never a silent state.** When these features are turned on
for hosted, this is the explicit list of what to un-deny and what has to be true first.

| Route | File | Remove | Un-deny only when |
|---|---|---|---|
| `GET /transcription/turns` | `Api/TranscriptionAnalysisEndpoint.cs` | group filter calling `DenyOnHosted` | thefrederiksen/devthrottle_internal#896: the telemetry log is partitioned by tenant AND existing unattributed records are deleted or quarantined (they cannot be attributed after the fact) |
| `GET /transcription/stats` | same | same filter | same as above |
| `GET /transcription/terms` | same | same filter | same as above |
| `GET /transcription/words` | same | same filter | same as above |
| `GET /gateway/wingman/instructions` | `Api/WingmanInstructionsEndpoint.cs` | group filter calling `DenyOnHosted` | A per-tenant wingman prompt exists in the schema. Today a Gateway has exactly ONE, so there is no correct hosted answer |
| `PUT /gateway/wingman/instructions` | same | same filter | same as above |
| `GET /gateway/wingman/instructions/versions` | same | same filter | same as above |
| `POST /gateway/wingman/instructions/revert` | same | same filter | same as above |
| `GET /gateway/wingman/instructions/default` | same | same filter | same as above |
| `GET /gateway/wingman/instructions/update` | same | same filter | same as above |
| `POST /gateway/wingman/instructions/switch-to-default` | same | same filter | same as above |
| `GET /gateway/wingman/instructions/records` | same | same filter | thefrederiksen/devthrottle_internal#876: `WingmanTrainingStore` partitioned by tenant, the training WRITE deny lands, AND pre-existing records on the hosted box are dealt with |
| `POST /gateway/wingman/instructions/test` | same | same filter | thefrederiksen/devthrottle_internal#876 as above, PLUS a decision on who may spend model calls on shared infrastructure |
| `POST /wingman/utterance/upload` | `Api/GatewayWingmanVoiceEndpoint.cs` | group filter calling `DenyUtteranceOnHosted` | thefrederiksen/devthrottle_internal#895: store root AND record partitioned by tenant, tenant resolved and AUTHORIZED on all three legs, same-upload-id canaries proving chunks and transcript cannot cross in either direction, each with a positive control |
| `PUT /wingman/utterance/{uploadId}/chunk/{index}` | same | same filter | same as above |
| `POST /wingman/utterance/{uploadId}/complete` | same | same filter | same as above |
| `POST /dictation/upload` | `Api/GatewayDictationEndpoint.cs` | group filter calling `DenyOnHosted` | thefrederiksen/devthrottle_internal#889: the `VoiceUploadStore` root, the `DictationDeliveryRecord` and the static `_completes` cache all tenant-keyed, and the tenant authorized on every leg - not only `/complete` |
| `PUT /dictation/{uploadId}/chunk/{index}` | same | same filter | same as above |
| `POST /dictation/{uploadId}/complete` | same | same filter | same as above |
| `POST /dictation/{uploadId}/ack` | same | same filter | same as above |
| `POST /dictation/{uploadId}/abandon` | same | same filter | same as above |

## Two things deliberately NOT done here

- **The transcription audio archive has no HTTP read route on `main`.** thefrederiksen/devthrottle_internal#896 names it alongside the
  telemetry log, so it was searched for specifically: `TranscriptionAudioArchive` exposes `FileFor`
  and `TrySave` and nothing that reads, no route resolves it, and the Gateway serves no static files.
  The raw audio is still unpartitioned on disk - the rest of thefrederiksen/devthrottle_internal#896's job - but there is no read
  surface to deny.
- **The training-capture WRITE (#1853) is still open on `main`.** The interim hosted write deny that
  issue describes is not merged. This closes the READ, which a write deny would not have done anyway.

## Proof status

Rebased onto `origin/main` at f2028deb. `git range-diff` reports every commit identical across the
rebase - the verification is that range-diff, not a rebuild that happened to succeed.

There is no replacement proof on this head yet, and the old results stay retired. The registration
above is what will be run, in one drained sitting, and it is deliberately smaller than the one it
replaces because the code no longer needs the difference.

A run that produces no real `Passed!`/`Failed!` summary line is UNPROVEN and re-run individually,
never scored as "no red" in either direction. Full seven-project counts go up with the arms.







