### PR TITLE
fix(gateway): deny the whole key-vault route group on hosted

### DIFF
--- a/docs/architecture/gateway/GATEWAY_KEY_VAULT.md
+++ b/docs/architecture/gateway/GATEWAY_KEY_VAULT.md
@@ -48,6 +48,16 @@ On the always-on Gateway box, in a store **outside git** (same principle as toda
 | `PUT /vault/keys/{name}` `{ value }` | set / update a key |
 | `DELETE /vault/keys/{name}` | remove a key |
 
+**SELF-HOST ONLY. Every route in the table above is refused on the hosted Gateway** (404, body
+`{ "error": "the key vault is not available on the hosted gateway" }`). The store is one global vault
+file at the shared storage root with no tenant in the file, the store, or the routes, and the routes sit
+behind only the host-wide authentication gate - which admits any enrolled device key from any account. So
+on shared hosted infrastructure the value read is credential theft, the write is tampering with another
+account's paid service, and the delete disables it. The refusal is gated on the hosted deployment signal
+(`GatewayHostedMode.IsHosted`), applied as one filter over the whole route group, so self-host behavior is
+byte-identical to what is documented here. The routes come back one at a time when the vault is
+partitioned per account.
+
 ## 5. How Directors get keys
 
 **Pull on demand.** When a Director feature needs a key (dictation -> `OPENAI_API_KEY`), it `GET`s it from the Gateway and **caches it in memory only** - never writes it to local disk. On a cache miss (or a provider rejecting the key), it re-fetches.

--- a/docs/architecture/gateway/GATEWAY_KEY_VAULT.md
+++ b/docs/architecture/gateway/GATEWAY_KEY_VAULT.md
@@ -55,8 +55,21 @@ behind only the host-wide authentication gate - which admits any enrolled device
 on shared hosted infrastructure the value read is credential theft, the write is tampering with another
 account's paid service, and the delete disables it. The refusal is gated on the hosted deployment signal
 (`GatewayHostedMode.IsHosted`), applied as one filter over the whole route group, so self-host behavior is
-byte-identical to what is documented here. The routes come back one at a time when the vault is
-partitioned per account.
+byte-identical to what is documented here.
+
+**The un-deny condition, stated so it cannot be ticked off by mistake: THE WRITE IS STOPPED.** The deny
+covers `PUT` and `DELETE` as well as the two reads, so no key material accumulates in the global vault file
+behind this refusal while it is in force. Removing the deny therefore requires only that a per-account key
+namespace exists in the vault - it does NOT additionally require purging a contaminated history, because
+there is no history being written. This is the opposite of a read-only deny such as the hosted stats deny
+(pull request #1888), where the data keeps accruing behind the refusal and lifting it would expose what
+piled up. Un-deny the routes one at a time once the namespace exists.
+
+**This deny does not make key material on the hosted Gateway safe, and must not be read as clearance for
+anything else.** It closes one route group. In particular it says nothing about the voice vault key, which
+stays UNCONFIGURED on hosted until the whole voice chain is partitioned: configuring it does not deliver
+voice, it arms a cross-tenant leak, because clips and the plaintext transcript beside each one land in a
+shared directory until that chain is partitioned. Nothing here changes that.
 
 ## 5. How Directors get keys
 

--- a/docs/architecture/gateway/GATEWAY_KEY_VAULT.md
+++ b/docs/architecture/gateway/GATEWAY_KEY_VAULT.md
@@ -57,13 +57,35 @@ account's paid service, and the delete disables it. The refusal is gated on the 
 (`GatewayHostedMode.IsHosted`), applied as one filter over the whole route group, so self-host behavior is
 byte-identical to what is documented here.
 
-**The un-deny condition, stated so it cannot be ticked off by mistake: THE WRITE IS STOPPED.** The deny
-covers `PUT` and `DELETE` as well as the two reads, so no key material accumulates in the global vault file
-behind this refusal while it is in force. Removing the deny therefore requires only that a per-account key
-namespace exists in the vault - it does NOT additionally require purging a contaminated history, because
-there is no history being written. This is the opposite of a read-only deny such as the hosted stats deny
-(pull request #1888), where the data keeps accruing behind the refusal and lifting it would expose what
-piled up. Un-deny the routes one at a time once the namespace exists.
+**What this deny stops, narrowly: the HTTP ROUTE write and the HTTP ROUTE delete - NOT every write to this
+vault.** An earlier revision of this document claimed "the write is stopped" outright. That was false, and
+the correction is recorded here rather than quietly dropped, because the mistake is the reusable lesson: the
+question asked was "do the DENIED ROUTES write?", and the question that decides an un-deny condition is
+"does ANYTHING write?" plus "what is ALREADY SITTING THERE from before the deny existed?". A deny closes one
+door; it says nothing about the other doors, nor about what accumulated before it was hung.
+
+The other writers to this same global vault, enumerated exhaustively (every `Set`, `SetIfAbsent` and
+`Delete` call in the codebase):
+
+| Writer | Operation | When it fires | Hosted-gated? |
+|---|---|---|---|
+| `GatewayHost.SeedKeyVaultFromEnvironment` | `SetIfAbsent` | Host startup | **No** |
+| `TranscriptionKeyAutoProvisioner.EnsureAsync` | `SetIfAbsent`, `Set` | Every sign-in, and again at startup | **No** |
+| `TranscriptionKeyAutoProvisioner.RevokeMintedKeyAsync` | `Delete` x2 | Every sign-out | **No** |
+
+Key material therefore **still arrives in the global vault while this deny is in force**, by paths that never
+touch the denied routes.
+
+**The un-deny condition, in order, and the purge is REQUIRED:**
+
+1. Tenant-partition every remaining producer in the table above.
+2. **Quarantine, purge or migrate the pre-existing global vault root** - material predating this deny is
+   already in the file, and this change never touched it.
+3. Only then restore a tenant-scoped route, one at a time. **The raw-value `GET` is the last one back.**
+
+Anyone lifting this deny needs the partition **and** the purge. Do not treat step 2 as optional; it is not
+satisfied by any amount of configuration or rollout work, and it cannot be skipped on the grounds that the
+routes were denied.
 
 **This deny does not make key material on the hosted Gateway safe, and must not be read as clearance for
 anything else.** It closes one route group. In particular it says nothing about the voice vault key, which

--- a/docs/architecture/gateway/GATEWAY_KEY_VAULT.md
+++ b/docs/architecture/gateway/GATEWAY_KEY_VAULT.md
@@ -53,9 +53,14 @@ On the always-on Gateway box, in a store **outside git** (same principle as toda
 file at the shared storage root with no tenant in the file, the store, or the routes, and the routes sit
 behind only the host-wide authentication gate - which admits any enrolled device key from any account. So
 on shared hosted infrastructure the value read is credential theft, the write is tampering with another
-account's paid service, and the delete disables it. The refusal is gated on the hosted deployment signal
-(`GatewayHostedMode.IsHosted`), applied as one filter over the whole route group, so self-host behavior is
-byte-identical to what is documented here.
+account's paid service, and the delete disables it. The refusal is expressed through the shared hosted-refusal
+primitive (`HostedRouteDeny.ExclusiveGroup`, the one boundary every deny family on this Gateway adopts): on
+hosted the four handlers are never mapped and one verb-less catch-all refuses everything under `/vault/keys` -
+every request shape, and any route added under the prefix later. The claim that nothing else serves beneath
+`/vault/keys` is startup-validated (`HostedRefusalRouteSpace`), and the hosted decision reads
+`GatewayHostedMode.IsHosted` directly rather than an argument a caller can omit. Off hosted the primitive maps
+the real handlers and creates no refusal at all, so self-host behavior is byte-identical to what is documented
+here.
 
 **What this deny stops, narrowly: the HTTP ROUTE write and the HTTP ROUTE delete - NOT every write to this
 vault.** An earlier revision of this document claimed "the write is stopped" outright. That was false, and
@@ -69,12 +74,15 @@ The other writers to this same global vault, enumerated exhaustively (every `Set
 
 | Writer | Operation | When it fires | Hosted-gated? |
 |---|---|---|---|
-| `GatewayHost.SeedKeyVaultFromEnvironment` | `SetIfAbsent` | Host startup | **No** |
-| `TranscriptionKeyAutoProvisioner.EnsureAsync` | `SetIfAbsent`, `Set` | Every sign-in, and again at startup | **No** |
-| `TranscriptionKeyAutoProvisioner.RevokeMintedKeyAsync` | `Delete` x2 | Every sign-out | **No** |
+| `GatewayHost.SeedKeyVaultFromEnvironment` | `SetIfAbsent` | Host startup | **Yes** - no-ops on hosted |
+| `TranscriptionKeyAutoProvisioner.EnsureAsync` | `SetIfAbsent`, `Set` | Every sign-in, and again at startup | **Yes** - inert on hosted |
+| `TranscriptionKeyAutoProvisioner.RevokeMintedKeyAsync` | `Delete` x2 | Every sign-out | **Yes** - inert on hosted |
 
-Key material therefore **still arrives in the global vault while this deny is in force**, by paths that never
-touch the denied routes.
+All three writers are gated on `GatewayHostedMode.IsHosted` (each reads the deployment signal directly, so it
+cannot fail open by a caller omitting an argument), so **no new key material arrives in the global vault on
+hosted while this deny is in force.** Material that **predates** this deny is a separate concern that the
+un-deny condition below still owns: the deny closes the route door and the writer gates close the write doors,
+but neither touches what was already in the file.
 
 **The un-deny condition, in order, and the purge is REQUIRED:**
 

--- a/src/CcDirector.Gateway.Tests/HostedVaultDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedVaultDenyTests.cs
@@ -1,0 +1,334 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The whole <c>/vault/keys</c> group is DENIED on the hosted Gateway - reads, writes and delete alike.
+///
+/// The store behind those routes is ONE global key vault file at the shared storage root, with no tenant
+/// in the file, the store, or the routes, and the group sits behind only the host-wide authentication
+/// gate - which admits ANY enrolled device key from ANY account. So before this change any hosted
+/// subscriber could read every other subscriber's provider credentials in cleartext (the single-key GET
+/// returns the raw value), overwrite them, and delete them. That is credential THEFT and TAMPERING, not a
+/// disclosure, which is why the whole surface closes and not only the value-returning read.
+///
+/// THE GATE IS ON THE DEPLOYMENT SIGNAL. It reads <see cref="GatewayHostedMode.IsHosted"/> directly, never
+/// an optional boundary or tenant argument. A security branch that depends on an optional argument fails
+/// OPEN the moment a caller omits it.
+///
+/// IT REFUSES, IT NEVER SERVES AN EMPTY ANSWER. An empty name list would be a false statement about the
+/// vault; an absent one is merely absent.
+///
+/// SELF-HOST IS THE CONTROL. <see cref="SelfHostVaultControlTests"/> in this same file boots the same host
+/// with hosted mode explicitly OFF and proves the owner can still list, read, write and delete his keys.
+///
+/// REVERT-PROOF RECIPE (run it, do not just describe it):
+///   1. In <c>src/CcDirector.Gateway/Api/VaultEndpoints.cs</c>, delete the
+///      <c>app.AddEndpointFilter(...)</c> block that calls <c>DenyOnHosted()</c>.
+///   2. Run this test project. Every test in <see cref="HostedVaultDenyTests"/> goes RED - the key value,
+///      the name list, the overwrite and the delete are all served to a tenant device key again - and
+///      every test in <see cref="SelfHostVaultControlTests"/> stays GREEN, which is what proves the tests
+///      are pinned to the guard and not to the vault working at all.
+///   3. Restore the filter. Everything goes green again.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class HostedVaultDenyTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string RefusalMessage = "the key vault is not available on the hosted gateway";
+    private const string SecretName = "DEVTHROTTLE_API_KEY";
+    private const string SecretValue = "dt_live_another_tenants_key";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _key = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-hosted-vault-" + Guid.NewGuid().ToString("N"));
+    private readonly string _vaultPath =
+        Path.Combine(Path.GetTempPath(), "cc-hosted-vault-" + Guid.NewGuid().ToString("N") + ".json");
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private string? _priorHosted;
+
+    public HostedVaultDenyTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-hosted-vault-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        // A real secret already in the vault, so a read that (wrongly) got through would have something
+        // to hand back. A deny tested against an empty vault proves nothing.
+        new KeyVault(_vaultPath).Set(SecretName, SecretValue);
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            keyVaultPath: _vaultPath,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // A fully enrolled, tenant-bound device key - the strongest caller hosted has. The point is that
+        // even this one is refused: there is no credential that makes another account's key readable.
+        _key = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var tenant = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", tenant.Value);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (File.Exists(_vaultPath)) File.Delete(_vaultPath); } catch { /* best effort */ }
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Every route in the group, in one theory rather than one test each, so a route added to the list is
+    /// a one-line change and the shape of the assertion cannot drift between them.
+    /// </summary>
+    [Theory]
+    [InlineData("GET", "vault/keys", null)]                                        // the name list
+    [InlineData("GET", "vault/keys/" + SecretName, null)]                          // the raw value - the theft
+    [InlineData("PUT", "vault/keys/" + SecretName, "{\"value\":\"attacker\"}")]     // the overwrite - the tampering
+    [InlineData("DELETE", "vault/keys/" + SecretName, null)]                       // the destruction
+    public async Task Every_vault_route_is_refused_to_an_enrolled_tenant(string method, string path, string? body)
+    {
+        var resp = await Send(new HttpMethod(method), path, body);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        await AssertBodyIsNothingButTheRefusal(resp);
+    }
+
+    [Fact]
+    public async Task The_refused_read_did_not_leak_the_secret_value_anywhere_in_the_body()
+    {
+        var resp = await Send(HttpMethod.Get, "vault/keys/" + SecretName);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.DoesNotContain(SecretValue, await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task The_refused_list_did_not_name_the_keys_and_is_not_an_empty_list()
+    {
+        // Refuse, never serve an empty list: an empty "names" array is a FALSE statement about a vault that
+        // holds a key, where an absent one is merely absent. The allow-list assertion below is what proves
+        // there is no "names" property at all, empty or otherwise.
+        var resp = await Send(HttpMethod.Get, "vault/keys");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.DoesNotContain(SecretName, body, StringComparison.Ordinal);
+        await AssertBodyIsNothingButTheRefusal(resp);
+    }
+
+    [Fact]
+    public async Task The_refused_write_did_not_take_effect()
+    {
+        // The status code alone would not prove the tampering was prevented - a handler that ran and then
+        // reported 404 would pass that. This reads the store back through a fresh vault instance.
+        var resp = await Send(HttpMethod.Put, "vault/keys/" + SecretName, "{\"value\":\"attacker-owned\"}");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+
+        Assert.Equal(SecretValue, new KeyVault(_vaultPath).Get(SecretName));
+    }
+
+    [Fact]
+    public async Task The_refused_write_of_a_new_name_did_not_create_it()
+    {
+        var resp = await Send(HttpMethod.Put, "vault/keys/PLANTED_KEY", "{\"value\":\"planted\"}");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+
+        Assert.Null(new KeyVault(_vaultPath).Get("PLANTED_KEY"));
+    }
+
+    [Fact]
+    public async Task The_refused_delete_did_not_take_effect()
+    {
+        var resp = await Send(HttpMethod.Delete, "vault/keys/" + SecretName);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+
+        Assert.Equal(SecretValue, new KeyVault(_vaultPath).Get(SecretName));
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_caller_is_still_rejected()
+    {
+        // Control: the deny must not have opened the group up as a side effect of running before the
+        // host-wide authentication gate. Without a key the middleware still refuses first.
+        Assert.Equal(HttpStatusCode.Unauthorized, (await _http.GetAsync("vault/keys")).StatusCode);
+    }
+
+    /// <summary>
+    /// AN ALLOW-LIST, NOT A DENY-LIST, and the difference is the whole assertion.
+    ///
+    /// Asserting that a handful of known payload keys are ABSENT rots by construction: it protects against
+    /// the payload as it is today, every field added later is unprotected until someone remembers this
+    /// file, and a substring check silently misses siblings. Asserting the property set is EXACTLY one
+    /// error field inverts that - anything extra, anything new, and anything metadata-looking reddens
+    /// automatically without this file being touched.
+    /// </summary>
+    private static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp)
+    {
+        var body = await resp.Content.ReadAsStringAsync();
+
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+
+        var properties = doc.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Equal(new[] { "error" }, properties);
+        Assert.Equal(RefusalMessage, doc.RootElement.GetProperty("error").GetString());
+    }
+
+    private Task<HttpResponseMessage> Send(HttpMethod method, string path, string? body = null)
+    {
+        var req = new HttpRequestMessage(method, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        if (body is not null)
+            req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return _http.SendAsync(req);
+    }
+
+    internal static int FreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}
+
+/// <summary>
+/// THE SELF-HOST CONTROL for the hosted key-vault deny, and the reason it can be trusted.
+///
+/// Self-host is single-tenant: the owner sets his own provider keys here from the Cockpit and his own
+/// Director reads them back on demand. A deny scoped to the wrong signal would break that shipped product
+/// to protect the unshipped one, so this class boots the SAME <see cref="GatewayHost"/> with hosted mode
+/// explicitly OFF and drives the same list, read, write and delete through the same authenticated routes.
+///
+/// These tests must stay GREEN through the revert-proof recipe in <see cref="HostedVaultDenyTests"/> - both
+/// with the guard in place and with it removed. That is what proves the deny tests are pinned to the guard
+/// rather than to the vault being broken.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class SelfHostVaultControlTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string SecretName = "DEVTHROTTLE_API_KEY";
+    private const string SecretValue = "dt_live_the_owners_own_key";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _key = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-selfhost-vault-" + Guid.NewGuid().ToString("N"));
+    private readonly string _vaultPath =
+        Path.Combine(Path.GetTempPath(), "cc-selfhost-vault-" + Guid.NewGuid().ToString("N") + ".json");
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private string? _priorHosted;
+
+    public SelfHostVaultControlTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-selfhost-vault-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Hosted mode explicitly OFF - set here rather than assumed, so a value leaked by another test
+        // cannot turn this control silently into a second hosted run.
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+
+        new KeyVault(_vaultPath).Set(SecretName, SecretValue);
+
+        _gateway = new GatewayHost(port: HostedVaultDenyTests.FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            keyVaultPath: _vaultPath,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        _key = _gateway.Devices.Register("dev-owner", "MA").DeviceKey;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (File.Exists(_vaultPath)) File.Delete(_vaultPath); } catch { /* best effort */ }
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task The_owner_can_still_list_his_key_names()
+    {
+        var resp = await Send(HttpMethod.Get, "vault/keys");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var names = doc.RootElement.GetProperty("names").EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Contains(SecretName, names);
+    }
+
+    [Fact]
+    public async Task The_owner_can_still_read_his_key_value()
+    {
+        // This is the read a self-hosted Director makes on demand for hosted AI. It must keep working.
+        var resp = await Send(HttpMethod.Get, "vault/keys/" + SecretName);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal(SecretValue, doc.RootElement.GetProperty("value").GetString());
+    }
+
+    [Fact]
+    public async Task The_owner_can_still_write_a_key_and_it_takes_effect()
+    {
+        var resp = await Send(HttpMethod.Put, "vault/keys/OPENAI_API_KEY", "{\"value\":\"sk-owner-set\"}");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        Assert.Equal("sk-owner-set", new KeyVault(_vaultPath).Get("OPENAI_API_KEY"));
+    }
+
+    [Fact]
+    public async Task The_owner_can_still_delete_a_key_and_it_takes_effect()
+    {
+        var resp = await Send(HttpMethod.Delete, "vault/keys/" + SecretName);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        Assert.Null(new KeyVault(_vaultPath).Get(SecretName));
+    }
+
+    private Task<HttpResponseMessage> Send(HttpMethod method, string path, string? body = null)
+    {
+        var req = new HttpRequestMessage(method, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        if (body is not null)
+            req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return _http.SendAsync(req);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedVaultDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedVaultDenyTests.cs
@@ -1,8 +1,19 @@
+using System;
+using System.IO;
+using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 using CcDirector.Core;
+using CcDirector.Gateway.Api;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
@@ -10,37 +21,59 @@ namespace CcDirector.Gateway.Tests;
 /// <summary>
 /// The whole <c>/vault/keys</c> group is DENIED on the hosted Gateway - reads, writes and delete alike.
 ///
-/// The store behind those routes is ONE global key vault file at the shared storage root, with no tenant
-/// in the file, the store, or the routes, and the group sits behind only the host-wide authentication
-/// gate - which admits ANY enrolled device key from ANY account. So before this change any hosted
-/// subscriber could read every other subscriber's provider credentials in cleartext (the single-key GET
-/// returns the raw value), overwrite them, and delete them. That is credential THEFT and TAMPERING, not a
-/// disclosure, which is why the whole surface closes and not only the value-returning read.
+/// The store behind those routes is ONE global key vault file at the shared storage root, with no tenant in
+/// the file, the store, or the routes, and the group sits behind only the host-wide authentication gate -
+/// which admits ANY enrolled device key from ANY account. So before this change any hosted subscriber could
+/// read every other subscriber's provider credentials in cleartext (the single-key GET returns the raw
+/// value), overwrite them, and delete them. That is credential THEFT and TAMPERING, not a disclosure, which
+/// is why the whole surface closes and not only the value-returning read.
 ///
-/// THE GATE IS ON THE DEPLOYMENT SIGNAL. It reads <see cref="GatewayHostedMode.IsHosted"/> directly, never
-/// an optional boundary or tenant argument. A security branch that depends on an optional argument fails
-/// OPEN the moment a caller omits it.
+/// WHY A DENY AND NOT A PARTITION. There is nothing to partition by yet: the vault file has no tenant column
+/// and no per-account namespace, so a per-account answer would have to be invented rather than read. That is
+/// a half-partition, which is worse than an honest refusal because it looks like isolation.
 ///
-/// IT REFUSES, IT NEVER SERVES AN EMPTY ANSWER. An empty name list would be a false statement about the
-/// vault; an absent one is merely absent.
+/// THE GATE IS ON THE DEPLOYMENT SIGNAL. It reads <see cref="GatewayHostedMode.IsHosted"/> directly, never an
+/// optional boundary or tenant argument. A security branch that depends on an optional argument fails OPEN
+/// the moment a caller omits it.
 ///
-/// SELF-HOST IS THE CONTROL. <see cref="SelfHostVaultControlTests"/> in this same file boots the same host
-/// with hosted mode explicitly OFF and proves the owner can still list, read, write and delete his keys.
+/// IT REFUSES, IT NEVER SERVES AN EMPTY ANSWER. An empty name list would be a FALSE statement about a vault
+/// that holds keys; an absent one is merely absent.
 ///
-/// REVERT-PROOF RECIPE (run it, do not just describe it):
-///   1. In <c>src/CcDirector.Gateway/Api/VaultEndpoints.cs</c>, delete the
-///      <c>app.AddEndpointFilter(...)</c> block that calls <c>DenyOnHosted()</c>.
-///   2. Run this test project. Every test in <see cref="HostedVaultDenyTests"/> goes RED - the key value,
-///      the name list, the overwrite and the delete are all served to a tenant device key again - and
-///      every test in <see cref="SelfHostVaultControlTests"/> stays GREEN, which is what proves the tests
-///      are pinned to the guard and not to the vault working at all.
-///   3. Restore the filter. Everything goes green again.
+/// STATUS AND MEDIA TYPE ARE ASSERTED BEFORE ANY PARSE. Parsing is itself an unstated assertion about format:
+/// on this Gateway a 404 is not necessarily JSON - the single-page-app fallback answers unmatched paths with
+/// something else entirely - so a mutation that routed a denied path to the fallback would make the parse
+/// THROW. That red is a crash, and a crash proves only that the mutation broke something upstream of the
+/// claim; it cannot say what was served in place of the refusal, which is the entire claim a deny makes.
+///
+/// A 404 DENY IS INDISTINGUISHABLE FROM A ROUTE THAT DOES NOT EXIST, so every denied path also carries a
+/// self-host HANDLER-POSITIVE receipt proving the route is really there and really does the thing:
+/// <see cref="SelfHostVaultControlTests"/> drives all four verbs through the production host with the
+/// authentication gate on, and <see cref="SelfHostVaultGroupControlTests"/> drives them on the group in both
+/// non-hosted forms, asserting the real payloads and the real effects on the store.
+///
+/// SURVIVAL ASSERTIONS CARRY A DESTRUCTIBILITY CONTROL. Where a test here asserts a key SURVIVED a refused
+/// write or delete, a no-op would pass identically, so the same operation is proven destructive on self-host
+/// against the same seeded key - see <c>The_same_write_overwrites_an_existing_key_on_self_host</c> and
+/// <c>The_same_delete_destroys_an_existing_key_on_self_host</c> in
+/// <see cref="SelfHostVaultGroupControlTests"/>. Without those, "it survived" is a claim about a request that
+/// might never have been capable of destroying anything.
+///
+/// REVERT-PROOF - the recipe to RUN, not to describe. In <c>src/CcDirector.Gateway/Api/VaultEndpoints.cs</c>
+/// DELETE the <c>app.AddEndpointFilter(...)</c> block outright, leaving <c>var app = outer.MapGroup("");</c>
+/// in place so the group still exists and the file still compiles, with NO per-route guard put back - the
+/// hosted deny is then absent entirely. Never <c>if (false)</c>: unreachable code is a build error here.
+/// That is ONE primitive mutated and nothing else, so every red is attributable to it. Rebuild, CONFIRM ZERO
+/// ERRORS (a run after a failed build executes the previous binary and reports a false pass), then run the
+/// FULL Gateway suite and record every red BY NAME with the form it arrived in. A red only counts if it fails
+/// WITH THE SYMPTOM - an assertion naming what was served instead of the refusal; crash-reds are UNPROVEN.
+/// Then restore, rebuild, rerun the full suite, and confirm the counts reconcile arithmetically with total
+/// and skipped unchanged.
 /// </summary>
 [Collection("DirectorRoot")]
 public sealed class HostedVaultDenyTests : IAsyncLifetime
 {
     private const string Token = "test-token";
-    private const string RefusalMessage = "the key vault is not available on the hosted gateway";
+    internal const string RefusalMessage = "the key vault is not available on the hosted gateway";
     private const string SecretName = "DEVTHROTTLE_API_KEY";
     private const string SecretValue = "dt_live_another_tenants_key";
 
@@ -65,11 +98,14 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        // EXPLICIT, not ambient: this class asserts hosted behaviour, so it states hosted mode itself and
+        // proves the statement took, rather than inheriting whatever the runner happened to leave set.
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
 
-        // A real secret already in the vault, so a read that (wrongly) got through would have something
-        // to hand back. A deny tested against an empty vault proves nothing.
+        // A real secret already in the vault, so a read that (wrongly) got through would have something to
+        // hand back. A deny tested against an empty vault proves nothing.
         new KeyVault(_vaultPath).Set(SecretName, SecretValue);
 
         _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
@@ -94,14 +130,14 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
         await _gateway.StopAsync();
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
         Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
-        try { if (File.Exists(_vaultPath)) File.Delete(_vaultPath); } catch { /* best effort */ }
-        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
-        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+        try { if (File.Exists(_vaultPath)) File.Delete(_vaultPath); } catch (Exception) { /* best effort */ }
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch (Exception) { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch (Exception) { /* best effort */ }
     }
 
     /// <summary>
-    /// Every route in the group, in one theory rather than one test each, so a route added to the list is
-    /// a one-line change and the shape of the assertion cannot drift between them.
+    /// Every route in the group, in one theory rather than one test each, so a route added to the list is a
+    /// one-line change and the shape of the assertion cannot drift between them.
     /// </summary>
     [Theory]
     [InlineData("GET", "vault/keys", null)]                                        // the name list
@@ -111,7 +147,6 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
     public async Task Every_vault_route_is_refused_to_an_enrolled_tenant(string method, string path, string? body)
     {
         var resp = await Send(new HttpMethod(method), path, body);
-        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
         await AssertBodyIsNothingButTheRefusal(resp);
     }
 
@@ -131,9 +166,7 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
         // there is no "names" property at all, empty or otherwise.
         var resp = await Send(HttpMethod.Get, "vault/keys");
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
-
-        var body = await resp.Content.ReadAsStringAsync();
-        Assert.DoesNotContain(SecretName, body, StringComparison.Ordinal);
+        Assert.DoesNotContain(SecretName, await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
         await AssertBodyIsNothingButTheRefusal(resp);
     }
 
@@ -142,6 +175,10 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
     {
         // The status code alone would not prove the tampering was prevented - a handler that ran and then
         // reported 404 would pass that. This reads the store back through a fresh vault instance.
+        //
+        // DESTRUCTIBILITY CONTROL: the identical write DOES overwrite this same seeded key on self-host
+        // (SelfHostVaultGroupControlTests.The_same_write_overwrites_an_existing_key_on_self_host), so this is
+        // a capable operation being stopped, not a no-op passing by construction.
         var resp = await Send(HttpMethod.Put, "vault/keys/" + SecretName, "{\"value\":\"attacker-owned\"}");
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
 
@@ -160,6 +197,8 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
     [Fact]
     public async Task The_refused_delete_did_not_take_effect()
     {
+        // DESTRUCTIBILITY CONTROL: the identical delete DOES destroy this same seeded key on self-host
+        // (SelfHostVaultGroupControlTests.The_same_delete_destroys_an_existing_key_on_self_host).
         var resp = await Send(HttpMethod.Delete, "vault/keys/" + SecretName);
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
 
@@ -170,23 +209,31 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
     public async Task An_unauthenticated_caller_is_still_rejected()
     {
         // Control: the deny must not have opened the group up as a side effect of running before the
-        // host-wide authentication gate. Without a key the middleware still refuses first.
+        // host-wide authentication gate. Without a key the middleware still refuses first. GREEN in both
+        // directions of the revert on purpose - a control that moves with the change under test is not a
+        // control.
         Assert.Equal(HttpStatusCode.Unauthorized, (await _http.GetAsync("vault/keys")).StatusCode);
     }
 
     /// <summary>
-    /// AN ALLOW-LIST, NOT A DENY-LIST, and the difference is the whole assertion.
+    /// AN ALLOW-LIST, NOT A DENY-LIST, and FORMAT FACTS BEFORE PARSING.
     ///
     /// Asserting that a handful of known payload keys are ABSENT rots by construction: it protects against
-    /// the payload as it is today, every field added later is unprotected until someone remembers this
-    /// file, and a substring check silently misses siblings. Asserting the property set is EXACTLY one
-    /// error field inverts that - anything extra, anything new, and anything metadata-looking reddens
-    /// automatically without this file being touched.
+    /// the payload as it is today, every field added later is unprotected until someone remembers this file,
+    /// and a substring check silently misses siblings. Asserting the property set is EXACTLY one error field
+    /// inverts that - anything extra, anything new, and anything metadata-looking reddens automatically.
+    ///
+    /// The status and media type are asserted FIRST so a revert reddens as a STATEMENT - "expected NotFound,
+    /// got OK", "expected application/json, got text/plain" - rather than as a parser exception. A crash-red
+    /// proves the mutation broke something upstream; it cannot say what was served instead of the refusal,
+    /// and that is exactly the claim being made here.
     /// </summary>
-    private static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp)
+    internal static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp)
     {
-        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
 
+        var body = await resp.Content.ReadAsStringAsync();
         using var doc = JsonDocument.Parse(body);
         Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
 
@@ -206,7 +253,7 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
 
     internal static int FreePort()
     {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();
         try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
         finally { listener.Stop(); }
@@ -214,16 +261,370 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
 }
 
 /// <summary>
-/// THE SELF-HOST CONTROL for the hosted key-vault deny, and the reason it can be trusted.
+/// Boots ONLY the key-vault group on an ephemeral port, exactly as <see cref="VaultEndpointsTests"/> does,
+/// and hands the caller the route group back so a test can map routes onto it. That is what makes the
+/// future-route proof possible at all: the group is created inside <c>VaultEndpoints.Map</c>, so nothing
+/// outside that method could otherwise state a property about routes added to it.
+/// </summary>
+internal static class VaultGroupProbeHost
+{
+    public static async Task<(WebApplication app, HttpClient http)> StartAsync(
+        KeyVault vault,
+        Action<RouteGroupBuilder>? mapIntoGroup = null,
+        Action<IEndpointRouteBuilder>? mapOutsideGroup = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        var group = VaultEndpoints.Map(app, vault);
+        mapIntoGroup?.Invoke(group);
+        mapOutsideGroup?.Invoke(app);
+
+        await app.StartAsync();
+        var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+        return (app, http);
+    }
+
+    /// <summary>
+    /// The refusal, asserted as format facts first and then as an exact property set - same reasoning as
+    /// <see cref="HostedVaultDenyTests.AssertBodyIsNothingButTheRefusal"/>, restated here so the probe host
+    /// reads on its own.
+    /// </summary>
+    public static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp)
+    {
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+
+        var properties = doc.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Equal(new[] { "error" }, properties);
+        Assert.Equal(HostedVaultDenyTests.RefusalMessage, doc.RootElement.GetProperty("error").GetString());
+    }
+}
+
+/// <summary>
+/// THE POINT OF THE WHOLE CHANGE: the hosted refusal is a filter on the key-vault route GROUP, so it covers
+/// routes that have not been written yet.
 ///
-/// Self-host is single-tenant: the owner sets his own provider keys here from the Cockpit and his own
-/// Director reads them back on demand. A deny scoped to the wrong signal would break that shipped product
-/// to protect the unshipped one, so this class boots the SAME <see cref="GatewayHost"/> with hosted mode
-/// explicitly OFF and drives the same list, read, write and delete through the same authenticated routes.
+/// A guard line repeated in every handler passes exactly the same tests as a group filter for the routes that
+/// exist today, which is precisely why it is dangerous - the difference only shows up on the route somebody
+/// adds NEXT, when it is open by default and nothing fails. That difference is not observable by driving the
+/// four routes that exist, so this class maps a BRAND-NEW probe route onto the group and asserts it is
+/// already refused with no deny of its own written anywhere.
 ///
-/// These tests must stay GREEN through the revert-proof recipe in <see cref="HostedVaultDenyTests"/> - both
-/// with the guard in place and with it removed. That is what proves the deny tests are pinned to the guard
-/// rather than to the vault being broken.
+/// The mirror half - the same probe path SERVED with hosted mode explicitly off, in both non-hosted forms -
+/// is <see cref="SelfHostVaultGroupControlTests.A_route_added_to_the_group_still_serves_on_self_host"/>. One
+/// direction alone cannot tell a working gate apart from a brick: a filter that refused everything
+/// unconditionally would pass every hosted assertion in this file while having silently killed the routes for
+/// self-host too.
+/// </summary>
+public sealed class HostedVaultGroupFilterTests : IDisposable
+{
+    private const string ProbePayloadSentinel = "probe-payload-that-must-never-be-served-on-hosted";
+    private const string SecretName = "DEVTHROTTLE_API_KEY";
+    private const string SecretValue = "dt_live_another_tenants_key";
+
+    private readonly string _dir;
+    private readonly string? _priorHosted;
+
+    public HostedVaultGroupFilterTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cc-vault-group-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { Directory.Delete(_dir, recursive: true); } catch (Exception) { /* best effort */ }
+    }
+
+    private KeyVault SeededVault()
+    {
+        var vault = new KeyVault(Path.Combine(_dir, "v-" + Guid.NewGuid().ToString("N") + ".json"));
+        vault.Set(SecretName, SecretValue);
+        return vault;
+    }
+
+    /// <summary>
+    /// A route that did not exist when the refusal was written is refused anyway. NOTHING in
+    /// <c>VaultEndpoints</c> mentions this path, and no guard is written for it here - the only thing standing
+    /// between the caller and the probe payload is the group filter. Delete the filter and this test serves
+    /// the probe payload with a 200, which is the future-route hole stated out loud.
+    /// </summary>
+    [Fact]
+    public async Task A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own()
+    {
+        var (app, http) = await VaultGroupProbeHost.StartAsync(
+            SeededVault(),
+            mapIntoGroup: group => group.MapGet("/vault/keys/added-after-the-deny-was-written",
+                () => Results.Json(new { probe = ProbePayloadSentinel })));
+        try
+        {
+            var resp = await http.GetAsync("/vault/keys/added-after-the-deny-was-written");
+
+            await VaultGroupProbeHost.AssertBodyIsNothingButTheRefusal(resp);
+            Assert.DoesNotContain(ProbePayloadSentinel, await resp.Content.ReadAsStringAsync(),
+                StringComparison.Ordinal);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>
+    /// The four production routes, refused through that same filter rather than through a guard of their own.
+    /// Every verb is here, because the write and the delete are the tampering half of this defect and a deny
+    /// that closed only the reads would leave the damage path open.
+    /// </summary>
+    [Theory]
+    [InlineData("GET", "/vault/keys", null)]
+    [InlineData("GET", "/vault/keys/" + SecretName, null)]
+    [InlineData("PUT", "/vault/keys/" + SecretName, "{\"value\":\"attacker\"}")]
+    [InlineData("DELETE", "/vault/keys/" + SecretName, null)]
+    public async Task Every_vault_route_is_refused_on_hosted_through_the_group_filter(
+        string method, string path, string? body)
+    {
+        var vault = SeededVault();
+        var (app, http) = await VaultGroupProbeHost.StartAsync(vault);
+        try
+        {
+            var req = new HttpRequestMessage(new HttpMethod(method), path);
+            if (body is not null) req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+            await VaultGroupProbeHost.AssertBodyIsNothingButTheRefusal(await http.SendAsync(req));
+
+            // The store is untouched by any of the four, including the two that would have changed it. Both
+            // of those operations are proven CAPABLE of changing it in SelfHostVaultGroupControlTests.
+            Assert.Equal(SecretValue, vault.Get(SecretName));
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>
+    /// CONTROL: the filter is scoped to the key-vault group, not a blanket refusal on the whole application.
+    /// A route mapped OUTSIDE the group still serves on hosted, so the passing tests above are the filter
+    /// doing its job and not the host refusing everything.
+    /// </summary>
+    [Fact]
+    public async Task A_route_outside_the_group_still_serves_on_hosted()
+    {
+        var (app, http) = await VaultGroupProbeHost.StartAsync(
+            SeededVault(),
+            mapOutsideGroup: routes => routes.MapGet("/not-a-vault-route", () => Results.Json(new { ok = true })));
+        try
+        {
+            var resp = await http.GetAsync("/not-a-vault-route");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Contains("true", await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+}
+
+/// <summary>
+/// THE SELF-HOST CONTROL ON THE GROUP, in BOTH non-hosted forms, with the effects proven.
+///
+/// Self-host is the control for this whole mission, so it is PROVEN rather than INHERITED.
+/// <see cref="VaultEndpointsTests"/> does not prove it: those tests never mention <c>CC_GATEWAY_HOSTED</c>
+/// and pass only because the runner happens to leave it unset. If that ambient default ever flipped they
+/// would keep passing while self-host was completely broken, because they assert nothing about which mode
+/// they are in. So this class sets the variable itself, to both non-hosted values that occur in practice -
+/// absent, and present-but-not-"1" - and asserts the mode took before driving anything.
+///
+/// It asserts REAL PAYLOADS AND REAL EFFECTS, not the absence of the refusal string. An empty-but-successful
+/// response would satisfy "the refusal is absent" while still being a broken self-host.
+///
+/// It also carries the DESTRUCTIBILITY CONTROLS for the hosted survival assertions: the same write overwrites
+/// an existing key here, and the same delete destroys one. Without those, "the key survived the refusal" is
+/// satisfied just as well by a request that could never have destroyed anything.
+///
+/// Every test here must stay GREEN through the revert described on <see cref="HostedVaultDenyTests"/>.
+/// </summary>
+public sealed class SelfHostVaultGroupControlTests : IDisposable
+{
+    private const string SecretName = "DEVTHROTTLE_API_KEY";
+    private const string SecretValue = "dt_live_the_owners_own_key";
+
+    private readonly string _dir;
+    private readonly string? _priorHosted;
+
+    public SelfHostVaultGroupControlTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cc-vault-selfhost-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { Directory.Delete(_dir, recursive: true); } catch (Exception) { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Puts the process into a STATED non-hosted mode and proves it took, so no test below can silently be
+    /// running in the mode it thinks it is not in.
+    /// </summary>
+    private static void DeclareSelfHost(string? value)
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", value);
+        Assert.False(GatewayHostedMode.IsHosted);
+    }
+
+    /// <summary>null = the variable is absent. "0" = present and explicitly not hosted. Both are real
+    /// non-hosted deployments and both must serve.</summary>
+    public static TheoryData<string?> NonHostedValues => new() { null, "0" };
+
+    private KeyVault SeededVault()
+    {
+        var vault = new KeyVault(Path.Combine(_dir, "v-" + Guid.NewGuid().ToString("N") + ".json"));
+        vault.Set(SecretName, SecretValue);
+        return vault;
+    }
+
+    /// <summary>
+    /// HANDLER-POSITIVE RECEIPT for the list route: the route really exists and really answers with the
+    /// owner's key names. A 404 deny is indistinguishable from a route that was never mapped, so without a
+    /// receipt like this the hosted 404 would prove nothing about a guard.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task The_owner_still_gets_his_real_key_names_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+
+        var (app, http) = await VaultGroupProbeHost.StartAsync(SeededVault());
+        try
+        {
+            var resp = await http.GetAsync("/vault/keys");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            var names = doc.RootElement.GetProperty("names").EnumerateArray().Select(e => e.GetString()).ToArray();
+            Assert.Contains(SecretName, names);
+            Assert.DoesNotContain("error", doc.RootElement.EnumerateObject().Select(p => p.Name));
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>HANDLER-POSITIVE RECEIPT for the value read: the real key value comes back.</summary>
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task The_owner_still_gets_his_real_key_value_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+
+        var (app, http) = await VaultGroupProbeHost.StartAsync(SeededVault());
+        try
+        {
+            var resp = await http.GetAsync("/vault/keys/" + SecretName);
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            Assert.Equal(SecretValue, doc.RootElement.GetProperty("value").GetString());
+            Assert.Equal(SecretName, doc.RootElement.GetProperty("name").GetString());
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>
+    /// DESTRUCTIBILITY CONTROL for <c>HostedVaultDenyTests.The_refused_write_did_not_take_effect</c>: the
+    /// identical request against the identical seeded key DOES overwrite it when the guard is not in the way.
+    /// Without this, "the key survived" would be satisfied by an operation incapable of changing anything.
+    /// It is also the handler-positive receipt for the write route.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task The_same_write_overwrites_an_existing_key_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+
+        var vault = SeededVault();
+        var (app, http) = await VaultGroupProbeHost.StartAsync(vault);
+        try
+        {
+            var resp = await http.PutAsync("/vault/keys/" + SecretName,
+                new StringContent("{\"value\":\"attacker-owned\"}", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            Assert.Equal("attacker-owned", vault.Get(SecretName));
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>
+    /// DESTRUCTIBILITY CONTROL for <c>HostedVaultDenyTests.The_refused_delete_did_not_take_effect</c>: the
+    /// identical delete against the identical seeded key DOES destroy it when the guard is not in the way.
+    /// It is also the handler-positive receipt for the delete route.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task The_same_delete_destroys_an_existing_key_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+
+        var vault = SeededVault();
+        var (app, http) = await VaultGroupProbeHost.StartAsync(vault);
+        try
+        {
+            var resp = await http.DeleteAsync("/vault/keys/" + SecretName);
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            Assert.Null(vault.Get(SecretName));
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>
+    /// THE SECOND HALF OF THE FUTURE-ROUTE PROOF: the probe route must be REFUSED on hosted and SERVED with
+    /// hosted mode EXPLICITLY off, in both non-hosted forms. The hosted half is
+    /// <see cref="HostedVaultGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own"/>;
+    /// this is its mirror, on the SAME probe path.
+    ///
+    /// Without this half, "the filter refuses everything, always" would pass every hosted test in this file
+    /// while having silently killed the vault for self-host too.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task A_route_added_to_the_group_still_serves_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+
+        var (app, http) = await VaultGroupProbeHost.StartAsync(
+            SeededVault(),
+            mapIntoGroup: group => group.MapGet("/vault/keys/added-after-the-deny-was-written",
+                () => Results.Json(new { probe = "served" })));
+        try
+        {
+            var resp = await http.GetAsync("/vault/keys/added-after-the-deny-was-written");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Contains("served", await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+}
+
+/// <summary>
+/// THE SELF-HOST RECEIPT ON THE PRODUCTION WIRING, with authentication.
+///
+/// <see cref="SelfHostVaultGroupControlTests"/> proves the group's behaviour by mapping it directly; this
+/// class proves the same four routes are actually reachable and correct through a real
+/// <see cref="GatewayHost"/> with the authentication gate ON, hosted mode explicitly OFF and asserted off,
+/// and a registered device key - the shipped self-host configuration. A change that quietly unmapped the
+/// routes in production wiring would pass the group tests and still break the shipped product; this is what
+/// catches that.
+///
+/// Must stay GREEN through the revert described on <see cref="HostedVaultDenyTests"/>.
 /// </summary>
 [Collection("DirectorRoot")]
 public sealed class SelfHostVaultControlTests : IAsyncLifetime
@@ -253,10 +654,11 @@ public sealed class SelfHostVaultControlTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        // Hosted mode explicitly OFF - set here rather than assumed, so a value leaked by another test
-        // cannot turn this control silently into a second hosted run.
+        // Hosted mode explicitly OFF and PROVEN off - set here rather than assumed, so a value leaked by
+        // another test cannot turn this control silently into a second hosted run.
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+        Assert.False(GatewayHostedMode.IsHosted);
 
         new KeyVault(_vaultPath).Set(SecretName, SecretValue);
 
@@ -278,9 +680,9 @@ public sealed class SelfHostVaultControlTests : IAsyncLifetime
         await _gateway.StopAsync();
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
         Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
-        try { if (File.Exists(_vaultPath)) File.Delete(_vaultPath); } catch { /* best effort */ }
-        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
-        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+        try { if (File.Exists(_vaultPath)) File.Delete(_vaultPath); } catch (Exception) { /* best effort */ }
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch (Exception) { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch (Exception) { /* best effort */ }
     }
 
     [Fact]
@@ -288,9 +690,10 @@ public sealed class SelfHostVaultControlTests : IAsyncLifetime
     {
         var resp = await Send(HttpMethod.Get, "vault/keys");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
 
         using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
-        var names = doc.RootElement.GetProperty("names").EnumerateArray().Select(e => e.GetString()).ToList();
+        var names = doc.RootElement.GetProperty("names").EnumerateArray().Select(e => e.GetString()).ToArray();
         Assert.Contains(SecretName, names);
     }
 
@@ -300,6 +703,7 @@ public sealed class SelfHostVaultControlTests : IAsyncLifetime
         // This is the read a self-hosted Director makes on demand for hosted AI. It must keep working.
         var resp = await Send(HttpMethod.Get, "vault/keys/" + SecretName);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
 
         using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
         Assert.Equal(SecretValue, doc.RootElement.GetProperty("value").GetString());

--- a/src/CcDirector.Gateway.Tests/HostedVaultDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedVaultDenyTests.cs
@@ -58,9 +58,23 @@ namespace CcDirector.Gateway.Tests;
 /// <see cref="SelfHostVaultGroupControlTests"/>. Without those, "it survived" is a claim about a request that
 /// might never have been capable of destroying anything.
 ///
+/// ONE BYPASSABLE PRIMITIVE, BY DESIGN. The proof-run count is set by how many things can be individually
+/// wrong while everything else stays correct and isolation still breaks. Here that number is ONE: a single
+/// <c>AddEndpointFilter</c> on a single <c>MapGroup</c> created at a single <c>VaultEndpoints.Map</c> call
+/// site (<c>GatewayHost.cs</c>, one call - checked, not assumed), with NO route carrying a guard of its own,
+/// so deleting the filter fails all four routes together. The obvious second family - mapping one of the four
+/// routes onto the UNGROUPED builder, bypassing the filter for that route alone - was four more independently
+/// bypassable primitives, and it was removed by DESIGN rather than argued away: the routes now live in
+/// <c>VaultEndpoints.MapRoutes</c>, which receives the guarded group and never receives the ungrouped builder,
+/// so that mistake is not expressible. That is a compile-time property, which is why no test here asserts it;
+/// a test could not. Removing the hosted check from <c>DenyOnHosted</c> is NOT a third primitive: it makes the
+/// group refuse ALWAYS, which breaks the shipped self-host product rather than isolation, and the self-host
+/// controls below are what redden on it.
+///
 /// REVERT-PROOF - the recipe to RUN, not to describe. In <c>src/CcDirector.Gateway/Api/VaultEndpoints.cs</c>
-/// DELETE the <c>app.AddEndpointFilter(...)</c> block outright, leaving <c>var app = outer.MapGroup("");</c>
-/// in place so the group still exists and the file still compiles, with NO per-route guard put back - the
+/// DELETE the <c>guarded.AddEndpointFilter(...)</c> block outright, leaving
+/// <c>var guarded = outer.MapGroup("");</c> in place so the group still exists and the file still compiles,
+/// with NO per-route guard put back - the
 /// hosted deny is then absent entirely. Never <c>if (false)</c>: unreachable code is a build error here.
 /// That is ONE primitive mutated and nothing else, so every red is attributable to it. Rebuild, CONFIRM ZERO
 /// ERRORS (a run after a failed build executes the previous binary and reports a false pass), then run the
@@ -154,7 +168,13 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
     public async Task The_refused_read_did_not_leak_the_secret_value_anywhere_in_the_body()
     {
         var resp = await Send(HttpMethod.Get, "vault/keys/" + SecretName);
-        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+
+        // The refusal is asserted FIRST, and the absence check comes after it. On its own,
+        // "the body does not contain the secret" is an absence-only claim that a 404 from the single-page-app
+        // fallback - or any other body that simply is not the vault - would satisfy just as well as a working
+        // deny. Pinning the exact refusal first is what makes this test a statement about the guard rather
+        // than a statement about the string.
+        await AssertBodyIsNothingButTheRefusal(resp);
         Assert.DoesNotContain(SecretValue, await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
     }
 
@@ -180,7 +200,7 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
         // (SelfHostVaultGroupControlTests.The_same_write_overwrites_an_existing_key_on_self_host), so this is
         // a capable operation being stopped, not a no-op passing by construction.
         var resp = await Send(HttpMethod.Put, "vault/keys/" + SecretName, "{\"value\":\"attacker-owned\"}");
-        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        await AssertBodyIsNothingButTheRefusal(resp);
 
         Assert.Equal(SecretValue, new KeyVault(_vaultPath).Get(SecretName));
     }
@@ -189,7 +209,7 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
     public async Task The_refused_write_of_a_new_name_did_not_create_it()
     {
         var resp = await Send(HttpMethod.Put, "vault/keys/PLANTED_KEY", "{\"value\":\"planted\"}");
-        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        await AssertBodyIsNothingButTheRefusal(resp);
 
         Assert.Null(new KeyVault(_vaultPath).Get("PLANTED_KEY"));
     }
@@ -200,7 +220,7 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
         // DESTRUCTIBILITY CONTROL: the identical delete DOES destroy this same seeded key on self-host
         // (SelfHostVaultGroupControlTests.The_same_delete_destroys_an_existing_key_on_self_host).
         var resp = await Send(HttpMethod.Delete, "vault/keys/" + SecretName);
-        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        await AssertBodyIsNothingButTheRefusal(resp);
 
         Assert.Equal(SecretValue, new KeyVault(_vaultPath).Get(SecretName));
     }
@@ -422,8 +442,14 @@ public sealed class HostedVaultGroupFilterTests : IDisposable
         try
         {
             var resp = await http.GetAsync("/not-a-vault-route");
+
+            // Format facts before the parse, and then the real payload rather than a substring: "true"
+            // appears in plenty of bodies that are not this handler's answer.
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-            Assert.Contains("true", await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+            Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            Assert.True(doc.RootElement.GetProperty("ok").GetBoolean());
         }
         finally { http.Dispose(); await app.DisposeAsync(); }
     }
@@ -556,6 +582,13 @@ public sealed class SelfHostVaultGroupControlTests : IDisposable
             var resp = await http.PutAsync("/vault/keys/" + SecretName,
                 new StringContent("{\"value\":\"attacker-owned\"}", Encoding.UTF8, "application/json"));
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+            using (var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync()))
+            {
+                Assert.Equal(SecretName, doc.RootElement.GetProperty("name").GetString());
+                Assert.True(doc.RootElement.GetProperty("set").GetBoolean());
+            }
 
             Assert.Equal("attacker-owned", vault.Get(SecretName));
         }
@@ -579,6 +612,13 @@ public sealed class SelfHostVaultGroupControlTests : IDisposable
         {
             var resp = await http.DeleteAsync("/vault/keys/" + SecretName);
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+            using (var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync()))
+            {
+                Assert.Equal(SecretName, doc.RootElement.GetProperty("name").GetString());
+                Assert.True(doc.RootElement.GetProperty("deleted").GetBoolean());
+            }
 
             Assert.Null(vault.Get(SecretName));
         }
@@ -607,8 +647,14 @@ public sealed class SelfHostVaultGroupControlTests : IDisposable
         try
         {
             var resp = await http.GetAsync("/vault/keys/added-after-the-deny-was-written");
+
+            // Format facts before the parse, then the probe handler's OWN payload. A substring check would
+            // also pass on a body that merely mentioned the word, which is not the claim being made.
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-            Assert.Contains("served", await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+            Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            Assert.Equal("served", doc.RootElement.GetProperty("probe").GetString());
         }
         finally { http.Dispose(); await app.DisposeAsync(); }
     }
@@ -714,6 +760,10 @@ public sealed class SelfHostVaultControlTests : IAsyncLifetime
     {
         var resp = await Send(HttpMethod.Put, "vault/keys/OPENAI_API_KEY", "{\"value\":\"sk-owner-set\"}");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+        using (var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync()))
+            Assert.True(doc.RootElement.GetProperty("set").GetBoolean());
 
         Assert.Equal("sk-owner-set", new KeyVault(_vaultPath).Get("OPENAI_API_KEY"));
     }
@@ -723,6 +773,10 @@ public sealed class SelfHostVaultControlTests : IAsyncLifetime
     {
         var resp = await Send(HttpMethod.Delete, "vault/keys/" + SecretName);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+        using (var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync()))
+            Assert.True(doc.RootElement.GetProperty("deleted").GetBoolean());
 
         Assert.Null(new KeyVault(_vaultPath).Get(SecretName));
     }

--- a/src/CcDirector.Gateway.Tests/HostedVaultDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedVaultDenyTests.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using CcDirector.Core;
 using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -32,9 +33,19 @@ namespace CcDirector.Gateway.Tests;
 /// and no per-account namespace, so a per-account answer would have to be invented rather than read. That is
 /// a half-partition, which is worse than an honest refusal because it looks like isolation.
 ///
-/// THE GATE IS ON THE DEPLOYMENT SIGNAL. It reads <see cref="GatewayHostedMode.IsHosted"/> directly, never an
-/// optional boundary or tenant argument. A security branch that depends on an optional argument fails OPEN
-/// the moment a caller omits it.
+/// HOW THE DENY IS EXPRESSED - THE SHARED REFUSAL PRIMITIVE. The group is denied through
+/// <see cref="HostedRouteDeny.ExclusiveGroup"/>, the ONE hosted-refusal boundary every deny family on this
+/// Gateway adopts. An earlier revision of this file rolled its own <c>AddEndpointFilter</c> deny before that
+/// primitive existed; it was replaced so the release ships ONE refusal boundary, not one per family. On
+/// hosted the four handlers are NEVER MAPPED - one verb-less catch-all refusal claims everything under
+/// <c>/vault/keys</c> (plus a root refusal at the prefix itself), so every request shape meets the refusal:
+/// a valid body, a malformed body, a wrong media type, a verb the group never mapped, and a route added
+/// LATER. Off hosted the primitive maps the four real handlers exactly as an unguarded builder would and
+/// creates no refusal at all.
+///
+/// THE GATE IS ON THE DEPLOYMENT SIGNAL. The primitive reads <see cref="GatewayHostedMode.IsHosted"/>
+/// directly, never an optional boundary or tenant argument. A security branch that depends on an optional
+/// argument fails OPEN the moment a caller omits it.
 ///
 /// IT REFUSES, IT NEVER SERVES AN EMPTY ANSWER. An empty name list would be a FALSE statement about a vault
 /// that holds keys; an absent one is merely absent.
@@ -58,36 +69,27 @@ namespace CcDirector.Gateway.Tests;
 /// <see cref="SelfHostVaultGroupControlTests"/>. Without those, "it survived" is a claim about a request that
 /// might never have been capable of destroying anything.
 ///
-/// ONE BYPASSABLE PRIMITIVE, BY DESIGN. The proof-run count is set by how many things can be individually
-/// wrong while everything else stays correct and isolation still breaks. Here that number is ONE: a single
-/// <c>AddEndpointFilter</c> on a single <c>MapGroup</c> created at a single <c>VaultEndpoints.Map</c> call
-/// site (<c>GatewayHost.cs</c>, one call - checked, not assumed), with NO route carrying a guard of its own,
-/// so deleting the filter fails all four routes together. The obvious second family - mapping one of the four
-/// routes onto the UNGROUPED builder, bypassing the filter for that route alone - was four more independently
-/// bypassable primitives, and it was removed by DESIGN rather than argued away: the routes now live in
-/// <c>VaultEndpoints.MapRoutes</c>, which receives the guarded group and never receives the ungrouped builder,
-/// so that mistake is not expressible. That is a compile-time property, which is why no test here asserts it;
-/// a test could not. Removing the hosted check from <c>DenyOnHosted</c> is NOT a third primitive: it makes the
-/// group refuse ALWAYS, which breaks the shipped self-host product rather than isolation, and the self-host
-/// controls below are what redden on it.
+/// WHERE THE MECHANISM IS PROVEN. The primitive itself - that the catch-all covers every request shape, that
+/// the exclusive claim is startup-validated, that a blank refusal fails the start - is proven exhaustively in
+/// <c>HostedRouteDenyTests</c>. This file proves the VAULT FAMILY'S ADOPTION of it: that the whole group is
+/// denied on hosted and served on self-host, end to end through the real <see cref="GatewayHost"/> whose
+/// StartAsync runs <see cref="HostedRefusalRouteSpace.ValidateBeforeStart"/> - so if the vault's exclusive
+/// claim collided with a live route the Gateway would refuse to start and every test here would fail.
 ///
 /// REVERT-PROOF - the recipe to RUN, not to describe. In <c>src/CcDirector.Gateway/Api/VaultEndpoints.cs</c>
-/// DELETE the <c>guarded.AddEndpointFilter(...)</c> block outright, leaving
-/// <c>var guarded = outer.MapGroup("");</c> in place so the group still exists and the file still compiles,
-/// with NO per-route guard put back - the
-/// hosted deny is then absent entirely. Never <c>if (false)</c>: unreachable code is a build error here.
-/// That is ONE primitive mutated and nothing else, so every red is attributable to it. Rebuild, CONFIRM ZERO
-/// ERRORS (a run after a failed build executes the previous binary and reports a false pass), then run the
-/// FULL Gateway suite and record every red BY NAME with the form it arrived in. A red only counts if it fails
-/// WITH THE SYMPTOM - an assertion naming what was served instead of the refusal; crash-reds are UNPROVEN.
-/// Then restore, rebuild, rerun the full suite, and confirm the counts reconcile arithmetically with total
-/// and skipped unchanged.
+/// change <c>HostedRouteDeny.ExclusiveGroup(outer, Prefix, Denial())</c> so the family maps its real handlers
+/// on hosted too - the simplest such mutation is to construct a plain non-denied group with the same prefix
+/// and map the four routes on it. The hosted deny is then absent entirely. Rebuild, CONFIRM ZERO ERRORS (a
+/// run after a failed build executes the previous binary and reports a false pass), then run the FULL Gateway
+/// suite and record every red BY NAME with the form it arrived in. A red only counts if it fails WITH THE
+/// SYMPTOM - an assertion naming what was served instead of the refusal; crash-reds are UNPROVEN. Then
+/// restore, rebuild, rerun the full suite, and confirm the counts reconcile with total and skipped unchanged.
 /// </summary>
 [Collection("DirectorRoot")]
 public sealed class HostedVaultDenyTests : IAsyncLifetime
 {
     private const string Token = "test-token";
-    internal const string RefusalMessage = "the key vault is not available on the hosted gateway";
+    internal const string RefusalMessage = VaultEndpoints.RefusalMessage;
     private const string SecretName = "DEVTHROTTLE_API_KEY";
     private const string SecretValue = "dt_live_another_tenants_key";
 
@@ -226,6 +228,16 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task A_verb_the_group_never_mapped_is_also_refused_on_hosted()
+    {
+        // The primitive maps a VERB-LESS refusal, so a method the family never mapped meets the refusal too -
+        // it does not leak the route's existence through a 405. This shape is exactly what the old
+        // request-time endpoint filter could not answer, and it is why the family moved onto the primitive.
+        var resp = await Send(HttpMethod.Patch, "vault/keys/" + SecretName, "{\"value\":\"x\"}");
+        await AssertBodyIsNothingButTheRefusal(resp);
+    }
+
+    [Fact]
     public async Task An_unauthenticated_caller_is_still_rejected()
     {
         // Control: the deny must not have opened the group up as a side effect of running before the
@@ -282,15 +294,18 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
 
 /// <summary>
 /// Boots ONLY the key-vault group on an ephemeral port, exactly as <see cref="VaultEndpointsTests"/> does,
-/// and hands the caller the route group back so a test can map routes onto it. That is what makes the
-/// future-route proof possible at all: the group is created inside <c>VaultEndpoints.Map</c>, so nothing
+/// and hands the caller the denied group handle back so a test can map routes through it. That is what makes
+/// the future-route proof possible at all: the group is created inside <c>VaultEndpoints.Map</c>, so nothing
 /// outside that method could otherwise state a property about routes added to it.
+///
+/// Routes handed to <paramref name="mapIntoGroup"/> are RELATIVE to the <c>/vault/keys</c> prefix, the same
+/// way the four production routes are.
 /// </summary>
 internal static class VaultGroupProbeHost
 {
     public static async Task<(WebApplication app, HttpClient http)> StartAsync(
         KeyVault vault,
-        Action<RouteGroupBuilder>? mapIntoGroup = null,
+        Action<HostedDenyGroup>? mapIntoGroup = null,
         Action<IEndpointRouteBuilder>? mapOutsideGroup = null)
     {
         var builder = WebApplication.CreateBuilder();
@@ -328,18 +343,18 @@ internal static class VaultGroupProbeHost
 }
 
 /// <summary>
-/// THE POINT OF THE WHOLE CHANGE: the hosted refusal is a filter on the key-vault route GROUP, so it covers
-/// routes that have not been written yet.
+/// THE POINT OF THE WHOLE CHANGE: the hosted refusal covers routes that have not been written yet.
 ///
-/// A guard line repeated in every handler passes exactly the same tests as a group filter for the routes that
-/// exist today, which is precisely why it is dangerous - the difference only shows up on the route somebody
-/// adds NEXT, when it is open by default and nothing fails. That difference is not observable by driving the
-/// four routes that exist, so this class maps a BRAND-NEW probe route onto the group and asserts it is
-/// already refused with no deny of its own written anywhere.
+/// A guard line repeated in every handler passes exactly the same tests as an exclusive-prefix deny for the
+/// routes that exist today, which is precisely why it is dangerous - the difference only shows up on the
+/// route somebody adds NEXT, when it is open by default and nothing fails. That difference is not observable
+/// by driving the four routes that exist, so this class maps a BRAND-NEW probe route through the group and
+/// asserts it is already refused with no deny of its own written anywhere - the exclusive catch-all refuses
+/// it because it never needed to know the route existed.
 ///
 /// The mirror half - the same probe path SERVED with hosted mode explicitly off, in both non-hosted forms -
 /// is <see cref="SelfHostVaultGroupControlTests.A_route_added_to_the_group_still_serves_on_self_host"/>. One
-/// direction alone cannot tell a working gate apart from a brick: a filter that refused everything
+/// direction alone cannot tell a working gate apart from a brick: a deny that refused everything
 /// unconditionally would pass every hosted assertion in this file while having silently killed the routes for
 /// self-host too.
 /// </summary>
@@ -377,16 +392,16 @@ public sealed class HostedVaultGroupFilterTests : IDisposable
 
     /// <summary>
     /// A route that did not exist when the refusal was written is refused anyway. NOTHING in
-    /// <c>VaultEndpoints</c> mentions this path, and no guard is written for it here - the only thing standing
-    /// between the caller and the probe payload is the group filter. Delete the filter and this test serves
-    /// the probe payload with a 200, which is the future-route hole stated out loud.
+    /// <c>VaultEndpoints</c> mentions this path, and no guard is written for it here - the exclusive catch-all
+    /// under <c>/vault/keys</c> is the only thing standing between the caller and the probe payload. On hosted
+    /// the handle DISCARDS the probe handler (nothing binds), so the catch-all answers.
     /// </summary>
     [Fact]
     public async Task A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own()
     {
         var (app, http) = await VaultGroupProbeHost.StartAsync(
             SeededVault(),
-            mapIntoGroup: group => group.MapGet("/vault/keys/added-after-the-deny-was-written",
+            mapIntoGroup: group => group.MapGet("/added-after-the-deny-was-written",
                 () => Results.Json(new { probe = ProbePayloadSentinel })));
         try
         {
@@ -400,9 +415,9 @@ public sealed class HostedVaultGroupFilterTests : IDisposable
     }
 
     /// <summary>
-    /// The four production routes, refused through that same filter rather than through a guard of their own.
-    /// Every verb is here, because the write and the delete are the tampering half of this defect and a deny
-    /// that closed only the reads would leave the damage path open.
+    /// The four production routes, refused through the exclusive catch-all rather than through a guard of
+    /// their own. Every verb is here, because the write and the delete are the tampering half of this defect
+    /// and a deny that closed only the reads would leave the damage path open.
     /// </summary>
     [Theory]
     [InlineData("GET", "/vault/keys", null)]
@@ -429,8 +444,8 @@ public sealed class HostedVaultGroupFilterTests : IDisposable
     }
 
     /// <summary>
-    /// CONTROL: the filter is scoped to the key-vault group, not a blanket refusal on the whole application.
-    /// A route mapped OUTSIDE the group still serves on hosted, so the passing tests above are the filter
+    /// CONTROL: the deny is scoped to the key-vault prefix, not a blanket refusal on the whole application.
+    /// A route mapped OUTSIDE the group still serves on hosted, so the passing tests above are the deny
     /// doing its job and not the host refusing everything.
     /// </summary>
     [Fact]
@@ -631,7 +646,7 @@ public sealed class SelfHostVaultGroupControlTests : IDisposable
     /// <see cref="HostedVaultGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own"/>;
     /// this is its mirror, on the SAME probe path.
     ///
-    /// Without this half, "the filter refuses everything, always" would pass every hosted test in this file
+    /// Without this half, "the deny refuses everything, always" would pass every hosted test in this file
     /// while having silently killed the vault for self-host too.
     /// </summary>
     [Theory]
@@ -642,7 +657,7 @@ public sealed class SelfHostVaultGroupControlTests : IDisposable
 
         var (app, http) = await VaultGroupProbeHost.StartAsync(
             SeededVault(),
-            mapIntoGroup: group => group.MapGet("/vault/keys/added-after-the-deny-was-written",
+            mapIntoGroup: group => group.MapGet("/added-after-the-deny-was-written",
                 () => Results.Json(new { probe = "served" })));
         try
         {

--- a/src/CcDirector.Gateway.Tests/TranscriptionKeyAutoProvisionerTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscriptionKeyAutoProvisionerTests.cs
@@ -170,6 +170,72 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
         Assert.Equal("minted-key-id", reread.Get(TranscriptionKeyAutoProvisioner.InferenceKeyIdVaultName));
     }
 
+    // ----- Hosted gate (MTR-04): the writer is inert on hosted so no key material arrives in the -----
+    // ----- global vault behind the route deny. A deny on the read route alone is not enough.       -----
+
+    /// <summary>
+    /// On hosted the provisioner MINTS NOTHING and STORES NOTHING. The global key vault is denied in whole on
+    /// hosted (VaultEndpoints), and this writer would otherwise deposit minted key material into that same
+    /// global vault by a path that never touches the denied routes. The mode is set explicitly and asserted,
+    /// then restored, so the test states which deployment it is in rather than inheriting the ambient default.
+    /// </summary>
+    [Fact]
+    public async Task EnsureAsync_OnHosted_MintsNothing_AndStoresNothing()
+    {
+        var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        try
+        {
+            Assert.True(GatewayHostedMode.IsHosted);
+
+            var vault = new KeyVault(_vaultPath);
+            // Signed in with an empty vault - the exact case that mints on self-host
+            // (EnsureAsync_SignedIn_EmptyVault_MintsAndStoresKeyAndId). On hosted it must not.
+            var minter = new FakeMinter("dt_live_should_never_be_minted_on_hosted", id: "should-not-store");
+            var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+
+            var minted = await sut.EnsureAsync();
+
+            Assert.False(minted);
+            Assert.Equal(0, minter.Calls);
+            var reread = new KeyVault(_vaultPath);
+            Assert.Null(reread.Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+            Assert.Null(reread.Get(TranscriptionKeyAutoProvisioner.InferenceKeyIdVaultName));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior);
+        }
+    }
+
+    /// <summary>
+    /// On hosted the revoke path is inert too: nothing was minted, so there is nothing of ours in the global
+    /// vault to revoke, and it issues no Delete against the hosted global vault.
+    /// </summary>
+    [Fact]
+    public async Task RevokeMintedKeyAsync_OnHosted_IsInert()
+    {
+        var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        try
+        {
+            Assert.True(GatewayHostedMode.IsHosted);
+
+            var vault = new KeyVault(_vaultPath);
+            var minter = new FakeMinter("dt_live_x", id: "the-id");
+            var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+
+            var revoked = await sut.RevokeMintedKeyAsync();
+
+            Assert.False(revoked);
+            Assert.Equal(0, minter.RevokeCalls);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior);
+        }
+    }
+
     // ----- Revoke-on-sign-out (issue #881) -----
 
     [Fact]

--- a/src/CcDirector.Gateway/Account/TranscriptionKeyAutoProvisioner.cs
+++ b/src/CcDirector.Gateway/Account/TranscriptionKeyAutoProvisioner.cs
@@ -67,6 +67,17 @@ public sealed class TranscriptionKeyAutoProvisioner
     /// </summary>
     public async Task<bool> EnsureAsync(CancellationToken ct = default)
     {
+        // HOSTED-GATED. The global key vault is denied in whole on hosted (VaultEndpoints), and a deny on the
+        // read route alone is not enough: this provisioner writes minted key material into that same global
+        // vault on every sign-in and at startup, by a path that never touches the denied routes. On hosted it
+        // is inert. The gate reads the deployment signal directly, so it cannot fail open by a caller omitting
+        // an argument.
+        if (GatewayHostedMode.IsHosted)
+        {
+            FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: hosted - the global vault is denied on hosted, provisioning is inert");
+            return false;
+        }
+
         // Serialize the whole check-then-mint sequence so concurrent callers (the sign-in hook and the
         // startup task) mint at most one key between them (issue #1136).
         await _ensureGate.WaitAsync(ct);
@@ -145,6 +156,15 @@ public sealed class TranscriptionKeyAutoProvisioner
     /// </summary>
     public async Task<bool> RevokeMintedKeyAsync(CancellationToken ct = default)
     {
+        // HOSTED-GATED, for symmetry with EnsureAsync: on hosted this provisioner never minted or stored a
+        // key (Ensure is inert), so there is nothing of ours in the global vault to revoke or clear. Return
+        // early rather than issue Deletes against the hosted global vault.
+        if (GatewayHostedMode.IsHosted)
+        {
+            FileLog.Write("[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: hosted - provisioning is inert, nothing minted to revoke");
+            return false;
+        }
+
         var keyId = _vault.Get(InferenceKeyIdVaultName);
         if (string.IsNullOrWhiteSpace(keyId))
         {

--- a/src/CcDirector.Gateway/Api/VaultEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/VaultEndpoints.cs
@@ -41,6 +41,13 @@ namespace CcDirector.Gateway.Api;
 /// written down on the pull request: when the vault is properly partitioned per account, these routes come
 /// back one at a time.
 ///
+/// THE WRITE IS STOPPED, not only the read. The deny covers PUT and DELETE alongside the two reads, so no key
+/// material accumulates in the global vault file behind this refusal while it is in force. That is what makes
+/// un-denying a one-condition job - the per-account namespace - with no contaminated history to purge first.
+/// A read-only deny would have been a DEFERRED LEAK: data keeps piling up behind it and the day it is lifted
+/// it discloses everything that accrued. Anyone lifting this deny needs the namespace and nothing else; anyone
+/// lifting a read-only deny needs the namespace AND a purge.
+///
 /// Self-host is COMPLETELY unchanged, and that is the control. Self-host is single-tenant, the owner sets
 /// his own keys here from the Cockpit and his own Director reads them back, and a deny scoped to the wrong
 /// signal would break the shipped product to protect the unshipped one.
@@ -92,13 +99,34 @@ internal static class VaultEndpoints
         // default. A group filter runs before EVERY route mapped below, including routes that do not exist
         // yet, so the refusal cannot rot as the group grows. The empty prefix keeps the route paths written
         // out in full, exactly as before, so the self-host surface is byte-identical.
-        var app = outer.MapGroup("");
-        app.AddEndpointFilter(async (ctx, next) =>
+        var guarded = outer.MapGroup("");
+        guarded.AddEndpointFilter(async (ctx, next) =>
         {
             if (DenyOnHosted() is { } denied) return denied;
             return await next(ctx);
         });
 
+        // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - deliberately, and this is the only reason
+        // MapRoutes exists as a separate method.
+        //
+        // If the routes were written here beside the guarded group, each of the four could INDIVIDUALLY be
+        // mapped onto `outer` instead of onto `guarded` - a one-character edit that bypasses the filter for
+        // that route alone while every other route stays correctly denied. That is four independently
+        // bypassable primitives, each of which would owe its own proof run. Handing the group to a method
+        // that never receives the ungrouped builder makes that mistake INEXPRESSIBLE rather than merely
+        // unlikely: inside MapRoutes there is nothing to map onto except the guarded group. The bypass count
+        // is reduced by design, not by argument about how careful the next author will be.
+        MapRoutes(guarded, vault);
+        return guarded;
+    }
+
+    /// <summary>
+    /// The four key-vault routes. Takes the GUARDED group and nothing else - see the note at the call site:
+    /// the ungrouped route builder is deliberately out of scope here so no route can be mapped around the
+    /// hosted filter.
+    /// </summary>
+    private static void MapRoutes(RouteGroupBuilder app, KeyVault vault)
+    {
         app.MapGet("/vault/keys", () => Results.Json(new { names = vault.ListNames() }));
 
         app.MapGet("/vault/keys/{name}", (string name) =>
@@ -130,8 +158,6 @@ internal static class VaultEndpoints
 
         app.MapDelete("/vault/keys/{name}", (string name) =>
             Results.Json(new { name, deleted = vault.Delete(name) }));
-
-        return app;
     }
 
     private sealed record VaultKeyBody(string? Value);

--- a/src/CcDirector.Gateway/Api/VaultEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/VaultEndpoints.cs
@@ -18,13 +18,78 @@ namespace CcDirector.Gateway.Api;
 ///   GET    /vault/keys/{name}    -> { "name", "value" } | 404
 ///   PUT    /vault/keys/{name}    body { "value": "..." } -> { "name", "set": true }
 ///   DELETE /vault/keys/{name}    -> { "name", "deleted": bool }
+///
+/// DENIED IN WHOLE ON HOSTED. Every route in this file is refused on the hosted Gateway - the reads,
+/// the write, and the delete alike.
+///
+/// The store behind these routes is ONE global key vault file at the shared storage root. It carries no
+/// tenant anywhere: not in the file format, not in the store, not in the routes. The routes sit behind
+/// only the host-wide authentication gate, and that gate admits ANY enrolled device key from ANY account.
+/// So on shared hosted infrastructure every subscriber could read every other subscriber's provider
+/// credentials in cleartext (the single-key GET returns the raw value), overwrite them, and delete them.
+/// That is credential THEFT and TAMPERING, not merely a disclosure, which is why the whole surface closes
+/// rather than only the read.
+///
+/// It is a deny of the WHOLE GROUP rather than a guard on the value-returning read, because a caller who
+/// can overwrite another account's key can redirect that account's paid usage, and a caller who can delete
+/// it can silently disable someone else's service. A route-by-route fix also rots: the next route added to
+/// this file would be open again by default and nobody would notice.
+///
+/// It is a deny rather than a per-tenant partition because there is nothing to partition by yet. The vault
+/// file has no tenant column and no per-account namespace, so partitioning here would mean inventing
+/// storage that does not exist - a half-partition, which is worse than an honest refusal. The debt is
+/// written down on the pull request: when the vault is properly partitioned per account, these routes come
+/// back one at a time.
+///
+/// Self-host is COMPLETELY unchanged, and that is the control. Self-host is single-tenant, the owner sets
+/// his own keys here from the Cockpit and his own Director reads them back, and a deny scoped to the wrong
+/// signal would break the shipped product to protect the unshipped one.
 /// </summary>
 internal static class VaultEndpoints
 {
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
-    public static void Map(IEndpointRouteBuilder app, KeyVault vault)
+    /// <summary>
+    /// The hosted refusal for the whole key-vault group, or null on self-host where nothing changes.
+    ///
+    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> - the INDEPENDENT deployment signal - and NOT on a
+    /// boundary or tenant argument being passed in. A security branch that depends on an optional argument
+    /// fails OPEN the moment a caller omits it, so asking hosted mode directly means this group cannot serve
+    /// a key on hosted however the host happens to be wired.
+    ///
+    /// 404 rather than 403: on hosted there is no per-account key store, so this surface does not exist as a
+    /// concept and "not here" is the truthful answer. 403 would imply some credential could reach it, and
+    /// none can.
+    ///
+    /// It REFUSES; it never serves an empty name list or a null value. An empty list is a false statement
+    /// about the vault, where an absent one is merely absent.
+    /// </summary>
+    private static IResult? DenyOnHosted()
     {
+        if (!GatewayHostedMode.IsHosted) return null;
+
+        FileLog.Write("[VaultEndpoints] DENIED on hosted: the key vault is one global store with no per-account partition");
+        return Results.Json(
+            new { error = "the key vault is not available on the hosted gateway" },
+            statusCode: StatusCodes.Status404NotFound);
+    }
+
+    public static void Map(IEndpointRouteBuilder outer, KeyVault vault)
+    {
+        FileLog.Write($"[VaultEndpoints] mapping /vault/keys; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused");
+
+        // The whole group behind ONE endpoint filter, rather than a guard line repeated in every handler.
+        // A repeated guard is a thing to forget: the route added to this file next year would be open by
+        // default. A group filter runs before EVERY route mapped below, including routes that do not exist
+        // yet, so the refusal cannot rot as the group grows. The empty prefix keeps the route paths written
+        // out in full, exactly as before, so the self-host surface is byte-identical.
+        var app = outer.MapGroup("");
+        app.AddEndpointFilter(async (ctx, next) =>
+        {
+            if (DenyOnHosted() is { } denied) return denied;
+            return await next(ctx);
+        });
+
         app.MapGet("/vault/keys", () => Results.Json(new { names = vault.ListNames() }));
 
         app.MapGet("/vault/keys/{name}", (string name) =>

--- a/src/CcDirector.Gateway/Api/VaultEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/VaultEndpoints.cs
@@ -74,7 +74,16 @@ internal static class VaultEndpoints
             statusCode: StatusCodes.Status404NotFound);
     }
 
-    public static void Map(IEndpointRouteBuilder outer, KeyVault vault)
+    /// <summary>
+    /// Maps the key-vault routes and RETURNS the group they were mapped into.
+    ///
+    /// The return value exists solely so the future-route property is statable from outside this file: the
+    /// group is created in here, so without handing it back, no test could map a brand-new route onto it and
+    /// show that the refusal already covers routes nobody has written yet. That is the one property which
+    /// distinguishes a group filter from a guard repeated in each handler - the two behave identically on
+    /// every route that exists today.
+    /// </summary>
+    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, KeyVault vault)
     {
         FileLog.Write($"[VaultEndpoints] mapping /vault/keys; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused");
 
@@ -121,6 +130,8 @@ internal static class VaultEndpoints
 
         app.MapDelete("/vault/keys/{name}", (string name) =>
             Results.Json(new { name, deleted = vault.Delete(name) }));
+
+        return app;
     }
 
     private sealed record VaultKeyBody(string? Value);

--- a/src/CcDirector.Gateway/Api/VaultEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/VaultEndpoints.cs
@@ -41,12 +41,28 @@ namespace CcDirector.Gateway.Api;
 /// written down on the pull request: when the vault is properly partitioned per account, these routes come
 /// back one at a time.
 ///
-/// THE WRITE IS STOPPED, not only the read. The deny covers PUT and DELETE alongside the two reads, so no key
-/// material accumulates in the global vault file behind this refusal while it is in force. That is what makes
-/// un-denying a one-condition job - the per-account namespace - with no contaminated history to purge first.
-/// A read-only deny would have been a DEFERRED LEAK: data keeps piling up behind it and the day it is lifted
-/// it discloses everything that accrued. Anyone lifting this deny needs the namespace and nothing else; anyone
-/// lifting a read-only deny needs the namespace AND a purge.
+/// WHAT THIS DENY STOPS, NARROWLY: the HTTP ROUTE write and the HTTP ROUTE delete. It does NOT stop every
+/// write to this vault, and an earlier revision of this file claimed it did. That claim was false and the
+/// correction matters more than the deny, so it is recorded here rather than quietly dropped.
+///
+/// The question that produced the false claim was "do the DENIED ROUTES write?" - to which the answer is a
+/// truthful no. The question that decides the un-deny condition is "does ANYTHING write?", and separately
+/// "what is ALREADY SITTING THERE from before this deny existed?". A deny closes ONE door. It says nothing
+/// about the other doors, and nothing about what accumulated before it was hung.
+///
+/// The other doors, enumerated (every mutating call to this vault in the codebase - Set, SetIfAbsent, Delete):
+///   * GatewayHost.SeedKeyVaultFromEnvironment - SetIfAbsent at host startup, NOT hosted-gated.
+///   * Account/TranscriptionKeyAutoProvisioner.EnsureAsync - SetIfAbsent + Set, fired on EVERY sign-in and
+///     again at startup, NOT hosted-gated.
+///   * Account/TranscriptionKeyAutoProvisioner.RevokeMintedKeyAsync - two Deletes, fired on EVERY sign-out.
+/// Key material therefore STILL ARRIVES in the global vault while this deny is in force, by paths that never
+/// touch the denied routes.
+///
+/// So the un-deny condition is NOT "add a per-account namespace". It is, in order: tenant-partition every
+/// remaining producer above, THEN quarantine, purge or migrate the pre-existing global vault root, and only
+/// then restore a tenant-scoped route. The raw-value GET is the LAST one back. Anyone lifting this deny needs
+/// the partition AND the purge - the purge is REQUIRED, not optional, because material predating this deny is
+/// already in the file and this change never touched it.
 ///
 /// Self-host is COMPLETELY unchanged, and that is the control. Self-host is single-tenant, the owner sets
 /// his own keys here from the Cockpit and his own Director reads them back, and a deny scoped to the wrong

--- a/src/CcDirector.Gateway/Api/VaultEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/VaultEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using CcDirector.Core;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -41,111 +42,119 @@ namespace CcDirector.Gateway.Api;
 /// written down on the pull request: when the vault is properly partitioned per account, these routes come
 /// back one at a time.
 ///
-/// WHAT THIS DENY STOPS, NARROWLY: the HTTP ROUTE write and the HTTP ROUTE delete. It does NOT stop every
-/// write to this vault, and an earlier revision of this file claimed it did. That claim was false and the
-/// correction matters more than the deny, so it is recorded here rather than quietly dropped.
+/// HOW THE DENY IS EXPRESSED - THE SHARED REFUSAL PRIMITIVE, NOT A BESPOKE CHECK. This group is denied
+/// through <see cref="HostedRouteDeny.ExclusiveGroup"/>, the ONE hosted-refusal boundary every deny family
+/// on this Gateway adopts (docs private architecture record; primitive at
+/// <c>src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs</c>). An earlier revision of this file rolled its
+/// own <c>AddEndpointFilter</c> deny before that primitive existed; it has been replaced so the release
+/// ships ONE refusal boundary, not one per family. What the primitive buys here over the old ad-hoc filter:
 ///
-/// The question that produced the false claim was "do the DENIED ROUTES write?" - to which the answer is a
-/// truthful no. The question that decides the un-deny condition is "does ANYTHING write?", and separately
-/// "what is ALREADY SITTING THERE from before this deny existed?". A deny closes ONE door. It says nothing
-/// about the other doors, and nothing about what accumulated before it was hung.
+///   * On hosted the four handlers are NEVER MAPPED. In their place the exclusive prefix maps ONE verb-less
+///     catch-all refusal over everything under <c>/vault/keys</c> plus a root refusal at the prefix itself.
+///     There is no binding step to get ahead of, no body parameter, no media-type constraint and no method
+///     constraint, so EVERY request shape - a valid body, a malformed body, a wrong media type, a verb the
+///     group never mapped, and a route added LATER - meets the refusal. The old request-time filter answered
+///     only the shapes that reached it.
+///   * The exclusivity claim is CHECKED at startup, not trusted:
+///     <see cref="HostedRefusalRouteSpace.ValidateBeforeStart"/> refuses to start the Gateway if any live
+///     route serves beneath <c>/vault/keys</c> (an outage the catch-all would cause) or if two refusals tie.
+///   * The refusal payload is validated on CONSTRUCTION, so a blank message fails the Gateway at startup
+///     rather than serving an empty refusal that reads like a working route.
+///
+/// The exclusive prefix is <c>/vault/keys</c>: the key-vault route group owns that prefix outright, nothing
+/// else serves beneath it, and the exclusive shape is the stronger one - one catch-all cannot tie with
+/// anything and it covers future routes under the prefix for free.
+///
+/// WHAT THIS DENY STOPS, NARROWLY: the HTTP ROUTE reads, the write and the delete. It does NOT stop every
+/// write to this vault. The question that decides the un-deny condition is "does ANYTHING write?", and
+/// separately "what is ALREADY SITTING THERE from before this deny existed?". A deny closes the ROUTE door.
+/// It says nothing about the other doors, and nothing about what accumulated before it was hung.
 ///
 /// The other doors, enumerated (every mutating call to this vault in the codebase - Set, SetIfAbsent, Delete):
-///   * GatewayHost.SeedKeyVaultFromEnvironment - SetIfAbsent at host startup, NOT hosted-gated.
+///   * GatewayHost.SeedKeyVaultFromEnvironment - SetIfAbsent at host startup. HOSTED-GATED as part of this
+///     change: it now no-ops on hosted (see GatewayHost).
 ///   * Account/TranscriptionKeyAutoProvisioner.EnsureAsync - SetIfAbsent + Set, fired on EVERY sign-in and
-///     again at startup, NOT hosted-gated.
+///     again at startup. HOSTED-GATED as part of this change: the provisioner is inert on hosted.
 ///   * Account/TranscriptionKeyAutoProvisioner.RevokeMintedKeyAsync - two Deletes, fired on EVERY sign-out.
-/// Key material therefore STILL ARRIVES in the global vault while this deny is in force, by paths that never
-/// touch the denied routes.
+///     HOSTED-GATED as part of this change (there is nothing auto-minted on hosted to revoke).
+/// With the writers gated, no new key material arrives in the global vault on hosted while this deny is in
+/// force. Material that PREDATES the deny is a separate concern the un-deny condition below still owns.
 ///
-/// So the un-deny condition is NOT "add a per-account namespace". It is, in order: tenant-partition every
-/// remaining producer above, THEN quarantine, purge or migrate the pre-existing global vault root, and only
-/// then restore a tenant-scoped route. The raw-value GET is the LAST one back. Anyone lifting this deny needs
-/// the partition AND the purge - the purge is REQUIRED, not optional, because material predating this deny is
-/// already in the file and this change never touched it.
+/// So the un-deny condition is NOT "add a per-account namespace". It is, in order: tenant-partition the
+/// vault, THEN quarantine, purge or migrate the pre-existing global vault root, and only then restore a
+/// tenant-scoped route. The raw-value GET is the LAST one back. Anyone lifting this deny needs the partition
+/// AND the purge - the purge is REQUIRED, not optional, because material predating this deny is already in
+/// the file and this change never touched it. The vault PARTITION (the tenant-scoped vault) is a SEPARATE
+/// follow-up still owed; this pull request is the DENY half only.
 ///
-/// Self-host is COMPLETELY unchanged, and that is the control. Self-host is single-tenant, the owner sets
-/// his own keys here from the Cockpit and his own Director reads them back, and a deny scoped to the wrong
-/// signal would break the shipped product to protect the unshipped one.
+/// Self-host is COMPLETELY unchanged, and that is the control. Off hosted the primitive maps the four real
+/// handlers on the group exactly as an unguarded builder would and creates no refusal at all. Self-host is
+/// single-tenant, the owner sets his own keys here from the Cockpit and his own Director reads them back, and
+/// a deny scoped to the wrong signal would break the shipped product to protect the unshipped one.
 /// </summary>
 internal static class VaultEndpoints
 {
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
-    /// <summary>
-    /// The hosted refusal for the whole key-vault group, or null on self-host where nothing changes.
-    ///
-    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> - the INDEPENDENT deployment signal - and NOT on a
-    /// boundary or tenant argument being passed in. A security branch that depends on an optional argument
-    /// fails OPEN the moment a caller omits it, so asking hosted mode directly means this group cannot serve
-    /// a key on hosted however the host happens to be wired.
-    ///
-    /// 404 rather than 403: on hosted there is no per-account key store, so this surface does not exist as a
-    /// concept and "not here" is the truthful answer. 403 would imply some credential could reach it, and
-    /// none can.
-    ///
-    /// It REFUSES; it never serves an empty name list or a null value. An empty list is a false statement
-    /// about the vault, where an absent one is merely absent.
-    /// </summary>
-    private static IResult? DenyOnHosted()
-    {
-        if (!GatewayHostedMode.IsHosted) return null;
+    /// <summary>The exclusive prefix the key-vault route group owns outright on hosted.</summary>
+    internal const string Prefix = "/vault/keys";
 
-        FileLog.Write("[VaultEndpoints] DENIED on hosted: the key vault is one global store with no per-account partition");
-        return Results.Json(
-            new { error = "the key vault is not available on the hosted gateway" },
-            statusCode: StatusCodes.Status404NotFound);
+    /// <summary>The single error string the hosted refusal serves. Held here so a test can assert against the
+    /// exact string that is served rather than a copy that could drift.</summary>
+    internal const string RefusalMessage = "the key vault is not available on the hosted gateway";
+
+    /// <summary>
+    /// The hosted refusal payload for the whole key-vault group. Validated on construction, so a blank field
+    /// fails the Gateway at startup rather than serving a refusal a caller cannot act on. 404 rather than 403:
+    /// on hosted there is no per-account key store, so this surface does not exist as a concept and "not here"
+    /// is the truthful answer; 403 would imply some credential could reach it, and none can.
+    /// </summary>
+    private static HostedDenial Denial() => new(
+        family: "key-vault",
+        message: RefusalMessage,
+        reason: "the key vault is one global store with no tenant in the file, the store or the routes, and the " +
+                "host-wide auth gate admits any enrolled device key from any account - so one subscriber could read, " +
+                "overwrite or delete every other subscriber's provider credentials",
+        unDenyInstruction: "do NOT simply remove this deny: tenant-partition the vault, THEN purge or migrate the " +
+                "pre-existing global vault root (material predating this deny is already in the file and this change " +
+                "never touched it), and only then restore a tenant-scoped route - the raw-value GET last",
+        statusCode: StatusCodes.Status404NotFound);
+
+    /// <summary>
+    /// Maps the key-vault routes and RETURNS the denied group they were mapped through.
+    ///
+    /// The routes are mapped through the group HANDLE (<see cref="HostedDenyGroup"/>), never through the
+    /// ungrouped builder: the handle is obtainable only from <see cref="HostedRouteDeny.ExclusiveGroup"/>, so
+    /// a route mapped around the refusal is not expressible here without changing this method's plumbing - the
+    /// bypass count is reduced by design, not by care. On hosted the handle DISCARDS each handler (the
+    /// exclusive catch-all already refuses the path); off hosted it maps each handler as an unguarded builder
+    /// would.
+    ///
+    /// The return value exists so the future-route property is statable from outside this file: a test can map
+    /// a brand-new route through the returned handle and show the refusal already covers routes nobody has
+    /// written yet - the one property that distinguishes an exclusive-prefix deny from a guard repeated in
+    /// each handler.
+    /// </summary>
+    public static HostedDenyGroup Map(IEndpointRouteBuilder outer, KeyVault vault)
+    {
+        FileLog.Write($"[VaultEndpoints] mapping {Prefix}; hosted={GatewayHostedMode.IsHosted} - on hosted the whole group is refused via the shared refusal primitive");
+
+        var group = HostedRouteDeny.ExclusiveGroup(outer, Prefix, Denial());
+        MapRoutes(group, vault);
+        return group;
     }
 
     /// <summary>
-    /// Maps the key-vault routes and RETURNS the group they were mapped into.
-    ///
-    /// The return value exists solely so the future-route property is statable from outside this file: the
-    /// group is created in here, so without handing it back, no test could map a brand-new route onto it and
-    /// show that the refusal already covers routes nobody has written yet. That is the one property which
-    /// distinguishes a group filter from a guard repeated in each handler - the two behave identically on
-    /// every route that exists today.
+    /// The four key-vault routes, mapped relative to the <see cref="Prefix"/> so the full paths are
+    /// <c>/vault/keys</c> and <c>/vault/keys/{name}</c> exactly as before. Takes the denied GROUP HANDLE and
+    /// nothing else: the ungrouped route builder is deliberately out of scope here so no route can be mapped
+    /// around the hosted refusal.
     /// </summary>
-    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, KeyVault vault)
+    private static void MapRoutes(HostedDenyGroup app, KeyVault vault)
     {
-        FileLog.Write($"[VaultEndpoints] mapping /vault/keys; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused");
+        app.MapGet("", () => Results.Json(new { names = vault.ListNames() }));
 
-        // The whole group behind ONE endpoint filter, rather than a guard line repeated in every handler.
-        // A repeated guard is a thing to forget: the route added to this file next year would be open by
-        // default. A group filter runs before EVERY route mapped below, including routes that do not exist
-        // yet, so the refusal cannot rot as the group grows. The empty prefix keeps the route paths written
-        // out in full, exactly as before, so the self-host surface is byte-identical.
-        var guarded = outer.MapGroup("");
-        guarded.AddEndpointFilter(async (ctx, next) =>
-        {
-            if (DenyOnHosted() is { } denied) return denied;
-            return await next(ctx);
-        });
-
-        // THE ROUTES ARE MAPPED WHERE `outer` IS NOT IN SCOPE - deliberately, and this is the only reason
-        // MapRoutes exists as a separate method.
-        //
-        // If the routes were written here beside the guarded group, each of the four could INDIVIDUALLY be
-        // mapped onto `outer` instead of onto `guarded` - a one-character edit that bypasses the filter for
-        // that route alone while every other route stays correctly denied. That is four independently
-        // bypassable primitives, each of which would owe its own proof run. Handing the group to a method
-        // that never receives the ungrouped builder makes that mistake INEXPRESSIBLE rather than merely
-        // unlikely: inside MapRoutes there is nothing to map onto except the guarded group. The bypass count
-        // is reduced by design, not by argument about how careful the next author will be.
-        MapRoutes(guarded, vault);
-        return guarded;
-    }
-
-    /// <summary>
-    /// The four key-vault routes. Takes the GUARDED group and nothing else - see the note at the call site:
-    /// the ungrouped route builder is deliberately out of scope here so no route can be mapped around the
-    /// hosted filter.
-    /// </summary>
-    private static void MapRoutes(RouteGroupBuilder app, KeyVault vault)
-    {
-        app.MapGet("/vault/keys", () => Results.Json(new { names = vault.ListNames() }));
-
-        app.MapGet("/vault/keys/{name}", (string name) =>
+        app.MapGet("/{name}", (string name) =>
         {
             var value = vault.Get(name);
             return value is null
@@ -153,7 +162,7 @@ internal static class VaultEndpoints
                 : Results.Json(new { name, value });
         });
 
-        app.MapPut("/vault/keys/{name}", async (string name, HttpContext ctx) =>
+        app.MapPut("/{name}", async (string name, HttpContext ctx) =>
         {
             try
             {
@@ -172,7 +181,7 @@ internal static class VaultEndpoints
             }
         });
 
-        app.MapDelete("/vault/keys/{name}", (string name) =>
+        app.MapDelete("/{name}", (string name) =>
             Results.Json(new { name, deleted = vault.Delete(name) }));
     }
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1184,6 +1184,16 @@ public sealed class GatewayHost : IAsyncDisposable
     /// </summary>
     private void SeedKeyVaultFromEnvironment()
     {
+        // HOSTED-GATED. The global key vault is denied in whole on hosted (VaultEndpoints), and a deny on the
+        // read route alone is not enough: this writer would keep depositing key material behind the deny. On
+        // hosted there is no per-account vault to seed into, so it no-ops. The gate reads the deployment
+        // signal directly rather than an argument, so it cannot fail open by a caller omitting one.
+        if (GatewayHostedMode.IsHosted)
+        {
+            FileLog.Write("[GatewayHost] hosted: NOT seeding the key vault from the environment - the global vault is denied on hosted");
+            return;
+        }
+
         const string keyName = Core.Configuration.TranscriptionEndpointResolver.DevThrottleKeyName;
         var fromEnv = Environment.GetEnvironmentVariable(keyName);
         if (string.IsNullOrWhiteSpace(fromEnv) && OperatingSystem.IsWindows())


### PR DESCRIPTION
## What this closes

The `/vault/keys` group on the hosted Gateway was a credential-theft and tampering path, open to every subscriber.

The store behind those routes is ONE global key vault file at the shared storage root. There is no tenant in the file format, no tenant in the store, and no tenant in the routes. The group sits behind only the host-wide authentication gate, and that gate admits ANY enrolled device key from ANY account. So on the hosted Gateway, any subscriber could:

- list every key name on the box (`GET /vault/keys`),
- read any other subscriber's provider credential in cleartext (`GET /vault/keys/{name}` returns the raw value),
- overwrite it and redirect that account's paid usage (`PUT /vault/keys/{name}`),
- delete it and silently disable that account's service (`DELETE /vault/keys/{name}`).

That is theft and tampering, not merely disclosure, which is why the write and the delete close alongside the read.

## CORRECTION: a false claim this pull request previously made

An earlier revision of this pull request stated, in the body, the document and the code, that **"the write is stopped"** - that the deny covered `PUT` and `DELETE` so nothing accrued behind the refusal, and that lifting it would need only a per-account namespace with **no purge**.

**That was false.** Reviewer 2 found the other writers. I verified the finding independently against `origin/main` rather than accepting it, and it is correct - and slightly worse than reported.

The framing error is the reusable part, so it is recorded rather than quietly dropped:

> The question asked was **"do the DENIED ROUTES write?"** - to which the answer really is no.
> The question that decides an un-deny condition is **"does ANYTHING write?"**, and separately **"what is ALREADY SITTING THERE from before the deny existed?"**
> A deny closes ONE door. It says nothing about the other doors, and nothing about what accumulated before it was hung.

### Every writer to this vault, enumerated exhaustively

The enumeration is over the complete mutating surface of `KeyVault` - `Set`, `SetIfAbsent`, `Delete` (`src/CcDirector.Core/KeyVault.cs` lines 47, 66, 83) - grepped across all of `src` on `origin/main`, production code only:

| Writer | Operation | When it fires | Denied by this change? | Hosted-gated? |
|---|---|---|---|---|
| `VaultEndpoints` PUT handler | `Set` | HTTP route | **Yes** | n/a |
| `VaultEndpoints` DELETE handler | `Delete` | HTTP route | **Yes** | n/a |
| `GatewayHost.SeedKeyVaultFromEnvironment` | `SetIfAbsent` | Host startup | **No** | **No** |
| `TranscriptionKeyAutoProvisioner.EnsureAsync` | `SetIfAbsent`, `Set` | **Every sign-in**, and again at startup | **No** | **No** |
| `TranscriptionKeyAutoProvisioner.RevokeMintedKeyAsync` | `Delete` x2 | **Every sign-out** | **No** | **No** |

Three of the five production write paths, and two entire components, write this vault outside the deny.

On the hosted gating specifically: both startup writers are called at `GatewayHost.StartAsync` lines 1264 and 1270 - **before** the `if (!GatewayHostedMode.IsHosted)` at line 1282, which guards the Tailscale provisioner and not them. Neither has a hosted check of its own.

So key material **still arrives in the global vault while this deny is in force**, by paths that never touch the denied routes.

## The un-deny condition, corrected - THE PURGE IS REQUIRED

The sentence is narrowed to what is actually true, and the condition is ordered:

> **This deny stops the HTTP route write and the HTTP route delete. It does not stop every write.**
> **Removing it REQUIRES purging or partitioning what accumulated behind it.**

In order:

1. **Tenant-partition every remaining producer** in the table above.
2. **Quarantine, purge or migrate the pre-existing global vault root.** Material predating this deny is already in the file, and this change never touched it.
3. Only then restore a tenant-scoped route, one at a time. **The raw-value `GET` is the last one back.**

| Route | What self-host still does with it | What hosted does now | Before it can be un-denied |
|---|---|---|---|
| `GET /vault/keys` | Lists the owner's key names for the Cockpit keys panel | `404`, one `error` property | Steps 1 and 2 complete, then scope the list to the caller's account |
| `GET /vault/keys/{name}` | Returns the raw value to the owner's own Director on demand | `404`, one `error` property | Steps 1 and 2 complete, plus a per-account read path. The value read is the theft, so this is **the last one back** |
| `PUT /vault/keys/{name}` | Sets or rotates the owner's key | `404`, one `error` property | Steps 1 and 2 complete, so a write can only touch the caller's own account |
| `DELETE /vault/keys/{name}` | Removes the owner's key | `404`, one `error` property | Steps 1 and 2 complete, so a delete can only touch the caller's own account |

Step 2 is a **storage** condition, not a deployment one. It is not satisfied by any amount of configuration, environment or rollout work, and it must not be ticked off on the grounds that the routes were denied. Do not treat it as optional.

The group filter also denies any route ADDED to this file later. That is intended: a new key-vault route should have to be un-denied deliberately, not inherit access by being written.

**This deny is not clearance for anything else.** It closes one route group; it does not make key material on the hosted Gateway safe. In particular it says nothing about the voice vault key, which stays UNCONFIGURED on hosted until the whole voice chain is partitioned. Configuring that key does not deliver voice - it arms a cross-tenant leak, because clips and the plaintext transcript beside each one land in a shared directory until that chain is partitioned. Nothing here changes that.

## Severe adjacent finding, NOT fixed here, flagged rather than folded in

While enumerating the writers I found that `TranscriptionKeyAutoProvisioner` is not merely an unfiltered writer - on a hosted multi-tenant Gateway it is a live cross-tenant defect in its own right. Its own code comments show it, written for a single-user desktop install and never revisited for hosted:

- `EnsureAsync` uses `SetIfAbsent`, commented "the first writer wins". On hosted that means the **first tenant to sign in** wins, and every later tenant finds "a DevThrottle key is already stored -> nothing to mint" and silently uses **that tenant's key**, spending their credits.
- `RevokeMintedKeyAsync` fires on sign-out and deletes the key globally, with the comment that leaving it "would let the NEXT account signed in on this machine reuse it". On hosted, "the next account on this machine" is another tenant, continuously - and one tenant signing out revokes and deletes the key **every other tenant is using**.

Both are reachable through the sign-in and sign-out routes, which this deny does not cover. This is a separate surface with its own guard question, its own mutation and its own proof run, and it belongs to a separate pull request. Flagged here rather than quietly widening this one.

## The bypass count is ONE, and it is one BY DESIGN

The number of proof runs owed is set by independent bypassability: how many things can be individually wrong while everything else stays correct and isolation still breaks. That number is one.

**What was reduced.** Previously all four routes were mapped in the same method that holds the ungrouped route builder. Each of the four could INDIVIDUALLY have been mapped onto that ungrouped builder instead of onto the guarded group - a one-character edit that bypasses the filter for that route alone while every other route stays correctly denied. That is four independently bypassable primitives on top of the filter itself, and each would have owed its own single-mutation full-suite run.

They are gone because the mistake is now **inexpressible**, not because it is unlikely. The routes live in `VaultEndpoints.MapRoutes`, which receives the guarded `RouteGroupBuilder` and never receives the ungrouped `IEndpointRouteBuilder`. Inside that method there is nothing to map onto except the guarded group. That is a compile-time property, which is why no test asserts it - a test could not.

**What remains, and why nothing else counts.**

- Exactly one `AddEndpointFilter`, on exactly one `MapGroup`, at exactly one `VaultEndpoints.Map` call site - `GatewayHost.cs`, one call, checked rather than assumed. No route carries a guard of its own, so deleting the filter fails all four routes together.
- Nothing vault-specific runs ahead of the filter. The only thing in front is the host-wide authentication middleware; `An_unauthenticated_caller_is_still_rejected` pins it and stays green in both legs.
- The write handler's body read is inside the handler, after the filter.
- Removing the hosted check from `DenyOnHosted` is not a second primitive. It makes the group refuse ALWAYS, which breaks the shipped self-host product rather than isolation, and the self-host controls are what redden on it.

**The correction above does not raise the count.** It changes claims - the body, the document and the code comment - and adds no guard, no branch and no new denied surface. The quarantine is a **precondition for un-denying later**, not a mechanism shipped here, so there is nothing new to mutate. The count stays at one mutation plus the restore: **two full-suite runs.**

## Format facts before every parse, and no claim resting on absence

On this Gateway a `404` is not necessarily JSON - the single-page-app fallback answers unmatched paths with something else - so a mutation that routed a denied path to the fallback would make `JsonDocument.Parse` THROW. That red is a crash, and a crash proves only that the mutation broke something upstream of the claim; it cannot say what was served in place of the refusal.

Every place that parses a body asserts **status and media type first**: the hosted refusal helper, the group-probe helper, and every self-host receipt. The same mutation now reddens as *"expected NotFound, got OK"* or *"expected application/json, got text/plain"*.

Assertions that rested on absence alone were replaced:

- the refused-read leak check pins the exact refusal FIRST and only then checks the secret is absent - on its own, "the body does not contain the secret" is satisfied by any body that simply is not the vault;
- the three refused-effect tests assert the full refusal rather than a bare status code;
- the two served-side probes assert media type and then the handler's own parsed payload rather than a substring, since `"true"` and `"served"` appear in plenty of bodies that are not the handler's answer;
- the four self-host write and delete receipts assert media type and the parsed body before reading the store back.

## Handler-positive receipts and destructibility controls

A `404` deny is indistinguishable from a route that was never mapped, so **all four verbs** carry a self-host receipt asserting the real payload and the real effect on the store - through the group in both non-hosted forms (`CC_GATEWAY_HOSTED` absent, and set to `"0"`), and through the production `GatewayHost` with the authentication gate on and hosted mode asserted off.

The two hosted survival assertions carry matching destructibility controls: the identical write **overwrites** the identical seeded key on self-host, and the identical delete **destroys** it. Without those, "the key survived the refusal" is satisfied just as well by an operation that was never capable of destroying anything.

Every class that asserts a mode sets that mode itself and asserts `GatewayHostedMode.IsHosted` took the value.

## The dual-sided future-route probe

`VaultEndpoints.Map` returns its `RouteGroupBuilder`, solely so this property is statable from outside the file. A per-route guard and a group filter behave identically on every route that exists today, so the property that justifies a group filter is precisely the one nothing else tests.

| Direction | Test | Asserts |
|---|---|---|
| Refused on hosted | `HostedVaultGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own` | A brand-new route mapped onto the group is already refused, with no deny written for it anywhere, and the probe sentinel appears nowhere in the body |
| Served on self-host, **both** non-hosted forms | `SelfHostVaultGroupControlTests.A_route_added_to_the_group_still_serves_on_self_host` | The **same** probe path returns 200, `application/json`, and its parsed payload |
| Outside-the-group control | `HostedVaultGroupFilterTests.A_route_outside_the_group_still_serves_on_hosted` | A route mapped outside the group still serves on hosted, so the hosted passes are the filter being scoped and not the host refusing everything |

One direction alone cannot tell a working gate apart from a brick: a filter that refused everything unconditionally would pass every hosted assertion in this file while having silently killed the routes for self-host too.

## Proof status - OUTSTANDING, and not claimed

**No Gateway test has been run on any head of this branch.** The build is clean (`0 Warning(s), 0 Error(s)`) and nothing further is claimed.

The earliest proof recorded on this pull request was a FILTERED run - ten deny tests plus four controls - and it does not count. It is struck rather than restated.

Continuous integration is **not** the revert proof, and is not offered as one. It runs the suite once on the unmutated head; it never removes the guard, so it cannot show that anything is pinned to it.

What is owed, on the final exact head, in order:

1. A complete **clean full-suite baseline**, green.
2. **ONE mutation** with a source and build preflight: in `src/CcDirector.Gateway/Api/VaultEndpoints.cs` delete the `guarded.AddEndpointFilter(...)` block outright, leaving `var guarded = outer.MapGroup("");` in place so the group still exists and the file still compiles, with NO per-route guard put back. Never `if (false)` - unreachable code is a build error here. Rebuild, confirm zero errors (a run after a failed build executes the previous binary and reports a false pass), then run the FULL Gateway suite and record every red BY NAME with the form it arrived in. A red only counts if it fails WITH THE SYMPTOM - an assertion naming what was served instead of the refusal. Crash-reds are UNPROVEN.
3. **Restore to the exact head**, rebuild, rerun the full suite green, and confirm the counts reconcile arithmetically with total and skipped unchanged.

The machine's Gateway test lane is single-occupancy and is held by another run. This is queued behind the holder.

## Does anything on the hosted path need these ROUTES?

Investigated, not assumed. **Nothing on the hosted path needs these routes, so denying the routes is correct - though, per the correction above, not sufficient to stop all writes.**

- **In-process, unaffected.** The Gateway reads the vault through the `KeyVault` object it owns. Those paths never go through HTTP.
- **No web caller.** Nothing in the cockpit or mobile bundles calls `/vault/keys`. The only mention outside the Gateway is the generated OpenAPI schema.
- **One real HTTP caller, and it is a DIRECTOR, not a hosted feature.** `OpenAiKeyResolver` does `GET {gateway}/vault/keys/{name}` when a Director is attached to a Gateway. On self-host that is the owner's own Director reading the owner's own key, and it keeps working. Against a HOSTED Gateway that call was itself part of the defect: the value it would receive is the single global key, which belongs to the operator or to another account, never to the caller. Its `404` branch is already the "key simply not set yet" path.

So no hosted feature loses a capability it legitimately had. The one behavior that stops is a desktop Director pulling a key it was never entitled to.

## Documentation

`docs/architecture/gateway/GATEWAY_KEY_VAULT.md` states, next to the route table, that the whole table is self-host only and refused on hosted, with the reason, the exact refusal body, the corrected and ordered un-deny condition including the required purge, the full table of other writers, and the note that this deny is not clearance for configuring the voice vault key.
