### PR TITLE
perf(installer): move cc-* tools provisioning out of the installer to first launch

### DIFF
--- a/tools/cc-director-setup-avalonia/Services/EngineInstallRunner.cs
+++ b/tools/cc-director-setup-avalonia/Services/EngineInstallRunner.cs
@@ -43,12 +43,10 @@ public sealed class EngineInstallRunner
         else dItem.SizeText = FormatSize(dAsset.Size);
         items.Add(dItem); byId["director"] = dItem;
 
-        var bItem = new ToolDownloadItem { Name = PythonToolsInstaller.ComponentId, AssetName = PythonToolsInstaller.ToolsAsset };
-        var pyAsset = release.Manifest.TryGetAsset(PythonToolsInstaller.PythonAsset);
-        var toolsAsset = release.Manifest.TryGetAsset(PythonToolsInstaller.ToolsAsset);
-        if (pyAsset is null || toolsAsset is null) { bItem.Status = "Skipped"; bItem.SizeText = "Not in release"; }
-        else bItem.SizeText = FormatSize(pyAsset.Size + toolsAsset.Size);
-        items.Add(bItem); byId[PythonToolsInstaller.ComponentId] = bItem;
+        // The shared-venv cc-* Python tools bundle is deliberately NOT an install-time row anymore: the
+        // installer no longer provisions it (that ~334 MB download + venv build was the dominant install
+        // time). The app provisions the bundle from nothing on first launch (ToolReconciler startup
+        // reconcile), so the Install screen shows an honest "finishes on first launch" note instead.
 
         // The launcher installs on macOS only in THIS wizard: the Windows wizard (the WPF one)
         // already installs it there. Older releases have no macOS launcher asset - skip cleanly.
@@ -78,7 +76,11 @@ public sealed class EngineInstallRunner
         ArgumentNullException.ThrowIfNull(prep);
 
         var directorOk = await PlaceDirectorAsync(prep, status, ct);
-        var toolCount = await InstallPythonToolsAsync(prep, status, ct);
+        // The installer does NOT provision the Python tools bundle - the app provisions it from nothing on
+        // first launch (see InstallerToolsProvisioning). The real provisioner is wired but deliberately not
+        // invoked, so re-enabling it is a one-line revert pinned by InstallerToolsProvisioningTests.
+        var toolCount = await InstallerToolsProvisioning.ProvisionDuringInstallAsync(
+            innerCt => InstallPythonToolsAsync(prep, status, innerCt), ct);
         var launcherOk = await InstallLauncherAsync(prep, status, ct);
         FinalizeInstall();
 

--- a/tools/cc-director-setup-avalonia/Steps/InstallStep.axaml
+++ b/tools/cc-director-setup-avalonia/Steps/InstallStep.axaml
@@ -1,10 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:converters="clr-namespace:CcDirectorSetup.Converters"
              x:Class="CcDirectorSetup.Steps.InstallStep">
-    <UserControl.Resources>
-        <converters:HexColorToBrushConverter x:Key="HexToBrush" />
-    </UserControl.Resources>
     <DockPanel>
         <StackPanel DockPanel.Dock="Top">
             <TextBlock x:Name="HeadingText"
@@ -82,77 +78,20 @@
                     </Grid>
                 </Border>
 
-                <!-- Tools section -->
+                <!-- Tools section: the cc-* command-line tools are provisioned by the app on first launch,
+                     not by the installer (that kept the install snappy). This is an honest note, not a
+                     live install row. -->
                 <Border Background="#2A2D2E" CornerRadius="6" Padding="16">
                     <StackPanel>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-
-                            <StackPanel Grid.Column="0">
-                                <TextBlock Text="Tools"
-                                           Foreground="White"
-                                           FontSize="16"
-                                           FontWeight="SemiBold" />
-                                <TextBlock x:Name="ToolsSummary"
-                                           Text="0 tools"
-                                           Foreground="#888888"
-                                           FontSize="12"
-                                           Margin="0,2,0,0" />
-                                <ProgressBar x:Name="ToolsOverallProgress"
-                                             Height="3" Margin="0,8,24,0"
-                                             Background="#3C3C3C" Foreground="#007ACC"
-                                             IsVisible="False"
-                                             Minimum="0" Maximum="100" />
-                            </StackPanel>
-
-                            <TextBlock x:Name="ToolsStatus"
-                                       Grid.Column="1"
-                                       Text="Pending"
-                                       Foreground="#CCCCCC"
-                                       FontSize="13" FontWeight="SemiBold"
-                                       VerticalAlignment="Center" />
-                        </Grid>
-
-                        <!-- Tool details -->
-                        <Expander Header="Show details"
-                                  Foreground="#888888"
-                                  FontSize="11"
-                                  Margin="0,12,0,0"
-                                  IsExpanded="False">
-                            <ItemsControl x:Name="ToolList" Margin="0,8,0,0">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <Grid Margin="0,0,0,3">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="60" />
-                                                <ColumnDefinition Width="70" />
-                                            </Grid.ColumnDefinitions>
-
-                                            <TextBlock Text="{Binding Name}"
-                                                       Foreground="#AAAAAA"
-                                                       FontSize="12" />
-
-                                            <TextBlock Grid.Column="1"
-                                                       Text="{Binding SizeText}"
-                                                       Foreground="#666666"
-                                                       FontSize="11"
-                                                       HorizontalAlignment="Right" />
-
-                                            <TextBlock Grid.Column="2"
-                                                       Text="{Binding Status}"
-                                                       FontSize="11"
-                                                       FontWeight="SemiBold"
-                                                       HorizontalAlignment="Right"
-                                                       Foreground="{Binding StatusColor, Converter={StaticResource HexToBrush}}" />
-                                        </Grid>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </Expander>
+                        <TextBlock Text="Tools"
+                                   Foreground="White"
+                                   FontSize="16"
+                                   FontWeight="SemiBold" />
+                        <TextBlock Text="Your cc-* command-line tools finish setting up the first time you open DevThrottle."
+                                   Foreground="#888888"
+                                   FontSize="12"
+                                   TextWrapping="Wrap"
+                                   Margin="0,2,0,0" />
                     </StackPanel>
                 </Border>
 

--- a/tools/cc-director-setup-avalonia/Steps/InstallStep.axaml.cs
+++ b/tools/cc-director-setup-avalonia/Steps/InstallStep.axaml.cs
@@ -14,7 +14,6 @@ namespace CcDirectorSetup.Steps;
 public partial class InstallStep : UserControl
 {
     private ToolDownloadItem? _directorItem;
-    private List<ToolDownloadItem> _toolItems = [];
     private List<SkillItem> _skillItems = [];
 
     public InstallStep()
@@ -89,10 +88,9 @@ public partial class InstallStep : UserControl
     public void SetItems(List<ToolDownloadItem> items)
     {
         _directorItem = items.FirstOrDefault(i => i.Name == "cc-director");
-        _toolItems = items.Where(i => i.Name != "cc-director").ToList();
 
-        ToolList.ItemsSource = _toolItems;
-        ToolsSummary.Text = $"{_toolItems.Count} tools";
+        // The cc-* tools are no longer installed here (the app provisions them on first launch), so the
+        // Tools card is a static note - there are no tool rows to bind or track.
 
         // Set up skills list
         _skillItems = ToolInstaller.SkillNames
@@ -124,21 +122,6 @@ public partial class InstallStep : UserControl
                 });
             };
         }
-
-        // Track overall tool progress. Status drives the summary text; Progress (set live by the
-        // download byte counter and pip streaming inside PythonToolsInstaller) drives the bar so
-        // the user sees motion during the multi-minute python-tools step.
-        foreach (var tool in _toolItems)
-        {
-            var capturedTool = tool;
-            capturedTool.PropertyChanged += (_, e) =>
-            {
-                if (e.PropertyName == nameof(ToolDownloadItem.Status))
-                    Dispatcher.UIThread.Post(UpdateToolsSummaryStatus);
-                else if (e.PropertyName == nameof(ToolDownloadItem.Progress))
-                    Dispatcher.UIThread.Post(() => ToolsOverallProgress.Value = capturedTool.Progress);
-            };
-        }
     }
 
     public event Action? OnRepairRequested;
@@ -160,8 +143,6 @@ public partial class InstallStep : UserControl
 
         DirectorStatus.Text = "Up to date";
         DirectorStatus.Foreground = upToDateBrush;
-        ToolsStatus.Text = "Up to date";
-        ToolsStatus.Foreground = upToDateBrush;
         SkillsStatus.Text = "Up to date";
         SkillsStatus.Foreground = upToDateBrush;
     }
@@ -181,7 +162,6 @@ public partial class InstallStep : UserControl
     public void ShowProgress()
     {
         DirectorProgress.IsVisible = true;
-        ToolsOverallProgress.IsVisible = true;
     }
 
     public List<SkillItem> GetSkillItems() => _skillItems;
@@ -192,34 +172,5 @@ public partial class InstallStep : UserControl
         SkillsStatus.Text = $"{done} installed";
         SkillsStatus.Foreground = SolidColorBrush.Parse("#22C55E");
         SkillsSummary.Text = $"{done}/{_skillItems.Count} skills installed";
-    }
-
-    private void UpdateToolsSummaryStatus()
-    {
-        var done = _toolItems.Count(t => t.Status == "Done");
-        var failed = _toolItems.Count(t => t.Status == "Failed");
-        var locked = _toolItems.Count(t => t.Status == "Locked");
-        var skipped = _toolItems.Count(t => t.Status == "Skipped");
-        var total = _toolItems.Count;
-        var processed = done + failed + locked + skipped;
-
-        if (processed == total)
-        {
-            ToolsStatus.Text = $"{done} installed";
-            ToolsStatus.Foreground = SolidColorBrush.Parse("#22C55E");
-            ToolsSummary.Text = skipped > 0
-                ? $"{done} installed, {skipped} not yet released"
-                : $"{done} installed";
-            ToolsOverallProgress.IsVisible = false;
-        }
-        else
-        {
-            // Surface the bundle row's live Status (e.g. "Downloading 118.2 MB / 334.5 MB") so the
-            // user sees motion even when the details Expander is collapsed. Bar value is driven from
-            // the row's Progress property (download bytes + pip streaming) — don't overwrite it here.
-            var active = _toolItems.FirstOrDefault(
-                t => t.Status is not "Pending" and not "Done" and not "Failed" and not "Locked" and not "Skipped");
-            ToolsStatus.Text = active?.Status ?? "Installing...";
-        }
     }
 }

--- a/tools/cc-director-setup-cli.Tests/InstallScopeTests.cs
+++ b/tools/cc-director-setup-cli.Tests/InstallScopeTests.cs
@@ -6,19 +6,19 @@ namespace CcDirector.Setup.Cli.Tests;
 
 public class InstallScopeTests
 {
-    // The headline regression guard: a Gateway install is a true superset of a Workstation install,
+    // The headline regression guard: a full Gateway install is a true superset of a Workstation install,
     // so it MUST also install the per-user Python tools bundle. (A stale workstation-only gate once
     // dropped the cc-* tools on a Gateway install; this locks that it never returns.)
     [Fact]
     public void InstallsPythonTools_GatewayInstall_True()
     {
-        Assert.True(InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: true, dryRun: false));
+        Assert.True(InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: true, dryRun: false, componentScoped: false));
     }
 
     [Fact]
     public void InstallsPythonTools_WorkstationInstall_True()
     {
-        Assert.True(InstallScope.InstallsPythonTools(InstallRole.Workstation, installMode: true, dryRun: false));
+        Assert.True(InstallScope.InstallsPythonTools(InstallRole.Workstation, installMode: true, dryRun: false, componentScoped: false));
     }
 
     [Theory]
@@ -27,17 +27,17 @@ public class InstallScopeTests
     public void InstallsPythonTools_BothRolesAgree(InstallRole role)
     {
         // Role-independent by design: whatever Workstation does, Gateway does too.
-        var gateway = InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: true, dryRun: false);
-        var workstation = InstallScope.InstallsPythonTools(InstallRole.Workstation, installMode: true, dryRun: false);
+        var gateway = InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: true, dryRun: false, componentScoped: false);
+        var workstation = InstallScope.InstallsPythonTools(InstallRole.Workstation, installMode: true, dryRun: false, componentScoped: false);
         Assert.Equal(workstation, gateway);
         // The parameterized role still resolves to the same decision.
-        Assert.True(InstallScope.InstallsPythonTools(role, installMode: true, dryRun: false));
+        Assert.True(InstallScope.InstallsPythonTools(role, installMode: true, dryRun: false, componentScoped: false));
     }
 
     [Fact]
     public void InstallsPythonTools_DryRun_False()
     {
-        Assert.False(InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: true, dryRun: true));
+        Assert.False(InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: true, dryRun: true, componentScoped: false));
     }
 
     [Fact]
@@ -45,7 +45,7 @@ public class InstallScopeTests
     {
         // A plain `update` pass (installMode: false) refreshes apps/tools already present; it does not
         // run the full bundle install step.
-        Assert.False(InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: false, dryRun: false));
+        Assert.False(InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: false, dryRun: false, componentScoped: false));
     }
 
     [Fact]
@@ -54,6 +54,51 @@ public class InstallScopeTests
         // The decision is platform-independent: PythonToolsInstaller selects the right bundle
         // assets per platform itself, and the release ships macOS bundles. The old Windows-only
         // gate silently skipped the cc-* tools on a macOS install (issue #1445).
-        Assert.True(InstallScope.InstallsPythonTools(InstallRole.Workstation, installMode: true, dryRun: false));
+        Assert.True(InstallScope.InstallsPythonTools(InstallRole.Workstation, installMode: true, dryRun: false, componentScoped: false));
+    }
+
+    // A component-scoped install (--component <id>) is narrowed to that one component; the Python tools
+    // bundle is not a narrowable component, so it must NOT be provisioned. This is what keeps the GUI's
+    // Gateway sub-install fast. Revert-proof: drop the componentScoped term from InstallsPythonTools ->
+    // this reds.
+    [Fact]
+    public void InstallsPythonTools_ComponentScoped_False()
+    {
+        Assert.False(InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: true, dryRun: false, componentScoped: true));
+        Assert.False(InstallScope.InstallsPythonTools(InstallRole.Workstation, installMode: true, dryRun: false, componentScoped: true));
+    }
+
+    [Theory]
+    [InlineData(null, false)]        // no --component -> full install -> not scoped
+    [InlineData("", false)]
+    [InlineData("all", false)]       // --component all is the explicit "everything" -> not scoped
+    [InlineData("ALL", false)]
+    [InlineData("gateway", true)]    // the GUI's Gateway sub-install -> scoped
+    [InlineData("director", true)]
+    public void IsComponentScoped_Cases(string? option, bool expected)
+    {
+        Assert.Equal(expected, InstallScope.IsComponentScoped(option));
+    }
+
+    // Production-path proof for the exact invocation the WPF Gateway GUI shells
+    // (GatewayTrayLauncher: `install --role gateway --component gateway`): the parsed args map to a
+    // component-scoped install whose tools gate is FALSE, so the GUI's Gateway sub-install does NOT pay the
+    // bundle install. A normal full CLI install (no --component) still provisions the tools.
+    // Revert-proof: make InstallsPythonTools ignore componentScoped, or make IsComponentScoped ignore the
+    // option -> the Gateway assertion reds.
+    [Fact]
+    public void GatewayGuiSubInstall_DoesNotProvisionTools_ButFullInstallDoes()
+    {
+        var gatewayGui = CliArgs.Parse(["install", "--role", "gateway", "--component", "gateway"]);
+        var gatewayScoped = InstallScope.IsComponentScoped(gatewayGui.Option("component"));
+        Assert.True(gatewayScoped);
+        Assert.False(InstallScope.InstallsPythonTools(
+            InstallRole.Gateway, installMode: true, dryRun: gatewayGui.HasFlag("dry-run"), componentScoped: gatewayScoped));
+
+        var fullInstall = CliArgs.Parse(["install", "--role", "gateway"]);
+        var fullScoped = InstallScope.IsComponentScoped(fullInstall.Option("component"));
+        Assert.False(fullScoped);
+        Assert.True(InstallScope.InstallsPythonTools(
+            InstallRole.Gateway, installMode: true, dryRun: fullInstall.HasFlag("dry-run"), componentScoped: fullScoped));
     }
 }

--- a/tools/cc-director-setup-cli/Commands.cs
+++ b/tools/cc-director-setup-cli/Commands.cs
@@ -309,7 +309,7 @@ internal static class Commands
 
         // Optionally narrow to one component.
         var only = args.Option("component");
-        if (!string.IsNullOrWhiteSpace(only) && !only.Equals("all", StringComparison.OrdinalIgnoreCase))
+        if (InstallScope.IsComponentScoped(only))
         {
             var filtered = plan.Items.Where(i => i.ComponentId.Equals(only, StringComparison.OrdinalIgnoreCase)).ToList();
             if (filtered.Count == 0) throw new UsageException($"--component '{only}' is not in scope.");
@@ -400,7 +400,8 @@ internal static class Commands
         // old workstation-only gate dated from when the Gateway was an elevated Windows service that
         // ran as admin while the venv belonged in the logged-in user's profile; that model is retired.
         var toolsInstalled = false;
-        if (InstallScope.InstallsPythonTools(Role(args), installMode, args.HasFlag("dry-run")))
+        if (InstallScope.InstallsPythonTools(Role(args), installMode, args.HasFlag("dry-run"),
+                InstallScope.IsComponentScoped(args.Option("component"))))
         {
             var py = await new PythonToolsInstaller(layout).InstallAsync(release, source);
             if (json)

--- a/tools/cc-director-setup-cli/InstallScope.cs
+++ b/tools/cc-director-setup-cli/InstallScope.cs
@@ -9,18 +9,34 @@ namespace CcDirector.Setup.Cli;
 public static class InstallScope
 {
     /// <summary>
+    /// True when the install is narrowed to a single component (<c>--component &lt;id&gt;</c>) rather than a
+    /// full install. <c>--component all</c> (or no option) is NOT narrowing. This is the single source of
+    /// truth both the plan narrowing and the Python-tools gate read, so "is this a scoped sub-install?" is
+    /// decided in exactly one place.
+    /// </summary>
+    public static bool IsComponentScoped(string? componentOption) =>
+        !string.IsNullOrWhiteSpace(componentOption)
+        && !componentOption.Equals("all", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Whether this pass installs the per-user Python tools bundle (the shared venv that carries
-    /// every cc-* tool). True for an install of EITHER role on either platform: the Gateway is a
+    /// every cc-* tool). True for a FULL install of EITHER role on either platform: the Gateway is a
     /// per-user tray app (no elevation), so a Gateway install is a true SUPERSET of a Workstation
     /// install and must include the tools too (INSTALLATION.md section 1), and the release ships
     /// macOS bundles (cc-python-macos-arm64 / cc-tools-pyenv-macos-arm64) that the platform-aware
     /// PythonToolsInstaller consumes - the old Windows-only gate silently skipped the tools on a
     /// macOS install (issue #1445). It is deliberately role-INDEPENDENT; <paramref name="role"/>
     /// is kept in the signature to document and lock that fact.
+    ///
+    /// FALSE for a COMPONENT-SCOPED install (<paramref name="componentScoped"/>): the tools bundle is not
+    /// a narrowable component, so <c>--component &lt;id&gt;</c> is asking for that one component only. This
+    /// is what the GUI's Gateway sub-install (<c>install --role gateway --component gateway</c>) relies on -
+    /// without it the GUI would still pay the multi-minute bundle install through the CLI subprocess, and
+    /// the app-provisions-on-first-launch slice would be defeated for every Gateway install.
     /// </summary>
-    public static bool InstallsPythonTools(InstallRole role, bool installMode, bool dryRun)
+    public static bool InstallsPythonTools(InstallRole role, bool installMode, bool dryRun, bool componentScoped)
     {
         _ = role; // role-independent by design (see summary); both roles get the tools bundle.
-        return installMode && !dryRun;
+        return installMode && !dryRun && !componentScoped;
     }
 }

--- a/tools/cc-director-setup-engine.Tests/InstallerToolsProvisioningTests.cs
+++ b/tools/cc-director-setup-engine.Tests/InstallerToolsProvisioningTests.cs
@@ -1,0 +1,35 @@
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// Revert-proof for the snappy install (slice: tools out of the installer): the installer's tools step
+/// (<see cref="InstallerToolsProvisioning.ProvisionDuringInstallAsync"/>) - the SINGLE production seam both
+/// the WPF and Avalonia wizard install runners route their tools step through - must NOT invoke the real
+/// Python-tools provisioner. The app provisions the bundle from nothing on first launch instead.
+///
+/// Revert-proof: change ProvisionDuringInstallAsync to `return provisionTools(ct);` (re-adding the real
+/// call site) -> the provisioner is invoked, the count is non-zero, and both tests below go red.
+/// </summary>
+public sealed class InstallerToolsProvisioningTests
+{
+    [Fact]
+    public async Task ProvisionDuringInstallAsync_DoesNotInvokeTheRealProvisioner()
+    {
+        var invoked = false;
+        var count = await InstallerToolsProvisioning.ProvisionDuringInstallAsync(
+            _ => { invoked = true; return Task.FromResult(26); },
+            CancellationToken.None);
+
+        Assert.False(invoked, "the installer must NOT provision the Python tools bundle - the app does it on first launch");
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task ProvisionDuringInstallAsync_NullProvisioner_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => InstallerToolsProvisioning.ProvisionDuringInstallAsync(null!, CancellationToken.None));
+    }
+}

--- a/tools/cc-director-setup-engine.Tests/ToolReconcilerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/ToolReconcilerTests.cs
@@ -44,6 +44,14 @@ public sealed class ToolReconcilerTests : IDisposable
     private void RecordExpectedScripts(params string[] names)
         => PythonToolsState.SaveScripts(_layout, names);
 
+    /// <summary>Record an installed Python-tools bundle version so the state does not read as truly-empty.</summary>
+    private void RecordBundleInstalled(string version = "1.0.0")
+    {
+        var manifest = InstalledManifest.Load(_layout);
+        manifest.Set(PythonToolsInstaller.ComponentId, version);
+        manifest.Save(_layout);
+    }
+
     private string ShimPath(string name) => Path.Combine(_layout.BinDir, name + ".cmd");
 
     /// <summary>A heavy-repair delegate that records whether it was called and returns a fixed result.</summary>
@@ -109,7 +117,10 @@ public sealed class ToolReconcilerTests : IDisposable
     [Fact]
     public async Task ReconcileAsync_OrphanedLegacyShim_Purged_ReturnsReconciled()
     {
-        // A retired alias shim left by an older install; no other drift.
+        // A retired alias shim left by an older install; no other drift. A legacy shim only exists on a
+        // machine that already installed the bundle, so record the bundle - otherwise the state reads as a
+        // truly-empty fresh install and the from-nothing provision (case d) fires instead of a pure purge.
+        RecordBundleInstalled();
         Directory.CreateDirectory(_layout.BinDir);
         var legacy = Path.Combine(_layout.BinDir, "cc-send.cmd");
         File.WriteAllText(legacy, "@echo off\r\n");
@@ -231,6 +242,93 @@ public sealed class ToolReconcilerTests : IDisposable
             release.Set();
             holderThread.Join();
         }
+    }
+
+    // (d) EMPTY tools state -> provision from nothing (the snappy-install first-run trigger) -------------
+
+    // Revert-proof for "first-run provisions from nothing": with a truly-empty tools state (no recorded
+    // bundle, no sidecar, no venv, no shims - exactly what the installer now leaves behind), ReconcileAsync
+    // must drive the from-scratch provision via the heavy release-backed path. Revert-proof: make
+    // ToolsBundleAbsent() return false (gate out the case-(d) escalation) -> heavy.Calls == 0 and this reds.
+    [Fact]
+    public async Task ReconcileAsync_EmptyToolsState_ProvisionsFromNothing()
+    {
+        // Nothing on disk at all: no PlaceVenvScripts, no RecordExpectedScripts, no RecordBundleInstalled.
+        var heavy = new FakeHeavyRepair(success: true);
+
+        var result = await new ToolReconciler(_layout, heavy.InvokeAsync).ReconcileAsync();
+
+        Assert.Equal(1, heavy.Calls); // the empty state escalated to the from-nothing provision
+        Assert.Equal(ReconcileOutcome.Reconciled, result.Outcome);
+        Assert.Contains(result.Actions, a => a.Contains("bundle", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_EmptyToolsState_ProvisionFails_ReturnsFailed()
+    {
+        var heavy = new FakeHeavyRepair(success: false);
+
+        var result = await new ToolReconciler(_layout, heavy.InvokeAsync).ReconcileAsync();
+
+        Assert.Equal(1, heavy.Calls);
+        Assert.Equal(ReconcileOutcome.Failed, result.Outcome);
+        Assert.False(string.IsNullOrEmpty(result.Error));
+    }
+
+    // A recorded bundle version means the machine already provisioned once, so the empty-state provision
+    // must NOT fire - the ordinary drift/health checks govern instead (here: a lone healthy install, InSync).
+    [Fact]
+    public async Task ReconcileAsync_BundleRecorded_DoesNotReprovision()
+    {
+        RecordBundleInstalled();
+        PlaceVenvScripts("cc-pdf");
+        RecordExpectedScripts("cc-pdf");
+        new PythonToolsInstaller(_layout).WriteShims(new[] { "cc-pdf" });
+        var heavy = new FakeHeavyRepair(success: true);
+
+        var result = await new ToolReconciler(_layout, heavy.InvokeAsync).ReconcileAsync();
+
+        Assert.Equal(0, heavy.Calls); // already provisioned -> no from-nothing rebuild
+        Assert.Equal(ReconcileOutcome.InSync, result.Outcome);
+    }
+
+    // Two first-launch Directors: the second (mutex held by the first) does NOT force a second provision.
+    [Fact]
+    public async Task ReconcileAsync_EmptyToolsState_AnotherDirectorHoldsMutex_SkipsProvision()
+    {
+        var heavy = new FakeHeavyRepair(success: true);
+
+        using var acquired = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+        var holderThread = new Thread(() =>
+        {
+            using var holder = new Mutex(initiallyOwned: false, ToolReconciler.HeavyRepairMutexName, out _);
+            holder.WaitOne();
+            acquired.Set();
+            release.Wait();
+            holder.ReleaseMutex();
+        });
+        holderThread.Start();
+        Assert.True(acquired.Wait(TimeSpan.FromSeconds(5)), "holder thread did not acquire the mutex");
+        try
+        {
+            var result = await new ToolReconciler(_layout, heavy.InvokeAsync).ReconcileAsync();
+
+            Assert.Equal(0, heavy.Calls); // did not force a provision while another first-launch Director holds the lock
+            Assert.Contains(result.Actions, a => a.Contains("skipped", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            release.Set();
+            holderThread.Join();
+        }
+    }
+
+    [Fact]
+    public void HasDrift_EmptyToolsState_ReturnsTrue()
+    {
+        // Nothing installed yet -> the indicator must show "Syncing tools..." and drive the provision.
+        Assert.True(new ToolReconciler(_layout).HasDrift());
     }
 
     // HasDrift: the read-only probe the active indicator uses (issue #829) --------------------------------

--- a/tools/cc-director-setup-engine.Tests/ToolReconcilerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/ToolReconcilerTests.cs
@@ -54,6 +54,47 @@ public sealed class ToolReconcilerTests : IDisposable
 
     private string ShimPath(string name) => Path.Combine(_layout.BinDir, name + ".cmd");
 
+    /// <summary>
+    /// Place ONLY the venv interpreter (no manifest, no sidecar, no console scripts) - the residue a FAILED
+    /// first provision leaves: PythonToolsInstaller creates the interpreter before pip runs, and pip can then
+    /// fail, so the post-success records are never written.
+    /// </summary>
+    private void PlaceVenvInterpreter()
+    {
+        Directory.CreateDirectory(_layout.PyenvBinDir);
+        File.WriteAllText(Path.Combine(_layout.PyenvBinDir, "python.exe"), "fake-python");
+    }
+
+    /// <summary>
+    /// A heavy-repair delegate that records its calls and, on success, writes exactly what a real successful
+    /// provision writes (console script + shim + installed manifest + expected-scripts sidecar) so a later
+    /// reconcile can tell a recovered install from a still-empty one.
+    /// </summary>
+    private sealed class RecordingHeavyRepair
+    {
+        private readonly InstallLayout _layout;
+        private readonly bool _success;
+        public int Calls { get; private set; }
+        public RecordingHeavyRepair(InstallLayout layout, bool success) { _layout = layout; _success = success; }
+
+        public Task<PythonToolsResult> InvokeAsync(CancellationToken ct)
+        {
+            Calls++;
+            if (_success)
+            {
+                Directory.CreateDirectory(_layout.PyenvScriptsDir);
+                File.WriteAllText(PythonToolsInstaller.ConsoleScriptPath(_layout, "cc-pdf"), "fake-exe");
+                new PythonToolsInstaller(_layout).WriteShims(new[] { "cc-pdf" });
+                var manifest = InstalledManifest.Load(_layout);
+                manifest.Set(PythonToolsInstaller.ComponentId, "1.0.0");
+                manifest.Save(_layout);
+                PythonToolsState.SaveScripts(_layout, new[] { "cc-pdf" });
+            }
+            return Task.FromResult(new PythonToolsResult(
+                _success, _success ? "provisioned" : "provision failed", Array.Empty<string>(), _success ? 1 : 0, _success ? "1.0.0" : null));
+        }
+    }
+
     /// <summary>A heavy-repair delegate that records whether it was called and returns a fixed result.</summary>
     private sealed class FakeHeavyRepair
     {
@@ -322,6 +363,47 @@ public sealed class ToolReconcilerTests : IDisposable
             release.Set();
             holderThread.Join();
         }
+    }
+
+    // Retry-safety: a FAILED first provision leaves a bare venv interpreter but neither post-success record.
+    // The reconcile must still provision (retry) - the partial interpreter must NOT be read as "installed".
+    // Revert-proof: re-add `&& !PythonToolsInstaller.IsVenvPresent(_layout)` to ToolsBundleAbsent (the exact
+    // bug) -> the partial interpreter suppresses provision, heavy.Calls == 0, and this reds.
+    [Fact]
+    public async Task ReconcileAsync_PartialVenvInterpreterNoRecords_StillProvisions()
+    {
+        PlaceVenvInterpreter(); // interpreter present, but no manifest and no sidecar (pip failed on first run)
+        var heavy = new FakeHeavyRepair(success: true);
+
+        var result = await new ToolReconciler(_layout, heavy.InvokeAsync).ReconcileAsync();
+
+        Assert.Equal(1, heavy.Calls); // the partial interpreter did NOT suppress the retry
+        Assert.Equal(ReconcileOutcome.Reconciled, result.Outcome);
+        Assert.Contains(result.Actions, a => a.Contains("bundle", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // Full lifecycle: a failed first provision leaves an interpreter; the next reconcile retries even though
+    // the first still fails; a later succeeding provision recovers (writes the post-success records); once
+    // recovered, further reconciles do NOT re-provision.
+    [Fact]
+    public async Task ReconcileAsync_FailedFirstProvision_RetriesUntilRecovery_ThenStops()
+    {
+        PlaceVenvInterpreter();
+
+        var stillFailing = new FakeHeavyRepair(success: false);
+        var firstRetry = await new ToolReconciler(_layout, stillFailing.InvokeAsync).ReconcileAsync();
+        Assert.Equal(1, stillFailing.Calls);                 // retried despite the leftover interpreter
+        Assert.Equal(ReconcileOutcome.Failed, firstRetry.Outcome);
+
+        var recovering = new RecordingHeavyRepair(_layout, success: true);
+        var recovered = await new ToolReconciler(_layout, recovering.InvokeAsync).ReconcileAsync();
+        Assert.Equal(1, recovering.Calls);                   // retried AGAIN and this time succeeded
+        Assert.Equal(ReconcileOutcome.Reconciled, recovered.Outcome);
+
+        var afterRecovery = new RecordingHeavyRepair(_layout, success: true);
+        var steady = await new ToolReconciler(_layout, afterRecovery.InvokeAsync).ReconcileAsync();
+        Assert.Equal(0, afterRecovery.Calls);                // records now present -> no more re-provision
+        Assert.Equal(ReconcileOutcome.InSync, steady.Outcome);
     }
 
     [Fact]

--- a/tools/cc-director-setup-engine/InstallerToolsProvisioning.cs
+++ b/tools/cc-director-setup-engine/InstallerToolsProvisioning.cs
@@ -1,0 +1,38 @@
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// The installer's Python-tools provisioning step, extracted from the (Avalonia/WPF) wizard install
+/// runners so the "snappy install" decision lives in ONE pinnable place away from the untestable
+/// wizard bootstrap - the same seam discipline as <c>GatewayRefresh</c>.
+///
+/// In the snappy-install design the INSTALLER does NOT provision the shared-venv cc-* tools bundle:
+/// downloading the ~334 MB bundle, building the venv, and offline pip-installing ~20 wheels is the
+/// dominant install time ("3-8 min"). Instead the app provisions the bundle FROM NOTHING on first
+/// launch via the startup reconcile (<see cref="ToolReconciler.ReconcileAsync"/>), so the install
+/// places only the Director + Launcher (+ skills) and returns fast.
+///
+/// The real provisioner (<see cref="PythonToolsInstaller.InstallAsync"/>, wrapped by each wizard) is
+/// passed in so a test can prove the installer NEVER invokes it.
+/// </summary>
+public static class InstallerToolsProvisioning
+{
+    /// <summary>
+    /// Run the installer's tools step. Returns the number of cc-* tools the installer provisioned.
+    /// By design this is 0 and <paramref name="provisionTools"/> is never invoked - the app provisions
+    /// the tools on first launch. The real provisioner is accepted (and deliberately not called) so the
+    /// removal is pinnable at the exact production line.
+    /// </summary>
+    public static Task<int> ProvisionDuringInstallAsync(
+        Func<CancellationToken, Task<int>> provisionTools,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(provisionTools);
+
+        // SNAPPY INSTALL: the installer does NOT provision the shared-venv cc-* tools bundle. The app
+        // provisions it from nothing on first launch (ToolReconciler startup reconcile), so the multi-
+        // minute bundle download never runs during install. Reverting this to
+        //     return provisionTools(ct);
+        // re-introduces tool provisioning into the installer -> InstallerToolsProvisioningTests reds.
+        return Task.FromResult(0);
+    }
+}

--- a/tools/cc-director-setup-engine/PythonToolsInstaller.cs
+++ b/tools/cc-director-setup-engine/PythonToolsInstaller.cs
@@ -389,6 +389,19 @@ public sealed class PythonToolsInstaller
     }
 
     /// <summary>
+    /// True when the shared venv interpreter is present on disk - the earliest "the tools bundle has been
+    /// provisioned" signal (the venv python is created before any console script or manifest record). A pure
+    /// read used by <see cref="ToolReconciler"/> to tell a truly-empty fresh install (no venv at all) apart
+    /// from an installed-but-possibly-drifted one, so the reconcile knows when to provision from nothing.
+    /// </summary>
+    public static bool IsVenvPresent(InstallLayout layout)
+    {
+        ArgumentNullException.ThrowIfNull(layout);
+        var venvPython = Path.Combine(layout.PyenvBinDir, OperatingSystem.IsWindows() ? "python.exe" : "python3");
+        return File.Exists(venvPython);
+    }
+
+    /// <summary>
     /// The retired per-tool fleet commands that were consolidated into the single cc-devthrottle command
     /// (issue #823): cc-send, cc-ask, cc-spawn, cc-sessions, cc-whoami, cc-settings, cc-cron,
     /// cc-fleet-selftest. Their executables no longer ship in the venv, so any bin shim an older install

--- a/tools/cc-director-setup-engine/PythonToolsInstaller.cs
+++ b/tools/cc-director-setup-engine/PythonToolsInstaller.cs
@@ -389,19 +389,6 @@ public sealed class PythonToolsInstaller
     }
 
     /// <summary>
-    /// True when the shared venv interpreter is present on disk - the earliest "the tools bundle has been
-    /// provisioned" signal (the venv python is created before any console script or manifest record). A pure
-    /// read used by <see cref="ToolReconciler"/> to tell a truly-empty fresh install (no venv at all) apart
-    /// from an installed-but-possibly-drifted one, so the reconcile knows when to provision from nothing.
-    /// </summary>
-    public static bool IsVenvPresent(InstallLayout layout)
-    {
-        ArgumentNullException.ThrowIfNull(layout);
-        var venvPython = Path.Combine(layout.PyenvBinDir, OperatingSystem.IsWindows() ? "python.exe" : "python3");
-        return File.Exists(venvPython);
-    }
-
-    /// <summary>
     /// The retired per-tool fleet commands that were consolidated into the single cc-devthrottle command
     /// (issue #823): cc-send, cc-ask, cc-spawn, cc-sessions, cc-whoami, cc-settings, cc-cron,
     /// cc-fleet-selftest. Their executables no longer ship in the venv, so any bin shim an older install

--- a/tools/cc-director-setup-engine/ToolReconciler.cs
+++ b/tools/cc-director-setup-engine/ToolReconciler.cs
@@ -240,17 +240,20 @@ public sealed class ToolReconciler
     }
 
     /// <summary>
-    /// True when NO shared-venv Python tools bundle is provisioned yet - the truly-empty fresh-install state
-    /// the (snappy) installer now leaves behind. Empty means NONE of the "the bundle exists in some form"
-    /// signals are present: no bundle version recorded in the installed manifest, no recorded expected-scripts
-    /// sidecar (written after a healthy install), and no venv interpreter on disk. A pure read. When this is
-    /// true the reconcile provisions the bundle from nothing; once any of those signals exists, this is false
-    /// and the ordinary drift/health checks (a)/(b)/(c) govern instead.
+    /// True when NO shared-venv Python tools bundle has been SUCCESSFULLY provisioned - the state the (snappy)
+    /// installer now leaves behind, AND the residue a FAILED first provision leaves. It keys ONLY off the two
+    /// post-success records that <see cref="PythonToolsInstaller.InstallAsync"/> writes together and only after
+    /// pip fully succeeds and every console script is verified: the installed-manifest bundle version and the
+    /// expected-scripts sidecar. It deliberately does NOT treat a bare venv interpreter as "provisioned":
+    /// the installer creates the interpreter BEFORE pip runs, so a pip failure/timeout leaves an interpreter
+    /// with neither record - if that suppressed provisioning, a transient first-run failure would brick the
+    /// tools until manual repair (the broken-venv check can't see it either, since it needs the sidecar). A
+    /// pure read. When true the reconcile provisions from nothing and RETRIES after a partial failure; once a
+    /// healthy install writes its records, this is false and the ordinary drift/health checks (a)/(b)/(c) govern.
     /// </summary>
     private bool ToolsBundleAbsent()
         => InstalledManifest.Load(_layout).Get(PythonToolsInstaller.ComponentId) is null
-           && PythonToolsState.LoadScripts(_layout).Count == 0
-           && !PythonToolsInstaller.IsVenvPresent(_layout);
+           && PythonToolsState.LoadScripts(_layout).Count == 0;
 
     /// <summary>
     /// Run the heavy release-backed venv work under the machine-wide mutex - either a repair of a broken venv

--- a/tools/cc-director-setup-engine/ToolReconciler.cs
+++ b/tools/cc-director-setup-engine/ToolReconciler.cs
@@ -83,6 +83,27 @@ public sealed class ToolReconciler
         FileLog.Write("[ToolReconciler] ReconcileAsync: detecting tool drift");
         try
         {
+            // (d) EMPTY tools state (the first-run trigger the snappy install relies on): the installer no
+            //     longer provisions the shared-venv cc-* tools bundle, so a fresh install arrives here with
+            //     NOTHING - no recorded bundle version and no venv on disk. Provision the full bundle FROM
+            //     NOTHING via the same release-backed heavy path, under the machine-wide mutex so two
+            //     first-launch Directors never provision the shared venv at once. This runs BEFORE the
+            //     shim/venv drift checks below, which all assume an already-provisioned venv.
+            if (ToolsBundleAbsent())
+            {
+                FileLog.Write("[ToolReconciler] no Python tools bundle present (fresh install); provisioning from nothing");
+                var provisionActions = new List<string>();
+                var provisionFailure = await EscalateHeavyRepairAsync(
+                    provisionActions, ct,
+                    logReason: "no Python tools bundle present; provisioning it from nothing",
+                    successAction: "provisioned the Python tools bundle from nothing (first run)");
+                if (provisionFailure is { } failed)
+                    return failed;
+                var provisionOutcome = provisionActions.Count > 0 ? ReconcileOutcome.Reconciled : ReconcileOutcome.InSync;
+                FileLog.Write($"[ToolReconciler] ReconcileAsync done: outcome={provisionOutcome}, actions={provisionActions.Count}");
+                return new ReconcileResult(provisionOutcome, provisionActions);
+            }
+
             // --- DETECT (pure reads, no mutation) -----------------------------------------------------
             var installer = new PythonToolsInstaller(_layout);
             var catalog = new ToolCatalogService(_layout.BinDir);
@@ -147,7 +168,10 @@ public sealed class ToolReconciler
             //     the machine-wide mutex so two Directors never rebuild the shared venv at once.
             if (venvBroken)
             {
-                var heavy = await EscalateHeavyRepairAsync(actions, ct);
+                var heavy = await EscalateHeavyRepairAsync(
+                    actions, ct,
+                    logReason: "venv is broken; escalating to the release-backed repair",
+                    successAction: "rebuilt the shared Python tools venv");
                 if (heavy is { } failure)
                     return failure; // heavy repair failed -> Failed (light actions already recorded)
                 if (actions.Count > 0)
@@ -179,6 +203,12 @@ public sealed class ToolReconciler
     {
         try
         {
+            // (d) EMPTY tools state (fresh install): nothing to shim/repair yet, but the reconcile WILL
+            //     provision the bundle from nothing - so the active indicator must show "Syncing tools..."
+            //     and drive a reconcile. Mirrors ReconcileAsync's case (d).
+            if (ToolsBundleAbsent())
+                return true;
+
             var installer = new PythonToolsInstaller(_layout);
             var catalog = new ToolCatalogService(_layout.BinDir);
             var descriptors = catalog.GetCatalog();
@@ -210,12 +240,28 @@ public sealed class ToolReconciler
     }
 
     /// <summary>
-    /// Run the heavy release-backed venv repair under the machine-wide mutex. Returns null on success (the
-    /// action is appended to <paramref name="actions"/>) or a skip-note; returns a Failed result when the
-    /// repair itself failed. If another Director already holds the mutex, we do NOT force - we log the skip
-    /// and leave the rebuild to the holder.
+    /// True when NO shared-venv Python tools bundle is provisioned yet - the truly-empty fresh-install state
+    /// the (snappy) installer now leaves behind. Empty means NONE of the "the bundle exists in some form"
+    /// signals are present: no bundle version recorded in the installed manifest, no recorded expected-scripts
+    /// sidecar (written after a healthy install), and no venv interpreter on disk. A pure read. When this is
+    /// true the reconcile provisions the bundle from nothing; once any of those signals exists, this is false
+    /// and the ordinary drift/health checks (a)/(b)/(c) govern instead.
     /// </summary>
-    private async Task<ReconcileResult?> EscalateHeavyRepairAsync(List<string> actions, CancellationToken ct)
+    private bool ToolsBundleAbsent()
+        => InstalledManifest.Load(_layout).Get(PythonToolsInstaller.ComponentId) is null
+           && PythonToolsState.LoadScripts(_layout).Count == 0
+           && !PythonToolsInstaller.IsVenvPresent(_layout);
+
+    /// <summary>
+    /// Run the heavy release-backed venv work under the machine-wide mutex - either a repair of a broken venv
+    /// or a from-nothing provision on first run. Returns null on success (the action is appended to
+    /// <paramref name="actions"/>) or a skip-note; returns a Failed result when the work itself failed. If
+    /// another Director already holds the mutex, we do NOT force - we log the skip and leave the work to the
+    /// holder. <paramref name="logReason"/> and <paramref name="successAction"/> tailor the wording so the log
+    /// and the reported action distinguish a repair from a first-run provision.
+    /// </summary>
+    private async Task<ReconcileResult?> EscalateHeavyRepairAsync(
+        List<string> actions, CancellationToken ct, string logReason, string successAction)
     {
         using var mutex = new Mutex(initiallyOwned: false, HeavyRepairMutexName, out _);
         var held = false;
@@ -227,20 +273,20 @@ public sealed class ToolReconciler
             if (!held)
             {
                 FileLog.Write("[ToolReconciler] reconcile skipped - another Director is reconciling");
-                actions.Add("heavy venv repair skipped - another Director is reconciling");
+                actions.Add("heavy venv work skipped - another Director is reconciling");
                 return null;
             }
 
-            FileLog.Write("[ToolReconciler] venv is broken; escalating to the release-backed repair");
+            FileLog.Write($"[ToolReconciler] {logReason}");
             var repair = await _heavyRepairAsync(ct);
             if (!repair.Success)
             {
-                FileLog.Write($"[ToolReconciler] heavy venv repair FAILED: {repair.Message}");
+                FileLog.Write($"[ToolReconciler] heavy venv work FAILED: {repair.Message}");
                 return new ReconcileResult(ReconcileOutcome.Failed, actions, repair.Message);
             }
 
-            FileLog.Write($"[ToolReconciler] heavy venv repair succeeded: {repair.Message}");
-            actions.Add($"rebuilt the shared Python tools venv ({repair.Message})");
+            FileLog.Write($"[ToolReconciler] heavy venv work succeeded: {repair.Message}");
+            actions.Add($"{successAction} ({repair.Message})");
             return null;
         }
         finally

--- a/tools/cc-director-setup/MainWindow.xaml.cs
+++ b/tools/cc-director-setup/MainWindow.xaml.cs
@@ -304,7 +304,6 @@ public partial class MainWindow : Window
         var runner = new EngineInstallRunner
         {
             OnProcessBlocking = OnProcessBlockingAsync,
-            OnToolsInstalled = c => Dispatcher.BeginInvoke(() => _installStep?.SetToolsInstalledCount(c)),
         };
         _installPath = runner.BinDir;
         _directorExePath = runner.AppExePath;
@@ -395,7 +394,6 @@ public partial class MainWindow : Window
         var runner = new EngineInstallRunner
         {
             OnProcessBlocking = OnProcessBlockingAsync,
-            OnToolsInstalled = c => Dispatcher.BeginInvoke(() => _installStep?.SetToolsInstalledCount(c)),
         };
         _installPath = runner.BinDir;
         _directorExePath = runner.AppExePath;

--- a/tools/cc-director-setup/Services/EngineInstallRunner.cs
+++ b/tools/cc-director-setup/Services/EngineInstallRunner.cs
@@ -84,18 +84,10 @@ public sealed class EngineInstallRunner
             byId[c.Id] = item;
         }
 
-        // One row for all cc-* Python tools (the shared-venv bundle).
-        var bundleItem = new ToolDownloadItem
-        {
-            Name = PythonToolsInstaller.ComponentId,
-            AssetName = PythonToolsInstaller.ToolsAsset,
-        };
-        var pyAsset = release.Manifest.TryGetAsset(PythonToolsInstaller.PythonAsset);
-        var toolsAsset = release.Manifest.TryGetAsset(PythonToolsInstaller.ToolsAsset);
-        if (pyAsset is null || toolsAsset is null) { bundleItem.Status = "Skipped"; bundleItem.SizeText = "Not in release"; }
-        else bundleItem.SizeText = FormatSize(pyAsset.Size + toolsAsset.Size);
-        items.Add(bundleItem);
-        byId[PythonToolsInstaller.ComponentId] = bundleItem;
+        // The shared-venv cc-* Python tools bundle is deliberately NOT an install-time row anymore: the
+        // installer no longer provisions it (that ~334 MB download + venv build was the dominant install
+        // time). The app provisions the bundle from nothing on first launch (ToolReconciler startup
+        // reconcile), so the Install screen shows an honest "finishes on first launch" note instead.
 
         var reader = new InstalledStateReader(_layout);
         var installedDirector = reader.Read(ComponentRegistry.Director).Version;
@@ -161,8 +153,11 @@ public sealed class EngineInstallRunner
             Set(prep, r.ComponentId, status, r.Error);
         }
 
-        // Install every Python tool as one shared venv (no-ops cleanly if the release has no bundle).
-        var toolCount = await InstallPythonToolsAsync(prep, ct);
+        // The installer does NOT provision the Python tools bundle - the app provisions it from nothing on
+        // first launch (see InstallerToolsProvisioning). The real provisioner is wired but deliberately not
+        // invoked, so re-enabling it is a one-line revert pinned by InstallerToolsProvisioningTests.
+        var toolCount = await InstallerToolsProvisioning.ProvisionDuringInstallAsync(
+            innerCt => InstallPythonToolsAsync(prep, innerCt), ct);
 
         MigrateLegacyDirector();
         PathManager.AddToPath(_layout.BinDir);

--- a/tools/cc-director-setup/Steps/InstallStep.xaml
+++ b/tools/cc-director-setup/Steps/InstallStep.xaml
@@ -78,97 +78,20 @@
                     </Grid>
                 </Border>
 
-                <!-- Tools section -->
+                <!-- Tools section: the cc-* command-line tools are provisioned by the app on first launch,
+                     not by the installer (that kept the install snappy). This is an honest note, not a
+                     live install row. -->
                 <Border Background="#2A2D2E" CornerRadius="6" Padding="16">
                     <StackPanel>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-
-                            <StackPanel Grid.Column="0">
-                                <TextBlock Text="Tools"
-                                           Foreground="White"
-                                           FontSize="16"
-                                           FontWeight="SemiBold" />
-                                <TextBlock x:Name="ToolsSummary"
-                                           Text="0 tools"
-                                           Foreground="#888888"
-                                           FontSize="12"
-                                           Margin="0,2,0,0" />
-                                <ProgressBar x:Name="ToolsOverallProgress"
-                                             Height="3" Margin="0,8,24,0"
-                                             Background="#3C3C3C" Foreground="#007ACC"
-                                             BorderThickness="0"
-                                             Visibility="Collapsed" />
-                            </StackPanel>
-
-                            <TextBlock x:Name="ToolsStatus"
-                                       Grid.Column="1"
-                                       Text="Pending"
-                                       Foreground="#CCCCCC"
-                                       FontSize="13" FontWeight="SemiBold"
-                                       VerticalAlignment="Center" />
-                        </Grid>
-
-                        <!-- Expandable tool details -->
-                        <Expander x:Name="ToolsExpander"
-                                  Header="Show details"
-                                  Foreground="#888888"
-                                  FontSize="11"
-                                  Margin="0,12,0,0"
-                                  IsExpanded="False">
-                            <ItemsControl x:Name="ToolList" Margin="0,8,0,0">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <Grid Margin="0,0,0,3">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="60" />
-                                                <ColumnDefinition Width="70" />
-                                            </Grid.ColumnDefinitions>
-
-                                            <TextBlock Text="{Binding Name}"
-                                                       Foreground="#AAAAAA"
-                                                       FontSize="12" />
-
-                                            <TextBlock Grid.Column="1"
-                                                       Text="{Binding SizeText}"
-                                                       Foreground="#666666"
-                                                       FontSize="11"
-                                                       HorizontalAlignment="Right" />
-
-                                            <TextBlock Grid.Column="2"
-                                                       Text="{Binding Status}"
-                                                       FontSize="11"
-                                                       FontWeight="SemiBold"
-                                                       HorizontalAlignment="Right">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Setter Property="Foreground" Value="#666666" />
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding Status}" Value="Done">
-                                                                <Setter Property="Foreground" Value="#22C55E" />
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding Status}" Value="Downloading">
-                                                                <Setter Property="Foreground" Value="#007ACC" />
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding Status}" Value="Failed">
-                                                                <Setter Property="Foreground" Value="#CC4444" />
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding Status}" Value="Locked">
-                                                                <Setter Property="Foreground" Value="#E5A100" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-                                        </Grid>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </Expander>
+                        <TextBlock Text="Tools"
+                                   Foreground="White"
+                                   FontSize="16"
+                                   FontWeight="SemiBold" />
+                        <TextBlock Text="Your cc-* command-line tools finish setting up the first time you open DevThrottle."
+                                   Foreground="#888888"
+                                   FontSize="12"
+                                   TextWrapping="Wrap"
+                                   Margin="0,2,0,0" />
                     </StackPanel>
                 </Border>
 

--- a/tools/cc-director-setup/Steps/InstallStep.xaml.cs
+++ b/tools/cc-director-setup/Steps/InstallStep.xaml.cs
@@ -13,12 +13,7 @@ namespace CcDirectorSetup.Steps;
 public partial class InstallStep : UserControl
 {
     private ToolDownloadItem? _directorItem;
-    private List<ToolDownloadItem> _toolItems = [];
     private List<SkillItem> _skillItems = [];
-
-    // The real cc-* tool count, reported by the installer once the bundle finishes. The bundle is a
-    // single row, so the row count is not the tool count; null until known.
-    private int? _toolsInstalledCount;
 
     public InstallStep()
     {
@@ -87,12 +82,9 @@ public partial class InstallStep : UserControl
     public void SetItems(List<ToolDownloadItem> items)
     {
         _directorItem = items.FirstOrDefault(i => i.Name == "cc-director");
-        _toolItems = items.Where(i => i.Name != "cc-director").ToList();
 
-        ToolList.ItemsSource = _toolItems;
-        // The bundle is one row representing many cc-* tools, so don't show the row count ("1 tools").
-        // The real count arrives via SetToolsInstalledCount when the bundle finishes.
-        ToolsSummary.Text = "cc-* command-line tools";
+        // The cc-* tools are no longer installed here (the app provisions them on first launch), so the
+        // Tools card is a static note - there are no tool rows to bind or track.
 
         // Set up skills list
         _skillItems = SkillInstaller.SkillNames
@@ -125,21 +117,6 @@ public partial class InstallStep : UserControl
                 });
             };
         }
-
-        // Track overall tool progress. Status drives the summary text; Progress (set live by pip
-        // streaming inside PythonToolsInstaller) drives the bar so the user sees motion during
-        // the multi-minute python-tools step.
-        foreach (var tool in _toolItems)
-        {
-            var capturedTool = tool;
-            capturedTool.PropertyChanged += (_, e) =>
-            {
-                if (e.PropertyName == nameof(ToolDownloadItem.Status))
-                    Dispatcher.BeginInvoke(UpdateToolsSummaryStatus);
-                else if (e.PropertyName == nameof(ToolDownloadItem.Progress))
-                    Dispatcher.BeginInvoke(() => ToolsOverallProgress.Value = capturedTool.Progress);
-            };
-        }
     }
 
     public event Action? OnRepairRequested;
@@ -162,8 +139,6 @@ public partial class InstallStep : UserControl
 
         DirectorStatus.Text = "Up to date";
         DirectorStatus.Foreground = upToDateColor;
-        ToolsStatus.Text = "Up to date";
-        ToolsStatus.Foreground = upToDateColor;
         SkillsStatus.Text = "Up to date";
         SkillsStatus.Foreground = upToDateColor;
     }
@@ -208,17 +183,9 @@ public partial class InstallStep : UserControl
         GatewayProgress.Visibility = Visibility.Collapsed;
     }
 
-    /// <summary>Record the real installed cc-* tool count (the bundle is one row) and refresh the summary.</summary>
-    public void SetToolsInstalledCount(int count)
-    {
-        _toolsInstalledCount = count;
-        UpdateToolsSummaryStatus();
-    }
-
     public void ShowProgress()
     {
         DirectorProgress.Visibility = Visibility.Visible;
-        ToolsOverallProgress.Visibility = Visibility.Visible;
     }
 
     public List<SkillItem> GetSkillItems() => _skillItems;
@@ -230,38 +197,5 @@ public partial class InstallStep : UserControl
         SkillsStatus.Foreground = new SolidColorBrush(
             (Color)ColorConverter.ConvertFromString("#22C55E"));
         SkillsSummary.Text = $"{done}/{_skillItems.Count} skills installed";
-    }
-
-    private void UpdateToolsSummaryStatus()
-    {
-        var done = _toolItems.Count(t => t.Status == "Done");
-        var failed = _toolItems.Count(t => t.Status == "Failed");
-        var locked = _toolItems.Count(t => t.Status == "Locked");
-        var skipped = _toolItems.Count(t => t.Status == "Skipped");
-        var total = _toolItems.Count;
-        var processed = done + failed + locked + skipped;
-
-        if (processed == total)
-        {
-            // The bundle row counts as one; prefer the real cc-* tool count when the installer
-            // has reported it (e.g. 26), falling back to the row count only if unknown.
-            var shown = _toolsInstalledCount ?? done;
-            ToolsStatus.Text = $"{shown} installed";
-            ToolsStatus.Foreground = new SolidColorBrush(
-                (Color)ColorConverter.ConvertFromString("#22C55E"));
-            ToolsSummary.Text = skipped > 0
-                ? $"{shown} installed, {skipped} not yet released"
-                : $"{shown} installed";
-            ToolsOverallProgress.Visibility = Visibility.Collapsed;
-        }
-        else
-        {
-            // Surface the bundle row's live Status (e.g. "Installing 5/23: scipy...") so the user sees
-            // motion even when the install details Expander is collapsed. Bar value is driven from the
-            // row's Progress property (set live by pip streaming) — don't overwrite it here.
-            var active = _toolItems.FirstOrDefault(
-                t => t.Status is not "Pending" and not "Done" and not "Failed" and not "Locked" and not "Skipped");
-            ToolsStatus.Text = active?.Status ?? "Installing...";
-        }
     }
 }


### PR DESCRIPTION
Moves the `cc-*` Python tools provisioning out of the installer and onto first launch, so the Install step finishes in seconds instead of waiting on a bundle download plus an offline pip install.

This is finished, independently reviewed work that was never delivered. The branch was approved and then sat: no pull request had ever been opened for it.

## Correcting the numbers this change has been carried under

The slice brief describes the tools bundle as "~334 MB" taking "3-8 min", and the win has been described as removing that from install time. Both figures are stale, and the second describes the win incorrectly.

Measured on a real install log on a Windows machine on a 94 megabit line (`%LOCALAPPDATA%\cc-director\logs\setup\setup-20260719-023305.log`):

| Phase | Duration |
|---|---|
| Tools bundle: download 22.0 MB + 98.4 MB, stage Python, build the venv, install 95 wheels | **66.7 s** |
| Everything else: place 11 components, shortcut, 3 skills, launcher | 1.2 s |
| **Total, Install click to Complete** | **74.1 s** |

So the bundle on the wire is **120.4 MB, not 334 MB**, and the step took **67 seconds, not 3-8 minutes**.

Where the stale numbers came from:

- **334 MB** is a comment in `tools/cc-director-setup-engine/PythonToolsInstaller.cs:93-94` quoting an old progress string, `"Downloading 118.2 MB / 334.5 MB"`.
- **3 minutes** is `docs/install/INSTALLER_HANDOVER.md:125`, which dates from v0.6.3 and describes installing **23** tools. The release ships **9** today (`tools/registry.json`, entries with `"ship": true`). The bundle shrank and nobody re-measured.

**And the win is a move, not a removal.** The 67 seconds does not disappear - it relocates to first launch, where the app provisions the bundle in the background. The user still waits for it before any `cc-*` tool works. What actually improves:

- the Install step drops from about 74 seconds to about 7 seconds, so the wizard reaches Complete quickly and the window opens;
- the wait overlaps with the user's first actions instead of blocking a progress bar;
- an update no longer rebuilds the whole venv when the app is going to reconcile it anyway.

That is a real improvement and worth shipping. It is not several minutes off the clock, and nothing downstream should be planned as though it were.

## What is in the change

- The installer no longer runs Python tools provisioning. Both WPF and Avalonia runners call a common no-op seam (`InstallerToolsProvisioning`).
- The Install screen says so honestly rather than silently dropping the row.
- First-run provisioning from nothing is guaranteed: `ToolReconciler` treats an absent bundle record as drift and drives a full heavy provision, so a fresh install with no tools present provisions the whole bundle on first launch.
- The Gateway GUI's child `install --role gateway --component gateway` pass no longer provisions Python tools, via one component-scope decision used both to narrow the plan and to gate the tools install.
- Partial first-provision residue (a bare venv interpreter with no manifest and no sidecar) is now recognised and retried instead of being mistaken for a healthy install.

## Review status

Independently reviewed at `3d26c6d3` - `devthrottle_internal` `docs/install/codex-review-tools-out-v2.md`: **no blocking findings, both fixes PASS with revert-proofs reproduced against the production lines, verdict APPROVE.** Suites at review time: engine 329 passed, cli 27 passed, WPF setup 32 passed; release builds of the WPF setup, the Avalonia setup and the Director app all clean.

Rebased from `3d26c6d3` onto current `origin/main` for this pull request. The rebase is content-identical: the only differences in the patch are blob hashes and a 20-line offset in `Commands.cs`, where main has since added the hosted enrolment code above it.

## Not covered

Live network provisioning of the bundle and human GUI rendering were not exercised by the review. Those need a real install on a real machine, which is the human QA handoff.
