### PR TITLE
test: report the rejected value when the hosted identity assertion fails

### DIFF
--- a/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
@@ -146,18 +146,23 @@ public sealed class HostedAccountStatusTests : IAsyncLifetime
 
         Assert.True(root.GetProperty("signedIn").GetBoolean());
 
-        // DIAGNOSTIC for issue #1894 - temporary, remove once the source is named.
+        // The identity must be ABSENT here. This assertion reports the value it rejects, deliberately and
+        // permanently - an assertion that rejects a value should say what the value was.
         //
-        // This assertion fails intermittently in CI and passes in isolation. The value it rejects has never
-        // been printed, so the source has only ever been reasoned about. It cannot come from this caller's
-        // own tenant row: the subjects are GUID-unique per class instance, the registry looks up strictly on
-        // account_subject under a unique index, and this one is minted fresh with a null email. So when it
-        // is present it came from SOMEWHERE ELSE, and this makes the failure say where instead of leaving
-        // it to be deduced.
+        // It is written this way because of issue #1894. This test failed intermittently in CI while passing
+        // in isolation, and the rejected value had never been printed, so its source was only ever reasoned
+        // about and was never named. The value cannot come from this caller's own tenant row: the subjects
+        // are GUID-unique per class instance, TenantRegistry looks up strictly on account_subject under a
+        // unique index, and this subject is minted fresh with a null email. So when an email is present it
+        // came from SOMEWHERE ELSE.
         //
-        // "alice@example.com" would mean the leak is inside this class and is almost certainly benign.
-        // Anything else means it crossed a class boundary, in a suite whose job is to prove that identity
-        // never crosses a tenant boundary.
+        // If this fails again, read the message rather than re-running:
+        //   "alice@example.com"  -> the leak is inside this class, and is almost certainly benign
+        //   anything else        -> it crossed a class boundary, in a suite whose job is to prove that
+        //                           identity never crosses a TENANT boundary
+        //
+        // #1894 stays open until that source is named and fixed. A subsequent green run does not discharge
+        // it: a passing run with no named cause is the instrument certifying itself.
         var hasEmail = root.TryGetProperty("email", out var emailProperty);
         var hasProvider = root.TryGetProperty("provider", out var providerProperty);
         Assert.False(

--- a/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
@@ -145,8 +145,28 @@ public sealed class HostedAccountStatusTests : IAsyncLifetime
         var root = await StatusFor(_keyNoEmail);
 
         Assert.True(root.GetProperty("signedIn").GetBoolean());
-        Assert.False(root.TryGetProperty("email", out _));      // omitted, not null, not fabricated
-        Assert.False(root.TryGetProperty("provider", out _));
+
+        // DIAGNOSTIC for issue #1894 - temporary, remove once the source is named.
+        //
+        // This assertion fails intermittently in CI and passes in isolation. The value it rejects has never
+        // been printed, so the source has only ever been reasoned about. It cannot come from this caller's
+        // own tenant row: the subjects are GUID-unique per class instance, the registry looks up strictly on
+        // account_subject under a unique index, and this one is minted fresh with a null email. So when it
+        // is present it came from SOMEWHERE ELSE, and this makes the failure say where instead of leaving
+        // it to be deduced.
+        //
+        // "alice@example.com" would mean the leak is inside this class and is almost certainly benign.
+        // Anything else means it crossed a class boundary, in a suite whose job is to prove that identity
+        // never crosses a tenant boundary.
+        var hasEmail = root.TryGetProperty("email", out var emailProperty);
+        var hasProvider = root.TryGetProperty("provider", out var providerProperty);
+        Assert.False(
+            hasEmail || hasProvider,
+            $"#1894 DIAGNOSTIC: expected the identity to be ABSENT for a tenant with no recorded email. " +
+            $"email={(hasEmail ? $"'{emailProperty.GetString()}'" : "<absent>")}, " +
+            $"provider={(hasProvider ? $"'{providerProperty.GetString()}'" : "<absent>")}. " +
+            $"This subject ({_subjectNoEmail}) is unique to this test instance, so any value here came from " +
+            $"outside this caller's own tenant row. Full response body: {root}");
     }
 
     [Fact]


### PR DESCRIPTION
A permanent assertion improvement that also happens to be the instrument for thefrederiksen/devthrottle_internal#894.

*(This pull request previously read "expected to fail, do not merge". That was true while the failure was the deliverable. The diagnostic ran and went **green**, so the failure was not captured — and the right response is to land the instrumentation rather than re-run until it fails.)*

## What it changes

One assertion. When the hosted identity is unexpectedly present, the failure now reports the **email**, the **provider**, the **subject under test** and the **full response body**. When the test passes, behaviour is identical.

This is not a probe or a debugging hack. An assertion that rejects a value should say what the value was.

## Why land it rather than investigate

`HostedAccountStatusTests.Enrolled_without_a_recorded_email_is_signed_in_with_the_identity_absent` failed the .NET check on four pull requests, each with a diff that could not have caused it, and passes both in isolation and in a full local run. The rejected value has never been printed, so its source has only ever been reasoned about.

What is established: the value **cannot** come from the caller's own tenant row. Subjects are GUID-unique per class instance, `TenantRegistry.MintOrLookupBySubject` looks up strictly on `account_subject` under a unique index, and that subject is minted fresh with a null email. Two hypotheses were ruled out by evidence — a parallel-class race (`DisableTestParallelization` is set) and a cached hosted-mode selector (`IsHosted` reads the environment variable per call).

A deterministic reproduction would cost several ~19-minute CI cycles, with no local failure to bisect against. This is cheaper and strictly better:

- on a branch, instrumentation only helps if **that** branch loses the lottery
- on `main`, it rides **every** future CI run, so the next occurrence anywhere **names the source automatically**

Waiting is cheap when the wait is instrumented.

## Standing of thefrederiksen/devthrottle_internal#894

**Open.** It is discharged when the fault is *named and fixed* — never by a subsequent green run, because a passing run with no named cause is the instrument certifying itself. The code comment records that, so a future reader meeting a green suite does not close it.