### PR TITLE
fix(gateway): tenant-composite primary keys for caller-supplied keys (snoozes, session_spend, push_subscriptions)

### DIFF
--- a/docs/architecture/hosted-gateway-qa.md
+++ b/docs/architecture/hosted-gateway-qa.md
@@ -445,3 +445,93 @@ The hosted Gateway is validated end to end: a real Director authenticates and tu
 URL, a real operation persists through it into the isolated Supabase gateway schema, state survives an App
 Service restart, and the tunnel holds past the idle cap. The isolated test Director (pid 38432) and its
 scratch CC_DIRECTOR_ROOT were torn down after the run.
+
+## Tenant scoping - the PRIMARY KEY half (snoozes, session_spend, push_subscriptions)
+
+Date: 2026-07-19
+
+Issue #1840 made `cron_jobs`, `workflows`, `workflow_versions` and `mission_notes` tenant-composite. A
+persistence census afterwards found three tenant-scoped tables still keyed on CALLER-SUPPLIED input with
+`tenant_id` present only as a data column:
+
+- `snoozes` - primary key `SessionId` (the session id a Director presents on a snooze request)
+- `session_spend` - primary key `SessionId` (the session id on a record-spend request)
+- `push_subscriptions` - primary key `Endpoint` (the browser's push URL)
+
+### Why that is a defect, not a style point
+
+Every store upserts the same way: read THROUGH the tenant query filter, and add when the read finds nothing.
+So a second tenant presenting an identifier the first tenant already holds reads nothing (the filter hides the
+other tenant's row), takes the insert branch, and the database rejects it on the primary key. That is a
+cross-tenant SQUAT (the second tenant cannot use that identifier at all, because another tenant has it) and an
+EXISTENCE ORACLE (the failure discloses that another tenant holds it). No row content crosses the boundary,
+but the key space does.
+
+Reproduced before the fix by driving the REAL stores (`SnoozeRegistry`, `SessionSpendStore`,
+`PushSubscriptionStore`) with two tenants over one database - three tests, three failures, each
+`SQLite Error 19: 'UNIQUE constraint failed: <table>.<key>'`.
+
+### The fix
+
+`GatewayDbContext` now gives all three a composite primary key, following #1840 exactly:
+`(tenant_id, SessionId)`, `(tenant_id, SessionId)`, `(tenant_id, Endpoint)`. No store code changed - every
+lookup already goes through a filtered LINQ query, never `Find(key)`.
+
+### The guard that should have caught it
+
+`TenantScopeGuardTests` asserted the tenant COLUMN and the query FILTER, and is structurally blind to the KEY -
+which is exactly how these three passed it. A third assertion,
+`EveryTenantScopedTable_HasTenantIdInItsPrimaryKey_UnlessTheGatewayMintsTheKeyItself`, now requires every
+tenant-scoped table's primary key to include `tenant_id`, unless the key is one the Gateway itself mints.
+
+That exemption is a TYPE, not a written list. The first attempt was an allowlist of ten table names, each with a
+sentence asserting "this store mints the key with `Guid.NewGuid()`", re-checked by asserting the key was still a
+single `Guid`. That check could not fail for the change it existed to catch: a store switching from minting its
+key to accepting one from the caller keeps the key a single `Guid`, so the guard stayed green in precisely the
+dangerous case - which is worse than no guard, because it reads as protection and stops anyone downstream from
+looking.
+
+The exemption is now `GatewayMintedKeyEntity`, whose `Id` has a PRIVATE setter and is minted by the base class
+itself. The ten entities derive from it and no longer declare their own `Id`. Assigning a caller-supplied value
+to one of these keys is not a test failure found later - it does not compile. The three ways to escape that are
+each closed by construction:
+
+| Escape | What stops it |
+|---|---|
+| Assign a caller-supplied value to the key | Compile error `CS0272` - the setter is inaccessible |
+| Widen the setter so that compiles again | `TheGatewayMintedKey_CanOnlyBeWrittenByTheBaseClassThatMintsIt` turns red |
+| Re-declare a settable `Id` on the derived entity, or drop the base class | The primary-key test requires the mapped key property to be DECLARED ON `GatewayMintedKeyEntity`, so it turns red |
+
+Each of those three was verified by making the change and watching the failure, and both guards were confirmed
+green again once it was reverted.
+
+### The migration, and what it does to existing rows
+
+One migration per provider, generated from the same model:
+`Data/Migrations/20260719201700_CallerSuppliedKeysScopedByTenant` (SQLite) and
+`Migrations/20260719201740_CallerSuppliedKeysScopedByTenant` (Postgres). Each drops the three single-column
+primary keys and adds the composite ones. `dotnet ef migrations has-pending-model-changes` reports no pending
+changes on BOTH providers.
+
+Existing rows are preserved, and that is established by RUNNING the upgrade, not by reading the operations.
+`CallerSuppliedKeyUpgradePreservesRowsTests` migrates a database to the migration immediately before this one,
+inserts rows through raw SQL the way a database in the field holds them, migrates the rest of the way, and
+asserts every row and every column value is unchanged. It also asserts the migration actually ran - by name out
+of `__EFMigrationsHistory`, and by the key really being composite afterwards - so a migration that silently did
+nothing cannot pass by leaving the rows undisturbed. A second test shows the upgrade delivers what it is for:
+before it, a second tenant reusing a session id is refused on the primary key; after it, both rows coexist.
+
+This matters because the reasoning below is NOT sufficient on its own. On SQLite a primary key cannot be altered
+in place, so EF turns each operation pair into a table rebuild, and whether the copy carries every row and every
+column value is a property of that generated rebuild rather than of the three lines anyone reads in the
+migration file. The supporting reasons:
+
+- No row is deleted, inserted, or edited. On SQLite a primary-key change is a table REBUILD (EF creates the new
+  table, copies every row, drops the old, renames); on Postgres it is `ALTER TABLE ... DROP CONSTRAINT` plus
+  `ADD PRIMARY KEY`, with no table rewrite.
+- Uniqueness cannot be violated by existing data: the OLD key already made the second column unique on its own,
+  so `(tenant_id, <that column>)` is unique a fortiori. There is no possible duplicate to trip on.
+- `tenant_id` is already NOT NULL on all three tables (`ApplyTenantScope` marks it required), which a primary-key
+  column must be, so no backfill and no nullability change is needed.
+- On a single-tenant install every row is `tenant_id = 'local'`, so the composite key behaves identically to the
+  old one and the upgrade is invisible.

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260719201740_CallerSuppliedKeysScopedByTenant.Designer.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260719201740_CallerSuppliedKeysScopedByTenant.Designer.cs
@@ -3,42 +3,51 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace CcDirector.Gateway.Data.Migrations
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719201740_CallerSuppliedKeysScopedByTenant")]
+    partial class CallerSuppliedKeysScopedByTenant
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "9.0.2");
+            modelBuilder
+                .HasDefaultSchema("gateway")
+                .HasAnnotation("ProductVersion", "9.0.2")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountHostedAiSpendEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<long>("AmountMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Kind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("TransactionCreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -48,108 +57,108 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "Kind", "AmountMicros", "TransactionCreatedUtc");
 
-                    b.ToTable("account_hosted_ai_spend", (string)null);
+                    b.ToTable("account_hosted_ai_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CronExpression")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("LastFiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LastStatus")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("NextRunUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("NotifyOn")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("NotifyWebhookUrl")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("PreventOverlap")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("RunAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ScheduleKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TimeZoneId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("cron_jobs", (string)null);
+                    b.ToTable("cron_jobs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("FiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("InfraStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("JobId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Machine")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ScheduledUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("Sequence")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TargetDirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TaskStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -158,44 +167,44 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("JobId", "Sequence");
 
-                    b.ToTable("cron_runs", (string)null);
+                    b.ToTable("cron_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceAuditEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Actor")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Category")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -208,40 +217,40 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_audit_events", (string)null);
+                    b.ToTable("governance_audit_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Reason")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("State")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SubjectKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -254,109 +263,112 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_events", (string)null);
+                    b.ToTable("governance_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.MissionNoteEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Mission")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Why")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("mission_notes", (string)null);
+                    b.ToTable("mission_notes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.PushSubscriptionEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Endpoint")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Auth")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("P256dh")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Endpoint");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("push_subscriptions", (string)null);
+                    b.ToTable("push_subscriptions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionSpendEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AgentKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BillingMode")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("CacheCreationTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<long>("CacheReadTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("FirstObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("InputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("LastObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long?>("MeteredCostMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Model")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("OutputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("TokensCaptured")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.HasKey("TenantId", "SessionId");
 
@@ -364,138 +376,141 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "LastObservedUtc");
 
-                    b.ToTable("session_spend", (string)null);
+                    b.ToTable("session_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SnoozeEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("OwnerTurnBaselineUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int?>("PendingMinutes")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime?>("SnoozeUntilUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("TenantId", "SessionId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("snoozes", (string)null);
+                    b.ToTable("snoozes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AccountSubject")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Email")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
                     b.HasIndex("AccountSubject")
                         .IsUnique();
 
-                    b.ToTable("tenants", (string)null);
+                    b.ToTable("tenants", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WingmanInstructionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AckDefaultContent")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AckDefaultVersion")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActiveVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("wingman_instructions", (string)null);
+                    b.ToTable("wingman_instructions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Consumer")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("worklists", (string)null);
+                    b.ToTable("worklists", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListItemEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Area")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ItemId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("Position")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("WorkListId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -503,75 +518,75 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkListId", "Position");
 
-                    b.ToTable("worklist_items", (string)null);
+                    b.ToTable("worklist_items", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Archived")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("Enabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("boolean")
                         .HasDefaultValue(true);
 
                     b.Property<bool>("IsBuiltIn")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<int>("LatestVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("PublishedVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ShippedContentHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflows", (string)null);
+                    b.ToTable("workflows", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowFileEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("VersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -579,71 +594,71 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("VersionId");
 
-                    b.ToTable("workflow_files", (string)null);
+                    b.ToTable("workflow_files", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AcceptanceStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AcceptedBy")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("AcceptedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("CompletedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("MissionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Outcome")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Guid?>("ParentRunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("StartedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("WorkflowVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<Guid>("WorkflowVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -653,66 +668,66 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkflowId");
 
-                    b.ToTable("workflow_runs", (string)null);
+                    b.ToTable("workflow_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowVersionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AuthoredBy")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ChangeNote")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("HumanCheckpoint")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("InstructionsMarkdown")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("PublishedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Summary")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<int>("Version")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("WhenToUse")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -721,7 +736,7 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.HasIndex("TenantId", "WorkflowId", "Version")
                         .IsUnique();
 
-                    b.ToTable("workflow_versions", (string)null);
+                    b.ToTable("workflow_versions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
@@ -729,28 +744,28 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobAction", "Action", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<bool>("AutoDismiss")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("boolean");
 
                             b1.Property<string>("RepoPath")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Seed")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("WorkListName")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Action");
 
@@ -761,18 +776,18 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobTarget", "Target", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Target");
 
@@ -792,36 +807,36 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Data.Entities.WingmanInstructionVersionOwned", "Versions", b1 =>
                         {
                             b1.Property<Guid>("WingmanInstructionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Content")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("CreatedAtUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Hash")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Id")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Label")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Source")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WingmanInstructionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("wingman_instructions");
+                            b1.ToTable("wingman_instructions", "gateway");
 
                             b1.ToJson("Versions");
 
@@ -846,35 +861,35 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunCriterionResultDto", "CriteriaResults", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime?>("EvaluatedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Evaluator")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Note")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofUrl")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Status")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("CriteriaResults");
 
@@ -885,37 +900,37 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunParticipantDto", "Participants", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("AgentKind")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("JoinedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<DateTime?>("LeftUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Role")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("SessionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("Participants");
 
@@ -926,23 +941,23 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunProofLinkDto", "ProofLinks", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Label")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Url")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("ProofLinks");
 
@@ -962,26 +977,26 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowOutcomeCriterionDto", "OutcomeCriteria", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofHint")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("OutcomeCriteria");
 
@@ -992,34 +1007,34 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowStepDto", "Steps", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Doer")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Done")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Name")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Reviewer")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("Steps");
 

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260719201740_CallerSuppliedKeysScopedByTenant.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260719201740_CallerSuppliedKeysScopedByTenant.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class CallerSuppliedKeysScopedByTenant : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_snoozes",
+                schema: "gateway",
+                table: "snoozes");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_session_spend",
+                schema: "gateway",
+                table: "session_spend");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_push_subscriptions",
+                schema: "gateway",
+                table: "push_subscriptions");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_snoozes",
+                schema: "gateway",
+                table: "snoozes",
+                columns: new[] { "tenant_id", "SessionId" });
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_session_spend",
+                schema: "gateway",
+                table: "session_spend",
+                columns: new[] { "tenant_id", "SessionId" });
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_push_subscriptions",
+                schema: "gateway",
+                table: "push_subscriptions",
+                columns: new[] { "tenant_id", "Endpoint" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_snoozes",
+                schema: "gateway",
+                table: "snoozes");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_session_spend",
+                schema: "gateway",
+                table: "session_spend");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_push_subscriptions",
+                schema: "gateway",
+                table: "push_subscriptions");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_snoozes",
+                schema: "gateway",
+                table: "snoozes",
+                column: "SessionId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_session_spend",
+                schema: "gateway",
+                table: "session_spend",
+                column: "SessionId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_push_subscriptions",
+                schema: "gateway",
+                table: "push_subscriptions",
+                column: "Endpoint");
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
@@ -293,6 +293,10 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.PushSubscriptionEntity", b =>
                 {
+                    b.Property<string>("TenantId")
+                        .HasColumnType("text")
+                        .HasColumnName("tenant_id");
+
                     b.Property<string>("Endpoint")
                         .HasColumnType("text")
                         .UseCollation("C");
@@ -308,12 +312,7 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<string>("TenantId")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("tenant_id");
-
-                    b.HasKey("Endpoint");
+                    b.HasKey("TenantId", "Endpoint");
 
                     b.HasIndex("TenantId");
 
@@ -322,6 +321,10 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionSpendEntity", b =>
                 {
+                    b.Property<string>("TenantId")
+                        .HasColumnType("text")
+                        .HasColumnName("tenant_id");
+
                     b.Property<string>("SessionId")
                         .HasColumnType("text")
                         .UseCollation("C");
@@ -361,15 +364,10 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.Property<string>("RepoPath")
                         .HasColumnType("text");
 
-                    b.Property<string>("TenantId")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("tenant_id");
-
                     b.Property<bool>("TokensCaptured")
                         .HasColumnType("boolean");
 
-                    b.HasKey("SessionId");
+                    b.HasKey("TenantId", "SessionId");
 
                     b.HasIndex("TenantId");
 
@@ -380,6 +378,10 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SnoozeEntity", b =>
                 {
+                    b.Property<string>("TenantId")
+                        .HasColumnType("text")
+                        .HasColumnName("tenant_id");
+
                     b.Property<string>("SessionId")
                         .HasColumnType("text")
                         .UseCollation("C");
@@ -396,12 +398,7 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.Property<DateTime?>("SnoozeUntilUtc")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("TenantId")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("tenant_id");
-
-                    b.HasKey("SessionId");
+                    b.HasKey("TenantId", "SessionId");
 
                     b.HasIndex("TenantId");
 

--- a/src/CcDirector.Gateway.Tests/Data/CallerSuppliedKeyUpgradePreservesRowsPostgresTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/CallerSuppliedKeyUpgradePreservesRowsPostgresTests.cs
@@ -1,0 +1,307 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Data;
+
+/// <summary>
+/// The PostgreSQL half of the upgrade proof: an actual pre-change Postgres database, with rows in it, carried
+/// through this exact migration.
+///
+/// The SQLite sibling (<see cref="CallerSuppliedKeyUpgradePreservesRowsTests"/>) proves nothing about this
+/// provider, and neither do the existing Postgres proof tests. Those migrate an EMPTY schema from nothing, so
+/// they exercise SQL generation and constraint naming but never carry a single row across a primary-key
+/// change. The two providers also do genuinely different things here: SQLite cannot alter a primary key in
+/// place and rebuilds the whole table, while Postgres issues <c>ALTER TABLE ... DROP CONSTRAINT</c> plus
+/// <c>ADD PRIMARY KEY</c> and rewrites nothing. Postgres therefore has strictly less to lose - but "strictly
+/// less to lose" is a reason to expect it to pass, not evidence that it does, and reasoning from the generated
+/// DDL is exactly what this test exists to replace.
+///
+/// GATING. Like <see cref="PostgresProviderProofTests"/>, the whole class is gated on the
+/// <c>CC_GATEWAY_TEST_PG_CONNECTION</c> environment variable and reports SKIPPED when it is unset, so the
+/// ordinary SQLite test run is untouched. Skipped is not passed: with no server configured this test makes no
+/// claim at all rather than a false one. Point the variable at a throwaway Postgres to run it.
+///
+/// The test must start from a database with NO gateway schema, because it migrates forward from a specific
+/// earlier migration. It therefore drops first, and <see cref="GuardThrowawayDatabase"/> refuses to drop
+/// anything whose database name does not begin with the dedicated <c>ccpg</c> prefix - the same guard, and the
+/// same reasoning, as the existing Postgres proofs.
+/// </summary>
+public sealed class CallerSuppliedKeyUpgradePreservesRowsPostgresTests
+{
+    private const string ConnectionEnvVar = "CC_GATEWAY_TEST_PG_CONNECTION";
+
+    /// <summary>The migration immediately before the change under test - the "pre-change database".</summary>
+    private const string MigrationBeforeTheChange = "CompositeTenantKeys";
+
+    /// <summary>The change under test.</summary>
+    private const string MigrationUnderTest = "CallerSuppliedKeysScopedByTenant";
+
+    /// <summary>A Fact that skips itself when <see cref="ConnectionEnvVar"/> is unset, so the default test run
+    /// (SQLite, no Postgres server) is unaffected. Setting Skip in the attribute reports the test as SKIPPED
+    /// rather than passed, so an unconfigured machine never mistakes absence for proof.</summary>
+    private sealed class RequiresPostgresFactAttribute : FactAttribute
+    {
+        public RequiresPostgresFactAttribute()
+        {
+            if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ConnectionEnvVar)))
+                Skip = $"Set {ConnectionEnvVar} to a Postgres connection string to run the real-Postgres " +
+                       "pre-change-row upgrade proof.";
+        }
+    }
+
+    private static string Connection =>
+        Environment.GetEnvironmentVariable(ConnectionEnvVar)
+        ?? throw new InvalidOperationException($"{ConnectionEnvVar} is not set.");
+
+    /// <summary>The same wiring the runtime hosted Gateway uses: Npgsql, the Postgres migrations assembly, and
+    /// the migrations history table in the <c>gateway</c> schema.</summary>
+    private static GatewayDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<GatewayDbContext>()
+            .UseNpgsql(Connection, npg =>
+            {
+                npg.MigrationsAssembly("CcDirector.Gateway.Migrations.Postgres");
+                npg.MigrationsHistoryTable("__EFMigrationsHistory", "gateway");
+            })
+            .Options;
+        return new GatewayDbContext(options) { ActiveTenant = TenantId.Local.Value };
+    }
+
+    /// <summary>
+    /// Refuse to drop a database that is not obviously a throwaway. <c>EnsureDeleted()</c> would DROP whatever
+    /// the connection points at, so the target database NAME must begin with the dedicated throwaway prefix
+    /// "ccpg" - a token no real database would carry. A loose substring marker like "test" is deliberately NOT
+    /// used: it matches ordinary names such as "latest" or "contest", which would defeat the guard.
+    /// </summary>
+    private static void GuardThrowawayDatabase()
+    {
+        var database = new NpgsqlConnectionStringBuilder(Connection).Database ?? "";
+        if (!database.StartsWith("ccpg", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException(
+                $"Refusing to drop database '{database}': the upgrade proof recreates the database from " +
+                $"nothing, so {ConnectionEnvVar} must point at a throwaway whose name starts with 'ccpg'.");
+    }
+
+    private static void MigrateTo(string? target)
+    {
+        using var ctx = NewContext();
+        AccessorExtensions.GetService<IMigrator>(ctx).Migrate(target);
+    }
+
+    /// <summary>
+    /// The assumption this whole proof rests on, asserted instead of assumed: that
+    /// <see cref="MigrationBeforeTheChange"/> is the migration IMMEDIATELY before
+    /// <see cref="MigrationUnderTest"/> in the POSTGRES migration set, so migrating to it produces the exact
+    /// pre-change schema and the second migrate applies THIS change and nothing else.
+    ///
+    /// It is checked because breaking it is SILENT, and independently so per provider - the two sets are
+    /// generated separately, so one can gain a migration in between while the other does not. If that
+    /// happens, nothing in this file changes, a range-diff of this branch shows everything identical, and
+    /// every assertion below still passes: the rows are still preserved and the key still ends up composite.
+    /// The test would simply have stopped isolating this change. Text-identity is not meaning-identity.
+    /// </summary>
+    private static void AssertThisProofStillIsolatesTheMigrationUnderTest()
+    {
+        using var ctx = NewContext();
+        var all = ctx.Database.GetMigrations().ToList();
+
+        var underTest = all.FindIndex(m => m.EndsWith(MigrationUnderTest, StringComparison.Ordinal));
+        Assert.True(underTest >= 0,
+            $"'{MigrationUnderTest}' is not in the Postgres migration set at all - this proof is pointed at " +
+            "a migration that no longer exists.");
+        Assert.True(underTest > 0, $"'{MigrationUnderTest}' is now the FIRST Postgres migration, so there " +
+            "is no pre-change schema to upgrade from.");
+
+        Assert.True(all[underTest - 1].EndsWith(MigrationBeforeTheChange, StringComparison.Ordinal),
+            $"This proof assumes '{MigrationBeforeTheChange}' is the migration immediately before " +
+            $"'{MigrationUnderTest}' on Postgres, but the migration before it is now " +
+            $"'{all[underTest - 1]}'. Another change has landed in between, so migrating to the named one no " +
+            "longer produces the pre-change schema and this test would be carrying rows across that other " +
+            "migration too while reporting the result as evidence about this one. Re-point the constant and " +
+            "re-read the fixture against the new predecessor - do not simply update the name.");
+    }
+
+    private static void Execute(string sql)
+    {
+        using var connection = new NpgsqlConnection(Connection);
+        connection.Open();
+        using var command = new NpgsqlCommand(sql, connection);
+        command.ExecuteNonQuery();
+    }
+
+    private static List<Dictionary<string, object?>> Query(string sql)
+    {
+        var rows = new List<Dictionary<string, object?>>();
+        using var connection = new NpgsqlConnection(Connection);
+        connection.Open();
+        using var command = new NpgsqlCommand(sql, connection);
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            var row = new Dictionary<string, object?>(StringComparer.Ordinal);
+            for (var i = 0; i < reader.FieldCount; i++)
+                row[reader.GetName(i)] = reader.IsDBNull(i) ? null : reader.GetValue(i);
+            rows.Add(row);
+        }
+
+        return rows;
+    }
+
+    /// <summary>The columns of a table's PRIMARY KEY, in key order, straight from the Postgres catalogue.</summary>
+    private static List<string> PrimaryKeyColumns(string table)
+        => Query(
+                "SELECT a.attname FROM pg_index i " +
+                "JOIN pg_class c ON c.oid = i.indrelid " +
+                "JOIN pg_namespace n ON n.oid = c.relnamespace " +
+                "JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(i.indkey) " +
+                $"WHERE n.nspname = 'gateway' AND c.relname = '{table}' AND i.indisprimary " +
+                "ORDER BY array_position(i.indkey, a.attnum)")
+            .Select(r => (string)r["attname"]!)
+            .ToList();
+
+    [RequiresPostgresFact]
+    public void UpgradingAPostgresDatabaseThatAlreadyHasRows_KeepsEveryRow_AndMakesTheKeyComposite()
+    {
+        GuardThrowawayDatabase();
+        using (var ctx = NewContext())
+            ctx.Database.EnsureDeleted();
+
+        // 0. The proof still isolates THIS migration - see the method for why this cannot be assumed.
+        AssertThisProofStillIsolatesTheMigrationUnderTest();
+
+        // 1. A database at exactly the pre-change schema.
+        MigrateTo(MigrationBeforeTheChange);
+
+        // The pre-change keys really are the single-column ones - otherwise step 3 would prove nothing,
+        // because the schema would already have been what we are trying to migrate TO.
+        Assert.Equal(new[] { "SessionId" }, PrimaryKeyColumns("snoozes"));
+        Assert.Equal(new[] { "SessionId" }, PrimaryKeyColumns("session_spend"));
+        Assert.Equal(new[] { "Endpoint" }, PrimaryKeyColumns("push_subscriptions"));
+
+        // 2. Rows written the way a database in the field holds them - two tenants, and nullable columns
+        //    exercised both null and populated.
+        Execute("""
+            INSERT INTO gateway.snoozes ("SessionId", tenant_id, "DirectorId", "OwnerTurnBaselineUtc", "PendingMinutes", "SnoozeUntilUtc")
+            VALUES ('session-alpha', 'tenant-one', 'director-a', TIMESTAMPTZ '2026-07-20 09:00:00Z',   15, TIMESTAMPTZ '2026-07-20 10:00:00Z'),
+                   ('session-beta',  'tenant-two', 'director-b', NULL,                               NULL, TIMESTAMPTZ '2026-07-21 11:30:00Z');
+
+            INSERT INTO gateway.session_spend
+                ("SessionId", tenant_id, "AgentKind", "BillingMode", "CacheCreationTokens", "CacheReadTokens",
+                 "FirstObservedUtc", "InputTokens", "LastObservedUtc", "MeteredCostMicros", "Model",
+                 "OutputTokens", "RepoPath", "TokensCaptured")
+            VALUES ('session-alpha', 'tenant-one', 'claude', 'subscription', 11, 22,
+                    TIMESTAMPTZ '2026-07-20 08:00:00Z', 33, TIMESTAMPTZ '2026-07-20 09:00:00Z', 1234567,
+                    'opus', 44, 'D:\ReposFred\devthrottle', true),
+                   ('session-gamma', 'tenant-two', 'codex', 'metered', 0, 0,
+                    TIMESTAMPTZ '2026-07-20 09:15:00Z', 5, TIMESTAMPTZ '2026-07-20 09:30:00Z', NULL,
+                    NULL, 6, NULL, false);
+
+            INSERT INTO gateway.push_subscriptions ("Endpoint", tenant_id, "Auth", "CreatedAtUtc", "P256dh")
+            VALUES ('https://push.example/one', 'tenant-one', 'auth-one', TIMESTAMPTZ '2026-07-19 08:00:00Z', 'key-one'),
+                   ('https://push.example/two', 'tenant-two', 'auth-two', TIMESTAMPTZ '2026-07-19 08:05:00Z', 'key-two');
+            """);
+
+        var snoozesBefore = Query("""SELECT * FROM gateway.snoozes ORDER BY "SessionId" """);
+        var spendBefore = Query("""SELECT * FROM gateway.session_spend ORDER BY "SessionId" """);
+        var pushBefore = Query("""SELECT * FROM gateway.push_subscriptions ORDER BY "Endpoint" """);
+        Assert.Equal(2, snoozesBefore.Count);
+        Assert.Equal(2, spendBefore.Count);
+        Assert.Equal(2, pushBefore.Count);
+
+        // 3. The upgrade under test.
+        MigrateTo(target: null);
+
+        // 4a. The migration genuinely ran - by name out of the history table, and by its effect on the schema.
+        //     Without both, a migration that had silently done nothing would sail through the row assertions
+        //     below: the rows would be intact precisely because nothing had touched them.
+        Assert.Contains(
+            Query("""SELECT "MigrationId" FROM gateway."__EFMigrationsHistory" """)
+                .Select(r => (string)r["MigrationId"]!),
+            id => id.EndsWith(MigrationUnderTest, StringComparison.Ordinal));
+
+        Assert.Equal(new[] { "tenant_id", "SessionId" }, PrimaryKeyColumns("snoozes"));
+        Assert.Equal(new[] { "tenant_id", "SessionId" }, PrimaryKeyColumns("session_spend"));
+        Assert.Equal(new[] { "tenant_id", "Endpoint" }, PrimaryKeyColumns("push_subscriptions"));
+
+        // 4b. Every row survived, with every column value exactly what it was before the upgrade.
+        AssertRowsUnchanged(snoozesBefore, Query("""SELECT * FROM gateway.snoozes ORDER BY "SessionId" """), "snoozes");
+        AssertRowsUnchanged(spendBefore, Query("""SELECT * FROM gateway.session_spend ORDER BY "SessionId" """), "session_spend");
+        AssertRowsUnchanged(pushBefore, Query("""SELECT * FROM gateway.push_subscriptions ORDER BY "Endpoint" """), "push_subscriptions");
+    }
+
+    /// <summary>
+    /// Proves the Postgres upgrade also DELIVERS what it is for: after it, two tenants can each hold the same
+    /// caller-supplied session id, which the old single-column key made impossible. Before the change the
+    /// second insert is refused on the primary key - that refusal being both the cross-tenant squat and the
+    /// existence oracle this change removes.
+    /// </summary>
+    [RequiresPostgresFact]
+    public void AfterThePostgresUpgrade_TwoTenantsCanHoldTheSameCallerSuppliedIdentifier()
+    {
+        GuardThrowawayDatabase();
+        using (var ctx = NewContext())
+            ctx.Database.EnsureDeleted();
+
+        MigrateTo(MigrationBeforeTheChange);
+        Execute("""
+            INSERT INTO gateway.snoozes ("SessionId", tenant_id, "DirectorId", "SnoozeUntilUtc")
+            VALUES ('shared-session', 'tenant-one', 'director-first', TIMESTAMPTZ '2026-07-20 10:00:00Z');
+            """);
+
+        // The pre-change schema refuses the second tenant outright - the defect, demonstrated on Postgres.
+        var squat = Assert.Throws<PostgresException>(() => Execute("""
+            INSERT INTO gateway.snoozes ("SessionId", tenant_id, "DirectorId", "SnoozeUntilUtc")
+            VALUES ('shared-session', 'tenant-two', 'director-second', TIMESTAMPTZ '2026-07-20 10:00:00Z');
+            """));
+        Assert.Equal(PostgresErrorCodes.UniqueViolation, squat.SqlState);
+
+        MigrateTo(target: null);
+
+        // After the upgrade the same insert is accepted, and both rows coexist.
+        Execute("""
+            INSERT INTO gateway.snoozes ("SessionId", tenant_id, "DirectorId", "SnoozeUntilUtc")
+            VALUES ('shared-session', 'tenant-two', 'director-second', TIMESTAMPTZ '2026-07-20 10:00:00Z');
+            """);
+
+        var rows = Query("""
+            SELECT tenant_id, "DirectorId" FROM gateway.snoozes
+            WHERE "SessionId" = 'shared-session' ORDER BY tenant_id
+            """);
+        Assert.Equal(2, rows.Count);
+        Assert.Equal("tenant-one", rows[0]["tenant_id"]);
+        Assert.Equal("director-first", rows[0]["DirectorId"]);
+        Assert.Equal("tenant-two", rows[1]["tenant_id"]);
+        Assert.Equal("director-second", rows[1]["DirectorId"]);
+    }
+
+    private static void AssertRowsUnchanged(
+        List<Dictionary<string, object?>> before,
+        List<Dictionary<string, object?>> after,
+        string table)
+    {
+        Assert.True(before.Count == after.Count,
+            $"{table}: the upgrade changed the row count from {before.Count} to {after.Count} - rows were " +
+            "lost or duplicated.");
+
+        for (var i = 0; i < before.Count; i++)
+        {
+            Assert.True(before[i].Count == after[i].Count,
+                $"{table} row {i}: the upgrade changed the column count from {before[i].Count} to " +
+                $"{after[i].Count}.");
+
+            foreach (var (column, value) in before[i])
+            {
+                Assert.True(after[i].ContainsKey(column),
+                    $"{table} row {i}: column '{column}' is gone after the upgrade.");
+                Assert.True(Equals(value, after[i][column]),
+                    $"{table} row {i}: column '{column}' changed across the upgrade - was '{value}', " +
+                    $"now '{after[i][column]}'.");
+            }
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Data/CallerSuppliedKeyUpgradePreservesRowsTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/CallerSuppliedKeyUpgradePreservesRowsTests.cs
@@ -1,0 +1,270 @@
+using CcDirector.Gateway.Data;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Data;
+
+/// <summary>
+/// Proves the caller-supplied-key composite migration is a SAFE UPGRADE for a database that already holds
+/// rows - by actually running it, on a real database, with real rows in it.
+///
+/// This exists because the claim it checks cannot be established by reading the migration. The generated
+/// operations are three <c>DropPrimaryKey</c> / <c>AddPrimaryKey</c> pairs, and on SQLite a primary key
+/// cannot be altered in place at all: the provider silently turns each pair into a TABLE REBUILD - create a
+/// new table with the new key, copy the rows across, drop the original, rename. Whether the copy carries
+/// every row and every column value is a property of that generated rebuild, not of the three lines anyone
+/// reads in the migration file, so reasoning about the operations proves nothing about the data. The only
+/// evidence that counts is a database that had rows before and has the same rows after.
+///
+/// So the test walks the real upgrade path a deployed Gateway will walk:
+///   1. Migrate a fresh database to <c>CompositeTenantKeys</c> - the migration immediately BEFORE this
+///      change - so the schema is exactly the pre-change one, with single-column primary keys.
+///   2. Insert rows through raw SQL, not through EF. EF would map them with today's model and today's
+///      composite keys; raw SQL writes them the way a database in the field actually holds them.
+///   3. Migrate the rest of the way, applying the change under test.
+///   4. Assert every row is still present, with every column value unchanged - and that the key really did
+///      become composite, so a green result cannot come from the migration having quietly not run.
+///
+/// Postgres runs the same three operations against a provider that CAN alter a primary key in place, so it
+/// never rebuilds a table and has strictly less to lose. It is covered by the gated live-Postgres proof
+/// tests rather than here; this test needs no external service and always runs.
+/// </summary>
+public sealed class CallerSuppliedKeyUpgradePreservesRowsTests : IDisposable
+{
+    /// <summary>The migration immediately before the change under test - the "pre-change database".</summary>
+    private const string MigrationBeforeTheChange = "CompositeTenantKeys";
+
+    /// <summary>The change under test.</summary>
+    private const string MigrationUnderTest = "CallerSuppliedKeysScopedByTenant";
+
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cc-gateway-upgrade-tests-" + Guid.NewGuid().ToString("N"));
+
+    private string DbPath => Path.Combine(_dir, "gateway.db");
+
+    private string ConnectionString => "Data Source=" + DbPath;
+
+    public CallerSuppliedKeyUpgradePreservesRowsTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { /* best effort - the OS may hold the file briefly after the pool clear */ }
+    }
+
+    private GatewayDbContext NewContext()
+    {
+        var builder = new DbContextOptionsBuilder<GatewayDbContext>();
+        builder.UseSqlite(ConnectionString);
+        return new GatewayDbContext(builder.Options);
+    }
+
+    private void MigrateTo(string? target)
+    {
+        using var ctx = NewContext();
+        var migrator = AccessorExtensions.GetService<IMigrator>(ctx);
+        migrator.Migrate(target);
+    }
+
+    /// <summary>
+    /// The assumption this whole proof rests on, asserted instead of assumed: that
+    /// <see cref="MigrationBeforeTheChange"/> is the migration IMMEDIATELY before
+    /// <see cref="MigrationUnderTest"/>, so migrating to it produces the exact pre-change schema and the
+    /// second migrate applies THIS change and nothing else.
+    ///
+    /// It is checked because breaking it is SILENT. If another branch lands a migration between those two,
+    /// nothing in this file changes, a range-diff of this branch shows everything identical, and every
+    /// assertion below still passes - the rows are still preserved, the key still ends up composite. But the
+    /// test would no longer be isolating this change: it would be carrying rows across someone else's
+    /// migration as well and reporting the result as evidence about this one. Text-identity is not
+    /// meaning-identity, and a clean rebase is not a guarantee that a proof still proves what it did.
+    /// </summary>
+    private void AssertThisProofStillIsolatesTheMigrationUnderTest()
+    {
+        using var ctx = NewContext();
+        var all = ctx.Database.GetMigrations().ToList();
+
+        var underTest = all.FindIndex(m => m.EndsWith(MigrationUnderTest, StringComparison.Ordinal));
+        Assert.True(underTest >= 0,
+            $"'{MigrationUnderTest}' is not in the migration set at all - this proof is pointed at a " +
+            "migration that no longer exists.");
+        Assert.True(underTest > 0, $"'{MigrationUnderTest}' is now the FIRST migration, so there is no " +
+            "pre-change schema to upgrade from.");
+
+        Assert.True(all[underTest - 1].EndsWith(MigrationBeforeTheChange, StringComparison.Ordinal),
+            $"This proof assumes '{MigrationBeforeTheChange}' is the migration immediately before " +
+            $"'{MigrationUnderTest}', but the migration before it is now '{all[underTest - 1]}'. Another " +
+            "change has landed in between, so migrating to the named one no longer produces the pre-change " +
+            "schema and this test would be carrying rows across that other migration too while reporting " +
+            "the result as evidence about this one. Re-point the constant and re-read the fixture against " +
+            "the new predecessor - do not simply update the name.");
+    }
+
+    private void Execute(string sql)
+    {
+        using var connection = new SqliteConnection(ConnectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
+    private List<Dictionary<string, object?>> Query(string sql)
+    {
+        var rows = new List<Dictionary<string, object?>>();
+        using var connection = new SqliteConnection(ConnectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            var row = new Dictionary<string, object?>(StringComparer.Ordinal);
+            for (var i = 0; i < reader.FieldCount; i++)
+                row[reader.GetName(i)] = reader.IsDBNull(i) ? null : reader.GetValue(i);
+            rows.Add(row);
+        }
+
+        return rows;
+    }
+
+    /// <summary>The columns of a table's PRIMARY KEY, in key order, straight from SQLite's own catalogue.</summary>
+    private List<string> PrimaryKeyColumns(string table)
+        => Query($"SELECT name, pk FROM pragma_table_info('{table}') WHERE pk > 0 ORDER BY pk")
+            .Select(r => (string)r["name"]!)
+            .ToList();
+
+    [Fact]
+    public void UpgradingADatabaseThatAlreadyHasRows_KeepsEveryRow_AndMakesTheKeyComposite()
+    {
+        // 0. The proof still isolates THIS migration - see the method for why this cannot be assumed.
+        AssertThisProofStillIsolatesTheMigrationUnderTest();
+
+        // 1. A database at exactly the pre-change schema.
+        MigrateTo(MigrationBeforeTheChange);
+
+        // The pre-change keys really are the single-column ones - otherwise step 3 would prove nothing,
+        // because the schema would already have been what we are trying to migrate TO.
+        Assert.Equal(new[] { "SessionId" }, PrimaryKeyColumns("snoozes"));
+        Assert.Equal(new[] { "SessionId" }, PrimaryKeyColumns("session_spend"));
+        Assert.Equal(new[] { "Endpoint" }, PrimaryKeyColumns("push_subscriptions"));
+
+        // 2. Rows written the way a database in the field holds them - including two tenants, which is the
+        //    state the whole change exists to make representable.
+        Execute("""
+            INSERT INTO snoozes (SessionId, tenant_id, DirectorId, OwnerTurnBaselineUtc, PendingMinutes, SnoozeUntilUtc)
+            VALUES ('session-alpha', 'tenant-one', 'director-a', '2026-07-20 09:00:00',   15, '2026-07-20 10:00:00'),
+                   ('session-beta',  'tenant-two', 'director-b', NULL,                  NULL, '2026-07-21 11:30:00');
+
+            INSERT INTO session_spend
+                (SessionId, tenant_id, AgentKind, BillingMode, CacheCreationTokens, CacheReadTokens,
+                 FirstObservedUtc, InputTokens, LastObservedUtc, MeteredCostMicros, Model, OutputTokens,
+                 RepoPath, TokensCaptured)
+            VALUES ('session-alpha', 'tenant-one', 'claude', 'subscription', 11, 22,
+                    '2026-07-20 08:00:00', 33, '2026-07-20 09:00:00', 1234567, 'opus', 44,
+                    'D:\ReposFred\devthrottle', 1),
+                   ('session-gamma', 'tenant-two', 'codex',  'metered',       0,  0,
+                    '2026-07-20 09:15:00',  5, '2026-07-20 09:30:00',    NULL, NULL,   6,
+                    NULL, 0);
+
+            INSERT INTO push_subscriptions (Endpoint, tenant_id, Auth, CreatedAtUtc, P256dh)
+            VALUES ('https://push.example/one', 'tenant-one', 'auth-one', '2026-07-19 08:00:00', 'key-one'),
+                   ('https://push.example/two', 'tenant-two', 'auth-two', '2026-07-19 08:05:00', 'key-two');
+            """);
+
+        var snoozesBefore = Query("SELECT * FROM snoozes ORDER BY SessionId");
+        var spendBefore = Query("SELECT * FROM session_spend ORDER BY SessionId");
+        var pushBefore = Query("SELECT * FROM push_subscriptions ORDER BY Endpoint");
+        Assert.Equal(2, snoozesBefore.Count);
+        Assert.Equal(2, spendBefore.Count);
+        Assert.Equal(2, pushBefore.Count);
+
+        // 3. The upgrade under test - the SQLite table rebuild actually executes here.
+        MigrateTo(target: null);
+
+        // 4a. The migration genuinely ran - by name, out of the migrations history table, and by its effect
+        //     on the schema. Without both, a migration that had silently done nothing would sail through the
+        //     row assertions below: the rows would be intact precisely because nothing had touched them.
+        Assert.Contains(
+            Query("SELECT MigrationId FROM __EFMigrationsHistory").Select(r => (string)r["MigrationId"]!),
+            id => id.EndsWith(MigrationUnderTest, StringComparison.Ordinal));
+
+        Assert.Equal(new[] { "tenant_id", "SessionId" }, PrimaryKeyColumns("snoozes"));
+        Assert.Equal(new[] { "tenant_id", "SessionId" }, PrimaryKeyColumns("session_spend"));
+        Assert.Equal(new[] { "tenant_id", "Endpoint" }, PrimaryKeyColumns("push_subscriptions"));
+
+        // 4b. Every row survived, with every column value byte-for-byte what it was before the upgrade.
+        AssertRowsUnchanged(snoozesBefore, Query("SELECT * FROM snoozes ORDER BY SessionId"), "snoozes");
+        AssertRowsUnchanged(spendBefore, Query("SELECT * FROM session_spend ORDER BY SessionId"), "session_spend");
+        AssertRowsUnchanged(pushBefore, Query("SELECT * FROM push_subscriptions ORDER BY Endpoint"),
+            "push_subscriptions");
+    }
+
+    /// <summary>
+    /// Proves the upgrade also DELIVERS what it is for: after it, the two tenants can each hold the same
+    /// session id, which is precisely what the old single-column key made impossible. Before the change this
+    /// insert fails on the primary key - that failure being both the cross-tenant squat and the existence
+    /// oracle the change removes.
+    /// </summary>
+    [Fact]
+    public void AfterTheUpgrade_TwoTenantsCanHoldTheSameCallerSuppliedIdentifier()
+    {
+        MigrateTo(MigrationBeforeTheChange);
+        Execute("""
+            INSERT INTO snoozes (SessionId, tenant_id, DirectorId, SnoozeUntilUtc)
+            VALUES ('shared-session', 'tenant-one', 'director-first', '2026-07-20 10:00:00');
+            """);
+
+        // The pre-change schema refuses the second tenant outright - the defect, demonstrated.
+        var squat = Assert.Throws<SqliteException>(() => Execute("""
+            INSERT INTO snoozes (SessionId, tenant_id, DirectorId, SnoozeUntilUtc)
+            VALUES ('shared-session', 'tenant-two', 'director-second', '2026-07-20 10:00:00');
+            """));
+        Assert.Contains("UNIQUE constraint failed", squat.Message, StringComparison.Ordinal);
+
+        MigrateTo(target: null);
+
+        // After the upgrade the same insert is accepted, and both rows coexist.
+        Execute("""
+            INSERT INTO snoozes (SessionId, tenant_id, DirectorId, SnoozeUntilUtc)
+            VALUES ('shared-session', 'tenant-two', 'director-second', '2026-07-20 10:00:00');
+            """);
+
+        var rows = Query("SELECT tenant_id, DirectorId FROM snoozes WHERE SessionId = 'shared-session' ORDER BY tenant_id");
+        Assert.Equal(2, rows.Count);
+        Assert.Equal("tenant-one", rows[0]["tenant_id"]);
+        Assert.Equal("director-first", rows[0]["DirectorId"]);
+        Assert.Equal("tenant-two", rows[1]["tenant_id"]);
+        Assert.Equal("director-second", rows[1]["DirectorId"]);
+    }
+
+    private static void AssertRowsUnchanged(
+        List<Dictionary<string, object?>> before,
+        List<Dictionary<string, object?>> after,
+        string table)
+    {
+        Assert.True(before.Count == after.Count,
+            $"{table}: the upgrade changed the row count from {before.Count} to {after.Count} - rows were " +
+            "lost or duplicated by the table rebuild.");
+
+        for (var i = 0; i < before.Count; i++)
+        {
+            Assert.True(before[i].Count == after[i].Count,
+                $"{table} row {i}: the upgrade changed the column count from {before[i].Count} to " +
+                $"{after[i].Count}.");
+
+            foreach (var (column, value) in before[i])
+            {
+                Assert.True(after[i].ContainsKey(column),
+                    $"{table} row {i}: column '{column}' is gone after the upgrade.");
+                Assert.True(Equals(value, after[i][column]),
+                    $"{table} row {i}: column '{column}' changed across the upgrade - was '{value}', " +
+                    $"now '{after[i][column]}'.");
+            }
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Data/CompositeTenantKeyTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/CompositeTenantKeyTests.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Linq;
 using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Data.Entities;
+using CcDirector.Gateway.Governance;
+using CcDirector.Gateway.Push;
+using CcDirector.Gateway.Snooze;
 using CcDirector.Gateway.Tests.Data;
 using CcDirector.Gateway.Workflows;
 using Xunit;
@@ -11,12 +15,21 @@ namespace CcDirector.Gateway.Tests.Data;
 /// <summary>
 /// The composite tenant keys (Hosted Multi-Tenancy). Tables whose natural/fixed key is only unique PER TENANT
 /// - workflows (fixed built-in id), workflow_versions (built-in WorkflowId + version), mission_notes (mission
-/// name) - carry a COMPOSITE primary key/unique index that includes tenant_id, so the reserved SYSTEM tenant
-/// and a real (or leftover 'local') tenant can each hold their own copy without colliding at the database.
+/// name), cron_jobs (per-tenant minted short id), snoozes and session_spend (the session id a caller
+/// presents), push_subscriptions (the browser push endpoint a caller presents) - carry a COMPOSITE primary
+/// key/unique index that includes tenant_id, so the reserved SYSTEM tenant and a real (or leftover 'local')
+/// tenant can each hold their own copy without colliding at the database.
 ///
 /// The first test reproduces the EXACT production crash: a live single-tenant gateway (built-ins under
 /// 'local') upgrading to multi-tenant, whose startup SYSTEM seed would collide with the leftover 'local'
 /// built-ins on a non-composite key. With the composite key it upgrades automatically - no crash, no truncate.
+///
+/// The last three tests cover the CALLER-SUPPLIED half of the same hazard. Every store upserts by reading
+/// THROUGH the tenant query filter and adding when it finds nothing, so on a single-column key a second
+/// tenant presenting an identifier the first tenant already holds finds nothing (the filter hides the other
+/// tenant's row), inserts, and hits a PRIMARY KEY violation. That is a cross-tenant SQUAT (the second tenant
+/// cannot use an identifier the first holds) and an EXISTENCE ORACLE (the failure tells it the first holds
+/// it). These three drive the REAL stores, not the context directly, so they exercise the actual upsert.
 /// </summary>
 public sealed class CompositeTenantKeyTests
 {
@@ -118,6 +131,144 @@ public sealed class CompositeTenantKeyTests
         Assert.Equal("alice-job", ReadCronName(db, ambient, tenantA, "cj_shared"));
         Assert.Equal("bob-job", ReadCronName(db, ambient, tenantB, "cj_shared"));
     }
+
+    // ---- Caller-supplied keys: two tenants present the SAME session id / push endpoint ------------------
+
+    [Fact]
+    public void TwoTenants_SnoozeTheSameSessionId_BothSucceed_AndStayIsolated()
+    {
+        using var harness = new GatewayDbTestHarness();
+        var ambient = new AsyncLocalTenantContext();
+        var db = harness.Open(ambient);
+
+        var tenantA = new TenantId(Guid.NewGuid().ToString());
+        var tenantB = new TenantId(Guid.NewGuid().ToString());
+
+        SnoozeRegistry registry;
+        using (ambient.Enter(tenantA))
+            registry = new SnoozeRegistry(db, harness.LegacyPath("snoozes.json"));
+
+        // The session id is CALLER-SUPPLIED: it arrives on the snooze request from whatever Director asked.
+        // Nothing stops two tenants from presenting the same string.
+        const string sharedSessionId = "11111111-1111-1111-1111-111111111111";
+        var untilA = new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var untilB = new DateTime(2031, 2, 2, 0, 0, 0, DateTimeKind.Utc);
+
+        using (ambient.Enter(tenantA))
+            registry.Snooze(sharedSessionId, untilA, "director-a");
+
+        // On a SessionId-ONLY primary key the tenant filter hides tenant A's row, the store's upsert takes
+        // the insert branch, and the database rejects it - tenant A has squatted the id for everyone.
+        var crash = Record.Exception(() =>
+        {
+            using (ambient.Enter(tenantB))
+                registry.Snooze(sharedSessionId, untilB, "director-b");
+        });
+        Assert.Null(crash);
+
+        // Both directions of isolation: each tenant reads back its OWN hold and never the other's.
+        using (ambient.Enter(tenantA))
+        {
+            Assert.Equal(untilA, registry.SnoozeUntilFor(sharedSessionId));
+            Assert.Equal("director-a", registry.DirectorIdFor(sharedSessionId));
+        }
+        using (ambient.Enter(tenantB))
+        {
+            Assert.Equal(untilB, registry.SnoozeUntilFor(sharedSessionId));
+            Assert.Equal("director-b", registry.DirectorIdFor(sharedSessionId));
+        }
+    }
+
+    [Fact]
+    public void TwoTenants_RecordSpendForTheSameSessionId_BothSucceed_AndStayIsolated()
+    {
+        using var harness = new GatewayDbTestHarness();
+        var ambient = new AsyncLocalTenantContext();
+        var db = harness.Open(ambient);
+
+        var tenantA = new TenantId(Guid.NewGuid().ToString());
+        var tenantB = new TenantId(Guid.NewGuid().ToString());
+        var store = new SessionSpendStore(db);
+
+        const string sharedSessionId = "22222222-2222-2222-2222-222222222222";
+
+        using (ambient.Enter(tenantA))
+            store.Record(SpendRequest(sharedSessionId, "claude", inputTokens: 111));
+
+        var crash = Record.Exception(() =>
+        {
+            using (ambient.Enter(tenantB))
+                store.Record(SpendRequest(sharedSessionId, "codex", inputTokens: 222));
+        });
+        Assert.Null(crash);
+
+        using (ambient.Enter(tenantA))
+        {
+            var a = store.Get(sharedSessionId);
+            Assert.NotNull(a);
+            Assert.Equal("claude", a!.AgentKind);
+            Assert.Equal(111, a.InputTokens);
+        }
+        using (ambient.Enter(tenantB))
+        {
+            var b = store.Get(sharedSessionId);
+            Assert.NotNull(b);
+            Assert.Equal("codex", b!.AgentKind);
+            Assert.Equal(222, b.InputTokens);
+        }
+    }
+
+    [Fact]
+    public void TwoTenants_RegisterTheSamePushEndpoint_BothSucceed_AndStayIsolated()
+    {
+        using var harness = new GatewayDbTestHarness();
+        var ambient = new AsyncLocalTenantContext();
+        var db = harness.Open(ambient);
+
+        var tenantA = new TenantId(Guid.NewGuid().ToString());
+        var tenantB = new TenantId(Guid.NewGuid().ToString());
+
+        PushSubscriptionStore store;
+        using (ambient.Enter(tenantA))
+            store = new PushSubscriptionStore(db, harness.LegacyPath("push-subscriptions.json"));
+
+        // The endpoint is the browser's push URL - entirely caller-supplied, and the table's whole key.
+        const string sharedEndpoint = "https://push.example.test/send/shared-endpoint";
+
+        // Written in the OTHER order from the snooze test (tenant B first) so neither order is privileged.
+        using (ambient.Enter(tenantB))
+            store.Add(sharedEndpoint, "p256dh-b", "auth-b");
+
+        var crash = Record.Exception(() =>
+        {
+            using (ambient.Enter(tenantA))
+                store.Add(sharedEndpoint, "p256dh-a", "auth-a");
+        });
+        Assert.Null(crash);
+
+        using (ambient.Enter(tenantA))
+        {
+            var only = Assert.Single(store.All());
+            Assert.Equal(sharedEndpoint, only.Endpoint);
+            Assert.Equal("p256dh-a", only.P256dh);
+        }
+        using (ambient.Enter(tenantB))
+        {
+            var only = Assert.Single(store.All());
+            Assert.Equal(sharedEndpoint, only.Endpoint);
+            Assert.Equal("p256dh-b", only.P256dh);
+        }
+    }
+
+    private static RecordSessionSpendRequest SpendRequest(string sessionId, string agentKind, long inputTokens)
+        => new()
+        {
+            SessionId = sessionId,
+            AgentKind = agentKind,
+            TokensCaptured = true,
+            InputTokens = inputTokens,
+            BillingMode = "subscription-included",
+        };
 
     private static void WriteCronJob(CcDirector.Gateway.Data.GatewayDatabase db, AsyncLocalTenantContext ambient,
         TenantId tenant, string id, string name)

--- a/src/CcDirector.Gateway.Tests/Data/GatewayDatabaseLivePostgresProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/GatewayDatabaseLivePostgresProofTests.cs
@@ -106,14 +106,15 @@ public sealed class GatewayDatabaseLivePostgresProofTests
     public void JsonOwnedColumns_RoundTrip_OnConfiguredPostgres()
     {
         using var db = OpenGateway();
-        var id = Guid.NewGuid();
+        // The key is minted by GatewayMintedKeyEntity, not chosen here - read it back off the row we added.
+        // Left empty until then so the cleanup below is a no-op if the insert never happened.
+        var id = Guid.Empty;
         try
         {
             using (var ctx = db.CreateContext())
             {
-                ctx.WorkflowVersions.Add(new WorkflowVersionEntity
+                var row = new WorkflowVersionEntity
                 {
-                    Id = id,
                     TenantId = TenantId.Local.Value,
                     WorkflowId = "wf-live-json-proof",
                     Version = 1,
@@ -134,8 +135,10 @@ public sealed class GatewayDatabaseLivePostgresProofTests
                     ContentHash = "hash",
                     AuthoredBy = "test",
                     CreatedUtc = DateTime.UtcNow,
-                });
+                };
+                ctx.WorkflowVersions.Add(row);
                 ctx.SaveChanges();
+                id = row.Id;
             }
 
             using (var ctx = db.CreateContext())

--- a/src/CcDirector.Gateway.Tests/Data/PostgresProviderProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/PostgresProviderProofTests.cs
@@ -153,12 +153,12 @@ public sealed class PostgresProviderProofTests
     {
         EnsureMigrated();
 
-        var id = Guid.NewGuid();
+        // The key is minted by GatewayMintedKeyEntity, not chosen here - read it back off the row we added.
+        Guid id;
         using (var ctx = NewContext())
         {
-            ctx.WorkflowVersions.Add(new WorkflowVersionEntity
+            var row = new WorkflowVersionEntity
             {
-                Id = id,
                 TenantId = TenantId.Local.Value,
                 WorkflowId = "wf-json-proof",
                 Version = 1,
@@ -179,8 +179,10 @@ public sealed class PostgresProviderProofTests
                 ContentHash = "hash",
                 AuthoredBy = "test",
                 CreatedUtc = DateTime.UtcNow,
-            });
+            };
+            ctx.WorkflowVersions.Add(row);
             ctx.SaveChanges();
+            id = row.Id;
         }
 
         using (var ctx = NewContext())

--- a/src/CcDirector.Gateway.Tests/Data/TenantScopeGuardTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/TenantScopeGuardTests.cs
@@ -18,6 +18,20 @@ namespace CcDirector.Gateway.Tests.Data;
 ///    a global query filter (deny-by-default isolation).
 ///  - The GLOBAL mapping table <see cref="TenantEntity"/> MUST NOT be scoped: it is the table the filter's
 ///    tenant values come from, so it carries no <c>tenant_id</c> column and no query filter.
+///
+/// And a THIRD rule, the other half of tenant scoping:
+///  - EVERY tenant-scoped table's PRIMARY KEY must INCLUDE the tenant, unless its key is a value the Gateway
+///    itself mints and guarantees globally unique - which is not a list of table names but a TYPE,
+///    <see cref="GatewayMintedKeyEntity"/>, whose key only that base class can write.
+///
+/// That third rule exists because the column-and-filter checks above are structurally BLIND to the key. A
+/// table can carry a perfect <c>tenant_id</c> column and a perfect query filter and STILL have a primary key
+/// built only from caller-supplied input - and three did (<c>snoozes</c>, <c>session_spend</c>,
+/// <c>push_subscriptions</c>). Every store upserts by reading THROUGH the filter and adding when it finds
+/// nothing, so on such a key a second tenant presenting an identifier the first tenant already holds finds
+/// nothing, inserts, and hits a PRIMARY KEY violation: a cross-tenant SQUAT plus an EXISTENCE ORACLE. A guard
+/// that checked only the column and the filter was exactly how those three survived, so the key check lives
+/// here beside them rather than in a separate file that could be forgotten.
 /// </summary>
 public sealed class TenantScopeGuardTests : IDisposable
 {
@@ -113,5 +127,130 @@ public sealed class TenantScopeGuardTests : IDisposable
             "could read another tenant's rows: " + string.Join(", ", offenders) +
             ". Derive the entity from TenantScopedEntity, or - only if it is genuinely global mapping data - " +
             "add it to allowedGlobalTables with a reason.");
+    }
+
+    /// <summary>
+    /// The OTHER half of tenant scoping: the PRIMARY KEY. The two tests above check the tenant COLUMN and the
+    /// query FILTER, and are structurally blind to the key - which is why <c>snoozes</c>, <c>session_spend</c>
+    /// and <c>push_subscriptions</c> shipped with a primary key built from CALLER-SUPPLIED input while passing
+    /// every guard here. Every store upserts by reading THROUGH the filter and adding when it finds nothing,
+    /// so with such a key a second tenant presenting an identifier the first tenant already holds finds
+    /// nothing (the filter hides the row), inserts, and hits a PRIMARY KEY violation: it cannot use that
+    /// identifier at all (a cross-tenant SQUAT) and the failure tells it another tenant holds it (an EXISTENCE
+    /// ORACLE).
+    ///
+    /// The rule: every tenant-scoped table's primary key MUST include <c>tenant_id</c>. The only exemption is
+    /// a key the GATEWAY ITSELF mints as a fresh <see cref="Guid"/> - globally unique by construction and
+    /// never a value a caller can present.
+    ///
+    /// THE EXEMPTION IS A TYPE, NOT A LIST. It used to be a written allowlist of table names, each with a
+    /// sentence asserting "this store mints the key with Guid.NewGuid()", and the check beside it re-tested
+    /// only the SHAPE of the key - that it was still a single <see cref="Guid"/>. That is true both before AND
+    /// after the one change that matters: a store switching from minting the value to accepting one from the
+    /// caller keeps the key a single Guid, so the guard stayed green in the exact case it was written to
+    /// catch. A check that cannot fail for the dangerous change is worse than no check, because everyone
+    /// downstream reads it as protection and stops looking.
+    ///
+    /// So the exemption now IS <see cref="GatewayMintedKeyEntity"/>, whose <c>Id</c> has a private setter and
+    /// is minted by the base class itself. Assigning a caller-supplied value to it does not fail here - it
+    /// does not COMPILE. What is left for this test is the two ways to escape that type while keeping a
+    /// tenant-less key, and it closes both by construction:
+    ///
+    ///  - DROP the base class (and re-add a settable <c>Id</c>): the entity is then not a
+    ///    <see cref="GatewayMintedKeyEntity"/>, so it needs <c>tenant_id</c> in its key and turns this red.
+    ///  - KEEP the base class but key the table on something else - a re-declared <c>Id</c> that shadows the
+    ///    base one, or any caller-supplied column: the mapped key property is then no longer DECLARED ON
+    ///    <see cref="GatewayMintedKeyEntity"/>, which is what this test requires, so it turns red too.
+    ///
+    /// The third escape - widening the private setter so a caller value compiles again - is held by
+    /// <see cref="TheGatewayMintedKey_CanOnlyBeWrittenByTheBaseClassThatMintsIt"/> below.
+    /// </summary>
+    [Fact]
+    public void EveryTenantScopedTable_HasTenantIdInItsPrimaryKey_UnlessTheGatewayMintsTheKeyItself()
+    {
+        var model = Model();
+        var scoped = model.GetEntityTypes()
+            .Where(e => !e.IsOwned())
+            .Where(e => typeof(TenantScopedEntity).IsAssignableFrom(e.ClrType))
+            .ToList();
+
+        // Sanity: the scan actually found the scoped stores (guard against a reflection no-op passing green).
+        Assert.NotEmpty(scoped);
+
+        // Sanity: the exempt population is not empty either. If a refactor ever unhooked every entity from
+        // GatewayMintedKeyEntity, the exemption branch below would stop executing and this test would go
+        // green while testing nothing about it.
+        Assert.Contains(scoped, e => typeof(GatewayMintedKeyEntity).IsAssignableFrom(e.ClrType));
+
+        var offenders = new List<string>();
+        foreach (var entity in scoped)
+        {
+            var key = entity.FindPrimaryKey();
+            Assert.True(key is not null, $"{entity.ClrType.Name} is tenant-scoped but has no primary key.");
+
+            var keyHasTenant = key!.Properties.Any(
+                p => string.Equals(p.GetColumnName(), "tenant_id", StringComparison.Ordinal));
+            if (keyHasTenant)
+                continue;
+
+            // The ONLY exemption: the key is the Id that GatewayMintedKeyEntity itself declares and mints.
+            // Note this asks where the key property is DECLARED, not merely what type it is - a re-declared
+            // or shadowing Id on the derived entity is settable by callers again and is therefore NOT this.
+            var keyIsTheMintedId = key.Properties.Count == 1
+                                   && key.Properties[0].PropertyInfo?.DeclaringType
+                                       == typeof(GatewayMintedKeyEntity);
+            if (keyIsTheMintedId)
+                continue;
+
+            offenders.Add(entity.ClrType.Name + " (key: " +
+                          string.Join(", ", key.Properties.Select(p => p.GetColumnName())) + ")");
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These tenant-scoped tables have a PRIMARY KEY that does not include tenant_id and is not the " +
+            "Gateway-minted Id, so one tenant can squat a key value for every other tenant and learn that " +
+            "another tenant holds it: " + string.Join("; ", offenders) +
+            ". Make the key composite - HasKey(e => new { e.TenantId, e.<Key> }) - and add the migration on " +
+            "BOTH providers; or, only if the key is genuinely the Gateway's to mint, derive the entity from " +
+            "GatewayMintedKeyEntity and key the table on its Id.");
+    }
+
+    /// <summary>
+    /// The mechanism behind the exemption above, asserted directly. <see cref="GatewayMintedKeyEntity"/> earns
+    /// a primary key without <c>tenant_id</c> on exactly one ground: no caller can choose that key, because
+    /// only the base class can write it. That is not a property of the key's TYPE (a caller-supplied Guid
+    /// looks identical to a minted one) - it is a property of its ACCESSIBILITY, so accessibility is what this
+    /// checks.
+    ///
+    /// This is the test that fails for the dangerous change. Widening the setter is the ONLY way to make
+    /// <c>entity.Id = someCallerSuppliedGuid</c> compile again, so the moment someone does it to unblock
+    /// themselves, this turns red and names the reason instead of letting the exemption quietly go false.
+    /// </summary>
+    [Fact]
+    public void TheGatewayMintedKey_CanOnlyBeWrittenByTheBaseClassThatMintsIt()
+    {
+        var id = typeof(GatewayMintedKeyEntity).GetProperty(nameof(GatewayMintedKeyEntity.Id));
+        Assert.True(id is not null, "GatewayMintedKeyEntity no longer declares an Id property.");
+
+        var setter = id!.SetMethod;
+        Assert.True(setter is not null,
+            "GatewayMintedKeyEntity.Id has no setter at all. EF needs one (or the backing field) to " +
+            "materialize a loaded row - restore a PRIVATE setter.");
+
+        Assert.True(setter!.IsPrivate,
+            "GatewayMintedKeyEntity.Id's setter is no longer private (it is now " +
+            (setter.IsPublic ? "public" : setter.IsFamily ? "protected" : "internal or protected internal") +
+            "). That setter being private is the WHOLE reason these tables are exempt from having tenant_id " +
+            "in their primary key: it is what makes 'the Gateway mints this key' something the compiler " +
+            "enforces rather than a sentence someone wrote. With a wider setter a caller-supplied value can " +
+            "be assigned, and then one tenant can squat that key for every other tenant and learn from the " +
+            "insert failure that another tenant holds it. Put the setter back to private; if the key really " +
+            "must be caller-supplied, stop deriving from GatewayMintedKeyEntity and put tenant_id in the key.");
+
+        // And nothing else on the type may hand the value out for writing either.
+        Assert.DoesNotContain(typeof(GatewayMintedKeyEntity).GetFields(
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.Static),
+            f => !f.IsInitOnly);
     }
 }

--- a/src/CcDirector.Gateway/CronRunHistoryStore.cs
+++ b/src/CcDirector.Gateway/CronRunHistoryStore.cs
@@ -114,7 +114,6 @@ public sealed class CronRunHistoryStore
 
     private static CronRunEntity ToEntity(string jobId, CronRunRecord r, long sequence, string tenantId) => new()
     {
-        Id = Guid.NewGuid(),
         JobId = jobId,
         Sequence = sequence,
         TenantId = tenantId,

--- a/src/CcDirector.Gateway/Data/Entities/AccountHostedAiSpendEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/AccountHostedAiSpendEntity.cs
@@ -20,11 +20,8 @@ namespace CcDirector.Gateway.Data.Entities;
 /// the cloud returns without a created_at cannot be de-duplicated and is therefore skipped rather than risk
 /// double-counting real money (the honest choice - an undercount that is disclosed, never a silent overcount).
 /// </summary>
-public sealed class AccountHostedAiSpendEntity : TenantScopedEntity
+public sealed class AccountHostedAiSpendEntity : GatewayMintedKeyEntity
 {
-    /// <summary>Primary key, minted in code - never a database default.</summary>
-    public Guid Id { get; set; }
-
     /// <summary>The debit magnitude in micro-dollars (1_000_000 = $1), stored POSITIVE (the cloud returns a
     /// debit as a negative amount; we mirror its magnitude). Integer smallest-units, never a bare decimal.</summary>
     public long AmountMicros { get; set; }

--- a/src/CcDirector.Gateway/Data/Entities/CronRunEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/CronRunEntity.cs
@@ -14,11 +14,8 @@ namespace CcDirector.Gateway.Data.Entities;
 /// and survives the one-time import (records are assigned sequences in their stored newest-first order), so
 /// a tie in <see cref="Contracts.CronRunRecord.FiredUtc"/> can never reorder the list.
 /// </summary>
-public sealed class CronRunEntity : TenantScopedEntity
+public sealed class CronRunEntity : GatewayMintedKeyEntity
 {
-    /// <summary>Row primary key. A GUID generated in code (never a database default).</summary>
-    public Guid Id { get; set; }
-
     /// <summary>The owning cron job's id. Indexed; not a foreign key (independent lifecycle).</summary>
     public string JobId { get; set; } = "";
 

--- a/src/CcDirector.Gateway/Data/Entities/GatewayMintedKeyEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/GatewayMintedKeyEntity.cs
@@ -1,0 +1,52 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// A tenant-scoped entity whose primary key is a <see cref="Guid"/> the GATEWAY ITSELF mints, and which is
+/// therefore allowed to keep a primary key that does NOT include <c>tenant_id</c>.
+///
+/// WHY THIS IS A TYPE AND NOT AN ALLOWLIST
+///
+/// Every other tenant-scoped table must put <c>tenant_id</c> in its primary key, because its key comes from
+/// the caller: on a caller-supplied key, one tenant presenting an identifier another tenant already holds
+/// cannot insert (a cross-tenant SQUAT) and learns from the failure that someone else holds it (an EXISTENCE
+/// ORACLE). A freshly minted <see cref="Guid"/> has neither problem - no caller can present it, so there is
+/// nothing to squat and nothing to disclose.
+///
+/// That exemption used to be a written allowlist: a table name plus a sentence asserting "the store mints
+/// this with Guid.NewGuid()". A sentence is not enforceable. The guard beside it could only re-check the
+/// SHAPE of the key - that it was still one Guid - which is true both before and after the one change that
+/// actually matters. Had any store switched from minting the value to accepting one from the caller, the key
+/// would still have been a single Guid and every guard would still have been green: the check could not fail
+/// in the precise case it existed to catch, which is worse than no check, because it reads as protection.
+///
+/// So the claim is now carried by this type instead of by prose:
+///
+///  - <see cref="Id"/> has a PRIVATE setter. No store, endpoint, test or caller can assign it. Writing
+///    <c>new CronRunEntity { Id = callerSuppliedGuid }</c> is not a test failure to be discovered later -
+///    it DOES NOT COMPILE.
+///  - The value is minted by the initializer below, inside a class whose entire scope is this one property.
+///    There is no caller input reachable from here, so there is no expression this initializer could be
+///    changed to that would smuggle a caller's value in.
+///  - EF Core still materializes rows normally: it writes the compiler-generated backing field directly when
+///    loading, so a persisted key round-trips unchanged and only NEW rows take a minted value.
+///
+/// The remaining ways to defeat it are both covered by <c>TenantScopeGuardTests</c>, by name and by
+/// construction rather than by argument: widening this setter is caught by the reflection test on this type,
+/// and re-declaring an <c>Id</c> on a derived entity - or dropping this base class entirely - is caught by
+/// the primary-key test, which requires the mapped key property to be THIS class's <see cref="Id"/>, the one
+/// only this class can write. Deriving from this type is therefore a claim the compiler and the guard both
+/// hold you to, and adding a new one costs a base class rather than a sentence.
+/// </summary>
+public abstract class GatewayMintedKeyEntity : TenantScopedEntity
+{
+    /// <summary>
+    /// The primary key: a fresh <see cref="Guid"/> minted by the Gateway at construction, globally unique by
+    /// construction and never a value a caller can present or choose.
+    ///
+    /// The setter is PRIVATE on purpose and must stay private - it is the whole mechanism. See the type
+    /// remarks: it is what makes "the Gateway mints this key" a fact the compiler enforces rather than a
+    /// sentence in a list. EF Core sets the backing field directly when it materializes a loaded row, so a
+    /// private setter costs nothing at read time.
+    /// </summary>
+    public Guid Id { get; private set; } = Guid.NewGuid();
+}

--- a/src/CcDirector.Gateway/Data/Entities/GovernanceAuditEventEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/GovernanceAuditEventEntity.cs
@@ -18,11 +18,8 @@ namespace CcDirector.Gateway.Data.Entities;
 /// prompt content. The <see cref="Actor"/> is the audit "who": the human identity on a human decision, the
 /// agent on an agent event.
 /// </summary>
-public sealed class GovernanceAuditEventEntity : TenantScopedEntity
+public sealed class GovernanceAuditEventEntity : GatewayMintedKeyEntity
 {
-    /// <summary>Primary key, minted in code - never a database default.</summary>
-    public Guid Id { get; set; }
-
     /// <summary>The canonical fleet session GUID the event belongs to (audit events are session-scoped).
     /// The same id run participants, the event ledger, and session spend key on.</summary>
     public string SessionId { get; set; } = "";

--- a/src/CcDirector.Gateway/Data/Entities/GovernanceEventEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/GovernanceEventEntity.cs
@@ -21,11 +21,8 @@ namespace CcDirector.Gateway.Data.Entities;
 /// of the run the session was working, so a per-run duration rollup needs no participant lookup), but the
 /// subject's own key is always present.
 /// </summary>
-public sealed class GovernanceEventEntity : TenantScopedEntity
+public sealed class GovernanceEventEntity : GatewayMintedKeyEntity
 {
-    /// <summary>Primary key, minted in code - never a database default.</summary>
-    public Guid Id { get; set; }
-
     /// <summary>What kind of thing transitioned: "session" or "run". The subject's own key
     /// (<see cref="SessionId"/> for a session, <see cref="RunId"/> for a run) is required for that kind.</summary>
     public string SubjectKind { get; set; } = "";

--- a/src/CcDirector.Gateway/Data/Entities/WingmanInstructionEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/WingmanInstructionEntity.cs
@@ -19,12 +19,8 @@ namespace CcDirector.Gateway.Data.Entities;
 /// A surrogate GUID <see cref="Id"/> is the key (the document has no external id); the store keeps exactly one
 /// row per tenant. <c>tenant_id</c> + the global query filter are inherited from the base.
 /// </summary>
-public sealed class WingmanInstructionEntity : TenantScopedEntity
+public sealed class WingmanInstructionEntity : GatewayMintedKeyEntity
 {
-    /// <summary>Surrogate primary key (code-generated). The document has no natural external id; the store
-    /// keeps a single row per tenant.</summary>
-    public Guid Id { get; set; }
-
     /// <summary>The active custom version's id, or null to ride the deployed default. The active-version
     /// pointer, reproduced exactly.</summary>
     public string? ActiveVersionId { get; set; }

--- a/src/CcDirector.Gateway/Data/Entities/WorkListEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/WorkListEntity.cs
@@ -23,11 +23,8 @@ namespace CcDirector.Gateway.Data.Entities;
 /// column) so reorder and targeted remove stay exact and queryable - the same child-table pattern the cron
 /// run history uses.
 /// </summary>
-public sealed class WorkListEntity : TenantScopedEntity
+public sealed class WorkListEntity : GatewayMintedKeyEntity
 {
-    /// <summary>Surrogate primary key. A GUID generated in code (never a database default).</summary>
-    public Guid Id { get; set; }
-
     /// <summary>The list's human name, in its original case.</summary>
     public string Name { get; set; } = "";
 

--- a/src/CcDirector.Gateway/Data/Entities/WorkListItemEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/WorkListItemEntity.cs
@@ -7,11 +7,8 @@ namespace CcDirector.Gateway.Data.Entities;
 /// targeted remove-by-source-and-id stay exact and queryable - the child-table pattern the cron run history
 /// established.
 /// </summary>
-public sealed class WorkListItemEntity : TenantScopedEntity
+public sealed class WorkListItemEntity : GatewayMintedKeyEntity
 {
-    /// <summary>Row primary key. A GUID generated in code (never a database default).</summary>
-    public Guid Id { get; set; }
-
     /// <summary>The owning work list's id (foreign key).</summary>
     public Guid WorkListId { get; set; }
 

--- a/src/CcDirector.Gateway/Data/Entities/WorkflowFileEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/WorkflowFileEntity.cs
@@ -9,11 +9,8 @@ namespace CcDirector.Gateway.Data.Entities;
 /// File names are validated by the store (no path separators, a short allow-listed extension set,
 /// size-capped) so a bundle can always be materialized to disk safely.
 /// </summary>
-public sealed class WorkflowFileEntity : TenantScopedEntity
+public sealed class WorkflowFileEntity : GatewayMintedKeyEntity
 {
-    /// <summary>Primary key, minted in code - never a database default.</summary>
-    public Guid Id { get; set; }
-
     /// <summary>The <see cref="WorkflowVersionEntity"/> this file belongs to. Indexed; not a foreign
     /// key (independent lifecycle, like cron runs to cron jobs).</summary>
     public Guid VersionId { get; set; }

--- a/src/CcDirector.Gateway/Data/Entities/WorkflowRunEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/WorkflowRunEntity.cs
@@ -18,11 +18,8 @@ namespace CcDirector.Gateway.Data.Entities;
 /// path opens a run beside the Mission record and references it (<see cref="MissionId"/>) - a
 /// reference, not a merge, because standalone runs have no Mission.
 /// </summary>
-public sealed class WorkflowRunEntity : TenantScopedEntity
+public sealed class WorkflowRunEntity : GatewayMintedKeyEntity
 {
-    /// <summary>Primary key, minted in code - never a database default.</summary>
-    public Guid Id { get; set; }
-
     /// <summary>The workflow definition this run executes. Indexed.</summary>
     public string WorkflowId { get; set; } = "";
 

--- a/src/CcDirector.Gateway/Data/Entities/WorkflowVersionEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/WorkflowVersionEntity.cs
@@ -14,11 +14,8 @@ namespace CcDirector.Gateway.Data.Entities;
 /// Steps and criteria reuse the wire contract types as EF owned types serialized to JSON columns
 /// (the cron store's "bulky sub-doc -> JSON in a column" pattern).
 /// </summary>
-public sealed class WorkflowVersionEntity : TenantScopedEntity
+public sealed class WorkflowVersionEntity : GatewayMintedKeyEntity
 {
-    /// <summary>Primary key, minted in code - never a database default.</summary>
-    public Guid Id { get; set; }
-
     /// <summary>The workflow this version belongs to. (WorkflowId, Version) is unique.</summary>
     public string WorkflowId { get; set; } = "";
 

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -214,11 +214,20 @@ public sealed class GatewayDbContext : DbContext
         modelBuilder.Entity<SnoozeEntity>(b =>
         {
             b.ToTable("snoozes");
-            // SessionId is the natural key - a globally unique, ordinally-compared GUID string - so it is the
-            // primary key directly (no surrogate id). SQLite's default BINARY text collation compares it
-            // ordinally, matching the legacy Dictionary(StringComparer.Ordinal). The armed-vs-deferred
-            // invariant is kept in the store, not as a database CHECK (provider-divergent), matching today.
-            b.HasKey(e => e.SessionId);
+            // SessionId is the natural key - an ordinally-compared GUID string - so there is no surrogate id.
+            // SQLite's default BINARY text collation compares it ordinally, matching the legacy
+            // Dictionary(StringComparer.Ordinal). The armed-vs-deferred invariant is kept in the store, not as
+            // a database CHECK (provider-divergent), matching today.
+            //
+            // COMPOSITE primary key (tenant_id, SessionId) - Hosted Multi-Tenancy. The session id is
+            // CALLER-SUPPLIED (it arrives on the snooze request from a Director), so it is a value one tenant
+            // hands us, never something the Gateway mints and guarantees globally unique. The store upserts by
+            // reading THROUGH the tenant query filter and adding when it finds nothing, so on a SessionId-only
+            // key a second tenant presenting an id the first tenant already holds finds nothing, inserts, and
+            // hits a PRIMARY KEY violation: a cross-tenant SQUAT (the second tenant cannot use that id at all)
+            // and an EXISTENCE ORACLE (the failure tells it the first tenant holds it). Scoping the key by
+            // tenant gives each tenant its own session-id space, which is what the store already assumes.
+            b.HasKey(e => new { e.TenantId, e.SessionId });
         });
 
         modelBuilder.Entity<GovernanceEventEntity>(b =>
@@ -241,10 +250,17 @@ public sealed class GatewayDbContext : DbContext
         modelBuilder.Entity<PushSubscriptionEntity>(b =>
         {
             b.ToTable("push_subscriptions");
-            // Endpoint is the natural key - a unique-per-subscription URL compared ordinally (SQLite's default
-            // BINARY collation), matching the legacy Dictionary(StringComparer.Ordinal) - so it is the primary
-            // key directly, no surrogate id. There is no per-user column: the legacy shape had none.
-            b.HasKey(e => e.Endpoint);
+            // Endpoint is the natural key - a per-subscription URL compared ordinally (SQLite's default BINARY
+            // collation), matching the legacy Dictionary(StringComparer.Ordinal) - so there is no surrogate
+            // id. There is no per-user column: the legacy shape had none.
+            //
+            // COMPOSITE primary key (tenant_id, Endpoint) - Hosted Multi-Tenancy. The endpoint is the browser's
+            // push URL, entirely CALLER-SUPPLIED, and it is the whole key. The store upserts by reading THROUGH
+            // the tenant query filter and adding when it finds nothing, so on an Endpoint-only key a second
+            // tenant presenting an endpoint the first tenant already holds finds nothing, inserts, and hits a
+            // PRIMARY KEY violation: a cross-tenant SQUAT plus an EXISTENCE ORACLE, exactly as for snoozes.
+            // Scoping the key by tenant lets each tenant own its own subscription for a given endpoint.
+            b.HasKey(e => new { e.TenantId, e.Endpoint });
         });
 
         modelBuilder.Entity<WingmanInstructionEntity>(b =>
@@ -260,9 +276,13 @@ public sealed class GatewayDbContext : DbContext
         modelBuilder.Entity<SessionSpendEntity>(b =>
         {
             b.ToTable("session_spend");
-            // SessionId is the natural key - one row per session, globally-unique GUID string - so it is the
-            // primary key directly (the snoozes-table pattern), no surrogate id.
-            b.HasKey(e => e.SessionId);
+            // SessionId is the natural key - one row per session per tenant - so there is no surrogate id.
+            //
+            // COMPOSITE primary key (tenant_id, SessionId) - Hosted Multi-Tenancy, the snoozes-table reasoning
+            // exactly: the session id is CALLER-SUPPLIED (it arrives on the record-spend request), the store
+            // upserts through the tenant query filter, so a SessionId-only key would let one tenant SQUAT an id
+            // for every other tenant and would leak the fact that it holds it.
+            b.HasKey(e => new { e.TenantId, e.SessionId });
             // The reporting cut is a last-observed time window, tenant-leading for the global filter.
             b.HasIndex(e => new { e.TenantId, e.LastObservedUtc });
         });

--- a/src/CcDirector.Gateway/Data/Migrations/20260719201700_CallerSuppliedKeysScopedByTenant.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260719201700_CallerSuppliedKeysScopedByTenant.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719201700_CallerSuppliedKeysScopedByTenant")]
+    partial class CallerSuppliedKeysScopedByTenant
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260719201700_CallerSuppliedKeysScopedByTenant.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260719201700_CallerSuppliedKeysScopedByTenant.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class CallerSuppliedKeysScopedByTenant : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_snoozes",
+                table: "snoozes");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_session_spend",
+                table: "session_spend");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_push_subscriptions",
+                table: "push_subscriptions");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_snoozes",
+                table: "snoozes",
+                columns: new[] { "tenant_id", "SessionId" });
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_session_spend",
+                table: "session_spend",
+                columns: new[] { "tenant_id", "SessionId" });
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_push_subscriptions",
+                table: "push_subscriptions",
+                columns: new[] { "tenant_id", "Endpoint" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_snoozes",
+                table: "snoozes");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_session_spend",
+                table: "session_spend");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_push_subscriptions",
+                table: "push_subscriptions");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_snoozes",
+                table: "snoozes",
+                column: "SessionId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_session_spend",
+                table: "session_spend",
+                column: "SessionId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_push_subscriptions",
+                table: "push_subscriptions",
+                column: "Endpoint");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Governance/AccountHostedAiSpendStore.cs
+++ b/src/CcDirector.Gateway/Governance/AccountHostedAiSpendStore.cs
@@ -80,7 +80,6 @@ public sealed class AccountHostedAiSpendStore
 
                 ctx.AccountHostedAiSpend.Add(new AccountHostedAiSpendEntity
                 {
-                    Id = Guid.NewGuid(),
                     TenantId = tenant,
                     AmountMicros = debit.AmountMicros,
                     Kind = DebitKind,

--- a/src/CcDirector.Gateway/Governance/GovernanceAuditLog.cs
+++ b/src/CcDirector.Gateway/Governance/GovernanceAuditLog.cs
@@ -205,7 +205,6 @@ public sealed class GovernanceAuditLog
 
         return new GovernanceAuditEventEntity
         {
-            Id = Guid.NewGuid(),
             TenantId = tenant,
             SessionId = request.SessionId.Trim(),
             RunId = request.RunId,

--- a/src/CcDirector.Gateway/Governance/GovernanceEventLedger.cs
+++ b/src/CcDirector.Gateway/Governance/GovernanceEventLedger.cs
@@ -213,7 +213,6 @@ public sealed class GovernanceEventLedger
 
         return new GovernanceEventEntity
         {
-            Id = Guid.NewGuid(),
             TenantId = tenant,
             SubjectKind = subject,
             SessionId = sessionId,

--- a/src/CcDirector.Gateway/Wingman/WingmanInstructionsStore.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanInstructionsStore.cs
@@ -115,7 +115,7 @@ public sealed class WingmanInstructionsStore
         var row = ctx.WingmanInstructions.FirstOrDefault();
         if (row is null)
         {
-            row = new WingmanInstructionEntity { Id = Guid.NewGuid(), TenantId = ctx.ActiveTenant! };
+            row = new WingmanInstructionEntity { TenantId = ctx.ActiveTenant! };
             ctx.WingmanInstructions.Add(row);
         }
         row.ActiveVersionId = _state.ActiveVersionId;
@@ -349,7 +349,6 @@ public sealed class WingmanInstructionsStore
         using var ctx = _db.CreateContext();
         ctx.WingmanInstructions.Add(new WingmanInstructionEntity
         {
-            Id = Guid.NewGuid(),
             TenantId = ctx.ActiveTenant!,
             ActiveVersionId = parsed.ActiveVersionId,
             AckDefaultVersion = parsed.AckDefaultVersion,

--- a/src/CcDirector.Gateway/WorkListStore.cs
+++ b/src/CcDirector.Gateway/WorkListStore.cs
@@ -111,7 +111,7 @@ public sealed class WorkListStore
                 return false;
             }
 
-            ctx.WorkLists.Add(new WorkListEntity { Id = Guid.NewGuid(), TenantId = ctx.ActiveTenant!, Name = name });
+            ctx.WorkLists.Add(new WorkListEntity { TenantId = ctx.ActiveTenant!, Name = name });
             ctx.SaveChanges();
             FileLog.Write($"[WorkListStore] Create: name={name}");
             return true;
@@ -367,7 +367,6 @@ public sealed class WorkListStore
 
     private static WorkListItemEntity NewItem(WorkListEntity list, string tenantId, int position, WorkListItemRef item) => new()
     {
-        Id = Guid.NewGuid(),
         WorkListId = list.Id,
         TenantId = tenantId,
         Position = position,
@@ -444,7 +443,6 @@ public sealed class WorkListStore
 
             var entity = new WorkListEntity
             {
-                Id = Guid.NewGuid(),
                 TenantId = ctx.ActiveTenant!,
                 Name = list.Name,
                 Consumer = list.Consumer,

--- a/src/CcDirector.Gateway/Workflows/BuiltInWorkflowSeeder.cs
+++ b/src/CcDirector.Gateway/Workflows/BuiltInWorkflowSeeder.cs
@@ -77,7 +77,6 @@ public static class BuiltInWorkflowSeeder
     public static WorkflowVersionEntity BuildShippedVersion(
         GatewayDbContext ctx, WorkflowDefinition definition, int versionNumber, DateTime createdUtc) => new()
     {
-        Id = Guid.NewGuid(),
         TenantId = ctx.ActiveTenant!,
         WorkflowId = definition.Id,
         Version = versionNumber,

--- a/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
@@ -95,7 +95,6 @@ public sealed class WorkflowRunStore
             var now = DateTime.UtcNow;
             var entity = new WorkflowRunEntity
             {
-                Id = Guid.NewGuid(),
                 TenantId = ctx.ActiveTenant!,
                 WorkflowId = key,
                 WorkflowVersionId = version.Id,

--- a/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
@@ -450,7 +450,6 @@ public sealed class WorkflowStore
 
         var row = existing ?? new WorkflowVersionEntity
         {
-            Id = Guid.NewGuid(),
             TenantId = ctx.ActiveTenant!,
             WorkflowId = workflowId,
             Version = versionNumber,
@@ -470,7 +469,6 @@ public sealed class WorkflowStore
 
         var files = hashedFiles.Select(f => new WorkflowFileEntity
         {
-            Id = Guid.NewGuid(),
             TenantId = ctx.ActiveTenant!,
             VersionId = row.Id,
             FileName = f.FileName,


### PR DESCRIPTION
## The defect

Three tenant-scoped tables in `src/CcDirector.Gateway/Data/GatewayDbContext.cs` had a PRIMARY KEY built
entirely from CALLER-SUPPLIED input, with `tenant_id` present as a data column but not part of the key:

| table | old primary key | where the value comes from |
|---|---|---|
| `snoozes` | `SessionId` | the session id a Director presents on a snooze request |
| `session_spend` | `SessionId` | the session id on a record-spend request |
| `push_subscriptions` | `Endpoint` | the browser's Web Push URL |

Every store upserts the same way: read THROUGH the tenant query filter, add when the read finds nothing. So a
second tenant presenting an identifier the first tenant already holds reads nothing (the filter hides the other
tenant's row), takes the insert branch, and the database rejects it on the primary key. That is a cross-tenant
SQUAT - the second tenant cannot use that identifier at all, because another tenant has it - and an EXISTENCE
ORACLE, because the failure discloses that another tenant holds it. No row content crosses the boundary, but
the key space does.

Proven before the fix, driving the REAL stores (`SnoozeRegistry`, `SessionSpendStore`, `PushSubscriptionStore`)
with two tenants over one database. Three tests, three failures:

```
SQLite Error 19: 'UNIQUE constraint failed: snoozes.SessionId'
SQLite Error 19: 'UNIQUE constraint failed: session_spend.SessionId'
SQLite Error 19: 'UNIQUE constraint failed: push_subscriptions.Endpoint'
```

## The fix

Composite primary keys, following #1840 exactly (which did this for `cron_jobs`, `workflows`,
`workflow_versions` and `mission_notes`): `(tenant_id, SessionId)`, `(tenant_id, SessionId)`,
`(tenant_id, Endpoint)`. No store code changed - every lookup already goes through a filtered query, never
`Find(key)`.

## The sibling guard: the exemption is a TYPE, not a written allowlist

`TenantScopeGuardTests` asserted the tenant COLUMN and the query FILTER and is structurally blind to the KEY,
which is exactly how these three passed it. It now also requires every tenant-scoped table's primary key to
include `tenant_id` - unless the key is one the Gateway itself mints.

**The first version of that exemption was rejected, and was rejected correctly.** It was an allowlist of ten
table names, each with a sentence asserting "this store mints the key with `Guid.NewGuid()`", re-checked by
asserting the key was still a single `Guid`. That check could not fail for the change it existed to catch: a
store switching from minting its key to accepting one from the caller keeps the key a single `Guid`, so the
guard stayed green in precisely the dangerous case. A check that cannot fail for its own motivating case is
worse than no check, because it reads as protection and stops everyone downstream from looking.

The exemption is now the type `GatewayMintedKeyEntity`, whose `Id` has a **private setter** and is minted by
the base class itself. The ten entities that had a Gateway-minted key derive from it and no longer declare
their own `Id`, and the thirteen `Id = Guid.NewGuid()` assignments are gone - minting lives in the type.

**Assigning a caller-supplied value to one of these keys is now a compile error, not something a guard notices
afterwards:**

```
error CS0272: The property or indexer 'GatewayMintedKeyEntity.Id' cannot be used in this context
              because the set accessor is inaccessible
```

The compiler enumerated all thirteen existing assignment sites and every one was a fresh `Guid.NewGuid()`, so
the old prose claim was true *today* - it is now enforced rather than asserted.

The three ways to escape the type are each closed by construction, and each was verified by making the change
and watching it fail:

| Escape | What stops it - observed, not argued |
|---|---|
| A store's key switches from minted to caller-supplied | **Does not compile** (`CS0272`, single error, at the assignment) |
| Widen the setter so the above compiles again | `TheGatewayMintedKey_CanOnlyBeWrittenByTheBaseClassThatMintsIt` goes red: `setter.IsPrivate = False (public=True)` |
| Re-declare a settable `Id` on the derived entity, or drop the base class - still a single `Guid` key, the shape the old check accepted | `EveryTenantScopedTable_HasTenantIdInItsPrimaryKey_UnlessTheGatewayMintsTheKeyItself` goes red, naming it: `CronRunEntity (key: Id; declared on: CronRunEntity)` - the test requires the mapped key property to be DECLARED ON `GatewayMintedKeyEntity`, not merely to be a `Guid` |

Negative control: with every mutation reverted, both guards are green.

This already caught something real. #1906, developed in parallel, adds a `WorkListEntity { Id = rowId }`
construction site, which this change makes a compile error. No prose allowlist and no reflection guard had
flagged it. That branch rebases onto this one and lets the base type mint the row identifier - see the
convergence note at the bottom.

## Migrations, and what they do to existing rows

One migration per provider, generated from the same model:
`Data/Migrations/20260719201700_CallerSuppliedKeysScopedByTenant` (SQLite) and
`Migrations/20260719201740_CallerSuppliedKeysScopedByTenant` (Postgres). Each drops the three single-column
primary keys and adds the composite ones. `dotnet ef migrations has-pending-model-changes` reports no pending
changes on BOTH providers, re-run on the current head.

**Row preservation is established by running the upgrade, not by reading the operations.** That distinction
matters here: on SQLite a primary key cannot be altered in place, so EF turns each operation pair into a table
REBUILD - create a new table, copy every row, drop the original, rename - and whether that copy carries every
row and every column value is a property of the generated rebuild, not of the three lines anyone reads in the
migration file.

Two test classes, one per provider, both doing the same thing: migrate to `CompositeTenantKeys` (the migration
immediately before this one), insert rows through raw SQL the way a database in the field holds them (two
tenants, nullable columns exercised both null and populated), migrate the rest of the way, then assert every
row and every column value is unchanged. Both also assert the migration GENUINELY RAN - by name out of the
migrations history table, and by the key really being composite afterwards - so a migration that silently did
nothing cannot pass by leaving the rows undisturbed. A second test in each proves the upgrade delivers what it
is for: before it, a second tenant reusing an identifier is refused on the primary key; after it, both rows
coexist.

- `CallerSuppliedKeyUpgradePreservesRowsTests` (SQLite) - always runs, no external service.
- `CallerSuppliedKeyUpgradePreservesRowsPostgresTests` (Postgres) - gated on `CC_GATEWAY_TEST_PG_CONNECTION`
  exactly as `PostgresProviderProofTests` is, and reports SKIPPED when it is unset. Skipped is not passed: with
  no server configured it makes no claim rather than a false one. It drops and recreates, so it carries the
  same `ccpg`-prefix throwaway-database guard as the existing Postgres proofs.

Executed evidence, both providers, on this head. SQLite:

```
PRE-CHANGE KEYS:  snoozes=[SessionId] session_spend=[SessionId] push_subscriptions=[Endpoint]
ROWS BEFORE:      snoozes=2 session_spend=2 push_subscriptions=2
POST-CHANGE KEYS: snoozes=[tenant_id,SessionId] session_spend=[tenant_id,SessionId] push_subscriptions=[tenant_id,Endpoint]
APPLIED:          20260719201700_CallerSuppliedKeysScopedByTenant
ROWS AFTER:       snoozes=2 session_spend=2 push_subscriptions=2
CROSS-TENANT SAME SESSION ID: ACCEPTED (correct)
RESULT: PASS - every row and every column value preserved
```

Postgres 16, in a throwaway container, running the Postgres migration set through the `gateway` schema:

```
PRE-CHANGE KEYS:  snoozes=[SessionId] session_spend=[SessionId] push_subscriptions=[Endpoint]
ROWS BEFORE:      snoozes=2 session_spend=2 push_subscriptions=2
POST-CHANGE KEYS: snoozes=[tenant_id,SessionId] session_spend=[tenant_id,SessionId] push_subscriptions=[tenant_id,Endpoint]
APPLIED:          20260719201740_CallerSuppliedKeysScopedByTenant
OK  snoozes / session_spend / push_subscriptions: all rows and every column value preserved
OK  BEFORE the upgrade the second tenant is refused on the primary key (SqlState=23505)
OK  AFTER the upgrade the same insert is ACCEPTED
RESULT: PASS - all checks
```

The Postgres arm was also run with the upgrade suppressed, as a negative control: the four
migration-actually-ran assertions go red while the row-preservation assertions stay green - which is exactly
why those anti-vacuity assertions exist, since untouched rows survive trivially when nothing runs.

## Base, and what is still outstanding

Rebased onto current `origin/main`. `git range-diff` reports `=` across each rebase - content unchanged,
verified by range-diff rather than by a rebuild. The overlapping range was inspected: #1901 changed
`GatewayDbContext` and `TenantScopeGuardTests`, and its guard change (adding `EntitlementEntity` to
`allowedGlobalTables`) survived intact. It did NOT change either provider snapshot - `EntitlementEntity` is
mapped `ExcludeFromMigrations` and `entitlements` appears in neither snapshot, checked directly.

**The full-suite mutation proof is NOT yet run, and this is not mergeable until it is.** The suite lock is held
by another unit and this one is not admitted. Seven serialized full Gateway suite runs are owed, pre-registered
with their predicted reds by name in the durable comment below:

| Run | Mutation |
|---|---|
| baseline | none - a green AND explicitly complete run at the final head |
| M1 | `SnoozeEntity` key reverted to `HasKey(e => e.SessionId)` |
| M2 | `SessionSpendEntity` key reverted |
| M3 | `PushSubscriptionEntity` key reverted |
| M4 | `GatewayMintedKeyEntity.Id` setter widened to public |
| M5 | `public new Guid Id { get; set; }` re-declared on `CronRunEntity` |
| restored | exact restoration, green at the exact head |

One primitive per run, never combined - the three mappings are independently bypassable. Reconciliation will be
computed: passed plus failed under the mutation equals passed under the restored run. A predicted red that does
not appear is a finding, not something to explain away.

### Why every red is classified by WHERE it arrived

Each red in each arm is classified by where it arrived - **fixture, migration, or assertion** - and not merely
by whether the arm was red. That rule exists for one reason, and the reason must travel with it, because a rule
without its reason gets dropped by whoever is next and is sure they understand better:

> **The arm's colour is not evidence about the thing the arm was testing.**

Everything this branch has had to patch is an instance of that. A stale build gives a GREEN that is not
evidence of the mutation's absence - only that the mutation never reached the assembly. A fixture that throws
on a renamed column gives a RED that is not evidence the guard fired - only that the seed never ran. An
emptied fixture gives a GREEN that is not evidence anything survived - only that nothing was there to lose. A
migration that silently did nothing gives a GREEN row-preservation result that is not evidence the upgrade is
safe - untouched rows survive trivially.

In each case the colour is a statement about the HARNESS, and it was read as a statement about the SUBJECT.
That is why this proof asserts that the seed inserted rows, that the migration is recorded by name, and that
the migration under test is still the immediate successor of its named predecessor: each of those turns a
harness fact that would otherwise be invisible into something the arm has to state out loud before its colour
means anything.

Note the Postgres upgrade tests will report SKIPPED on the admission machine, so they contribute nothing to
those runs; their evidence is the executed container run above.

Proof-hygiene note for whoever runs the arms: restore each mutation with `git checkout --`, which stamps a
current modification time. Restoring by moving or copying an older backup over the file preserves that older
timestamp, MSBuild then treats the build as up to date, and the run silently executes the PREVIOUS binary. That
was observed on this branch while producing the evidence above - a restored source printed the mutation's
output because the assembly was never rebuilt - and in the direction that matters it would show a mutation
producing no red at all.

## Convergence with #1906

#1906 currently adds a `WorkListEntity { Id = rowId }` construction site and predates this private setter, so
the two branches cannot coexist unchanged. The order is: land this first, then rebase #1906 and let the base
type mint the row identifier before it is recorded or asserted. Final evidence for the two heads must not be
produced independently and then merged without reconciling that overlap.

