### PR TITLE
release: v1.6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Version bump only - `Directory.Build.props` is the single version source, and the release workflow fails the build if the tag and this file disagree.

Ships two changes that together take a new user from roughly 25-45 minutes to 3-4:

- `145e456c` - the cc-* tools bundle no longer runs during the install. The install step drops from about 74 seconds to about 7; the bundle work moves to first launch.
- `ee7ff768` - only the .NET runtime is required to install. Claude Code, Python and Node.js became recommended, each with a one-click install, so a new user is no longer stopped on the Prerequisites screen and sent off to install three programs by hand.

The tag `v1.6.0` goes on the merge commit of this pull request.