### PR TITLE
test(gateway): serialize Gateway test runs machine-wide, automatically

### DIFF
--- a/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
@@ -56,6 +56,23 @@ namespace CcDirector.Gateway.Tests;
 /// They exist so a blocked run can name its blocker - a blocked run that cannot say who is blocking it is
 /// indistinguishable from a hang, and somebody will kill the wrong thing. They never decide ownership.
 ///
+/// THE GUARANTEE IS PER-USER-PER-MACHINE. Not machine-wide - say it precisely, because someone will
+/// eventually rely on the words. Two runs by the SAME operating-system user on the SAME machine cannot
+/// overlap. Two runs by DIFFERENT users on one machine are NOT serialized by this, and on Windows they
+/// cannot be, because the lock lives under the per-user local application data directory.
+///
+/// That scope was chosen, not overlooked. Every process that actually contends here runs as the same user:
+/// each agent is a subprocess of a session running under that account, and that was verified rather than
+/// assumed. A machine-shared home would have to sit somewhere writable by every account, which brings
+/// permission and cleanup failures of its own - and those failures are themselves wedge risks, which is the
+/// exact class of problem this mechanism exists to remove. Buying protection against a collision we do not
+/// have, at the cost of new ways to jam, is a bad trade.
+///
+/// REVISIT THIS if a second operating-system user ever runs this suite on one machine - a service account,
+/// a continuous-integration agent alongside an interactive login, a second person on a shared box. At that
+/// point the scope is genuinely too narrow and the home must move somewhere shared, with the permission
+/// model worked out deliberately. Until then, this is the observed contention boundary.
+///
 /// EVERY RUN OF THIS ASSEMBLY IS SERIALIZED, FILTERED OR NOT. That is a feature, not an oversight, and it
 /// is the first thing somebody will try to "optimise" - a filtered run looks small and harmless, so surely
 /// it can be let through. It cannot, because nobody can show that it is harmless. A filtered run of this
@@ -107,10 +124,41 @@ internal static class GatewayTestSuiteLock
     private const string LockFileName = "gateway-test-suite.lock";
 
     /// <summary>The lock file every run of this assembly contends for.</summary>
-    internal static string LockFilePath { get; } = ComputeLockFilePath();
+    internal static string LockFilePath { get; } = ComputeLockFilePath(ReadAmbient());
 
     /// <summary>
-    /// Derives the lock path from a location the PROCESS ENVIRONMENT CANNOT MOVE.
+    /// Everything the lock path could conceivably be derived from, captured as VALUES.
+    ///
+    /// The temporary-directory variables are carried here despite the derivation never using them, and that
+    /// is the point: it lets a test hand over a hostile environment and assert the answer does not move.
+    /// A property proved by passing arguments needs no global state mutated to prove it.
+    /// </summary>
+    internal readonly record struct AmbientEnvironment(
+        string? Temp,
+        string? Tmp,
+        string? TmpDir,
+        string? LocalAppDataVariable,
+        string LocalApplicationDataFolder,
+        string UserName,
+        bool IsWindows);
+
+    /// <summary>
+    /// The ONE place that touches process-global state. Everything downstream is a pure function of what
+    /// this returns, so nothing else in the lock can be perturbed by whatever else is running in the process.
+    /// </summary>
+    internal static AmbientEnvironment ReadAmbient() => new(
+        Temp: Environment.GetEnvironmentVariable("TEMP"),
+        Tmp: Environment.GetEnvironmentVariable("TMP"),
+        TmpDir: Environment.GetEnvironmentVariable("TMPDIR"),
+        LocalAppDataVariable: Environment.GetEnvironmentVariable("LOCALAPPDATA"),
+        LocalApplicationDataFolder: Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify),
+        UserName: Environment.UserName,
+        IsWindows: OperatingSystem.IsWindows());
+
+    /// <summary>
+    /// Derives the lock path from a location the PROCESS ENVIRONMENT CANNOT MOVE. A pure function of its
+    /// argument - it reads no ambient state, which is what makes the claim testable rather than assertable.
     ///
     /// This is the difference between a lock and a decoration, and it was got wrong first time round. The
     /// original used <see cref="Path.GetTempPath"/>, which reads TEMP and TMP from the environment. Two runs
@@ -123,33 +171,41 @@ internal static class GatewayTestSuiteLock
     /// The rule this now follows: a lock's identity may depend on the MACHINE and the USER, never on
     /// anything the caller can set. On Windows the shell folder API supplies the per-user local application
     /// data directory from the user profile, and ignores the LOCALAPPDATA environment variable even when it
-    /// is overridden - measured, not assumed. Elsewhere the path is a literal, because
+    /// is overridden - measured, not assumed. Elsewhere the path is a fixed literal, because
     /// <see cref="Path.GetTempPath"/> reads TMPDIR and the folder API reads XDG_DATA_HOME and HOME; the user
-    /// name goes in the file name instead, since a shared directory needs the per-user split somewhere.
+    /// name goes into the file name instead, since a shared directory needs the per-user split somewhere.
     ///
-    /// <see cref="GatewayTestSuiteLockTests"/> pins this by mutating TEMP, TMP and TMPDIR and asserting the
-    /// derived path does not move - so the regression is caught on whatever platform the tests run on,
-    /// including ones not available to whoever wrote this.
+    /// Because the platform is an INPUT rather than something read from the running process,
+    /// <see cref="GatewayTestSuiteLockTests"/> exercises BOTH branches on either platform - so the Unix
+    /// branch is covered by a Windows developer's run, and not left to be discovered by continuous
+    /// integration on a machine that developer never sees.
     /// </summary>
-    internal static string ComputeLockFilePath()
+    internal static string ComputeLockFilePath(AmbientEnvironment ambient)
     {
-        if (!OperatingSystem.IsWindows())
-            return Path.Combine("/tmp", "cc-director-" + Environment.UserName + "-" + LockFileName);
+        if (!ambient.IsWindows)
+        {
+            // Built by hand rather than with Path.Combine, which would join with a backslash when this
+            // branch is evaluated on Windows and produce a path no Unix machine would ever resolve. The
+            // separator belongs to the TARGET platform, not the running one.
+            return "/tmp/cc-director-" + ambient.UserName + "-" + LockFileName;
+        }
 
-        var localAppData = Environment.GetFolderPath(
-            Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify);
-
-        if (string.IsNullOrWhiteSpace(localAppData))
+        if (string.IsNullOrWhiteSpace(ambient.LocalApplicationDataFolder))
         {
             // Nothing to fall back to that would still be a lock: every alternative is environment-settable,
             // which is the defect this method exists to close. Better to stop than to serialize nothing.
             throw new InvalidOperationException(
-                "Cannot locate the per-user local application data directory, so the machine-wide Gateway "
+                "Cannot locate the per-user local application data directory, so the per-user Gateway "
                 + "test lock has no environment-independent home. Running without it would let two Gateway "
                 + "test runs execute concurrently and corrupt each other. See GatewayTestSuiteLock.");
         }
 
-        return Path.Combine(localAppData, "cc-director", LockFileName);
+        // A clearly-namespaced subdirectory rather than sitting beside product state. The parent directory
+        // holds the owner's live fleet data - missions, cron jobs, the key vault - and something enumerating
+        // it should never have to wonder whether a stray ".lock" file is product data or test scaffolding.
+        // The name says what it is and who put it there.
+        return Path.Combine(
+            ambient.LocalApplicationDataFolder, "cc-director", "test-locks", LockFileName);
     }
 
     /// <summary>A copy of everything this run printed while acquiring, kept next to the lock so a human
@@ -182,7 +238,7 @@ internal static class GatewayTestSuiteLock
         {
             if (TryOpenExclusively())
             {
-                Say($"[gateway-test-lock] Acquired the machine-wide Gateway test lock. Starting the run. "
+                Say($"[gateway-test-lock] Acquired the per-user Gateway test lock. Starting the run. "
                     + $"Lock file: {LockFilePath}");
                 return;
             }
@@ -194,7 +250,7 @@ internal static class GatewayTestSuiteLock
                 announcedWait = true;
                 lastProgress = DateTime.UtcNow;
                 Say($"[gateway-test-lock] WAITING. Another run of CcDirector.Gateway.Tests holds the "
-                    + $"machine-wide test lock, and this suite is destroyed by concurrent runs, so this run "
+                    + $"per-user test lock, and this suite is destroyed by concurrent runs, so this run "
                     + $"is queued rather than started. THIS IS NOT A HANG. Holder: {Describe(holder)}. "
                     + $"Lock file: {LockFilePath}. When the holder's process ends the lock is released by "
                     + $"the operating system and this run starts on its own. If the holder is still alive "
@@ -210,7 +266,7 @@ internal static class GatewayTestSuiteLock
 
             if (DateTime.UtcNow - started >= MaxWait)
             {
-                Say($"[gateway-test-lock] *** REFUSING TO RUN. A live process has held the machine-wide "
+                Say($"[gateway-test-lock] *** REFUSING TO RUN. A live process has held the per-user "
                     + $"Gateway test lock for {MaxWait.TotalMinutes:0} minutes. NO TESTS WILL RUN. This run "
                     + $"stops instead of starting alongside it, because two concurrent runs of this suite "
                     + $"corrupt each other's results, and a run that quietly overlapped would report "
@@ -358,7 +414,7 @@ internal static class GatewayTestSuiteLock
     private static void FailSetup(string what, Exception? exception)
     {
         var detail = exception is null ? "" : $" Underlying failure: {exception.GetType().Name}: {exception.Message}.";
-        Say($"[gateway-test-lock] *** CANNOT SET UP THE MACHINE-WIDE GATEWAY TEST LOCK: {what}.{detail} "
+        Say($"[gateway-test-lock] *** CANNOT SET UP THE PER-USER GATEWAY TEST LOCK: {what}.{detail} "
             + "NO TESTS WILL RUN. This is NOT another run holding the lock - it is a fault in the lock's "
             + "location that will not clear by waiting, so this run stops immediately rather than blocking "
             + "and then blaming a holder that does not exist. Fix the path above and run again. ***");

--- a/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
@@ -276,18 +276,18 @@ internal static class GatewayTestSuiteLock
             + $"owner {session}, working directory {dir}";
     }
 
-    /// <summary>Identifies the run for a human reading a blocked run's error message.</summary>
+    /// <summary>
+    /// Identifies the run for a human reading a blocked run's error message. Every fleet-launched session
+    /// carries CC_SESSION_ID, which is the case that matters - it names a session somebody can go and talk
+    /// to. A run started outside the fleet has no session to name, and says so rather than inventing one;
+    /// the working directory recorded alongside this is what identifies those.
+    /// </summary>
     private static string SessionIdentifier()
     {
         var id = Environment.GetEnvironmentVariable("CC_SESSION_ID");
-        if (!string.IsNullOrWhiteSpace(id))
-            return "cc-director session " + id;
-
-        id = Environment.GetEnvironmentVariable("CLAUDE_CODE_SESSION_ID");
-        if (!string.IsNullOrWhiteSpace(id))
-            return "coding-agent session " + id;
-
-        return "(no session identifier in this run's environment)";
+        return string.IsNullOrWhiteSpace(id)
+            ? "(no session identifier in this run's environment - identify it by the working directory below)"
+            : "cc-director session " + id;
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
@@ -99,12 +99,58 @@ internal static class GatewayTestSuiteLock
     /// <summary>Exit code used when this run refuses to start because a live holder never let go.</summary>
     internal const int BlockedExitCode = 99;
 
-    /// <summary>The lock file every run of this assembly contends for, whatever working tree it was built
-    /// from. Under the temporary directory because that is the one location every account is guaranteed to
-    /// be able to write; note that on Windows this is per-user, so the lock serializes all runs by one user
-    /// account - which is the contention actually observed here.</summary>
-    internal static string LockFilePath { get; } =
-        Path.Combine(Path.GetTempPath(), "cc-director-gateway-test-suite.lock");
+    /// <summary>Exit code used when the lock location itself is unusable - a setup failure, not contention.</summary>
+    internal const int SetupFailureExitCode = 98;
+
+    /// <summary>The file name every run of this assembly contends for, whatever working tree it was built
+    /// from.</summary>
+    private const string LockFileName = "gateway-test-suite.lock";
+
+    /// <summary>The lock file every run of this assembly contends for.</summary>
+    internal static string LockFilePath { get; } = ComputeLockFilePath();
+
+    /// <summary>
+    /// Derives the lock path from a location the PROCESS ENVIRONMENT CANNOT MOVE.
+    ///
+    /// This is the difference between a lock and a decoration, and it was got wrong first time round. The
+    /// original used <see cref="Path.GetTempPath"/>, which reads TEMP and TMP from the environment. Two runs
+    /// launched with different TEMP values computed different lock files, so neither ever saw the other:
+    /// both printed "Acquired" in the same second and both ran concurrently. That was demonstrated, not
+    /// theorised. It is also the worst possible way to fail, because the environments most likely to differ
+    /// are precisely the ones this exists to serialize - different agents, different shells, different
+    /// working trees, a scheduled task against an interactive session.
+    ///
+    /// The rule this now follows: a lock's identity may depend on the MACHINE and the USER, never on
+    /// anything the caller can set. On Windows the shell folder API supplies the per-user local application
+    /// data directory from the user profile, and ignores the LOCALAPPDATA environment variable even when it
+    /// is overridden - measured, not assumed. Elsewhere the path is a literal, because
+    /// <see cref="Path.GetTempPath"/> reads TMPDIR and the folder API reads XDG_DATA_HOME and HOME; the user
+    /// name goes in the file name instead, since a shared directory needs the per-user split somewhere.
+    ///
+    /// <see cref="GatewayTestSuiteLockTests"/> pins this by mutating TEMP, TMP and TMPDIR and asserting the
+    /// derived path does not move - so the regression is caught on whatever platform the tests run on,
+    /// including ones not available to whoever wrote this.
+    /// </summary>
+    internal static string ComputeLockFilePath()
+    {
+        if (!OperatingSystem.IsWindows())
+            return Path.Combine("/tmp", "cc-director-" + Environment.UserName + "-" + LockFileName);
+
+        var localAppData = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify);
+
+        if (string.IsNullOrWhiteSpace(localAppData))
+        {
+            // Nothing to fall back to that would still be a lock: every alternative is environment-settable,
+            // which is the defect this method exists to close. Better to stop than to serialize nothing.
+            throw new InvalidOperationException(
+                "Cannot locate the per-user local application data directory, so the machine-wide Gateway "
+                + "test lock has no environment-independent home. Running without it would let two Gateway "
+                + "test runs execute concurrently and corrupt each other. See GatewayTestSuiteLock.");
+        }
+
+        return Path.Combine(localAppData, "cc-director", LockFileName);
+    }
 
     /// <summary>A copy of everything this run printed while acquiring, kept next to the lock so a human
     /// investigating a blocked machine can read the history without a console to look at.</summary>
@@ -129,6 +175,8 @@ internal static class GatewayTestSuiteLock
         var started = DateTime.UtcNow;
         var lastProgress = DateTime.MinValue;
         var announcedWait = false;
+
+        EnsureLockLocationUsable();
 
         while (true)
         {
@@ -198,18 +246,125 @@ internal static class GatewayTestSuiteLock
             stream = new FileStream(
                 LockFilePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
         }
-        catch (IOException)
+        catch (IOException ex) when (IsSharingContention(ex))
         {
             return false;
         }
-        catch (UnauthorizedAccessException)
+        catch (Exception ex)
         {
-            return false;
+            // ONLY a sharing conflict means "somebody else is running". Everything else - a permission
+            // failure, a read-only file, a directory at the path, a broken or full disk - is a setup fault,
+            // and treating it as contention is how the wedge we designed this to avoid comes back through
+            // the error path: the run would wait the full timeout while naming a holder that does not
+            // exist, then the next run would do the same, forever. So these stop the run at once, saying
+            // what actually happened.
+            FailSetup("cannot open the lock file", ex);
+            throw; // unreachable: FailSetup ends the process. Present so the compiler sees a terminal path.
         }
 
         _held = stream;
         WriteDiagnostics(stream);
         return true;
+    }
+
+    /// <summary>
+    /// Distinguishes "another process holds this file" from every other input/output failure.
+    ///
+    /// On Windows the operating system names it exactly, so the test is exact: a sharing violation or a
+    /// lock violation, and nothing else. Elsewhere the errno mapping for an advisory-lock conflict is not
+    /// something this code has verified on the platform in question, and guessing at it would be the same
+    /// class of mistake as the temp-path defect - so instead the question is answered with EVIDENCE: a live
+    /// holder grants readers access, so if the file can still be opened for reading, somebody is holding it.
+    /// If it cannot even be read, this is not contention and must not be reported as a holder.
+    /// </summary>
+    private static bool IsSharingContention(IOException ex)
+    {
+        const int SharingViolation = 32;
+        const int LockViolation = 33;
+
+        if (OperatingSystem.IsWindows())
+        {
+            var code = ex.HResult & 0xFFFF;
+            return code is SharingViolation or LockViolation;
+        }
+
+        try
+        {
+            using var probe = new FileStream(
+                LockFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Checks the lock's home before the acquisition loop starts, so the common setup faults are reported
+    /// precisely rather than as whatever the open call happens to throw. Each of these would otherwise have
+    /// been indistinguishable from a live holder.
+    /// </summary>
+    private static void EnsureLockLocationUsable()
+    {
+        var directory = Path.GetDirectoryName(LockFilePath);
+        if (string.IsNullOrEmpty(directory))
+        {
+            FailSetup($"the lock path '{LockFilePath}' has no containing directory", exception: null);
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(directory);
+        }
+        catch (Exception ex)
+        {
+            FailSetup($"cannot create the lock directory '{directory}'", ex);
+            return;
+        }
+
+        if (Directory.Exists(LockFilePath))
+        {
+            FailSetup(
+                $"a DIRECTORY sits at the lock file path '{LockFilePath}', so the lock file can never be "
+                + "opened. Remove that directory.",
+                exception: null);
+            return;
+        }
+
+        try
+        {
+            if (File.Exists(LockFilePath)
+                && (File.GetAttributes(LockFilePath) & FileAttributes.ReadOnly) != 0)
+            {
+                FailSetup(
+                    $"the lock file '{LockFilePath}' is marked READ-ONLY, so it can never be opened for "
+                    + "writing. Clear the read-only attribute.",
+                    exception: null);
+            }
+        }
+        catch (Exception ex)
+        {
+            FailSetup($"cannot inspect the lock file '{LockFilePath}'", ex);
+        }
+    }
+
+    /// <summary>
+    /// Stops the run because the lock's home is broken. Deliberately NOT a wait and NOT a retry: a setup
+    /// fault does not clear on its own, so retrying it produces a run that hangs for the full timeout and
+    /// then fails for the wrong reason. This says what is wrong and stops.
+    /// </summary>
+    private static void FailSetup(string what, Exception? exception)
+    {
+        var detail = exception is null ? "" : $" Underlying failure: {exception.GetType().Name}: {exception.Message}.";
+        Say($"[gateway-test-lock] *** CANNOT SET UP THE MACHINE-WIDE GATEWAY TEST LOCK: {what}.{detail} "
+            + "NO TESTS WILL RUN. This is NOT another run holding the lock - it is a fault in the lock's "
+            + "location that will not clear by waiting, so this run stops immediately rather than blocking "
+            + "and then blaming a holder that does not exist. Fix the path above and run again. ***");
+        Console.Out.Flush();
+        Console.Error.Flush();
+        Environment.Exit(SetupFailureExitCode);
     }
 
     /// <summary>
@@ -327,10 +482,14 @@ internal static class GatewayTestSuiteLock
         {
             File.AppendAllText(LogFilePath, stamped + Environment.NewLine);
         }
-        catch (IOException)
+        catch (Exception)
         {
-            // The channels above are the ones that matter; the log is a convenience for a human looking at
-            // a machine with no console attached.
+            // Every failure, not merely IOException. This previously caught IOException alone, which meant
+            // an unwritable or read-only log file threw UnauthorizedAccessException out of a DIAGNOSTIC
+            // write - after the lock was already acquired - and would have aborted every future run. A
+            // channel whose only job is to explain a problem must never be able to cause one. The console
+            // channels above already carry the message; this file is a convenience for reading a machine
+            // afterwards with no console attached.
         }
     }
 

--- a/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
@@ -56,6 +56,18 @@ namespace CcDirector.Gateway.Tests;
 /// They exist so a blocked run can name its blocker - a blocked run that cannot say who is blocking it is
 /// indistinguishable from a hang, and somebody will kill the wrong thing. They never decide ownership.
 ///
+/// EVERY RUN OF THIS ASSEMBLY IS SERIALIZED, FILTERED OR NOT. That is a feature, not an oversight, and it
+/// is the first thing somebody will try to "optimise" - a filtered run looks small and harmless, so surely
+/// it can be let through. It cannot, because nobody can show that it is harmless. A filtered run of this
+/// assembly still loads the whole assembly, still boots real hosts, still touches shared machine state, and
+/// is still exposed to the host-crash mode that has never been proven purely intra-process. Each test class
+/// does redirect its storage root to a unique temporary path, so roots do not collide - but that is the
+/// only isolation anybody has actually demonstrated, and "no collision was found" is not "no collision
+/// exists". The lock takes the strong position deliberately: serialize everything, and let anyone who wants
+/// an exemption produce the evidence first. This is also why the acquisition sits in a module initializer
+/// rather than anywhere test-shaped - a module initializer cannot see the filter, and therefore cannot be
+/// talked into making an exception it has no basis for.
+///
 /// WHY A MODULE INITIALIZER. It runs on assembly load, before any test, it is independent of the xUnit
 /// version (assembly-level fixtures are a v3 feature and this project is on xunit 2.9), and it works for
 /// every runner - "dotnet test", the development-environment runner, and anything else that loads this

--- a/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
@@ -1,0 +1,342 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Serializes runs of THIS test assembly across the whole machine, automatically, before any test runs.
+///
+/// WHY THIS EXISTS - READ THIS BEFORE YOU DELETE IT.
+///
+/// This suite cannot tolerate two concurrent runs on one machine. Overlapping runs kill the test host:
+/// they report failures in areas nobody touched, and frequently end with no summary line at all, which is
+/// the shape of a crashed host rather than a failed assertion. On 2026-07-19 four runs overlapped and every
+/// one of the four had to be discarded. Corrupted test evidence is worse than no test evidence, because
+/// somebody acts on it.
+///
+/// Several people and several agents work in this repository at once, each in their own working tree, and
+/// each one runs "dotnet test src/CcDirector.Gateway.Tests". Telling them not to overlap DOES NOT WORK, and
+/// the reason it does not work is the whole design argument for this file: a runner can only observe its
+/// OWN run. Each one honours the rule individually while the aggregate still breaks it. A rule that
+/// requires global knowledge cannot be obeyed by an actor holding only local knowledge. A lock that a
+/// runner must REMEMBER to take is the same convention wearing a new name - somebody who was never briefed,
+/// or who arrives tomorrow, walks straight past it. We have direct evidence of that too: a full suite ran
+/// on this machine from a working tree with no owning session at all, so there was nobody to tell.
+///
+/// So acquisition is AUTOMATIC and lives inside the test process. A plain "dotnet test" serializes without
+/// the caller knowing this file exists. That is the entire point, and it is the property to preserve if you
+/// ever rework this.
+///
+/// HOW OWNERSHIP IS DECIDED: BY THE OPERATING SYSTEM, NEVER BY METADATA.
+///
+/// The lock is a file opened for writing with <see cref="FileShare.Read"/> and held open for the lifetime
+/// of the process. A second run's open fails, because its request to write is not among the shares the
+/// first run granted. Readers are still admitted, which is how a blocked run tells you WHO is holding it.
+///
+/// Two consequences, both deliberate:
+///
+///  1. A HOLDER THAT DIES NEEDS NO CLEANUP LOGIC. Crash, kill, or the known file-system-watcher dispose
+///     race that can take this test host down mid-run - in every case the operating system closes the
+///     handle, and the next run simply acquires. There is no stale-detection code here because there is
+///     nothing for it to do. That matters: a lock that could wedge permanently would stop the Gateway
+///     suite for every working tree on the machine after the first crash, trading a corrupted-evidence
+///     problem for a total-stoppage problem.
+///
+///  2. A HOLDER THAT IS ALIVE BUT STUCK MAKES THIS RUN FAIL LOUDLY - it does not make this run start.
+///     An earlier draft broke the lock once the holder passed an age cap. That was wrong, and the reason
+///     is worth keeping: an age cap cannot distinguish "wedged" from "merely slow", so breaking on age
+///     starts a second suite next to a live first one, which is exactly the corruption this file exists to
+///     prevent. Nothing here ever takes a lock away from a living process. Past
+///     <see cref="MaxWait"/> the run stops with an error naming the holder, and a human or agent decides.
+///     A loud failure is recoverable. A silent second concurrent suite is corrupted evidence that looks
+///     clean.
+///
+/// The process id, process start time and session identifier written into the file are DIAGNOSTICS ONLY.
+/// They exist so a blocked run can name its blocker - a blocked run that cannot say who is blocking it is
+/// indistinguishable from a hang, and somebody will kill the wrong thing. They never decide ownership.
+///
+/// WHY A MODULE INITIALIZER. It runs on assembly load, before any test, it is independent of the xUnit
+/// version (assembly-level fixtures are a v3 feature and this project is on xunit 2.9), and it works for
+/// every runner - "dotnet test", the development-environment runner, and anything else that loads this
+/// assembly. It also suits a lock held for process lifetime exactly, because there is no teardown hook to
+/// get right. It is the same form <see cref="TestStorageRootRedirect"/> already uses in this assembly, for
+/// the same reason: there is no call site to forget. It is pinned by
+/// <see cref="GatewayTestSuiteLockTests"/>, because a guard that silently fails to run leaves no trace.
+/// </summary>
+internal static class GatewayTestSuiteLock
+{
+    /// <summary>
+    /// How long this run queues behind a live holder before failing loudly.
+    ///
+    /// The suite takes roughly nine minutes, so forty-five minutes accommodates a queue of about four full
+    /// runs ahead of this one - which is the worst real contention observed here, four agents overlapping
+    /// on one afternoon. Beyond that the holder is far more likely stuck than busy, and the right answer is
+    /// to tell a human rather than to guess. The cost of the timeout being too short is a clear, re-runnable
+    /// error; the cost of breaking the lock instead would be a corrupted run. That asymmetry is why this
+    /// number can be wrong without being dangerous.
+    /// </summary>
+    internal static readonly TimeSpan MaxWait = TimeSpan.FromMinutes(45);
+
+    /// <summary>Pause between acquisition attempts while queued behind a live holder.</summary>
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(3);
+
+    /// <summary>How often to repeat the "still waiting" line, so a queued run never looks like a hang.</summary>
+    private static readonly TimeSpan ProgressInterval = TimeSpan.FromSeconds(30);
+
+    /// <summary>Exit code used when this run refuses to start because a live holder never let go.</summary>
+    internal const int BlockedExitCode = 99;
+
+    /// <summary>The lock file every run of this assembly contends for, whatever working tree it was built
+    /// from. Under the temporary directory because that is the one location every account is guaranteed to
+    /// be able to write; note that on Windows this is per-user, so the lock serializes all runs by one user
+    /// account - which is the contention actually observed here.</summary>
+    internal static string LockFilePath { get; } =
+        Path.Combine(Path.GetTempPath(), "cc-director-gateway-test-suite.lock");
+
+    /// <summary>A copy of everything this run printed while acquiring, kept next to the lock so a human
+    /// investigating a blocked machine can read the history without a console to look at.</summary>
+    private static string LogFilePath => LockFilePath + ".log";
+
+    /// <summary>
+    /// The held handle. Static and never disposed ON PURPOSE: the lock lasts as long as the process, and
+    /// the operating system closes it however the process ends. Nothing here has to run on a particular
+    /// thread, so the thread-affinity trap that a named <see cref="Mutex"/> would have brought does not
+    /// arise at all.
+    /// </summary>
+#pragma warning disable CA2213
+    private static FileStream? _held;
+#pragma warning restore CA2213
+
+    /// <summary>True once this run owns the lock.</summary>
+    internal static bool IsHeld => _held is not null;
+
+    [ModuleInitializer]
+    internal static void Acquire()
+    {
+        var started = DateTime.UtcNow;
+        var lastProgress = DateTime.MinValue;
+        var announcedWait = false;
+
+        while (true)
+        {
+            if (TryOpenExclusively())
+            {
+                Say($"[gateway-test-lock] Acquired the machine-wide Gateway test lock. Starting the run. "
+                    + $"Lock file: {LockFilePath}");
+                return;
+            }
+
+            var holder = ReadHolder();
+
+            if (!announcedWait)
+            {
+                announcedWait = true;
+                lastProgress = DateTime.UtcNow;
+                Say($"[gateway-test-lock] WAITING. Another run of CcDirector.Gateway.Tests holds the "
+                    + $"machine-wide test lock, and this suite is destroyed by concurrent runs, so this run "
+                    + $"is queued rather than started. THIS IS NOT A HANG. Holder: {Describe(holder)}. "
+                    + $"Lock file: {LockFilePath}. When the holder's process ends the lock is released by "
+                    + $"the operating system and this run starts on its own. If the holder is still alive "
+                    + $"after {MaxWait.TotalMinutes:0} minutes this run FAILS rather than running "
+                    + $"alongside it.");
+            }
+            else if (DateTime.UtcNow - lastProgress >= ProgressInterval)
+            {
+                lastProgress = DateTime.UtcNow;
+                Say($"[gateway-test-lock] Still waiting after {(DateTime.UtcNow - started).TotalSeconds:0}s. "
+                    + $"Holder: {Describe(holder)}.");
+            }
+
+            if (DateTime.UtcNow - started >= MaxWait)
+            {
+                Say($"[gateway-test-lock] *** REFUSING TO RUN. A live process has held the machine-wide "
+                    + $"Gateway test lock for {MaxWait.TotalMinutes:0} minutes. NO TESTS WILL RUN. This run "
+                    + $"stops instead of starting alongside it, because two concurrent runs of this suite "
+                    + $"corrupt each other's results, and a run that quietly overlapped would report "
+                    + $"failures nobody caused. Holder: {Describe(holder)}. Lock file: {LockFilePath}. "
+                    + $"Decide whether that holder is genuinely still working; if it is stuck, end that "
+                    + $"process and run this again. ***");
+
+                // Environment.Exit rather than an exception: an exception thrown from a module initializer
+                // surfaces as a type-initialization failure on whichever test happened to touch this type
+                // first, which reads as an unrelated test failure. Stopping the process is unambiguous -
+                // no test ran, and the reason is the last thing on the console.
+                Console.Out.Flush();
+                Console.Error.Flush();
+                Environment.Exit(BlockedExitCode);
+            }
+
+            Thread.Sleep(PollInterval);
+        }
+    }
+
+    /// <summary>
+    /// One acquisition attempt. Exclusivity is the operating system's answer to this open call - the file's
+    /// contents are written only AFTER the handle is granted, and are never consulted to decide anything.
+    /// </summary>
+    private static bool TryOpenExclusively()
+    {
+        FileStream stream;
+        try
+        {
+            // FileAccess.Write with FileShare.Read: a second run asking to write is refused, because write
+            // is not among the shares this handle grants. Readers are admitted so a blocked run can read
+            // the diagnostics below and name its blocker.
+            stream = new FileStream(
+                LockFilePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+
+        _held = stream;
+        WriteDiagnostics(stream);
+        return true;
+    }
+
+    /// <summary>
+    /// Writes who holds the lock, for a human to read. Purely informational - see the class remarks. Kept
+    /// flushed to disk so a waiter reading the file sees it immediately rather than after the holder exits.
+    /// </summary>
+    private static void WriteDiagnostics(FileStream stream)
+    {
+        using var self = Process.GetCurrentProcess();
+        var text = string.Join(Environment.NewLine, new[]
+        {
+            "processId=" + Environment.ProcessId.ToString(CultureInfo.InvariantCulture),
+            "processStartUtc=" + self.StartTime.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
+            "acquiredUtc=" + DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture),
+            "session=" + SessionIdentifier(),
+            "machine=" + Environment.MachineName,
+            "user=" + Environment.UserName,
+            "directory=" + Environment.CurrentDirectory,
+        }) + Environment.NewLine;
+
+        var bytes = System.Text.Encoding.UTF8.GetBytes(text);
+        stream.SetLength(0);
+        stream.Write(bytes, 0, bytes.Length);
+        stream.Flush(flushToDisk: true);
+    }
+
+    /// <summary>
+    /// Who to go and talk to. Opened read-only, sharing everything, so reading never disturbs the holder
+    /// and never itself becomes a lock.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string>? ReadHolder()
+    {
+        try
+        {
+            using var stream = new FileStream(
+                LockFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var reader = new StreamReader(stream);
+
+            var fields = new Dictionary<string, string>(StringComparer.Ordinal);
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                var split = line.IndexOf('=');
+                if (split > 0)
+                    fields[line[..split]] = line[(split + 1)..];
+            }
+
+            return fields.Count == 0 ? null : fields;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    private static string Describe(IReadOnlyDictionary<string, string>? holder)
+    {
+        if (holder is null)
+            return "(the lock file carries no readable diagnostics)";
+
+        var pid = holder.TryGetValue("processId", out var p) ? p : "unknown";
+        var since = holder.TryGetValue("acquiredUtc", out var a) ? a : "unknown";
+        var startedAt = holder.TryGetValue("processStartUtc", out var s) ? s : "unknown";
+        var session = holder.TryGetValue("session", out var ss) ? ss : "unknown";
+        var dir = holder.TryGetValue("directory", out var d) ? d : "unknown";
+
+        var held = "";
+        if (DateTime.TryParse(since, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var t))
+            held = $" ({(DateTime.UtcNow - t.ToUniversalTime()).TotalSeconds:0}s ago)";
+
+        return $"process {pid}, started {startedAt}, holding since {since}{held}, "
+            + $"owner {session}, working directory {dir}";
+    }
+
+    /// <summary>Identifies the run for a human reading a blocked run's error message.</summary>
+    private static string SessionIdentifier()
+    {
+        var id = Environment.GetEnvironmentVariable("CC_SESSION_ID");
+        if (!string.IsNullOrWhiteSpace(id))
+            return "cc-director session " + id;
+
+        id = Environment.GetEnvironmentVariable("CLAUDE_CODE_SESSION_ID");
+        if (!string.IsNullOrWhiteSpace(id))
+            return "coding-agent session " + id;
+
+        return "(no session identifier in this run's environment)";
+    }
+
+    /// <summary>
+    /// Says it on standard output, standard error, the attached terminal, and into a log beside the lock
+    /// file.
+    ///
+    /// Four channels because the message that matters most is the one printed while a run is BLOCKED, and
+    /// a waiting message nobody sees is a hang - somebody will kill it, or kill the holder. Measured, not
+    /// assumed: "dotnet test" launches the test host as a child with its standard streams redirected, and
+    /// at the DEFAULT console verbosity it relays none of that output. So the terminal is written
+    /// DIRECTLY as well (CONOUT$ on Windows, /dev/tty elsewhere), which the test host can do because it
+    /// still inherits the console its parent is attached to. The log file covers the remaining case: a run
+    /// with no terminal at all, such as a scheduled or continuous-integration invocation, where a human
+    /// arrives afterwards asking what blocked.
+    /// </summary>
+    private static void Say(string message)
+    {
+        var stamped = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} pid {Environment.ProcessId}: {message}";
+        Console.Out.WriteLine(stamped);
+        Console.Out.Flush();
+        Console.Error.WriteLine(stamped);
+        Console.Error.Flush();
+        SayOnTerminal(stamped);
+        try
+        {
+            File.AppendAllText(LogFilePath, stamped + Environment.NewLine);
+        }
+        catch (IOException)
+        {
+            // The channels above are the ones that matter; the log is a convenience for a human looking at
+            // a machine with no console attached.
+        }
+    }
+
+    /// <summary>Writes straight to the inherited terminal, bypassing the parent runner's stream capture.</summary>
+    private static void SayOnTerminal(string stamped)
+    {
+        var device = OperatingSystem.IsWindows() ? "CONOUT$" : "/dev/tty";
+        try
+        {
+            using var terminal = new StreamWriter(
+                new FileStream(device, FileMode.Open, FileAccess.Write, FileShare.ReadWrite));
+            terminal.WriteLine(stamped);
+            terminal.Flush();
+        }
+        catch (Exception)
+        {
+            // No terminal is attached (a scheduled run, a continuous-integration agent, a redirected
+            // pipe with no console). The standard streams and the log file already carry the message.
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
@@ -5,7 +5,9 @@ using System.Runtime.CompilerServices;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// Serializes runs of THIS test assembly across the whole machine, automatically, before any test runs.
+/// Serializes runs of THIS test assembly for one user on one machine, automatically, before any test runs.
+/// The exact scope is stated below and is deliberately narrower than "machine-wide" - do not widen the
+/// wording without widening the mechanism.
 ///
 /// WHY THIS EXISTS - READ THIS BEFORE YOU DELETE IT.
 ///

--- a/src/CcDirector.Gateway.Tests/GatewayTestSuiteLockTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTestSuiteLockTests.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves the machine-wide suite lock is actually HELD while this assembly's tests run.
+///
+/// This exists for the same reason <see cref="TestStorageRootRedirectTests"/> does: a module initializer
+/// that silently does not run leaves no trace at all. The suite would go straight back to letting two runs
+/// overlap and corrupt each other, and every test here would still pass. A guard whose failure is invisible
+/// is not coverage, so the guard gets a guard.
+/// </summary>
+public sealed class GatewayTestSuiteLockTests
+{
+    [Fact]
+    public void TheLockIsHeldWhileTestsRun()
+    {
+        Assert.True(
+            GatewayTestSuiteLock.IsHeld,
+            "This run does not hold the machine-wide Gateway test lock, so nothing is stopping a second "
+            + "run of this suite from executing alongside it and corrupting both. See GatewayTestSuiteLock.");
+    }
+
+    [Fact]
+    public void ASecondExclusiveOpenIsRefused_WhichIsWhatBlocksAConcurrentRun()
+    {
+        // The exact open a second run would attempt. Share modes are per-handle, not per-process, so this
+        // is refused inside the holding process too - which makes it a real proof of exclusivity rather
+        // than a restatement of a flag we set ourselves.
+        var refused = Assert.ThrowsAny<IOException>(() =>
+        {
+            using var _ = new FileStream(
+                GatewayTestSuiteLock.LockFilePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
+        });
+
+        Assert.NotNull(refused);
+    }
+
+    [Fact]
+    public void TheLockFileNamesThisProcess_SoABlockedRunCanSayWhoIsBlockingIt()
+    {
+        // Read exactly the way a blocked run reads it: read-only, sharing everything, while the holder
+        // still has the file open for writing.
+        using var stream = new FileStream(
+            GatewayTestSuiteLock.LockFilePath, FileMode.Open, FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(stream);
+        var text = reader.ReadToEnd();
+
+        Assert.Contains(
+            "processId=" + Environment.ProcessId.ToString(CultureInfo.InvariantCulture),
+            text,
+            StringComparison.Ordinal);
+        Assert.Contains("acquiredUtc=", text, StringComparison.Ordinal);
+        Assert.Contains("session=", text, StringComparison.Ordinal);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayTestSuiteLockTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTestSuiteLockTests.cs
@@ -37,6 +37,89 @@ public sealed class GatewayTestSuiteLockTests
         Assert.NotNull(refused);
     }
 
+    /// <summary>
+    /// The regression test for a DEMONSTRATED defect, not a hypothesis. The lock path was originally derived
+    /// from <see cref="Path.GetTempPath"/>, which reads TEMP and TMP from the process environment. Two runs
+    /// launched with different TEMP values computed two different lock files, so neither could see the
+    /// other: both reported acquiring the lock in the same second and both ran concurrently. The whole
+    /// mechanism was inert one environment variable away from its intended use.
+    ///
+    /// This asserts the property that closes it - the lock's identity does not move when the environment
+    /// moves - on whatever platform the tests run on, including platforms the author could not reach.
+    /// </summary>
+    [Fact]
+    public void TheLockPathDoesNotMoveWhenTheTemporaryDirectoryEnvironmentMoves()
+    {
+        var original = GatewayTestSuiteLock.ComputeLockFilePath();
+        var names = new[] { "TEMP", "TMP", "TMPDIR" };
+        var saved = names.ToDictionary(n => n, Environment.GetEnvironmentVariable);
+
+        try
+        {
+            foreach (var name in names)
+                Environment.SetEnvironmentVariable(name, Path.Combine(Path.GetTempPath(), "moved-" + name));
+
+            Assert.Equal(original, GatewayTestSuiteLock.ComputeLockFilePath());
+        }
+        finally
+        {
+            foreach (var (name, value) in saved)
+                Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+
+    /// <summary>
+    /// The end-to-end half of the same defect, against the REAL lock this run is really holding.
+    ///
+    /// A second run launched with a different TEMP would compute its lock path, then open it. This does
+    /// exactly that - recomputes the path under a changed environment, then attempts the same exclusive
+    /// open a second run would attempt - and requires it to be REFUSED. Under the defect the recomputed
+    /// path was a different file and the open succeeded, which is precisely how two suites ran side by
+    /// side.
+    /// </summary>
+    [Fact]
+    public void ARunWithADifferentTemporaryDirectoryStillCollidesWithThisHeldLock()
+    {
+        var names = new[] { "TEMP", "TMP", "TMPDIR" };
+        var saved = names.ToDictionary(n => n, Environment.GetEnvironmentVariable);
+        var elsewhere = Path.Combine(Path.GetTempPath(), "another-runs-temp-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(elsewhere);
+
+        try
+        {
+            foreach (var name in names)
+                Environment.SetEnvironmentVariable(name, elsewhere);
+
+            var asAnotherRunWouldComputeIt = GatewayTestSuiteLock.ComputeLockFilePath();
+
+            // Same file this run holds - that is the property being pinned.
+            Assert.Equal(GatewayTestSuiteLock.LockFilePath, asAnotherRunWouldComputeIt);
+
+            Assert.ThrowsAny<IOException>(() =>
+            {
+                using var _ = new FileStream(
+                    asAnotherRunWouldComputeIt, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
+            });
+        }
+        finally
+        {
+            foreach (var (name, value) in saved)
+                Environment.SetEnvironmentVariable(name, value);
+            try { Directory.Delete(elsewhere, recursive: true); } catch (IOException) { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void TheLockDoesNotLiveUnderTheEnvironmentSettableTemporaryDirectory()
+    {
+        // Stated as its own fact because it is the shape of the defect: anything under the temporary
+        // directory is relocatable by whoever launches the run, and a relocatable lock is not a lock.
+        Assert.False(
+            GatewayTestSuiteLock.LockFilePath.StartsWith(Path.GetTempPath(), StringComparison.OrdinalIgnoreCase),
+            $"The lock lives at {GatewayTestSuiteLock.LockFilePath}, under the environment-settable "
+            + "temporary directory, so two runs with different TEMP values would not see each other.");
+    }
+
     [Fact]
     public void TheLockFileNamesThisProcess_SoABlockedRunCanSayWhoIsBlockingIt()
     {

--- a/src/CcDirector.Gateway.Tests/GatewayTestSuiteLockTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTestSuiteLockTests.cs
@@ -4,21 +4,44 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// Proves the machine-wide suite lock is actually HELD while this assembly's tests run.
+/// Proves the per-user-per-machine suite lock is actually HELD while this assembly's tests run.
 ///
 /// This exists for the same reason <see cref="TestStorageRootRedirectTests"/> does: a module initializer
 /// that silently does not run leaves no trace at all. The suite would go straight back to letting two runs
 /// overlap and corrupt each other, and every test here would still pass. A guard whose failure is invisible
 /// is not coverage, so the guard gets a guard.
+///
+/// NOTHING HERE MUTATES PROCESS-GLOBAL STATE. An earlier draft proved the environment-immunity property by
+/// redirecting TEMP, TMP and TMPDIR and then recursively deleting the directory it had redirected them to.
+/// Hundreds of tests in this assembly resolve paths through <see cref="Path.GetTempPath"/>, so that draft
+/// could have deleted a tree another test had been redirected into - introducing cross-class nondeterminism
+/// inside the fix for cross-process nondeterminism. Serializing those tests into a non-parallel collection
+/// would have hidden the hazard behind a convention someone must remember on every future test that touches
+/// those variables. Instead the derivation takes its environment as an ARGUMENT, so a hostile environment is
+/// passed in and there is no global to mutate, nothing to remember, and nothing to delete.
 /// </summary>
 public sealed class GatewayTestSuiteLockTests
 {
+    /// <summary>The real ambient values, with every temporary-directory variable replaced by a hostile one.
+    /// A run launched this way must still land on exactly the same lock.</summary>
+    private static GatewayTestSuiteLock.AmbientEnvironment WithHostileTemporaryDirectories(string hostile)
+    {
+        var real = GatewayTestSuiteLock.ReadAmbient();
+        return real with
+        {
+            Temp = hostile,
+            Tmp = hostile,
+            TmpDir = hostile,
+            LocalAppDataVariable = hostile,
+        };
+    }
+
     [Fact]
     public void TheLockIsHeldWhileTestsRun()
     {
         Assert.True(
             GatewayTestSuiteLock.IsHeld,
-            "This run does not hold the machine-wide Gateway test lock, so nothing is stopping a second "
+            "This run does not hold the per-user Gateway test lock, so nothing is stopping a second "
             + "run of this suite from executing alongside it and corrupting both. See GatewayTestSuiteLock.");
     }
 
@@ -50,22 +73,11 @@ public sealed class GatewayTestSuiteLockTests
     [Fact]
     public void TheLockPathDoesNotMoveWhenTheTemporaryDirectoryEnvironmentMoves()
     {
-        var original = GatewayTestSuiteLock.ComputeLockFilePath();
-        var names = new[] { "TEMP", "TMP", "TMPDIR" };
-        var saved = names.ToDictionary(n => n, Environment.GetEnvironmentVariable);
+        var hostile = WithHostileTemporaryDirectories("D:/somewhere-a-different-run-was-launched-from");
 
-        try
-        {
-            foreach (var name in names)
-                Environment.SetEnvironmentVariable(name, Path.Combine(Path.GetTempPath(), "moved-" + name));
-
-            Assert.Equal(original, GatewayTestSuiteLock.ComputeLockFilePath());
-        }
-        finally
-        {
-            foreach (var (name, value) in saved)
-                Environment.SetEnvironmentVariable(name, value);
-        }
+        Assert.Equal(
+            GatewayTestSuiteLock.LockFilePath,
+            GatewayTestSuiteLock.ComputeLockFilePath(hostile));
     }
 
     /// <summary>
@@ -80,44 +92,78 @@ public sealed class GatewayTestSuiteLockTests
     [Fact]
     public void ARunWithADifferentTemporaryDirectoryStillCollidesWithThisHeldLock()
     {
-        var names = new[] { "TEMP", "TMP", "TMPDIR" };
-        var saved = names.ToDictionary(n => n, Environment.GetEnvironmentVariable);
-        var elsewhere = Path.Combine(Path.GetTempPath(), "another-runs-temp-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(elsewhere);
+        var asAnotherRunWouldComputeIt = GatewayTestSuiteLock.ComputeLockFilePath(
+            WithHostileTemporaryDirectories("D:/another-runs-temp-" + Guid.NewGuid().ToString("N")));
 
-        try
+        // Same file this run holds - that is the property being pinned.
+        Assert.Equal(GatewayTestSuiteLock.LockFilePath, asAnotherRunWouldComputeIt);
+
+        // And therefore the open that run would attempt is refused by the operating system. Under the
+        // defect the recomputed path was a DIFFERENT file, this open succeeded, and two suites ran side
+        // by side.
+        Assert.ThrowsAny<IOException>(() =>
         {
-            foreach (var name in names)
-                Environment.SetEnvironmentVariable(name, elsewhere);
+            using var _ = new FileStream(
+                asAnotherRunWouldComputeIt, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
+        });
+    }
 
-            var asAnotherRunWouldComputeIt = GatewayTestSuiteLock.ComputeLockFilePath();
+    /// <summary>
+    /// The invariant is IMMUNITY TO THE ENVIRONMENT, not a particular directory - and getting that wrong is
+    /// how an earlier version of this test would have failed DETERMINISTICALLY on Linux, where the lock
+    /// legitimately lives under /tmp and the assertion said it must not. Continuous integration runs
+    /// ubuntu-latest, so that branch genuinely executes; the test written to protect a branch its author
+    /// could not observe would have broken the platform it was written for.
+    ///
+    /// Both branches are exercised HERE, on whatever machine runs this, because the platform is an input
+    /// rather than something read from the running process. A Windows developer's run now covers the Unix
+    /// derivation, instead of leaving it to be discovered by a continuous-integration machine nobody is
+    /// watching.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void TheLockPathIsNotRelocatableByWhoeverLaunchesTheRun(bool isWindows)
+    {
+        const string hostile = "D:/relocated-by-the-launching-environment";
+        var ambient = WithHostileTemporaryDirectories(hostile) with { IsWindows = isWindows };
 
-            // Same file this run holds - that is the property being pinned.
-            Assert.Equal(GatewayTestSuiteLock.LockFilePath, asAnotherRunWouldComputeIt);
+        var path = GatewayTestSuiteLock.ComputeLockFilePath(ambient);
 
-            Assert.ThrowsAny<IOException>(() =>
-            {
-                using var _ = new FileStream(
-                    asAnotherRunWouldComputeIt, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
-            });
+        Assert.DoesNotContain("relocated-by-the-launching-environment", path, StringComparison.Ordinal);
+
+        if (isWindows)
+        {
+            // Anchored to the folder API's answer, which no environment variable moves.
+            Assert.StartsWith(ambient.LocalApplicationDataFolder, path, StringComparison.Ordinal);
         }
-        finally
+        else
         {
-            foreach (var (name, value) in saved)
-                Environment.SetEnvironmentVariable(name, value);
-            try { Directory.Delete(elsewhere, recursive: true); } catch (IOException) { /* best effort */ }
+            // A fixed, well-known location that TMPDIR does not move, with the per-user split in the file
+            // name because /tmp is shared. Forward slashes because the separator belongs to the TARGET
+            // platform - Path.Combine here would emit a backslash when this branch is evaluated on Windows.
+            Assert.StartsWith("/tmp/cc-director-", path, StringComparison.Ordinal);
+            Assert.Contains(ambient.UserName, path, StringComparison.Ordinal);
+            Assert.DoesNotContain('\\', path);
         }
     }
 
+    /// <summary>
+    /// The Windows branch refuses to invent a home rather than falling back to somewhere the environment
+    /// controls. A fallback here would look like robustness and would silently restore the defect: every
+    /// alternative location is environment-settable, so the run would serialize nothing while appearing to
+    /// work.
+    /// </summary>
     [Fact]
-    public void TheLockDoesNotLiveUnderTheEnvironmentSettableTemporaryDirectory()
+    public void WithNoLocalApplicationDataFolder_ItRefusesRatherThanFallingBack()
     {
-        // Stated as its own fact because it is the shape of the defect: anything under the temporary
-        // directory is relocatable by whoever launches the run, and a relocatable lock is not a lock.
-        Assert.False(
-            GatewayTestSuiteLock.LockFilePath.StartsWith(Path.GetTempPath(), StringComparison.OrdinalIgnoreCase),
-            $"The lock lives at {GatewayTestSuiteLock.LockFilePath}, under the environment-settable "
-            + "temporary directory, so two runs with different TEMP values would not see each other.");
+        var ambient = GatewayTestSuiteLock.ReadAmbient() with
+        {
+            IsWindows = true,
+            LocalApplicationDataFolder = "",
+        };
+
+        Assert.Throws<InvalidOperationException>(() => GatewayTestSuiteLock.ComputeLockFilePath(ambient));
     }
 
     [Fact]


### PR DESCRIPTION
## The problem

Two concurrent runs of `CcDirector.Gateway.Tests` on one machine destroy each other. Overlapping runs report failures in areas nobody touched, and frequently end with no summary line at all - the shape of a crashed test host rather than a failed assertion. On one afternoon four runs overlapped and all four had to be discarded. Corrupted test evidence is worse than none, because somebody acts on it.

Asking people and agents not to overlap does not work, and cannot work. A runner can only observe its own run, so each one honours the rule individually while the aggregate still breaks it. A rule needing global knowledge cannot be obeyed by an actor holding local knowledge. A lock somebody has to remember to take is the same convention under a new name.

## What this does

Acquisition is automatic, inside the test process, before any test runs. A plain `dotnet test` serializes without the caller knowing this exists.

- **A module initializer** takes the lock on assembly load. Chosen over an assembly fixture because assembly-level fixtures are an xunit v3 feature and this project is on xunit 2.9; it is runner-independent and is the form `TestStorageRootRedirect` already uses here.
- **The operating system decides ownership, never metadata.** The lock is a file opened `FileAccess.Write` with `FileShare.Read`, held open for the process lifetime. A second run's open is refused; readers are still admitted, which is how a blocked run names its blocker.
- **A holder that dies needs no cleanup logic.** Crash, kill, or the known file-system-watcher dispose race - the kernel closes the handle and the next run acquires. No stale-detection code, so no way to wedge the lock permanently.
- **A holder alive but stuck makes the waiting run fail loudly and run no tests**, after forty-five minutes. It never breaks the lock on age: an age cap cannot distinguish "wedged" from "merely slow", so breaking on age would start a second suite beside a live first one - the exact corruption this prevents.
- **The path cannot be moved by the environment.** Derived from the Windows shell folder API, which ignores an overridden `LOCALAPPDATA` (measured); on Unix a fixed literal, because `GetTempPath` reads `TMPDIR` and the folder API reads `XDG_DATA_HOME` and `HOME`.
- **The derivation is a pure function of its inputs.** It reads no process-global state; one call site reads the real environment and passes it in.
- **Only sharing violations are treated as contention.** Permission failures, a read-only file, a directory at the path - all stop the run immediately with a message saying explicitly that this is not a holder.

### Scope: per-user-per-machine

Stated precisely, because someone will rely on the words. Two runs by the **same operating-system user** on one machine cannot overlap. Two runs by **different users** are not serialized, and on Windows cannot be, since the lock lives under per-user local application data.

That scope was chosen, not overlooked: every process that actually contends runs as the same user, verified rather than assumed. A machine-shared home would need somewhere writable by every account, bringing permission and cleanup failures that are themselves wedge risks - the class of problem this removes. **Revisit if a second operating-system user ever runs this suite** on one machine.

### Every run is serialized, filtered or not

Deliberate, and the first thing somebody will try to relax. A filtered run still loads the whole assembly, boots real hosts, touches shared machine state, and is exposed to the host-crash mode never shown to be intra-process. Per-class storage-root redirection is the only isolation actually demonstrated, and "no collision was found" is not "no collision exists". Acquisition sits in a module initializer precisely because it cannot see the filter, and so cannot be talked into an exception it has no basis for.

## Two defects found in review, both fixed

**The lock did not exclude.** The path came from `Path.GetTempPath()`, which reads `TEMP` and `TMP`. Two runs launched with different `TEMP` values computed different lock files, both reported acquiring, and ran concurrently - demonstrated, not theorised. The environments most likely to differ are exactly the ones this serializes: different agents, different shells, different working trees, a scheduled task against an interactive session.

**Setup faults were reported as contention.** Every `IOException` and `UnauthorizedAccessException` counted as "a live holder", so a read-only lock file or a directory at the path made the run wait the full timeout naming a holder that did not exist - then repeat forever. That is the permanent wedge, arriving through the error path. Measured before fixing: contention gives `IOException 0x80070020`; a directory at the path and a read-only file both give `UnauthorizedAccessException 0x80070005`. The diagnostic log also caught `IOException` alone, so an unwritable log would have thrown out of a diagnostic write after acquisition and aborted every later run.

## Evidence - all on head 3e28d771, one sitting, box verified drained first

**1. The lock's own tests - 8 passed.** Including both platform branches of the path derivation, exercised on Windows because the platform is an input rather than read from the running process. The Unix branch is therefore covered by a Windows run instead of being discovered by the `ubuntu-latest` continuous-integration leg.

**2. Two runs, two different `TEMP` values - the second waited.** The reviewer's exact experiment, which previously produced two simultaneous acquisitions:

```
19:45:26 pid 57920: Acquired the per-user Gateway test lock.     <- run A, TEMP=D:/two-temp-demo/temp-A
19:45:29 pid 40120: WAITING ... Holder: process 57920, started   <- run B, TEMP=D:/two-temp-demo/temp-B
                    2026-07-19T23:45:26Z, holding since ...
                    (3s ago), owner cc-director session c584f16f-...
19:45:35 pid 40120: Acquired the per-user Gateway test lock.     <- only after A exited
```

Both runs green (93 and 8 tests). Stated pass criterion met: B named A's process id and acquired only after A ended.

**3. A killed holder - the next run acquires cleanly.** Holder force-killed at 19:45:59; the waiter acquired the same second and passed. No stale logic involved - the kernel released the handle.

**4. A live holder past the timeout - loud refusal, zero tests run.** Exercised with the timeout temporarily shortened in a throwaway build; the shipped value is forty-five minutes, restored and rebuilt before the suite below. The refusal is visible at **default** verbosity, because the runner echoes the test host's standard error in the abort reason:

```
*** REFUSING TO RUN. A live process has held the per-user Gateway test lock ... NO TESTS WILL RUN.
This run stops instead of starting alongside it, because two concurrent runs of this suite corrupt
each other's results ... Holder: process 60368 ... ***
Test Run Aborted.   (exit 1, no tests executed)
```

**5. One isolated full Gateway suite - green.**

```
Passed! - Failed: 0, Passed: 2949, Skipped: 10, Total: 2959, Duration: 6 m 56 s
```

Started 19:47:19, finished 19:54:17, clean tree at `3e28d771`. The 10 skips are the environment-gated real-Postgres proofs. The box was independently re-censused immediately beforehand - zero `testhost` or `vstest` processes, zero non-PowerShell processes referencing `Gateway.Tests`, zero non-idle `dotnet` processes - because this is the last full suite that runs *without* the lock protecting it, so its cleanliness rests entirely on the box being drained.

## Notes for the reviewer

- No testability seam was added. An in-assembly test cannot spawn `dotnet test` children of its own assembly - the parent holds the lock, so the children would correctly wait forty-five minutes and the test would deadlock. The only way to make that shape work is a flag letting children target a different lock file, which is a bypass hole in the mechanism it would be testing. The property is pinned from inside the held lock instead, and the two-process demonstration lives outside the suite as evidence.
- Nothing in the tests mutates process-global state. An earlier draft proved environment-immunity by redirecting `TEMP`, `TMP` and `TMPDIR` and then recursively deleting the directory it redirected them to - which could have deleted a tree another test had been redirected into, introducing cross-class nondeterminism inside the fix for cross-process nondeterminism.
