### PR TITLE
fix(gateway): deny the recording ingest and cached wingman voice surfaces on hosted

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedRecordingDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedRecordingDenyTests.cs
@@ -406,12 +406,16 @@ public sealed class HostedRecordingGroupFilterTests : IDisposable
     /// primitive's own body-bound <c>/family/future</c> in <see cref="Tenancy.HostedRouteDenyOnHostedTests"/>).
     /// So the future route takes a plain <see cref="RecordingProbeBody"/> the framework binds from JSON, and:
     ///
-    ///  * on hosted every shape meets the refusal - a valid body, a malformed body, and a verb the route never
-    ///    mapped;
+    ///  * on hosted every shape meets the refusal - a valid body, a malformed body, a WRONG MEDIA TYPE, and a
+    ///    verb the route never mapped;
     ///  * the FRAMEWORK-400 CONTROL fires the identical malformed body at an UNDENIED equivalent of the same
     ///    handler mapped OUTSIDE <c>/ingest</c>, which really reaches the framework and returns its own 400 -
     ///    so the denied route's refusal is a short-circuit BEFORE framework binding, not a route that merely
     ///    happens not to bind;
+    ///  * the FRAMEWORK-415 CONTROL fires the identical wrong media type at that same undenied equivalent,
+    ///    which reaches the framework's endpoint SELECTION and returns its own 415 - so the denied route's
+    ///    wrong-media refusal short-circuits BEFORE selection, the one shape a per-handler guard answering
+    ///    after binding could never intercept;
     ///  * the OBSERVABLE-BINDING SEAM (<see cref="RecordingProbeBinding"/>), a distinct custom-bound route
     ///    mapped alongside, carries the "no handler-bound code ran at all" assertion the framework record
     ///    cannot make on its own: its binder counter stays zero across every shape behind the refusal.
@@ -441,14 +445,18 @@ public sealed class HostedRecordingGroupFilterTests : IDisposable
         try
         {
             // The framework-bound future route is refused on hosted across every shape: a valid body, a
-            // malformed body (off hosted the framework's own 400), and a verb it never mapped (off hosted a
-            // 405 disclosing the route exists).
+            // malformed body (off hosted the framework's own 400), a WRONG MEDIA TYPE (off hosted the
+            // framework's own 415 - a shape endpoint SELECTION enforces ahead of any handler, so a per-handler
+            // guard that answered after binding would leak it), and a verb it never mapped (off hosted a 405
+            // disclosing the route exists).
             foreach (var resp in new[]
                      {
                          await http.PostAsync("/ingest/added-after-the-deny-was-written",
                              new StringContent("{\"text\":\"hello\"}", Encoding.UTF8, "application/json")),
                          await http.PostAsync("/ingest/added-after-the-deny-was-written",
                              new StringContent("{ not json", Encoding.UTF8, "application/json")),
+                         await http.PostAsync("/ingest/added-after-the-deny-was-written",
+                             new StringContent("hello", Encoding.UTF8, "text/plain")),
                          await http.GetAsync("/ingest/added-after-the-deny-was-written"),
                      })
             {
@@ -464,6 +472,15 @@ public sealed class HostedRecordingGroupFilterTests : IDisposable
                 new StringContent("{ not json", Encoding.UTF8, "application/json"));
             Assert.Equal(HttpStatusCode.BadRequest, undeniedMalformed.StatusCode);
 
+            // THE FRAMEWORK-415 CONTROL. A wrong media type reaches the framework's own 415 on the undenied
+            // equivalent, while the denied route returns the refusal above - so the denied route's wrong-media
+            // refusal is a short-circuit BEFORE endpoint SELECTION would 415, not a route that merely happens
+            // to reject the media type. This is the shape a per-handler guard answering after model binding
+            // could never intercept: selection would 415 first and the leak would be invisible.
+            var undeniedWrongMedia = await http.PostAsync("/undenied-equivalent",
+                new StringContent("hello", Encoding.UTF8, "text/plain"));
+            Assert.Equal(HttpStatusCode.UnsupportedMediaType, undeniedWrongMedia.StatusCode);
+
             // NOTHING behind the refusal bound an argument, on any shape - the assertion a parameterless GET
             // or a body-ignoring custom binder could never make, and the one that separates the exclusive
             // catch-all (refusal placed BEFORE binding) from the rejected per-handler filter (which ran the
@@ -474,6 +491,8 @@ public sealed class HostedRecordingGroupFilterTests : IDisposable
                              new StringContent("{\"text\":\"hello\"}", Encoding.UTF8, "application/json")),
                          await http.PostAsync("/ingest/added-after-the-deny-was-written-observed",
                              new StringContent("{ not json", Encoding.UTF8, "application/json")),
+                         await http.PostAsync("/ingest/added-after-the-deny-was-written-observed",
+                             new StringContent("hello", Encoding.UTF8, "text/plain")),
                          await http.GetAsync("/ingest/added-after-the-deny-was-written-observed"),
                      })
             {
@@ -672,6 +691,14 @@ public sealed class SelfHostRecordingGroupControlTests : IDisposable
             var malformed = await http.PostAsync("/ingest/added-after-the-deny-was-written",
                 new StringContent("{ not json", Encoding.UTF8, "application/json"));
             Assert.Equal(HttpStatusCode.BadRequest, malformed.StatusCode);
+
+            // And the SAME future route is capable of the 415 the hosted wrong-media refusal short-circuits: a
+            // wrong media type off hosted hits the framework's own endpoint-selection 415. Paired with the
+            // hosted wrong-media refusal, this proves the hosted 404 on text/plain is the deny firing before
+            // selection, not the route simply refusing the media type on both sides.
+            var wrongMedia = await http.PostAsync("/ingest/added-after-the-deny-was-written",
+                new StringContent("hello", Encoding.UTF8, "text/plain"));
+            Assert.Equal(HttpStatusCode.UnsupportedMediaType, wrongMedia.StatusCode);
 
             // The observable custom binder really ran off hosted - the positive twin of the hosted count of 0.
             var observed = await http.PostAsync("/ingest/added-after-the-deny-was-written-observed",

--- a/src/CcDirector.Gateway.Tests/HostedRecordingDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedRecordingDenyTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http.Headers;
 using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using CcDirector.Core.Recording;
 using CcDirector.Core.Storage;
@@ -160,6 +161,7 @@ public sealed class HostedRecordingDenyTests : IAsyncLifetime
     [InlineData("POST", "ingest/recording/" + SeededId + "/complete", "{}")]
     [InlineData("POST", "ingest/recording/" + SeededId + "/promote", null)]                        // promote into the vault
     [InlineData("PATCH", "ingest/recording/" + SeededId + "/meta", "{\"title\":\"hijacked\"}")]     // overwrite metadata
+    [InlineData("POST", "ingest/recording/" + SeededId + "/meta", "{\"title\":\"hijacked\"}")]      // /meta maps POST too - the omitted verb
     [InlineData("DELETE", "ingest/recording/" + SeededId, null)]                                   // destroy the record
     [InlineData("GET", "ingest/dictionary", null)]                                                 // the shared glossary
     [InlineData("PUT", "ingest/dictionary", "{\"vocabulary\":[],\"commonMistranscriptions\":{},\"profiles\":{}}")]
@@ -368,8 +370,6 @@ internal static class RecordingGroupProbeHost
 [Collection("DirectorRoot")]
 public sealed class HostedRecordingGroupFilterTests : IDisposable
 {
-    private const string ProbePayloadSentinel = "probe-payload-that-must-never-be-served-on-hosted";
-
     private readonly string _root;
     private readonly string? _prevRoot;
     private readonly string? _priorHosted;
@@ -395,22 +395,93 @@ public sealed class HostedRecordingGroupFilterTests : IDisposable
     /// <summary>
     /// A route that did not exist when the refusal was written is refused anyway. NOTHING in
     /// <see cref="RecordingEndpoints"/> mentions this path, and no guard is written for it here - the
-    /// exclusive catch-all under <c>/ingest</c> is the only thing standing between the caller and the probe
-    /// payload. On hosted the handle DISCARDS the probe handler (nothing binds), so the catch-all answers.
+    /// exclusive catch-all under <c>/ingest</c> is the only thing standing between the caller and the handler.
+    /// On hosted the handle DISCARDS the future handler (nothing binds), so the catch-all answers.
+    ///
+    /// THE FUTURE ROUTE IS A FRAMEWORK BODY-BOUND POST, NOT A CUSTOM-BOUND ONE AND NOT A PARAMETERLESS GET. A
+    /// parameterless probe is exactly the request shape the original pre-binding defect is invisible through;
+    /// a CUSTOM binder (<c>IBindableFromHttpContext</c>/<c>BindAsync</c>) is just as blind, because it ignores
+    /// the request body and binds unconditionally, so a malformed body could never reach the framework's own
+    /// 400. The shared primitive's contract requires the future-route proof to be FRAMEWORK-bound (see the
+    /// primitive's own body-bound <c>/family/future</c> in <see cref="Tenancy.HostedRouteDenyOnHostedTests"/>).
+    /// So the future route takes a plain <see cref="RecordingProbeBody"/> the framework binds from JSON, and:
+    ///
+    ///  * on hosted every shape meets the refusal - a valid body, a malformed body, and a verb the route never
+    ///    mapped;
+    ///  * the FRAMEWORK-400 CONTROL fires the identical malformed body at an UNDENIED equivalent of the same
+    ///    handler mapped OUTSIDE <c>/ingest</c>, which really reaches the framework and returns its own 400 -
+    ///    so the denied route's refusal is a short-circuit BEFORE framework binding, not a route that merely
+    ///    happens not to bind;
+    ///  * the OBSERVABLE-BINDING SEAM (<see cref="RecordingProbeBinding"/>), a distinct custom-bound route
+    ///    mapped alongside, carries the "no handler-bound code ran at all" assertion the framework record
+    ///    cannot make on its own: its binder counter stays zero across every shape behind the refusal.
     /// </summary>
     [Fact]
     public async Task A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own()
     {
+        RecordingProbeBinding.Reset();
+
         var (app, http) = await RecordingGroupProbeHost.StartAsync(
-            mapIntoGroup: group => group.MapGet("/added-after-the-deny-was-written",
-                () => Results.Json(new { probe = ProbePayloadSentinel })));
+            mapIntoGroup: group =>
+            {
+                // The future route: FRAMEWORK-bound body record. Off hosted a malformed body reaches the
+                // framework's JSON-binding 400; on hosted the exclusive catch-all refuses before any binding.
+                group.MapPost("/added-after-the-deny-was-written",
+                    (RecordingProbeBody body) => Results.Json(new { echoed = body.Text }));
+                // The observable-binding seam, a SEPARATE route: a custom binder whose execution is counted,
+                // so the proof can assert NO handler-bound code ran - not merely that the sentinel was absent.
+                group.MapPost("/added-after-the-deny-was-written-observed",
+                    (RecordingProbeBinding probe) => Results.Json(new { probe = probe.Value }));
+            },
+            mapOutsideGroup: routes =>
+                // The UNDENIED EQUIVALENT: the identical framework-bound handler mapped OUTSIDE /ingest. A
+                // malformed body here really reaches the framework and 400s.
+                routes.MapPost("/undenied-equivalent",
+                    (RecordingProbeBody body) => Results.Json(new { echoed = body.Text })));
         try
         {
-            var resp = await http.GetAsync("/ingest/added-after-the-deny-was-written");
+            // The framework-bound future route is refused on hosted across every shape: a valid body, a
+            // malformed body (off hosted the framework's own 400), and a verb it never mapped (off hosted a
+            // 405 disclosing the route exists).
+            foreach (var resp in new[]
+                     {
+                         await http.PostAsync("/ingest/added-after-the-deny-was-written",
+                             new StringContent("{\"text\":\"hello\"}", Encoding.UTF8, "application/json")),
+                         await http.PostAsync("/ingest/added-after-the-deny-was-written",
+                             new StringContent("{ not json", Encoding.UTF8, "application/json")),
+                         await http.GetAsync("/ingest/added-after-the-deny-was-written"),
+                     })
+            {
+                await RecordingGroupProbeHost.AssertBodyIsNothingButTheRefusal(resp);
+                Assert.DoesNotContain("echoed", await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+            }
 
-            await RecordingGroupProbeHost.AssertBodyIsNothingButTheRefusal(resp);
-            Assert.DoesNotContain(ProbePayloadSentinel, await resp.Content.ReadAsStringAsync(),
-                StringComparison.Ordinal);
+            // THE FRAMEWORK-400 CONTROL. The identical malformed body meets the framework's own 400 on the
+            // undenied equivalent, while the denied route returns the refusal above - so the denied route
+            // short-circuits BEFORE framework binding, and the malformed-body refusal is not a route that
+            // merely happens not to bind.
+            var undeniedMalformed = await http.PostAsync("/undenied-equivalent",
+                new StringContent("{ not json", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.BadRequest, undeniedMalformed.StatusCode);
+
+            // NOTHING behind the refusal bound an argument, on any shape - the assertion a parameterless GET
+            // or a body-ignoring custom binder could never make, and the one that separates the exclusive
+            // catch-all (refusal placed BEFORE binding) from the rejected per-handler filter (which ran the
+            // binder first and then refused).
+            foreach (var resp in new[]
+                     {
+                         await http.PostAsync("/ingest/added-after-the-deny-was-written-observed",
+                             new StringContent("{\"text\":\"hello\"}", Encoding.UTF8, "application/json")),
+                         await http.PostAsync("/ingest/added-after-the-deny-was-written-observed",
+                             new StringContent("{ not json", Encoding.UTF8, "application/json")),
+                         await http.GetAsync("/ingest/added-after-the-deny-was-written-observed"),
+                     })
+            {
+                await RecordingGroupProbeHost.AssertBodyIsNothingButTheRefusal(resp);
+                Assert.DoesNotContain(RecordingProbeBinding.Sentinel, await resp.Content.ReadAsStringAsync(),
+                    StringComparison.Ordinal);
+            }
+            Assert.Equal(0, RecordingProbeBinding.Count);
         }
         finally { http.Dispose(); await app.DisposeAsync(); }
     }
@@ -559,31 +630,98 @@ public sealed class SelfHostRecordingGroupControlTests : IDisposable
     }
 
     /// <summary>
-    /// The self-host mirror of the future-route probe: the SAME brand-new route mapped through the group
-    /// SERVES on self-host, in both non-hosted forms. Paired with
+    /// The self-host mirror of the future-route probe: the SAME framework body-bound POST route mapped through
+    /// the group SERVES on self-host, in both non-hosted forms. Paired with
     /// <see cref="HostedRecordingGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own"/>,
     /// this proves the group is a working gate (refuse on hosted, serve off it) and not a brick that refuses
     /// everything unconditionally.
+    ///
+    /// It also proves the future route's binding is REALLY the framework's: a valid body serves with the body
+    /// bound, and a malformed body off hosted hits the framework's own 400 - the exact capability the hosted
+    /// refusal short-circuits before reaching. And it is the POSITIVE twin of the hosted no-binding assertion:
+    /// off hosted the observable custom binder DID run (count == 1) and served the bound sentinel, so the
+    /// hosted count of zero is a working gate and not a binder broken on every deployment.
     /// </summary>
     [Theory]
     [MemberData(nameof(NonHostedValues))]
     public async Task A_route_added_to_the_group_still_serves_on_self_host(string? hostedValue)
     {
         DeclareSelfHost(hostedValue);
-        const string sentinel = "probe-payload-served-on-self-host";
+        RecordingProbeBinding.Reset();
 
         var (app, http) = await RecordingGroupProbeHost.StartAsync(
-            mapIntoGroup: group => group.MapGet("/added-after-the-deny-was-written",
-                () => Results.Json(new { probe = sentinel })));
+            mapIntoGroup: group =>
+            {
+                group.MapPost("/added-after-the-deny-was-written",
+                    (RecordingProbeBody body) => Results.Json(new { echoed = body.Text }));
+                group.MapPost("/added-after-the-deny-was-written-observed",
+                    (RecordingProbeBinding probe) => Results.Json(new { probe = probe.Value }));
+            });
         try
         {
-            var resp = await http.GetAsync("/ingest/added-after-the-deny-was-written");
-            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-            Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+            // The framework-bound future route SERVES off hosted, with the body really bound.
+            var served = await http.PostAsync("/ingest/added-after-the-deny-was-written",
+                new StringContent("{\"text\":\"hello\"}", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.OK, served.StatusCode);
+            Assert.Equal("application/json", served.Content.Headers.ContentType?.MediaType);
+            using (var doc = JsonDocument.Parse(await served.Content.ReadAsStringAsync()))
+                Assert.Equal("hello", doc.RootElement.GetProperty("echoed").GetString());
 
-            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
-            Assert.Equal(sentinel, doc.RootElement.GetProperty("probe").GetString());
+            // The binding is the framework's and is capable of the 400 the hosted refusal short-circuits: a
+            // malformed body off hosted hits the framework's own 400 on the SAME future route.
+            var malformed = await http.PostAsync("/ingest/added-after-the-deny-was-written",
+                new StringContent("{ not json", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.BadRequest, malformed.StatusCode);
+
+            // The observable custom binder really ran off hosted - the positive twin of the hosted count of 0.
+            var observed = await http.PostAsync("/ingest/added-after-the-deny-was-written-observed",
+                new StringContent("{\"text\":\"hello\"}", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.OK, observed.StatusCode);
+            using (var doc = JsonDocument.Parse(await observed.Content.ReadAsStringAsync()))
+                Assert.Equal(RecordingProbeBinding.Sentinel, doc.RootElement.GetProperty("probe").GetString());
+            Assert.Equal(1, RecordingProbeBinding.Count);
         }
         finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+}
+
+/// <summary>
+/// The future route's body record, bound by the FRAMEWORK ([FromBody] on a minimal-API handler), exactly as
+/// the shared primitive's own <see cref="Tenancy"/> reference future route binds its <c>EchoBody</c>. This is
+/// what makes the future-route canary a real framework-binding proof: off hosted a malformed body posted to
+/// this route reaches the framework's JSON-binding boundary and returns its own 400, and on hosted the
+/// exclusive catch-all refuses BEFORE that binding is ever attempted. A custom
+/// <c>IBindableFromHttpContext</c>/<c>BindAsync</c> parameter would ignore the request body entirely and bind
+/// unconditionally, so a malformed body could never reach the framework 400 - which is precisely why the
+/// future route must be framework-bound and not custom-bound.
+/// </summary>
+internal sealed record RecordingProbeBody(string Text);
+
+/// <summary>
+/// The OBSERVABLE-BINDING SEAM, kept as a SEPARATE route from the framework-bound future route above.
+/// Argument binding leaves no trace of its own, so proving that NOTHING bound behind the hosted refusal - on a
+/// valid body, a malformed body, or a verb the route never mapped - requires a parameter that records the fact
+/// it was bound. This mirrors the shared primitive's own <see cref="Tenancy.ObservableBinding"/> (its
+/// <c>/family/custom</c> route, distinct from its framework-bound <c>/family/echo</c> and <c>/family/future</c>
+/// routes), kept local so this file stays self-contained. It is NOT the future route: the future route is
+/// framework-bound (<see cref="RecordingProbeBody"/>); this is the counting instrument mapped alongside it.
+/// </summary>
+internal sealed class RecordingProbeBinding
+{
+    /// <summary>The payload the binder produces off hosted, and the string that must NEVER appear on hosted.</summary>
+    public const string Sentinel = "probe-payload-that-must-never-be-served-on-hosted";
+
+    private static int _count;
+
+    public string Value { get; init; } = "";
+
+    public static int Count => Volatile.Read(ref _count);
+
+    public static void Reset() => Interlocked.Exchange(ref _count, 0);
+
+    public static ValueTask<RecordingProbeBinding?> BindAsync(HttpContext context)
+    {
+        Interlocked.Increment(ref _count);
+        return ValueTask.FromResult<RecordingProbeBinding?>(new RecordingProbeBinding { Value = Sentinel });
     }
 }

--- a/src/CcDirector.Gateway.Tests/HostedRecordingDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedRecordingDenyTests.cs
@@ -1,0 +1,589 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Recording;
+using CcDirector.Core.Storage;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The whole <c>/ingest</c> group is DENIED on the hosted Gateway - the recording reads, the writes, the
+/// promote and delete, and the shared dictation glossary alike.
+///
+/// The store behind those routes carries NO tenant: the durable directory for a recording is built from the
+/// caller-supplied recording id alone, and the glossary is one global file, and the group sits behind only
+/// the host-wide authentication gate - which admits ANY enrolled device key from ANY account. So before this
+/// change any hosted subscriber could list every recording on the box, read another account's raw audio and
+/// its transcript, overwrite its metadata and chunks, promote it into the vault, or delete it outright. That
+/// is theft and tampering of recorded conversations, which is why the whole surface closes and not only a
+/// value-returning read.
+///
+/// WHY A DENY AND NOT A PARTITION. Partitioning this store is real work - the on-disk layout, the promote
+/// target and the shared glossary all have to grow an owner - so a per-account answer would have to be
+/// invented rather than read. That is a half-partition, which is worse than an honest refusal because it
+/// looks like isolation. (The cached wingman voice READ surface, by contrast, WAS partitioned per tenant in
+/// #1973 and is therefore SERVED, not denied - so this file deliberately says nothing about it.)
+///
+/// HOW THE DENY IS EXPRESSED - THE SHARED REFUSAL PRIMITIVE. The group is denied through
+/// <see cref="HostedRouteDeny.ExclusiveGroup"/>, the ONE hosted-refusal boundary every deny family on this
+/// Gateway adopts (the key-vault group in <see cref="VaultEndpoints"/> is the reference adoption). On hosted
+/// the handlers are NEVER MAPPED - one verb-less catch-all refusal claims everything under <c>/ingest</c>
+/// (plus a root refusal at the prefix itself), so every request shape meets the refusal: a valid body, a
+/// malformed body, a wrong media type, a verb the group never mapped, and a route added LATER. Off hosted the
+/// primitive maps the real handlers exactly as an unguarded builder would and creates no refusal at all.
+///
+/// THE GATE IS ON THE DEPLOYMENT SIGNAL. The primitive reads <see cref="GatewayHostedMode.IsHosted"/>
+/// directly, never an optional argument that would fail OPEN the moment a caller omits it.
+///
+/// IT REFUSES, IT NEVER SERVES AN EMPTY ANSWER. An empty recordings list would be a FALSE statement about a
+/// box that holds recordings; an absent route is merely absent.
+///
+/// STATUS AND MEDIA TYPE ARE ASSERTED BEFORE ANY PARSE. On this Gateway a 404 is not necessarily JSON - the
+/// single-page-app fallback answers unmatched paths with something else - so a mutation that routed a denied
+/// path to the fallback would make the parse THROW. That red is a crash, which proves only that the mutation
+/// broke something upstream of the claim; it cannot say WHAT was served in place of the refusal, which is the
+/// entire claim a deny makes.
+///
+/// A 404 DENY IS INDISTINGUISHABLE FROM A ROUTE THAT DOES NOT EXIST, so <see cref="SelfHostRecordingGroupControlTests"/>
+/// carries handler-positive receipts proving each route is really there and really does the thing on
+/// self-host, in both non-hosted forms. Survival assertions here carry a DESTRUCTIBILITY control there: the
+/// same delete that is refused on hosted really destroys the same seeded recording on self-host, so "it
+/// survived" is a claim about a request that was CAPABLE of destroying something.
+///
+/// REVERT-PROOF - the recipe to RUN, not to describe. In <c>src/CcDirector.Gateway/Api/RecordingEndpoints.cs</c>
+/// change <c>HostedRouteDeny.ExclusiveGroup(outer, Prefix, Denial())</c> so the family maps its real handlers
+/// on hosted too - the simplest such mutation is to construct a plain non-denied group with the same prefix
+/// (<c>outer.MapGroup(Prefix)</c> wrapped so <c>MapRoutes</c> still accepts it) and map the routes on it, or
+/// simply return <c>outer</c>'s group unguarded. The hosted deny is then absent. Rebuild, CONFIRM ZERO ERRORS
+/// (a run after a failed build executes the previous binary and reports a false pass), then run this file and
+/// record every red BY NAME: <see cref="Every_ingest_route_is_refused_to_an_enrolled_tenant"/> flips to
+/// "expected NotFound, got OK/202" as each handler answers, and <see cref="The_refused_delete_did_not_take_effect"/>
+/// reddens because the seeded recording is really gone. A red only counts if it fails WITH THE SYMPTOM - an
+/// assertion naming what was served instead of the refusal; crash-reds are UNPROVEN.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class HostedRecordingDenyTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    internal const string RefusalMessage = RecordingEndpoints.RefusalMessage;
+    private const string SeededId = "seeded-recording-of-another-tenant";
+    private const string SeededTitle = "Another tenant's private call";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _key = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-hosted-rec-" + Guid.NewGuid().ToString("N"));
+    private readonly string _vaultPath =
+        Path.Combine(Path.GetTempPath(), "cc-hosted-rec-" + Guid.NewGuid().ToString("N") + ".json");
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private string? _priorHosted;
+
+    public HostedRecordingDenyTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-hosted-rec-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // EXPLICIT, not ambient: this class asserts hosted behaviour, so it states hosted mode itself and
+        // proves the statement took, rather than inheriting whatever the runner happened to leave set.
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+
+        // A real recording already on disk (via the production writer), so a read or a delete that WRONGLY
+        // got through would have something real to hand back or destroy. A deny tested against an empty
+        // transcripts root proves nothing.
+        RecordingSeeder.Seed(SeededId, SeededTitle);
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            keyVaultPath: _vaultPath,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // A fully enrolled, tenant-bound device key - the strongest caller hosted has. The point is that even
+        // this one is refused: there is no credential that makes another account's recording readable.
+        _key = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var tenant = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", tenant.Value);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (File.Exists(_vaultPath)) File.Delete(_vaultPath); } catch (Exception) { /* best effort */ }
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch (Exception) { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch (Exception) { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Every production route in the group, in one theory rather than one test each, so a route added to the
+    /// list is a one-line change and the shape of the assertion cannot drift between them. Every verb is
+    /// here, because the write, the promote and the delete are the tampering half of this defect and a deny
+    /// that closed only the reads would leave the damage path open.
+    /// </summary>
+    [Theory]
+    [InlineData("GET", "ingest/recordings", null)]                                                 // list every record
+    [InlineData("GET", "ingest/recording/" + SeededId + "/status", null)]                          // one record's status
+    [InlineData("GET", "ingest/recording/" + SeededId + "/transcript", null)]                      // the transcript text
+    [InlineData("GET", "ingest/recording/" + SeededId + "/audio/0", null)]                         // raw audio - the theft
+    [InlineData("POST", "ingest/recording", "{\"recordingId\":\"x\",\"title\":\"t\",\"deviceId\":\"d\",\"startedAt\":\"2026-01-01T00:00:00Z\",\"codec\":\"mp3\",\"sampleRateHz\":16000,\"channels\":1}")]
+    [InlineData("PUT", "ingest/recording/" + SeededId + "/chunk/0", "not-audio")]                  // overwrite a chunk
+    [InlineData("POST", "ingest/recording/" + SeededId + "/complete", "{}")]
+    [InlineData("POST", "ingest/recording/" + SeededId + "/promote", null)]                        // promote into the vault
+    [InlineData("PATCH", "ingest/recording/" + SeededId + "/meta", "{\"title\":\"hijacked\"}")]     // overwrite metadata
+    [InlineData("DELETE", "ingest/recording/" + SeededId, null)]                                   // destroy the record
+    [InlineData("GET", "ingest/dictionary", null)]                                                 // the shared glossary
+    [InlineData("PUT", "ingest/dictionary", "{\"vocabulary\":[],\"commonMistranscriptions\":{},\"profiles\":{}}")]
+    [InlineData("POST", "ingest/dictionary/terms", "{\"terms\":[\"planted\"]}")]                    // mutate the glossary
+    [InlineData("GET", "ingest/agent-info", null)]                                                 // the API guide
+    public async Task Every_ingest_route_is_refused_to_an_enrolled_tenant(string method, string path, string? body)
+    {
+        var resp = await Send(new HttpMethod(method), path, body);
+        await AssertBodyIsNothingButTheRefusal(resp);
+    }
+
+    [Fact]
+    public async Task The_refused_list_did_not_name_the_recording_and_is_not_an_empty_list()
+    {
+        // Refuse, never serve an empty list: an empty "records" array is a FALSE statement about a box that
+        // holds a recording, where an absent one is merely absent. The exact-property assertion below proves
+        // there is no records array at all, empty or otherwise.
+        var resp = await Send(HttpMethod.Get, "ingest/recordings");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.DoesNotContain(SeededId, await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        Assert.DoesNotContain(SeededTitle, await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        await AssertBodyIsNothingButTheRefusal(resp);
+    }
+
+    [Fact]
+    public async Task The_refused_delete_did_not_take_effect()
+    {
+        // The status code alone would not prove the destruction was prevented - a handler that ran, deleted,
+        // and then reported 404 would pass that. This reads the store back through a fresh service.
+        //
+        // DESTRUCTIBILITY CONTROL: the identical delete DOES destroy this same seeded recording on self-host
+        // (SelfHostRecordingGroupControlTests.The_same_delete_destroys_the_recording_on_self_host), so this
+        // is a capable operation being stopped, not a no-op passing by construction.
+        var resp = await Send(HttpMethod.Delete, "ingest/recording/" + SeededId);
+        await AssertBodyIsNothingButTheRefusal(resp);
+
+        Assert.True(RecordingSeeder.Exists(SeededId), "the seeded recording must survive a refused delete");
+    }
+
+    [Fact]
+    public async Task The_refused_register_of_a_new_recording_did_not_create_it()
+    {
+        const string planted = "planted-by-attacker";
+        var resp = await Send(HttpMethod.Post, "ingest/recording",
+            "{\"recordingId\":\"" + planted + "\",\"title\":\"t\",\"deviceId\":\"d\",\"startedAt\":\"2026-01-01T00:00:00Z\",\"codec\":\"mp3\",\"sampleRateHz\":16000,\"channels\":1}");
+        await AssertBodyIsNothingButTheRefusal(resp);
+
+        Assert.False(RecordingSeeder.Exists(planted), "a refused register must not create a recording");
+    }
+
+    [Fact]
+    public async Task A_verb_the_group_never_mapped_is_also_refused_on_hosted()
+    {
+        // The primitive maps a VERB-LESS refusal, so a method the family never mapped meets the refusal too -
+        // it does not leak the route's existence through a 405. /ingest/recordings is a GET-only route; a
+        // DELETE on it was never mapped by any verb, yet the catch-all refuses it.
+        var resp = await Send(HttpMethod.Delete, "ingest/recordings");
+        await AssertBodyIsNothingButTheRefusal(resp);
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_caller_is_still_rejected()
+    {
+        // Control: the deny must not have opened the group up as a side effect of running before the
+        // host-wide authentication gate. Without a key the middleware still refuses first. GREEN in both
+        // directions of the revert on purpose - a control that moves with the change under test is not a
+        // control.
+        Assert.Equal(HttpStatusCode.Unauthorized, (await _http.GetAsync("ingest/recordings")).StatusCode);
+    }
+
+    /// <summary>
+    /// AN ALLOW-LIST, NOT A DENY-LIST, and FORMAT FACTS BEFORE PARSING. Asserting the property set is EXACTLY
+    /// one error field inverts a rotting deny-list: anything extra, anything new, anything that leaked reddens
+    /// automatically. The status and media type are asserted FIRST so a revert reddens as a STATEMENT -
+    /// "expected NotFound, got OK" - rather than as a parser exception on a non-JSON fallback body.
+    /// </summary>
+    internal static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp)
+    {
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+
+        var properties = doc.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Equal(new[] { "error" }, properties);
+        Assert.Equal(RefusalMessage, doc.RootElement.GetProperty("error").GetString());
+    }
+
+    private Task<HttpResponseMessage> Send(HttpMethod method, string path, string? body = null)
+    {
+        var req = new HttpRequestMessage(method, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        if (body is not null)
+            req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return _http.SendAsync(req);
+    }
+
+    internal static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}
+
+/// <summary>
+/// Seeds and inspects a recording through the PRODUCTION writer (<see cref="RecordingIngestService"/>)
+/// against the process's <see cref="CcStorage.Transcripts"/> root, so a survival/destructibility assertion
+/// is made against exactly the store the endpoint reads and writes - never a hand-authored status file that
+/// could drift from what the service actually produces. The background worker is off (a deny test never
+/// transcribes) and the transcriber factory throws (it must never be built); neither is reached by Register,
+/// GetStatus or DeleteRecording.
+/// </summary>
+internal static class RecordingSeeder
+{
+    private static RecordingIngestService NewService() => new(
+        CcStorage.Transcripts(),
+        transcriberFactory: () => throw new InvalidOperationException("a deny test must never build the transcriber"),
+        new CcVaultFiler(CcStorage.VaultTranscripts()),
+        CcStorage.VaultTranscripts(),
+        runWorker: false);
+
+    public static void Seed(string recordingId, string title)
+    {
+        var svc = NewService();
+        try
+        {
+            svc.Register(new RecordingRegisterRequest(
+                recordingId, title, "seed-device", "2026-01-01T00:00:00Z", "mp3", 16000, 1));
+        }
+        finally { svc.Dispose(); }
+    }
+
+    public static bool Exists(string recordingId)
+    {
+        var svc = NewService();
+        try { svc.GetStatus(recordingId); return true; }
+        catch (InvalidOperationException) { return false; }
+        finally { svc.Dispose(); }
+    }
+
+    public static void Delete(string recordingId)
+    {
+        var svc = NewService();
+        try { svc.DeleteRecording(recordingId); }
+        finally { svc.Dispose(); }
+    }
+}
+
+/// <summary>
+/// Boots ONLY the recording-ingest group on an ephemeral port and hands the caller the denied group handle
+/// back so a test can map routes through it. That is what makes the future-route proof possible at all: the
+/// group is created inside <see cref="RecordingEndpoints.Map"/>, so nothing outside that method could
+/// otherwise state a property about routes added to it. Routes handed to <paramref name="mapIntoGroup"/> are
+/// RELATIVE to the <c>/ingest</c> prefix, the same way the production routes are.
+/// </summary>
+internal static class RecordingGroupProbeHost
+{
+    public static async Task<(WebApplication app, HttpClient http)> StartAsync(
+        Action<HostedDenyGroup>? mapIntoGroup = null,
+        Action<IEndpointRouteBuilder>? mapOutsideGroup = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        var group = RecordingEndpoints.Map(app);
+        mapIntoGroup?.Invoke(group);
+        mapOutsideGroup?.Invoke(app);
+
+        await app.StartAsync();
+        var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+        return (app, http);
+    }
+
+    public static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp)
+    {
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+
+        var properties = doc.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Equal(new[] { "error" }, properties);
+        Assert.Equal(HostedRecordingDenyTests.RefusalMessage, doc.RootElement.GetProperty("error").GetString());
+    }
+}
+
+/// <summary>
+/// THE POINT OF THE WHOLE CHANGE: the hosted refusal covers routes that have not been written yet.
+///
+/// A guard line repeated in every handler passes exactly the same tests as an exclusive-prefix deny for the
+/// routes that exist today, which is why it is dangerous - the difference only shows up on the route somebody
+/// adds NEXT, when it is open by default and nothing fails. So this class maps a BRAND-NEW route through the
+/// group and asserts it is already refused with no deny of its own written anywhere. The mirror half - the
+/// same probe path SERVED with hosted mode explicitly off - is
+/// <see cref="SelfHostRecordingGroupControlTests.A_route_added_to_the_group_still_serves_on_self_host"/>: one
+/// direction alone cannot tell a working gate from a brick that refuses everything unconditionally.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class HostedRecordingGroupFilterTests : IDisposable
+{
+    private const string ProbePayloadSentinel = "probe-payload-that-must-never-be-served-on-hosted";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string? _priorHosted;
+
+    public HostedRecordingGroupFilterTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "cc-rec-group-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch (Exception) { /* best effort */ }
+    }
+
+    /// <summary>
+    /// A route that did not exist when the refusal was written is refused anyway. NOTHING in
+    /// <see cref="RecordingEndpoints"/> mentions this path, and no guard is written for it here - the
+    /// exclusive catch-all under <c>/ingest</c> is the only thing standing between the caller and the probe
+    /// payload. On hosted the handle DISCARDS the probe handler (nothing binds), so the catch-all answers.
+    /// </summary>
+    [Fact]
+    public async Task A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own()
+    {
+        var (app, http) = await RecordingGroupProbeHost.StartAsync(
+            mapIntoGroup: group => group.MapGet("/added-after-the-deny-was-written",
+                () => Results.Json(new { probe = ProbePayloadSentinel })));
+        try
+        {
+            var resp = await http.GetAsync("/ingest/added-after-the-deny-was-written");
+
+            await RecordingGroupProbeHost.AssertBodyIsNothingButTheRefusal(resp);
+            Assert.DoesNotContain(ProbePayloadSentinel, await resp.Content.ReadAsStringAsync(),
+                StringComparison.Ordinal);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>
+    /// CONTROL: the deny is scoped to the <c>/ingest</c> prefix, not a blanket refusal on the whole
+    /// application. A route mapped OUTSIDE the group still serves on hosted, so the passing tests above are
+    /// the deny doing its job and not the host refusing everything.
+    /// </summary>
+    [Fact]
+    public async Task A_route_outside_the_group_still_serves_on_hosted()
+    {
+        var (app, http) = await RecordingGroupProbeHost.StartAsync(
+            mapOutsideGroup: routes => routes.MapGet("/not-an-ingest-route", () => Results.Json(new { ok = true })));
+        try
+        {
+            var resp = await http.GetAsync("/not-an-ingest-route");
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            Assert.True(doc.RootElement.GetProperty("ok").GetBoolean());
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+}
+
+/// <summary>
+/// THE SELF-HOST CONTROL ON THE GROUP, in BOTH non-hosted forms, with the effects proven.
+///
+/// Self-host is the control for this whole mission, so it is PROVEN rather than INHERITED. This class sets
+/// <c>CC_GATEWAY_HOSTED</c> itself, to both non-hosted values that occur in practice - absent, and
+/// present-but-not-"1" - and asserts the mode took before driving anything. It asserts REAL PAYLOADS AND REAL
+/// EFFECTS, not the absence of the refusal string: an empty-but-successful response would satisfy "the
+/// refusal is absent" while still being a broken self-host.
+///
+/// It also carries the DESTRUCTIBILITY CONTROL for the hosted survival assertion: the same delete that is
+/// refused on hosted really destroys the seeded recording here. Every test here must stay GREEN through the
+/// revert described on <see cref="HostedRecordingDenyTests"/>.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class SelfHostRecordingGroupControlTests : IDisposable
+{
+    private const string SeededId = "the-owners-own-recording";
+    private const string SeededTitle = "The owner's own call";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string? _priorHosted;
+
+    public SelfHostRecordingGroupControlTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "cc-rec-selfhost-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch (Exception) { /* best effort */ }
+    }
+
+    /// <summary>Puts the process into a STATED non-hosted mode and proves it took, so no test below can
+    /// silently be running in the mode it thinks it is not in.</summary>
+    private static void DeclareSelfHost(string? value)
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", value);
+        Assert.False(GatewayHostedMode.IsHosted);
+    }
+
+    /// <summary>null = the variable is absent. "0" = present and explicitly not hosted. Both are real
+    /// non-hosted deployments and both must serve.</summary>
+    public static TheoryData<string?> NonHostedValues => new() { null, "0" };
+
+    /// <summary>
+    /// HANDLER-POSITIVE RECEIPT for the list route: the route really exists and really answers with the
+    /// owner's recording. A 404 deny is indistinguishable from a route that was never mapped, so without a
+    /// receipt like this the hosted 404 would prove nothing about a guard.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task The_owner_still_lists_his_real_recording_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+        RecordingSeeder.Seed(SeededId, SeededTitle);
+
+        var (app, http) = await RecordingGroupProbeHost.StartAsync();
+        try
+        {
+            var resp = await http.GetAsync("/ingest/recordings");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            var ids = doc.RootElement.EnumerateArray().Select(e => e.GetProperty("recordingId").GetString()).ToArray();
+            Assert.Contains(SeededId, ids);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>HANDLER-POSITIVE RECEIPT for register: the route really creates a recording on disk.</summary>
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task The_owner_can_register_a_recording_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+        const string newId = "freshly-registered";
+
+        var (app, http) = await RecordingGroupProbeHost.StartAsync();
+        try
+        {
+            var resp = await http.PostAsync("/ingest/recording", new StringContent(
+                "{\"recordingId\":\"" + newId + "\",\"title\":\"t\",\"deviceId\":\"d\",\"startedAt\":\"2026-01-01T00:00:00Z\",\"codec\":\"mp3\",\"sampleRateHz\":16000,\"channels\":1}",
+                Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.True(RecordingSeeder.Exists(newId), "register must really create the recording on self-host");
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>
+    /// DESTRUCTIBILITY CONTROL for the hosted survival assertion. The hosted test asserts a seeded recording
+    /// SURVIVES a refused DELETE; that claim is only meaningful if the same operation is CAPABLE of destroying
+    /// it. This drives <see cref="RecordingIngestService.DeleteRecording"/> - the exact method the DELETE
+    /// handler invokes (<c>lazyService.Value.DeleteRecording(id)</c>) - and proves the seeded recording is
+    /// really gone afterwards. It is driven through the production writer rather than over HTTP on purpose:
+    /// the mode gate lives in the route mapping (proven by the hosted refusal + the self-host register/list
+    /// receipts above), while THIS control is about the delete's capability, which the service call carries
+    /// directly and without racing a freshly-built endpoint worker that is scanning the same directory.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public void The_same_delete_destroys_the_recording(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+        RecordingSeeder.Seed(SeededId, SeededTitle);
+        Assert.True(RecordingSeeder.Exists(SeededId));
+
+        RecordingSeeder.Delete(SeededId);
+
+        Assert.False(RecordingSeeder.Exists(SeededId), "the same DeleteRecording the route invokes must really destroy the recording");
+    }
+
+    /// <summary>
+    /// The self-host mirror of the future-route probe: the SAME brand-new route mapped through the group
+    /// SERVES on self-host, in both non-hosted forms. Paired with
+    /// <see cref="HostedRecordingGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own"/>,
+    /// this proves the group is a working gate (refuse on hosted, serve off it) and not a brick that refuses
+    /// everything unconditionally.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task A_route_added_to_the_group_still_serves_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+        const string sentinel = "probe-payload-served-on-self-host";
+
+        var (app, http) = await RecordingGroupProbeHost.StartAsync(
+            mapIntoGroup: group => group.MapGet("/added-after-the-deny-was-written",
+                () => Results.Json(new { probe = sentinel })));
+        try
+        {
+            var resp = await http.GetAsync("/ingest/added-after-the-deny-was-written");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            Assert.Equal(sentinel, doc.RootElement.GetProperty("probe").GetString());
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+}

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -8,6 +8,7 @@ using CcDirector.Core.Recording;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.Transcription;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -16,28 +17,81 @@ using Microsoft.AspNetCore.Routing;
 namespace CcDirector.Gateway.Api;
 
 /// <summary>
-/// Maps the <c>/ingest/recording</c> REST surface the phone recorder uploads
-/// to. The phone records offline; when it has connectivity it registers a
-/// recording, PUTs each finalized audio segment (idempotent by index + hash),
-/// then POSTs <c>complete</c>, which queues the recording and returns 202
-/// immediately. A background worker transcribes every segment through the
-/// existing dictation pipeline and assembles + cleans the transcript into the
-/// local transcripts area, retrying flaky segments and re-queueing a failed
-/// job for a later attempt. The phone polls <c>status</c> to watch progress.
-/// Transcripts stay local (transient) until the user promotes one into the vault.
+/// Maps the <c>/ingest</c> REST surface the phone recorder uploads to. The phone records offline; when it
+/// has connectivity it registers a recording, PUTs each finalized audio segment (idempotent by index +
+/// hash), then POSTs <c>complete</c>, which queues the recording and returns 202 immediately. A background
+/// worker transcribes every segment through the existing dictation pipeline and assembles + cleans the
+/// transcript into the local transcripts area, retrying flaky segments and re-queueing a failed job for a
+/// later attempt. The phone polls <c>status</c> to watch progress. Transcripts stay local (transient) until
+/// the user promotes one into the vault. A shared dictation glossary lives under the same prefix.
 ///
-/// Routes (all JSON except the raw-bytes chunk PUT):
-///   POST /ingest/recording                      register, body RecordingRegisterRequest
-///   PUT  /ingest/recording/{id}/chunk/{index}   raw audio bytes, header X-Chunk-Sha256
-///   POST /ingest/recording/{id}/complete        body RecordingManifest
-///   GET  /ingest/recording/{id}/status          RecordingStatusDto
-///   POST /ingest/recording/{id}/promote         copy transcript + audio into the vault
-///   PATCH /ingest/recording/{id}/meta           set human-readable title/subtitle/summary
-///   DELETE /ingest/recording/{id}               delete the transient local transcript
-///   GET  /ingest/agent-info                     copy-paste API guide for an external agent
+/// Routes (all JSON except the raw-bytes chunk PUT), all under <c>/ingest</c>:
+///   POST   /ingest/recording                      register, body RecordingRegisterRequest
+///   PUT    /ingest/recording/{id}/chunk/{index}   raw audio bytes, header X-Chunk-Sha256
+///   POST   /ingest/recording/{id}/complete        body RecordingManifest
+///   GET    /ingest/recording/{id}/status          RecordingStatusDto
+///   GET    /ingest/recordings                     list EVERY recording on this gateway
+///   GET    /ingest/recording/{id}/transcript      the cleaned transcript as plain text
+///   GET    /ingest/recording/{id}/audio/{index}   one raw audio segment
+///   POST   /ingest/recording/{id}/promote         copy transcript + audio into the vault
+///   PATCH  /ingest/recording/{id}/meta            set human-readable title/subtitle/summary
+///   DELETE /ingest/recording/{id}                 delete the transient local transcript
+///   GET    /ingest/dictionary                     the shared dictation glossary
+///   PUT    /ingest/dictionary                     replace the shared dictation glossary
+///   POST   /ingest/dictionary/terms               add terms to the shared dictation glossary
+///   GET    /ingest/agent-info                     copy-paste API guide for an external agent
 ///
-/// Auth is the Gateway's existing token middleware (applied host-wide when
-/// enabled), so these routes inherit it without extra checks here.
+/// Auth is the Gateway's existing token middleware (applied host-wide when enabled), so these routes
+/// inherit it without extra checks here.
+///
+/// DENIED IN WHOLE ON HOSTED. Every route under <c>/ingest</c> is refused on the hosted Gateway, because
+/// nothing in this surface carries a tenant. The durable directory for a recording is built from the
+/// CALLER-SUPPLIED recording id alone, so on shared hosted infrastructure any authenticated device can name
+/// another account's recording and be served it: list every record on the box, read its raw audio and its
+/// raw and cleaned transcript, overwrite its title, subtitle, summary and chunks, promote it into the vault,
+/// or delete it outright. The id sanitiser only replaces invalid characters, so two distinct caller ids can
+/// alias onto the same directory as well. The dictionary routes have the same shape: one shared glossary
+/// file, no tenant, read and written by anyone. It is a deny of the WHOLE GROUP, not a guard on the worst
+/// route, because the read, the write and the destruction are all equally wrong here, and because a
+/// route-by-route fix rots: the next ingest route added would be open again by default.
+///
+/// It is a DENY rather than a per-tenant partition because partitioning this store is real work - the
+/// on-disk layout, the promote target and the shared glossary all have to grow an owner - and a
+/// half-partition is worse than an honest refusal. (Contrast the cached wingman voice READ surface, which
+/// WAS partitioned per tenant in #1973 and is therefore served, not denied - the two surfaces looked alike
+/// but had different work done to them.)
+///
+/// HOW THE DENY IS EXPRESSED - THE SHARED REFUSAL PRIMITIVE, NOT A BESPOKE CHECK. This group is denied
+/// through <see cref="HostedRouteDeny.ExclusiveGroup"/>, the ONE hosted-refusal boundary every deny family
+/// on this Gateway adopts (primitive at <c>src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs</c>; the
+/// key-vault group in <see cref="VaultEndpoints"/> is the reference adoption). On hosted the handlers are
+/// NEVER MAPPED. In their place the exclusive prefix maps ONE verb-less catch-all refusal over everything
+/// under <c>/ingest</c> plus a root refusal at the prefix itself. There is no binding step to get ahead of,
+/// no body parameter, no media-type constraint and no method constraint, so EVERY request shape - a valid
+/// body, a malformed body, a wrong media type, a verb the group never mapped, and a route added LATER -
+/// meets the refusal. The exclusivity claim is CHECKED at startup by
+/// <see cref="HostedRefusalRouteSpace.ValidateBeforeStart"/>: the Gateway refuses to start if any live route
+/// serves beneath <c>/ingest</c>. Nothing else on this Gateway serves under <c>/ingest</c>, so the whole
+/// prefix is this group's to claim.
+///
+/// NO OFF-ROUTE WRITER TO HOST-GATE. Unlike the key-vault group (which had a startup seed, a provisioner and
+/// a revocation firing off-route), NOTHING writes this surface's state except the routes themselves.
+/// <see cref="RecordingIngestService"/> is constructed in exactly one place - <see cref="BuildService"/>,
+/// reached only through the per-request Lazy below - and on hosted the catch-all answers before any handler
+/// runs, so the Lazy is never forced, the service is never built and its transcription worker never starts.
+/// The shared glossary is written only by the two denied dictionary routes. (DictionaryResolver's cache
+/// write is a Director-side consumer of a Gateway glossary, not a Gateway writer of this store.) So there is
+/// no defence-in-depth writer to gate; the deny is the whole mechanism.
+///
+/// UN-DENY DEBT: a deny closes the ROUTE door only. Before it is lifted: (1) give recordings and the shared
+/// glossary a per-tenant layout (keyed by tenant, not by caller-supplied id alone, which also closes the
+/// id-aliasing hazard), (2) quarantine, purge or migrate the PRE-DENY root rather than adopting un-owned
+/// material into the new layout, and ONLY THEN (3) lift this refusal. This is recorded on the payload's
+/// unDenyInstruction so it travels with the deny.
+///
+/// Self-host is COMPLETELY unchanged - the owner records, transcribes, edits and deletes exactly as before -
+/// and that is the control. Off hosted the primitive maps the real handlers on the group exactly as an
+/// unguarded builder would and creates no refusal at all.
 /// </summary>
 internal static class RecordingEndpoints
 {
@@ -46,22 +100,82 @@ internal static class RecordingEndpoints
         PropertyNameCaseInsensitive = true,
     };
 
-    public static void Map(
-        IEndpointRouteBuilder app,
+    /// <summary>The exclusive prefix the recording-ingest group owns outright on hosted.</summary>
+    internal const string Prefix = "/ingest";
+
+    /// <summary>The single error string the hosted refusal serves. Held here so a test can assert against the
+    /// exact string that is served rather than a copy that could drift.</summary>
+    internal const string RefusalMessage = "recordings are not available on the hosted gateway";
+
+    /// <summary>
+    /// The hosted refusal payload for the whole recording-ingest group. Validated on construction, so a blank
+    /// field fails the Gateway at startup rather than serving a refusal a caller cannot act on. 404 rather
+    /// than 403: on hosted this surface does not exist as a concept, so "not here" is the truthful answer;
+    /// 403 would imply some credential could reach it, and none can.
+    /// </summary>
+    private static HostedDenial Denial() => new(
+        family: "recording-ingest",
+        message: RefusalMessage,
+        reason: "recordings and the shared dictation glossary carry no tenant - the recording directory is keyed on " +
+                "a caller-supplied id alone and the glossary is one global file - and the host-wide auth gate admits " +
+                "any enrolled device key from any account, so one subscriber could list, read, overwrite, promote or " +
+                "delete every other subscriber's recorded conversations",
+        unDenyInstruction: "do NOT simply remove this deny: give recordings and the shared glossary a per-tenant " +
+                "layout (keyed by tenant, not by caller-supplied id alone), THEN quarantine, purge or migrate the " +
+                "pre-existing global recording root (material predating this deny is already on disk and this change " +
+                "never touched it), and only then restore tenant-scoped routes",
+        statusCode: StatusCodes.Status404NotFound);
+
+    /// <summary>
+    /// Maps the recording-ingest routes and RETURNS the denied group they were mapped through.
+    ///
+    /// The routes are mapped through the group HANDLE (<see cref="HostedDenyGroup"/>), never through the
+    /// ungrouped builder: the handle is obtainable only from <see cref="HostedRouteDeny.ExclusiveGroup"/>, so
+    /// a route mapped around the refusal is not expressible in <see cref="MapRoutes"/> without changing its
+    /// signature. On hosted the handle DISCARDS each handler (the exclusive catch-all already refuses the
+    /// path); off hosted it maps each handler as an unguarded builder would.
+    ///
+    /// The return value exists so the future-route property is statable from outside this file: a test can map
+    /// a brand-new route through the returned handle and show the refusal already covers routes nobody has
+    /// written yet - the one property that distinguishes an exclusive-prefix deny from a guard repeated in
+    /// each handler.
+    /// </summary>
+    public static HostedDenyGroup Map(
+        IEndpointRouteBuilder outer,
         KeyVault? keyVault = null,
         TranscriptionTelemetryLog? telemetry = null,
         TranscriptionAudioArchive? audioArchive = null)
+    {
+        FileLog.Write($"[RecordingEndpoints] mapping {Prefix} recording + dictionary routes; hosted={GatewayHostedMode.IsHosted} - on hosted the whole group is refused via the shared refusal primitive");
+
+        var group = HostedRouteDeny.ExclusiveGroup(outer, Prefix, Denial());
+        MapRoutes(group, keyVault, telemetry, audioArchive);
+        return group;
+    }
+
+    /// <summary>
+    /// Every /ingest route, mapped relative to the <see cref="Prefix"/> so the full paths are
+    /// <c>/ingest/recording</c>, <c>/ingest/dictionary</c> and so on exactly as before. Takes the denied
+    /// GROUP HANDLE and nothing else: the ungrouped route builder is deliberately out of scope here so no
+    /// route can be mapped around the hosted refusal.
+    /// </summary>
+    private static void MapRoutes(
+        HostedDenyGroup app,
+        KeyVault? keyVault,
+        TranscriptionTelemetryLog? telemetry,
+        TranscriptionAudioArchive? audioArchive)
     {
         // Lazily built on FIRST USE, not at host startup: constructing the service resolves
         // the OpenAI API key (the transcriber needs it), and the Gateway must boot on machines
         // without that key. A missing key then fails the individual recording request loudly
         // (500 with an explicit hosted-AI setup message) instead of preventing
-        // the entire Gateway host from starting.
+        // the entire Gateway host from starting. On hosted the group discards every handler, so this
+        // Lazy is never forced and the service is never built.
         // In production the host owns the key vault + telemetry + audio archive and passes them, so the
         // recording transcriber shares the host's single instances rather than newing its own copies.
         var lazyService = new Lazy<RecordingIngestService>(() => BuildService(keyVault, telemetry, audioArchive));
 
-        app.MapPost("/ingest/recording", async (HttpContext ctx) =>
+        app.MapPost("/recording", async (HttpContext ctx) =>
         {
             try
             {
@@ -79,7 +193,7 @@ internal static class RecordingEndpoints
             }
         });
 
-        app.MapPut("/ingest/recording/{id}/chunk/{index:int}", async (string id, int index, HttpContext ctx) =>
+        app.MapPut("/recording/{id}/chunk/{index:int}", async (string id, int index, HttpContext ctx) =>
         {
             try
             {
@@ -100,7 +214,7 @@ internal static class RecordingEndpoints
             }
         });
 
-        app.MapPost("/ingest/recording/{id}/complete", async (string id, HttpContext ctx) =>
+        app.MapPost("/recording/{id}/complete", async (string id, HttpContext ctx) =>
         {
             try
             {
@@ -150,7 +264,7 @@ internal static class RecordingEndpoints
             }
         });
 
-        app.MapGet("/ingest/recording/{id}/status", (string id) =>
+        app.MapGet("/recording/{id}/status", (string id) =>
         {
             try
             {
@@ -171,13 +285,13 @@ internal static class RecordingEndpoints
         // transcription and desktop dictation. The page sends the whole document
         // on save (no partial merge) so the file stays the single source of truth.
 
-        app.MapGet("/ingest/dictionary", () =>
+        app.MapGet("/dictionary", () =>
         {
             var dict = DictionaryLoader.LoadFromDisk(DictionaryFilePath());
             return Results.Json(ToDto(dict));
         });
 
-        app.MapPut("/ingest/dictionary", async (HttpContext ctx) =>
+        app.MapPut("/dictionary", async (HttpContext ctx) =>
         {
             try
             {
@@ -200,7 +314,7 @@ internal static class RecordingEndpoints
         // Additive convenience endpoint so an agent in a session can add a term
         // (and optional mistranscription spellings) without round-tripping the
         // whole document. Existing entries are preserved; duplicates are ignored.
-        app.MapPost("/ingest/dictionary/terms", async (HttpContext ctx) =>
+        app.MapPost("/dictionary/terms", async (HttpContext ctx) =>
         {
             try
             {
@@ -249,9 +363,9 @@ internal static class RecordingEndpoints
             }
         });
 
-        app.MapGet("/ingest/recordings", () => Results.Json(lazyService.Value.ListAll()));
+        app.MapGet("/recordings", () => Results.Json(lazyService.Value.ListAll()));
 
-        app.MapGet("/ingest/recording/{id}/transcript", (string id) =>
+        app.MapGet("/recording/{id}/transcript", (string id) =>
         {
             var text = lazyService.Value.GetTranscript(id);
             return text is null
@@ -259,7 +373,7 @@ internal static class RecordingEndpoints
                 : Results.Text(text, "text/plain; charset=utf-8");
         });
 
-        app.MapGet("/ingest/recording/{id}/audio/{index:int}", (string id, int index) =>
+        app.MapGet("/recording/{id}/audio/{index:int}", (string id, int index) =>
         {
             var audio = lazyService.Value.GetAudioFile(id, index);
             return audio is null
@@ -267,7 +381,7 @@ internal static class RecordingEndpoints
                 : Results.File(audio.Value.path, audio.Value.contentType, enableRangeProcessing: true);
         });
 
-        app.MapDelete("/ingest/recording/{id}", (string id) =>
+        app.MapDelete("/recording/{id}", (string id) =>
         {
             try
             {
@@ -281,7 +395,7 @@ internal static class RecordingEndpoints
             }
         });
 
-        app.MapPost("/ingest/recording/{id}/promote", async (string id) =>
+        app.MapPost("/recording/{id}/promote", async (string id) =>
         {
             try
             {
@@ -302,7 +416,7 @@ internal static class RecordingEndpoints
 
         // Update human-readable metadata (title, subtitle, summary). Accepts both
         // PATCH (partial update) and POST so simple clients can use either.
-        app.MapMethods("/ingest/recording/{id}/meta", new[] { "PATCH", "POST" }, async (string id, HttpContext ctx) =>
+        app.MapMethods("/recording/{id}/meta", new[] { "PATCH", "POST" }, async (string id, HttpContext ctx) =>
         {
             try
             {
@@ -329,7 +443,7 @@ internal static class RecordingEndpoints
         // tailnet front door (resolved via Tailscale, independent of how this
         // page was reached) so an agent on any tailnet machine gets a URL that
         // actually works. Access is API-only; the guide does not expose the disk.
-        app.MapGet("/ingest/agent-info", () =>
+        app.MapGet("/agent-info", () =>
         {
             var baseUrl = TailscaleIdentity.TryGetFrontDoorBaseUrl();
             var guide = BuildAgentInfo(baseUrl);


### PR DESCRIPTION
Two live cross-tenant content leaks on the hosted gateway are closed by refusal. Self-host keeps both features entirely and is proven unchanged.

Rebased onto `origin/main` at `f2028deb`. The rebase was verified with `git range-diff`, not a rebuild: a rebuild proves it compiles, only a range-diff proves nothing crept in. Three of the four pre-existing commits came across byte-identical; the fourth differs in exactly two places, both intended and both forced by what landed on main in the meantime - see "What the rebase changed" below.

## What was wrong

Neither surface carries a tenant anywhere.

**Recording ingest.** `RecordingEndpoints` production-constructs `RecordingIngestService`, and the service builds a recording's durable directory from the CALLER-SUPPLIED recording id alone. Neither file mentions a tenant. So on the hosted gateway any authenticated device could enumerate every recording on the box, read any raw audio and any raw or cleaned transcript, overwrite chunks, titles, subtitles and summaries, promote another account's recording into a shared vault, or delete it. The id sanitiser only replaces invalid characters, so two distinct caller ids can also alias onto one directory. The same file's dictation dictionary routes read and write one shared glossary file with no tenant.

**Cached wingman voice.** `GatewayWingmanVoiceEndpoint` enumerates every ready session id, returns the spoken text and the agent's reply text and the mp3 by BARE session id, and deletes by bare session id.

The voice half needs restating after the per-tenant voice partition landed on main, because the obvious reading of that change is that this deny is now unnecessary, and it is not. `WingmanVoiceService` does now keep a per-tenant bucket and a per-tenant directory. But that change deliberately left these routes unconverted, in its own words: *"The voice routes and the background narration sweep are deliberately NOT converted here. They still pass the local tenant."* Every one of the four denied routes reads the state through the hardcoded constant `TenantId.Local`. **A partitioned store read through a constant is not a partitioned read** - it points every hosted caller at one shared partition, which is the same disclosure by a different mechanism.

## What the rebase changed

Only two hunks in the deny commit, and neither is new content:

1. The voice routes now call `voice.Get(TenantId.Local, sid)`, `ReadySessionIds(TenantId.Local)` and so on, because the partition change made the tenant a required first parameter. This is main's signature flowing through the group conversion.
2. The deny comment was rewritten to state the post-partition truth above, replacing the stale sentence "partitioning the voice state is separate, deferred work". The state is partitioned; the ROUTES are not. Leaving that sentence would have been a false statement pointing the next reader at work that is already done.

## Defects the rebase exposed, and the design change it prompted

**The rig was seeding a location nothing reads.** The cached-voice fixtures were written to the pre-partition path (`voice-sessions.json` and `voice-audio` directly under the storage root). Partitioning made that the LEGACY path, and the service now treats it as legacy at construction: on hosted it DELETES it, on self-host it MOVES it into the local partition. So:

- the hosted suite would have been proving a refusal in front of an EMPTY cache - absence proved twice, presence never - and would have stayed green regardless, because the deny answers before the handler ever looks;
- the self-host control would have passed by way of the migration, exercising a path its name does not mention.

The rig now seeds the partition directly, and asserts its path against the production `PartitionDirectoryFor` rather than against a second copy of the same arithmetic.

**The per-route bypass is now structurally impossible.** Both files kept the filtered and unfiltered builders in one scope. That makes every route-mapping line independently bypassable: one word - `outer` for `app`, or `app` for `cachedVoice` - opens exactly one route on hosted, compiles, and leaves every other route and every existing test green. Nineteen lines, nineteen chances, and nothing in the suite would show it.

Each family's routes now live in a method that receives ONLY the filtered group (`RecordingEndpoints.MapRoutes`, `GatewayWingmanVoiceEndpoint.MapCachedVoiceRoutes`). The unfiltered builder is not a parameter and is not in scope, so the bypass does not compile. The voice file needed this most, and it is exactly the coexistence the review flagged: most of that file is deliberately not denied, so `cachedVoice.MapGet` and `app.MapGet` genuinely sit a few lines apart and differ only in whether the route is reachable on hosted.

This is what takes the mutation plan from twenty-three runs to four, and the reduction is by construction rather than by argument.

## The shape of the deny

- ONE endpoint-group filter per surface, not a guard line per handler, so a route added next year is refused by default. The empty prefix keeps every route path written out in full, so the self-host surface is byte-identical.
- Gated on `GatewayHostedMode.IsHosted`, the INDEPENDENT deployment signal, never on an optional tenant or boundary argument. A security branch resting on an optional argument fails OPEN the moment a caller omits it.
- 404 rather than 403: on hosted these surfaces do not exist as a concept, and no credential can reach them.
- The refusal body is EXACTLY one `error` property, asserted by enumerating the property set as an allow-list, so any field added later reddens automatically.
- Refuses; never serves an empty list. An empty recording list is a FALSE statement about the box where an absent route is merely absent.

## The un-deny debt - and the two halves are NOT the same kind

A deny that stops only the READ is a DEFERRED LEAK: cross-tenant data keeps accumulating behind it, and the day the deny is lifted it exposes a contaminated history. So the entry is written per surface, now, in the pull request and at the guard itself.

### The frame: two questions, not one

Assessing the write-stop by looking at THE DENIED ROUTES is the wrong question, and it produced one unsupported claim per surface in the previous revision. A deny closes ONE door. It says nothing about the other doors, and nothing about what was already sitting behind it before it was hung. Each entry below answers two:

- **Q1** - does anything, ANYWHERE, still write this state on hosted?
- **Q2** - what is ALREADY sitting there, from before the deny existed?

### Recording ingest

**Q1 - no new writes.** `RecordingIngestService` is constructed in exactly one place in production (`BuildService`), reached only from a `Lazy` whose every `.Value` use is inside a handler mapped on the filtered group. No startup seed, no provisioner, no background job and no other endpoint constructs it. On hosted the filter answers before any handler runs, so the `Lazy` is never forced: the service is never built and its transcription worker never starts.

**Q2 - unknown, therefore assumed contaminated.** The previous revision argued straight from Q1 to "there is nothing to purge - the store is exactly as the deny found it". **That does not follow**, and it is withdrawn. What the deny FOUND is precisely what was never established. The recording root is ONE un-partitioned directory keyed on caller-supplied ids, it predates this refusal, and nothing in it records an owner - so anything written before the deny landed is still there, un-owned and un-attributable after the fact. "No new writes" is a statement about the future, not evidence about the past.

**Un-deny condition:** give recordings a per-tenant layout (keyed by tenant, not by caller-supplied id alone, which also closes the id-aliasing hazard), AND explicitly quarantine, purge or migrate the pre-deny root rather than adopting it - adopting it would silently assign un-owned material to whichever tenant happened to be inferred - and only then lift the refusal.

### Cached wingman voice

**Q1 - the writers are LATENT, not active. The previous revision's ongoing-write story was false and is withdrawn.** It claimed `voice-turn`, `explain`, `voice-mode/all` and the narration sweep keep filling the local partition on hosted. This code does not do that. Each of the four is gated behind a Local-scoped lookup that is empty on hosted and fails closed:

| Producer | Gate that stops it on hosted |
| --- | --- |
| `POST /sessions/{sid}/wingman/voice-turn` | `SessionVerbClient.ResolveAsync` locates with `TenantId.Local`, returns null; the route answers 404 before `OnSessionWorking`/`StoreSpokenAsync` |
| `POST /sessions/{sid}/wingman/explain` | same resolve, same 404, before `Mark`/`StoreSpokenAsync` |
| `POST /sessions/voice-mode/all` | targets come from `FleetByDirector(..., TenantId.Local)`; empty Local fleet = empty target list, no `Mark` |
| the narration sweep in `GatewayHost` | iterates `VoiceSessionIds(TenantId.Local)`; the turn-end path first tests `IsVoiceSession(TenantId.Local, sid)`. Both empty or false |

The error was reading call sites and concluding the loop runs - a call site proves the code EXISTS, not that it RUNS. The production comment on the sweep says it directly: *"on hosted a Local read is empty (never a wrong-tenant read)"*.

These writers are still wrong and must still be removed before un-deny, because converting the routes or otherwise populating the Local scope ARMS them. "Currently unreachable" is one merge away from reachable, and nothing would announce it.

**Q2 - this is the risk the deny actually closes, and it is a READ risk.** A pre-existing Local partition whose contents these routes hand to any hosted caller. It gets there with no hosted write at all: a box that ran self-host earlier, a build from before the routes were scoped, or migrated state. `WingmanVoiceService`'s constructor deleting the PRE-PARTITION legacy files on hosted is easy to misread as "the box starts clean" - it does not touch `tenants/local/`, and `tenants/local/` is exactly what these four routes read.

**Un-deny condition (unchanged - the conservative one is kept, only its justification is corrected):** convert the four latent writers off the hardcoded Local, AND dispose of the existing Local pile (quarantine, purge or attribute), and only then lift the refusal. Converting the routes alone is not sufficient: each account would read its own partition while the un-owned Local pile stayed on disk and the writers stayed aimed at it.

Neither entry is filed as "blocked on partitioning". The voice state IS already partitioned per tenant and this exposure survived it untouched, so that phrase would be ticked off in good faith by the next partitioning change while the pile stayed on disk.

### Route-by-route

| Route | Method | Tier | What it does on self-host | Before the deny is lifted |
| --- | --- | --- | --- | --- |
| `/ingest/recordings` | GET | 1 | Lists every recording on the gateway | Recordings owned by a tenant; the list filtered to the caller's |
| `/wingman/voice/ready` | GET | 1 | Lists every session with a ready clip | Writers converted, local pile purged, then filtered to the caller's |
| `/ingest/recording/{id}` | DELETE | 2 | Deletes the transient local recording | Ownership check before deleting |
| `/ingest/recording/{id}/chunk/{index}` | PUT | 2 | Stores one audio segment | Recording directory keyed by tenant; id aliasing closed |
| `/ingest/recording/{id}/meta` | PATCH, POST | 2 | Sets title, subtitle, summary | Ownership check before writing |
| `/ingest/recording/{id}/promote` | POST | 2 | Copies transcript and audio into the vault | A per-tenant vault target |
| `/ingest/recording` | POST | 2 | Registers a new recording | Recording directory keyed by tenant |
| `/ingest/recording/{id}/complete` | POST | 2 | Queues transcription | Ownership check plus per-tenant spend accounting |
| `/ingest/dictionary` | PUT | 2 | Replaces the whole shared glossary | A per-tenant glossary |
| `/ingest/dictionary/terms` | POST | 2 | Adds terms to the shared glossary | A per-tenant glossary |
| `/sessions/{sid}/wingman/voice/stop` | POST | 2 | Turns voice off and deletes the cached clip | Writers converted, local pile purged |
| `/ingest/recording/{id}/status` | GET | 3 | Reads one recording's status | Ownership check |
| `/ingest/recording/{id}/transcript` | GET | 3 | Reads the cleaned transcript | Ownership check |
| `/ingest/recording/{id}/audio/{index}` | GET | 3 | Streams one raw audio segment | Ownership check |
| `/ingest/dictionary` | GET | 3 | Reads the shared glossary | A per-tenant glossary |
| `/ingest/agent-info` | GET | 3 | An API guide naming the tailnet front door | Denied because it documents the routes above and names the owner's address |
| `/sessions/{sid}/wingman/voice` | GET | 3 | Returns spoken summary and agent reply text | Writers converted, local pile purged |
| `/sessions/{sid}/wingman/voice/audio` | GET | 3 | Streams the mp3 | Writers converted, local pile purged |

NOT denied, deliberately: the wingman generation and speech routes (`/wingman/tts`, `/wingman/transcribe`, `/wingman/utterance/*`, `/sessions/{sid}/wingman/voice-turn`, `/wingman/ask-direct`, `/wingman/ask-devthrottle`, `/sessions/{sid}/wingman/explain`, `/sessions/{sid}/wingman/menu`, `/sessions/voice-mode/all`). That is the judgement, and it is also precisely why the voice write is not stopped - those routes are the writers.

## Coverage

**Every denied route, both directions, from ONE table.** `RecordingAndVoiceDenyRig.DeniedRoutes` holds all nineteen routes with the verb, the body each needs, the refusal its group answers with, and the fingerprint its own handler produces. The hosted suite requires a refusal on every row; `SelfHostRecordingAndVoiceStillWorkTests.Every_denied_route_resolves_to_its_own_handler` requires every row to answer with its own fingerprint. A route added to a group and to that table is checked both ways automatically, so the suites cannot drift.

Handler-positive proof for the four routes the review named as uncovered:

| Route | Proof |
| --- | --- |
| `GET /ingest/recording/{id}/audio/{index}` | The owner uploads a segment and reads THOSE EXACT BYTES back, compared byte for byte, plus a second test against the seeded clip's bytes |
| `POST /ingest/recording/{id}/complete` | The completeness gate's own 409 receipt: `state` is `incomplete` and `missingOrBadIndices` is exactly `[0]`. Nothing is transcribed, so it needs no key and is deterministic |
| `POST /ingest/recording/{id}/promote` | The ingest service's own `is not ready to promote`, naming the recording id, with no vault write required |
| `POST /ingest/recording/{id}/meta` | Both verbs write, then the change is read back through DIFFERENT routes (the list and the status route) - a state change on the box, not the handler quoting its input |

**No status-shaped assertions.** On this Gateway "a missing route answers 404, a wrong verb answers 405" is false in two separately measured ways: `CockpitReactApp` maps `MapFallback("{*path}")` whose not-found page is release-build-only, and `SessionWsProxyEndpoints` maps an all-verb `/sessions/{sid}/{**rest}` catch-all that the cached-voice routes sit under. No 405 is produced on these paths in either condition. Every row matches a per-handler fingerprint instead.

**Future-route probe on BOTH groups.** `RecordingEndpoints.Map` and `GatewayWingmanVoiceEndpoint.Map` return the group they filtered; production callers ignore it. `HostedDenyGroupFutureRouteProbeTests` maps a brand-new route onto each group - written after the filter, carrying no guard, exactly like a future edit - and asserts hosted returns 404 with a body of exactly one `error` property and no probe fingerprint, while hosted-off serves 200 with the fingerprint. It runs on a bare host with neither the single-page-app fallback nor the session catch-all mapped, so nothing else can answer for the probe path. This is the only assertion that shows a group filter covers routes nobody has written yet, which is the entire reason the deny is one filter per family.

**The mode signal is set and read back.** Both rigs set `CC_GATEWAY_HOSTED` explicitly and then assert `GatewayHostedMode.IsHosted` agrees before driving a route - writing an environment variable is a request, not a result. The self-host arms run BOTH non-hosted forms, unset and explicitly `"0"`; the unset form alone cannot tell self-host apart from the runner's ambient default, which is what every runner supplies for free.

**Status and media type asserted BEFORE every parse.** Parsing is itself an assertion about format, and a parse failure launders a served route into a crash that names nothing. Removing a guard now reddens as "expected NotFound, got OK" and "expected application/json, got text/plain".

**Survival assertions carry destructibility controls.** "The recording survived a refusal" and "the clip survived a refusal" are worth nothing unless the operation demonstrably destroys them when permitted. Both controls are named at the assertion: the self-host life-cycle test watches the recording actually disappear, and the self-host voice test asserts those two exact files are gone after a permitted stop.

## Pre-registered mutation plan - six runs, and why not twenty-five

Written into the test class BEFORE any of these runs, with predicted reds AND predicted greens per mutation. Each mutation is applied ALONE in its own full-assembly run: a run with two mutations cannot attribute any red to either, and once one red is unassignable the rest is inference.

**Six complete units, not five.** An earlier revision listed only the four arms plus the restore. That cannot support what the arms claim: an arm's reds are attributable to its mutation only if the SAME assembly at the SAME head was green immediately before it. Without a baseline, a test already failing on this head is read as caused by the arm, and the restore at the end cannot substitute - it answers a different question (did everything come back) after the evidence was needed.

| # | Mutation | Individually wrong while everything else is correct? |
| --- | --- | --- |
| M0 | **Baseline - no mutation** | n/a - fixes the green total every arm reconciles against BY NAME |
| M1 | Delete the recording group filter | Yes - hosted serves recordings, self-host untouched |
| M2 | Delete the cached-voice group filter | Yes - hosted serves voice, self-host untouched |
| M3 | Invert the recording hosted gate | Yes - a DIFFERENT defect from M1: M1 asks whether the filter is attached, M3 asks whether it reads the signal in the right direction. Their signatures differ, which is what separates them - M3 also breaks self-host |
| M4 | Invert the cached-voice hosted gate | Yes, same reason |
| M5 | Restore everything | The whole assembly green at that exact head |

The nineteen route-mapping lines are NOT argued away - they are gone, removed by the scope split above, so there is no bypass left to mutate. Overlap does not exempt anything: the three table-driven tests redden under all four mutations, which is not a reason to merge runs but the reason not to - they are the reds a combined run could never attribute.

The self-host class states its own direction under each mutation rather than claiming to stay green throughout. Green throughout was true only of M1 and M2; under M3 and M4 the self-host tests for that surface MUST go red, because an inverted gate refuses the deployment that is supposed to be served, and green there would mean the control cannot see self-host being broken.

## Status of the runs - none have been made

Everything above is written and BUILDS CLEAN (`0 Warning(s), 0 Error(s)`, verified against a full non-incremental rebuild, with the new symbols confirmed present in the built assembly).

**NO test has been run on this head, and no claim of a passing run is made.** The single machine-wide Gateway test lane is held by another worker, and a concurrent run kills the test host and produces failures in untouched areas. The counts in earlier revisions of this body predate this rebase and the changes above and are therefore withdrawn rather than restated - they were measured against a rig that seeded a location nothing reads, so they were not measuring what they claimed.

When the lane opens, the whole proof runs in one sitting at this exact head and is posted here: the M0 baseline with its total, the four single-mutation full-assembly runs with their reds named individually and reconciled against that baseline by name, the restored green at the exact same head, and a clean seven-project count. Each unit is preceded by a source and build preflight - exactly one production file differing from pristine, and a build line reading 0 Error(s) - because a run after a failed build executes the stale binary and reports a false pass.
