### PR TITLE
fix(tests): stop HostedAccountStatusTests sharing an account subject with other suites (#1911)

### DIFF
--- a/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
@@ -51,6 +51,19 @@ public sealed class HostedAccountStatusTests : IAsyncLifetime
 {
     private const string Token = "test-token";
 
+    // Account subjects UNIQUE to this class. They used to be the shared literals "sub-alice" and
+    // "sub-bob", which several other Gateway test classes also mint - and at least one of them
+    // (PromptLogTenantIsolationTests) mints "sub-bob" WITH an email. MintOrLookupBySubject records
+    // an email on a FRESH MINT ONLY and returns the existing tenant otherwise, so whichever class
+    // ran first decided whether this class's no-email caller actually had an email. That made
+    // Enrolled_without_a_recorded_email... pass or fail purely on test ORDER (issue #1911): green
+    // alone, red in a full suite run, and red or green at random in continuous integration.
+    //
+    // A per-instance subject cannot collide with any other class, present or future. The point of
+    // this fixture is a tenant with NO email, so it must own the identity that carries that fact.
+    private readonly string _subjectWithEmail = "sub-alice-" + Guid.NewGuid().ToString("N");
+    private readonly string _subjectNoEmail = "sub-bob-" + Guid.NewGuid().ToString("N");
+
     private GatewayHost _gateway = null!;
     private HttpClient _http = null!;
 
@@ -82,14 +95,14 @@ public sealed class HostedAccountStatusTests : IAsyncLifetime
 
         // Minted through the REAL registry, exactly as POST /devices/enroll-hosted does it, so the tenant
         // these keys are bound to is a genuine tenant row rather than a string invented by the test.
-        var withEmail = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
-        var noEmail = _gateway.TenantRegistry.MintOrLookupBySubject("sub-bob", null);
+        var withEmail = _gateway.TenantRegistry.MintOrLookupBySubject(_subjectWithEmail, "alice@example.com");
+        var noEmail = _gateway.TenantRegistry.MintOrLookupBySubject(_subjectNoEmail, null);
 
         _keyWithEmail = _gateway.Devices.Register("dev-alice", "MA").DeviceKey;
         _keyNoEmail = _gateway.Devices.Register("dev-bob", "MB").DeviceKey;
         _keyUnbound = _gateway.Devices.Register("dev-x", "MX").DeviceKey;
-        _gateway.Devices.SetAccountBinding("dev-alice", "sub-alice", withEmail.Value);
-        _gateway.Devices.SetAccountBinding("dev-bob", "sub-bob", noEmail.Value);
+        _gateway.Devices.SetAccountBinding("dev-alice", _subjectWithEmail, withEmail.Value);
+        _gateway.Devices.SetAccountBinding("dev-bob", _subjectNoEmail, noEmail.Value);
     }
 
     public async Task DisposeAsync()


### PR DESCRIPTION
Closes #1911.

`Enrolled_without_a_recorded_email_is_signed_in_with_the_identity_absent` passed alone and failed in a full run, and failed **twice in a row in continuous integration on a pull request that changed one line of a version string**. It looked flaky. It is not.

## The cause

The fixture minted the tenant subjects `"sub-alice"` and `"sub-bob"`. Those exact literals are minted by several other Gateway test classes, and `PromptLogTenantIsolationTests` mints `"sub-bob"` **with** `bob@example.com`.

`TenantRegistry.MintOrLookupBySubject` records an email on a **fresh mint only** and otherwise returns the existing tenant, ignoring the email argument - which is correct behaviour and is documented on the method. So whichever class ran first decided whether this class's deliberately-no-email caller actually had an email. When the other class won, the endpoint correctly reported an email, and the assertion that the field is *omitted* failed.

**The test was red about a product that was behaving properly.**

## The fix

The fixture now owns per-instance subjects (`sub-bob-&lt;guid&gt;`) that cannot collide with any other class, present or future. Fixing the consumer rather than the other tests is deliberate: this fixture's whole purpose is a tenant carrying no email, so it must own the identity that carries that fact instead of borrowing a shared literal. Any future test that mints `sub-bob` is now harmless.

## Reproduced deterministically, not re-run until green

| Combination | Before | After |
|---|---|---|
| `HostedAccountStatusTests` + `PromptLogTenantIsolationTests` | **1 failed**, 10 passed - the exact continuous-integration failure, in ~5 s | **11 passed** |
| `HostedAccountStatusTests` + `HostedTenancyActivationTests` | 12 passed (that class mints its own tenants first, so the collision does not bite) | 12 passed |
| `HostedAccountStatusTests` alone | 6 passed | 6 passed |

## Why it was worth stopping for

It sat in the path of **every merge and every release** and it blocked the v1.6.0 release cut. A required check that fails at random teaches everyone to press re-run without reading it - and the one time it is telling the truth, it gets re-run too.

I re-ran it once before diagnosing it, and it failed again; that second failure is what made me stop calling it flaky and go and read it.

## Scope

**Test-only.** No product code is touched, and the behaviour the test describes was correct throughout. This is in the hosted tenancy area another mission owns - flagging that plainly, since I changed one of its test files to unblock the release.