### PR TITLE
fix(gateway): partition the voice state per tenant

### DIFF
--- a/src/CcDirector.Gateway.Tests/GatewayTurnJobStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTurnJobStoreTests.cs
@@ -1,5 +1,6 @@
 using CcDirector.Gateway.Voice;
 using Xunit;
+using CcDirector.Core.Tenancy;
 
 namespace CcDirector.Gateway.Tests;
 
@@ -15,8 +16,8 @@ public sealed class GatewayTurnJobStoreTests
         var store = new GatewayTurnJobStore();
         var uploadId = Guid.NewGuid().ToString("N");
 
-        var job = store.Create("sid-1", uploadId);
-        var found = store.FindTurnByUpload(uploadId);
+        var job = store.Create(TenantId.Local, "sid-1", uploadId);
+        var found = store.FindTurnByUpload(TenantId.Local, uploadId);
 
         Assert.NotNull(found);
         Assert.Equal(job.TurnId, found!.TurnId);
@@ -27,8 +28,8 @@ public sealed class GatewayTurnJobStoreTests
     public void FindTurnByUpload_UnknownOrEmpty_ReturnsNull()
     {
         var store = new GatewayTurnJobStore();
-        Assert.Null(store.FindTurnByUpload(Guid.NewGuid().ToString("N")));
-        Assert.Null(store.FindTurnByUpload(""));
+        Assert.Null(store.FindTurnByUpload(TenantId.Local, Guid.NewGuid().ToString("N")));
+        Assert.Null(store.FindTurnByUpload(TenantId.Local, ""));
     }
 
     [Fact]
@@ -36,22 +37,22 @@ public sealed class GatewayTurnJobStoreTests
     {
         var store = new GatewayTurnJobStore();
         var uploadId = Guid.NewGuid().ToString("N");
-        var job = store.Create("sid-1", uploadId);
+        var job = store.Create(TenantId.Local, "sid-1", uploadId);
 
         // Age the job past its TTL via the documented test seam; the next lookup must drop it.
         job.OverrideCreatedAtForTest(DateTime.UtcNow.AddMinutes(-11), GatewayTurnJobStore.Ttl);
 
-        Assert.Null(store.FindTurnByUpload(uploadId));
+        Assert.Null(store.FindTurnByUpload(TenantId.Local, uploadId));
     }
 
     [Fact]
     public void Create_WithoutUploadId_HasEmptyUploadIdAndNoIndex()
     {
         var store = new GatewayTurnJobStore();
-        var job = store.Create("sid-1");
+        var job = store.Create(TenantId.Local, "sid-1");
 
         Assert.Equal("", job.UploadId);
         // A retried completion with no upload context never collides with this job.
-        Assert.Null(store.FindTurnByUpload(""));
+        Assert.Null(store.FindTurnByUpload(TenantId.Local, ""));
     }
 }

--- a/src/CcDirector.Gateway.Tests/VoiceTurnArchiveTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceTurnArchiveTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using CcDirector.Gateway.Voice;
 using Xunit;
+using CcDirector.Core.Tenancy;
 
 namespace CcDirector.Gateway.Tests;
 
@@ -39,14 +40,14 @@ public sealed class VoiceTurnArchiveTests : IDisposable
     {
         var turnId = Guid.NewGuid().ToString();
         var audio = Encoding.UTF8.GetBytes("ID3-fake-mp3-bytes");
-        _archive.Save(Record(turnId, "sid-1"), audio);
+        _archive.Save(TenantId.Local, Record(turnId, "sid-1"), audio);
 
-        var got = _archive.Get(turnId);
+        var got = _archive.Get(TenantId.Local, turnId);
         Assert.NotNull(got);
         Assert.Equal("It is four.", got!.Summary);
         Assert.Equal("what is two plus two", got.Transcript);
 
-        var gotAudio = _archive.GetAudio(turnId);
+        var gotAudio = _archive.GetAudio(TenantId.Local, turnId);
         Assert.NotNull(gotAudio);
         Assert.Equal(audio, gotAudio);
     }
@@ -57,17 +58,17 @@ public sealed class VoiceTurnArchiveTests : IDisposable
         var turnId = Guid.NewGuid().ToString();
         var rec = Record(turnId, "sid-1");
         rec.HasAudio = false;
-        _archive.Save(rec, replyAudio: null);
+        _archive.Save(TenantId.Local, rec, replyAudio: null);
 
-        Assert.NotNull(_archive.Get(turnId));
-        Assert.Null(_archive.GetAudio(turnId));
+        Assert.NotNull(_archive.Get(TenantId.Local, turnId));
+        Assert.Null(_archive.GetAudio(TenantId.Local, turnId));
     }
 
     [Fact]
     public void Get_UnknownTurn_ReturnsNull()
     {
-        Assert.Null(_archive.Get(Guid.NewGuid().ToString()));
-        Assert.Null(_archive.Get("not-a-guid"));
+        Assert.Null(_archive.Get(TenantId.Local, Guid.NewGuid().ToString()));
+        Assert.Null(_archive.Get(TenantId.Local, "not-a-guid"));
     }
 
     [Fact]
@@ -75,14 +76,14 @@ public sealed class VoiceTurnArchiveTests : IDisposable
     {
         var turnId = Guid.NewGuid().ToString();
         var uploadId = Guid.NewGuid().ToString("N");
-        _archive.Save(Record(turnId, "sid-1", uploadId), null);
+        _archive.Save(TenantId.Local, Record(turnId, "sid-1", uploadId), null);
 
-        var found = _archive.FindByUpload(uploadId);
+        var found = _archive.FindByUpload(TenantId.Local, uploadId);
         Assert.NotNull(found);
         Assert.Equal(turnId, found!.TurnId);
 
-        Assert.Null(_archive.FindByUpload(Guid.NewGuid().ToString("N")));
-        Assert.Null(_archive.FindByUpload(""));
+        Assert.Null(_archive.FindByUpload(TenantId.Local, Guid.NewGuid().ToString("N")));
+        Assert.Null(_archive.FindByUpload(TenantId.Local, ""));
     }
 
     [Fact]
@@ -95,11 +96,11 @@ public sealed class VoiceTurnArchiveTests : IDisposable
         late.Summary = "newer";
         var other = Record(Guid.NewGuid().ToString(), "sid-B");
 
-        _archive.Save(early, null);
-        _archive.Save(late, null);
-        _archive.Save(other, null);
+        _archive.Save(TenantId.Local, early, null);
+        _archive.Save(TenantId.Local, late, null);
+        _archive.Save(TenantId.Local, other, null);
 
-        var list = _archive.ListForSession("sid-A");
+        var list = _archive.ListForSession(TenantId.Local, "sid-A");
         Assert.Equal(2, list.Count);
         Assert.Equal("newer", list[0].Summary);   // newest first
         Assert.Equal("older", list[1].Summary);
@@ -112,10 +113,10 @@ public sealed class VoiceTurnArchiveTests : IDisposable
         var old = Record(Guid.NewGuid().ToString(), "sid-A");
         old.CreatedAtUtc = DateTime.UtcNow.AddHours(-2);
         var fresh = Record(Guid.NewGuid().ToString(), "sid-A");
-        _archive.Save(old, null);
-        _archive.Save(fresh, null);
+        _archive.Save(TenantId.Local, old, null);
+        _archive.Save(TenantId.Local, fresh, null);
 
-        var list = _archive.ListForSession("sid-A", DateTime.UtcNow.AddHours(-1));
+        var list = _archive.ListForSession(TenantId.Local, "sid-A", DateTime.UtcNow.AddHours(-1));
         Assert.Single(list);
         Assert.Equal(fresh.TurnId, list[0].TurnId);
     }

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceFallbackTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceFallbackTests.cs
@@ -4,6 +4,7 @@ using CcDirector.Core;
 using CcDirector.Core.HostedAi;
 using CcDirector.Gateway.Wingman;
 using Xunit;
+using CcDirector.Core.Tenancy;
 
 namespace CcDirector.Gateway.Tests;
 
@@ -61,11 +62,11 @@ public sealed class WingmanVoiceFallbackTests
         // The generic marker "1" is what the cloud proxy now sends (never the provider name).
         var svc = ServiceWith(new SpeechStub(new byte[] { 1, 2, 3 }, withFallbackHeader: true, headerValue: "1"), TempPersist());
 
-        await svc.StoreSpokenAsync("sid-1", "a spoken summary", "the reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-1", "a spoken summary", "the reply");
 
-        Assert.True(svc.HasVoice("sid-1"));                       // a fallback is a real, playable clip
-        Assert.True(svc.ServedViaFallbackFor("sid-1"));           // ...noted as backup-served
-        Assert.Null(svc.VoiceUnavailableFor("sid-1"));            // ...and NEVER an outage/unavailable state
+        Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));                       // a fallback is a real, playable clip
+        Assert.True(svc.ServedViaFallbackFor(TenantId.Local, "sid-1"));           // ...noted as backup-served
+        Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));            // ...and NEVER an outage/unavailable state
     }
 
     // The Gateway must detect the fallback by the header's PRESENCE alone, never by its value. This
@@ -81,11 +82,11 @@ public sealed class WingmanVoiceFallbackTests
     {
         var svc = ServiceWith(new SpeechStub(new byte[] { 1, 2, 3 }, withFallbackHeader: true, headerValue), TempPersist());
 
-        await svc.StoreSpokenAsync("sid-1", "a spoken summary", "the reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-1", "a spoken summary", "the reply");
 
-        Assert.True(svc.HasVoice("sid-1"));
-        Assert.True(svc.ServedViaFallbackFor("sid-1"));           // fires regardless of the header value
-        Assert.Null(svc.VoiceUnavailableFor("sid-1"));
+        Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));
+        Assert.True(svc.ServedViaFallbackFor(TenantId.Local, "sid-1"));           // fires regardless of the header value
+        Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
     }
 
     [Fact]
@@ -93,10 +94,10 @@ public sealed class WingmanVoiceFallbackTests
     {
         var svc = ServiceWith(new SpeechStub(new byte[] { 1, 2, 3 }, withFallbackHeader: false), TempPersist());
 
-        await svc.StoreSpokenAsync("sid-1", "a spoken summary", "the reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-1", "a spoken summary", "the reply");
 
-        Assert.True(svc.HasVoice("sid-1"));
-        Assert.False(svc.ServedViaFallbackFor("sid-1"));
+        Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));
+        Assert.False(svc.ServedViaFallbackFor(TenantId.Local, "sid-1"));
     }
 
     [Fact]
@@ -106,13 +107,13 @@ public sealed class WingmanVoiceFallbackTests
         // does not vanish on a gateway restart while that clip is still the current one.
         var persist = TempPersist();
         var first = ServiceWith(new SpeechStub(Array.Empty<byte>(), withFallbackHeader: false), persist);
-        first.StoreReadyAudioForTest("sid-1", "spoken", "reply", new byte[] { 9, 9, 9 }, "audio/mpeg", servedViaFallback: true);
-        Assert.True(first.ServedViaFallbackFor("sid-1"));
+        first.StoreReadyAudioForTest(TenantId.Local, "sid-1", "spoken", "reply", new byte[] { 9, 9, 9 }, "audio/mpeg", servedViaFallback: true);
+        Assert.True(first.ServedViaFallbackFor(TenantId.Local, "sid-1"));
 
         // A fresh instance from the SAME persist path reloads the durable cache.
         var reloaded = ServiceWith(new SpeechStub(Array.Empty<byte>(), withFallbackHeader: false), persist);
-        Assert.True(reloaded.HasVoice("sid-1"));
-        Assert.True(reloaded.ServedViaFallbackFor("sid-1"));
+        Assert.True(reloaded.HasVoice(TenantId.Local, "sid-1"));
+        Assert.True(reloaded.ServedViaFallbackFor(TenantId.Local, "sid-1"));
     }
 
     /// <summary>A speech upstream that STALLS on its first call (the primary goes silent - a
@@ -151,21 +152,21 @@ public sealed class WingmanVoiceFallbackTests
 
         // First narration: the primary goes silent. No audio, Retrying, and the request did NOT yet ask
         // for the backup (a fresh session has no reason to skip the primary).
-        await svc.StoreSpokenAsync("sid-1", "first summary", "reply one");
-        Assert.False(svc.HasVoice("sid-1"));
-        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-1"));
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-1", "first summary", "reply one");
+        Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
         Assert.Equal(1, stub.Calls);
         Assert.False(stub.LastRequest!.Headers.Contains("X-DevThrottle-TTS-Prefer-Backup"));
 
         // Second narration (same session, inside the armed window): the Gateway routes past the hung
         // primary - the request carries the prefer-backup header, the proxy serves the backup, and the
         // session becomes playable with the backup-voice note.
-        await svc.StoreSpokenAsync("sid-1", "second summary", "reply two");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-1", "second summary", "reply two");
         Assert.Equal(2, stub.Calls);
         Assert.True(stub.LastRequest!.Headers.Contains("X-DevThrottle-TTS-Prefer-Backup"));
-        Assert.True(svc.HasVoice("sid-1"));
-        Assert.True(svc.ServedViaFallbackFor("sid-1"));
-        Assert.Null(svc.VoiceUnavailableFor("sid-1"));   // a served backup clears the Retrying state
+        Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));
+        Assert.True(svc.ServedViaFallbackFor(TenantId.Local, "sid-1"));
+        Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));   // a served backup clears the Retrying state
     }
 
     [Fact]
@@ -176,10 +177,10 @@ public sealed class WingmanVoiceFallbackTests
         var stub = new HangThenBackupStub();
         var svc = ServiceWith(stub, TempPersist());
 
-        await svc.StoreSpokenAsync("sid-hang", "summary", "reply");   // sid-hang hits the silent primary
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-hang", "summary", "reply");   // sid-hang hits the silent primary
         Assert.Equal(1, stub.Calls);
 
-        await svc.StoreSpokenAsync("sid-other", "summary", "reply");  // a DIFFERENT session
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-other", "summary", "reply");  // a DIFFERENT session
         Assert.Equal(2, stub.Calls);
         Assert.False(stub.LastRequest!.Headers.Contains("X-DevThrottle-TTS-Prefer-Backup"));   // not armed for sid-other
     }

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
@@ -10,6 +10,7 @@ using CcDirector.Gateway.HostedAi;
 using CcDirector.Gateway.Discovery;
 using CcDirector.Gateway.Wingman;
 using Xunit;
+using CcDirector.Core.Tenancy;
 
 namespace CcDirector.Gateway.Tests;
 
@@ -34,26 +35,26 @@ public sealed class WingmanVoiceServiceTests
     public void IsGenerating_DefaultsFalse()
     {
         var svc = NewService();
-        Assert.False(svc.IsGenerating("sid-1"));
+        Assert.False(svc.IsGenerating(TenantId.Local, "sid-1"));
     }
 
     [Fact]
     public void BeginGenerating_ThenIsGenerating_IsTrue()
     {
         var svc = NewService();
-        svc.BeginGenerating("sid-1");
-        Assert.True(svc.IsGenerating("sid-1"));
+        svc.BeginGenerating(TenantId.Local, "sid-1");
+        Assert.True(svc.IsGenerating(TenantId.Local, "sid-1"));
         // Independent per session: a second session is unaffected.
-        Assert.False(svc.IsGenerating("sid-2"));
+        Assert.False(svc.IsGenerating(TenantId.Local, "sid-2"));
     }
 
     [Fact]
     public void EndGenerating_ClearsTheFlag()
     {
         var svc = NewService();
-        svc.BeginGenerating("sid-1");
-        svc.EndGenerating("sid-1");
-        Assert.False(svc.IsGenerating("sid-1"));
+        svc.BeginGenerating(TenantId.Local, "sid-1");
+        svc.EndGenerating(TenantId.Local, "sid-1");
+        Assert.False(svc.IsGenerating(TenantId.Local, "sid-1"));
     }
 
     [Fact]
@@ -62,9 +63,9 @@ public sealed class WingmanVoiceServiceTests
         // A new turn (blue) supersedes any in-flight wingman run for the previous turn, so the
         // yellow marker must drop - raw activity wins while the agent works.
         var svc = NewService();
-        svc.BeginGenerating("sid-1");
-        svc.OnSessionWorking("sid-1");
-        Assert.False(svc.IsGenerating("sid-1"));
+        svc.BeginGenerating(TenantId.Local, "sid-1");
+        svc.OnSessionWorking(TenantId.Local, "sid-1");
+        Assert.False(svc.IsGenerating(TenantId.Local, "sid-1"));
     }
 
     // ---------- Durable audio cache (issue #553) ----------
@@ -97,18 +98,18 @@ public sealed class WingmanVoiceServiceTests
         // No OpenAI key in the vault -> TtsAsync returns null -> the "if anything fails, remove the
         // triangle" rule: the session is a voice session but has NO playable audio, so no triangle.
         var svc = NewService();
-        await svc.StoreSpokenAsync("sid-1", "a spoken summary", "the reply");
-        Assert.True(svc.IsVoiceSession("sid-1"));
-        Assert.False(svc.HasVoice("sid-1"));
-        Assert.DoesNotContain("sid-1", svc.ReadySessionIds());
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-1", "a spoken summary", "the reply");
+        Assert.True(svc.IsVoiceSession(TenantId.Local, "sid-1"));
+        Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+        Assert.DoesNotContain("sid-1", svc.ReadySessionIds(TenantId.Local));
     }
 
     [Fact]
     public async Task StoreSpokenAsync_WithEmptySpoken_DoesNotMarkReady()
     {
         var svc = NewService();
-        await svc.StoreSpokenAsync("sid-1", "   ", "the reply");
-        Assert.False(svc.HasVoice("sid-1"));
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-1", "   ", "the reply");
+        Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
     }
 
     [Fact]
@@ -121,17 +122,17 @@ public sealed class WingmanVoiceServiceTests
         {
             var svc = ServiceAt(persistPath);
             var audio = new byte[] { 1, 2, 3, 4, 5 };
-            svc.StoreReadyAudioForTest("sid-1", "spoken text", "reply text", audio, "audio/wav");
-            Assert.True(svc.HasVoice("sid-1"));
+            svc.StoreReadyAudioForTest(TenantId.Local, "sid-1", "spoken text", "reply text", audio, "audio/wav");
+            Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));
 
             // Simulate a gateway restart: a brand-new service over the same path.
             var reloaded = ServiceAt(persistPath);
-            Assert.True(reloaded.HasVoice("sid-1"));
-            Assert.Contains("sid-1", reloaded.ReadySessionIds());
-            var got = reloaded.GetAudio("sid-1");
+            Assert.True(reloaded.HasVoice(TenantId.Local, "sid-1"));
+            Assert.Contains("sid-1", reloaded.ReadySessionIds(TenantId.Local));
+            var got = reloaded.GetAudio(TenantId.Local, "sid-1");
             Assert.NotNull(got);
             Assert.Equal(audio, got);
-            var ready = reloaded.Get("sid-1");
+            var ready = reloaded.Get(TenantId.Local, "sid-1");
             Assert.NotNull(ready);
             Assert.Equal("spoken text", ready.Spoken);
             Assert.Equal("reply text", ready.Reply);
@@ -157,7 +158,7 @@ public sealed class WingmanVoiceServiceTests
 
             var reloaded = ServiceAt(persistPath);
 
-            var ready = reloaded.Get("sid-1");
+            var ready = reloaded.Get(TenantId.Local, "sid-1");
             Assert.NotNull(ready);
             Assert.Equal("audio/wav", ready.ContentType);
         }
@@ -173,15 +174,15 @@ public sealed class WingmanVoiceServiceTests
         try
         {
             var svc = ServiceAt(persistPath);
-            svc.StoreReadyAudioForTest("sid-1", "spoken", "reply", new byte[] { 9, 9, 9 });
-            Assert.True(svc.HasVoice("sid-1"));
+            svc.StoreReadyAudioForTest(TenantId.Local, "sid-1", "spoken", "reply", new byte[] { 9, 9, 9 });
+            Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));
 
-            svc.OnSessionWorking("sid-1");
-            Assert.False(svc.HasVoice("sid-1"));
+            svc.OnSessionWorking(TenantId.Local, "sid-1");
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
 
             // A restart must NOT resurrect the dropped audio.
             var reloaded = ServiceAt(persistPath);
-            Assert.False(reloaded.HasVoice("sid-1"));
+            Assert.False(reloaded.HasVoice(TenantId.Local, "sid-1"));
         }
         finally { Cleanup(persistPath); }
     }
@@ -271,13 +272,13 @@ public sealed class WingmanVoiceServiceTests
             var brain = new TimingOutBrain();
             var svc = ServiceWithBrainAndTts(brain, new byte[] { 7, 7, 7 }, persistPath);
 
-            await svc.GenerateAsync("sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
 
             Assert.Equal(1, brain.AskCount);                                          // it tried the model
-            Assert.False(svc.HasVoice("sid-1"));                                      // nothing to play
-            Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-1"));   // and it says WHY, calmly
-            Assert.NotEqual(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-1")); // a non-answer is not "down"
-            Assert.False(svc.IsGenerating("sid-1"));                                  // the yellow window closed
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));                                      // nothing to play
+            Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));   // and it says WHY, calmly
+            Assert.NotEqual(HostedAiState.ServiceDown, svc.VoiceUnavailableFor(TenantId.Local, "sid-1")); // a non-answer is not "down"
+            Assert.False(svc.IsGenerating(TenantId.Local, "sid-1"));                                  // the yellow window closed
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ } }
     }
@@ -288,9 +289,9 @@ public sealed class WingmanVoiceServiceTests
         // The on-demand "generate" (explain) path calls this when its translation times out, so the phone
         // shows "voice on its way" instead of the old false 502 "this session's computer is offline".
         var svc = NewService();
-        Assert.Null(svc.VoiceUnavailableFor("sid-1"));
-        svc.NoteRetrying("sid-1");
-        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-1"));
+        Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+        svc.NoteRetrying(TenantId.Local, "sid-1");
+        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
     }
 
     // ---------- "Nothing to narrate": the session is waiting on a prompt, no text reply to read ----------
@@ -309,11 +310,11 @@ public sealed class WingmanVoiceServiceTests
             var brain = new RecordingBrain();
             var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath);
 
-            await svc.GenerateAsync("sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
 
-            Assert.True(svc.NothingToNarrateFor("sid-1"));
-            Assert.False(svc.HasVoice("sid-1"));
-            Assert.Null(svc.VoiceUnavailableFor("sid-1"));   // NOT a failure - no Retrying/ServiceDown
+            Assert.True(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));   // NOT a failure - no Retrying/ServiceDown
             Assert.Equal(0, brain.AskCount);                 // nothing to translate, so the model was never called
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
@@ -330,12 +331,12 @@ public sealed class WingmanVoiceServiceTests
         {
             var brain = new RecordingBrain();
             var svc = ServiceWithBrainAndTts(brain, new byte[] { 9, 9, 9 }, persistPath);
-            svc.SetNothingToNarrate("sid-1", true);   // a stale marker from an earlier empty read
+            svc.SetNothingToNarrate(TenantId.Local, "sid-1", true);   // a stale marker from an earlier empty read
 
-            await svc.GenerateAsync("sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: false);
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: false);
 
-            Assert.False(svc.NothingToNarrateFor("sid-1"));   // cleared - there IS text now
-            Assert.True(svc.HasVoice("sid-1"));
+            Assert.False(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));   // cleared - there IS text now
+            Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }
@@ -344,11 +345,11 @@ public sealed class WingmanVoiceServiceTests
     public void SetNothingToNarrate_TogglesTheFact()
     {
         var svc = NewService();
-        Assert.False(svc.NothingToNarrateFor("s"));
-        svc.SetNothingToNarrate("s", true);
-        Assert.True(svc.NothingToNarrateFor("s"));
-        svc.SetNothingToNarrate("s", false);
-        Assert.False(svc.NothingToNarrateFor("s"));
+        Assert.False(svc.NothingToNarrateFor(TenantId.Local, "s"));
+        svc.SetNothingToNarrate(TenantId.Local, "s", true);
+        Assert.True(svc.NothingToNarrateFor(TenantId.Local, "s"));
+        svc.SetNothingToNarrate(TenantId.Local, "s", false);
+        Assert.False(svc.NothingToNarrateFor(TenantId.Local, "s"));
     }
 
     [Fact]
@@ -356,19 +357,19 @@ public sealed class WingmanVoiceServiceTests
     {
         // A new turn supersedes the old "nothing to narrate" verdict - it is re-evaluated on the next turn-end.
         var svc = NewService();
-        svc.SetNothingToNarrate("s", true);
-        svc.OnSessionWorking("s");
-        Assert.False(svc.NothingToNarrateFor("s"));
+        svc.SetNothingToNarrate(TenantId.Local, "s", true);
+        svc.OnSessionWorking(TenantId.Local, "s");
+        Assert.False(svc.NothingToNarrateFor(TenantId.Local, "s"));
     }
 
     [Fact]
     public void Unmark_ClearsNothingToNarrate()
     {
         var svc = NewService();
-        svc.Mark("s");
-        svc.SetNothingToNarrate("s", true);
-        svc.Unmark("s");
-        Assert.False(svc.NothingToNarrateFor("s"));
+        svc.Mark(TenantId.Local, "s");
+        svc.SetNothingToNarrate(TenantId.Local, "s", true);
+        svc.Unmark(TenantId.Local, "s");
+        Assert.False(svc.NothingToNarrateFor(TenantId.Local, "s"));
     }
 
     /// <summary>A voice service wired to a recording brain and a text-to-speech stub that returns
@@ -417,13 +418,13 @@ public sealed class WingmanVoiceServiceTests
         {
             var brain = new RecordingBrain();
             var svc = ServiceWithBrainAndTts(brain, new byte[] { 4, 4, 4 }, persistPath);
-            svc.StoreReadyAudioForTest("sid-1", "old spoken", "the OLD interim reply", new byte[] { 1, 2, 3 });
-            Assert.True(svc.HasVoice("sid-1"));
+            svc.StoreReadyAudioForTest(TenantId.Local, "sid-1", "old spoken", "the OLD interim reply", new byte[] { 1, 2, 3 });
+            Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));
 
-            await svc.GenerateAsync("sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: false);
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: false);
 
             Assert.Equal(1, brain.AskCount);                          // it regenerated (translated the new reply)
-            var ready = svc.Get("sid-1");
+            var ready = svc.Get(TenantId.Local, "sid-1");
             Assert.NotNull(ready);
             Assert.Equal("the NEW final answer", ready!.Reply);       // the cache now holds the CURRENT reply
         }
@@ -443,16 +444,16 @@ public sealed class WingmanVoiceServiceTests
         {
             var brain = new RecordingBrain();
             var svc = ServiceWithBrainAndTts(brain, new byte[] { 9, 9 }, persistPath);
-            svc.StoreReadyAudioForTest("sid-1", "old spoken", "the same reply", new byte[] { 1, 2, 3 });
-            Assert.True(svc.HasVoice("sid-1"));
+            svc.StoreReadyAudioForTest(TenantId.Local, "sid-1", "old spoken", "the same reply", new byte[] { 1, 2, 3 });
+            Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));
 
-            await svc.GenerateAsync("sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
 
             Assert.Equal(0, brain.AskCount);              // never regenerated
             Assert.True(director.Hits >= 1);              // but it DID fetch to compare (identity-aware, not blind)
-            Assert.True(svc.HasVoice("sid-1"));           // the existing clip is untouched
-            Assert.False(svc.IsGenerating("sid-1"));      // and it never flipped the session yellow
-            Assert.Equal(new byte[] { 1, 2, 3 }, svc.GetAudio("sid-1"));   // same original audio, not re-minted
+            Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));           // the existing clip is untouched
+            Assert.False(svc.IsGenerating(TenantId.Local, "sid-1"));      // and it never flipped the session yellow
+            Assert.Equal(new byte[] { 1, 2, 3 }, svc.GetAudio(TenantId.Local, "sid-1"));   // same original audio, not re-minted
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ } }
     }
@@ -463,7 +464,7 @@ public sealed class WingmanVoiceServiceTests
     public void ShouldRegenerate_NoCachedNarration_IsTrue()
     {
         var svc = NewService();
-        Assert.True(svc.ShouldRegenerate("sid-x", "a reply to narrate"));
+        Assert.True(svc.ShouldRegenerate(TenantId.Local, "sid-x", "a reply to narrate"));
     }
 
     [Fact]
@@ -471,16 +472,16 @@ public sealed class WingmanVoiceServiceTests
     {
         // Nothing to narrate yet - do not touch or regenerate.
         var svc = NewService();
-        Assert.False(svc.ShouldRegenerate("sid-x", null));
-        Assert.False(svc.ShouldRegenerate("sid-x", "   "));
+        Assert.False(svc.ShouldRegenerate(TenantId.Local, "sid-x", null));
+        Assert.False(svc.ShouldRegenerate(TenantId.Local, "sid-x", "   "));
     }
 
     [Fact]
     public void ShouldRegenerate_SameReplyAlreadyCached_IsFalse()
     {
         var svc = NewService();
-        svc.StoreReadyAudioForTest("sid-1", "spoken", "the reply text", new byte[] { 1 });
-        Assert.False(svc.ShouldRegenerate("sid-1", "the reply text"));
+        svc.StoreReadyAudioForTest(TenantId.Local, "sid-1", "spoken", "the reply text", new byte[] { 1 });
+        Assert.False(svc.ShouldRegenerate(TenantId.Local, "sid-1", "the reply text"));
     }
 
     [Fact]
@@ -489,8 +490,8 @@ public sealed class WingmanVoiceServiceTests
         // The two sources are the same JSONL text block; incidental leading/trailing whitespace must
         // not force a needless re-mint (which would restart a listener's clip).
         var svc = NewService();
-        svc.StoreReadyAudioForTest("sid-1", "spoken", "the reply text", new byte[] { 1 });
-        Assert.False(svc.ShouldRegenerate("sid-1", "  the reply text\n"));
+        svc.StoreReadyAudioForTest(TenantId.Local, "sid-1", "spoken", "the reply text", new byte[] { 1 });
+        Assert.False(svc.ShouldRegenerate(TenantId.Local, "sid-1", "  the reply text\n"));
     }
 
     [Fact]
@@ -499,8 +500,8 @@ public sealed class WingmanVoiceServiceTests
         // The exact bug: an interim reply was narrated, then the real answer landed. A changed reply
         // must regenerate even though a cached clip exists.
         var svc = NewService();
-        svc.StoreReadyAudioForTest("sid-1", "spoken", "the interim reply", new byte[] { 1 });
-        Assert.True(svc.ShouldRegenerate("sid-1", "the FINAL answer"));
+        svc.StoreReadyAudioForTest(TenantId.Local, "sid-1", "spoken", "the interim reply", new byte[] { 1 });
+        Assert.True(svc.ShouldRegenerate(TenantId.Local, "sid-1", "the FINAL answer"));
     }
 
     // ---------- Turn voice off / Unmark (issue #859) ----------
@@ -512,17 +513,17 @@ public sealed class WingmanVoiceServiceTests
         // background sweep (both gate on IsVoiceSession / VoiceSessionIds) skip it - no more per-turn
         // Opus + text-to-speech spend.
         var svc = NewService();
-        svc.Mark("sid-1");
-        svc.Mark("sid-2");
-        Assert.True(svc.IsVoiceSession("sid-1"));
+        svc.Mark(TenantId.Local, "sid-1");
+        svc.Mark(TenantId.Local, "sid-2");
+        Assert.True(svc.IsVoiceSession(TenantId.Local, "sid-1"));
 
-        svc.Unmark("sid-1");
+        svc.Unmark(TenantId.Local, "sid-1");
 
-        Assert.False(svc.IsVoiceSession("sid-1"));
-        Assert.DoesNotContain("sid-1", svc.VoiceSessionIds());
+        Assert.False(svc.IsVoiceSession(TenantId.Local, "sid-1"));
+        Assert.DoesNotContain("sid-1", svc.VoiceSessionIds(TenantId.Local));
         // Independent per session: a second voice session is unaffected.
-        Assert.True(svc.IsVoiceSession("sid-2"));
-        Assert.Contains("sid-2", svc.VoiceSessionIds());
+        Assert.True(svc.IsVoiceSession(TenantId.Local, "sid-2"));
+        Assert.Contains("sid-2", svc.VoiceSessionIds(TenantId.Local));
     }
 
     [Fact]
@@ -531,14 +532,14 @@ public sealed class WingmanVoiceServiceTests
         // After unmark, GET /wingman/voice/ready (ReadySessionIds) must no longer list the session,
         // so the roster/phone stop offering a stale clip.
         var svc = NewService();
-        svc.Mark("sid-1");
-        svc.StoreReadyAudioForTest("sid-1", "spoken", "reply", new byte[] { 1, 2, 3 });
-        Assert.True(svc.HasVoice("sid-1"));
+        svc.Mark(TenantId.Local, "sid-1");
+        svc.StoreReadyAudioForTest(TenantId.Local, "sid-1", "spoken", "reply", new byte[] { 1, 2, 3 });
+        Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));
 
-        svc.Unmark("sid-1");
+        svc.Unmark(TenantId.Local, "sid-1");
 
-        Assert.False(svc.HasVoice("sid-1"));
-        Assert.DoesNotContain("sid-1", svc.ReadySessionIds());
+        Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+        Assert.DoesNotContain("sid-1", svc.ReadySessionIds(TenantId.Local));
     }
 
     [Fact]
@@ -550,17 +551,17 @@ public sealed class WingmanVoiceServiceTests
         try
         {
             var svc = ServiceAt(persistPath);
-            svc.Mark("sid-1");
-            svc.StoreReadyAudioForTest("sid-1", "spoken", "reply", new byte[] { 7, 7, 7 });
-            Assert.True(svc.IsVoiceSession("sid-1"));
+            svc.Mark(TenantId.Local, "sid-1");
+            svc.StoreReadyAudioForTest(TenantId.Local, "sid-1", "spoken", "reply", new byte[] { 7, 7, 7 });
+            Assert.True(svc.IsVoiceSession(TenantId.Local, "sid-1"));
 
-            svc.Unmark("sid-1");
+            svc.Unmark(TenantId.Local, "sid-1");
 
             // Simulate a gateway restart over the same persist path.
             var reloaded = ServiceAt(persistPath);
-            Assert.False(reloaded.IsVoiceSession("sid-1"));
-            Assert.DoesNotContain("sid-1", reloaded.VoiceSessionIds());
-            Assert.False(reloaded.HasVoice("sid-1")); // and the durable clip is gone too
+            Assert.False(reloaded.IsVoiceSession(TenantId.Local, "sid-1"));
+            Assert.DoesNotContain("sid-1", reloaded.VoiceSessionIds(TenantId.Local));
+            Assert.False(reloaded.HasVoice(TenantId.Local, "sid-1")); // and the durable clip is gone too
         }
         finally { Cleanup(persistPath); }
     }
@@ -570,8 +571,8 @@ public sealed class WingmanVoiceServiceTests
     {
         // Idempotent: unmarking a session that was never a voice session does nothing and does not throw.
         var svc = NewService();
-        svc.Unmark("never-marked");
-        Assert.False(svc.IsVoiceSession("never-marked"));
+        svc.Unmark(TenantId.Local, "never-marked");
+        Assert.False(svc.IsVoiceSession(TenantId.Local, "never-marked"));
     }
 
     // ---------- Voice-unavailable state (issue #939): no more silent turn-end failures ----------
@@ -643,7 +644,7 @@ public sealed class WingmanVoiceServiceTests
     public void VoiceUnavailableFor_DefaultsNull()
     {
         var svc = NewService();
-        Assert.Null(svc.VoiceUnavailableFor("sid-1"));
+        Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
     }
 
     [Fact]
@@ -652,19 +653,19 @@ public sealed class WingmanVoiceServiceTests
         // Issue #939: a 402 out-of-credits at turn-end must no longer be swallowed - it records the
         // shared NeedsCredits state (and leaves no play triangle).
         var svc = ServiceWithTts(HttpStatusCode.PaymentRequired, "{\"error\":{\"code\":\"insufficient_credits\"}}");
-        await svc.StoreSpokenAsync("sid-1", "a spoken summary", "the reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-1", "a spoken summary", "the reply");
 
-        Assert.Equal(HostedAiState.NeedsCredits, svc.VoiceUnavailableFor("sid-1"));
-        Assert.False(svc.HasVoice("sid-1"));
+        Assert.Equal(HostedAiState.NeedsCredits, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+        Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
     }
 
     [Fact]
     public async Task StoreSpokenAsync_MonthlyLimit402_RecordsCapReached()
     {
         var svc = ServiceWithTts(HttpStatusCode.PaymentRequired, "{\"error\":{\"code\":\"monthly_limit_reached\"}}");
-        await svc.StoreSpokenAsync("sid-1", "a spoken summary", "the reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-1", "a spoken summary", "the reply");
 
-        Assert.Equal(HostedAiState.CapReached, svc.VoiceUnavailableFor("sid-1"));
+        Assert.Equal(HostedAiState.CapReached, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
     }
 
     [Fact]
@@ -673,16 +674,16 @@ public sealed class WingmanVoiceServiceTests
         // A successful synthesis marks the session ready AND clears any prior unavailable-state
         // (dismissible: the next good turn removes the banner).
         var svc = ServiceWithTts(HttpStatusCode.PaymentRequired, "{\"error\":{\"code\":\"insufficient_credits\"}}");
-        await svc.StoreSpokenAsync("sid-1", "spoken", "reply");
-        Assert.Equal(HostedAiState.NeedsCredits, svc.VoiceUnavailableFor("sid-1"));
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-1", "spoken", "reply");
+        Assert.Equal(HostedAiState.NeedsCredits, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
 
         var good = ServiceWithTts(HttpStatusCode.OK, "", audio: new byte[] { 1, 2, 3, 4 });
         // Re-run on the SAME service would need a mutable stub; instead prove success on a fresh call
         // clears + marks ready. Seed the unavailable state first via a failing service is covered above;
         // here assert the success path's postconditions directly.
-        await good.StoreSpokenAsync("sid-2", "spoken", "reply");
-        Assert.True(good.HasVoice("sid-2"));
-        Assert.Null(good.VoiceUnavailableFor("sid-2"));
+        await good.StoreSpokenAsync(TenantId.Local, "sid-2", "spoken", "reply");
+        Assert.True(good.HasVoice(TenantId.Local, "sid-2"));
+        Assert.Null(good.VoiceUnavailableFor(TenantId.Local, "sid-2"));
     }
 
     /// <summary>A text-to-speech transport that throws <see cref="OperationCanceledException"/> - the
@@ -746,16 +747,16 @@ public sealed class WingmanVoiceServiceTests
 
         // The stalled call fails - one attempt, bounded, and it says so honestly. A timeout is the
         // absence of an answer, so it is Retrying ("audio on its way, trying again"), NOT ServiceDown.
-        await svc.StoreSpokenAsync("sid-retry", "spoken", "reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-retry", "spoken", "reply");
         Assert.Equal(1, handler.Calls);                                        // exactly one attempt: no in-call retry
-        Assert.False(svc.HasVoice("sid-retry"));                               // nothing to play
-        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-retry"));
+        Assert.False(svc.HasVoice(TenantId.Local, "sid-retry"));                               // nothing to play
+        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-retry"));
 
         // The session tries again - the provider is fine now, and it just works.
-        await svc.StoreSpokenAsync("sid-retry", "spoken", "reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-retry", "spoken", "reply");
         Assert.Equal(2, handler.Calls);
-        Assert.True(svc.HasVoice("sid-retry"));
-        Assert.Null(svc.VoiceUnavailableFor("sid-retry"));
+        Assert.True(svc.HasVoice(TenantId.Local, "sid-retry"));
+        Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-retry"));
     }
 
     [Fact]
@@ -765,10 +766,10 @@ public sealed class WingmanVoiceServiceTests
         // attempts (no infinite spin, no 60-second freeze) and the turn-end records no audio.
         var handler = new TtsTimeoutHandler(timeouts: int.MaxValue);
         var svc = ServiceWithHandler(handler);
-        await svc.StoreSpokenAsync("sid-dead", "spoken", "reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-dead", "spoken", "reply");
 
         Assert.Equal(TtsSynthesis.Attempts, handler.Calls);    // exactly the attempt cap, then stop
-        Assert.False(svc.HasVoice("sid-dead"));
+        Assert.False(svc.HasVoice(TenantId.Local, "sid-dead"));
     }
 
     // ---- The 2026-07-15 outage: the service failed for ~45 minutes and the phone blamed the user's own
@@ -788,10 +789,10 @@ public sealed class WingmanVoiceServiceTests
         // Every one of these used to return a bare null ("other provider error: logged, no shared
         // state"), so the session recorded NOTHING and the phone invented a cause.
         var svc = ServiceWithTts((HttpStatusCode)status, "{\"error\":\"upstream\"}");
-        await svc.StoreSpokenAsync("sid-down", "spoken", "reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-down", "spoken", "reply");
 
-        Assert.False(svc.HasVoice("sid-down"));
-        Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-down"));
+        Assert.False(svc.HasVoice(TenantId.Local, "sid-down"));
+        Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor(TenantId.Local, "sid-down"));
     }
 
     [Fact]
@@ -805,10 +806,10 @@ public sealed class WingmanVoiceServiceTests
         // this test now guards against.
         var handler = new TtsTimeoutHandler(timeouts: int.MaxValue);
         var svc = ServiceWithHandler(handler);
-        await svc.StoreSpokenAsync("sid-timeout", "spoken", "reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-timeout", "spoken", "reply");
 
-        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-timeout"));
-        Assert.NotEqual(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-timeout"));
+        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-timeout"));
+        Assert.NotEqual(HostedAiState.ServiceDown, svc.VoiceUnavailableFor(TenantId.Local, "sid-timeout"));
     }
 
     // ONE SLOW NARRATION MUST NOT SILENCE THE FLEET - AND NOW IT CANNOT, BY CONSTRUCTION.
@@ -832,10 +833,10 @@ public sealed class WingmanVoiceServiceTests
         var handler = new TtsTimeoutHandler(timeouts: TtsSynthesis.Attempts);
         var svc = ServiceWithHandler(handler);
 
-        await svc.StoreSpokenAsync("sid-slow", "spoken", "reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-slow", "spoken", "reply");
 
-        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-slow"));
-        Assert.Null(svc.VoiceUnavailableFor("sid-other"));   // a session that never called is untouched
+        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-slow"));
+        Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-other"));   // a session that never called is untouched
     }
 
     [Fact]
@@ -851,16 +852,16 @@ public sealed class WingmanVoiceServiceTests
         var handler = new TtsTimeoutHandler(timeouts: int.MaxValue);
         var svc = ServiceWithHandler(handler);
 
-        await svc.StoreSpokenAsync("sid-a", "spoken", "reply");
-        await svc.StoreSpokenAsync("sid-b", "spoken", "reply");
-        await svc.StoreSpokenAsync("sid-c", "spoken", "reply");
-        await svc.StoreSpokenAsync("sid-d", "spoken", "reply");
-        await svc.StoreSpokenAsync("sid-e", "spoken", "reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-a", "spoken", "reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-b", "spoken", "reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-c", "spoken", "reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-d", "spoken", "reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-e", "spoken", "reply");
 
         // Each session tells the truth about ITSELF: nothing to play yet, retrying - Retrying, never
         // ServiceDown, because none of these calls got an answer from the service.
-        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-a"));
-        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor("sid-e"));
+        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-a"));
+        Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-e"));
     }
 
     [Fact]
@@ -884,15 +885,15 @@ public sealed class WingmanVoiceServiceTests
             var svc = ServiceWithBrainAndHandler(new RecordingBrain(), handler, persistPath);
 
             // A fails 5xx first - on the OLD code this armed the shared cooldown before B/C ever ask.
-            await svc.GenerateAsync("sid-A", RouteFor(director), CancellationToken.None, showReadingWindow: false);
-            Assert.False(svc.HasVoice("sid-A"));
-            Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-A"));
+            await svc.GenerateAsync(TenantId.Local, "sid-A", RouteFor(director), CancellationToken.None, showReadingWindow: false);
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-A"));
+            Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor(TenantId.Local, "sid-A"));
 
             // B and C race. Their success-path speech call blocks in the handler, so the ONE the old gate
             // would let through sits in-flight and cannot free the probe slot - making the old code's skip
             // of the other deterministic rather than timing-dependent.
-            var b = svc.GenerateAsync("sid-B", RouteFor(director), CancellationToken.None, showReadingWindow: false);
-            var c = svc.GenerateAsync("sid-C", RouteFor(director), CancellationToken.None, showReadingWindow: false);
+            var b = svc.GenerateAsync(TenantId.Local, "sid-B", RouteFor(director), CancellationToken.None, showReadingWindow: false);
+            var c = svc.GenerateAsync(TenantId.Local, "sid-C", RouteFor(director), CancellationToken.None, showReadingWindow: false);
 
             // Wait - without a fixed sleep - until EITHER both reached the provider (new code) OR one of
             // them returned early having been skipped (old code). Bounded by an overall deadline so a hang
@@ -910,8 +911,8 @@ public sealed class WingmanVoiceServiceTests
             // The whole point: NO session's voice was collateral damage to another session's 5xx. Both
             // reached the provider and both are playable. On the pre-change gated code exactly one of these
             // is false, so this pair of assertions IS the regression.
-            Assert.True(svc.HasVoice("sid-B"), "session B's voice must not be gated by session A's failure");
-            Assert.True(svc.HasVoice("sid-C"), "session C's voice must not be gated by session A's failure");
+            Assert.True(svc.HasVoice(TenantId.Local, "sid-B"), "session B's voice must not be gated by session A's failure");
+            Assert.True(svc.HasVoice(TenantId.Local, "sid-C"), "session C's voice must not be gated by session A's failure");
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ } }
     }
@@ -922,9 +923,9 @@ public sealed class WingmanVoiceServiceTests
         // The control. 402 is the user's to fix, so it must NOT be swept into ServiceDown - telling
         // someone "not your fault, retrying" when they are out of credit would strand them forever.
         var svc = ServiceWithTts(HttpStatusCode.PaymentRequired, "{\"error\":{\"code\":\"insufficient_credits\"}}");
-        await svc.StoreSpokenAsync("sid-402", "spoken", "reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-402", "spoken", "reply");
 
-        var state = svc.VoiceUnavailableFor("sid-402");
+        var state = svc.VoiceUnavailableFor(TenantId.Local, "sid-402");
         Assert.NotNull(state);
         Assert.NotEqual(HostedAiState.ServiceDown, state);
     }
@@ -950,31 +951,31 @@ public sealed class WingmanVoiceServiceTests
         // Voice must come back BY ITSELF when the service returns (the idle sweep regenerates), so a
         // success has to clear the state - otherwise the phone would keep saying "down" after recovery.
         var svc = ServiceWithTts(HttpStatusCode.OK, "", audio: new byte[] { 1, 2, 3, 4 });
-        await svc.StoreSpokenAsync("sid-back", "spoken", "reply");
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-back", "spoken", "reply");
 
-        Assert.True(svc.HasVoice("sid-back"));
-        Assert.Null(svc.VoiceUnavailableFor("sid-back"));
+        Assert.True(svc.HasVoice(TenantId.Local, "sid-back"));
+        Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-back"));
     }
 
     [Fact]
     public async Task OnSessionWorking_ClearsVoiceUnavailable()
     {
         var svc = ServiceWithTts(HttpStatusCode.PaymentRequired, "{\"error\":{\"code\":\"insufficient_credits\"}}");
-        await svc.StoreSpokenAsync("sid-1", "spoken", "reply");
-        Assert.Equal(HostedAiState.NeedsCredits, svc.VoiceUnavailableFor("sid-1"));
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-1", "spoken", "reply");
+        Assert.Equal(HostedAiState.NeedsCredits, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
 
-        svc.OnSessionWorking("sid-1");
-        Assert.Null(svc.VoiceUnavailableFor("sid-1"));
+        svc.OnSessionWorking(TenantId.Local, "sid-1");
+        Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
     }
 
     [Fact]
     public async Task Unmark_ClearsVoiceUnavailable()
     {
         var svc = ServiceWithTts(HttpStatusCode.PaymentRequired, "{\"error\":{\"code\":\"insufficient_credits\"}}");
-        await svc.StoreSpokenAsync("sid-1", "spoken", "reply");
-        Assert.Equal(HostedAiState.NeedsCredits, svc.VoiceUnavailableFor("sid-1"));
+        await svc.StoreSpokenAsync(TenantId.Local, "sid-1", "spoken", "reply");
+        Assert.Equal(HostedAiState.NeedsCredits, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
 
-        svc.Unmark("sid-1");
-        Assert.Null(svc.VoiceUnavailableFor("sid-1"));
+        svc.Unmark(TenantId.Local, "sid-1");
+        Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
     }
 }

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
@@ -21,14 +21,38 @@ namespace CcDirector.Gateway.Tests;
 /// </summary>
 public sealed class WingmanVoiceServiceTests
 {
+    /// <summary>
+    /// A persist path inside a DIRECTORY unique to this call - never a unique filename in the shared machine
+    /// temp directory.
+    ///
+    /// This distinction is the whole isolation guarantee, and it is worth spelling out because the harness
+    /// that preceded it was not careless - it was correct, and then quietly stopped being correct without a
+    /// line of it changing. It randomized the persist FILENAME, which was sufficient while the file was the
+    /// deepest thing the service derived anything from. Then the voice state was partitioned by tenant, and
+    /// the service began deriving its per-tenant root from that file's PARENT directory. Every instance
+    /// pointed at a bare temp filename now resolves to ONE shared tenants/local partition under the machine
+    /// temp path, so a clip written for "sid-1" by one test is loaded by the next test's fresh service (the
+    /// constructor loads every partition), and tests start passing or failing on each other's leftovers.
+    ///
+    /// The rule to carry: a test's isolation is only as deep as the deepest path component the production
+    /// code derives from. Randomize the DIRECTORY, so the isolation survives the next time something moves
+    /// the derivation up a level. Callers that need two service instances to see the SAME state (the
+    /// gateway-restart cases) must call this ONCE and share the result deliberately.
+    /// </summary>
+    private static string TempPersist()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return Path.Combine(dir, "voice-sessions.json");
+    }
+
     private static WingmanVoiceService NewService()
     {
         // The flag methods never touch the brain; a provider that throws proves that.
         Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
             (_, _) => throw new InvalidOperationException("brain must not be called for flag state");
         var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
-        var persistPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".json");
-        return new WingmanVoiceService(brain, new KeyVault(vaultPath), persistPath);
+        return new WingmanVoiceService(brain, new KeyVault(vaultPath), TempPersist());
     }
 
     [Fact]
@@ -80,14 +104,16 @@ public sealed class WingmanVoiceServiceTests
         return new WingmanVoiceService(brain, new KeyVault(vaultPath), persistPath);
     }
 
+    /// <summary>Remove the whole per-test directory. It deletes the DIRECTORY rather than picking out the
+    /// individual files it expects, because <see cref="TempPersist"/> owns that directory outright, and a
+    /// cleanup that enumerates known filenames goes stale the moment the layout underneath changes - which
+    /// is exactly what happened when the per-tenant partition was introduced under it.</summary>
     private static void Cleanup(string persistPath)
     {
         try
         {
             var dir = Path.GetDirectoryName(persistPath);
-            if (dir is not null && Directory.Exists(Path.Combine(dir, "voice-audio")))
-                Directory.Delete(Path.Combine(dir, "voice-audio"), recursive: true);
-            if (File.Exists(persistPath)) File.Delete(persistPath);
+            if (dir is not null && Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
         }
         catch { /* best-effort cleanup */ }
     }
@@ -117,7 +143,9 @@ public sealed class WingmanVoiceServiceTests
     {
         // A successful synthesis is durable: a fresh service over the same persist path reloads the
         // ready audio, so the triangle/playability survives a gateway restart and a tap still plays.
-        var persistPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".json");
+        // ONE root, shared DELIBERATELY by the two service instances below: this test is the gateway-restart
+        // case, and a second instance that could not see what the first wrote would not be testing anything.
+        var persistPath = TempPersist();
         try
         {
             var svc = ServiceAt(persistPath);
@@ -146,11 +174,20 @@ public sealed class WingmanVoiceServiceTests
     {
         // Older cache metadata had no content type. Kokoro can return WAV bytes, so reload must detect
         // RIFF instead of serving those bytes as audio/mpeg.
-        var persistPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".json");
+        //
+        // The seed goes in the LOCAL TENANT PARTITION, which is where the service actually reads its cache
+        // from now. It used to be written to <root>/voice-audio, the pre-partition location. That kept
+        // passing after the partition landed - but only because the self-host legacy migration moved the
+        // file into the partition before the load ran, which is not what this test is about. It would have
+        // gone on passing with the partition deleted entirely, so it was proving nothing about it while
+        // silently testing a different code path than its name claims. Seeding the real location keeps this
+        // test on content-type detection; the migration has its own coverage in
+        // WingmanVoiceTenantPartitionTests.
+        var persistPath = TempPersist();
         try
         {
             var dir = Path.GetDirectoryName(persistPath)!;
-            var audioDir = Path.Combine(dir, "voice-audio");
+            var audioDir = Path.Combine(dir, "tenants", "local", "voice-audio");
             Directory.CreateDirectory(audioDir);
             File.WriteAllBytes(Path.Combine(audioDir, "sid-1.mp3"), new byte[] { (byte)'R', (byte)'I', (byte)'F', (byte)'F', 1, 2, 3 });
             File.WriteAllText(Path.Combine(audioDir, "sid-1.json"),
@@ -170,7 +207,9 @@ public sealed class WingmanVoiceServiceTests
     {
         // A new turn drops the stale audio from disk too, so a 5s-stale list row cannot point at
         // audio that no longer exists (which would 404 on /audio).
-        var persistPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".json");
+        // ONE root, shared DELIBERATELY by the two service instances below: this test is the gateway-restart
+        // case, and a second instance that could not see what the first wrote would not be testing anything.
+        var persistPath = TempPersist();
         try
         {
             var svc = ServiceAt(persistPath);
@@ -547,7 +586,9 @@ public sealed class WingmanVoiceServiceTests
     {
         // The removal is durable: a gateway restart must NOT bring the session back as a voice
         // session (otherwise turn-end re-narration would resume on its own after a restart).
-        var persistPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".json");
+        // ONE root, shared DELIBERATELY by the two service instances below: this test is the gateway-restart
+        // case, and a second instance that could not see what the first wrote would not be testing anything.
+        var persistPath = TempPersist();
         try
         {
             var svc = ServiceAt(persistPath);
@@ -632,7 +673,9 @@ public sealed class WingmanVoiceServiceTests
         Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
             (_, _) => throw new InvalidOperationException("brain must not be called for the store-spoken path");
         var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
-        var persistPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".json");
+        // A fresh root per CALL. Each invocation of this helper builds an independent service, so they must
+        // not share state; the restart tests get their sharing by calling TempPersist() once themselves.
+        var persistPath = TempPersist();
         var vault = new KeyVault(vaultPath);
         vault.Set("OPENAI_API_KEY", "sk-test");
         vault.Set("DEVTHROTTLE_API_KEY", "dt_live_test");
@@ -715,7 +758,9 @@ public sealed class WingmanVoiceServiceTests
         Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
             (_, _) => throw new InvalidOperationException("brain must not be called for the store-spoken path");
         var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
-        var persistPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".json");
+        // A fresh root per CALL. Each invocation of this helper builds an independent service, so they must
+        // not share state; the restart tests get their sharing by calling TempPersist() once themselves.
+        var persistPath = TempPersist();
         var vault = new KeyVault(vaultPath);
         vault.Set("OPENAI_API_KEY", "sk-test");
         vault.Set("DEVTHROTTLE_API_KEY", "dt_live_test");

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
@@ -103,6 +103,23 @@ namespace CcDirector.Gateway.Tests;
 ///   B4 <c>GatewayTurnJobStore.StateFor</c> - 1 red:
 ///     Turn_job_store_is_partitioned_and_a_turn_id_alone_does_not_read_it   Assert.Null (B read A's job)
 ///
+/// PRE-REGISTERED PREDICTION, committed while the B1-only run was still executing and before any
+/// per-primitive result existed. Recorded in advance deliberately: a prediction written beforehand is
+/// evidence about the model that produced it, whereas the same sentence added afterwards is only a
+/// description of what happened.
+///
+///   PREDICTION: the three pre-existing tests below are sensitive to B2 (the on-disk directory), NOT to
+///   B1 (the in-memory bucket). Expected: B1 alone leaves all three GREEN; B2 alone reddens all three.
+///   REASONING: all three are gateway-RESTART tests. They construct a second service over the same root
+///   and assert it reloads what the first wrote. A restart discards the in-memory buckets entirely, so
+///   B1 should be invisible to them, while the directory layout is the only channel by which their state
+///   survives at all.
+///   IF WRONG - if B1 reddens them - that is the more interesting outcome and must be reported just as
+///   plainly: it would mean the in-memory bucket is load-bearing for durable restart in a way none of us
+///   expected, and the reload path would need re-reading before this change is trusted.
+///
+/// OUTCOME: see the per-primitive results recorded above; the prediction is scored there explicitly.
+///
 /// THREE TESTS THAT ARE NOT MINE ALSO WENT RED, all on B2, all as assertions:
 ///   WingmanVoiceServiceTests.ReadyAudio_PersistsAndReloadsAcrossRestart
 ///   WingmanVoiceServiceTests.ReadyAudio_ReloadsLegacyWavCacheWithDetectedContentType

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
@@ -118,24 +118,57 @@ namespace CcDirector.Gateway.Tests;
 ///
 /// OUTCOME: see the per-primitive results recorded above; the prediction is scored there explicitly.
 ///
-/// THREE TESTS OUTSIDE THIS CLASS ALSO DETECT THIS PARTITION - which primitive, see the matrix:
+/// IF YOU MOVE THE VOICE ON-DISK LAYOUT: THREE TESTS IN TWO OTHER CLASSES GO RED, AND NONE OF THEM HAS
+/// "TENANT" IN THE NAME.
 ///   WingmanVoiceServiceTests.ReadyAudio_PersistsAndReloadsAcrossRestart
 ///   WingmanVoiceServiceTests.ReadyAudio_ReloadsLegacyWavCacheWithDetectedContentType
 ///   WingmanVoiceFallbackTests.ServedViaFallback_SurvivesAGatewayRestart
-/// This is the answer to a question a filtered run cannot ask: the durable restart path was ALREADY
-/// covered before this change. If you move the on-disk layout, three tests in two other classes go red
-/// and their names will not mention tenancy - the matrix is how you find out why.
+/// They are reddened by the on-disk DIRECTORY primitive and NOT by the in-memory bucket - observed both
+/// ways round, one run per primitive, not inferred. The durable restart path was already covered before
+/// tenant partitioning existed, which is why nothing in those names hints at tenancy and why a filtered
+/// run of this class alone can never tell you they exist. If you are here because one of those three went
+/// red and you were not expecting it, this paragraph is the answer.
 ///
-/// A WRONG EXPECTATION, RECORDED ON PURPOSE. Before the single-primitive runs, the author expected
+/// TWO TESTS STRADDLE TWO PRIMITIVES, AND THE FAILURE KIND IS HOW YOU CAN TELL.
 /// Voice_session_set_reloads_into_the_tenant_that_owned_it and
-/// Self_host_moves_the_pre_partition_voice_state_into_the_local_partition to be sensitive to the on-disk
-/// DIRECTORY. They are not: the in-memory BUCKET alone reddens both, and the failure kind is what gives
-/// the reason away - both fail on their cross-tenant <c>Assert.False</c>, not on their reload assertion.
-/// These tests are split across two primitives: the RELOAD half rides on the directory, the ISOLATION
-/// half rides on the bucket. That is a real structural fact about this code, it contradicted the author's
-/// model, and no combined run could ever have surfaced it - a combined run would have shown both
-/// primitives mutated and both tests red, which is consistent with any explanation at all.
-/// Distrust the intuition that "restart test" implies "on-disk sensitivity". Read the matrix instead.
+/// Self_host_moves_the_pre_partition_voice_state_into_the_local_partition are reddened by the in-memory
+/// bucket AND by the on-disk directory, INDEPENDENTLY - either mutation alone is enough - but they fail
+/// on DIFFERENT assertions in each case:
+///   bucket collapsed    -> fails its cross-tenant <c>Assert.False</c> ("the other tenant must not see it")
+///   directory collapsed -> fails its <c>Assert.True</c>   ("the state must survive the restart")
+/// So one test carries two independent claims: ISOLATION rides on the bucket, RELOAD rides on the
+/// directory. That is a real structural fact about this code and no combined run could surface it - with
+/// everything mutated at once both tests are simply red, which is consistent with any explanation at all.
+///
+/// TWO CORRECTIONS THE AUTHOR OWES, both recorded rather than smoothed away:
+///  1. Before these runs the author expected both tests to be DIRECTORY-sensitive only. The bucket run
+///     reddened them too. Distrust the intuition that "restart test" implies "on-disk sensitivity".
+///  2. After the bucket run - and before the directory run had produced anything - the author wrote that
+///     these two were bucket-sensitive and NOT directory-sensitive. That was also wrong, in the opposite
+///     direction, and for a worse reason: it generalised from a single run while the run that could
+///     refute it had not yet been done. They are sensitive to BOTH. A claim of the form "X and not Y" is
+///     not supported by an experiment that only varied X.
+///
+/// TWO RULES THIS PROOF PAID FOR. Both are general; both nearly produced a wrong published claim here.
+///
+/// RULE ONE - WHEN COMPARING OBSERVATIONS FROM DIFFERENT BUILDS, COMPARE PROPERTIES THAT CANNOT SHIFT.
+/// The temptation was to prove the straddle above from POSITIONS: the bucket run failed at line 306, the
+/// directory run at line 322, therefore different assertions. Invalid. Seventeen lines of COMMENT were
+/// added to this file between the two builds, so 306 in the earlier build maps to about 323 in the later
+/// one - within one line of 322. The line numbers were consistent with "the same assertion" the whole
+/// time and would have been read as proof of the opposite. A change with no behaviour whatsoever was
+/// enough to invert the conclusion. Line numbers, offsets, ordinals and indices all move when a file is
+/// edited; test name, assertion TYPE, message text and explicit identifiers do not. What actually settles
+/// the straddle is <c>Assert.False</c> versus <c>Assert.True</c>: the executable source did not change
+/// between the builds, and one line cannot be both.
+///
+/// RULE TWO - A CLAIM OF THE FORM "X AND NOT Y" IS NOT SUPPORTED BY AN EXPERIMENT THAT ONLY VARIED X.
+/// After the bucket run, and before the directory run existed, the author published "these two tests are
+/// bucket-sensitive and NOT directory-sensitive". The directory run showed both. This is worse than an
+/// ordinary wrong guess in a specific way: it generalises from a single arm while the arm that could
+/// refute it is still unrun, and it arrives dressed as a finding rather than as a hypothesis. The honest
+/// form after one arm is: "X is sufficient; whether Y also suffices is UNTESTED." Say that instead, and
+/// then go and run Y.
 ///
 /// The Assert.NotEqual red on Each_tenants_clips_live_in_its_own_directory is the one to look at hardest,
 /// because that assertion previously compared two paths the TEST had built and could not fail. Rewritten

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
@@ -16,47 +16,67 @@ namespace CcDirector.Gateway.Tests;
 /// empty answer proves nothing on its own: a seed that silently failed also returns empty, and that reads as
 /// isolation. The control is what separates "isolated" from "nothing was ever stored".
 ///
-/// REVERT-PROOF RECIPE. Do NOT neutralise a guard with <c>if (false)</c>: unreachable code is a build error
-/// in this repository, the build then fails, and a test run after a failed build executes the STALE binary
-/// and reports a false pass. DELETE the guard, and CONFIRM the build line says succeeded before believing
-/// any result. Run the WHOLE Gateway suite, not a filter on this class - a filter cannot see whether an
-/// existing test elsewhere already covered the behaviour, nor whether removing a guard broke something
-/// unrelated. The Gateway suite is serialized on the build machine; a run that ends with no summary line is
-/// contention, not a result.
+/// The cross-tenant question is deliberately asked BEFORE its control in every test. That ordering is not
+/// cosmetic - see the laundering note in the recipe below.
 ///
-/// ONE run removes all four guards at once, because each one has its own test with its own assertion, so
-/// their reds stay individually attributable:
+/// REVERT-PROOF RECIPE.
 ///
-///  1. <c>WingmanVoiceService.CanonicalTenantKey</c> - DELETE the <c>IsMintedAccountTenant</c> refusal.
-///  2. <c>VoiceTurnArchive.PartitionDirectoryFor</c> - DELETE its <c>IsMintedAccountTenant</c> refusal.
-///  3. <c>WingmanVoiceService.MigrateLegacyUnpartitionedState</c> - DELETE the whole body, BOTH the hosted
-///     delete branch and the self-host move.
-///  4. <c>VoiceTurnArchive.MigrateLegacyUnpartitionedTurns</c> - DELETE the whole body, both directions.
+/// WHY THIS RECIPE LOOKS THE WAY IT DOES. An earlier version reverted four things: the two minted-shape
+/// refusals and the two migration bodies. Eight tests went red and the isolation tests all stayed green,
+/// and that green was written up as "the control". It was not a control - it was the finding. Those four
+/// reverts are the PERIMETER (shape validation and one-time migration); none of them touches the
+/// partitioning itself, so every isolation test stayed green because nothing they test had been mutated.
+/// A revert-proof whose core assertions never move has shown you where the guard ISN'T. The rule this cost
+/// us: A CONTROL HAS TO BE SHOWN TO BE SENSITIVE TO SOMETHING, OR IT IS JUST A TEST THAT ALWAYS PASSES.
 ///
-/// Deleting both branches of a migration still distinguishes its two directions, and that is not an
-/// accident - it is why the two migration tests assert in the order they do. The hosted test leads with
-/// "the clip is GONE", the self-host test leads with "the clip ARRIVED in the local partition". With no
-/// migration at all they therefore fail on OPPOSITE claims about different files, not on one shared
-/// assertion. Had both led with "gone from the old location" they would have failed identically and the
-/// run would have proved only "something broke". If a future edit makes these two fail for the same
-/// reason, the pair has stopped being a two-direction proof - split the run rather than accept it.
+/// So the recipe below mutates the BOUNDARY - the four places that actually make one tenant's state
+/// unreachable from another - and the perimeter reverts are kept as a secondary group.
 ///
-/// OBSERVED with all four deleted (build succeeded; 8 RED, and each red names its own guard):
-///   Assert.Throws, no exception thrown - the tenant-shape guards:
-///     Case_variant_of_a_minted_tenant_is_refused_rather_than_aliased_to_the_same_partition   (guard 1)
-///     System_tenant_is_refused_a_voice_partition                                             (guard 1)
-///     Traversal_tenant_is_refused_rather_than_resolved_to_the_parent_partition               (guard 1)
-///     Turn_archive_refuses_a_traversal_tenant                                                (guard 2)
-///   Assert.False failure, "it is still there" - the HOSTED delete direction:
-///     Hosted_deletes_the_pre_partition_voice_state_rather_than_guessing_an_owner             (guard 3)
-///     Hosted_deletes_pre_partition_archived_turns                                            (guard 4)
-///   Assert.True / Assert.NotNull failure, "it never arrived" - the SELF-HOST move direction:
-///     Self_host_moves_the_pre_partition_voice_state_into_the_local_partition                 (guard 3)
-///     Self_host_moves_pre_partition_archived_turns_into_the_local_partition                  (guard 4)
+/// MECHANICS. Do NOT neutralise anything with <c>if (false)</c>: unreachable code is a build error here, so
+/// the build fails and the run then executes a STALE binary and reports a false pass. Make the mutation
+/// real, and CONFIRM the build line says succeeded before believing any result. Run the WHOLE Gateway
+/// assembly - never a filter, which cannot see whether some other test already covered the behaviour or
+/// whether the mutation broke something unrelated. Every Gateway run needs the serialized lane; a run that
+/// ends with no summary line is contention, not a result.
 ///
-/// The eleven isolation tests stayed GREEN throughout, which is the control: they use a valid tenant and
-/// seed their own state, so no deleted guard is on their path. Restoring all four returns the suite to
-/// green.
+/// NO EXCEPTION-ONLY LAUNDERING. A mutation that makes a test die on a NullReferenceException or an
+/// input/output error BEFORE its distinguishing assertion has proved that the harness crashed, not that
+/// isolation holds. Every test in this class is therefore written so the cross-tenant question is asked
+/// FIRST, while nothing can have thrown, and every dereference is guarded by an explicit null assertion.
+/// If a mutation below produces a stack trace instead of a failed assertion, that result does not count -
+/// fix the test's ordering and re-run.
+///
+/// GROUP ONE - THE BOUNDARY. Each mutation keeps the tenant validation call (so the shape tests stay green
+/// and attribution stays clean) and only collapses the partition:
+///
+///  B1. <c>WingmanVoiceService.StateFor</c> - return one shared bucket for every tenant.
+///      EXPECTED RED: the six in-memory A/B tests (ready audio, voice-session marking, generating and
+///      unavailable and nothing-to-narrate, served-via-fallback, cross-tenant clearing, regeneration
+///      decision) plus Clips_reload_into_the_tenant_that_owned_them.
+///  B2. <c>WingmanVoiceService.PartitionDirectoryFor</c> - return one shared directory for every tenant.
+///      EXPECTED RED: Each_tenants_clips_live_in_its_own_directory (on the production-derived NotEqual and
+///      the per-file byte assertions), Voice_session_set_reloads_into_the_tenant_that_owned_it, and
+///      Self_host_moves_the_pre_partition_voice_state_into_the_local_partition.
+///  B3. <c>VoiceTurnArchive.PartitionDirectoryFor</c> / <c>DirFor</c> - collapse to one directory.
+///      EXPECTED RED: Turn_archive_is_partitioned_and_a_turn_id_alone_does_not_read_it and
+///      Self_host_moves_pre_partition_archived_turns_into_the_local_partition.
+///  B4. <c>GatewayTurnJobStore.StateFor</c> - return one shared bucket.
+///      EXPECTED RED: Turn_job_store_is_partitioned_and_a_turn_id_alone_does_not_read_it.
+///
+/// GROUP TWO - THE PERIMETER (the original four; real, but they are not the boundary):
+///
+///  P1. <c>WingmanVoiceService.CanonicalTenantKey</c> - delete the <c>IsMintedAccountTenant</c> refusal.
+///  P2. <c>VoiceTurnArchive.PartitionDirectoryFor</c> - delete its <c>IsMintedAccountTenant</c> refusal.
+///  P3. <c>WingmanVoiceService.MigrateLegacyUnpartitionedState</c> - delete the whole body, both directions.
+///  P4. <c>VoiceTurnArchive.MigrateLegacyUnpartitionedTurns</c> - delete the whole body, both directions.
+///
+/// Deleting both branches of a migration still distinguishes its two directions, and that is by design: the
+/// hosted test leads with "the clip is GONE", the self-host test leads with "the clip ARRIVED in the local
+/// partition", so with no migration at all they fail on opposite claims about different files rather than
+/// on one shared assertion. If a future edit makes those two fail for the same reason, the pair has stopped
+/// being a two-direction proof - split the run rather than accept it.
+///
+/// RESULTS: recorded when the lane is granted. Nothing is recorded here from a filtered run.
 /// </summary>
 public sealed class WingmanVoiceTenantPartitionTests
 {
@@ -88,18 +108,25 @@ public sealed class WingmanVoiceTenantPartitionTests
         var svc = ServiceAt(NewBaseDir());
         svc.StoreReadyAudioForTest(TenantA, "s1", "spoken A", "reply A", Mp3("A"));
 
-        // CONTROL: the same call on the owning tenant DOES see it, so an empty answer below is isolation
-        // and not a failed seed.
-        Assert.True(svc.HasVoice(TenantA, "s1"));
-        Assert.Equal(Mp3("A"), svc.GetAudio(TenantA, "s1"));
-        Assert.Equal("spoken A", svc.Get(TenantA, "s1")!.Spoken);
-        Assert.Contains("s1", svc.ReadySessionIds(TenantA));
-
-        // The other tenant names the SAME session id and gets nothing.
+        // The DISTINGUISHING assertions come FIRST: the other tenant names the SAME session id and gets
+        // nothing. Ordering matters here for the same reason it matters in the migration pair - if the
+        // control ran first and a mutation made it null, the test would die on a null dereference before it
+        // ever asked the question it exists to ask, and a crash would be laundered as a pass-turned-red for
+        // the wrong reason. Ask the real question while nothing can have thrown yet.
         Assert.False(svc.HasVoice(TenantB, "s1"));
         Assert.Null(svc.GetAudio(TenantB, "s1"));
         Assert.Null(svc.Get(TenantB, "s1"));
         Assert.Empty(svc.ReadySessionIds(TenantB));
+
+        // CONTROL, second: the same calls on the OWNING tenant do see it, so an empty answer above is
+        // isolation and not a failed seed. Every dereference is guarded by an explicit null assertion, so a
+        // broken partition reports a failed assertion rather than a NullReferenceException.
+        Assert.True(svc.HasVoice(TenantA, "s1"));
+        Assert.Equal(Mp3("A"), svc.GetAudio(TenantA, "s1"));
+        var ownRead = svc.Get(TenantA, "s1");
+        Assert.NotNull(ownRead);
+        Assert.Equal("spoken A", ownRead!.Spoken);
+        Assert.Contains("s1", svc.ReadySessionIds(TenantA));
     }
 
     [Fact]
@@ -172,26 +199,62 @@ public sealed class WingmanVoiceTenantPartitionTests
 
     // ===== the partition is PHYSICAL and survives a restart =================================
 
+    /// <summary>
+    /// PRIMARY CANARY for <c>WingmanVoiceService.PartitionDirectoryFor</c>. Two tenants store a clip under
+    /// the SAME session id; each must land in its own directory on disk.
+    ///
+    /// The directories are read back from the production method, NOT recomputed by the test. An earlier
+    /// version of this test asserted <c>Assert.NotEqual(aDir, bDir)</c> over two paths the TEST had built
+    /// from the two tenant ids - which is true by arithmetic no matter what the production code does, and
+    /// would have stayed green with the partition deleted entirely. An assertion that cannot fail is not
+    /// coverage.
+    /// </summary>
     [Fact]
-    public void Each_tenants_clips_live_in_its_own_directory_and_reload_into_its_own_partition()
+    public void Each_tenants_clips_live_in_its_own_directory()
     {
         var baseDir = NewBaseDir();
         var svc = ServiceAt(baseDir);
         svc.StoreReadyAudioForTest(TenantA, "s1", "spoken A", "reply A", Mp3("A"));
         svc.StoreReadyAudioForTest(TenantB, "s1", "spoken B", "reply B", Mp3("B"));
 
-        var aDir = Path.Combine(baseDir, "tenants", TenantA.Value, "voice-audio");
-        var bDir = Path.Combine(baseDir, "tenants", TenantB.Value, "voice-audio");
-        Assert.True(File.Exists(Path.Combine(aDir, "s1.mp3")));
-        Assert.True(File.Exists(Path.Combine(bDir, "s1.mp3")));
-        // The tenant id is a PATH COMPONENT: the two identically-named sessions are different files.
+        // Production-derived, so this moves when the partitioning moves.
+        var aDir = Path.Combine(svc.PartitionDirectoryFor(TenantA), "voice-audio");
+        var bDir = Path.Combine(svc.PartitionDirectoryFor(TenantB), "voice-audio");
         Assert.NotEqual(aDir, bDir);
 
+        // Each tenant's clip is a SEPARATE FILE, and each holds its own bytes - so one did not overwrite
+        // the other at a shared path.
+        Assert.True(File.Exists(Path.Combine(aDir, "s1.mp3")));
+        Assert.True(File.Exists(Path.Combine(bDir, "s1.mp3")));
+        Assert.Equal(Mp3("A"), File.ReadAllBytes(Path.Combine(aDir, "s1.mp3")));
+        Assert.Equal(Mp3("B"), File.ReadAllBytes(Path.Combine(bDir, "s1.mp3")));
+    }
+
+    /// <summary>
+    /// PRIMARY CANARY for the restart path: a clip must reload into the tenant that owned it, not into a
+    /// shared bucket where the second tenant's load overwrites the first. Sensitive to BOTH
+    /// <c>StateFor</c> and <c>PartitionDirectoryFor</c>, which is stated rather than hidden.
+    /// </summary>
+    [Fact]
+    public void Clips_reload_into_the_tenant_that_owned_them()
+    {
+        var baseDir = NewBaseDir();
+        var svc = ServiceAt(baseDir);
+        svc.StoreReadyAudioForTest(TenantA, "s1", "spoken A", "reply A", Mp3("A"));
+        svc.StoreReadyAudioForTest(TenantB, "s1", "spoken B", "reply B", Mp3("B"));
+
         var reloaded = ServiceAt(baseDir);
-        Assert.Equal(Mp3("A"), reloaded.GetAudio(TenantA, "s1"));   // control
-        Assert.Equal(Mp3("B"), reloaded.GetAudio(TenantB, "s1"));   // control
-        Assert.Equal("spoken A", reloaded.Get(TenantA, "s1")!.Spoken);
-        Assert.Equal("spoken B", reloaded.Get(TenantB, "s1")!.Spoken);
+        // Byte comparisons first: a null or a wrong-tenant clip both fail as a plain assertion, never as a
+        // dereference of null.
+        Assert.Equal(Mp3("A"), reloaded.GetAudio(TenantA, "s1"));
+        Assert.Equal(Mp3("B"), reloaded.GetAudio(TenantB, "s1"));
+
+        var a = reloaded.Get(TenantA, "s1");
+        var b = reloaded.Get(TenantB, "s1");
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        Assert.Equal("spoken A", a!.Spoken);
+        Assert.Equal("spoken B", b!.Spoken);
     }
 
     [Fact]
@@ -320,17 +383,26 @@ public sealed class WingmanVoiceTenantPartitionTests
             Transcript = "transcript A", Summary = "summary A", HasAudio = true, CreatedAtUtc = DateTime.UtcNow,
         }, Mp3("A"));
 
-        // CONTROL: the owning tenant reads it on every path.
-        Assert.Equal("summary A", archive.Get(TenantA, turnId)!.Summary);
-        Assert.Equal(Mp3("A"), archive.GetAudio(TenantA, turnId));
-        Assert.Single(archive.ListForSession(TenantA, "s1"));
-        Assert.NotNull(archive.FindByUpload(TenantA, "u1"));
-
-        // The other tenant holds the exact turn id and still gets nothing.
+        // DISTINGUISHING first: the other tenant holds the exact turn id and still gets nothing on every
+        // path. Asked before anything can have thrown, so a broken partition reports these assertions
+        // rather than dying on a null dereference in the control below.
         Assert.Null(archive.Get(TenantB, turnId));
         Assert.Null(archive.GetAudio(TenantB, turnId));
         Assert.Empty(archive.ListForSession(TenantB, "s1"));
         Assert.Null(archive.FindByUpload(TenantB, "u1"));
+
+        // CONTROL, second: the owning tenant reads it on every path, so the emptiness above is isolation
+        // and not a failed save. The dereference is guarded.
+        var own = archive.Get(TenantA, turnId);
+        Assert.NotNull(own);
+        Assert.Equal("summary A", own!.Summary);
+        Assert.Equal(Mp3("A"), archive.GetAudio(TenantA, turnId));
+        Assert.Single(archive.ListForSession(TenantA, "s1"));
+        Assert.NotNull(archive.FindByUpload(TenantA, "u1"));
+
+        // And the partition is PHYSICAL: the two tenants resolve to different directories, read back from
+        // the production method rather than recomputed by the test.
+        Assert.NotEqual(archive.PartitionDirectoryFor(TenantA), archive.PartitionDirectoryFor(TenantB));
     }
 
     [Fact]
@@ -348,11 +420,14 @@ public sealed class WingmanVoiceTenantPartitionTests
         var store = new GatewayTurnJobStore();
         var job = store.Create(TenantA, "s1", "u1");
 
-        Assert.NotNull(store.Get(TenantA, job.TurnId));                 // control
-        Assert.NotNull(store.FindTurnByUpload(TenantA, "u1"));          // control
-
+        // DISTINGUISHING first, for the same anti-laundering reason as the stores above.
         Assert.Null(store.Get(TenantB, job.TurnId));
         Assert.Null(store.FindTurnByUpload(TenantB, "u1"));
+
+        // CONTROL second: the owning tenant does find it, so the nulls above are isolation, not a job that
+        // was never created.
+        Assert.NotNull(store.Get(TenantA, job.TurnId));
+        Assert.NotNull(store.FindTurnByUpload(TenantA, "u1"));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
@@ -16,42 +16,47 @@ namespace CcDirector.Gateway.Tests;
 /// empty answer proves nothing on its own: a seed that silently failed also returns empty, and that reads as
 /// isolation. The control is what separates "isolated" from "nothing was ever stored".
 ///
-/// REVERT-PROOF RECIPE - the four steps below were ACTUALLY RUN against this branch before it was
-/// committed, and the results recorded are the ones observed, not the ones expected. Re-run them whenever
-/// these guards are touched. Do NOT neutralise a guard with <c>if (false)</c>: unreachable code is a build
-/// error in this repository, the build then fails, and a test run after a failed build executes the STALE
-/// binary and reports a false pass. DELETE the guard, and CONFIRM the build line says succeeded / 0 errors
-/// before believing any result.
+/// REVERT-PROOF RECIPE. Do NOT neutralise a guard with <c>if (false)</c>: unreachable code is a build error
+/// in this repository, the build then fails, and a test run after a failed build executes the STALE binary
+/// and reports a false pass. DELETE the guard, and CONFIRM the build line says succeeded before believing
+/// any result. Run the WHOLE Gateway suite, not a filter on this class - a filter cannot see whether an
+/// existing test elsewhere already covered the behaviour, nor whether removing a guard broke something
+/// unrelated. The Gateway suite is serialized on the build machine; a run that ends with no summary line is
+/// contention, not a result.
 ///
-///  1. In <c>WingmanVoiceService.CanonicalTenantKey</c>, DELETE the <c>IsMintedAccountTenant</c> refusal so
-///     any tenant string is accepted as a partition name.
-///     OBSERVED: build succeeded; 3 RED, 16 green -
-///       Case_variant_of_a_minted_tenant_is_refused_rather_than_aliased_to_the_same_partition
-///       System_tenant_is_refused_a_voice_partition
-///       Traversal_tenant_is_refused_rather_than_resolved_to_the_parent_partition
-///     Turn_archive_refuses_a_traversal_tenant stayed GREEN, correctly: it exercises the archive's OWN
-///     copy of the guard, which this step did not touch. Every isolation test stayed GREEN too - they use a
-///     valid tenant, so the guard is not on their path. That is the control saying the three went red for
-///     the guard and not for the edit.
+/// ONE run removes all four guards at once, because each one has its own test with its own assertion, so
+/// their reds stay individually attributable:
 ///
-///  2. Restore step 1. In <c>VoiceTurnArchive.PartitionDirectoryFor</c>, DELETE its
-///     <c>IsMintedAccountTenant</c> refusal.
-///     OBSERVED: build succeeded; 1 RED, 18 green - Turn_archive_refuses_a_traversal_tenant. Exactly the
-///     mirror of step 1, which is what proves the two stores are guarded independently.
+///  1. <c>WingmanVoiceService.CanonicalTenantKey</c> - DELETE the <c>IsMintedAccountTenant</c> refusal.
+///  2. <c>VoiceTurnArchive.PartitionDirectoryFor</c> - DELETE its <c>IsMintedAccountTenant</c> refusal.
+///  3. <c>WingmanVoiceService.MigrateLegacyUnpartitionedState</c> - DELETE the whole body, BOTH the hosted
+///     delete branch and the self-host move.
+///  4. <c>VoiceTurnArchive.MigrateLegacyUnpartitionedTurns</c> - DELETE the whole body, both directions.
 ///
-///  3. Restore step 2. In <c>WingmanVoiceService.MigrateLegacyUnpartitionedState</c>, DELETE the whole
-///     <c>if (GatewayHostedMode.IsHosted)</c> DELETE branch, so hosted falls through to the self-host move.
-///     OBSERVED: build succeeded; 1 RED, 18 green -
-///       Hosted_deletes_the_pre_partition_voice_state_rather_than_guessing_an_owner
-///     while Self_host_moves_the_pre_partition_voice_state_into_the_local_partition stayed GREEN.
+/// Deleting both branches of a migration still distinguishes its two directions, and that is not an
+/// accident - it is why the two migration tests assert in the order they do. The hosted test leads with
+/// "the clip is GONE", the self-host test leads with "the clip ARRIVED in the local partition". With no
+/// migration at all they therefore fail on OPPOSITE claims about different files, not on one shared
+/// assertion. Had both led with "gone from the old location" they would have failed identically and the
+/// run would have proved only "something broke". If a future edit makes these two fail for the same
+/// reason, the pair has stopped being a two-direction proof - split the run rather than accept it.
 ///
-///  4. Restore step 3, then DELETE the self-host MOVE block instead (the opposite direction).
-///     OBSERVED: build succeeded; 1 RED, 18 green -
-///       Self_host_moves_the_pre_partition_voice_state_into_the_local_partition
-///     while the hosted test stayed GREEN. Steps 3 and 4 together prove the pair really tests two opposite
-///     behaviours; a single shared path could not redden one test at a time in both directions.
+/// OBSERVED with all four deleted (build succeeded; 8 RED, and each red names its own guard):
+///   Assert.Throws, no exception thrown - the tenant-shape guards:
+///     Case_variant_of_a_minted_tenant_is_refused_rather_than_aliased_to_the_same_partition   (guard 1)
+///     System_tenant_is_refused_a_voice_partition                                             (guard 1)
+///     Traversal_tenant_is_refused_rather_than_resolved_to_the_parent_partition               (guard 1)
+///     Turn_archive_refuses_a_traversal_tenant                                                (guard 2)
+///   Assert.False failure, "it is still there" - the HOSTED delete direction:
+///     Hosted_deletes_the_pre_partition_voice_state_rather_than_guessing_an_owner             (guard 3)
+///     Hosted_deletes_pre_partition_archived_turns                                            (guard 4)
+///   Assert.True / Assert.NotNull failure, "it never arrived" - the SELF-HOST move direction:
+///     Self_host_moves_the_pre_partition_voice_state_into_the_local_partition                 (guard 3)
+///     Self_host_moves_pre_partition_archived_turns_into_the_local_partition                  (guard 4)
 ///
-///  5. Restore everything. Build succeeded; all 19 GREEN.
+/// The eleven isolation tests stayed GREEN throughout, which is the control: they use a valid tenant and
+/// seed their own state, so no deleted guard is on their path. Restoring all four returns the suite to
+/// green.
 /// </summary>
 public sealed class WingmanVoiceTenantPartitionTests
 {
@@ -281,13 +286,20 @@ public sealed class WingmanVoiceTenantPartitionTests
         try
         {
             var svc = ServiceAt(baseDir);
-            // Moved: gone from the shared location, present in the local partition, and STILL READABLE.
-            Assert.False(File.Exists(Path.Combine(baseDir, "voice-sessions.json")));
-            Assert.False(Directory.Exists(Path.Combine(baseDir, "voice-audio")));
+            // ARRIVED is asserted FIRST, deliberately, and this ordering is load-bearing. Its twin above
+            // asserts the opposite outcome (the clip is GONE). If both tests led with "gone from the old
+            // location", then deleting the whole migration would fail BOTH on the same assertion for the
+            // same reason, and a revert run could no longer tell the two directions apart - it would prove
+            // only "something broke". Leading with the direction-specific claim keeps the pair honest:
+            // with no migration at all, the hosted twin fails on "still there" and this one fails on
+            // "never arrived", which are different assertions about different files.
             Assert.True(File.Exists(Path.Combine(baseDir, "tenants", "local", "voice-audio", "s1.mp3")));
             Assert.True(svc.IsVoiceSession(TenantId.Local, "s1"));
             Assert.True(svc.HasVoice(TenantId.Local, "s1"));
             Assert.Equal(Mp3("legacy"), svc.GetAudio(TenantId.Local, "s1"));
+            // ...and only then that it was MOVED rather than copied.
+            Assert.False(File.Exists(Path.Combine(baseDir, "voice-sessions.json")));
+            Assert.False(Directory.Exists(Path.Combine(baseDir, "voice-audio")));
             // It landed in LOCAL only - it was not fanned out to an account tenant.
             Assert.False(svc.HasVoice(TenantA, "s1"));
         }
@@ -376,8 +388,13 @@ public sealed class WingmanVoiceTenantPartitionTests
         try
         {
             var archive = new VoiceTurnArchive(root);
+            // ARRIVED first, for the same reason as the voice-state twin above: leading with the
+            // direction-specific claim keeps this test distinguishable from its hosted opposite when the
+            // whole migration is deleted in a revert run.
+            var moved = archive.Get(TenantId.Local, turnId.ToString());
+            Assert.NotNull(moved);
+            Assert.Equal("legacy summary", moved!.Summary);
             Assert.False(Directory.Exists(legacyTurn));
-            Assert.Equal("legacy summary", archive.Get(TenantId.Local, turnId.ToString())!.Summary);
             Assert.Null(archive.Get(TenantA, turnId.ToString()));
         }
         finally { Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior); }

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
@@ -99,7 +99,55 @@ namespace CcDirector.Gateway.Tests;
 ///   green  - observed passing. The test ran to completion and passed.
 ///   NOTRUN - no outcome line for that test in that run. Evidence of nothing at all.
 ///
-/// MATRIX_PLACEHOLDER
+/// RESULTS - four separate full-assembly runs, one primitive each, every one preceded by a build confirmed
+/// succeeded and by a harness check that exactly ONE production file differed from pristine. Head
+/// aa2bec63 onward, rebased onto lock-bearing main, all under the automatic Gateway suite lock.
+///
+///   Restored baseline: 2979 total, 2969 passed, 0 failed, 10 skipped.
+///
+///   | primitive mutated alone                          | passed | failed | passed+failed | crashes |
+///   |--------------------------------------------------|--------|--------|---------------|---------|
+///   | B1 WingmanVoiceService.StateFor        (bucket)  |  2960  |    9   | 2969 = 2969 OK |    0    |
+///   | B2 WingmanVoiceService.PartitionDirectoryFor(dir)|  2962  |    7   | 2969 = 2969 OK |    0    |
+///   | B3 VoiceTurnArchive.PartitionDirectoryFor  (dir) |  2967  |    2   | 2969 = 2969 OK |    0    |
+///   | B4 GatewayTurnJobStore.StateFor        (bucket)  |  2968  |    1   | 2969 = 2969 OK |    0    |
+///
+/// Four independent reconciliations, four chances to catch a dropped test, none dropped. Nineteen reds in
+/// total and every single one arrived as an ASSERTION - not one crash, in any arm.
+///
+/// THE MATRIX. Rows are tests, columns are the primitive mutated ALONE in that run.
+///
+///   | test                                                             | B1  | B2  | B3  | B4  |
+///   |------------------------------------------------------------------|-----|-----|-----|-----|
+///   | (this class) Ready_audio_stored_for_one_tenant_is_invisible_..    | RED |green|green|green|
+///   | (this class) Voice_session_marking_is_per_tenant                  | RED |green|green|green|
+///   | (this class) Generating_unavailable_and_nothing_to_narrate_..     | RED |green|green|green|
+///   | (this class) Served_via_fallback_is_per_tenant                    | RED |green|green|green|
+///   | (this class) Clearing_one_tenants_session_leaves_..._intact       | RED |green|green|green|
+///   | (this class) Regeneration_decision_reads_only_the_asking_..       | RED |green|green|green|
+///   | (this class) Each_tenants_clips_live_in_its_own_directory         |green| RED |green|green|
+///   | (this class) Clips_reload_into_the_tenant_that_owned_them         | RED | RED |green|green|
+///   | (this class) Voice_session_set_reloads_into_the_tenant_..         | RED | RED |green|green|
+///   | (this class) Self_host_moves_the_pre_partition_voice_state_..     | RED | RED |green|green|
+///   | (this class) Turn_archive_is_partitioned_and_a_turn_id_alone_..   |green|green| RED |green|
+///   | (this class) Self_host_moves_pre_partition_archived_turns_..      |green|green| RED |green|
+///   | (this class) Turn_job_store_is_partitioned_and_a_turn_id_alone_.. |green|green|green| RED |
+///   | WingmanVoiceServiceTests.ReadyAudio_PersistsAndReloadsAcross..    |green| RED |green|green|
+///   | WingmanVoiceServiceTests.ReadyAudio_ReloadsLegacyWavCache..       |green| RED |green|green|
+///   | WingmanVoiceFallbackTests.ServedViaFallback_SurvivesAGateway..    |green| RED |green|green|
+///
+/// Every cell is OBSERVED. There is no EXCL cell (no red anywhere arrived as a crash) and no NOTRUN cell
+/// (every test produced an outcome line in every run, verified BY NAME rather than inferred from a total).
+///
+/// HOW TO READ IT. Every row has at least one RED, so no test here is decorative. Three rows have TWO -
+/// they straddle primitives, see the note below. B3 and B4 are perfectly isolated: two reds and one red
+/// respectively, touching nothing else in the assembly, which is what proves the archive and the job store
+/// are guarded SEPARATELY from the voice state rather than incidentally by it.
+///
+/// AND THE REASON THIS COULD NOT HAVE BEEN ARGUED INSTEAD OF RUN: VoiceTurnArchive and WingmanVoiceService
+/// BOTH expose a method called PartitionDirectoryFor. Under a combined mutation a red in either could be
+/// attributed to "the directory primitive" with a completely straight face - the names agree and the story
+/// is coherent - and it would be wrong half the time. Only separate runs distinguish them.
 ///
 /// PRE-REGISTERED PREDICTION, committed while the B1-only run was still executing and before any
 /// per-primitive result existed. Recorded in advance deliberately: a prediction written beforehand is
@@ -148,6 +196,17 @@ namespace CcDirector.Gateway.Tests;
 ///     direction, and for a worse reason: it generalised from a single run while the run that could
 ///     refute it had not yet been done. They are sensitive to BOTH. A claim of the form "X and not Y" is
 ///     not supported by an experiment that only varied X.
+///
+/// A NOTE ON PARSING, TRANSLATED RATHER THAN COPIED. A sibling pull request established the rule "assert
+/// the status and media type BEFORE parsing the body", after a revert made an endpoint serve HTML and the
+/// test died inside JsonDocument.Parse instead of failing an assertion. The literal rule does not apply
+/// here - these tests make no HTTP calls and parse no bodies - and applying it literally would have been
+/// box-ticking. What the rule is FOR does apply: an operation that THROWS on unexpected shape is making an
+/// unstated assertion, and when it throws you learn only that something upstream broke, never what was
+/// there instead. The filesystem costume of the same rule is used throughout this class: assert
+/// <c>File.Exists</c> on each clip BEFORE <c>ReadAllBytes</c>, and guard every dereference with an
+/// explicit null assertion. That is why a collapsed partition reports "expected not-equal, got equal"
+/// rather than an input/output error, and why every red in the runs below is an assertion.
 ///
 /// TWO RULES THIS PROOF PAID FOR. Both are general; both nearly produced a wrong published claim here.
 ///

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
@@ -1,0 +1,385 @@
+using System.Text;
+using CcDirector.AgentBrain;
+using CcDirector.Core;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Voice;
+using CcDirector.Gateway.Wingman;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// VOICE V1: the voice STATE is partitioned per tenant, so one account's narration - its spoken text, the
+/// reply it was made from, and the audio clip - is never reachable by another.
+///
+/// Every "cannot see it" assertion here is paired with a SAME-TENANT control on the same call, because an
+/// empty answer proves nothing on its own: a seed that silently failed also returns empty, and that reads as
+/// isolation. The control is what separates "isolated" from "nothing was ever stored".
+///
+/// REVERT-PROOF RECIPE - the four steps below were ACTUALLY RUN against this branch before it was
+/// committed, and the results recorded are the ones observed, not the ones expected. Re-run them whenever
+/// these guards are touched. Do NOT neutralise a guard with <c>if (false)</c>: unreachable code is a build
+/// error in this repository, the build then fails, and a test run after a failed build executes the STALE
+/// binary and reports a false pass. DELETE the guard, and CONFIRM the build line says succeeded / 0 errors
+/// before believing any result.
+///
+///  1. In <c>WingmanVoiceService.CanonicalTenantKey</c>, DELETE the <c>IsMintedAccountTenant</c> refusal so
+///     any tenant string is accepted as a partition name.
+///     OBSERVED: build succeeded; 3 RED, 16 green -
+///       Case_variant_of_a_minted_tenant_is_refused_rather_than_aliased_to_the_same_partition
+///       System_tenant_is_refused_a_voice_partition
+///       Traversal_tenant_is_refused_rather_than_resolved_to_the_parent_partition
+///     Turn_archive_refuses_a_traversal_tenant stayed GREEN, correctly: it exercises the archive's OWN
+///     copy of the guard, which this step did not touch. Every isolation test stayed GREEN too - they use a
+///     valid tenant, so the guard is not on their path. That is the control saying the three went red for
+///     the guard and not for the edit.
+///
+///  2. Restore step 1. In <c>VoiceTurnArchive.PartitionDirectoryFor</c>, DELETE its
+///     <c>IsMintedAccountTenant</c> refusal.
+///     OBSERVED: build succeeded; 1 RED, 18 green - Turn_archive_refuses_a_traversal_tenant. Exactly the
+///     mirror of step 1, which is what proves the two stores are guarded independently.
+///
+///  3. Restore step 2. In <c>WingmanVoiceService.MigrateLegacyUnpartitionedState</c>, DELETE the whole
+///     <c>if (GatewayHostedMode.IsHosted)</c> DELETE branch, so hosted falls through to the self-host move.
+///     OBSERVED: build succeeded; 1 RED, 18 green -
+///       Hosted_deletes_the_pre_partition_voice_state_rather_than_guessing_an_owner
+///     while Self_host_moves_the_pre_partition_voice_state_into_the_local_partition stayed GREEN.
+///
+///  4. Restore step 3, then DELETE the self-host MOVE block instead (the opposite direction).
+///     OBSERVED: build succeeded; 1 RED, 18 green -
+///       Self_host_moves_the_pre_partition_voice_state_into_the_local_partition
+///     while the hosted test stayed GREEN. Steps 3 and 4 together prove the pair really tests two opposite
+///     behaviours; a single shared path could not redden one test at a time in both directions.
+///
+///  5. Restore everything. Build succeeded; all 19 GREEN.
+/// </summary>
+public sealed class WingmanVoiceTenantPartitionTests
+{
+    private static readonly TenantId TenantA = new("aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa");
+    private static readonly TenantId TenantB = new("bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb");
+
+    private static byte[] Mp3(string marker) => Encoding.ASCII.GetBytes("ID3" + marker);
+
+    private static string NewBaseDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cc-voice-partition-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static WingmanVoiceService ServiceAt(string baseDir)
+    {
+        Func<Core.Configuration.WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
+            (_, _) => Task.FromResult<IAgentBrain>(null!);
+        var vault = new KeyVault(Path.Combine(baseDir, "vault.json"));
+        return new WingmanVoiceService(brain, vault, Path.Combine(baseDir, "voice-sessions.json"));
+    }
+
+    // ===== cross-tenant isolation, each with its same-tenant control =========================
+
+    [Fact]
+    public void Ready_audio_stored_for_one_tenant_is_invisible_to_another()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        svc.StoreReadyAudioForTest(TenantA, "s1", "spoken A", "reply A", Mp3("A"));
+
+        // CONTROL: the same call on the owning tenant DOES see it, so an empty answer below is isolation
+        // and not a failed seed.
+        Assert.True(svc.HasVoice(TenantA, "s1"));
+        Assert.Equal(Mp3("A"), svc.GetAudio(TenantA, "s1"));
+        Assert.Equal("spoken A", svc.Get(TenantA, "s1")!.Spoken);
+        Assert.Contains("s1", svc.ReadySessionIds(TenantA));
+
+        // The other tenant names the SAME session id and gets nothing.
+        Assert.False(svc.HasVoice(TenantB, "s1"));
+        Assert.Null(svc.GetAudio(TenantB, "s1"));
+        Assert.Null(svc.Get(TenantB, "s1"));
+        Assert.Empty(svc.ReadySessionIds(TenantB));
+    }
+
+    [Fact]
+    public void Voice_session_marking_is_per_tenant()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        svc.Mark(TenantA, "s1");
+
+        Assert.True(svc.IsVoiceSession(TenantA, "s1"));            // control
+        Assert.Contains("s1", svc.VoiceSessionIds(TenantA));       // control
+        Assert.False(svc.IsVoiceSession(TenantB, "s1"));
+        Assert.Empty(svc.VoiceSessionIds(TenantB));
+    }
+
+    [Fact]
+    public void Generating_unavailable_and_nothing_to_narrate_are_per_tenant()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        svc.BeginGenerating(TenantA, "s1");
+        svc.NoteRetrying(TenantA, "s1");
+        svc.SetNothingToNarrate(TenantA, "s1", true);
+
+        Assert.True(svc.IsGenerating(TenantA, "s1"));              // control
+        Assert.NotNull(svc.VoiceUnavailableFor(TenantA, "s1"));    // control
+        Assert.True(svc.NothingToNarrateFor(TenantA, "s1"));       // control
+
+        Assert.False(svc.IsGenerating(TenantB, "s1"));
+        Assert.Null(svc.VoiceUnavailableFor(TenantB, "s1"));
+        Assert.False(svc.NothingToNarrateFor(TenantB, "s1"));
+    }
+
+    [Fact]
+    public void Served_via_fallback_is_per_tenant()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        svc.StoreReadyAudioForTest(TenantA, "s1", "spoken", "reply", Mp3("A"), servedViaFallback: true);
+
+        Assert.True(svc.ServedViaFallbackFor(TenantA, "s1"));       // control
+        Assert.False(svc.ServedViaFallbackFor(TenantB, "s1"));
+    }
+
+    [Fact]
+    public void Clearing_one_tenants_session_leaves_the_other_tenants_identically_named_session_intact()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        svc.StoreReadyAudioForTest(TenantA, "s1", "spoken A", "reply A", Mp3("A"));
+        svc.StoreReadyAudioForTest(TenantB, "s1", "spoken B", "reply B", Mp3("B"));
+
+        svc.OnSessionWorking(TenantA, "s1");
+        Assert.False(svc.HasVoice(TenantA, "s1"));
+        Assert.True(svc.HasVoice(TenantB, "s1"));                   // control: untouched
+        Assert.Equal(Mp3("B"), svc.GetAudio(TenantB, "s1"));
+
+        svc.Mark(TenantA, "s1");
+        svc.Unmark(TenantA, "s1");
+        Assert.True(svc.HasVoice(TenantB, "s1"));                   // control: still untouched
+    }
+
+    [Fact]
+    public void Regeneration_decision_reads_only_the_asking_tenants_cached_reply()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        svc.StoreReadyAudioForTest(TenantA, "s1", "spoken A", "the same reply", Mp3("A"));
+
+        // CONTROL: the owning tenant sees its own cached reply and stays quiet.
+        Assert.False(svc.ShouldRegenerate(TenantA, "s1", "the same reply"));
+        // The other tenant has nothing cached for that id, so it must regenerate - it cannot read A's clip.
+        Assert.True(svc.ShouldRegenerate(TenantB, "s1", "the same reply"));
+    }
+
+    // ===== the partition is PHYSICAL and survives a restart =================================
+
+    [Fact]
+    public void Each_tenants_clips_live_in_its_own_directory_and_reload_into_its_own_partition()
+    {
+        var baseDir = NewBaseDir();
+        var svc = ServiceAt(baseDir);
+        svc.StoreReadyAudioForTest(TenantA, "s1", "spoken A", "reply A", Mp3("A"));
+        svc.StoreReadyAudioForTest(TenantB, "s1", "spoken B", "reply B", Mp3("B"));
+
+        var aDir = Path.Combine(baseDir, "tenants", TenantA.Value, "voice-audio");
+        var bDir = Path.Combine(baseDir, "tenants", TenantB.Value, "voice-audio");
+        Assert.True(File.Exists(Path.Combine(aDir, "s1.mp3")));
+        Assert.True(File.Exists(Path.Combine(bDir, "s1.mp3")));
+        // The tenant id is a PATH COMPONENT: the two identically-named sessions are different files.
+        Assert.NotEqual(aDir, bDir);
+
+        var reloaded = ServiceAt(baseDir);
+        Assert.Equal(Mp3("A"), reloaded.GetAudio(TenantA, "s1"));   // control
+        Assert.Equal(Mp3("B"), reloaded.GetAudio(TenantB, "s1"));   // control
+        Assert.Equal("spoken A", reloaded.Get(TenantA, "s1")!.Spoken);
+        Assert.Equal("spoken B", reloaded.Get(TenantB, "s1")!.Spoken);
+    }
+
+    [Fact]
+    public void Voice_session_set_reloads_into_the_tenant_that_owned_it()
+    {
+        var baseDir = NewBaseDir();
+        var svc = ServiceAt(baseDir);
+        svc.Mark(TenantA, "s1");
+
+        var reloaded = ServiceAt(baseDir);
+        Assert.True(reloaded.IsVoiceSession(TenantA, "s1"));        // control
+        Assert.False(reloaded.IsVoiceSession(TenantB, "s1"));
+    }
+
+    // ===== a non-minted tenant shape is REFUSED, never coerced ==============================
+
+    [Fact]
+    public void Traversal_tenant_is_refused_rather_than_resolved_to_the_parent_partition()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        Assert.Throws<ArgumentException>(() => svc.PartitionDirectoryFor(new TenantId("..")));
+        Assert.Throws<ArgumentException>(() => svc.HasVoice(new TenantId(".."), "s1"));
+        Assert.Throws<ArgumentException>(() => svc.PartitionDirectoryFor(new TenantId("../local")));
+    }
+
+    [Fact]
+    public void Case_variant_of_a_minted_tenant_is_refused_rather_than_aliased_to_the_same_partition()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        var upper = new TenantId(TenantA.Value.ToUpperInvariant());
+        Assert.Throws<ArgumentException>(() => svc.PartitionDirectoryFor(upper));
+        Assert.Throws<ArgumentException>(() => svc.HasVoice(upper, "s1"));
+    }
+
+    [Fact]
+    public void System_tenant_is_refused_a_voice_partition()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        Assert.Throws<ArgumentException>(() => svc.PartitionDirectoryFor(TenantId.System));
+        Assert.Throws<ArgumentException>(() => svc.Mark(TenantId.System, "s1"));
+    }
+
+    [Fact]
+    public void An_unresolved_tenant_is_denied_never_defaulted()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        Assert.Throws<ArgumentException>(() => svc.HasVoice(default, "s1"));
+    }
+
+    // ===== the legacy migration, proved in BOTH deployment modes ============================
+
+    private static void SeedLegacyState(string baseDir)
+    {
+        File.WriteAllText(Path.Combine(baseDir, "voice-sessions.json"), "[\"s1\"]");
+        var audioDir = Path.Combine(baseDir, "voice-audio");
+        Directory.CreateDirectory(audioDir);
+        File.WriteAllBytes(Path.Combine(audioDir, "s1.mp3"), Mp3("legacy"));
+        File.WriteAllText(Path.Combine(audioDir, "s1.json"),
+            "{\"Spoken\":\"legacy spoken\",\"Reply\":\"legacy reply\",\"AtUtc\":\"2026-01-01T00:00:00Z\"}");
+    }
+
+    [Fact]
+    public void Hosted_deletes_the_pre_partition_voice_state_rather_than_guessing_an_owner()
+    {
+        var baseDir = NewBaseDir();
+        SeedLegacyState(baseDir);
+
+        var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        try
+        {
+            var svc = ServiceAt(baseDir);
+            // The clip is GONE from disk - not merely unreachable, actually deleted.
+            Assert.False(File.Exists(Path.Combine(baseDir, "voice-sessions.json")));
+            Assert.False(Directory.Exists(Path.Combine(baseDir, "voice-audio")));
+            // And it was not quietly re-homed into some tenant on the way out.
+            Assert.False(svc.HasVoice(TenantId.Local, "s1"));
+            Assert.False(svc.IsVoiceSession(TenantId.Local, "s1"));
+            Assert.False(svc.HasVoice(TenantA, "s1"));
+        }
+        finally { Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior); }
+    }
+
+    [Fact]
+    public void Self_host_moves_the_pre_partition_voice_state_into_the_local_partition()
+    {
+        var baseDir = NewBaseDir();
+        SeedLegacyState(baseDir);
+
+        var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+        try
+        {
+            var svc = ServiceAt(baseDir);
+            // Moved: gone from the shared location, present in the local partition, and STILL READABLE.
+            Assert.False(File.Exists(Path.Combine(baseDir, "voice-sessions.json")));
+            Assert.False(Directory.Exists(Path.Combine(baseDir, "voice-audio")));
+            Assert.True(File.Exists(Path.Combine(baseDir, "tenants", "local", "voice-audio", "s1.mp3")));
+            Assert.True(svc.IsVoiceSession(TenantId.Local, "s1"));
+            Assert.True(svc.HasVoice(TenantId.Local, "s1"));
+            Assert.Equal(Mp3("legacy"), svc.GetAudio(TenantId.Local, "s1"));
+            // It landed in LOCAL only - it was not fanned out to an account tenant.
+            Assert.False(svc.HasVoice(TenantA, "s1"));
+        }
+        finally { Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior); }
+    }
+
+    // ===== the voice-turn stores in the same state layer ====================================
+
+    [Fact]
+    public void Turn_archive_is_partitioned_and_a_turn_id_alone_does_not_read_it()
+    {
+        var root = NewBaseDir();
+        var archive = new VoiceTurnArchive(root);
+        var turnId = Guid.NewGuid().ToString();
+        archive.Save(TenantA, new VoiceTurnArchiveRecord
+        {
+            TurnId = turnId, SessionId = "s1", UploadId = "u1",
+            Transcript = "transcript A", Summary = "summary A", HasAudio = true, CreatedAtUtc = DateTime.UtcNow,
+        }, Mp3("A"));
+
+        // CONTROL: the owning tenant reads it on every path.
+        Assert.Equal("summary A", archive.Get(TenantA, turnId)!.Summary);
+        Assert.Equal(Mp3("A"), archive.GetAudio(TenantA, turnId));
+        Assert.Single(archive.ListForSession(TenantA, "s1"));
+        Assert.NotNull(archive.FindByUpload(TenantA, "u1"));
+
+        // The other tenant holds the exact turn id and still gets nothing.
+        Assert.Null(archive.Get(TenantB, turnId));
+        Assert.Null(archive.GetAudio(TenantB, turnId));
+        Assert.Empty(archive.ListForSession(TenantB, "s1"));
+        Assert.Null(archive.FindByUpload(TenantB, "u1"));
+    }
+
+    [Fact]
+    public void Turn_archive_refuses_a_traversal_tenant()
+    {
+        var archive = new VoiceTurnArchive(NewBaseDir());
+        Assert.Throws<ArgumentException>(() => archive.PartitionDirectoryFor(new TenantId("..")));
+        Assert.Throws<ArgumentException>(() => archive.Get(new TenantId(".."), Guid.NewGuid().ToString()));
+        Assert.Throws<ArgumentException>(() => archive.PartitionDirectoryFor(new TenantId(TenantA.Value.ToUpperInvariant())));
+    }
+
+    [Fact]
+    public void Turn_job_store_is_partitioned_and_a_turn_id_alone_does_not_read_it()
+    {
+        var store = new GatewayTurnJobStore();
+        var job = store.Create(TenantA, "s1", "u1");
+
+        Assert.NotNull(store.Get(TenantA, job.TurnId));                 // control
+        Assert.NotNull(store.FindTurnByUpload(TenantA, "u1"));          // control
+
+        Assert.Null(store.Get(TenantB, job.TurnId));
+        Assert.Null(store.FindTurnByUpload(TenantB, "u1"));
+    }
+
+    [Fact]
+    public void Hosted_deletes_pre_partition_archived_turns()
+    {
+        var root = NewBaseDir();
+        var legacyTurn = Path.Combine(root, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(legacyTurn);
+        File.WriteAllText(Path.Combine(legacyTurn, "meta.json"), "{}");
+
+        var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        try
+        {
+            _ = new VoiceTurnArchive(root);
+            Assert.False(Directory.Exists(legacyTurn));
+        }
+        finally { Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior); }
+    }
+
+    [Fact]
+    public void Self_host_moves_pre_partition_archived_turns_into_the_local_partition()
+    {
+        var root = NewBaseDir();
+        var turnId = Guid.NewGuid();
+        var legacyTurn = Path.Combine(root, turnId.ToString("N"));
+        Directory.CreateDirectory(legacyTurn);
+        File.WriteAllText(Path.Combine(legacyTurn, "meta.json"),
+            "{\"TurnId\":\"" + turnId + "\",\"SessionId\":\"s1\",\"UploadId\":\"u1\",\"Summary\":\"legacy summary\"}");
+
+        var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+        try
+        {
+            var archive = new VoiceTurnArchive(root);
+            Assert.False(Directory.Exists(legacyTurn));
+            Assert.Equal("legacy summary", archive.Get(TenantId.Local, turnId.ToString())!.Summary);
+            Assert.Null(archive.Get(TenantA, turnId.ToString()));
+        }
+        finally { Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
@@ -76,7 +76,44 @@ namespace CcDirector.Gateway.Tests;
 /// on one shared assertion. If a future edit makes those two fail for the same reason, the pair has stopped
 /// being a two-direction proof - split the run rather than accept it.
 ///
-/// RESULTS: recorded when the lane is granted. Nothing is recorded here from a filtered run.
+/// RESULTS - full Gateway assembly at head 103220b0, rebased onto lock-bearing main (e1b8825c), run under
+/// the automatic suite lock. Group one, all four boundary mutations applied together: build succeeded,
+/// 2979 tests, 2953 passed, 16 FAILED, 10 skipped. Restored to that exact head: green.
+///
+/// EVERY ONE OF THE 16 ARRIVED AS AN ASSERTION FAILURE. Not one NullReferenceException, not one
+/// input/output error. That is the result this recipe exists to produce: it converts the claim "these
+/// tests detect a collapsed partition" from hand-tracing into evidence, because a crash would have proved
+/// only that the harness fell over on the way to the question.
+///
+///   B1 <c>WingmanVoiceService.StateFor</c> - 6 reds, all in-memory isolation:
+///     Ready_audio_stored_for_one_tenant_is_invisible_to_another            Assert.False (B saw A's clip)
+///     Voice_session_marking_is_per_tenant                                  Assert.False
+///     Generating_unavailable_and_nothing_to_narrate_are_per_tenant         Assert.False
+///     Served_via_fallback_is_per_tenant                                    Assert.False
+///     Clearing_one_tenants_session_leaves_..._intact                       Assert.True (B's clip died with A's)
+///     Regeneration_decision_reads_only_the_asking_tenants_cached_reply     Assert.True
+///   B2 <c>WingmanVoiceService.PartitionDirectoryFor</c> - 3 reds of mine plus 3 pre-existing (below):
+///     Each_tenants_clips_live_in_its_own_directory                         Assert.NotEqual (paths equal)
+///     Voice_session_set_reloads_into_the_tenant_that_owned_it              Assert.True
+///     Self_host_moves_the_pre_partition_voice_state_into_the_local_partition  Assert.True
+///     Clips_reload_into_the_tenant_that_owned_them                         Assert.Equal (bytes vs null; B1+B2)
+///   B3 <c>VoiceTurnArchive.PartitionDirectoryFor</c> - 2 reds:
+///     Turn_archive_is_partitioned_and_a_turn_id_alone_does_not_read_it     Assert.Null (B read A's record)
+///     Self_host_moves_pre_partition_archived_turns_into_the_local_partition  Assert.Null
+///   B4 <c>GatewayTurnJobStore.StateFor</c> - 1 red:
+///     Turn_job_store_is_partitioned_and_a_turn_id_alone_does_not_read_it   Assert.Null (B read A's job)
+///
+/// THREE TESTS THAT ARE NOT MINE ALSO WENT RED, all on B2, all as assertions:
+///   WingmanVoiceServiceTests.ReadyAudio_PersistsAndReloadsAcrossRestart
+///   WingmanVoiceServiceTests.ReadyAudio_ReloadsLegacyWavCacheWithDetectedContentType
+///   WingmanVoiceFallbackTests.ServedViaFallback_SurvivesAGatewayRestart
+/// This is the answer to a question a filtered run cannot ask: the durable restart path was ALREADY
+/// covered, and that coverage is sensitive to the directory partition. Worth keeping in mind when
+/// changing the on-disk layout - three tests outside this class will notice.
+///
+/// The Assert.NotEqual red on Each_tenants_clips_live_in_its_own_directory is the one to look at hardest,
+/// because that assertion previously compared two paths the TEST had built and could not fail. Rewritten
+/// to read both paths back from the production method, it fired on the first mutation that collapsed them.
 /// </summary>
 public sealed class WingmanVoiceTenantPartitionTests
 {

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
@@ -76,32 +76,30 @@ namespace CcDirector.Gateway.Tests;
 /// on one shared assertion. If a future edit makes those two fail for the same reason, the pair has stopped
 /// being a two-direction proof - split the run rather than accept it.
 ///
-/// RESULTS - full Gateway assembly at head 103220b0, rebased onto lock-bearing main (e1b8825c), run under
-/// the automatic suite lock. Group one, all four boundary mutations applied together: build succeeded,
-/// 2979 tests, 2953 passed, 16 FAILED, 10 skipped. Restored to that exact head: green.
+/// WHY THE RESULTS BELOW ARE PER-PRIMITIVE AND NOT ONE COMBINED RUN. The first attempt mutated all four
+/// boundaries in a SINGLE run and produced a tidy-looking table attributing each red to a primitive. That
+/// table was not sound, and one row proved it: Clips_reload_into_the_tenant_that_owned_them had to be
+/// listed as "B1+B2", because a run with everything mutated cannot say which mutation caused any given
+/// red. Once one red is unassignable the whole set is inference rather than observation - for every other
+/// row, "B1 caused this" was me reasoning from which test it was, not from anything the run showed.
 ///
-/// EVERY ONE OF THE 16 ARRIVED AS AN ASSERTION FAILURE. Not one NullReferenceException, not one
-/// input/output error. That is the result this recipe exists to produce: it converts the claim "these
-/// tests detect a collapsed partition" from hand-tracing into evidence, because a crash would have proved
-/// only that the harness fell over on the way to the question.
+/// So each primitive is now mutated ALONE, in its own full-assembly run, and the run below tells you which
+/// primitive each test actually detects. That single-primitive discipline immediately corrected three
+/// attributions the combined run had wrong (see the SENSITIVITY MATRIX and the correction note under it).
 ///
-///   B1 <c>WingmanVoiceService.StateFor</c> - 6 reds, all in-memory isolation:
-///     Ready_audio_stored_for_one_tenant_is_invisible_to_another            Assert.False (B saw A's clip)
-///     Voice_session_marking_is_per_tenant                                  Assert.False
-///     Generating_unavailable_and_nothing_to_narrate_are_per_tenant         Assert.False
-///     Served_via_fallback_is_per_tenant                                    Assert.False
-///     Clearing_one_tenants_session_leaves_..._intact                       Assert.True (B's clip died with A's)
-///     Regeneration_decision_reads_only_the_asking_tenants_cached_reply     Assert.True
-///   B2 <c>WingmanVoiceService.PartitionDirectoryFor</c> - 3 reds of mine plus 3 pre-existing (below):
-///     Each_tenants_clips_live_in_its_own_directory                         Assert.NotEqual (paths equal)
-///     Voice_session_set_reloads_into_the_tenant_that_owned_it              Assert.True
-///     Self_host_moves_the_pre_partition_voice_state_into_the_local_partition  Assert.True
-///     Clips_reload_into_the_tenant_that_owned_them                         Assert.Equal (bytes vs null; B1+B2)
-///   B3 <c>VoiceTurnArchive.PartitionDirectoryFor</c> - 2 reds:
-///     Turn_archive_is_partitioned_and_a_turn_id_alone_does_not_read_it     Assert.Null (B read A's record)
-///     Self_host_moves_pre_partition_archived_turns_into_the_local_partition  Assert.Null
-///   B4 <c>GatewayTurnJobStore.StateFor</c> - 1 red:
-///     Turn_job_store_is_partitioned_and_a_turn_id_alone_does_not_read_it   Assert.Null (B read A's job)
+/// SENSITIVITY MATRIX - the durable artifact, and the reason it lives HERE rather than only in a pull
+/// request. If you are changing how voice state is partitioned, in memory or on disk, this table tells you
+/// which tests will go red and what each one is actually asserting. A pull request is read once by people
+/// who already have the context; this comment is read by whoever is standing here next, who has none.
+///
+/// Every cell is an OBSERVATION with one meaning, never a blank that could mean three things:
+///   RED    - observed reddening as an ASSERTION failure. Proof that this test detects this primitive.
+///   EXCL   - observed reddening as a CRASH. EXCLUDED and never counted as proof: a crash shows the
+///            harness fell over on the way to the question, which is not the boundary being guarded.
+///   green  - observed passing. The test ran to completion and passed.
+///   NOTRUN - no outcome line for that test in that run. Evidence of nothing at all.
+///
+/// MATRIX_PLACEHOLDER
 ///
 /// PRE-REGISTERED PREDICTION, committed while the B1-only run was still executing and before any
 /// per-primitive result existed. Recorded in advance deliberately: a prediction written beforehand is
@@ -120,17 +118,28 @@ namespace CcDirector.Gateway.Tests;
 ///
 /// OUTCOME: see the per-primitive results recorded above; the prediction is scored there explicitly.
 ///
-/// THREE TESTS THAT ARE NOT MINE ALSO WENT RED, all on B2, all as assertions:
+/// THREE TESTS OUTSIDE THIS CLASS ALSO DETECT THIS PARTITION - which primitive, see the matrix:
 ///   WingmanVoiceServiceTests.ReadyAudio_PersistsAndReloadsAcrossRestart
 ///   WingmanVoiceServiceTests.ReadyAudio_ReloadsLegacyWavCacheWithDetectedContentType
 ///   WingmanVoiceFallbackTests.ServedViaFallback_SurvivesAGatewayRestart
 /// This is the answer to a question a filtered run cannot ask: the durable restart path was ALREADY
-/// covered, and that coverage is sensitive to the directory partition. Worth keeping in mind when
-/// changing the on-disk layout - three tests outside this class will notice.
+/// covered before this change. If you move the on-disk layout, three tests in two other classes go red
+/// and their names will not mention tenancy - the matrix is how you find out why.
+///
+/// A WRONG EXPECTATION, RECORDED ON PURPOSE. Before the single-primitive runs, the author expected
+/// Voice_session_set_reloads_into_the_tenant_that_owned_it and
+/// Self_host_moves_the_pre_partition_voice_state_into_the_local_partition to be sensitive to the on-disk
+/// DIRECTORY. They are not: the in-memory BUCKET alone reddens both, and the failure kind is what gives
+/// the reason away - both fail on their cross-tenant <c>Assert.False</c>, not on their reload assertion.
+/// These tests are split across two primitives: the RELOAD half rides on the directory, the ISOLATION
+/// half rides on the bucket. That is a real structural fact about this code, it contradicted the author's
+/// model, and no combined run could ever have surfaced it - a combined run would have shown both
+/// primitives mutated and both tests red, which is consistent with any explanation at all.
+/// Distrust the intuition that "restart test" implies "on-disk sensitivity". Read the matrix instead.
 ///
 /// The Assert.NotEqual red on Each_tenants_clips_live_in_its_own_directory is the one to look at hardest,
 /// because that assertion previously compared two paths the TEST had built and could not fail. Rewritten
-/// to read both paths back from the production method, it fired on the first mutation that collapsed them.
+/// to read both paths back from the production method, it fired on the mutation that collapsed them.
 /// </summary>
 public sealed class WingmanVoiceTenantPartitionTests
 {

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -154,12 +154,12 @@ internal static class GatewayWingmanVoiceEndpoint
 
         // Which voice sessions have a ready, playable spoken summary right now (the phone's list
         // shows a play button on these and can play without entering).
-        app.MapGet("/wingman/voice/ready", () => Results.Json(new { sids = voice.ReadySessionIds() }));
+        app.MapGet("/wingman/voice/ready", () => Results.Json(new { sids = voice.ReadySessionIds(TenantId.Local) }));
 
         // The precomputed spoken summary for a session (instant on entry - no re-read needed).
         app.MapGet("/sessions/{sid}/wingman/voice", (string sid) =>
         {
-            var v = voice.Get(sid);
+            var v = voice.Get(TenantId.Local, sid);
             return v is null
                 ? Results.Json(new { ready = false })
                 : Results.Json(new { ready = true, spoken = v.Spoken, reply = v.Reply, generatedAt = v.AtUtc });
@@ -168,9 +168,9 @@ internal static class GatewayWingmanVoiceEndpoint
         // The precomputed audio for a session - streamed so the list can play it with one tap.
         app.MapGet("/sessions/{sid}/wingman/voice/audio", (string sid) =>
         {
-            var audio = voice.GetAudio(sid);
+            var audio = voice.GetAudio(TenantId.Local, sid);
             return audio is { Length: > 0 }
-                ? Results.Bytes(audio, voice.GetAudioContentType(sid) ?? "audio/mpeg", enableRangeProcessing: true)
+                ? Results.Bytes(audio, voice.GetAudioContentType(TenantId.Local, sid) ?? "audio/mpeg", enableRangeProcessing: true)
                 : Results.Json(new { error = "no voice ready for this session" }, statusCode: StatusCodes.Status404NotFound);
         });
 
@@ -185,7 +185,7 @@ internal static class GatewayWingmanVoiceEndpoint
             FileLog.Write($"[GatewayWingmanVoice] voice/stop sid={sid}");
             if (!Guid.TryParse(sid, out _))
                 return Results.Json(new { error = "invalid session id format" }, statusCode: StatusCodes.Status400BadRequest);
-            voice.Unmark(sid);
+            voice.Unmark(TenantId.Local, sid);
             return Results.Json(new { stopped = true });
         });
 
@@ -246,7 +246,7 @@ internal static class GatewayWingmanVoiceEndpoint
                 var ok = result is { Ok: true };
                 if (ok)
                 {
-                    if (enabled) voice.Mark(t.Sid); else voice.Unmark(t.Sid);
+                    if (enabled) voice.Mark(TenantId.Local, t.Sid); else voice.Unmark(TenantId.Local, t.Sid);
                     changed++;
                 }
                 var reason = ok
@@ -541,7 +541,7 @@ internal static class GatewayWingmanVoiceEndpoint
             // Clear them DETERMINISTICALLY here (do not rely on observing the Working state, which is
             // racy for fast turns) - the list stops showing it ready and nothing stale plays. The
             // fresh summary is stored below once the agent replies.
-            voice.OnSessionWorking(sid);
+            voice.OnSessionWorking(TenantId.Local, sid);
 
             // Snapshot the widget list BEFORE sending: gives both (a) the count for the issue #366
             // guard (only read widgets that are new after the send) and (b) the prior conversation
@@ -564,7 +564,7 @@ internal static class GatewayWingmanVoiceEndpoint
             // The agent replied; now the wingman translates it. This is gateway-owned work
             // (CancellationToken.None) so navigating away does not lose the summary, and the
             // session shows YELLOW while the wingman runs, then back to red (issue #531 voice mode).
-            voice.BeginGenerating(sid);
+            voice.BeginGenerating(TenantId.Local, sid);
             try
             {
                 // Full context: prior exchanges from the pre-send snapshot + the current question,
@@ -573,7 +573,7 @@ internal static class GatewayWingmanVoiceEndpoint
                     ? "You: " + req.Text.Trim()
                     : priorContext + "\n\nYou: " + req.Text.Trim();
                 var t = await translator.TranslateAsync(recentContext, reply, SessionTitle(sid), CancellationToken.None);
-                await voice.StoreSpokenAsync(sid, t.Spoken, reply, CancellationToken.None);   // make it a voice session + cache audio
+                await voice.StoreSpokenAsync(TenantId.Local, sid, t.Spoken, reply, CancellationToken.None);   // make it a voice session + cache audio
                 FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: replyLen={reply.Length}, spokenLen={t.Spoken.Length}");
                 // Training capture (no-op unless the setting is on); fire-and-forget so it adds no latency.
                 _ = voice.CaptureTrainingAsync(route, sid, "voice-turn", reply, recentContext, t.Spoken, t.ReplySeconds, CancellationToken.None);
@@ -585,7 +585,7 @@ internal static class GatewayWingmanVoiceEndpoint
                 return Results.Json(new { error = "wingman translation failed: " + ex.Message },
                     statusCode: StatusCodes.Status502BadGateway);
             }
-            finally { voice.EndGenerating(sid); }
+            finally { voice.EndGenerating(TenantId.Local, sid); }
         });
 
         // Transcription (issue #531 follow-up): the phone records audio locally (survives a bad
@@ -661,13 +661,13 @@ internal static class GatewayWingmanVoiceEndpoint
             // Recent conversation so the wingman can give context to a short/terse reply.
             var recentContext = WingmanTranslator.BuildRecentContext(widgets);
 
-            voice.Mark(sid);   // opening voice on a session makes it a voice session (kept fresh on turn-end)
+            voice.Mark(TenantId.Local, sid);   // opening voice on a session makes it a voice session (kept fresh on turn-end)
             if (string.IsNullOrWhiteSpace(lastReply))
             {
                 // No text reply to read aloud (waiting on a prompt / menu). Record the honest "nothing to
                 // narrate" fact so the Voice screen shows it via VoiceDisplayFold instead of a dead-end
                 // Generate button, then return the truthful canned line - no brain call.
-                voice.SetNothingToNarrate(sid, true);
+                voice.SetNothingToNarrate(TenantId.Local, sid, true);
                 return Results.Json(new
                 {
                     reply = "",
@@ -682,12 +682,12 @@ internal static class GatewayWingmanVoiceEndpoint
             // navigates away or the request is abandoned mid-read - returning to the session then
             // loads the finished summary from cache instead of losing it. Mark the session generating
             // so it shows YELLOW ("not ready yet") for the duration, then back to red.
-            voice.SetNothingToNarrate(sid, false);   // there IS a text reply - clear any stale "nothing to narrate"
-            voice.BeginGenerating(sid);
+            voice.SetNothingToNarrate(TenantId.Local, sid, false);   // there IS a text reply - clear any stale "nothing to narrate"
+            voice.BeginGenerating(TenantId.Local, sid);
             try
             {
                 var t = await translator.TranslateAsync(recentContext, lastReply, SessionTitle(sid), CancellationToken.None);
-                await voice.StoreSpokenAsync(sid, t.Spoken, lastReply, CancellationToken.None);   // cache spoken + audio, ready to play
+                await voice.StoreSpokenAsync(TenantId.Local, sid, t.Spoken, lastReply, CancellationToken.None);   // cache spoken + audio, ready to play
                 FileLog.Write($"[GatewayWingmanVoice] explain sid={sid}: replyLen={lastReply.Length}, spokenLen={t.Spoken.Length}");
                 // Training capture (no-op unless the setting is on); fire-and-forget so it adds no latency.
                 _ = voice.CaptureTrainingAsync(route, sid, "explain", lastReply, recentContext, t.Spoken, t.ReplySeconds, CancellationToken.None);
@@ -701,7 +701,7 @@ internal static class GatewayWingmanVoiceEndpoint
                 // return a benign 200, NOT the 502 the phone used to mislabel "this session's computer looks
                 // offline". Before this, a stalled model hung the request the full 180s and then 502'd, which
                 // is exactly the "I hit generate and nothing happens" the owner reported.
-                voice.NoteRetrying(sid);
+                voice.NoteRetrying(TenantId.Local, sid);
                 FileLog.Write($"[GatewayWingmanVoice] explain sid={sid} model did not answer: {ex.Message} - Retrying (audio on its way)");
                 return Results.Json(new
                 {
@@ -717,7 +717,7 @@ internal static class GatewayWingmanVoiceEndpoint
                 return Results.Json(new { error = "wingman could not summarize: " + ex.Message },
                     statusCode: StatusCodes.Status502BadGateway);
             }
-            finally { voice.EndGenerating(sid); }
+            finally { voice.EndGenerating(TenantId.Local, sid); }
         });
 
         app.MapPost("/wingman/ask-direct", async (WingmanVoiceTurnRequest? req, CancellationToken ct) =>

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -786,8 +786,8 @@ public sealed class GatewayHost : IAsyncDisposable
             () => PushedSessions.SnapshotFresh(TenantId.Local, AutoDismissStaleAfter),
             sessions => EnrichVoiceThenFoldForPush(
                 sessions,
-                voiceGeneratingFor: sid => _voiceService?.IsGenerating(sid) == true,
-                voiceAudioReadyFor: sid => _voiceService?.HasVoice(sid) == true,
+                voiceGeneratingFor: sid => _voiceService?.IsGenerating(TenantId.Local, sid) == true,
+                voiceAudioReadyFor: sid => _voiceService?.HasVoice(TenantId.Local, sid) == true,
                 needsYouStampFor: (sid, isRed) => _needsYouClock.Stamp(sid, isRed),
                 snoozeRegistry: _snoozeRegistry),
             SendCommandAsync);
@@ -1182,18 +1182,19 @@ public sealed class GatewayHost : IAsyncDisposable
             var stale = TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
             Api.DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = SendCommandAsync;
             var generated = 0;
-            foreach (var sid in vs.VoiceSessionIds())
+            foreach (var sid in vs.VoiceSessionIds(TenantId.Local))
             {
                 if (generated >= 3) break;          // gentle on the serialized brain
-                if (vs.HasVoice(sid)) continue;     // already cached, nothing to do
+                if (vs.HasVoice(TenantId.Local, sid)) continue;     // already cached, nothing to do
                 // Hosted Multi-Tenancy (session-serving): the voice sweep is NOT yet per-tenant.
-                // BLOCKED ON: partitioning the WingmanVoiceService caches by tenant (its markers, generated
-                // text and audio are all keyed by session id alone) AND tenant-checking /wingman/voice/ready,
-                // which today lists EVERY ready session id. Converting this loop first would ARM a leak rather
-                // than close one: per-tenant generation would fill a process-global cache that the voice read
-                // path serves to any tenant that names an id - and /wingman/voice/ready hands out the ids. A
-                // hosted no-op is strictly safer than a live cross-tenant audio path. Until then it serves
-                // Local: correct on self-host, and on hosted a Local read is empty (never a wrong-tenant read).
+                // The state it fills IS now partitioned (VOICE V1 - WingmanVoiceService holds a separate
+                // bucket and a separate directory per tenant, and every read and mutate takes the tenant),
+                // so the old blocker is gone. What remains is this loop and the /wingman/voice* routes: the
+                // routes still resolve no tenant and pass Local, and /wingman/voice/ready still lists the
+                // Local partition's ready ids. Converting THIS loop before those routes would generate into
+                // per-tenant buckets that no route can read, so it stays on Local until the route work lands:
+                // correct on self-host, and on hosted a Local read is empty (never a wrong-tenant read).
+                // The per-tenant form is a loop over WingmanVoiceService.PartitionedTenants().
                 var (director, session) = await Api.GatewayEndpoints.LocateSessionAsync(
                     Registry, sid, PushedSessions, stale, TenantId.Local, SessionOwners);
                 if (director is null || session is null) continue;   // not owned by any known Director
@@ -1204,7 +1205,7 @@ public sealed class GatewayHost : IAsyncDisposable
                     // A pre-build is not a new turn - generate quietly so an idle session a client
                     // may be listening to is never flipped yellow mid-play (issue #1322).
                     var route = new Api.SessionVerbClient(director, sendCommand);
-                    await vs.GenerateAsync(sid, route, CancellationToken.None, showReadingWindow: false);
+                    await vs.GenerateAsync(TenantId.Local, sid, route, CancellationToken.None, showReadingWindow: false);
                     generated++;
                 }
             }
@@ -1324,7 +1325,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 // Voice sessions (issue #531): the turn just finished on its own, so re-make the
                 // spoken summary + audio in the background. It is then "voice ready" in the session
                 // list with no wait. Non-voice sessions do nothing here - the watcher is voice-only.
-                if (_voiceService is { } vs && vs.IsVoiceSession(signal.SessionId))
+                if (_voiceService is { } vs && vs.IsVoiceSession(TenantId.Local, signal.SessionId))
                 {
                     // Gateway Cleanup mission, Phase 2: reach the owning Director (carried on the signal as
                     // its DirectorId) through the tunnel-first SessionVerbClient - no HTTP dial. The Director
@@ -1337,7 +1338,7 @@ public sealed class GatewayHost : IAsyncDisposable
                     // Show the yellow "wingman reading" hold only for a genuinely new turn; a startup
                     // catch-up of an earlier turn refreshes quietly so a listening client is not
                     // dropped out of the speaking screen (issue #1322).
-                    _ = vs.GenerateAsync(signal.SessionId, route, CancellationToken.None, showReadingWindow: signal.IsNewTurn);
+                    _ = vs.GenerateAsync(TenantId.Local, signal.SessionId, route, CancellationToken.None, showReadingWindow: signal.IsNewTurn);
                 }
             },
             onSessionWorking: sid =>
@@ -1345,7 +1346,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 // Working again: the cached voice/text summary is now stale - clear it so the list
                 // stops showing it ready and nothing stale plays (issue #531). It regenerates on the
                 // next turn-end.
-                _voiceService?.OnSessionWorking(sid);
+                _voiceService?.OnSessionWorking(TenantId.Local, sid);
             },
             // Gateway Cleanup mission, Phase 2: under stream mode the catch-up / reconcile reads the push
             // store instead of HTTP-pulling each Director's session list (no dial).
@@ -1586,7 +1587,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 // summary is stale - clear it (broad net for turns started outside the voice app, e.g.
                 // the desktop cockpit). The voice-turn endpoint also clears deterministically on send.
                 if (string.Equals(newState, "Working", StringComparison.OrdinalIgnoreCase))
-                    _voiceService?.OnSessionWorking(sessionId);
+                    _voiceService?.OnSessionWorking(TenantId.Local, sessionId);
                 if (_turnEndWatcher is null) return;
                 // Gateway Cleanup mission, Phase 2: the doorbell/heartbeat already carries the owning
                 // directorId, so feed THAT to the watcher (the voice-refresh path reaches the Director
@@ -1612,23 +1613,23 @@ public sealed class GatewayHost : IAsyncDisposable
             // Voice mode (issue #531): while the gateway's wingman is producing a session's spoken
             // summary, paint it yellow ("not ready yet") and back to red. Independent of any brief
             // agent and never via the Director's --print explain.
-            voiceGeneratingFor: sid => _voiceService?.IsGenerating(sid) == true,
+            voiceGeneratingFor: sid => _voiceService?.IsGenerating(TenantId.Local, sid) == true,
             // Issue #553: whether the gateway has fetchable, playable cached audio for this session -
             // the single truthful "voice you can play right now" signal. Holds a voice-mode waiting
             // session yellow until this is true, then lets it go red (SessionOrdering.IsVoicePreparing).
-            voiceAudioReadyFor: sid => _voiceService?.HasVoice(sid) == true,
+            voiceAudioReadyFor: sid => _voiceService?.HasVoice(TenantId.Local, sid) == true,
             // Issue #939: when turn-end voice could not be kept because hosted AI is unavailable (out
             // of credits / cap / no key), stamp the shared unavailable state onto the session so the UI
             // shows the consistent add-credit / add-key message instead of a silently missing triangle.
-            voiceUnavailableFor: sid => _voiceService?.VoiceUnavailableFor(sid),
+            voiceUnavailableFor: sid => _voiceService?.VoiceUnavailableFor(TenantId.Local, sid),
             // The last turn has no text reply to read aloud (waiting on a prompt / menu). Feeds the folded
             // VoiceDisplay so the screen shows an honest "nothing to read aloud" instead of a Generate
             // button that cannot work - the client no longer rules on this.
-            nothingToNarrateFor: sid => _voiceService?.NothingToNarrateFor(sid) == true,
+            nothingToNarrateFor: sid => _voiceService?.NothingToNarrateFor(TenantId.Local, sid) == true,
             // TTS fallback: this session's ready clip was made by the backup voice provider (the primary
             // was overloaded and the cloud proxy failed over). Feeds the folded VoiceDisplay so the screen
             // shows the generic backup-voice notice. A success-with-a-note, never an outage state.
-            servedViaFallbackFor: sid => _voiceService?.ServedViaFallbackFor(sid) == true,
+            servedViaFallbackFor: sid => _voiceService?.ServedViaFallbackFor(TenantId.Local, sid) == true,
             // Issue #218: stamp the Gateway-owned NeedsYouSince entry clock onto each session.
             needsYouStampFor: (sid, isRed) => _needsYouClock.Stamp(sid, isRed),
             // Stamp the orange "Transcribing..." flag while a dictated utterance is being uploaded

--- a/src/CcDirector.Gateway/Voice/GatewayTurnJobStore.cs
+++ b/src/CcDirector.Gateway/Voice/GatewayTurnJobStore.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Gateway.Voice;
@@ -174,71 +175,114 @@ public readonly record struct TurnJobSnapshot(
 /// expiry is checked lazily on every read and swept opportunistically on create, so no timer
 /// thread is needed. In-memory by design - a Gateway restart drops in-flight turns, and the
 /// phone simply re-submits (the same contract as the rest of the Gateway's in-memory state).
+///
+/// PARTITIONED BY TENANT (Hosted Multi-Tenancy, VOICE V1). A job carries the turn's transcript, its
+/// summary and its reply audio - all customer content - so each tenant gets its OWN pair of dictionaries
+/// and every read and mutate takes the tenant as a REQUIRED parameter. An unguessable turn id is not an
+/// authorization: proving you know an id is not proving you own the turn, so the id is never sufficient
+/// on its own. The tenant is canonicalized the same way the on-disk partitions are, and a shape this
+/// system does not mint is refused rather than coerced.
 /// </summary>
 public sealed class GatewayTurnJobStore
 {
     /// <summary>How long a completed (or in-flight) turn result stays pollable.</summary>
     public static readonly TimeSpan Ttl = TimeSpan.FromMinutes(10);
 
-    private readonly ConcurrentDictionary<string, TurnJob> _jobs = new(StringComparer.Ordinal);
-
-    /// <summary>Maps an upload id to the live turn it started, so a retried completion returns the
-    /// same turn_id instead of launching a duplicate. Bounded by the same TTL sweep as the jobs.</summary>
-    private readonly ConcurrentDictionary<string, string> _byUpload = new(StringComparer.OrdinalIgnoreCase);
-
-    /// <summary>Create and register a new job for <paramref name="sessionId"/> (stage=submitted).
-    /// When <paramref name="uploadId"/> is supplied the job is also indexed by it for idempotency.</summary>
-    public TurnJob Create(string sessionId, string? uploadId = null)
+    /// <summary>ONE tenant's jobs. The only way to reach it is <see cref="StateFor"/> with a validated
+    /// tenant, so a turn id alone can never name a job.</summary>
+    private sealed class TenantJobs
     {
-        SweepExpired();
+        public readonly ConcurrentDictionary<string, TurnJob> Jobs = new(StringComparer.Ordinal);
+
+        /// <summary>Maps an upload id to the live turn it started, so a retried completion returns the
+        /// same turn_id instead of launching a duplicate. Bounded by the same TTL sweep as the jobs.</summary>
+        public readonly ConcurrentDictionary<string, string> ByUpload = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private readonly ConcurrentDictionary<string, TenantJobs> _tenants = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// True only for the EXACT form the tenant registry mints: a canonical lowercase GUID. The same guard
+    /// the on-disk voice partitions use, so the in-memory and on-disk views can never disagree about which
+    /// spelling of a tenant id is that tenant.
+    /// </summary>
+    private static bool IsMintedAccountTenant(string value)
+        => Guid.TryParseExact(value, "D", out var parsed)
+           && string.Equals(value, parsed.ToString("D"), StringComparison.Ordinal);
+
+    private static string CanonicalTenantKey(TenantId tenant)
+    {
+        if (!tenant.IsValid)
+            throw new ArgumentException("A voice-turn job needs a valid tenant; an unresolved tenant is denied, never defaulted.", nameof(tenant));
+        if (tenant.IsLocal) return TenantId.Local.Value;
+        if (!IsMintedAccountTenant(tenant.Value))
+            throw new ArgumentException(
+                $"Tenant '{tenant.ToLogString()}' is not a minted account tenant and cannot own voice-turn jobs.", nameof(tenant));
+        return tenant.Value;
+    }
+
+    private TenantJobs StateFor(TenantId tenant)
+        => _tenants.GetOrAdd(CanonicalTenantKey(tenant), _ => new TenantJobs());
+
+    /// <summary>Create and register a new job for <paramref name="sessionId"/> (stage=submitted) inside
+    /// <paramref name="tenant"/>. When <paramref name="uploadId"/> is supplied the job is also indexed by
+    /// it for idempotency.</summary>
+    public TurnJob Create(TenantId tenant, string sessionId, string? uploadId = null)
+    {
+        var state = StateFor(tenant);
+        SweepExpired(state);
         var job = new TurnJob(Guid.NewGuid().ToString(), sessionId, DateTime.UtcNow, Ttl, uploadId);
-        _jobs[job.TurnId] = job;
+        state.Jobs[job.TurnId] = job;
         if (!string.IsNullOrEmpty(uploadId))
-            _byUpload[uploadId] = job.TurnId;
-        FileLog.Write($"[GatewayTurnJobStore] Create: turnId={job.TurnId}, sid={sessionId}, uploadId={uploadId}, expiresAt={job.ExpiresAt:O}");
+            state.ByUpload[uploadId] = job.TurnId;
+        FileLog.Write($"[GatewayTurnJobStore] Create: tenant={tenant.ToLogString()}, turnId={job.TurnId}, sid={sessionId}, uploadId={uploadId}, expiresAt={job.ExpiresAt:O}");
         return job;
     }
 
-    /// <summary>The live (non-expired) turn started from <paramref name="uploadId"/>, or null. The
-    /// idempotency fast path: an in-flight or recently-finished turn is found without touching disk.</summary>
-    public TurnJob? FindTurnByUpload(string uploadId)
+    /// <summary>The live (non-expired) turn started from <paramref name="uploadId"/> within this tenant, or
+    /// null. The idempotency fast path: an in-flight or recently-finished turn is found without touching disk.</summary>
+    public TurnJob? FindTurnByUpload(TenantId tenant, string uploadId)
     {
         if (string.IsNullOrEmpty(uploadId)) return null;
-        if (!_byUpload.TryGetValue(uploadId, out var turnId)) return null;
-        var job = Get(turnId);
-        if (job is null) _byUpload.TryRemove(uploadId, out _);
+        var state = StateFor(tenant);
+        if (!state.ByUpload.TryGetValue(uploadId, out var turnId)) return null;
+        var job = Get(tenant, turnId);
+        if (job is null) state.ByUpload.TryRemove(uploadId, out _);
         return job;
     }
 
     /// <summary>
-    /// The job for <paramref name="turnId"/>, or null when unknown or expired. An expired job is
-    /// removed on this read (lazy expiry) so the caller's 404 is also the cleanup.
+    /// The job for <paramref name="turnId"/> WITHIN <paramref name="tenant"/>, or null when unknown or
+    /// expired. Another tenant's turn id is simply unknown here - the lookup never leaves this tenant's
+    /// dictionary, so there is no cross-tenant answer to give. An expired job is removed on this read
+    /// (lazy expiry) so the caller's 404 is also the cleanup.
     /// </summary>
-    public TurnJob? Get(string turnId)
+    public TurnJob? Get(TenantId tenant, string turnId)
     {
         if (string.IsNullOrEmpty(turnId)) return null;
-        if (!_jobs.TryGetValue(turnId, out var job)) return null;
+        var state = StateFor(tenant);
+        if (!state.Jobs.TryGetValue(turnId, out var job)) return null;
         if (job.ExpiresAt <= DateTime.UtcNow)
         {
-            _jobs.TryRemove(turnId, out _);
+            state.Jobs.TryRemove(turnId, out _);
             FileLog.Write($"[GatewayTurnJobStore] Get: turnId={turnId} expired (created {job.CreatedAt:O}); removed");
             return null;
         }
         return job;
     }
 
-    /// <summary>Drop every expired job. Called on each create so the dictionary stays bounded
+    /// <summary>Drop every expired job in ONE tenant. Called on each create so the dictionary stays bounded
     /// by the number of turns submitted within one TTL window.</summary>
-    private void SweepExpired()
+    private static void SweepExpired(TenantJobs state)
     {
         var now = DateTime.UtcNow;
-        foreach (var kvp in _jobs)
+        foreach (var kvp in state.Jobs)
         {
             if (kvp.Value.ExpiresAt <= now)
             {
-                _jobs.TryRemove(kvp.Key, out _);
+                state.Jobs.TryRemove(kvp.Key, out _);
                 if (!string.IsNullOrEmpty(kvp.Value.UploadId))
-                    _byUpload.TryRemove(kvp.Value.UploadId, out _);
+                    state.ByUpload.TryRemove(kvp.Value.UploadId, out _);
             }
         }
     }

--- a/src/CcDirector.Gateway/Voice/VoiceTurnArchive.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceTurnArchive.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Gateway.Voice;
@@ -14,9 +15,16 @@ namespace CcDirector.Gateway.Voice;
 /// later and across restarts. It also records the originating <c>uploadId</c> so a retried
 /// completion finds the already-finished turn instead of starting a duplicate.
 ///
-/// Layout: <c>{CcStorage.VoiceTurnArchive()}/&lt;turnId&gt;/meta.json</c> plus <c>reply.mp3</c>
-/// (present only when TTS produced audio). One directory per turn, purged after
+/// Layout: <c>{CcStorage.VoiceTurnArchive()}/tenants/&lt;tenant&gt;/&lt;turnId&gt;/meta.json</c> plus
+/// <c>reply.mp3</c> (present only when TTS produced audio). One directory per turn, purged after
 /// <see cref="RetentionHours"/>.
+///
+/// PARTITIONED BY TENANT (Hosted Multi-Tenancy, VOICE V1). A turn's transcript, its summary and its
+/// reply audio are all customer content, so the partition is the DIRECTORY: a read for tenant A builds
+/// a path under tenant A's folder and physically cannot open tenant B's turn, whatever turn id it is
+/// handed. The tenant id is canonicalized before it becomes a path component and a shape this system
+/// does not mint is REFUSED, never coerced - the same rule as <see cref="Prompts.GatewayPromptLog"/>.
+/// Every public method takes the tenant as a REQUIRED parameter; there is no bare-turn-id read.
 ///
 /// Best-effort: a persistence failure must never break a live turn, so the writers swallow and
 /// log their own exceptions.
@@ -37,19 +45,99 @@ public sealed class VoiceTurnArchive
     {
         _root = root;
         Directory.CreateDirectory(_root);
+        MigrateLegacyUnpartitionedTurns();
+    }
+
+    /// <summary>
+    /// True only for the EXACT form the tenant registry mints: a canonical lowercase GUID. The tenant id
+    /// becomes a DIRECTORY NAME here, so it must be a shape this system actually produces rather than merely
+    /// "characters that look harmless" - <c>".."</c> is built from harmless characters and canonicalizes to
+    /// the parent partition, and an id differing only in letter case is a different identity to the
+    /// case-sensitive tenants table while naming the SAME directory on Windows and Azure Files. One spelling
+    /// only: parse strictly, then require the value to equal its own canonical round-trip.
+    /// </summary>
+    private static bool IsMintedAccountTenant(string value)
+        => Guid.TryParseExact(value, "D", out var parsed)
+           && string.Equals(value, parsed.ToString("D"), StringComparison.Ordinal);
+
+    /// <summary>
+    /// The directory holding ONE tenant's archived turns. <see cref="TenantId.Local"/> is the fixed literal
+    /// "local"; every other partition must be a minted account tenant. The reserved <see cref="TenantId.System"/>
+    /// identity is deliberately refused rather than given a partition - no voice turn belongs to it.
+    /// </summary>
+    public string PartitionDirectoryFor(TenantId tenant)
+    {
+        if (!tenant.IsValid)
+            throw new ArgumentException("A voice-turn archive partition needs a valid tenant; an unresolved tenant is denied, never defaulted.", nameof(tenant));
+        if (!tenant.IsLocal && !IsMintedAccountTenant(tenant.Value))
+            throw new ArgumentException(
+                $"Tenant '{tenant.ToLogString()}' is not a minted account tenant and cannot name a voice-turn archive partition.", nameof(tenant));
+
+        var combined = Path.Combine(_root, "tenants", tenant.Value);
+
+        // Belt and braces, because the cost of being wrong here is one tenant reading another's transcript
+        // and playing its reply audio: the result must actually LIE INSIDE the partition root. The guard
+        // above already excludes traversal, so this can only fire if it is ever loosened.
+        var expectedRoot = Path.GetFullPath(Path.Combine(_root, "tenants")) + Path.DirectorySeparatorChar;
+        if (!Path.GetFullPath(combined).StartsWith(expectedRoot, StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException(
+                $"Tenant '{tenant.ToLogString()}' resolves outside the voice-turn archive partition root.", nameof(tenant));
+
+        return combined;
+    }
+
+    /// <summary>
+    /// Deal, once, with turns archived BEFORE this store was partitioned - they sit directly under the root
+    /// with no tenant recorded anywhere. The mode is read from <see cref="GatewayHostedMode.IsHosted"/>
+    /// DIRECTLY, never from an argument a caller could omit (an omitted argument would fail open into "keep").
+    ///
+    ///  - HOSTED: DELETE them. A turn whose owning account cannot be established must not be handed to a
+    ///    guess; a lost turn is the cheap outcome, a mis-attributed transcript is a disclosure.
+    ///  - SELF-HOST: MOVE them into the Local partition. One tenant, so attribution is unambiguous.
+    /// </summary>
+    private void MigrateLegacyUnpartitionedTurns()
+    {
+        try
+        {
+            var legacy = Directory.EnumerateDirectories(_root)
+                .Where(d => !string.Equals(Path.GetFileName(d), "tenants", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (legacy.Count == 0) return;
+
+            if (GatewayHostedMode.IsHosted)
+            {
+                foreach (var dir in legacy) Directory.Delete(dir, recursive: true);
+                FileLog.Write($"[VoiceTurnArchive] hosted: deleted {legacy.Count} pre-partition turn(s) - they carry no tenant, and a turn whose owner cannot be established is deleted rather than guessed");
+                return;
+            }
+
+            var localDir = PartitionDirectoryFor(TenantId.Local);
+            Directory.CreateDirectory(localDir);
+            foreach (var dir in legacy)
+            {
+                var target = Path.Combine(localDir, Path.GetFileName(dir));
+                if (Directory.Exists(target)) Directory.Delete(target, recursive: true);
+                Directory.Move(dir, target);
+            }
+            FileLog.Write($"[VoiceTurnArchive] self-host: moved {legacy.Count} pre-partition turn(s) into the local tenant partition (one tenant, so attribution is unambiguous)");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[VoiceTurnArchive] pre-partition turn migration FAILED: {ex.Message}");
+        }
     }
 
     /// <summary>
     /// Persist a completed turn's reply. Writes meta.json (always) and reply.mp3 (when audio is
     /// present), then purges aged turns. Best-effort: failures are logged, never thrown.
     /// </summary>
-    public void Save(VoiceTurnArchiveRecord record, byte[]? replyAudio)
+    public void Save(TenantId tenant, VoiceTurnArchiveRecord record, byte[]? replyAudio)
     {
         try
         {
-            Purge();
+            Purge(tenant);
 
-            var dir = DirFor(record.TurnId);
+            var dir = DirFor(tenant, record.TurnId);
             if (dir is null)
             {
                 FileLog.Write($"[VoiceTurnArchive] Save: rejected non-GUID turnId={record.TurnId}");
@@ -71,18 +159,18 @@ public sealed class VoiceTurnArchive
     }
 
     /// <summary>The archived record for <paramref name="turnId"/>, or null when absent/aged-out.</summary>
-    public VoiceTurnArchiveRecord? Get(string turnId)
+    public VoiceTurnArchiveRecord? Get(TenantId tenant, string turnId)
     {
-        var dir = DirFor(turnId);
+        var dir = DirFor(tenant, turnId);
         if (dir is null) return null;
         return ReadMeta(dir);
     }
 
     /// <summary>The reply MP3 bytes for <paramref name="turnId"/>, or null when there is no
     /// archived audio (no key configured at turn time, or turn absent/aged-out).</summary>
-    public byte[]? GetAudio(string turnId)
+    public byte[]? GetAudio(TenantId tenant, string turnId)
     {
-        var dir = DirFor(turnId);
+        var dir = DirFor(tenant, turnId);
         if (dir is null) return null;
         var path = Path.Combine(dir, "reply.mp3");
         try { return File.Exists(path) ? File.ReadAllBytes(path) : null; }
@@ -97,12 +185,12 @@ public sealed class VoiceTurnArchive
     /// Completed turns for a session, newest first, optionally only those at/after
     /// <paramref name="sinceUtc"/>. Scans the (bounded, retention-limited) archive dirs.
     /// </summary>
-    public IReadOnlyList<VoiceTurnArchiveRecord> ListForSession(string sessionId, DateTime? sinceUtc = null)
+    public IReadOnlyList<VoiceTurnArchiveRecord> ListForSession(TenantId tenant, string sessionId, DateTime? sinceUtc = null)
     {
         var results = new List<VoiceTurnArchiveRecord>();
         try
         {
-            foreach (var dir in Directory.EnumerateDirectories(_root))
+            foreach (var dir in EnumerateTurnDirs(tenant))
             {
                 var rec = ReadMeta(dir);
                 if (rec is null) continue;
@@ -122,12 +210,12 @@ public sealed class VoiceTurnArchive
     /// The completed turn that originated from <paramref name="uploadId"/>, or null. Used to make a
     /// retried completion idempotent even after the in-memory job has expired.
     /// </summary>
-    public VoiceTurnArchiveRecord? FindByUpload(string uploadId)
+    public VoiceTurnArchiveRecord? FindByUpload(TenantId tenant, string uploadId)
     {
         if (string.IsNullOrWhiteSpace(uploadId)) return null;
         try
         {
-            foreach (var dir in Directory.EnumerateDirectories(_root))
+            foreach (var dir in EnumerateTurnDirs(tenant))
             {
                 var rec = ReadMeta(dir);
                 if (rec is not null && string.Equals(rec.UploadId, uploadId, StringComparison.OrdinalIgnoreCase))
@@ -155,11 +243,18 @@ public sealed class VoiceTurnArchive
         }
     }
 
-    /// <summary>Delete turn dirs older than the retention window. Best-effort.</summary>
-    private void Purge()
+    /// <summary>Every archived turn directory inside ONE tenant's partition (empty when it has none).</summary>
+    private IEnumerable<string> EnumerateTurnDirs(TenantId tenant)
+    {
+        var dir = PartitionDirectoryFor(tenant);
+        return Directory.Exists(dir) ? Directory.EnumerateDirectories(dir) : Enumerable.Empty<string>();
+    }
+
+    /// <summary>Delete one tenant's turn dirs older than the retention window. Best-effort.</summary>
+    private void Purge(TenantId tenant)
     {
         var cutoff = DateTime.UtcNow.AddHours(-RetentionHours);
-        foreach (var dir in Directory.EnumerateDirectories(_root))
+        foreach (var dir in EnumerateTurnDirs(tenant))
         {
             try
             {
@@ -173,10 +268,11 @@ public sealed class VoiceTurnArchive
         }
     }
 
-    /// <summary>Per-turn dir, or null when the turn id is not GUID-shaped (so it can never
-    /// escape the archive root).</summary>
-    private string? DirFor(string turnId)
-        => Guid.TryParse(turnId, out var g) ? Path.Combine(_root, g.ToString("N")) : null;
+    /// <summary>Per-turn dir INSIDE the tenant's partition, or null when the turn id is not GUID-shaped
+    /// (so it can never escape the partition). The tenant folder comes first, so a valid turn id belonging
+    /// to another tenant simply names a path that does not exist here.</summary>
+    private string? DirFor(TenantId tenant, string turnId)
+        => Guid.TryParse(turnId, out var g) ? Path.Combine(PartitionDirectoryFor(tenant), g.ToString("N")) : null;
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -8,6 +8,7 @@ using CcDirector.Core;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.HostedAi;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Api;
 using CcDirector.Gateway.Contracts;
@@ -25,6 +26,21 @@ namespace CcDirector.Gateway.Wingman;
 /// instant (the voice is already made). Since issue #549 the turn-end trigger is the always-running
 /// TurnEndWatcher, which calls <see cref="GenerateAsync"/> directly for voice sessions on turn-end
 /// (the retired turn-brief pipeline no longer mediates it).
+///
+/// PARTITIONED BY TENANT (Hosted Multi-Tenancy, VOICE V1). Everything this service holds is customer
+/// content: the spoken narration text, the reply text it was made from, and the audio clip itself. On the
+/// hosted Gateway one account's narration must never be reachable by another, so the partition is
+/// STRUCTURAL, not a predicate on the read:
+///  - In memory, each tenant gets its own bucket of per-session dictionaries. A read for tenant A is
+///    handed tenant A's bucket and physically cannot name a session id in tenant B's bucket.
+///  - On disk, each tenant gets its own DIRECTORY (<c>tenants/&lt;id&gt;/</c>) holding its own
+///    voice-sessions.json and its own voice-audio folder, so a read cannot open another tenant's clip.
+/// The tenant id is canonicalized before it becomes a bucket key or a path component, and a shape this
+/// system does not mint is REFUSED rather than coerced into something that looks valid - the same rule,
+/// and the same reasoning, as <see cref="Prompts.GatewayPromptLog"/>.
+///
+/// Every public read and mutate takes the tenant as a REQUIRED parameter. There is deliberately no
+/// bare-session-id overload: a bare-id method is a cross-tenant read waiting for its next caller.
 /// </summary>
 public sealed class WingmanVoiceService
 {
@@ -36,19 +52,107 @@ public sealed class WingmanVoiceService
     /// null. Both null means a generic provider error (logged, no shared state).</summary>
     private sealed record TtsResult(byte[]? Audio, string? ContentType, HostedAiState? Unavailable, bool ServedViaFallback = false);
 
+    /// <summary>
+    /// ONE tenant's voice state. Every dictionary here is keyed by session id, and the ONLY way to reach one
+    /// is through <see cref="StateFor"/> with a validated tenant - so a session id alone can never name a
+    /// row. This is the in-memory twin of the per-tenant directory on disk: the isolation is the container,
+    /// not a check performed at the point of read.
+    /// </summary>
+    private sealed class TenantVoiceState
+    {
+        public readonly ConcurrentDictionary<string, byte> VoiceSessions = new();          // sid -> marker
+        public readonly ConcurrentDictionary<string, VoiceReady> Ready = new();            // sid -> spoken+audio
+        public readonly ConcurrentDictionary<string, byte> Generating = new();             // sid -> wingman is running now
+        public readonly ConcurrentDictionary<string, HostedAiState> Unavailable = new();   // sid -> why voice is off (issue #939)
+        public readonly ConcurrentDictionary<string, byte> NothingToNarrate = new();       // sid -> the last turn has no text reply to read aloud (waiting on a prompt)
+        public readonly ConcurrentDictionary<string, DateTime> PreferBackupUntil = new();  // sid -> UTC deadline while this session routes past a silent primary (issue devthrottle_internal#405)
+        public readonly ConcurrentDictionary<string, byte> InFlight = new();               // sid -> a generation is running now
+    }
+
     private readonly WingmanTranslator _translator;
     private readonly KeyVault _vault;
     private readonly WingmanTrainingStore _training;
-    private readonly ConcurrentDictionary<string, byte> _voiceSessions = new();   // sid -> marker
-    private readonly ConcurrentDictionary<string, VoiceReady> _ready = new();      // sid -> spoken+audio
-    private readonly ConcurrentDictionary<string, byte> _generating = new();       // sid -> wingman is running now
-    private readonly ConcurrentDictionary<string, HostedAiState> _voiceUnavailable = new();  // sid -> why voice is off (issue #939)
-    private readonly ConcurrentDictionary<string, byte> _nothingToNarrate = new();  // sid -> the last turn has no text reply to read aloud (waiting on a prompt)
-    private readonly ConcurrentDictionary<string, DateTime> _preferBackupUntil = new();  // sid -> UTC deadline while this session routes past a silent primary (issue devthrottle_internal#405)
-    private readonly string _persistPath;
-    private readonly string _audioDir;
+    /// <summary>Tenant partition key (see <see cref="CanonicalTenantKey"/>) -> that tenant's whole voice
+    /// state. Ordinal, because the key is already canonical and two spellings must NEVER meet here.</summary>
+    private readonly ConcurrentDictionary<string, TenantVoiceState> _tenants = new(StringComparer.Ordinal);
+    /// <summary>The pre-partition file this Gateway used to keep the voice-session set in. Kept only so the
+    /// one-time legacy migration in the constructor can find it; nothing reads or writes it afterwards.</summary>
+    private readonly string _legacyPersistPath;
+    /// <summary>The directory the per-tenant partitions live under.</summary>
+    private readonly string _baseDir;
     private readonly HttpClient? _ttsHttp;   // test seam for TtsAsync (issue #939); the shared static when null
     private readonly Func<string, string?>? _sessionTitleResolver;   // sid -> session title, spoken first
+
+    /// <summary>
+    /// True only for the EXACT form <see cref="Tenancy.TenantRegistry"/> mints: a canonical lowercase GUID.
+    ///
+    /// A tenant id becomes a DIRECTORY NAME and a dictionary key here, so it must be a shape this system
+    /// actually produces - not merely "characters that look harmless". Two structural aliases have already
+    /// been found on this exact boundary in <see cref="Prompts.GatewayPromptLog"/>, and this is the same
+    /// guard for the same reason: <c>".."</c> is built entirely from harmless characters and canonicalizes
+    /// to the PARENT partition, and an id differing only in letter case is a different identity to the
+    /// case-sensitive tenants table while naming the SAME directory on Windows and Azure Files. So this
+    /// accepts ONE spelling: parse strictly, then require the value to equal its own canonical round-trip.
+    /// Anything else is refused rather than normalised - normalising is how two identities quietly share a
+    /// folder, and this folder holds narration audio and reply TEXT.
+    /// </summary>
+    private static bool IsMintedAccountTenant(string value)
+        => Guid.TryParseExact(value, "D", out var parsed)
+           && string.Equals(value, parsed.ToString("D"), StringComparison.Ordinal);
+
+    /// <summary>
+    /// The canonical partition key for a tenant - the single string used BOTH as the in-memory bucket key and
+    /// as the on-disk directory name, so the two can never disagree about which tenant a session belongs to.
+    ///
+    /// <see cref="TenantId.Local"/> is the fixed literal "local" (self-host's one tenant). Every other
+    /// partition must be a minted account tenant; the reserved <see cref="TenantId.System"/> identity is
+    /// deliberately REFUSED rather than given a partition, because no narration belongs to it - the safe
+    /// answer is that it has no voice state at all.
+    /// </summary>
+    private static string CanonicalTenantKey(TenantId tenant)
+    {
+        if (!tenant.IsValid)
+            throw new ArgumentException("Voice state needs a valid tenant; an unresolved tenant is denied, never defaulted.", nameof(tenant));
+        if (tenant.IsLocal)
+            return TenantId.Local.Value;
+        if (!IsMintedAccountTenant(tenant.Value))
+            throw new ArgumentException(
+                $"Tenant '{tenant.ToLogString()}' is not a minted account tenant and cannot name a voice-state partition.",
+                nameof(tenant));
+        return tenant.Value;
+    }
+
+    /// <summary>This tenant's in-memory bucket, created on first touch. The validation runs FIRST, so an
+    /// unminted or unresolved tenant never gets a bucket at all.</summary>
+    private TenantVoiceState StateFor(TenantId tenant)
+        => _tenants.GetOrAdd(CanonicalTenantKey(tenant), _ => new TenantVoiceState());
+
+    /// <summary>
+    /// The directory holding ONE tenant's voice state (its voice-sessions.json and its voice-audio folder).
+    /// The tenant id is a PATH COMPONENT, which is the whole point: a read for tenant A builds a path under
+    /// tenant A's folder and cannot name a file in tenant B's.
+    /// </summary>
+    public string PartitionDirectoryFor(TenantId tenant)
+    {
+        var key = CanonicalTenantKey(tenant);
+        var combined = Path.Combine(_baseDir, "tenants", key);
+
+        // Belt and braces, because the cost of being wrong here is one tenant playing another's narration:
+        // the result must actually LIE INSIDE the partition root. CanonicalTenantKey already excludes
+        // traversal, so this can only fire if that guard is ever loosened - which is exactly when it is wanted.
+        var expectedRoot = Path.GetFullPath(Path.Combine(_baseDir, "tenants")) + Path.DirectorySeparatorChar;
+        if (!Path.GetFullPath(combined).StartsWith(expectedRoot, StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException(
+                $"Tenant '{tenant.ToLogString()}' resolves outside the voice-state partition root.", nameof(tenant));
+
+        return combined;
+    }
+
+    /// <summary>The file holding one tenant's set of voice sessions.</summary>
+    private string PersistPathFor(TenantId tenant) => Path.Combine(PartitionDirectoryFor(tenant), "voice-sessions.json");
+
+    /// <summary>The folder holding one tenant's cached narration clips and their metadata.</summary>
+    private string AudioDirFor(TenantId tenant) => Path.Combine(PartitionDirectoryFor(tenant), "voice-audio");
 
     /// <summary>
     /// The one HTTP client for the narration speech leg, used whenever no test client is injected.
@@ -81,10 +185,10 @@ public sealed class WingmanVoiceService
     // is recorded as this ONE session's unavailable-state so its UI can say so, and nothing more - it
     // never reaches across to another session. Do NOT reintroduce a shared gate or a constant cap here.
     //
-    // _inFlight stays: it is NOT a fleet gate. It coalesces a single session so two generations for the
-    // SAME session never run at once (a slow turn overlapping the idle sweep would otherwise double the
-    // spend). It never makes one session wait on another.
-    private readonly ConcurrentDictionary<string, byte> _inFlight = new();   // sid -> a generation is running now
+    // The per-session coalescing marker (TenantVoiceState.InFlight) stays: it is NOT a fleet gate. It
+    // coalesces a single session so two generations for the SAME session never run at once (a slow turn
+    // overlapping the idle sweep would otherwise double the spend). It never makes one session wait on
+    // another, and it is per tenant like everything else here.
 
     /// <summary>On-disk shape of one ready session's metadata (the audio bytes live next to it as
     /// an .mp3). Persisted so the play triangle / playability survives a gateway restart (issue #553).</summary>
@@ -109,94 +213,225 @@ public sealed class WingmanVoiceService
         // audio cache is now ALSO durable - it is persisted next to voice-sessions.json under a
         // "voice-audio" folder so the triangle does not vanish-then-reappear-empty across a restart
         // and a tap after restart plays. Tests pass an isolated path so the two never collide.
-        _persistPath = persistPath ?? Path.Combine(CcStorage.Root(), "voice-sessions.json");
-        var baseDir = Path.GetDirectoryName(_persistPath);
+        //
+        // VOICE V1: both now live inside a per-tenant partition under _baseDir/tenants/<id>/. The
+        // constructor argument still names the LEGACY (pre-partition) file, because that is what the
+        // one-time migration below has to find, and because it is how every existing caller and test
+        // points this service at an isolated directory.
+        _legacyPersistPath = persistPath ?? Path.Combine(CcStorage.Root(), "voice-sessions.json");
+        var baseDir = Path.GetDirectoryName(_legacyPersistPath);
         if (string.IsNullOrWhiteSpace(baseDir)) baseDir = CcStorage.Root();
-        _audioDir = Path.Combine(baseDir, "voice-audio");
-        LoadVoiceSessions();
-        LoadReadyAudio();
+        _baseDir = baseDir;
+        MigrateLegacyUnpartitionedState();
+        LoadAllPartitions();
     }
 
-    private void LoadVoiceSessions()
+    /// <summary>
+    /// Deal, once, with the voice state that was written BEFORE this store was partitioned: a single
+    /// voice-sessions.json and a single voice-audio folder shared by whoever happened to be using the
+    /// Gateway. It has no tenant recorded anywhere, so the two deployment modes get OPPOSITE treatment, and
+    /// the mode is read from <see cref="GatewayHostedMode.IsHosted"/> DIRECTLY - never from an argument a
+    /// caller could omit, because an omitted argument would fail open into "keep it".
+    ///
+    ///  - HOSTED: DELETE it. The clip cannot be attributed to an account - the Director that made it may be
+    ///    long gone - and guessing an owner would hand one customer another customer's narration. A cached
+    ///    narration clip is regenerable; a mis-attributed one is a disclosure. Losing it is the cheap outcome.
+    ///  - SELF-HOST: MOVE it into the Local partition. Self-host has exactly one tenant, so attribution is
+    ///    unambiguous and the user keeps every ready clip across the upgrade.
+    ///
+    /// Best-effort and idempotent: a failure is logged and boot continues (a cached narration must never
+    /// stop the Gateway starting), and a second run finds nothing left to do.
+    /// </summary>
+    private void MigrateLegacyUnpartitionedState()
+    {
+        var legacyAudioDir = Path.Combine(_baseDir, "voice-audio");
+        var hasLegacy = File.Exists(_legacyPersistPath) || Directory.Exists(legacyAudioDir);
+        if (!hasLegacy) return;
+
+        if (GatewayHostedMode.IsHosted)
+        {
+            try
+            {
+                if (File.Exists(_legacyPersistPath)) File.Delete(_legacyPersistPath);
+                if (Directory.Exists(legacyAudioDir)) Directory.Delete(legacyAudioDir, recursive: true);
+                FileLog.Write("[WingmanVoiceService] hosted: deleted the pre-partition voice state - it carries no tenant, and a clip whose owner cannot be established is deleted rather than guessed");
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[WingmanVoiceService] hosted: deleting the pre-partition voice state FAILED: {ex.Message}");
+            }
+            return;
+        }
+
+        try
+        {
+            var localDir = PartitionDirectoryFor(TenantId.Local);
+            Directory.CreateDirectory(localDir);
+
+            var targetPersist = PersistPathFor(TenantId.Local);
+            if (File.Exists(_legacyPersistPath) && !File.Exists(targetPersist))
+                File.Move(_legacyPersistPath, targetPersist);
+            else if (File.Exists(_legacyPersistPath))
+                File.Delete(_legacyPersistPath);   // the partition already has its own; the legacy copy is superseded
+
+            var targetAudioDir = AudioDirFor(TenantId.Local);
+            if (Directory.Exists(legacyAudioDir))
+            {
+                Directory.CreateDirectory(targetAudioDir);
+                foreach (var file in Directory.EnumerateFiles(legacyAudioDir))
+                {
+                    var target = Path.Combine(targetAudioDir, Path.GetFileName(file));
+                    if (File.Exists(target)) File.Delete(target);
+                    File.Move(file, target);
+                }
+                Directory.Delete(legacyAudioDir, recursive: true);
+            }
+            FileLog.Write("[WingmanVoiceService] self-host: moved the pre-partition voice state into the local tenant partition (one tenant, so attribution is unambiguous)");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[WingmanVoiceService] self-host: moving the pre-partition voice state FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>Load every tenant partition present on disk. A directory whose name is not a partition key
+    /// this system mints is SKIPPED loudly rather than loaded under some coerced name - the same refusal the
+    /// write path applies, so a hand-made or half-renamed folder can never become a tenant.</summary>
+    private void LoadAllPartitions()
+    {
+        var tenantsRoot = Path.Combine(_baseDir, "tenants");
+        if (!Directory.Exists(tenantsRoot)) return;
+        foreach (var dir in Directory.EnumerateDirectories(tenantsRoot))
+        {
+            var name = Path.GetFileName(dir);
+            TenantId tenant;
+            try
+            {
+                tenant = new TenantId(name);
+                _ = CanonicalTenantKey(tenant);
+            }
+            catch (ArgumentException)
+            {
+                FileLog.Write($"[WingmanVoiceService] skipping voice partition directory '{name}' - not a tenant this system mints");
+                continue;
+            }
+            LoadVoiceSessions(tenant);
+            LoadReadyAudio(tenant);
+        }
+    }
+
+    private void LoadVoiceSessions(TenantId tenant)
     {
         try
         {
-            if (!File.Exists(_persistPath)) return;
-            var ids = JsonSerializer.Deserialize<string[]>(File.ReadAllText(_persistPath));
-            if (ids is not null) foreach (var id in ids) if (!string.IsNullOrWhiteSpace(id)) _voiceSessions[id] = 1;
-            FileLog.Write($"[WingmanVoiceService] loaded {_voiceSessions.Count} voice session(s) from disk");
+            var path = PersistPathFor(tenant);
+            if (!File.Exists(path)) return;
+            var state = StateFor(tenant);
+            var ids = JsonSerializer.Deserialize<string[]>(File.ReadAllText(path));
+            if (ids is not null) foreach (var id in ids) if (!string.IsNullOrWhiteSpace(id)) state.VoiceSessions[id] = 1;
+            FileLog.Write($"[WingmanVoiceService] loaded {state.VoiceSessions.Count} voice session(s) from disk for tenant={tenant.ToLogString()}");
         }
-        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] load voice sessions FAILED: {ex.Message}"); }
+        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] load voice sessions FAILED for tenant={tenant.ToLogString()}: {Redact(ex.Message, tenant)}"); }
     }
 
-    private void SaveVoiceSessions()
+    private void SaveVoiceSessions(TenantId tenant)
     {
-        try { File.WriteAllText(_persistPath, JsonSerializer.Serialize(_voiceSessions.Keys.ToArray())); }
-        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] save voice sessions FAILED: {ex.Message}"); }
+        try
+        {
+            var path = PersistPathFor(tenant);
+            Directory.CreateDirectory(PartitionDirectoryFor(tenant));
+            File.WriteAllText(path, JsonSerializer.Serialize(StateFor(tenant).VoiceSessions.Keys.ToArray()));
+        }
+        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] save voice sessions FAILED for tenant={tenant.ToLogString()}: {Redact(ex.Message, tenant)}"); }
     }
+
+    /// <summary>
+    /// Replace a tenant's raw account id with its hashed log form anywhere it appears in text bound for the
+    /// log - in practice a file path inside an exception message, since the partition directory IS the
+    /// tenant id. A single exact substitution of a value we hold, not a general-purpose scrub: it is
+    /// complete for the one way the id can get in here, and it keeps the failure LOUD rather than swallowing
+    /// the message to be safe. Same rule as <see cref="Prompts.GatewayPromptLog"/>.
+    /// </summary>
+    private static string Redact(string text, TenantId tenant)
+        => string.IsNullOrEmpty(text) || !tenant.IsValid
+            ? text
+            : text.Replace(tenant.Value, tenant.ToLogString(), StringComparison.Ordinal);
 
     /// <summary>Restore the per-session ready audio cache from disk on startup (issue #553) so
     /// HasVoice / ReadySessionIds survive a gateway restart. A session is only loaded ready when BOTH
     /// its metadata (.json) and its audio (.mp3, non-empty) are present - the "if anything fails,
     /// remove the triangle" rule extends to a half-written or missing cache.</summary>
-    private void LoadReadyAudio()
+    private void LoadReadyAudio(TenantId tenant)
     {
         try
         {
-            if (!Directory.Exists(_audioDir)) return;
+            var audioDir = AudioDirFor(tenant);
+            if (!Directory.Exists(audioDir)) return;
+            var state = StateFor(tenant);
             var loaded = 0;
-            foreach (var metaPath in Directory.EnumerateFiles(_audioDir, "*.json"))
+            foreach (var metaPath in Directory.EnumerateFiles(audioDir, "*.json"))
             {
                 var sid = Path.GetFileNameWithoutExtension(metaPath);
-                var audioPath = Path.Combine(_audioDir, sid + ".mp3");
+                var audioPath = Path.Combine(audioDir, sid + ".mp3");
                 if (!File.Exists(audioPath)) continue;
                 var audio = File.ReadAllBytes(audioPath);
                 if (audio.Length == 0) continue;
                 var meta = JsonSerializer.Deserialize<PersistedVoice>(File.ReadAllText(metaPath));
                 if (meta is null) continue;
                 var contentType = NormalizeContentType(meta.ContentType) ?? DetectAudioContentType(audio);
-                _ready[sid] = new VoiceReady(meta.Spoken, meta.Reply, audio, meta.AtUtc, contentType, meta.ServedViaFallback);
+                state.Ready[sid] = new VoiceReady(meta.Spoken, meta.Reply, audio, meta.AtUtc, contentType, meta.ServedViaFallback);
                 loaded++;
             }
-            FileLog.Write($"[WingmanVoiceService] loaded {loaded} ready voice audio cache(s) from disk");
+            FileLog.Write($"[WingmanVoiceService] loaded {loaded} ready voice audio cache(s) from disk for tenant={tenant.ToLogString()}");
         }
-        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] load ready audio FAILED: {ex.Message}"); }
+        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] load ready audio FAILED for tenant={tenant.ToLogString()}: {Redact(ex.Message, tenant)}"); }
     }
 
-    private void SaveReadyAudio(string sid, VoiceReady ready)
+    private void SaveReadyAudio(TenantId tenant, string sid, VoiceReady ready)
     {
         try
         {
-            Directory.CreateDirectory(_audioDir);
+            var audioDir = AudioDirFor(tenant);
+            Directory.CreateDirectory(audioDir);
             // Write the audio first, then the metadata, so a startup load (which requires BOTH the
             // .mp3 and the .json) never sees a session ready before its bytes are on disk.
-            File.WriteAllBytes(Path.Combine(_audioDir, sid + ".mp3"), ready.Audio);
-            File.WriteAllText(Path.Combine(_audioDir, sid + ".json"),
+            File.WriteAllBytes(Path.Combine(audioDir, sid + ".mp3"), ready.Audio);
+            File.WriteAllText(Path.Combine(audioDir, sid + ".json"),
                 JsonSerializer.Serialize(new PersistedVoice(ready.Spoken, ready.Reply, ready.AtUtc, ready.ContentType, ready.ServedViaFallback)));
         }
-        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] save ready audio FAILED sid={sid}: {ex.Message}"); }
+        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] save ready audio FAILED tenant={tenant.ToLogString()} sid={sid}: {Redact(ex.Message, tenant)}"); }
     }
 
-    private void DeleteReadyAudio(string sid)
+    private void DeleteReadyAudio(TenantId tenant, string sid)
     {
         try
         {
-            var meta = Path.Combine(_audioDir, sid + ".json");
-            var audio = Path.Combine(_audioDir, sid + ".mp3");
+            var audioDir = AudioDirFor(tenant);
+            var meta = Path.Combine(audioDir, sid + ".json");
+            var audio = Path.Combine(audioDir, sid + ".mp3");
             if (File.Exists(meta)) File.Delete(meta);
             if (File.Exists(audio)) File.Delete(audio);
         }
-        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] delete ready audio FAILED sid={sid}: {ex.Message}"); }
+        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] delete ready audio FAILED tenant={tenant.ToLogString()} sid={sid}: {Redact(ex.Message, tenant)}"); }
     }
 
-    /// <summary>This session has had voice used on it at least once.</summary>
-    public bool IsVoiceSession(string sid) => _voiceSessions.ContainsKey(sid);
+    /// <summary>This session has had voice used on it at least once, within this tenant.</summary>
+    public bool IsVoiceSession(TenantId tenant, string sid) => StateFor(tenant).VoiceSessions.ContainsKey(sid);
 
-    /// <summary>Every session the gateway is keeping voice for (the persisted set).</summary>
-    public IReadOnlyCollection<string> VoiceSessionIds() => _voiceSessions.Keys.ToArray();
+    /// <summary>Every session the gateway is keeping voice for, within ONE tenant (the persisted set).</summary>
+    public IReadOnlyCollection<string> VoiceSessionIds(TenantId tenant) => StateFor(tenant).VoiceSessions.Keys.ToArray();
 
-    /// <summary>True when this session currently has a fresh, playable cached summary.</summary>
-    public bool HasVoice(string sid) => _ready.ContainsKey(sid);
+    /// <summary>
+    /// Every tenant this service currently holds voice state for. The ONLY method here that is not scoped to
+    /// a single tenant, and it deliberately returns tenants rather than sessions: a caller that must visit
+    /// all of them (the background narration sweep) iterates tenants and then asks each one for its own
+    /// sessions, so it still never sees a session id outside the tenant it is asking about.
+    /// </summary>
+    public IReadOnlyCollection<TenantId> PartitionedTenants()
+        => _tenants.Keys.Select(k => new TenantId(k)).ToArray();
+
+    /// <summary>True when this session currently has a fresh, playable cached summary, within this tenant.</summary>
+    public bool HasVoice(TenantId tenant, string sid) => StateFor(tenant).Ready.ContainsKey(sid);
 
     /// <summary>The response header the cloud speech proxy sets when it quietly failed the primary
     /// provider over to the backup (Phase 1). Its mere PRESENCE means "served via backup". We key on
@@ -210,7 +445,8 @@ public sealed class WingmanVoiceService
     /// primary was overloaded and the cloud proxy failed over). Fed to <see cref="VoiceDisplayFold"/> so
     /// the Voice screen shows the generic backup-voice notice. False when there is no ready clip, or the
     /// ready clip was served normally. Never an outage signal - a fallback IS a successful narration.</summary>
-    public bool ServedViaFallbackFor(string sid) => _ready.TryGetValue(sid, out var v) && v.ServedViaFallback;
+    public bool ServedViaFallbackFor(TenantId tenant, string sid)
+        => StateFor(tenant).Ready.TryGetValue(sid, out var v) && v.ServedViaFallback;
 
     /// <summary>
     /// Whether a turn-end should (re)generate the spoken narration for this session. True when there is
@@ -223,15 +459,15 @@ public sealed class WingmanVoiceService
     /// Reply text is compared trimmed + ordinal - the two sources (cache vs the live /turns widget) are
     /// the same JSONL text block, so an unchanged turn matches exactly.
     /// </summary>
-    internal bool ShouldRegenerate(string sid, string? currentReply)
+    internal bool ShouldRegenerate(TenantId tenant, string sid, string? currentReply)
     {
         if (string.IsNullOrWhiteSpace(currentReply)) return false;   // nothing to narrate yet
-        if (!_ready.TryGetValue(sid, out var cached)) return true;    // never narrated -> make it
+        if (!StateFor(tenant).Ready.TryGetValue(sid, out var cached)) return true;   // never narrated -> make it
         return !string.Equals(cached.Reply?.Trim(), currentReply.Trim(), StringComparison.Ordinal);
     }
 
-    /// <summary>The sessions that currently have a ready, playable spoken summary.</summary>
-    public IReadOnlyCollection<string> ReadySessionIds() => _ready.Keys.ToArray();
+    /// <summary>The sessions within ONE tenant that currently have a ready, playable spoken summary.</summary>
+    public IReadOnlyCollection<string> ReadySessionIds(TenantId tenant) => StateFor(tenant).Ready.Keys.ToArray();
 
     /// <summary>
     /// True while the wingman is actively producing this session's spoken summary (issue #531
@@ -239,13 +475,13 @@ public sealed class WingmanVoiceService
     /// before flipping back to red when it needs the user again. The gateway surfaces it through
     /// the "Briefing" yellow path in the /sessions aggregation (see GatewayEndpoints voiceGeneratingFor).
     /// </summary>
-    public bool IsGenerating(string sid) => _generating.ContainsKey(sid);
+    public bool IsGenerating(TenantId tenant, string sid) => StateFor(tenant).Generating.ContainsKey(sid);
 
     /// <summary>Mark the wingman as running for this session (turns the session yellow).</summary>
-    public void BeginGenerating(string sid) => _generating[sid] = 1;
+    public void BeginGenerating(TenantId tenant, string sid) => StateFor(tenant).Generating[sid] = 1;
 
     /// <summary>The wingman finished running for this session (back to red / its raw color).</summary>
-    public void EndGenerating(string sid) => _generating.TryRemove(sid, out _);
+    public void EndGenerating(TenantId tenant, string sid) => StateFor(tenant).Generating.TryRemove(sid, out _);
 
     /// <summary>
     /// Why the Gateway could not keep this session's voice, or null when voice is fine (issue #939).
@@ -254,8 +490,8 @@ public sealed class WingmanVoiceService
     /// <c>/sessions</c> aggregation stamps the shared message onto <c>SessionDto.VoiceUnavailable</c>
     /// from this so the owning UI shows the consistent state.
     /// </summary>
-    public HostedAiState? VoiceUnavailableFor(string sid)
-        => _voiceUnavailable.TryGetValue(sid, out var s) ? s : (HostedAiState?)null;
+    public HostedAiState? VoiceUnavailableFor(TenantId tenant, string sid)
+        => StateFor(tenant).Unavailable.TryGetValue(sid, out var s) ? s : (HostedAiState?)null;
 
     /// <summary>
     /// True when this session's latest turn has NO assistant text reply to read aloud - it is waiting for
@@ -265,15 +501,16 @@ public sealed class WingmanVoiceService
     /// when voice is turned off. The <c>/sessions</c> aggregation feeds this to <see cref="VoiceDisplayFold"/>
     /// so the screen shows an honest "nothing to read aloud" instead of a Generate button that cannot work.
     /// </summary>
-    public bool NothingToNarrateFor(string sid) => _nothingToNarrate.ContainsKey(sid);
+    public bool NothingToNarrateFor(TenantId tenant, string sid) => StateFor(tenant).NothingToNarrate.ContainsKey(sid);
 
     /// <summary>Set or clear the "nothing to narrate" fact from a caller that has already read the turn
     /// (the on-demand explain path): true when the last reply is empty (waiting on a prompt), false the
     /// moment a text reply exists. The auto path sets/clears it inline in <c>GenerateOnceAsync</c>.</summary>
-    public void SetNothingToNarrate(string sid, bool nothing)
+    public void SetNothingToNarrate(TenantId tenant, string sid, bool nothing)
     {
-        if (nothing) _nothingToNarrate[sid] = 1;
-        else _nothingToNarrate.TryRemove(sid, out _);
+        var state = StateFor(tenant);
+        if (nothing) state.NothingToNarrate[sid] = 1;
+        else state.NothingToNarrate.TryRemove(sid, out _);
     }
 
     /// <summary>
@@ -284,7 +521,7 @@ public sealed class WingmanVoiceService
     /// successful generation, on the Working transition, and when voice is turned off - exactly like the
     /// speech-leg unavailable state.
     /// </summary>
-    public void NoteRetrying(string sid) => _voiceUnavailable[sid] = HostedAiState.Retrying;
+    public void NoteRetrying(TenantId tenant, string sid) => StateFor(tenant).Unavailable[sid] = HostedAiState.Retrying;
 
     /// <summary>
     /// True when an exception from the model (translation) leg means it DID NOT ANSWER - a bounded
@@ -308,13 +545,13 @@ public sealed class WingmanVoiceService
     internal Task CaptureTrainingAsync(SessionVerbClient route, string sid, string source, string reply, string recentContext, string spoken, double replySeconds, CancellationToken ct = default)
         => _training.CaptureAsync(route, sid, source, reply, recentContext, spoken, replySeconds, ct);
 
-    public VoiceReady? Get(string sid) => _ready.TryGetValue(sid, out var v) ? v : null;
-    public byte[]? GetAudio(string sid) => _ready.TryGetValue(sid, out var v) ? v.Audio : null;
-    public string? GetAudioContentType(string sid) => _ready.TryGetValue(sid, out var v) ? v.ContentType : null;
+    public VoiceReady? Get(TenantId tenant, string sid) => StateFor(tenant).Ready.TryGetValue(sid, out var v) ? v : null;
+    public byte[]? GetAudio(TenantId tenant, string sid) => StateFor(tenant).Ready.TryGetValue(sid, out var v) ? v.Audio : null;
+    public string? GetAudioContentType(TenantId tenant, string sid) => StateFor(tenant).Ready.TryGetValue(sid, out var v) ? v.ContentType : null;
 
     /// <summary>Mark the session as a voice session (persisted, so the gateway keeps its voice fresh
     /// across restarts via the background sweep + turn-end).</summary>
-    public void Mark(string sid) { if (_voiceSessions.TryAdd(sid, 1)) SaveVoiceSessions(); }
+    public void Mark(TenantId tenant, string sid) { if (StateFor(tenant).VoiceSessions.TryAdd(sid, 1)) SaveVoiceSessions(tenant); }
 
     /// <summary>
     /// Stop keeping voice for this session - it is no longer a voice session (issue #859). The user
@@ -327,18 +564,19 @@ public sealed class WingmanVoiceService
     /// voice session. Read-only: this changes only gateway-side voice marking; it sends nothing into
     /// the session. Re-entering voice (the explain path calls <see cref="Mark"/>) starts it again.
     /// </summary>
-    public void Unmark(string sid)
+    public void Unmark(TenantId tenant, string sid)
     {
-        var wasVoice = _voiceSessions.TryRemove(sid, out _);
-        if (wasVoice) SaveVoiceSessions();
-        _generating.TryRemove(sid, out _);
-        _voiceUnavailable.TryRemove(sid, out _);   // voice is off, so its unavailable-state is moot (issue #939)
-        _nothingToNarrate.TryRemove(sid, out _);   // voice is off, so "nothing to narrate" is moot too
-        _preferBackupUntil.TryRemove(sid, out _);  // voice is off, so the backup-routing window is moot too (issue devthrottle_internal#405)
-        if (_ready.TryRemove(sid, out _))
-            DeleteReadyAudio(sid);   // keep the durable cache in step so a stale tap can't 404
+        var state = StateFor(tenant);
+        var wasVoice = state.VoiceSessions.TryRemove(sid, out _);
+        if (wasVoice) SaveVoiceSessions(tenant);
+        state.Generating.TryRemove(sid, out _);
+        state.Unavailable.TryRemove(sid, out _);        // voice is off, so its unavailable-state is moot (issue #939)
+        state.NothingToNarrate.TryRemove(sid, out _);   // voice is off, so "nothing to narrate" is moot too
+        state.PreferBackupUntil.TryRemove(sid, out _);  // voice is off, so the backup-routing window is moot too (issue devthrottle_internal#405)
+        if (state.Ready.TryRemove(sid, out _))
+            DeleteReadyAudio(tenant, sid);   // keep the durable cache in step so a stale tap can't 404
         if (wasVoice)
-            FileLog.Write($"[WingmanVoiceService] voice unmarked (turned off): sid={sid}");
+            FileLog.Write($"[WingmanVoiceService] voice unmarked (turned off): tenant={tenant.ToLogString()} sid={sid}");
     }
 
     /// <summary>
@@ -347,17 +585,18 @@ public sealed class WingmanVoiceService
     /// served or played. The session stays a voice session, so when the turn finishes the turn-end
     /// hook regenerates a fresh summary. Called on the Working transition.
     /// </summary>
-    public void OnSessionWorking(string sid)
+    public void OnSessionWorking(TenantId tenant, string sid)
     {
+        var state = StateFor(tenant);
         // A new turn (blue) supersedes any in-flight generation for the old turn, so drop the
         // yellow "wingman running" marker too - raw activity wins while the agent works.
-        _generating.TryRemove(sid, out _);
-        _voiceUnavailable.TryRemove(sid, out _);   // a fresh turn clears the old unavailable-state (dismissible, issue #939)
-        _nothingToNarrate.TryRemove(sid, out _);   // a fresh turn supersedes "nothing to narrate" - re-evaluated on its turn-end
-        if (_ready.TryRemove(sid, out _))
+        state.Generating.TryRemove(sid, out _);
+        state.Unavailable.TryRemove(sid, out _);        // a fresh turn clears the old unavailable-state (dismissible, issue #939)
+        state.NothingToNarrate.TryRemove(sid, out _);   // a fresh turn supersedes "nothing to narrate" - re-evaluated on its turn-end
+        if (state.Ready.TryRemove(sid, out _))
         {
-            DeleteReadyAudio(sid);   // issue #553: keep the durable cache in step so a stale tap can't 404
-            FileLog.Write($"[WingmanVoiceService] voice + text cache cleared (session working): sid={sid}");
+            DeleteReadyAudio(tenant, sid);   // issue #553: keep the durable cache in step so a stale tap can't 404
+            FileLog.Write($"[WingmanVoiceService] voice + text cache cleared (session working): tenant={tenant.ToLogString()} sid={sid}");
         }
     }
 
@@ -366,26 +605,26 @@ public sealed class WingmanVoiceService
     /// paths), synthesize its audio, and mark the session as a voice session. Best-effort: if the
     /// audio can't be made (no key / outage) the session is still marked, so turn-end retries.
     /// </summary>
-    public async Task StoreSpokenAsync(string sid, string spoken, string reply, CancellationToken ct = default)
+    public async Task StoreSpokenAsync(TenantId tenant, string sid, string spoken, string reply, CancellationToken ct = default)
     {
-        Mark(sid);
+        Mark(tenant, sid);
         if (string.IsNullOrWhiteSpace(spoken)) return;
-        var tts = await TtsAsync(sid, spoken, ct);
+        var tts = await TtsAsync(tenant, sid, spoken, ct);
         // The "if anything fails, remove the triangle" rule: when synthesis returns null/empty we
-        // leave _ready WITHOUT this session, so HasVoice stays false and no triangle shows. Only a
+        // leave this tenant's Ready map WITHOUT this session, so HasVoice stays false and no triangle shows. Only a
         // real, playable summary becomes ready - and is persisted (issue #553) so it survives a restart.
         if (tts.Audio is { Length: > 0 })
         {
-            _voiceUnavailable.TryRemove(sid, out _);   // success clears any prior unavailable-state (dismissible)
-            StoreReady(sid, spoken, reply ?? "", tts.Audio, tts.ContentType, tts.ServedViaFallback);
+            StateFor(tenant).Unavailable.TryRemove(sid, out _);   // success clears any prior unavailable-state (dismissible)
+            StoreReady(tenant, sid, spoken, reply ?? "", tts.Audio, tts.ContentType, tts.ServedViaFallback);
         }
-        else if (tts.Unavailable is HostedAiState state)
+        else if (tts.Unavailable is HostedAiState unavailable)
         {
             // Issue #939: no longer swallowed. Record WHY voice is unavailable so the /sessions
             // aggregation can show the consistent add-credit / add-key state instead of a silently
             // missing triangle. Left as-is until the next successful turn-end generation clears it.
-            _voiceUnavailable[sid] = state;
-            FileLog.Write($"[WingmanVoiceService] voice unavailable sid={sid}: {state}");
+            StateFor(tenant).Unavailable[sid] = unavailable;
+            FileLog.Write($"[WingmanVoiceService] voice unavailable tenant={tenant.ToLogString()} sid={sid}: {unavailable}");
         }
     }
 
@@ -393,20 +632,21 @@ public sealed class WingmanVoiceService
     /// persist it to disk so it survives a gateway restart (issue #553). The single place the success
     /// branch lives - the test seam (<see cref="StoreReadyAudioForTest"/>) reuses it so persistence is
     /// exercised without a live provider call.</summary>
-    private void StoreReady(string sid, string spoken, string reply, byte[] audio, string? contentType, bool servedViaFallback = false)
+    private void StoreReady(TenantId tenant, string sid, string spoken, string reply, byte[] audio, string? contentType, bool servedViaFallback = false)
     {
         var ready = new VoiceReady(spoken, reply, audio, DateTime.UtcNow,
             NormalizeContentType(contentType) ?? DetectAudioContentType(audio), servedViaFallback);
-        _ready[sid] = ready;
-        _nothingToNarrate.TryRemove(sid, out _);   // audio exists, so there was something to narrate after all
-        SaveReadyAudio(sid, ready);
+        var state = StateFor(tenant);
+        state.Ready[sid] = ready;
+        state.NothingToNarrate.TryRemove(sid, out _);   // audio exists, so there was something to narrate after all
+        SaveReadyAudio(tenant, sid, ready);
     }
 
     /// <summary>Test seam: store ready audio exactly as a successful synthesis would (in-memory +
     /// durable), so the persistence round-trip can be tested without calling a provider. The optional
     /// <paramref name="servedViaFallback"/> lets a test store a backup-served clip and assert the notice.</summary>
-    internal void StoreReadyAudioForTest(string sid, string spoken, string reply, byte[] audio, string? contentType = null, bool servedViaFallback = false)
-        => StoreReady(sid, spoken, reply, audio, contentType, servedViaFallback);
+    internal void StoreReadyAudioForTest(TenantId tenant, string sid, string spoken, string reply, byte[] audio, string? contentType = null, bool servedViaFallback = false)
+        => StoreReady(tenant, sid, spoken, reply, audio, contentType, servedViaFallback);
 
     /// <summary>
     /// Regenerate the voice for a session from its latest turn: read the last reply, translate it,
@@ -425,9 +665,9 @@ public sealed class WingmanVoiceService
     /// boundary): show the yellow "wingman reading" hold until the summary lands. False for a
     /// background refresh, a startup catch-up, or an idle pre-build sweep: generate silently so a
     /// session a client is already listening to is never flipped yellow.</param>
-    internal async Task GenerateAsync(string sid, SessionVerbClient route, CancellationToken ct = default, bool showReadingWindow = true)
+    internal async Task GenerateAsync(TenantId tenant, string sid, SessionVerbClient route, CancellationToken ct = default, bool showReadingWindow = true)
     {
-        Mark(sid);
+        Mark(tenant, sid);
 
         // The "already narrated" skip is now IDENTITY-AWARE and lives in GenerateOnceAsync, after the
         // current reply has actually been read (issue #1322 done right). The old guard here was a bare
@@ -450,11 +690,12 @@ public sealed class WingmanVoiceService
         //
         // Coalesce: never run two generations for the SAME session at once (a slow turn overlapping the
         // idle sweep would otherwise double the spend). First caller wins.
-        if (!_inFlight.TryAdd(sid, 1))
+        var state = StateFor(tenant);
+        if (!state.InFlight.TryAdd(sid, 1))
             return;
         try
         {
-            await GenerateOnceAsync(sid, route, ct, showReadingWindow);
+            await GenerateOnceAsync(tenant, sid, route, ct, showReadingWindow);
         }
         catch (WingmanModelRateLimitedException rl)
         {
@@ -462,14 +703,14 @@ public sealed class WingmanVoiceService
             // audio this cycle and retries on its own next turn-end / idle sweep. Record Retrying so its
             // OWN UI says "voice on its way", exactly as the model-leg timeout path does - and it never
             // reaches across to another session (that coupling was the gate we removed).
-            _voiceUnavailable[sid] = HostedAiState.Retrying;
+            state.Unavailable[sid] = HostedAiState.Retrying;
             FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} rate limited (429){(rl.RetryAfter is { } ra ? $" (Retry-After {ra.TotalSeconds:F0}s)" : "")}; no audio this cycle, this session retries on its own");
         }
         catch (Exception ex)
         {
             FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} FAILED: {ex.Message}");
         }
-        finally { _inFlight.TryRemove(sid, out _); }
+        finally { state.InFlight.TryRemove(sid, out _); }
     }
 
     /// <summary>
@@ -483,8 +724,9 @@ public sealed class WingmanVoiceService
     /// no longer needs the distinction now that the shared rate-limit gate is gone, but it is kept because
     /// it honestly reports whether the provider was reached.
     /// </summary>
-    private async Task<bool> GenerateOnceAsync(string sid, SessionVerbClient route, CancellationToken ct, bool showReadingWindow)
+    private async Task<bool> GenerateOnceAsync(TenantId tenant, string sid, SessionVerbClient route, CancellationToken ct, bool showReadingWindow)
     {
+        var state = StateFor(tenant);
         var turns = await route.GetTurnsAsync(sid, ct);
         var widgets = turns?.Widgets ?? new List<TurnWidgetDto>();
         var lastReply = widgets.LastOrDefault(w => w.Kind == "Text")?.Content;
@@ -493,16 +735,16 @@ public sealed class WingmanVoiceService
             // No text reply to read aloud - the session is waiting on a prompt / menu. Record the honest
             // "nothing to narrate" fact so the Voice screen (via VoiceDisplayFold) says so, instead of
             // offering a Generate button that would re-run this same empty read and never produce audio.
-            _nothingToNarrate[sid] = 1;
+            state.NothingToNarrate[sid] = 1;
             return false;  // nothing to say yet - the provider was not called
         }
-        _nothingToNarrate.TryRemove(sid, out _);   // there IS a text reply now - clear any stale "nothing to narrate"
+        state.NothingToNarrate.TryRemove(sid, out _);   // there IS a text reply now - clear any stale "nothing to narrate"
         // Identity-aware skip (issue #1322 done right): only skip when the CURRENT last reply is the
         // exact one already narrated. Unlike the old bare HasVoice guard this does not depend on having
         // observed the Working transition, so a genuinely new/changed reply is never suppressed by a
         // stale cache the missed edge left behind - while the same reply stays quiet (no re-mint, no
         // yellow flip), preserving the "never disturb a listener mid-play" guarantee.
-        if (!ShouldRegenerate(sid, lastReply))
+        if (!ShouldRegenerate(tenant, sid, lastReply))
         {
             FileLog.Write($"[WingmanVoiceService] GenerateOnce skip (same reply already narrated): sid={sid}");
             return false;   // nothing to do - the provider was not called, so we know nothing new about it
@@ -512,7 +754,7 @@ public sealed class WingmanVoiceService
         // The wingman is now running for this session - show it yellow until the summary lands, but
         // only for a brand-new turn. A background refresh / catch-up stays quiet so a session a phone
         // may be listening to is never flipped yellow mid-play (issue #1322).
-        if (showReadingWindow) BeginGenerating(sid);
+        if (showReadingWindow) BeginGenerating(tenant, sid);
         try
         {
             WingmanTranslation t;
@@ -531,16 +773,16 @@ public sealed class WingmanVoiceService
                 // A rate-limit (WingmanModelRateLimitedException) is NOT caught here - it stays thrown so
                 // GenerateAsync's handler records THIS session's Retrying state (it does not reach any
                 // other session; the shared cooldown that used to do so is gone).
-                _voiceUnavailable[sid] = HostedAiState.Retrying;
+                state.Unavailable[sid] = HostedAiState.Retrying;
                 FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - Retrying (audio on its way); the session retries on its own");
                 return false;   // nothing produced; the provider was not usefully reached
             }
-            await StoreSpokenAsync(sid, t.Spoken, lastReply, ct);
+            await StoreSpokenAsync(tenant, sid, t.Spoken, lastReply, ct);
             // Log the TRUE outcome: StoreSpokenAsync only makes the session playable when the
             // text-to-speech synthesis actually returned audio. Logging "voice ready"
             // unconditionally (the old behavior) hid every failed synthesis behind a success
             // line, which made a text-to-speech outage look like it was working in the log.
-            if (HasVoice(sid))
+            if (HasVoice(tenant, sid))
                 FileLog.Write($"[WingmanVoiceService] voice ready: sid={sid}, spokenLen={t.Spoken.Length}");
             else
                 FileLog.Write($"[WingmanVoiceService] voice NOT ready (text-to-speech produced no audio): sid={sid}, spokenLen={t.Spoken.Length}");
@@ -552,7 +794,7 @@ public sealed class WingmanVoiceService
             // provider was reached (no caller acts on it now that the shared gate is gone).
             return true;
         }
-        finally { if (showReadingWindow) EndGenerating(sid); }
+        finally { if (showReadingWindow) EndGenerating(tenant, sid); }
     }
 
     /// <summary>
@@ -569,14 +811,14 @@ public sealed class WingmanVoiceService
 
     /// <summary>True while this session should route past a silent primary straight to the backup
     /// (the window armed by a recent hang has not yet expired).</summary>
-    private bool PrefersBackup(string sid)
-        => _preferBackupUntil.TryGetValue(sid, out var until) && until > DateTime.UtcNow;
+    private bool PrefersBackup(TenantId tenant, string sid)
+        => StateFor(tenant).PreferBackupUntil.TryGetValue(sid, out var until) && until > DateTime.UtcNow;
 
     /// <summary>Arm the "route to the backup" window for this session after the primary went silent.
     /// Overwrites any existing deadline (a fresh hang restarts the full window).</summary>
-    private void ArmPreferBackup(string sid)
+    private void ArmPreferBackup(TenantId tenant, string sid)
     {
-        _preferBackupUntil[sid] = DateTime.UtcNow + PreferBackupWindow;
+        StateFor(tenant).PreferBackupUntil[sid] = DateTime.UtcNow + PreferBackupWindow;
         FileLog.Write($"[WingmanVoiceService] primary voice provider went silent on sid={sid}; " +
                       $"routing this session to the backup provider for {PreferBackupWindow.TotalMinutes:0} min (issue devthrottle_internal#405)");
     }
@@ -590,7 +832,7 @@ public sealed class WingmanVoiceService
     /// condition is returned as a typed <see cref="HostedAiState"/> instead of a silent null, so the
     /// caller can surface the consistent unavailable state.
     /// </summary>
-    private async Task<TtsResult> TtsAsync(string sid, string text, CancellationToken ct)
+    private async Task<TtsResult> TtsAsync(TenantId tenant, string sid, string text, CancellationToken ct)
     {
         var mode = TranscriptionModeConfig.Get();
         var tts = TranscriptionEndpointResolver.ResolveTts(mode);
@@ -624,7 +866,7 @@ public sealed class WingmanVoiceService
         // If this session recently saw the primary go silent, ask the proxy to skip it and serve from the
         // backup (issue devthrottle_internal#405). A hang is invisible to the proxy's own failover, so this is how a hang
         // becomes a failover: the Gateway saw it, the proxy did not. The window expires on its own.
-        var preferBackup = PrefersBackup(sid);
+        var preferBackup = PrefersBackup(tenant, sid);
         // Time the whole synthesis call (request sent -> response in hand), so how long a narration
         // actually took is in the log next to transcription's transcribeMs. A healthy call is a second
         // or two; the per-attempt deadline caps it at <=108s, so any elapsedMs over ~108s means the
@@ -707,7 +949,7 @@ public sealed class WingmanVoiceService
             // idle-sweep retry (issue devthrottle_internal#405, Option B). A transport failure (HttpRequestException) is a
             // DIFFERENT fault - the proxy itself was unreachable, which does not implicate the primary -
             // so it does not arm the backup route.
-            if (ex is TimeoutException) ArmPreferBackup(sid);
+            if (ex is TimeoutException) ArmPreferBackup(tenant, sid);
             return new TtsResult(null, null, HostedAiState.Retrying);
         }
         // NOTE: no `finally { http.Dispose(); }`. `http` is now either the caller's injected client or


### PR DESCRIPTION
Partitions the voice STATE per tenant. Cut from `origin/main`, rebased onto lock-bearing main (`e1b8825c`, carrying #1918, #1916 and v1.6.0). Final head `4c2a8ebc`.

## What is partitioned

The voice state held one account's spoken narration, the reply text it was made from, and the audio clip itself, all keyed by bare session id in process-global dictionaries and one shared folder. On the hosted Gateway that is customer content reachable by whoever names the session id.

- **`WingmanVoiceService`** - one bucket of per-session dictionaries per tenant, plus one DIRECTORY per tenant on disk (`tenants/<id>/voice-sessions.json`, `tenants/<id>/voice-audio/`).
- **`VoiceTurnArchive`** - the same per-tenant directory for turn transcripts, summaries and reply audio.
- **`GatewayTurnJobStore`** - a per-tenant pair of dictionaries. Knowing an unguessable turn id is not owning the turn.

Every public read and mutate takes `TenantId` as a **required first parameter** - not optional, not nullable, not defaulted, never falling back to the local tenant. An unresolved tenant is refused, and a test passes `default` and asserts it throws. The tenant id is canonicalized before becoming a bucket key or path component; a shape this system does not mint - traversal, case variant, the reserved system identity - is refused rather than normalised.

**No entity model changed, so there is no migration in this pull request.**

## Legacy migration, asymmetric by deployment mode

Pre-partition state carries no tenant, so the mode is read from `GatewayHostedMode.IsHosted` **directly**, never from an argument a caller could omit - an optional argument fails open into "keep it".

- **Hosted: DELETE.** A clip whose owner cannot be established must not be handed to a guess. A cached narration is regenerable; a mis-attributed one is a disclosure.
- **Self-host: MOVE into the local partition.** One tenant, so attribution is unambiguous.

## Revert proof: four separate runs, one primitive each

### Why not one combined run

The first attempt mutated all four boundaries together and produced a tidy table attributing each red to a primitive. **That table was not sound, and one row proved it:** `Clips_reload_into_the_tenant_that_owned_them` had to be listed as "B1+B2", because a run with everything mutated cannot say which mutation caused any given red. Once one red is unassignable the rest is inference too.

Separated, three of the four arms turned out **mis-attributed** and one turned out right.

> That arm happened to be right - but it was right by luck, and I had no way to know which arms were lucky until each was run alone.

Being right by luck is indistinguishable from being right by evidence, from the inside. A method that is correct on an unknown subset is not a method.

**And it could not have been argued instead of run:** `VoiceTurnArchive` and `WingmanVoiceService` **both** expose a method called `PartitionDirectoryFor`. Under a combined mutation a red in either could be attributed to "the directory primitive" with a completely straight face - the names agree, the story is coherent - and it would be wrong half the time.

### Results

Each arm preceded by a build confirmed succeeded, and by a harness check that **exactly one** production file differed from pristine (it aborts otherwise - a mechanism, not care, closing the stale-edit hole).

Restored baseline at final head: **2979 total, 2969 passed, 0 failed, 10 skipped.**

| Primitive mutated alone | Passed | Failed | Reconciliation | Crashes |
|---|---|---|---|---|
| **B1** `WingmanVoiceService.StateFor` (bucket) | 2960 | 9 | 2960+9=2969 OK | 0 |
| **B2** `WingmanVoiceService.PartitionDirectoryFor` (dir) | 2962 | 7 | 2962+7=2969 OK | 0 |
| **B3** `VoiceTurnArchive.PartitionDirectoryFor` (dir) | 2967 | 2 | 2967+2=2969 OK | 0 |
| **B4** `GatewayTurnJobStore.StateFor` (bucket) | 2968 | 1 | 2968+1=2969 OK | 0 |

**Four independent reconciliations, four chances to catch a dropped test, none dropped. Nineteen reds, every one an ASSERTION - not a single crash in any arm.**

### The sensitivity matrix

The durable copy lives in the `WingmanVoiceTenantPartitionTests` class doc, not only here: a pull request is read once by people who already have the context; that comment is read by whoever is standing there next, who has none.

| Test | B1 | B2 | B3 | B4 |
|---|---|---|---|---|
| `Ready_audio_stored_for_one_tenant_is_invisible_to_another` | RED | green | green | green |
| `Voice_session_marking_is_per_tenant` | RED | green | green | green |
| `Generating_unavailable_and_nothing_to_narrate_are_per_tenant` | RED | green | green | green |
| `Served_via_fallback_is_per_tenant` | RED | green | green | green |
| `Clearing_one_tenants_session_leaves_..._intact` | RED | green | green | green |
| `Regeneration_decision_reads_only_the_asking_tenants_cached_reply` | RED | green | green | green |
| `Each_tenants_clips_live_in_its_own_directory` | green | RED | green | green |
| `Clips_reload_into_the_tenant_that_owned_them` | RED | RED | green | green |
| `Voice_session_set_reloads_into_the_tenant_that_owned_it` | RED | RED | green | green |
| `Self_host_moves_the_pre_partition_voice_state_into_the_local_partition` | RED | RED | green | green |
| `Turn_archive_is_partitioned_and_a_turn_id_alone_does_not_read_it` | green | green | RED | green |
| `Self_host_moves_pre_partition_archived_turns_into_the_local_partition` | green | green | RED | green |
| `Turn_job_store_is_partitioned_and_a_turn_id_alone_does_not_read_it` | green | green | green | RED |
| `WingmanVoiceServiceTests.ReadyAudio_PersistsAndReloadsAcrossRestart` | green | RED | green | green |
| `WingmanVoiceServiceTests.ReadyAudio_ReloadsLegacyWavCacheWithDetectedContentType` | green | RED | green | green |
| `WingmanVoiceFallbackTests.ServedViaFallback_SurvivesAGatewayRestart` | green | RED | green | green |

Every cell is OBSERVED, with exactly one meaning: `RED` = reddened as an assertion (proof), `EXCL` = reddened as a crash (excluded, never proof), `green` = ran and passed, `NOTRUN` = no outcome line (evidence of nothing). **There is no EXCL cell and no NOTRUN cell.**

Every row has at least one RED, so no test here is decorative. B3 and B4 are perfectly isolated, which is what proves the archive and job store are guarded **separately** rather than incidentally.

### Pre-registered prediction, confirmed

Committed at 20:54:47 (`8c853a54`) with the B1 run verified still executing, so it cannot have been written afterwards. Predicted: the three pre-existing tests are sensitive to the **directory**, not the **bucket**. Observed: B1 alone leaves all three green; B2 alone reddens all three.

**If you move the voice on-disk layout: three tests in two other classes go red, and none of them has "tenant" in the name.** That is the durable fact this exercise produced.

## Two rules this proof paid for

**Rule one - when comparing observations from different builds, compare properties that CANNOT shift.** I nearly proved the straddle from line numbers: bucket failed at 306, directory at 322, therefore different assertions. Invalid - I had added seventeen lines of *comment* between the builds, so 306 maps to ~323, within one line of 322. **A change with no behaviour whatsoever was enough to invert the conclusion.** What settles it is the assertion TYPE (`Assert.False` vs `Assert.True`), which cannot shift.

**Rule two - a claim of the form "X and not Y" is not supported by an experiment that only varied X.** After B1 I published "these two are bucket-sensitive and NOT directory-sensitive". B2 showed both. Worse than an ordinary wrong guess: it generalises from a single arm while the refuting arm is unrun, and arrives dressed as a finding rather than a hypothesis. The honest form after one arm is **"X is sufficient; whether Y also suffices is UNTESTED."**

Both are recorded in the test file, along with the two straddling tests: **isolation rides on the bucket, reload rides on the directory**, and the failure kind is how you tell.

## Anti-laundering, structural

Every canary asks its cross-tenant question **first**, before any control, with every dereference guarded by an explicit null assertion. A sibling pull request's rule - assert status and media type before parsing - does not literally apply here (no HTTP calls), but what it is *for* does: an operation that throws on unexpected shape makes an unstated assertion, and when it throws you learn only that something upstream broke. The filesystem form is asserting `File.Exists` before `ReadAllBytes`. That is why nineteen reds are nineteen assertions.

## Tests confirmed EXECUTED, by name

A green suite does not tell you your tests ran; it tells you nothing failed, and those differ exactly when a harness drops a class. All **20** declared `[Fact]`/`[Theory]` methods produced outcome lines in the restored run, listed individually. The three pre-existing tests and the retired `Enrolled_without_a_recorded_email` allowance were each confirmed passing by name.

## Test-harness defects found and fixed

**Isolation only as deep as the deepest derived path component.** The harness randomised the persist **filename** in the shared temp directory - correct while the file was the deepest thing derived from. Partitioning made the service derive its per-tenant root from that file's **parent**, so every instance collapsed onto one shared `tenants/local` and a clip written by one test was loaded by the next test's constructor. That is the continuous-integration failure in `StoreSpokenAsync_WithFailingTts_DoesNotMarkReady`. Each instance now gets a unique **directory**; four restart pairs keep a deliberately shared root, documented at each call site.

**A test passing by coincidence.** `ReadyAudio_ReloadsLegacyWavCacheWithDetectedContentType` seeded the pre-partition location and only kept passing because the migration moved the file before the load ran - silently exercising migration, not detection, and it would have passed with the partition deleted. It now seeds the location the service reads.

**An assertion true by arithmetic.** `Each_tenants_clips_live_in_its_own_directory` compared two paths the *test* had built from the tenant ids - true regardless of production code. It now reads both paths back from the production method, and it fires on the directory mutation.

## The suite lock (#1918), including its negative control

| Run | Queued | Acquired | Wait |
|---|---|---|---|
| B1 | 20:45:00 | 20:50:07 | 5m07s |
| B2 | 20:58:05 | 21:04:45 | 6m40s |
| B3 | 21:13:53 | 21:18:51 | 4m58s |
| B4 | - | 21:26:28 | **none** |
| restored | - | 21:35:59 | **none** |

Every wait named the holder precisely (`fix-1848-stats`, session `c584f16f`). The last two are the **negative control**: once that worktree finished, the lock stopped blocking. Seven observations show it blocks when it should; these show it does not block when it should not. A lock that always blocked would have produced seven identical-looking successes and been catastrophically wrong.

## Deliberately left for the route and sweep worker

The `/wingman/voice*` route handlers, `/wingman/voice/ready`, the narration sweep and turn-end refresh all still pass `TenantId.Local` - correct on self-host, empty on hosted, so they degrade to a no-op rather than a wrong-tenant read. Converting a route before its state is partitioned arms a cross-tenant audio path instead of closing one. The per-tenant form of the sweep is a loop over `PartitionedTenants()`.

## Test counts

| Project | Result |
|---|---|
| Gateway | 2979 total, **2969 passed**, 0 failed, 10 skipped |
| Core | 3306 passed, 8 skipped |
| Engine | 62 passed |
| HostedAgent | 86 passed |
| Launcher | 27 passed |
| Avalonia | 247 passed |
| Terminal.Avalonia | 21 passed |
