### PR TITLE
test(gateway): prove context-less database routes are tenant-isolated, not fail-loud

### DIFF
--- a/src/CcDirector.Gateway.Tests/ContextLessDatabaseRouteTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/ContextLessDatabaseRouteTenancyTests.cs
@@ -1,0 +1,528 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// VERIFICATION, BY EXECUTION, of a claim about the hosted Gateway's context-less routes.
+///
+/// THE CLAIM UNDER TEST. A census found sixty-six routes that take a path parameter but no
+/// <c>HttpContext</c>, and INFERRED that the database-backed ones must hit the deny-by-default throw in
+/// <c>AsyncLocalTenantContext.Current</c> - broken, but not leaking - because a handler with no
+/// <c>HttpContext</c> cannot resolve the caller's tenant. That inference had never been executed.
+///
+/// WHAT THIS FILE DOES. It seeds real rows for TWO tenants over real HTTP through the real auth middleware
+/// on a real hosted <see cref="GatewayHost"/>, then has tenant A name tenant B's object id on context-less
+/// database-backed routes, and records exactly what comes back.
+///
+/// SCOPE - READ THIS BEFORE QUOTING THE RESULT. This file CROSS-PROBES EIGHT of the sixty-six context-less
+/// routes, across four stores: two work-list operations, two cron operations, one session-spend read, and
+/// three workflow operations. A ninth context-less route, POST /gateway/workflows/{id}/publish, is exercised
+/// on the OWNER path only, as a seed, and is NOT cross-probed - it is not part of the claim.
+///
+/// It does NOT retire the other fifty-eight by inference; that was the census's error and repeating it here
+/// would be the same mistake in the opposite direction. The full code-derived inventory, and exactly what
+/// remains unproven, is stated in the pull request. Eight samples cannot stand for sixty-six.
+///
+/// HOW A POSITIVE CONTROL IS BUILT HERE. Asserting a status code does not prove the intended handler
+/// returned the seeded row - an unrelated 200, a catch-all, or a failed seed answering empty would all pass.
+/// So every owner control asserts the exact SEEDED FINGERPRINT (the values this test itself wrote), and
+/// every write or delete is judged by an independent RE-READ of the resulting state, never by the absence of
+/// a substring. Status and media type are asserted BEFORE any parse, because parsing is itself an assertion
+/// about format: parse-first would turn a wrong response into a parser crash, which proves nothing.
+///
+/// WHAT EXECUTION FOUND. Nothing threw and nothing leaked. Every route answered its owner with the exact
+/// seeded row and answered the other tenant with an ordinary not-found; tenant B's rows survived tenant A's
+/// delete attempts byte-for-byte, and tenant B could then perform those same deletes itself - so the refusals
+/// are refusals, not inert operations. The claim's conclusion about the database half is wrong in BOTH
+/// halves: these routes are neither broken nor leaking.
+///
+/// THE MECHANISM, AND WHY IT IS PROVEN ELSEWHERE. The tenant scope is not entered by the handler, so a
+/// handler's signature cannot decide whether one exists. It is entered by a host-wide middleware registered
+/// before routing that binds the AUTHENTICATED device key's tenant for the whole pipeline
+/// (<c>GatewayHost.cs</c>, the device-key HTTP boundary). A context-less handler therefore runs inside the
+/// caller's scope, and the entity global query filter answers about the caller's tenant only.
+///
+/// Those are TWO SEPARATE production mechanisms, and an end-to-end test like this one cannot tell them
+/// apart - it would pass if either did all the work. They are therefore isolated from each other, without
+/// HTTP and without the middleware, in <see cref="ContextLessRouteTenancyMechanismProofTests"/>, which is
+/// the companion to this file and is where the causal claims are actually earned.
+/// </summary>
+public sealed class ContextLessDatabaseRouteTenancyTests : IAsyncLifetime
+{
+    private const string SharedToken = "test-token";
+    private const string TenantA = "tenant-alice";
+    private const string TenantB = "tenant-bob";
+
+    private readonly ITestOutputHelper _out;
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _keyA = "";
+    private string _keyB = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-ctxless-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public ContextLessDatabaseRouteTenancyTests(ITestOutputHelper output) => _out = output;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: SharedToken, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            cronJobsPath: Path.Combine(_instancesDir, "cron", "cronjobs.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            missionsPath: Path.Combine(_instancesDir, "missions", "missions.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        _keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        _keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", TenantA);
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", TenantB);
+
+        Assert.True(_gateway.TenantBoundary.IsHosted, "The harness must be running the HOSTED tenant boundary.");
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    // ================================================================= work lists (worklists table)
+
+    /// <summary>
+    /// GET /lists/{name} - context-less (WorkListEndpoints.cs:56, handler <c>(string name)</c>).
+    /// The owner control asserts the exact seeded list AND its exact seeded item, so an empty or unrelated
+    /// 200 cannot pass for a served row.
+    /// </summary>
+    [Fact]
+    public async Task WorkListGetByName_ServesTheOwnerTheExactSeededList_AndIsAPlainNotFoundForTheOtherTenant()
+    {
+        const string list = "bobs-backlog";
+
+        var seed = await Json(await Send("POST", "lists", _keyB, "{\"name\":\"" + list + "\"}"),
+            HttpStatusCode.OK, "SEED    POST /lists (tenant B)");
+        Assert.Equal(list, Str(seed, "name"));
+
+        var seedItem = await Json(
+            await Send("POST", $"lists/{list}/items", _keyB,
+                "{\"source\":\"github\",\"id\":\"77\",\"area\":\"alpha\"}"),
+            HttpStatusCode.OK, "SEED    POST /lists/{name}/items (tenant B)");
+        Assert.Equal(list, Str(seedItem, "name"));
+
+        // CONTROL: the exact seeded fingerprint, not merely a 200.
+        var control = await Json(await Send("GET", $"lists/{list}", _keyB, null),
+            HttpStatusCode.OK, "CONTROL GET /lists/{name} (owner B)");
+        AssertIsBobsBacklogWithTheOneSeededItem(control, list);
+
+        // CROSS: tenant A naming tenant B's list.
+        var cross = await Json(await Send("GET", $"lists/{list}", _keyA, null),
+            HttpStatusCode.NotFound, "CROSS   GET /lists/{name} (tenant A naming B's list)");
+        Assert.Equal("no such list", Str(cross, "error"));
+        Assert.Equal(list, Str(cross, "name"));
+    }
+
+    /// <summary>
+    /// DELETE /lists/{name}/items/{source}/{id} - context-less (WorkListEndpoints.cs:110, handler
+    /// <c>(string name, string source, string id)</c>). A destructive context-less route.
+    ///
+    /// The refusal is judged by an independent RE-READ of tenant B's exact list state, never by the absence
+    /// of a substring in tenant A's response - absence can pass on an empty or wrong body. And the owner then
+    /// performs the SAME delete successfully, which is what makes tenant A's 404 a refusal rather than an
+    /// operation that was inert for everyone.
+    /// </summary>
+    [Fact]
+    public async Task WorkListDeleteItem_ContextLess_LeavesTheOtherTenantsListExactlyAsItWas_AndTheOwnerCanStillDeleteIt()
+    {
+        const string list = "bobs-delete-target";
+
+        Assert.Equal(list, Str(await Json(await Send("POST", "lists", _keyB, "{\"name\":\"" + list + "\"}"),
+            HttpStatusCode.OK, "SEED    POST /lists (tenant B)"), "name"));
+        await Json(await Send("POST", $"lists/{list}/items", _keyB,
+                "{\"source\":\"github\",\"id\":\"77\",\"area\":\"alpha\"}"),
+            HttpStatusCode.OK, "SEED    POST /lists/{name}/items (tenant B)");
+
+        // CROSS: tenant A tries to delete tenant B's item by name, source and id.
+        var cross = await Json(await Send("DELETE", $"lists/{list}/items/github/77", _keyA, null),
+            HttpStatusCode.NotFound, "CROSS   DELETE /lists/{name}/items/{source}/{id} (tenant A)");
+        Assert.Equal("no such list", Str(cross, "error"));
+
+        // INDEPENDENT RE-READ: B's list must still hold exactly the seeded item, unchanged.
+        var after = await Json(await Send("GET", $"lists/{list}", _keyB, null),
+            HttpStatusCode.OK, "AFTER   GET /lists/{name} (owner B, after A's delete attempt)");
+        AssertIsBobsBacklogWithTheOneSeededItem(after, list);
+
+        // CONTROL: the owner performs the SAME operation - so the refusal above is a refusal, not inertia.
+        var ownerDelete = await Json(await Send("DELETE", $"lists/{list}/items/github/77", _keyB, null),
+            HttpStatusCode.OK, "CONTROL DELETE /lists/{name}/items/{source}/{id} (owner B)");
+        Assert.Equal(list, Str(ownerDelete, "name"));
+        Assert.Equal("github", Str(ownerDelete, "source"));
+        Assert.Equal("77", Str(ownerDelete, "id"));
+        Assert.True(Bool(ownerDelete, "removed"), "the owner's own delete reported nothing removed");
+
+        // And the effect of the owner's delete is independently re-read.
+        var emptied = await Json(await Send("GET", $"lists/{list}", _keyB, null),
+            HttpStatusCode.OK, "AFTER   GET /lists/{name} (owner B, after its OWN delete)");
+        Assert.Equal(list, Str(emptied, "name"));
+        Assert.Empty(Arr(emptied, "items").EnumerateArray());
+    }
+
+    private static void AssertIsBobsBacklogWithTheOneSeededItem(JsonElement list, string expectedName)
+    {
+        Assert.Equal(expectedName, Str(list, "name"));
+        var items = Arr(list, "items");
+        Assert.Equal(1, items.GetArrayLength());
+        var only = items[0];
+        Assert.Equal("github", Str(only, "source"));
+        Assert.Equal("77", Str(only, "id"));
+        Assert.Equal("alpha", Str(only, "area"));
+    }
+
+    // ================================================================= cron jobs (cron_jobs table)
+
+    /// <summary>
+    /// GET /cron/jobs/{id} (CronJobEndpoints.cs:56) and DELETE /cron/jobs/{id} (CronJobEndpoints.cs:91) -
+    /// both context-less, handlers <c>(string id)</c>.
+    /// </summary>
+    [Fact]
+    public async Task CronJobGetAndDelete_ContextLess_ServeTheOwnerTheExactSeededJob_AndTheOtherTenantCanNeitherReadNorDeleteIt()
+    {
+        var seed = await Json(await Send("POST", "cron/jobs", _keyB, CronBody("bobs-nightly")),
+            HttpStatusCode.Created, "SEED    POST /cron/jobs (tenant B)");
+        var jobId = Str(seed, "id");
+        Assert.NotEmpty(jobId);
+
+        var control = await Json(await Send("GET", $"cron/jobs/{jobId}", _keyB, null),
+            HttpStatusCode.OK, "CONTROL GET /cron/jobs/{id} (owner B)");
+        AssertIsBobsNightly(control, jobId);
+
+        var cross = await Json(await Send("GET", $"cron/jobs/{jobId}", _keyA, null),
+            HttpStatusCode.NotFound, "CROSS   GET /cron/jobs/{id} (tenant A naming B's job)");
+        Assert.Equal("no such cron job", Str(cross, "error"));
+        Assert.Equal(jobId, Str(cross, "id"));
+
+        var crossDelete = await Json(await Send("DELETE", $"cron/jobs/{jobId}", _keyA, null),
+            HttpStatusCode.NotFound, "CROSS   DELETE /cron/jobs/{id} (tenant A deleting B's job)");
+        Assert.Equal("no such cron job", Str(crossDelete, "error"));
+
+        // INDEPENDENT RE-READ: the job is still there and still byte-for-byte the seeded job.
+        var survives = await Json(await Send("GET", $"cron/jobs/{jobId}", _keyB, null),
+            HttpStatusCode.OK, "AFTER   GET /cron/jobs/{id} (owner B, after A's delete attempt)");
+        AssertIsBobsNightly(survives, jobId);
+
+        // CONTROL: the owner performs the same delete, so A's 404 is a refusal and not an inert route.
+        var ownerDelete = await Json(await Send("DELETE", $"cron/jobs/{jobId}", _keyB, null),
+            HttpStatusCode.OK, "CONTROL DELETE /cron/jobs/{id} (owner B)");
+        Assert.Equal(jobId, Str(ownerDelete, "id"));
+        Assert.True(Bool(ownerDelete, "deleted"), "the owner's own delete reported nothing deleted");
+
+        var gone = await Json(await Send("GET", $"cron/jobs/{jobId}", _keyB, null),
+            HttpStatusCode.NotFound, "AFTER   GET /cron/jobs/{id} (owner B, after its OWN delete)");
+        Assert.Equal("no such cron job", Str(gone, "error"));
+    }
+
+    private static void AssertIsBobsNightly(JsonElement job, string expectedId)
+    {
+        Assert.Equal(expectedId, Str(job, "id"));
+        Assert.Equal("bobs-nightly", Str(job, "name"));
+        Assert.Equal("recurring", Str(job, "scheduleKind"));
+        Assert.Equal("0 0 * * *", Str(job, "cronExpression"));
+        Assert.Equal("America/Chicago", Str(job, "timeZoneId"));
+        Assert.Equal("MB", Str(Obj(job, "target"), "machine"));
+        Assert.Equal("/help", Str(Obj(job, "action"), "seed"));
+    }
+
+    // ================================================================= session spend (session_spend table)
+
+    /// <summary>
+    /// GET /gateway/governance/session-spend/{sessionId} - context-less
+    /// (GovernanceSpendEndpoints.cs:62, handler <c>(string sessionId)</c>). The owner control asserts the
+    /// exact seeded token counts, so a zeroed or unrelated record cannot pass for the seeded one.
+    /// </summary>
+    [Fact]
+    public async Task SessionSpendGetBySessionId_ContextLess_ServesTheOwnerTheExactSeededTokens_AndIsANotFoundForTheOtherTenant()
+    {
+        const string sid = "bobs-session-0001";
+
+        var seed = await Json(await Send("POST", "gateway/governance/session-spend", _keyB,
+                "{\"sessionId\":\"" + sid + "\",\"agentKind\":\"claude\",\"billingMode\":\"subscription-included\"," +
+                "\"tokensCaptured\":true,\"inputTokens\":111,\"outputTokens\":222}"),
+            HttpStatusCode.OK, "SEED    POST /gateway/governance/session-spend (tenant B)");
+        Assert.Equal(sid, Str(seed, "sessionId"));
+
+        var control = await Json(await Send("GET", $"gateway/governance/session-spend/{sid}", _keyB, null),
+            HttpStatusCode.OK, "CONTROL GET /gateway/governance/session-spend/{sessionId} (owner B)");
+        Assert.Equal(sid, Str(control, "sessionId"));
+        Assert.Equal("claude", Str(control, "agentKind"));
+        Assert.Equal("subscription-included", Str(control, "billingMode"));
+        Assert.True(Bool(control, "tokensCaptured"), "the seeded record did not come back with tokensCaptured");
+        Assert.Equal(111, Int(control, "inputTokens"));
+        Assert.Equal(222, Int(control, "outputTokens"));
+
+        var cross = await Json(await Send("GET", $"gateway/governance/session-spend/{sid}", _keyA, null),
+            HttpStatusCode.NotFound, "CROSS   GET /gateway/governance/session-spend/{sessionId} (tenant A)");
+        Assert.Contains(sid, Str(cross, "error"), StringComparison.Ordinal);
+    }
+
+    // ================================================================= workflows (workflows table)
+
+    /// <summary>
+    /// GET /gateway/workflows/{id} (WorkflowEndpoints.cs:57), GET /gateway/workflows/{id}/versions
+    /// (WorkflowEndpoints.cs:131), DELETE /gateway/workflows/{id} (WorkflowEndpoints.cs:123) and
+    /// POST /gateway/workflows/{id}/publish (WorkflowEndpoints.cs:105) - all context-less.
+    /// </summary>
+    [Fact]
+    public async Task WorkflowReadVersionsAndArchive_ContextLess_ServeTheOwnerTheExactSeededWorkflow_AndTheOtherTenantCanNeitherReadNorArchiveIt()
+    {
+        const string wid = "bobs-flow";
+
+        var draft = await Json(await Send("POST", "gateway/workflows", _keyB, WorkflowBody(wid)),
+            HttpStatusCode.Created, "SEED    POST /gateway/workflows (tenant B)");
+        Assert.Equal(wid, Str(draft, "workflowId"));
+        Assert.Equal(1, Int(draft, "version"));
+
+        var published = await Json(await Send("POST", $"gateway/workflows/{wid}/publish", _keyB, "{}"),
+            HttpStatusCode.OK, "SEED    POST /gateway/workflows/{id}/publish (tenant B, context-less)");
+        Assert.Equal(wid, Str(published, "id"));
+        Assert.Equal(1, Int(published, "version"));
+
+        var control = await Json(await Send("GET", $"gateway/workflows/{wid}", _keyB, null),
+            HttpStatusCode.OK, "CONTROL GET /gateway/workflows/{id} (owner B)");
+        AssertIsBobsFlow(control, wid);
+
+        var controlVersions = await Json(await Send("GET", $"gateway/workflows/{wid}/versions", _keyB, null),
+            HttpStatusCode.OK, "CONTROL GET /gateway/workflows/{id}/versions (owner B)");
+        var versions = Arr(controlVersions, "versions");
+        Assert.Equal(1, versions.GetArrayLength());
+        Assert.Equal(1, Int(versions[0], "version"));
+        Assert.Equal("test-session", Str(versions[0], "authoredBy"));
+
+        var cross = await Json(await Send("GET", $"gateway/workflows/{wid}", _keyA, null),
+            HttpStatusCode.NotFound, "CROSS   GET /gateway/workflows/{id} (tenant A)");
+        Assert.Contains(wid, Str(cross, "error"), StringComparison.Ordinal);
+
+        var crossVersions = await Json(await Send("GET", $"gateway/workflows/{wid}/versions", _keyA, null),
+            HttpStatusCode.NotFound, "CROSS   GET /gateway/workflows/{id}/versions (tenant A)");
+        Assert.Contains(wid, Str(crossVersions, "error"), StringComparison.Ordinal);
+
+        var crossDelete = await Json(await Send("DELETE", $"gateway/workflows/{wid}", _keyA, null),
+            HttpStatusCode.NotFound, "CROSS   DELETE /gateway/workflows/{id} (tenant A archiving B's workflow)");
+        Assert.Contains(wid, Str(crossDelete, "error"), StringComparison.Ordinal);
+
+        // INDEPENDENT RE-READ: still there, still exactly the seeded workflow.
+        var stillThere = await Json(await Send("GET", $"gateway/workflows/{wid}", _keyB, null),
+            HttpStatusCode.OK, "AFTER   GET /gateway/workflows/{id} (owner B, after A's archive attempt)");
+        AssertIsBobsFlow(stillThere, wid);
+
+        // CONTROL: the owner archives it itself - the refusal above was a refusal, not an inert route.
+        var ownerArchive = await Json(await Send("DELETE", $"gateway/workflows/{wid}", _keyB, null),
+            HttpStatusCode.OK, "CONTROL DELETE /gateway/workflows/{id} (owner B)");
+        Assert.Equal(wid, Str(ownerArchive, "id"));
+        Assert.True(Bool(ownerArchive, "archived"), "the owner's own archive reported nothing archived");
+
+        var goneForOwner = await Json(await Send("GET", $"gateway/workflows/{wid}", _keyB, null),
+            HttpStatusCode.NotFound, "AFTER   GET /gateway/workflows/{id} (owner B, after its OWN archive)");
+        Assert.Contains(wid, Str(goneForOwner, "error"), StringComparison.Ordinal);
+    }
+
+    private static void AssertIsBobsFlow(JsonElement workflow, string expectedId)
+    {
+        Assert.Equal(expectedId, Str(workflow, "id"));
+        Assert.Equal("Bobs flow", Str(workflow, "name"));
+        Assert.Equal("A workflow owned by tenant B.", Str(workflow, "summary"));
+        Assert.Equal("Never - it exists only to be named by the wrong tenant.", Str(workflow, "whenToUse"));
+        Assert.Equal(1, Int(workflow, "version"));
+        var steps = Arr(workflow, "steps");
+        Assert.Equal(1, steps.GetArrayLength());
+        Assert.Equal("Step", Str(steps[0], "name"));
+        Assert.Equal("Do the thing.", Str(steps[0], "description"));
+    }
+
+    // ================================================= the credential is the only variable
+
+    /// <summary>
+    /// THE THREE-WAY CREDENTIAL PROBE, on ONE route, with nothing else varied.
+    ///
+    /// The claim's premise was that the HANDLER's signature decides whether a tenant is in scope. It does
+    /// not - the CREDENTIAL does. This holds the route, the store and the payload fixed and varies only the
+    /// bearer token:
+    ///
+    ///   device key  -> 200, a served list  (the middleware resolved a tenant and entered its scope)
+    ///   shared token-> 500                  (authenticated, but no device key, so NO scope was entered)
+    ///   garbage     -> 401                  (never authenticated at all)
+    ///
+    /// The 401 arm is what stops the 500 from being read as an authentication artifact: the shared token is
+    /// demonstrably accepted by the auth middleware, and still cannot reach the database. The 500's exact
+    /// body is asserted too, because the pipeline boundary serves a fixed generic body.
+    ///
+    /// This test deliberately does NOT claim to identify WHICH internal error produced the 500 - a status
+    /// code cannot carry that. The exact exception, its type and its message are pinned separately and
+    /// without HTTP in <see cref="ContextLessRouteTenancyMechanismProofTests"/>.
+    /// </summary>
+    [Fact]
+    public async Task OnOneRoute_TheCredentialAloneDecidesWhetherATenantScopeExists()
+    {
+        var withDeviceKey = await Json(await Send("GET", "cron/jobs", _keyB, null),
+            HttpStatusCode.OK, "DEVICE KEY   GET /cron/jobs (a scope IS entered)");
+        Assert.Equal(JsonValueKind.Array, Arr(withDeviceKey, "jobs").ValueKind);
+
+        var withSharedToken = await Send("GET", "cron/jobs", SharedToken, null);
+        var sharedBody = await withSharedToken.Content.ReadAsStringAsync();
+        _out.WriteLine($"SHARED TOKEN GET /cron/jobs -> {(int)withSharedToken.StatusCode} " +
+                       $"[{withSharedToken.Content.Headers.ContentType?.MediaType}] {sharedBody}");
+        Assert.Equal(HttpStatusCode.InternalServerError, withSharedToken.StatusCode);
+        Assert.Equal("application/json", withSharedToken.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("{\"error\":\"internal error\"}", sharedBody);
+
+        var withGarbage = await Send("GET", "cron/jobs", "not-a-real-credential", null);
+        _out.WriteLine($"GARBAGE      GET /cron/jobs -> {(int)withGarbage.StatusCode}");
+        Assert.Equal(HttpStatusCode.Unauthorized, withGarbage.StatusCode);
+    }
+
+    /// <summary>
+    /// MECHANISM 1's RESOLUTION STEP, PROBED DIRECTLY. The middleware asks the tenant boundary what tenant an
+    /// authenticated device key belongs to, and enters that tenant's scope. This asks the boundary the same
+    /// question the middleware asks, on the same running Gateway, and pins the exact answers:
+    ///
+    ///   device key A -> tenant-alice        device key B -> tenant-bob        shared token -> nothing
+    ///
+    /// The two keys resolving to DIFFERENT tenants is the fact the cross-tenant tests above depend on, and
+    /// the shared token resolving to NOTHING is why the credential probe gets a 500 rather than a served row.
+    /// Both are asserted as exact values, not as a difference.
+    ///
+    /// The remaining half of mechanism 1 - that the middleware actually ENTERS the scope it resolved - is not
+    /// provable by inspection from out here, and is established causally by mutating the resolution in
+    /// production and watching the cross-tenant tests in this file turn red. See the pull request.
+    /// </summary>
+    [Fact]
+    public void TheAuthBoundary_ResolvesEachDeviceKeyToItsOwnTenant_AndResolvesNothingForANonDeviceKey()
+    {
+        var forA = _gateway.TenantBoundary.ResolveForDeviceKey(_keyA);
+        var forB = _gateway.TenantBoundary.ResolveForDeviceKey(_keyB);
+        var forSharedToken = _gateway.TenantBoundary.ResolveForDeviceKey(SharedToken);
+
+        _out.WriteLine($"device key A -> {forA?.Value ?? "(nothing)"}");
+        _out.WriteLine($"device key B -> {forB?.Value ?? "(nothing)"}");
+        _out.WriteLine($"shared token -> {forSharedToken?.Value ?? "(nothing)"}");
+
+        Assert.Equal(TenantA, forA?.Value);
+        Assert.Equal(TenantB, forB?.Value);
+        Assert.Null(forSharedToken);
+    }
+
+    // ================================================================= helpers
+
+    private static string CronBody(string name) => JsonSerializer.Serialize(new
+    {
+        name,
+        scheduleKind = "recurring",
+        cronExpression = "0 0 * * *",
+        timeZoneId = "America/Chicago",
+        target = new { machine = "MB" },
+        action = new { repoPath = @"D:\repo", seed = "/help" },
+    });
+
+    private static string WorkflowBody(string id) => JsonSerializer.Serialize(new
+    {
+        id,
+        name = "Bobs flow",
+        summary = "A workflow owned by tenant B.",
+        whenToUse = "Never - it exists only to be named by the wrong tenant.",
+        humanCheckpoint = "None.",
+        steps = new[] { new { name = "Step", description = "Do the thing.", doer = "Worker", done = "It is done." } },
+        instructionsMarkdown = "# Bobs flow\n\nDo the thing.",
+        authoredBy = "test-session",
+    });
+
+    /// <summary>
+    /// Assert STATUS and MEDIA TYPE first, and only then parse.
+    ///
+    /// Parsing is itself an assertion about format. The Gateway serves a single-page-application catch-all
+    /// and a generic 500 body, so a route that answered wrongly could hand back HTML or nothing at all -
+    /// and a parse attempted first would throw <see cref="JsonException"/>, laundering a wrong response into
+    /// a crash that says nothing about isolation. Asserting the format first means a wrong response fails as
+    /// an assertion this test raised, which is the only kind of red that counts.
+    /// </summary>
+    private async Task<JsonElement> Json(HttpResponseMessage resp, HttpStatusCode expectedStatus, string label)
+    {
+        var body = await resp.Content.ReadAsStringAsync();
+        var mediaType = resp.Content.Headers.ContentType?.MediaType;
+        _out.WriteLine($"{label} -> {(int)resp.StatusCode} {resp.StatusCode} [{mediaType}]");
+        _out.WriteLine("    " + (body.Length > 600 ? body[..600] + " ...(truncated)" : body));
+
+        Assert.True(expectedStatus == resp.StatusCode,
+            $"{label}: expected HTTP {(int)expectedStatus} but got {(int)resp.StatusCode}; body was: {body}");
+        Assert.True(mediaType == "application/json",
+            $"{label}: expected media type application/json but got '{mediaType}'; body was: {body}");
+
+        return JsonDocument.Parse(body).RootElement.Clone();
+    }
+
+    // Typed accessors. Every one of these is an ASSERTION, so a missing or wrongly-typed property fails as a
+    // red this test raised rather than as a KeyNotFoundException or an InvalidOperationException from the
+    // JSON reader - a crash would be unclassifiable evidence.
+
+    private static JsonElement Member(JsonElement el, string prop, JsonValueKind expected)
+    {
+        Assert.True(el.ValueKind == JsonValueKind.Object,
+            $"expected a JSON object to read '{prop}' from, but the value was {el.ValueKind}");
+        Assert.True(el.TryGetProperty(prop, out var v), $"the response has no '{prop}' property: {el}");
+        Assert.True(v.ValueKind == expected,
+            $"'{prop}' was {v.ValueKind}, expected {expected}: {el}");
+        return v;
+    }
+
+    private static string Str(JsonElement el, string prop) => Member(el, prop, JsonValueKind.String).GetString()!;
+
+    private static int Int(JsonElement el, string prop) => Member(el, prop, JsonValueKind.Number).GetInt32();
+
+    private static JsonElement Obj(JsonElement el, string prop) => Member(el, prop, JsonValueKind.Object);
+
+    private static JsonElement Arr(JsonElement el, string prop) => Member(el, prop, JsonValueKind.Array);
+
+    private static bool Bool(JsonElement el, string prop)
+    {
+        Assert.True(el.ValueKind == JsonValueKind.Object,
+            $"expected a JSON object to read '{prop}' from, but the value was {el.ValueKind}");
+        Assert.True(el.TryGetProperty(prop, out var v), $"the response has no '{prop}' property: {el}");
+        Assert.True(v.ValueKind is JsonValueKind.True or JsonValueKind.False,
+            $"'{prop}' was {v.ValueKind}, expected a boolean: {el}");
+        return v.GetBoolean();
+    }
+
+    private Task<HttpResponseMessage> Send(string method, string path, string bearer, string? body)
+    {
+        var req = new HttpRequestMessage(new HttpMethod(method), path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+        if (body is not null)
+            req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return _http.SendAsync(req);
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/ContextLessRouteTenancyMechanismProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/ContextLessRouteTenancyMechanismProofTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Linq;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Data.Entities;
+using CcDirector.Gateway.Tests.Data;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// THE MECHANISM, SEPARATED INTO ITS PARTS.
+///
+/// <see cref="ContextLessDatabaseRouteTenancyTests"/> proves the OUTCOME end-to-end: tenant A naming tenant
+/// B's object id on a context-less database route gets an ordinary not-found. That outcome rests on a
+/// conjunction of THREE production mechanisms, and an end-to-end test cannot tell them apart - it would pass
+/// if any one of them happened to be doing all the work, which is exactly how a proof comes to rest on an
+/// assumption nobody has looked at:
+///
+///   1a. THE AUTH BOUNDARY RESOLVES. A host-wide middleware, registered before routing, reads the
+///       AUTHENTICATED device key and resolves that key's tenant (GatewayHost.cs:1517).
+///   1b. AND IT ENTERS THE SCOPE IT RESOLVED, around the whole downstream pipeline (GatewayHost.cs:1520).
+///       This is a SEPARATE step from 1a and separately bypassable: resolution could be perfectly correct
+///       and simply never entered. The two therefore cannot share one mutation arm.
+///   2.  THE GLOBAL QUERY FILTER FILTERS. Every tenant-scoped entity carries a global query filter that
+///       restricts reads to the ambient tenant (GatewayDbContext.ApplyTenantScope).
+///   3.  NO SCOPE MEANS NO DATABASE. Opening a scoped context with no tenant in scope throws by design,
+///       rather than defaulting to some tenant (GatewayDatabase.CreateContext reading
+///       AsyncLocalTenantContext.Current).
+///
+/// This file exercises 2 and 3 with NO HTTP and NO MIDDLEWARE AT ALL - the tenant is entered by the test
+/// itself - so each one is observed doing its own job in isolation, and neither can be standing in for the
+/// other. Step 1a is probed directly against the running boundary in
+/// <see cref="ContextLessDatabaseRouteTenancyTests"/>, where the device registry lives. Step 1b - that the
+/// middleware actually enters what it resolved - is NOT provable by any test that enters the scope itself,
+/// and is established only causally, by removing that call in production; see the pull request.
+///
+/// Every isolation assertion here carries its own SERVED-SIDE POSITIVE FACT. Proving a row is absent proves
+/// nothing on its own - the row may never have been written. So the same query is re-run with the filter
+/// deliberately ignored, which shows the row was on disk the whole time and that the FILTER, not a failed
+/// seed, is what hid it.
+/// </summary>
+public sealed class ContextLessRouteTenancyMechanismProofTests : IDisposable
+{
+    private const string TenantA = "tenant-alice";
+    private const string TenantB = "tenant-bob";
+
+    private readonly ITestOutputHelper _out;
+    private readonly GatewayDbTestHarness _harness = new();
+
+    public ContextLessRouteTenancyMechanismProofTests(ITestOutputHelper output) => _out = output;
+
+    public void Dispose() => _harness.Dispose();
+
+    /// <summary>
+    /// MECHANISM 2, ALONE. One database file, two tenants, no middleware and no HTTP: the tenant is supplied
+    /// directly by the test, so nothing about the auth boundary can influence the result.
+    ///
+    /// The third read is the one that makes this a proof rather than an absence. Tenant A re-runs its own
+    /// query with the global filter ignored and finds the row, stamped with tenant B's id - so the row was
+    /// present and readable on that very connection, and the ONLY thing that hid it from tenant A was the
+    /// query filter. Without that arm, an unwritten row and a filtered row look identical.
+    /// </summary>
+    [Fact]
+    public void TheGlobalQueryFilterAlone_HidesTheOtherTenantsRow_AndIgnoringTheFilterProvesTheRowWasThereAllAlong()
+    {
+        var name = "bobs-isolated-list-" + Guid.NewGuid().ToString("N")[..8];
+        var rowId = Guid.NewGuid();
+        const string consumer = "bobs-consumer-token";
+
+        var asBob = _harness.Open(new FixedTenantContext(new TenantId(TenantB)));
+        var asAlice = _harness.Open(new FixedTenantContext(new TenantId(TenantA)));
+
+        // Seed one row as tenant B, with values only this test knows.
+        using (var ctx = asBob.CreateContext())
+        {
+            Assert.Equal(TenantB, ctx.ActiveTenant);
+            ctx.WorkLists.Add(new WorkListEntity
+            {
+                Id = rowId,
+                Name = name,
+                Consumer = consumer,
+                TenantId = TenantB,
+            });
+            Assert.Equal(1, ctx.SaveChanges());
+        }
+
+        // POSITIVE CONTROL - the owner reads the exact seeded fingerprint back.
+        using (var ctx = asBob.CreateContext())
+        {
+            var mine = ctx.WorkLists.Where(w => w.Name == name).ToList();
+            Assert.Single(mine);
+            Assert.Equal(rowId, mine[0].Id);
+            Assert.Equal(name, mine[0].Name);
+            Assert.Equal(consumer, mine[0].Consumer);
+            Assert.Equal(TenantB, mine[0].TenantId);
+            _out.WriteLine($"OWNER  (tenant B) sees the row: id={mine[0].Id} name={mine[0].Name} tenant={mine[0].TenantId}");
+        }
+
+        // ISOLATION - the other tenant, same file, same query, sees nothing.
+        using (var ctx = asAlice.CreateContext())
+        {
+            Assert.Equal(TenantA, ctx.ActiveTenant);
+            var theirs = ctx.WorkLists.Where(w => w.Name == name).ToList();
+            _out.WriteLine($"OTHER  (tenant A) sees {theirs.Count} row(s) for the same name");
+            Assert.Empty(theirs);
+
+            // THE SERVED-SIDE POSITIVE FACT for that emptiness: the row IS on disk, on THIS connection,
+            // and it belongs to tenant B. The emptiness above is therefore the filter's doing and not a
+            // seed that never landed.
+            var unfiltered = ctx.WorkLists.IgnoreQueryFilters().Where(w => w.Name == name).ToList();
+            Assert.Single(unfiltered);
+            Assert.Equal(rowId, unfiltered[0].Id);
+            Assert.Equal(consumer, unfiltered[0].Consumer);
+            Assert.Equal(TenantB, unfiltered[0].TenantId);
+            _out.WriteLine($"OTHER  (tenant A) with the filter IGNORED sees it: tenant={unfiltered[0].TenantId}");
+        }
+    }
+
+    /// <summary>
+    /// MECHANISM 3, ALONE, WITH ITS EXACT FINGERPRINT. Over HTTP this failure is a bare 500 with a generic
+    /// body, and a status code cannot say WHICH internal error produced it - any unrelated fault would look
+    /// the same. Here the exception itself is caught and pinned: its type, and the deny-by-default sentence
+    /// its own source carries.
+    ///
+    /// The positive control is the same call, on the same database, differing only in that a scope has been
+    /// entered - and it not only succeeds but carries exactly the entered tenant into the context. So the
+    /// throw is attributable to the absence of a scope and to nothing else.
+    /// </summary>
+    [Fact]
+    public void WithNoTenantScope_OpeningAScopedContextFailsClosed_AndInsideAScopeItCarriesExactlyThatTenant()
+    {
+        var ambient = new AsyncLocalTenantContext();
+        var db = _harness.Open(ambient);
+
+        // NO SCOPE - fails closed, and we pin what the failure actually is.
+        var ex = Assert.Throws<InvalidOperationException>(() => db.CreateContext());
+        _out.WriteLine($"NO SCOPE -> {ex.GetType().FullName}: {ex.Message}");
+        Assert.Contains("No tenant is in scope for this hosted operation", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("deny-by-default", ex.Message, StringComparison.Ordinal);
+
+        // POSITIVE CONTROL - identical call, one difference: a scope is in effect.
+        using (ambient.Enter(new TenantId(TenantB)))
+        {
+            using var ctx = db.CreateContext();
+            Assert.Equal(TenantB, ctx.ActiveTenant);
+            _out.WriteLine($"IN SCOPE -> a context opened with ActiveTenant={ctx.ActiveTenant}");
+        }
+
+        // And the denial returns the moment the scope is left, so the scope is what carried it.
+        var again = Assert.Throws<InvalidOperationException>(() => db.CreateContext());
+        Assert.Contains("deny-by-default", again.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// THE SCOPE PRIMITIVE ITSELF - it makes exactly the entered tenant ambient, nests, and restores on the
+    /// way out.
+    ///
+    /// READ THE LIMIT OF THIS TEST CAREFULLY. It proves the primitive WORKS. It does NOT prove that the
+    /// production middleware CALLS it - that is a different claim, and no test that enters the scope itself
+    /// can establish it. Resolving the caller's tenant and entering that resolved scope are two separately
+    /// bypassable production steps (GatewayHost.cs:1517 and :1520), and a mutation that cannot tell them
+    /// apart cannot say which one is load-bearing. That the middleware really enters the scope it resolved is
+    /// therefore established causally, by removing the EnterScope call in production and watching a distinct
+    /// set of tests turn red - device-key requests taking the no-scope path, which is a different signature
+    /// from constant resolution. See the pull request's pre-registered mutations.
+    /// </summary>
+    [Fact]
+    public void EnteringAScope_MakesExactlyThatTenantAmbient_Nests_AndRestoresTheDenialOnTheWayOut()
+    {
+        var ambient = new AsyncLocalTenantContext();
+        Assert.Null(ambient.CurrentOrNull);
+
+        using (ambient.Enter(new TenantId(TenantB)))
+        {
+            Assert.Equal(TenantB, ambient.Current.Value);
+
+            using (ambient.Enter(new TenantId(TenantA)))
+                Assert.Equal(TenantA, ambient.Current.Value);
+
+            // The inner scope restored the outer one exactly, rather than clearing it.
+            Assert.Equal(TenantB, ambient.Current.Value);
+        }
+
+        Assert.Null(ambient.CurrentOrNull);
+        Assert.Throws<InvalidOperationException>(() => ambient.Current);
+    }
+}


### PR DESCRIPTION
Reworked after review, twice. The first version asserted status codes and called that a positive control, parsed responses before proving they were JSON at all, reverted a FIXTURE rather than a production mechanism, and let a six-route result stand as a sixty-six-route claim. Those are fixed and the narrowed conclusion has been accepted on inspection for the eight cross-probed operations. This revision answers the three gates that remain.

**This pull request is BLOCKED and must not be admitted to the test lane yet.** #1909 lands first, then this branch rebases onto it, takes a fresh baseline there, and runs. That is the only gate. Details under "Convergence and the blocking dependency" below.

---

## What this proves, and what it does not

A census found roughly sixty-six routes taking a path parameter but no `HttpContext`, and INFERRED that the database-backed ones must hit the deny-by-default throw in `AsyncLocalTenantContext.Current` — broken, but not leaking. That inference halved the remaining security work on this mission and had never been executed.

Executed, the inference is wrong in both halves: these routes are **neither broken nor leaking**. They are correctly isolated, by a mechanism the inference did not consider.

**It proves that for eight routes.** Not sixty-six. See "The inventory, and what is still open" below — the honest count of what remains unexamined is stated there rather than buried.

## A defect in the previous version, found while re-deriving the inventory

The earlier version listed `POST /lists/{name}/items` as one of its context-less routes. It is not: its handler is `async (string name, HttpContext ctx)` (`src/CcDirector.Gateway/Api/WorkListEndpoints.cs:64`) — it takes an `HttpContext` to read the request body. It never belonged in the claim. It has been replaced by `DELETE /lists/{name}/items/{source}/{id}` (`WorkListEndpoints.cs:110`), which is genuinely context-less AND destructive, so the write-path probe is now both honest and stronger.

This is why the inventory below is re-derived from the code rather than taken from the census's own list: re-deriving it is the only way to test whether the census's frame was right.

## Positive controls now carry exact seeded fingerprints

Every owner control asserts the exact values this test itself wrote, not a status code:

- work list — the exact list name AND its one seeded item (`source=github`, `id=77`, `area=alpha`)
- cron job — identifier, name, schedule kind, cron expression, time zone, target machine, action seed
- session spend — session identifier, agent kind, billing mode, `tokensCaptured`, `inputTokens=111`, `outputTokens=222`
- workflow — identifier, name, summary, when-to-use, version, and the exact step name and description; the versions list asserts `version=1` and `authoredBy=test-session`

**Status and media type are asserted BEFORE any parse.** Parsing is itself an assertion about format: the single-page-application catch-all serves HTML and the pipeline boundary serves a generic body, so a parse attempted first would throw and launder a wrong response into a crash that proves nothing. Every property access also goes through a typed accessor that asserts presence and value kind, so a missing field fails as a red the test raised rather than as a `KeyNotFoundException`.

## No assertion rests on absence any more

The old work-list write check was `Assert.DoesNotContain("999")` — which passes just as happily on an empty or wrong response. Every denied path now carries a served-side positive fact:

- after tenant A's failed delete, tenant B's list is **re-read** and asserted to hold exactly the seeded item, unchanged
- then **tenant B performs the same delete itself and succeeds**, so tenant A's 404 is a refusal and not an operation that was inert for everybody
- the same shape is applied to the cron job delete and the workflow archive: cross-tenant attempt, exact re-read unchanged, then the owner does it and the effect is re-read again

## The two mechanisms are now separated, not conflated

Binding both fixture device keys to one tenant showed only that the tests react when their identities are collapsed. The outcome actually rests on **three** production mechanisms, and an end-to-end test passes if any one of them is doing all the work. They are now told apart:

1a. **The auth boundary resolves.** A host-wide middleware registered before routing reads the authenticated device key and resolves its tenant (`GatewayHost.cs:1517`).
1b. **And it enters the scope it resolved**, around the whole downstream pipeline (`GatewayHost.cs:1520`, before `UseRouting()` at `:1546`). This is a SEPARATE step: resolution could be perfectly correct and simply never entered, so 1a and 1b cannot share a mutation arm.
2. **The global query filter filters.** `GatewayDbContext.cs:404`, applied to sixteen entity types at `:341-356`.
3. **No scope means no database.** `GatewayDatabase.cs:196` reads `AsyncLocalTenantContext.Current`, which throws by design rather than defaulting to a tenant.

`ContextLessRouteTenancyMechanismProofTests` exercises 2 and 3 **with no HTTP and no middleware at all** — the tenant is entered by the test itself:

- the query filter alone hides tenant B's row from tenant A over one shared database file, and the **same query re-run with the filter ignored finds the row on that very connection**, stamped with tenant B's identifier. That arm is what makes the emptiness a filter result rather than a seed that never landed.
- the deny-by-default throw is caught and pinned by **type and message** (`InvalidOperationException`, containing "No tenant is in scope for this hosted operation" and "deny-by-default"), with the identical call inside a scope as the positive control, carrying exactly the entered tenant into the context.
- the scope primitive is shown to nest and to restore the denial on the way out. This proves the primitive WORKS; it does NOT prove the middleware calls it, and no test that enters the scope itself could. Step 1b is established only causally, by arm 3 below.

Step 1a is probed directly against the running boundary with exact values: key A resolves to `tenant-alice`, key B to `tenant-bob`, and the shared token to nothing.

The 500 is no longer asked to carry causal weight by status alone. It is now a **three-way probe on one route with nothing else varied but the credential** — device key 200, shared token 500 with the exact body `{"error":"internal error"}`, garbage credential 401. The 401 arm is what stops the 500 being read as an authentication artifact. Which internal error produced it is pinned separately and without HTTP, as above.

---

## The inventory, and what is still open

Re-derived from the code, not from the census: the Gateway registers **263** routes; **118** take a path parameter; **66** of those take a path parameter and no `HttpContext`. The census's magnitude was right.

Of those 66, exactly **18 reach a tenant-scoped database store from their own handler**. The other **48 do not** — they reach in-memory registries, the Director command router, and file-backed stores.

| route | store | source | status |
|---|---|---|---|
| `GET /cron/jobs/{id}` | CronJobStore | src/CcDirector.Gateway/Api/CronJobEndpoints.cs:56 | PROVEN |
| `DELETE /cron/jobs/{id}` | CronJobStore | src/CcDirector.Gateway/Api/CronJobEndpoints.cs:91 | PROVEN |
| `GET /cron/jobs/{id}/runs` | CronRunHistoryStore | src/CcDirector.Gateway/Api/CronRunEndpoints.cs:35 | UNPROVEN |
| `GET /gateway/governance/session-spend/{sessionId}` | SessionSpendStore | src/CcDirector.Gateway/Api/GovernanceSpendEndpoints.cs:62 | PROVEN |
| `GET /lists/{name}` | WorkListStore | src/CcDirector.Gateway/Api/WorkListEndpoints.cs:56 | PROVEN |
| `DELETE /lists/{name}/items/{source}/{id}` | WorkListStore | src/CcDirector.Gateway/Api/WorkListEndpoints.cs:110 | PROVEN |
| `DELETE /lists/{name}/consumer` | WorkListStore | src/CcDirector.Gateway/Api/WorkListEndpoints.cs:145 | UNPROVEN |
| `GET /gateway/workflows/{id}` | WorkflowStore | src/CcDirector.Gateway/Api/WorkflowEndpoints.cs:57 | PROVEN |
| `POST /gateway/workflows/{id}/publish` | WorkflowStore | src/CcDirector.Gateway/Api/WorkflowEndpoints.cs:105 | owner path only, never probed cross-tenant |
| `POST /gateway/workflows/{id}/reset` | WorkflowStore | src/CcDirector.Gateway/Api/WorkflowEndpoints.cs:114 | UNPROVEN |
| `DELETE /gateway/workflows/{id}` | WorkflowStore | src/CcDirector.Gateway/Api/WorkflowEndpoints.cs:123 | PROVEN |
| `GET /gateway/workflows/{id}/versions` | WorkflowStore | src/CcDirector.Gateway/Api/WorkflowEndpoints.cs:131 | PROVEN |
| `GET /gateway/workflows/{id}/versions/{version:int}` | WorkflowStore | src/CcDirector.Gateway/Api/WorkflowEndpoints.cs:137 | UNPROVEN |
| `GET /gateway/workflows/{id}/instructions` | WorkflowStore | src/CcDirector.Gateway/Api/WorkflowEndpoints.cs:145 | UNPROVEN |
| `POST /gateway/workflows/{id}/enable` | WorkflowStore | src/CcDirector.Gateway/Api/WorkflowEndpoints.cs:158 | UNPROVEN |
| `POST /gateway/workflows/{id}/disable` | WorkflowStore | src/CcDirector.Gateway/Api/WorkflowEndpoints.cs:163 | UNPROVEN |
| `GET /gateway/workflows/{id}/files/{fileName}` | WorkflowStore | src/CcDirector.Gateway/Api/WorkflowEndpoints.cs:168 | UNPROVEN |
| `GET /gateway/workflow-runs/{id:guid}` | WorkflowRunStore | src/CcDirector.Gateway/Api/WorkflowRunEndpoints.cs:57 | UNPROVEN |

**STILL OPEN, STATED PLAINLY.**

- **Ten of the eighteen database-backed context-less routes are unproven here.** They are named above. They are not covered by inference from the other eight, and nothing in this pull request should be read as retiring them.
- **All forty-eight non-database context-less routes are unproven, and the mechanism proven here cannot be their protection.** The isolation demonstrated in this pull request is the Entity Framework global query filter. A route reaching an in-memory registry, the Director command router, or a file-backed store is not touched by that filter at all, so whatever protects those forty-eight — if anything does — is a different mechanism that this unit did not examine. Among them: `GET /vault/keys/{name}`, `DELETE /vault/keys/{name}`, `GET /directors/{id}/fs/list`, `GET /directors/{id}/handovers/content`, `GET /ingest/recording/{id}/transcript`, `GET /sessions/{sid}/turnbriefs`. This gap has been raised as a finding in its own right and routed to the completeness audit; it is recorded here so that nobody reads this pull request's narrowed claim as the broad one, and it is NOT carried by this unit.
- **The census's framing is worth correcting for whoever picks this up.** It treated "database-backed" as the risky category. On the re-derived numbers the database-backed group is the *smaller* one — eighteen of sixty-six — and it is the group that turns out to be protected. The larger group is the one with no proven mechanism.

---

## Convergence and the blocking dependency

This commit parents `f5bb926f`; current main has already moved to `f2028deb`. The rebase is deliberately NOT done yet, because the base is still moving and two units must land first:

- **#1909 must land first, and it will break this branch on purpose.** It replaces a prose allowlist with a type whose identifier carries a private setter. `ContextLessRouteTenancyMechanismProofTests` currently does `Id = rowId` when it constructs a `WorkListEntity`, and that assignment will stop compiling. That is the guard doing its job: it caught a real caller-supplied key assignment in this unit that no prose rule and no reflection check had flagged. The fix is not to re-widen the setter — it is to construct the row WITHOUT assigning an identifier, capture `row.Id` after construction, and keep every exact-fingerprint assertion unchanged (the fingerprint already includes the name, the consumer token and the tenant identifier, so nothing is weakened by taking a base-minted identifier instead of a caller-chosen one).
**#1937 is NOT a gate on this unit, and an earlier revision of this body wrongly said it was.** That condition assumed #1937 would merge into the gap ahead of this unit; it is in rework and is no longer doing so, and blocking on it would park this unit behind one that is itself being rebuilt.

The rule that makes dropping it safe is general, and does not depend on #1937 at all: **every unit takes a fresh green-and-complete baseline at its OWN head and reconciles against THAT, never against a shared or quoted constant.** The lane lock serialises units, so merges land in the gaps BETWEEN them and never mid-unit. All this unit must guarantee is that its baseline and its five arms come from the same world. Whether #1937 has landed by then is irrelevant: if it lands before this unit's turn, the fresh baseline includes it; if after, it does not. The failure mode the rule exists to prevent — a baseline on one side of a merge and the arms on the other — is prevented by not merging mid-unit, not by waiting.

So: #1909 lands, this branch rebases onto it, takes a fresh baseline on that exact head, reconciles against itself, and runs. Nothing else gates it.

---

## Pre-registered mutations, and the reds predicted for each

One production primitive per full-suite run, never combined. Each is independently bypassable — each can be individually wrong while the others stay correct and isolation still breaks — so overlap does not exempt any of them from its own run. A predicted red that does not appear will be reported as a finding, not explained away. Every predicted red is an assertion the test's own logic raises; any red arriving as a crash will be classified as such and will not count.

The auth-bound mechanism is **two** separately bypassable steps, not one, and they now get separate arms:

- `GatewayHost.cs:1517` — resolving the authenticated device key to the caller's tenant.
- `GatewayHost.cs:1520` — actually entering `EnterScope(resolved)` around the downstream pipeline.

Resolution could be perfectly correct and simply never entered, so a single arm cannot say which is load-bearing. The direct `AsyncLocalTenantContext.Enter` test proves the primitive works; it does NOT prove the middleware calls it, and no test that enters the scope itself ever could. Only arm 3 below establishes that.

**Baseline.** Green and explicitly complete, taken fresh on the final rebased head, or the whole exercise aborts. Computed reconciliation on every arm: passed plus failed under the mutation equals passed under the restored run. Tests confirmed to have executed by name. A run with no summary line is not a result in either direction.

**Arm 2 — constant resolution** (`GatewayHost.cs:1517`): resolve every device key to one constant tenant. A scope is still entered and the query filter is untouched, but the scope no longer carries the CALLER's tenant.

- predicted red (5): `WorkListGetByName_...`, `WorkListDeleteItem_...`, `CronJobGetAndDelete_...`, `SessionSpendGetBySessionId_...`, `WorkflowReadVersionsAndArchive_...` — each at its cross-tenant arm, expecting 404 and receiving 200.
- predicted green: all three tests in `ContextLessRouteTenancyMechanismProofTests`, `TheAuthBoundary_ResolvesEachDeviceKeyToItsOwnTenant_...` (it probes the boundary, not the middleware), and — decisively — `OnOneRoute_TheCredentialAloneDecides...`, whose device-key arm still gets its 200.

**Arm 3 — middleware entry bypass** (`GatewayHost.cs:1520`): remove the `EnterScope(resolved)` call so the `await next()` runs outside any scope. Resolution at :1517 still executes and is still consulted by the branch; the query filter is untouched.

- **distinct signature: device-key requests take the no-scope path and 500 — they do NOT produce the cross-tenant 200s of arm 2.**
- predicted red (6): the five end-to-end tests fail at their SEED (a device-key write expecting 200 or 201 and receiving 500), **plus `OnOneRoute_TheCredentialAloneDecides...`, whose device-key control expects 200 and receives 500.** That last one is the discriminator: it is green under arm 2 and red here, so the two steps are told apart by a test rather than by argument.
- predicted green: `TheAuthBoundary_ResolvesEachDeviceKeyToItsOwnTenant_...` (resolution untouched) and all three mechanism-proof tests (no middleware involved).

**Arm 4 — the global query filter** (`GatewayDbContext.cs:404`): remove the filter. The middleware is untouched and still resolves and enters the correct caller tenant.

- predicted red: the same five cross-tenant arms, **plus** `TheGlobalQueryFilterAlone_HidesTheOtherTenantsRow_...`, plus `TenantScopeGuardTests.EveryTenantScopedEntity_HasTenantIdColumnAndQueryFilter`.
- predicted green: `WithNoTenantScope_...` and `EnteringAScope_...` (both upstream of the filter), `TheAuthBoundary_...`, `OnOneRoute_...`.
- **This is the arm that separates the filter from the middleware:** the isolated query-filter test reddens here and stays green under arms 2 and 3.

**Arm 5 — the deny-by-default** (`AsyncLocalTenantContext.Current`): return the local tenant instead of throwing.

- predicted red: `WithNoTenantScope_OpeningAScopedContextFailsClosed_...`, `EnteringAScope_..._RestoresTheDenialOnTheWayOut`, `OnOneRoute_TheCredentialAloneDecides...` (the shared token stops producing a 500), plus `AsyncLocalTenantContextTests` in the Core test project.
- predicted green: all five cross-tenant arms (a device-key request always had a scope) and `TheGlobalQueryFilterAlone_...`.

**Arm 6 — exact restoration, and restored green.**

**Run count: six** — baseline, constant resolution, middleware entry bypass, query-filter removal, deny-by-default removal, restored green. The count cannot be reduced by design: each arm has a distinct red signature and no two collapse into one another. This count is registered here by this unit, on its own reading of the call sites, and will be re-registered against the rebased head before any run is claimed.

**Admission conditions.** Continuous integration is read green on the rebased head before this unit declares itself ready — it is free, and it is an admission condition, not a formality. The six arms are re-registered against that head before any run is claimed.

**None of these runs has been performed.** The machine's single Gateway test lane is held by another unit and this one is not admitted; the reviewer has also ruled that an exact-head run would not be valid until the corrections above are in. What is claimed today is: the reworked tests, the code-derived inventory, the corrected count, and a clean build with zero warnings and zero errors. No run result is asserted.

Verification only — no production code is changed by this pull request.
