### PR TITLE
fix(setup): stop blocking the install on three prerequisites that are not required

### DIFF
--- a/docs/plans/install-autoupdate.md
+++ b/docs/plans/install-autoupdate.md
@@ -91,7 +91,8 @@ reinventing it.
 | D6 | Trigger | **Resident apps orchestrate** - Director (while open) and Gateway (always) run the CLI updater for all present components |
 | D7 | Gateway update privilege | **Self-updating service** - the LocalSystem service swaps + restarts its own build; no UAC after first install |
 | D8 | Update failure handling | **Keep `.old` backups + manual rollback** (`...setup rollback <component>`); no auto-rollback/health-check |
-| D9 | Framework bootstrap | **Detect + guide** (link to Claude Code / Codex official installer + Re-check); we never own their install mechanics |
+| D9 | Framework bootstrap | ~~**Detect + guide** (link to Claude Code / Codex official installer + Re-check); we never own their install mechanics~~ **SUPERSEDED (see D9a)** |
+| D9a | Framework bootstrap, revised | **Detect + offer + guide.** The graphical wizard offers a one-click `winget` install for a missing agent, and the download link stays as the fallback. Detect-and-guide alone was the single largest block in the path from download to a first agent: it stopped a new user on the Prerequisites screen and sent them off to install three programs by hand. We still do not *own* the install mechanics - we invoke the vendor's own published package (`Anthropic.ClaudeCode`), the user chooses to click, and the manual link is untouched. The headless CLI keeps detect-and-guide unchanged. |
 | D10 | Code signing | **Stay unsigned, document** the SmartScreen "More info -> Run anyway" step; revisit for external users |
 
 ---
@@ -237,10 +238,14 @@ read commands for agent consumption. No window in CLI mode.
 
 ### 4.8 Framework bootstrap (D9)
 
-`PrerequisiteChecker` detects Claude Code / Codex. If missing: the UI shows the
-official install link + a "Re-check" button; the CLI prints the link and exits
-with a distinct "prerequisite missing" code. The installer never runs the
-framework's installer itself.
+`PrerequisiteChecker` detects Claude Code / Codex. If missing: the graphical wizard
+shows an **Install automatically** action (the vendor's own `winget` package, run
+silently) **and** the official install link + a "Re-check" button. The CLI is
+unchanged - it prints the link and exits with a distinct "prerequisite missing" code.
+
+Superseded D9 (detect-and-guide only): the agent is no longer a required
+prerequisite either, so a missing agent never blocks the install. What the user gave
+up is reported on the Complete screen by `CapabilityNotice`.
 
 ---
 

--- a/docs/public/getting-started/02-installation.md
+++ b/docs/public/getting-started/02-installation.md
@@ -14,7 +14,7 @@ The DevThrottle **Setup** app checks for these on its Prerequisites screen. On W
 | [Node.js](#nodejs) | Recommended | 20+ | MCP servers and the browser tools |
 | [Tailscale](#tailscale-optional--remote-access) | Optional | latest | Reaching this gateway's Cockpit from a phone or another computer |
 
-Setup can install every one of these for you on Windows via `winget`; each row shows an **Install automatically** action while the tool is missing. If `winget` is unavailable, use the download link in the same row and click **Re-check**.
+On **Windows**, Setup can install every one of these for you via `winget`: each row shows an **Install automatically** action while the tool is missing. If `winget` is unavailable -- it is absent on some locked-down machines -- use the download link in the same row and click **Re-check**. On **macOS** there is no `winget`, so the links are the install path.
 
 > **Just installed one of these and Setup still says "Not found"?** See [If a tool is not detected after installing it](#if-a-tool-is-not-detected-after-installing-it).
 
@@ -29,9 +29,9 @@ Confirm: `dotnet --list-runtimes` includes a `Microsoft.AspNetCore.App 10.x` lin
 
 ### Claude Code
 
-The Anthropic CLI. Use the official **native installer** -- **do not use `npm`**, which is the usual cause of "`claude` command not found" and PATH problems.
+The Anthropic CLI. **The easiest route on Windows is to let Setup do it** -- the Claude Code row has an **Install automatically** action that runs `winget install Anthropic.ClaudeCode` silently. To install it yourself, use the official **native installer** -- **do not use `npm`**, which is the usual cause of "`claude` command not found" and PATH problems.
 
-- **Windows (PowerShell):** `irm https://claude.ai/install.ps1 | iex`
+- **Windows (PowerShell):** `irm https://claude.ai/install.ps1 | iex`, or `winget install Anthropic.ClaudeCode`
 - **macOS / Linux:** `curl -fsSL https://claude.ai/install.sh | bash`
 
 Then run `claude` once to sign in (requires a paid Claude plan -- Pro, Max, Team, or Enterprise).

--- a/docs/public/getting-started/02-installation.md
+++ b/docs/public/getting-started/02-installation.md
@@ -4,15 +4,17 @@ DevThrottle runs on Windows and macOS (Apple Silicon) and requires a few prerequ
 
 ## Prerequisites
 
-The DevThrottle **Setup** app checks for these on its Prerequisites screen. Four are required; Tailscale is optional. Each tool below has a setup section with the exact install command and how to confirm it is on your `PATH`.
+The DevThrottle **Setup** app checks for these on its Prerequisites screen. On Windows **only the .NET 10 Runtime is required** - it is what actually runs DevThrottle - and Setup can install it for you. The rest are recommended: Setup offers to install each one on the spot, and you can continue without them and add them later. On macOS nothing is required, because the macOS build carries its own runtime.
 
-| Tool | Required? | Minimum |
-|------|-----------|---------|
-| [.NET 10 Runtime](#net-10-runtime) | Required | 10.0 |
-| [Claude Code](#claude-code) | Required | latest |
-| [Python](#python) | Required | 3.11+ |
-| [Node.js](#nodejs) | Required | 20+ |
-| [Tailscale](#tailscale-optional--remote-access) | Optional | latest |
+| Tool | Required? | Minimum | What you lose without it |
+|------|-----------|---------|--------------------------|
+| [.NET 10 Runtime](#net-10-runtime) | **Required** (Windows only) | 10.0 | DevThrottle will not start |
+| [Claude Code](#claude-code) | Recommended | latest | No coding agent installed yet - but DevThrottle runs seven others |
+| [Python](#python) | Recommended | 3.11+ | Your own Python scripts. The `cc-*` tools bring their own Python and do not need this |
+| [Node.js](#nodejs) | Recommended | 20+ | MCP servers and the browser tools |
+| [Tailscale](#tailscale-optional--remote-access) | Optional | latest | Reaching this gateway's Cockpit from a phone or another computer |
+
+Setup can install every one of these for you on Windows via `winget`; each row shows an **Install automatically** action while the tool is missing. If `winget` is unavailable, use the download link in the same row and click **Re-check**.
 
 > **Just installed one of these and Setup still says "Not found"?** See [If a tool is not detected after installing it](#if-a-tool-is-not-detected-after-installing-it).
 

--- a/docs/public/getting-started/04-setup-wizard-walkthrough.md
+++ b/docs/public/getting-started/04-setup-wizard-walkthrough.md
@@ -45,7 +45,7 @@ Every run of the wizard moves left-to-right through the same rail:
 | Step | What happens |
 |------|--------------|
 | **1. Welcome** | On a first install, you choose the role (Workstation or Gateway). On an existing install, this becomes the Update / Uninstall screen. |
-| **2. Prerequisites** | The wizard checks for the .NET 10 Runtime, Claude Code, Python, Node.js, and (optionally) Tailscale. You cannot continue until the required ones are found. |
+| **2. Prerequisites** | The wizard checks for the .NET 10 Runtime, Claude Code, Python, Node.js, and (optionally) Tailscale, and offers to install each missing one for you. Only the .NET 10 Runtime blocks Next - the rest are recommended, and you can install them here or later. |
 | **3. Skills** | Shows the Claude Code skills that will be installed. |
 | **4. Install** | Downloads and places each component, verifying every file against the manifest's SHA-256. The Gateway role adds a Gateway + Cockpit phase here. |
 | **5. Complete** | Confirms what was installed and offers to launch the app. |

--- a/tools/cc-director-setup-avalonia/MainWindow.axaml.cs
+++ b/tools/cc-director-setup-avalonia/MainWindow.axaml.cs
@@ -113,7 +113,7 @@ public partial class MainWindow : Window
             StepSkills => _skillsStep ??= new SkillsStep(_isUpdate),
             StepInstall => _installStep ??= new InstallStep(),
             StepGateway => _gatewayStep ??= CreateGatewayStep(),
-            StepComplete => _completeStep ??= new CompleteStep(_installedCount, _skippedCount, _installPath, _isUpdate, _alreadyUpToDate, _latestVersion),
+            StepComplete => _completeStep ??= new CompleteStep(_installedCount, _skippedCount, _installPath, _isUpdate, _alreadyUpToDate, _latestVersion, BuildCapabilityNotice()),
             _ => null
         };
 
@@ -223,8 +223,21 @@ public partial class MainWindow : Window
     private void UpdateNextButtonForPrereqs()
     {
         if (_currentStep != StepPrereq) return;
-        var allRequiredMet = _prerequisites.Count == 0 || _prerequisites.Where(p => p.IsRequired).All(p => p.IsFound);
-        NextButton.IsEnabled = allRequiredMet;
+        NextButton.IsEnabled = PrerequisiteChecker.AllRequiredMet(_prerequisites);
+    }
+
+    /// <summary>
+    /// The Complete-screen line about recommended prerequisites the user did not install. Shared
+    /// with the Windows wizard (<see cref="CapabilityNotice"/>) so both say the same words. Null
+    /// when nothing is missing.
+    /// </summary>
+    private string? BuildCapabilityNotice()
+    {
+        var recommended = _prerequisites
+            .Where(p => p.IsRecommended)
+            .Select(p => new CapabilityStatus(p.Name, p.IsFound))
+            .ToList();
+        return CapabilityNotice.Describe(recommended, AgentPresence.AnyOtherAgent());
     }
 
     private async Task RunInstallAsync()

--- a/tools/cc-director-setup-avalonia/Models/PrerequisiteInfo.cs
+++ b/tools/cc-director-setup-avalonia/Models/PrerequisiteInfo.cs
@@ -11,6 +11,21 @@ public class PrerequisiteInfo : INotifyPropertyChanged
     public required string Name { get; init; }
     public required string Description { get; init; }
     public required bool IsRequired { get; init; }
+
+    /// <summary>
+    /// True for a row that is checked, offered and explained, but never gates the wizard - the
+    /// user is told on the Complete screen what skipping it costs. Distinct from merely
+    /// "not required": Tailscale is optional (a deliberate choice, not a gap) and is NOT
+    /// recommended, so it never appears in the Complete-screen capability notice.
+    /// </summary>
+    public bool IsRecommended { get; init; }
+
+    /// <summary>
+    /// The badge the user reads first: Required / Recommended / Optional. Bound by the row so the
+    /// badge can never disagree with the classification (it used to say "Optional" for every
+    /// non-required row, which made Claude Code indistinguishable from Tailscale).
+    /// </summary>
+    public string ImportanceLabel => IsRequired ? "Required" : (IsRecommended ? "Recommended" : "Optional");
     public required string InstallUrl { get; init; }
 
     /// <summary>Link to the CC Director install docs section for this prerequisite (setup help).</summary>

--- a/tools/cc-director-setup-avalonia/Services/PrerequisiteChecker.cs
+++ b/tools/cc-director-setup-avalonia/Services/PrerequisiteChecker.cs
@@ -28,7 +28,8 @@ public static class PrerequisiteChecker
         [
             new PrerequisiteInfo
             {
-                Name = "Claude Code",
+                Name = PrerequisiteNames.ClaudeCode,
+                IsRecommended = true,
                 Description = "Recommended: the default coding agent. DevThrottle runs other agents too, "
                     + "so you can install this later or use a different one.",
                 IsRequired = false,
@@ -37,7 +38,8 @@ public static class PrerequisiteChecker
             },
             new PrerequisiteInfo
             {
-                Name = "Python",
+                Name = PrerequisiteNames.Python,
+                IsRecommended = true,
                 Description = "Recommended: Python 3.11 or higher, for your own scripts. The cc-* tools "
                     + "bring their own Python and do not need this.",
                 IsRequired = false,
@@ -46,13 +48,26 @@ public static class PrerequisiteChecker
             },
             new PrerequisiteInfo
             {
-                Name = "Node.js",
+                Name = PrerequisiteNames.NodeJs,
+                IsRecommended = true,
                 Description = "Recommended: Node.js 20+, needed only for MCP servers and browser tools",
                 IsRequired = false,
                 InstallUrl = "https://nodejs.org/",
                 DocsUrl = $"{DocsBase}#nodejs"
             },
         ];
+    }
+
+    /// <summary>
+    /// The wizard's gate: may the user continue past the Prerequisites screen? One place decides,
+    /// so the Next button and the screen's own subtitle can never disagree. On macOS nothing is
+    /// required, so this is always true - which is correct, and is exactly why the subtitle must
+    /// speak for itself about the recommended rows.
+    /// </summary>
+    public static bool AllRequiredMet(IEnumerable<PrerequisiteInfo> items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        return items.Where(p => p.IsRequired).All(p => p.IsFound);
     }
 
     public static async Task CheckAllAsync(List<PrerequisiteInfo> items)

--- a/tools/cc-director-setup-avalonia/Services/PrerequisiteChecker.cs
+++ b/tools/cc-director-setup-avalonia/Services/PrerequisiteChecker.cs
@@ -15,29 +15,40 @@ public static class PrerequisiteChecker
 
     public static List<PrerequisiteInfo> CreateChecklist()
     {
+        // NONE of these is required, and this list carries no .NET row because the macOS Director
+        // publishes self-contained (--self-contained true) and needs no shared runtime. Marking
+        // these three required stopped a new user on this screen until they had installed three
+        // programs by hand, and none of them is needed to install DevThrottle or to start it:
+        // the cc-* tools ship their own relocatable CPython, Node.js is MCP and browser tools
+        // only, and Claude Code is one of the eight agent command line tools the Director runs.
+        // They stay checked and shown; what is missing is reported on the Complete screen.
+        //
+        // No winget on macOS, so there is no auto-install here - the install link is the path.
         return
         [
             new PrerequisiteInfo
             {
                 Name = "Claude Code",
-                Description = "AI coding assistant CLI",
-                IsRequired = true,
+                Description = "Recommended: the default coding agent. DevThrottle runs other agents too, "
+                    + "so you can install this later or use a different one.",
+                IsRequired = false,
                 InstallUrl = "https://docs.anthropic.com/en/docs/claude-code/overview",
                 DocsUrl = $"{DocsBase}#claude-code"
             },
             new PrerequisiteInfo
             {
                 Name = "Python",
-                Description = "Python 3.11 or higher",
-                IsRequired = true,
+                Description = "Recommended: Python 3.11 or higher, for your own scripts. The cc-* tools "
+                    + "bring their own Python and do not need this.",
+                IsRequired = false,
                 InstallUrl = "https://www.python.org/downloads/",
                 DocsUrl = $"{DocsBase}#python"
             },
             new PrerequisiteInfo
             {
                 Name = "Node.js",
-                Description = "Node.js 20+ (MCP servers, browser tools)",
-                IsRequired = true,
+                Description = "Recommended: Node.js 20+, needed only for MCP servers and browser tools",
+                IsRequired = false,
                 InstallUrl = "https://nodejs.org/",
                 DocsUrl = $"{DocsBase}#nodejs"
             },

--- a/tools/cc-director-setup-avalonia/Steps/CompleteStep.axaml
+++ b/tools/cc-director-setup-avalonia/Steps/CompleteStep.axaml
@@ -118,6 +118,16 @@
             </Border>
 
             <!-- Note about terminal PATH -->
+            <!-- What is missing because a recommended prerequisite was skipped. One shared place
+                 computes the wording (CapabilityNotice); this screen only renders it. -->
+            <Border x:Name="CapabilityPanel" Background="#2A2D2E" CornerRadius="6" Padding="12"
+                    Margin="0,0,0,12" IsVisible="False">
+                <TextBlock x:Name="CapabilityNoticeText"
+                           Foreground="#E0A030"
+                           FontSize="12"
+                           TextWrapping="Wrap" />
+            </Border>
+
             <TextBlock x:Name="PathNote"
                        Text="NOTE: Open a new terminal for cc-* commands to be available on PATH."
                        Foreground="#666666"

--- a/tools/cc-director-setup-avalonia/Steps/CompleteStep.axaml.cs
+++ b/tools/cc-director-setup-avalonia/Steps/CompleteStep.axaml.cs
@@ -23,9 +23,19 @@ public partial class CompleteStep : UserControl
         InitializeComponent();
     }
 
-    public CompleteStep(int installed, int skipped, string installPath, bool isUpdate, bool alreadyUpToDate = false, string? version = null)
+    public CompleteStep(int installed, int skipped, string installPath, bool isUpdate, bool alreadyUpToDate = false, string? version = null, string? capabilityNotice = null)
     {
         InitializeComponent();
+
+        // Recommended prerequisites no longer block the wizard, so this is where the user is told
+        // what they skipped and what it costs them - at the end, next to what they can do about it.
+        if (!string.IsNullOrWhiteSpace(capabilityNotice))
+        {
+            CapabilityNoticeText.Text = capabilityNotice;
+            CapabilityPanel.IsVisible = true;
+            SetupLog.Write($"[CompleteStep] capability notice shown: {capabilityNotice}");
+        }
+
         _installPath = installPath;
         _installed = installed;
         _skipped = skipped;

--- a/tools/cc-director-setup-avalonia/Steps/PrerequisitesStep.axaml
+++ b/tools/cc-director-setup-avalonia/Steps/PrerequisitesStep.axaml
@@ -115,7 +115,7 @@
                                             Background="#2A2F38"
                                             VerticalAlignment="Center"
                                             IsVisible="{Binding !IsRequired}">
-                                        <TextBlock Text="Optional"
+                                        <TextBlock Text="{Binding ImportanceLabel}"
                                                    Foreground="#8AA0B8"
                                                    FontSize="10"
                                                    FontWeight="SemiBold" />

--- a/tools/cc-director-setup-avalonia/Steps/PrerequisitesStep.axaml.cs
+++ b/tools/cc-director-setup-avalonia/Steps/PrerequisitesStep.axaml.cs
@@ -43,11 +43,19 @@ public partial class PrerequisitesStep : UserControl
 
         RefreshButton.IsEnabled = true;
 
-        var allRequiredMet = _items.Where(p => p.IsRequired).All(p => p.IsFound);
+        // On macOS NOTHING is required (the build is self-contained), so this branch is always
+        // taken. Saying "all prerequisites found" while three rows read Not found would be a
+        // flat lie against the screen the user is looking at - and macOS has no winget, so it is
+        // the platform where a user is most likely to finish with none of them installed.
+        var allRequiredMet = PrerequisiteChecker.AllRequiredMet(_items);
+        var missingRecommended = _items.Count(p => p.IsRecommended && !p.IsFound);
         if (allRequiredMet)
         {
-            SubtitleText.Text = "All required prerequisites found. You can install now.";
-            SuccessBanner.IsVisible = true;
+            SubtitleText.Text = missingRecommended == 0
+                ? "All prerequisites found. You can install now."
+                : $"Ready to install. {missingRecommended} recommended item(s) are missing - "
+                  + "install them from the links here, or later.";
+            SuccessBanner.IsVisible = missingRecommended == 0;
         }
         else
         {

--- a/tools/cc-director-setup-engine.Tests/CapabilityNoticeTests.cs
+++ b/tools/cc-director-setup-engine.Tests/CapabilityNoticeTests.cs
@@ -14,28 +14,54 @@ public class CapabilityNoticeTests
     {
         var notice = CapabilityNotice.Describe(
         [
-            new CapabilityStatus("Claude Code", IsFound: true),
-            new CapabilityStatus("Python", IsFound: true),
+            new CapabilityStatus(PrerequisiteNames.ClaudeCode, IsFound: true),
+            new CapabilityStatus(PrerequisiteNames.Python, IsFound: true),
         ]);
 
         Assert.Null(notice);
     }
 
     [Fact]
-    public void Describe_NoAgentInstalled_SaysTheBoardHasNothingToRun()
+    public void Describe_NoAgentAtAll_SaysTheBoardHasNothingToRun()
     {
         var notice = CapabilityNotice.Describe(
         [
-            new CapabilityStatus("Claude Code", IsFound: false),
-            new CapabilityStatus("Python", IsFound: true),
-            new CapabilityStatus("Node.js", IsFound: true),
-        ]);
+            new CapabilityStatus(PrerequisiteNames.ClaudeCode, IsFound: false),
+            new CapabilityStatus(PrerequisiteNames.NodeJs, IsFound: true),
+        ], anotherAgentPresent: false);
 
         Assert.NotNull(notice);
-        Assert.Contains("Claude Code", notice);
         Assert.Contains("nothing to run", notice);
         // Only the missing one is named - a found item must never be reported as missing.
-        Assert.DoesNotContain("Node.js", notice);
+        Assert.DoesNotContain(PrerequisiteNames.NodeJs, notice);
+    }
+
+    [Fact]
+    public void Describe_UserRunsAnotherAgent_DoesNotClaimTheyHaveNothingToRun()
+    {
+        // The whole point of the re-classification is that seven other agents exist. Telling a
+        // Codex or Gemini user their board has nothing to run would repeat, in words, the mistake
+        // the classification change removed.
+        var notice = CapabilityNotice.Describe(
+            [new CapabilityStatus(PrerequisiteNames.ClaudeCode, IsFound: false)],
+            anotherAgentPresent: true);
+
+        Assert.NotNull(notice);
+        Assert.DoesNotContain("nothing to run", notice);
+        Assert.Contains("other coding agent still works", notice);
+    }
+
+    [Fact]
+    public void Describe_NeverClaimsSomethingIsNotInstalled()
+    {
+        // IsFound is false for a Python 3.9 that is very much installed - the checker reports
+        // "Too old (need 3.11+)". Asserting "Not installed" would contradict the row the user
+        // just read on the previous screen.
+        var notice = CapabilityNotice.Describe([new CapabilityStatus(PrerequisiteNames.Python, IsFound: false)]);
+
+        Assert.NotNull(notice);
+        Assert.DoesNotContain("Not installed", notice);
+        Assert.Contains("Missing or out of date", notice);
     }
 
     [Fact]
@@ -43,16 +69,28 @@ public class CapabilityNoticeTests
     {
         var notice = CapabilityNotice.Describe(
         [
-            new CapabilityStatus("Claude Code", IsFound: false),
-            new CapabilityStatus("Python", IsFound: false),
-            new CapabilityStatus("Node.js", IsFound: false),
+            new CapabilityStatus(PrerequisiteNames.ClaudeCode, IsFound: false),
+            new CapabilityStatus(PrerequisiteNames.Python, IsFound: false),
+            new CapabilityStatus(PrerequisiteNames.NodeJs, IsFound: false),
         ]);
 
         Assert.NotNull(notice);
-        Assert.Contains("Claude Code", notice);
         Assert.Contains("MCP servers", notice);
         // Python's line must not imply the cc-* tools are broken - they ship their own Python.
         Assert.Contains("bring their own Python", notice);
+    }
+
+    [Fact]
+    public void Describe_EveryRecommendedName_HasItsOwnConsequence()
+    {
+        // Guards the magic-string linkage: rename a row and this fails rather than silently
+        // degrading every user to the generic "some features are unavailable".
+        foreach (var name in PrerequisiteNames.Recommended)
+        {
+            var notice = CapabilityNotice.Describe([new CapabilityStatus(name, IsFound: false)]);
+            Assert.NotNull(notice);
+            Assert.DoesNotContain("some features are unavailable", notice);
+        }
     }
 
     [Fact]
@@ -67,9 +105,19 @@ public class CapabilityNoticeTests
     [Fact]
     public void Describe_AlwaysSaysTheGapIsRecoverable()
     {
-        var notice = CapabilityNotice.Describe([new CapabilityStatus("Node.js", IsFound: false)]);
+        var notice = CapabilityNotice.Describe([new CapabilityStatus(PrerequisiteNames.NodeJs, IsFound: false)]);
 
         Assert.NotNull(notice);
         Assert.Contains("at any time", notice);
+    }
+
+    [Fact]
+    public void AnyOtherAgent_RecognisesTheNonClaudeAgents()
+    {
+        Assert.True(AgentPresence.AnyOtherAgent(exe => exe == "codex"));
+        Assert.True(AgentPresence.AnyOtherAgent(exe => exe == "gemini"));
+        Assert.False(AgentPresence.AnyOtherAgent(_ => false));
+        // Claude itself is not an "other" agent - it is the row being reported on.
+        Assert.False(AgentPresence.AnyOtherAgent(exe => exe == "claude"));
     }
 }

--- a/tools/cc-director-setup-engine.Tests/CapabilityNoticeTests.cs
+++ b/tools/cc-director-setup-engine.Tests/CapabilityNoticeTests.cs
@@ -1,0 +1,75 @@
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// The Complete screen's honesty guard. Recommended prerequisites no longer block the wizard, so
+/// this notice is the ONLY place a user is told what they skipped and what it costs them.
+/// </summary>
+public class CapabilityNoticeTests
+{
+    [Fact]
+    public void Describe_NothingMissing_SaysNothing()
+    {
+        var notice = CapabilityNotice.Describe(
+        [
+            new CapabilityStatus("Claude Code", IsFound: true),
+            new CapabilityStatus("Python", IsFound: true),
+        ]);
+
+        Assert.Null(notice);
+    }
+
+    [Fact]
+    public void Describe_NoAgentInstalled_SaysTheBoardHasNothingToRun()
+    {
+        var notice = CapabilityNotice.Describe(
+        [
+            new CapabilityStatus("Claude Code", IsFound: false),
+            new CapabilityStatus("Python", IsFound: true),
+            new CapabilityStatus("Node.js", IsFound: true),
+        ]);
+
+        Assert.NotNull(notice);
+        Assert.Contains("Claude Code", notice);
+        Assert.Contains("nothing to run", notice);
+        // Only the missing one is named - a found item must never be reported as missing.
+        Assert.DoesNotContain("Node.js", notice);
+    }
+
+    [Fact]
+    public void Describe_SeveralMissing_NamesEachWithItsOwnConsequence()
+    {
+        var notice = CapabilityNotice.Describe(
+        [
+            new CapabilityStatus("Claude Code", IsFound: false),
+            new CapabilityStatus("Python", IsFound: false),
+            new CapabilityStatus("Node.js", IsFound: false),
+        ]);
+
+        Assert.NotNull(notice);
+        Assert.Contains("Claude Code", notice);
+        Assert.Contains("MCP servers", notice);
+        // Python's line must not imply the cc-* tools are broken - they ship their own Python.
+        Assert.Contains("bring their own Python", notice);
+    }
+
+    [Fact]
+    public void Describe_UnknownItem_StillReportsItRatherThanDroppingIt()
+    {
+        var notice = CapabilityNotice.Describe([new CapabilityStatus("Something New", IsFound: false)]);
+
+        Assert.NotNull(notice);
+        Assert.Contains("Something New", notice);
+    }
+
+    [Fact]
+    public void Describe_AlwaysSaysTheGapIsRecoverable()
+    {
+        var notice = CapabilityNotice.Describe([new CapabilityStatus("Node.js", IsFound: false)]);
+
+        Assert.NotNull(notice);
+        Assert.Contains("at any time", notice);
+    }
+}

--- a/tools/cc-director-setup-engine/AgentPresence.cs
+++ b/tools/cc-director-setup-engine/AgentPresence.cs
@@ -1,0 +1,56 @@
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// Answers one question for the Complete screen: is a coding agent OTHER than Claude Code already
+/// on this machine?
+///
+/// It matters because the whole point of making Claude Code non-blocking is that the Director runs
+/// eight agent command line tools. Without this, a user who runs Codex or Gemini would finish the
+/// install and be told "no coding agent is set up yet" - repeating in words the exact mistake the
+/// classification change removed.
+///
+/// Presence only: no process is started, nothing is authenticated, and no version is read.
+/// </summary>
+public static class AgentPresence
+{
+    /// <summary>The non-Claude agent command line tools the Director can drive.</summary>
+    public static readonly IReadOnlyList<string> OtherAgentCommands =
+        ["codex", "gemini", "opencode", "copilot", "cursor-agent", "grok", "pi"];
+
+    /// <summary>Testable core: true when the probe finds any non-Claude agent.</summary>
+    public static bool AnyOtherAgent(Func<string, bool> isOnPath)
+    {
+        ArgumentNullException.ThrowIfNull(isOnPath);
+        return OtherAgentCommands.Any(isOnPath);
+    }
+
+    /// <summary>Production probe: walk PATH (honouring PATHEXT on Windows) without spawning anything.</summary>
+    public static bool AnyOtherAgent() => AnyOtherAgent(IsOnPath);
+
+    private static bool IsOnPath(string exe)
+    {
+        var pathVar = Environment.GetEnvironmentVariable("PATH") ?? "";
+        var exts = OperatingSystem.IsWindows()
+            ? (Environment.GetEnvironmentVariable("PATHEXT") ?? ".EXE;.CMD;.BAT")
+                .Split(';', StringSplitOptions.RemoveEmptyEntries)
+            : [""];
+
+        foreach (var dir in pathVar.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var ext in exts)
+            {
+                try
+                {
+                    if (File.Exists(Path.Combine(dir.Trim(), exe + ext)))
+                        return true;
+                }
+                catch
+                {
+                    // A malformed PATH entry must not take down the notice; keep probing the rest.
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tools/cc-director-setup-engine/CapabilityNotice.cs
+++ b/tools/cc-director-setup-engine/CapabilityNotice.cs
@@ -1,0 +1,46 @@
+namespace CcDirector.Setup.Engine;
+
+/// <summary>One recommended prerequisite and whether the checker found it.</summary>
+public sealed record CapabilityStatus(string Name, bool IsFound);
+
+/// <summary>
+/// Turns the recommended-prerequisite results into the one sentence the Complete screen shows.
+///
+/// The Prerequisites screen no longer blocks on Claude Code, Python or Node.js - none of them is
+/// needed to install DevThrottle or to start it. But a user who skipped them has a real, named
+/// gap, and the honest place to say so is at the END of the install, next to what they can do
+/// about it - not as a wall on screen two.
+///
+/// This is deliberately UI-free so both wizards render the same words and one test can prove
+/// them. The screen renders this verdict and never decides for itself what a missing item means.
+/// </summary>
+public static class CapabilityNotice
+{
+    /// <summary>What each recommended item costs the user when it is absent.</summary>
+    private static string Consequence(string name) => name switch
+    {
+        "Claude Code" => "no coding agent is installed yet, so your board has nothing to run",
+        "Python" => "your own Python scripts will not run (the cc-* tools bring their own Python)",
+        "Node.js" => "MCP servers and the browser tools are unavailable",
+        "Tailscale" => "phones and other computers cannot reach this gateway's Cockpit over a secure address "
+            + "(everything on this machine still works)",
+        _ => "some features are unavailable",
+    };
+
+    /// <summary>
+    /// The Complete-screen notice, or null when nothing is missing. Order follows the caller's
+    /// list so the wizard's own ordering is the one the user reads.
+    /// </summary>
+    public static string? Describe(IEnumerable<CapabilityStatus> recommended)
+    {
+        ArgumentNullException.ThrowIfNull(recommended);
+
+        var missing = recommended.Where(r => !r.IsFound).ToList();
+        if (missing.Count == 0)
+            return null;
+
+        var parts = missing.Select(m => $"{m.Name}: {Consequence(m.Name)}");
+        return "Not installed - " + string.Join("; ", parts)
+            + ". You can install any of these at any time and DevThrottle will pick them up.";
+    }
+}

--- a/tools/cc-director-setup-engine/CapabilityNotice.cs
+++ b/tools/cc-director-setup-engine/CapabilityNotice.cs
@@ -1,6 +1,28 @@
 namespace CcDirector.Setup.Engine;
 
-/// <summary>One recommended prerequisite and whether the checker found it.</summary>
+/// <summary>
+/// The canonical prerequisite row names. Both wizards build their checklists from these and
+/// <see cref="CapabilityNotice"/> keys off them, so a rename cannot silently detach a row from its
+/// consequence text (which is what a plain magic string would do, with every test still green).
+/// </summary>
+public static class PrerequisiteNames
+{
+    public const string DotNetRuntime = ".NET 10 Runtime";
+    public const string ClaudeCode = "Claude Code";
+    public const string Python = "Python";
+    public const string NodeJs = "Node.js";
+    public const string Tailscale = "Tailscale";
+
+    /// <summary>The rows that are recommended - checked and offered, but never gating.</summary>
+    public static readonly IReadOnlyList<string> Recommended = [ClaudeCode, Python, NodeJs];
+}
+
+/// <summary>One recommended prerequisite and whether the checker accepted it.</summary>
+/// <param name="Name">One of <see cref="PrerequisiteNames"/>.</param>
+/// <param name="IsFound">
+/// The checker's verdict, which means "present AND acceptable" - a Python 3.9 or a Node 18 is
+/// reported as not found. The notice wording must therefore not assert "not installed".
+/// </param>
 public sealed record CapabilityStatus(string Name, bool IsFound);
 
 /// <summary>
@@ -12,18 +34,28 @@ public sealed record CapabilityStatus(string Name, bool IsFound);
 /// about it - not as a wall on screen two.
 ///
 /// This is deliberately UI-free so both wizards render the same words and one test can prove
-/// them. The screen renders this verdict and never decides for itself what a missing item means.
+/// them. A screen renders this verdict and never decides for itself what a missing item means.
 /// </summary>
 public static class CapabilityNotice
 {
-    /// <summary>What each recommended item costs the user when it is absent.</summary>
-    private static string Consequence(string name) => name switch
+    /// <summary>
+    /// What each recommended item costs the user when it is absent or too old.
+    ///
+    /// <paramref name="anotherAgentPresent"/> exists because the whole point of the
+    /// re-classification is that DevThrottle runs eight agent command line tools. Telling a user
+    /// who runs Codex or Gemini that their "board has nothing to run" would repeat, in words, the
+    /// very mistake the classification change removed.
+    /// </summary>
+    private static string Consequence(string name, bool anotherAgentPresent) => name switch
     {
-        "Claude Code" => "no coding agent is installed yet, so your board has nothing to run",
-        "Python" => "your own Python scripts will not run (the cc-* tools bring their own Python)",
-        "Node.js" => "MCP servers and the browser tools are unavailable",
-        "Tailscale" => "phones and other computers cannot reach this gateway's Cockpit over a secure address "
-            + "(everything on this machine still works)",
+        PrerequisiteNames.ClaudeCode when anotherAgentPresent =>
+            "the Claude agent is unavailable - your other coding agent still works",
+        PrerequisiteNames.ClaudeCode =>
+            "no coding agent is set up yet, so your board has nothing to run",
+        PrerequisiteNames.Python =>
+            "your own Python scripts will not run (the cc-* tools bring their own Python)",
+        PrerequisiteNames.NodeJs =>
+            "MCP servers and the browser tools are unavailable",
         _ => "some features are unavailable",
     };
 
@@ -31,7 +63,13 @@ public static class CapabilityNotice
     /// The Complete-screen notice, or null when nothing is missing. Order follows the caller's
     /// list so the wizard's own ordering is the one the user reads.
     /// </summary>
-    public static string? Describe(IEnumerable<CapabilityStatus> recommended)
+    /// <param name="recommended">
+    /// The recommended rows only. Optional rows (Tailscale) must NOT be passed: they are a
+    /// deliberate choice rather than a gap, and their own row already explains which part is not
+    /// ready.
+    /// </param>
+    /// <param name="anotherAgentPresent">True when a non-Claude agent command line tool is on PATH.</param>
+    public static string? Describe(IEnumerable<CapabilityStatus> recommended, bool anotherAgentPresent = false)
     {
         ArgumentNullException.ThrowIfNull(recommended);
 
@@ -39,8 +77,11 @@ public static class CapabilityNotice
         if (missing.Count == 0)
             return null;
 
-        var parts = missing.Select(m => $"{m.Name}: {Consequence(m.Name)}");
-        return "Not installed - " + string.Join("; ", parts)
+        var parts = missing.Select(m => $"{m.Name}: {Consequence(m.Name, anotherAgentPresent)}");
+
+        // "Missing or out of date", never "Not installed": IsFound is false for a Python 3.9 that
+        // is very much installed, and claiming otherwise would contradict the row the user just read.
+        return "Missing or out of date - " + string.Join("; ", parts)
             + ". You can install any of these at any time and DevThrottle will pick them up.";
     }
 }

--- a/tools/cc-director-setup.Tests/PrerequisiteClassificationTests.cs
+++ b/tools/cc-director-setup.Tests/PrerequisiteClassificationTests.cs
@@ -1,0 +1,87 @@
+using CcDirector.Setup.Engine;
+using CcDirectorSetup.Models;
+using CcDirectorSetup.Services;
+using Xunit;
+
+namespace CcDirectorSetup.Tests;
+
+/// <summary>
+/// Guards the prerequisite re-classification. These call the REAL production checklist
+/// (<see cref="PrerequisiteChecker.CreateChecklist"/>) and the REAL gate
+/// (<see cref="PrerequisiteChecker.AllRequiredMet"/>) - the same two the wizard calls - so
+/// putting <c>IsRequired = true</c> back on any of the three recommended rows turns these red.
+/// </summary>
+public class PrerequisiteClassificationTests
+{
+    [Fact]
+    public void CreateChecklist_OnlyDotNetIsRequired()
+    {
+        var checklist = PrerequisiteChecker.CreateChecklist(InstallRole.Workstation);
+
+        var required = checklist.Where(p => p.IsRequired).Select(p => p.Name).ToList();
+
+        // The Windows Director publishes framework-dependent, so the runtime is the one genuine
+        // dependency. Claude Code, Python and Node.js must never gate the wizard again.
+        Assert.Equal([".NET 10 Runtime"], required);
+    }
+
+    [Theory]
+    [InlineData("Claude Code", "Anthropic.ClaudeCode")]
+    [InlineData("Python", "Python.Python.3.12")]
+    [InlineData("Node.js", "OpenJS.NodeJS.LTS")]
+    public void CreateChecklist_RecommendedItemsCanBeInstalledInPlace(string name, string wingetId)
+    {
+        var item = PrerequisiteChecker.CreateChecklist(InstallRole.Workstation)
+            .Single(p => p.Name == name);
+
+        Assert.True(item.CanAutoInstall);
+        Assert.Equal(wingetId, item.WingetId);
+
+        // The row's install action is what the user actually clicks; it must be offered while the
+        // item is missing and hide itself once found.
+        item.IsFound = false;
+        Assert.True(item.ShowAutoInstall);
+        item.IsFound = true;
+        Assert.False(item.ShowAutoInstall);
+    }
+
+    [Fact]
+    public void CreateChecklist_EveryItemKeepsAManualInstallLink()
+    {
+        // winget is absent on locked-down machines, so the link is the fallback path and must
+        // survive on every row - including the ones that gained an auto-install.
+        var checklist = PrerequisiteChecker.CreateChecklist(InstallRole.Gateway);
+
+        Assert.All(checklist, p => Assert.False(string.IsNullOrWhiteSpace(p.InstallUrl)));
+    }
+
+    [Fact]
+    public void AllRequiredMet_UserWithOnlyTheDotNetRuntime_CanContinue()
+    {
+        // The point of the change: a brand-new machine where Setup has installed the runtime and
+        // nothing else is NOT stopped on screen two.
+        var checklist = PrerequisiteChecker.CreateChecklist(InstallRole.Workstation);
+        foreach (var item in checklist)
+            item.IsFound = item.Name == ".NET 10 Runtime";
+
+        Assert.True(PrerequisiteChecker.AllRequiredMet(checklist));
+    }
+
+    [Fact]
+    public void AllRequiredMet_MissingDotNetRuntime_StillBlocks()
+    {
+        // The gate still protects the one real dependency: warn-and-continue alone would walk the
+        // user through to a Director that cannot start.
+        var checklist = PrerequisiteChecker.CreateChecklist(InstallRole.Workstation);
+        foreach (var item in checklist)
+            item.IsFound = item.Name != ".NET 10 Runtime";
+
+        Assert.False(PrerequisiteChecker.AllRequiredMet(checklist));
+    }
+
+    [Fact]
+    public void AllRequiredMet_NothingCheckedYet_IsTreatedAsMet()
+    {
+        Assert.True(PrerequisiteChecker.AllRequiredMet(new List<PrerequisiteInfo>()));
+    }
+}

--- a/tools/cc-director-setup.Tests/PrerequisiteClassificationTests.cs
+++ b/tools/cc-director-setup.Tests/PrerequisiteClassificationTests.cs
@@ -84,4 +84,52 @@ public class PrerequisiteClassificationTests
     {
         Assert.True(PrerequisiteChecker.AllRequiredMet(new List<PrerequisiteInfo>()));
     }
+
+    [Fact]
+    public void CreateChecklist_RecommendedRowsAreExactlyTheThree()
+    {
+        var recommended = PrerequisiteChecker.CreateChecklist(InstallRole.Gateway)
+            .Where(p => p.IsRecommended).Select(p => p.Name).ToList();
+
+        Assert.Equal(PrerequisiteNames.Recommended, recommended);
+    }
+
+    [Fact]
+    public void CreateChecklist_TailscaleIsOptionalNotRecommended()
+    {
+        // Tailscale is a deliberate choice, not a gap, and its own row already says which leg is
+        // not ready. Sweeping it in with !IsRequired would put "Tailscale: ..." on the Complete
+        // screen for a gateway that has Tailscale installed but MagicDNS switched off.
+        var tailscale = PrerequisiteChecker.CreateChecklist(InstallRole.Gateway)
+            .Single(p => p.Name == PrerequisiteNames.Tailscale);
+
+        Assert.False(tailscale.IsRequired);
+        Assert.False(tailscale.IsRecommended);
+        Assert.Equal("Optional", tailscale.ImportanceLabel);
+    }
+
+    [Fact]
+    public void ImportanceLabel_DistinguishesAllThreeStates()
+    {
+        var checklist = PrerequisiteChecker.CreateChecklist(InstallRole.Gateway);
+
+        // The badge is the first thing a user reads; it used to say "Optional" for every
+        // non-required row, making Claude Code indistinguishable from Tailscale.
+        Assert.Equal("Required", checklist.Single(p => p.Name == PrerequisiteNames.DotNetRuntime).ImportanceLabel);
+        Assert.Equal("Recommended", checklist.Single(p => p.Name == PrerequisiteNames.ClaudeCode).ImportanceLabel);
+        Assert.Equal("Optional", checklist.Single(p => p.Name == PrerequisiteNames.Tailscale).ImportanceLabel);
+    }
+
+    [Fact]
+    public async Task RuntimeInstaller_FailureNamesTheToolTheUserClicked()
+    {
+        // The class was written for the .NET row and hardcoded ".NET 10" in its failure text.
+        // With four rows able to auto-install, clicking Install on Python must not tell the user
+        // to go and download .NET 10.
+        var result = await RuntimeInstaller.InstallAsync("Definitely.Not.A.Real.Package", PrerequisiteNames.Python);
+
+        Assert.False(result.Success);
+        Assert.Contains(PrerequisiteNames.Python, result.Message);
+        Assert.DoesNotContain(".NET 10", result.Message);
+    }
 }

--- a/tools/cc-director-setup/MainWindow.xaml.cs
+++ b/tools/cc-director-setup/MainWindow.xaml.cs
@@ -302,11 +302,15 @@ public partial class MainWindow : Window
     /// </summary>
     private string? BuildCapabilityNotice()
     {
+        // IsRecommended, NOT !IsRequired: Tailscale is optional (a deliberate choice, not a gap)
+        // and its own row already says which leg is not ready, so it must never appear here.
         var recommended = _prerequisites
-            .Where(p => !p.IsRequired)
+            .Where(p => p.IsRecommended)
             .Select(p => new CcDirector.Setup.Engine.CapabilityStatus(p.Name, p.IsFound))
             .ToList();
-        return CcDirector.Setup.Engine.CapabilityNotice.Describe(recommended);
+        return CcDirector.Setup.Engine.CapabilityNotice.Describe(
+            recommended,
+            CcDirector.Setup.Engine.AgentPresence.AnyOtherAgent());
     }
 
     private async Task RunInstallAsync()

--- a/tools/cc-director-setup/MainWindow.xaml.cs
+++ b/tools/cc-director-setup/MainWindow.xaml.cs
@@ -194,7 +194,7 @@ public partial class MainWindow : Window
             StepPrivacy => _privacyStep ??= BuildPrivacyStep(),
             6 => _skillsStep ??= new SkillsStep(_isUpdate),
             StepInstall => _installStep ??= new InstallStep(),
-            StepComplete => _completeStep ??= new CompleteStep(_installedCount, _skippedCount, _installPath, _directorExePath, _isUpdate, _alreadyUpToDate, _cachedPrep?.Version, _gatewayFailureReason),
+            StepComplete => _completeStep ??= new CompleteStep(_installedCount, _skippedCount, _installPath, _directorExePath, _isUpdate, _alreadyUpToDate, _cachedPrep?.Version, _gatewayFailureReason, BuildCapabilityNotice()),
             _ => null
         };
 
@@ -292,9 +292,21 @@ public partial class MainWindow : Window
     {
         if (_currentStep != 2) return;
 
-        var allRequiredMet = _prerequisites.Count == 0 ||
-            _prerequisites.Where(p => p.IsRequired).All(p => p.IsFound);
-        NextButton.IsEnabled = allRequiredMet;
+        NextButton.IsEnabled = PrerequisiteChecker.AllRequiredMet(_prerequisites);
+    }
+
+    /// <summary>
+    /// The Complete-screen line about recommended prerequisites the user did not install. Left to
+    /// the shared <see cref="CcDirector.Setup.Engine.CapabilityNotice"/> so both wizards say the
+    /// same thing and one test can prove the words. Null when nothing is missing.
+    /// </summary>
+    private string? BuildCapabilityNotice()
+    {
+        var recommended = _prerequisites
+            .Where(p => !p.IsRequired)
+            .Select(p => new CcDirector.Setup.Engine.CapabilityStatus(p.Name, p.IsFound))
+            .ToList();
+        return CcDirector.Setup.Engine.CapabilityNotice.Describe(recommended);
     }
 
     private async Task RunInstallAsync()

--- a/tools/cc-director-setup/Models/PrerequisiteInfo.cs
+++ b/tools/cc-director-setup/Models/PrerequisiteInfo.cs
@@ -11,6 +11,21 @@ public class PrerequisiteInfo : INotifyPropertyChanged
     public required string Name { get; init; }
     public required string Description { get; init; }
     public required bool IsRequired { get; init; }
+
+    /// <summary>
+    /// True for a row that is checked, offered and explained, but never gates the wizard - the
+    /// user is told on the Complete screen what skipping it costs. Distinct from merely
+    /// "not required": Tailscale is optional (a deliberate choice, not a gap) and is NOT
+    /// recommended, so it never appears in the Complete-screen capability notice.
+    /// </summary>
+    public bool IsRecommended { get; init; }
+
+    /// <summary>
+    /// The badge the user reads first: Required / Recommended / Optional. Bound by the row so the
+    /// badge can never disagree with the classification (it used to say "Optional" for every
+    /// non-required row, which made Claude Code indistinguishable from Tailscale).
+    /// </summary>
+    public string ImportanceLabel => IsRequired ? "Required" : (IsRecommended ? "Recommended" : "Optional");
     public required string InstallUrl { get; init; }
 
     /// <summary>True when Setup can install this prerequisite itself (via winget).</summary>

--- a/tools/cc-director-setup/Services/PrerequisiteChecker.cs
+++ b/tools/cc-director-setup/Services/PrerequisiteChecker.cs
@@ -7,19 +7,28 @@ public static class PrerequisiteChecker
 {
     public static List<PrerequisiteInfo> CreateChecklist(CcDirector.Setup.Engine.InstallRole role)
     {
-        // Tailscale is NOT a product requirement on a workstation - the tunnel-only
-        // architecture means every Director and launcher dials OUT to the Gateway and no
-        // inbound port is ever opened, so a workstation shows no Tailscale row at all.
-        // The one optional use left is on the GATEWAY machine itself: phones and browsers
-        // reaching the Cockpit off-machine need a secure (HTTPS) address, which Tailscale
-        // can provide for free. Everything on the gateway machine itself works at
-        // localhost over plain HTTP without it.
+        // EXACTLY ONE prerequisite is genuinely required: the .NET runtime, because the Windows
+        // Director publishes framework-dependent (--self-contained false) and will not start
+        // without it. It is also the one item Setup can install itself, so the required gate is
+        // satisfiable without the user ever leaving the wizard.
+        //
+        // The other three were marked required and gated the Next button, which stopped a new user
+        // on this screen until they went away and installed three programs by hand. None of them
+        // is needed to install DevThrottle or to start it:
+        //   - Python: the cc-* tools ship their OWN relocatable CPython (cc-python-win-x64.zip,
+        //     staged by PythonToolsInstaller). They never use the system interpreter.
+        //   - Node.js: MCP servers and browser tools only.
+        //   - Claude Code: only the Claude agent. The Director runs eight agent command line
+        //     tools (see src/CcDirector.Core/Agents/), so requiring this one stopped a user who
+        //     came for Codex or Gemini for not having a different vendor's tool.
+        // They are still checked, still shown, and now installable with one click - but they no
+        // longer gate. What is missing is reported on the Complete screen instead (CapabilityNotice).
         var checklist = new List<PrerequisiteInfo>
         {
             new PrerequisiteInfo
             {
                 Name = ".NET 10 Runtime",
-                Description = "ASP.NET Core Runtime 10 (runs DevThrottle)",
+                Description = "ASP.NET Core Runtime 10 - required: DevThrottle will not start without it",
                 IsRequired = true,
                 CanAutoInstall = true,
                 WingetId = "Microsoft.DotNet.AspNetCore.10",
@@ -28,26 +37,41 @@ public static class PrerequisiteChecker
             new PrerequisiteInfo
             {
                 Name = "Claude Code",
-                Description = "AI coding assistant CLI",
-                IsRequired = true,
+                Description = "Recommended: the default coding agent. DevThrottle runs other agents too, "
+                    + "so you can install this later or use a different one.",
+                IsRequired = false,
+                CanAutoInstall = true,
+                WingetId = "Anthropic.ClaudeCode",
                 InstallUrl = "https://docs.anthropic.com/en/docs/claude-code/overview"
             },
             new PrerequisiteInfo
             {
                 Name = "Python",
-                Description = "Python 3.11 or higher",
-                IsRequired = true,
+                Description = "Recommended: Python 3.11 or higher, for your own scripts. The cc-* tools "
+                    + "bring their own Python and do not need this.",
+                IsRequired = false,
+                CanAutoInstall = true,
+                WingetId = "Python.Python.3.12",
                 InstallUrl = "https://www.python.org/downloads/"
             },
             new PrerequisiteInfo
             {
                 Name = "Node.js",
-                Description = "Node.js 20+ (MCP servers, browser tools)",
-                IsRequired = true,
+                Description = "Recommended: Node.js 20+, needed only for MCP servers and browser tools",
+                IsRequired = false,
+                CanAutoInstall = true,
+                WingetId = "OpenJS.NodeJS.LTS",
                 InstallUrl = "https://nodejs.org/"
             },
         };
 
+        // Tailscale is NOT a product requirement on a workstation - the tunnel-only
+        // architecture means every Director and launcher dials OUT to the Gateway and no
+        // inbound port is ever opened, so a workstation shows no Tailscale row at all.
+        // The one optional use left is on the GATEWAY machine itself: phones and browsers
+        // reaching the Cockpit off-machine need a secure (HTTPS) address, which Tailscale
+        // can provide for free. Everything on the gateway machine itself works at
+        // localhost over plain HTTP without it.
         if (role == CcDirector.Setup.Engine.InstallRole.Gateway)
         {
             checklist.Add(new PrerequisiteInfo
@@ -66,6 +90,17 @@ public static class PrerequisiteChecker
         }
 
         return checklist;
+    }
+
+    /// <summary>
+    /// The wizard's gate: may the user continue past the Prerequisites screen? One place decides,
+    /// so the Next button and the screen's own subtitle can never disagree. An empty list means
+    /// nothing has been checked yet and is treated as met, exactly as before.
+    /// </summary>
+    public static bool AllRequiredMet(IEnumerable<PrerequisiteInfo> items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        return items.Where(p => p.IsRequired).All(p => p.IsFound);
     }
 
     public static async Task CheckAllAsync(List<PrerequisiteInfo> items)

--- a/tools/cc-director-setup/Services/PrerequisiteChecker.cs
+++ b/tools/cc-director-setup/Services/PrerequisiteChecker.cs
@@ -27,7 +27,7 @@ public static class PrerequisiteChecker
         {
             new PrerequisiteInfo
             {
-                Name = ".NET 10 Runtime",
+                Name = CcDirector.Setup.Engine.PrerequisiteNames.DotNetRuntime,
                 Description = "ASP.NET Core Runtime 10 - required: DevThrottle will not start without it",
                 IsRequired = true,
                 CanAutoInstall = true,
@@ -36,7 +36,8 @@ public static class PrerequisiteChecker
             },
             new PrerequisiteInfo
             {
-                Name = "Claude Code",
+                Name = CcDirector.Setup.Engine.PrerequisiteNames.ClaudeCode,
+                IsRecommended = true,
                 Description = "Recommended: the default coding agent. DevThrottle runs other agents too, "
                     + "so you can install this later or use a different one.",
                 IsRequired = false,
@@ -46,7 +47,8 @@ public static class PrerequisiteChecker
             },
             new PrerequisiteInfo
             {
-                Name = "Python",
+                Name = CcDirector.Setup.Engine.PrerequisiteNames.Python,
+                IsRecommended = true,
                 Description = "Recommended: Python 3.11 or higher, for your own scripts. The cc-* tools "
                     + "bring their own Python and do not need this.",
                 IsRequired = false,
@@ -56,7 +58,8 @@ public static class PrerequisiteChecker
             },
             new PrerequisiteInfo
             {
-                Name = "Node.js",
+                Name = CcDirector.Setup.Engine.PrerequisiteNames.NodeJs,
+                IsRecommended = true,
                 Description = "Recommended: Node.js 20+, needed only for MCP servers and browser tools",
                 IsRequired = false,
                 CanAutoInstall = true,
@@ -76,7 +79,7 @@ public static class PrerequisiteChecker
         {
             checklist.Add(new PrerequisiteInfo
             {
-                Name = "Tailscale",
+                Name = CcDirector.Setup.Engine.PrerequisiteNames.Tailscale,
                 Description = "Optional, gateway machine only: lets your phone and browsers on "
                     + "other computers reach this gateway's Cockpit over a secure (HTTPS) "
                     + "connection. Directors and launchers connect to the gateway on their own "

--- a/tools/cc-director-setup/Services/RuntimeInstaller.cs
+++ b/tools/cc-director-setup/Services/RuntimeInstaller.cs
@@ -13,7 +13,9 @@ public sealed record RuntimeInstallResult(bool Success, string Message);
 /// </summary>
 public static class RuntimeInstaller
 {
-    public static async Task<RuntimeInstallResult> InstallAsync(string wingetId)
+    /// <param name="displayName">The row's name, so a failure names the tool the user clicked on
+    /// rather than the one this class was originally written for.</param>
+    public static async Task<RuntimeInstallResult> InstallAsync(string wingetId, string displayName = "this prerequisite")
     {
         SetupLog.Write($"[RuntimeInstaller] InstallAsync: wingetId={wingetId}");
 
@@ -22,7 +24,7 @@ public static class RuntimeInstaller
         {
             SetupLog.Write("[RuntimeInstaller] winget not available");
             return new RuntimeInstallResult(false,
-                "winget (the Windows Package Manager) was not found. Use the download link to install .NET 10 manually, then click Re-check.");
+                $"winget (the Windows Package Manager) was not found. Use the download link to install {displayName} manually, then click Re-check.");
         }
 
         var args =
@@ -37,7 +39,7 @@ public static class RuntimeInstaller
 
         SetupLog.Write($"[RuntimeInstaller] install failed: exit={exitCode}; {Trim(output)}");
         return new RuntimeInstallResult(false,
-            $"winget could not install {wingetId} (exit {exitCode}). Use the download link to install .NET 10 manually, then click Re-check.");
+            $"winget could not install {displayName} (exit {exitCode}). Use the download link to install it manually, then click Re-check.");
     }
 
     /// <summary>

--- a/tools/cc-director-setup/Steps/CompleteStep.xaml
+++ b/tools/cc-director-setup/Steps/CompleteStep.xaml
@@ -129,6 +129,16 @@
                 </StackPanel>
             </Border>
 
+            <!-- What is missing because a recommended prerequisite was skipped. One shared place
+                 computes the wording (CapabilityNotice); this screen only renders it. -->
+            <Border x:Name="CapabilityPanel" Background="#2A2D2E" CornerRadius="6" Padding="12"
+                    Margin="0,0,0,12" Visibility="Collapsed">
+                <TextBlock x:Name="CapabilityNoticeText"
+                           Foreground="#E0A030"
+                           FontSize="12"
+                           TextWrapping="Wrap" />
+            </Border>
+
             <!-- Note about terminal PATH -->
             <TextBlock x:Name="PathNote"
                        Text="NOTE: Open a new terminal for cc-* commands to be available on PATH."

--- a/tools/cc-director-setup/Steps/CompleteStep.xaml.cs
+++ b/tools/cc-director-setup/Steps/CompleteStep.xaml.cs
@@ -17,9 +17,19 @@ public partial class CompleteStep : UserControl
     private readonly int _skipped;
     private readonly bool _isUpdate;
 
-    public CompleteStep(int installed, int skipped, string installPath, string directorExePath, bool isUpdate, bool alreadyUpToDate = false, string? version = null, string? gatewayFailureReason = null)
+    public CompleteStep(int installed, int skipped, string installPath, string directorExePath, bool isUpdate, bool alreadyUpToDate = false, string? version = null, string? gatewayFailureReason = null, string? capabilityNotice = null)
     {
         InitializeComponent();
+
+        // Recommended prerequisites no longer block the wizard, so this is where the user is told
+        // what they skipped and what it costs them - at the end, next to what they can do about it.
+        if (!string.IsNullOrWhiteSpace(capabilityNotice))
+        {
+            CapabilityNoticeText.Text = capabilityNotice;
+            CapabilityPanel.Visibility = Visibility.Visible;
+            SetupLog.Write($"[CompleteStep] capability notice shown: {capabilityNotice}");
+        }
+
         _installPath = installPath;
         _directorExePath = directorExePath;
         _installed = installed;

--- a/tools/cc-director-setup/Steps/PrerequisitesStep.xaml
+++ b/tools/cc-director-setup/Steps/PrerequisitesStep.xaml
@@ -102,7 +102,7 @@
                                                 </Style.Triggers>
                                             </Style>
                                         </Border.Style>
-                                        <TextBlock Text="Optional"
+                                        <TextBlock Text="{Binding ImportanceLabel}"
                                                    Foreground="#888888"
                                                    FontSize="10"
                                                    FontWeight="SemiBold" />

--- a/tools/cc-director-setup/Steps/PrerequisitesStep.xaml.cs
+++ b/tools/cc-director-setup/Steps/PrerequisitesStep.xaml.cs
@@ -40,7 +40,7 @@ public partial class PrerequisitesStep : UserControl
         RefreshButton.IsEnabled = true;
 
         var allRequiredMet = PrerequisiteChecker.AllRequiredMet(_items);
-        var missingRecommended = _items.Count(p => !p.IsRequired && !p.IsFound);
+        var missingRecommended = _items.Count(p => p.IsRecommended && !p.IsFound);
         if (allRequiredMet)
         {
             // Honest about the recommended ones: they no longer block, but saying only "all
@@ -82,7 +82,7 @@ public partial class PrerequisitesStep : UserControl
             RefreshButton.IsEnabled = false;
             item.Status = "Installing...";
 
-            var result = await RuntimeInstaller.InstallAsync(item.WingetId);
+            var result = await RuntimeInstaller.InstallAsync(item.WingetId, item.Name);
             SetupLog.Write($"[PrerequisitesStep] InstallButton_Click: success={result.Success}, {result.Message}");
 
             if (result.Success)

--- a/tools/cc-director-setup/Steps/PrerequisitesStep.xaml.cs
+++ b/tools/cc-director-setup/Steps/PrerequisitesStep.xaml.cs
@@ -39,10 +39,16 @@ public partial class PrerequisitesStep : UserControl
 
         RefreshButton.IsEnabled = true;
 
-        var allRequiredMet = _items.Where(p => p.IsRequired).All(p => p.IsFound);
+        var allRequiredMet = PrerequisiteChecker.AllRequiredMet(_items);
+        var missingRecommended = _items.Count(p => !p.IsRequired && !p.IsFound);
         if (allRequiredMet)
         {
-            SubtitleText.Text = "All required prerequisites found.";
+            // Honest about the recommended ones: they no longer block, but saying only "all
+            // found" while three rows sit unfound would read as a lie against the screen.
+            SubtitleText.Text = missingRecommended == 0
+                ? "All prerequisites found."
+                : $"Ready to install. {missingRecommended} recommended item(s) are missing - "
+                  + "you can install them here, or later.";
             SuccessBanner.Visibility = Visibility.Visible;
         }
         else


### PR DESCRIPTION
A brand-new user on a clean Windows machine could not get past the Prerequisites screen. Four items were marked required and `NextButton.IsEnabled = allRequiredMet` stopped them dead until they left the wizard, installed three separate programs by hand, and came back. That is the single largest block in the path from downloading DevThrottle to running a first agent, and three quarters of it was never necessary.

## Only one of the four is genuinely required

| Prerequisite | What actually breaks without it | Required? |
|---|---|---|
| **.NET 10 Runtime** | The Director does not start. The Windows build publishes `--self-contained false`, so it needs the shared runtime. | **Yes** - and Setup already installs it |
| Python | **Nothing.** The `cc-*` tools ship their own relocatable CPython (`cc-python-win-x64.zip`, staged by `PythonToolsInstaller`) and never use the system interpreter. | No |
| Node.js | MCP servers and browser tools only. | No |
| Claude Code | Only the Claude agent. The Director runs eight agent command line tools (`src/CcDirector.Core/Agents/`). | No |

That last row was turning people away: a user who came for Codex or Gemini was stopped for not having a **different vendor's** tool installed.

## The order matters - please do not "simplify" it later

**Re-classify first, auto-install second, and leave the gate expression alone.**

Warn-and-continue *on its own* would be wrong: it would walk a user through to a Director that cannot start, because the .NET runtime really is load-bearing. Re-classification is what makes continuing safe - with only the runtime required, the gate is satisfied by the one item Setup can install itself, so nobody is ever stopped **and** the gate still protects the one real dependency. The expression at `MainWindow.xaml.cs` is unchanged in meaning; it simply has less to gate.

## What changed

- **Re-classification.** Claude Code, Python and Node.js become recommended. They are still checked and still shown; they no longer gate.
- **Auto-install, as data not logic.** The three gain the winget ids the existing generic path already knows how to drive - `Anthropic.ClaudeCode`, `Python.Python.3.12`, `OpenJS.NodeJS.LTS`. `RuntimeInstaller.InstallAsync` already takes any package id and already runs `--silent --accept-package-agreements --accept-source-agreements --disable-interactivity`, and `PrerequisiteInfo` already carries `CanAutoInstall` / `WingetId` / `ShowAutoInstall`. Each missing row now offers a one-click install with **per-row** progress ("Installing...") and a re-check on success - no single opaque wait.
- **The manual path survives.** Every row keeps its download link, because winget is absent on locked-down machines. A test asserts it on every row.
- **Degraded capabilities are reported at the END, not as a wall at the start.** New `CapabilityNotice` (shared, UI-free) computes one sentence naming each missing item and what it costs - "Claude Code: no coding agent is installed yet, so your board has nothing to run" - and the Complete screen renders it. The Prerequisites subtitle also stops claiming "All required prerequisites found" while three rows sit unfound.
- **One gate, one place.** `PrerequisiteChecker.AllRequiredMet` replaces the predicate that was duplicated in `MainWindow` and `PrerequisitesStep`, so the Next button and the screen's own subtitle cannot disagree.
- **macOS wizard** gets the same re-classification. It carries no runtime row at all, because that build is self-contained - so on macOS nothing is required, which is correct.
- **Docs** updated: the installation guide and the wizard walkthrough both said four were required.

## Verified

- `CcDirectorSetup.Tests` **40 passed** (was 32), `CcDirector.Setup.Engine.Tests` **345 passed** (was 340), `CcDirector.Setup.Cli.Tests` **28 passed**
- `CcDirector.Core.Tests` 3306 passed, `CcDirector.Avalonia.Tests` 247, `CcDirector.Engine.Tests` 62, `CcDirector.HostedAgent.Tests` 86, `CcDirector.Launcher.Tests` 27, `CcDirector.Terminal.Avalonia.Tests` 21
- Release builds of the WPF wizard, the Avalonia wizard and the Director: clean, zero warnings
- **Revert-proof on the production line:** setting `IsRequired = true` back on the real Claude Code row in `PrerequisiteChecker.CreateChecklist` turns two tests red - `CreateChecklist_OnlyDotNetIsRequired` and `AllRequiredMet_UserWithOnlyTheDotNetRuntime_CanContinue`. Production was restored before the final run.

## NOT verified

- **No winget install was run, and no installer was executed.** I confirmed all three package ids exist in the live winget catalogue (`Anthropic.ClaudeCode` 2.1.215 - the exact version the checker detects, `Python.Python.3.12` 3.12.10, `OpenJS.NodeJS.LTS` 24.18.0). Unattended install success, and the `PATH`-staleness behaviour that follows it, need a real machine and are for human QA.
- GUI rendering of the new Complete-screen panel was not seen; its content is covered by tests, its layout is not.

## Deliberately out of scope

The Anthropic account question. Installing Claude Code needs no account and no payment - the account is required only when an agent actually runs. That is a different problem on a different leg and should not be solved here.
