### PR TITLE
fix(gateway): authorize the Director that owns an up-stream (#1923)

### DIFF
--- a/src/CcDirector.Gateway.Tests/GatewayStreamRegistryTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStreamRegistryTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Streaming;
 using Xunit;
@@ -13,6 +14,11 @@ namespace CcDirector.Gateway.Tests;
 /// </summary>
 public sealed class GatewayStreamRegistryTests
 {
+    // Issue #1923: every stream now records the identity that owns it. These lifecycle tests are all
+    // single-owner, so they register and consume as the same identity - the ownership CHECK itself is proved
+    // in StreamOwnershipTests.
+    private static readonly StreamOwner Owner = new(TenantId.Local, "dir-1");
+
     // A sink that records the frames it is handed, optionally blocking each write on a supplied gate so a test
     // can hold the pull and observe backpressure.
     private sealed class RecordingSink : IStreamSink
@@ -54,9 +60,9 @@ public sealed class GatewayStreamRegistryTests
     {
         var registry = new GatewayStreamRegistry();
         var sink = new RecordingSink();
-        registry.Register("s1", sink);
+        registry.Register("s1", Owner, sink);
 
-        await registry.ConsumeAsync("s1", SizeBinaryClosed("s1"), CancellationToken.None);
+        await registry.ConsumeAsync("s1", Owner, SizeBinaryClosed("s1"), CancellationToken.None);
 
         Assert.Equal(3, sink.Frames.Count);
         Assert.Equal(DirectorStreamFrameType.Size, sink.Frames[0].Kind);
@@ -75,7 +81,7 @@ public sealed class GatewayStreamRegistryTests
         var registry = new GatewayStreamRegistry();
         var gate = new TaskCompletionSource();
         var sink = new RecordingSink(gate: () => gate.Task);
-        registry.Register("bp", sink);
+        registry.Register("bp", Owner, sink);
 
         var yielded = 0;
         async IAsyncEnumerable<DirectorStreamFrame> Produce([EnumeratorCancellation] CancellationToken ct = default)
@@ -89,7 +95,7 @@ public sealed class GatewayStreamRegistryTests
             yield return Closed("bp", "eof");
         }
 
-        var consume = registry.ConsumeAsync("bp", Produce(), CancellationToken.None);
+        var consume = registry.ConsumeAsync("bp", Owner, Produce(), CancellationToken.None);
         await Task.Delay(150); // let the consumer pull the first frame and block on the held sink write
 
         Assert.Equal(1, Volatile.Read(ref yielded)); // only the first frame was pulled; the next pull is blocked
@@ -107,7 +113,7 @@ public sealed class GatewayStreamRegistryTests
     {
         var registry = new GatewayStreamRegistry();
         var sink = new RecordingSink();
-        registry.Register("inf", sink);
+        registry.Register("inf", Owner, sink);
 
         var started = new TaskCompletionSource();
         async IAsyncEnumerable<DirectorStreamFrame> Forever([EnumeratorCancellation] CancellationToken ct = default)
@@ -122,7 +128,7 @@ public sealed class GatewayStreamRegistryTests
             }
         }
 
-        var consume = registry.ConsumeAsync("inf", Forever(), CancellationToken.None);
+        var consume = registry.ConsumeAsync("inf", Owner, Forever(), CancellationToken.None);
         await started.Task;
         await Task.Delay(60); // let a few frames flow
 
@@ -140,10 +146,10 @@ public sealed class GatewayStreamRegistryTests
         // registered sink, so consume returns at once without touching any sink.
         var registry = new GatewayStreamRegistry();
         var sink = new RecordingSink();
-        registry.Register("gone", sink);
+        registry.Register("gone", Owner, sink);
         registry.Close("gone"); // sink torn down before StreamUp arrives
 
-        await registry.ConsumeAsync("gone", SizeBinaryClosed("gone"), CancellationToken.None);
+        await registry.ConsumeAsync("gone", Owner, SizeBinaryClosed("gone"), CancellationToken.None);
 
         Assert.Empty(sink.Frames); // nothing was pumped into the gone sink
         Assert.Equal(0, registry.LiveStreamCount);
@@ -156,7 +162,7 @@ public sealed class GatewayStreamRegistryTests
         // must not wait forever - the open timeout tears it down and fires the caller's token.
         var registry = new GatewayStreamRegistry(openTimeout: TimeSpan.FromMilliseconds(100));
         var sink = new RecordingSink();
-        var token = registry.Register("late", sink);
+        var token = registry.Register("late", Owner, sink);
 
         await Task.Delay(400);
 
@@ -169,7 +175,7 @@ public sealed class GatewayStreamRegistryTests
     public void Register_DuplicateStreamId_ThrowsFailLoud()
     {
         var registry = new GatewayStreamRegistry();
-        registry.Register("dup", new RecordingSink());
-        Assert.Throws<InvalidOperationException>(() => registry.Register("dup", new RecordingSink()));
+        registry.Register("dup", Owner, new RecordingSink());
+        Assert.Throws<InvalidOperationException>(() => registry.Register("dup", Owner, new RecordingSink()));
     }
 }

--- a/src/CcDirector.Gateway.Tests/StreamOwnershipTests.cs
+++ b/src/CcDirector.Gateway.Tests/StreamOwnershipTests.cs
@@ -120,6 +120,69 @@ public sealed class StreamOwnershipTests : IDisposable
         Assert.DoesNotContain(victimSink.Frames, f => f.Data is { Length: > 0 } d && d[0] == 0xBB);
     }
 
+    [Fact]
+    public async Task Hosted_TwoTenantsUsingTheSameDirectorId_CrossTenantStreamUp_IsRefused()
+    {
+        // THIS is the test that makes the TENANT half of the owner load-bearing, and it exists because the
+        // test above cannot do that job. There the owner was (tenantA, "dir-a") and the attacker was
+        // (tenantB, "dir-b") - BOTH halves differ, so the Director comparison alone refuses it and the test
+        // stays green even if tenant equality is deleted outright. The property that JUSTIFIES the composite
+        // key was the one property with no failing test.
+        //
+        // So: both accounts run a Director calling itself THE SAME THING. A Director id is chosen by the
+        // client in its Hello payload, so an attacker picks it freely - this is not a coincidence to engineer,
+        // it is the obvious move. With the ids equal, tenant equality is the ONLY thing left that can refuse,
+        // which is exactly what separates this design from the single-key one it replaced.
+        const string sharedDirectorId = "dir-shared";
+
+        var devices = new DeviceRegistry(_devPath);
+        var boundary = new HostedTenantBoundary(new AsyncLocalTenantContext(), devices);
+        Assert.True(boundary.IsHosted);
+
+        var tenantA = new TenantId(Guid.NewGuid().ToString());
+        var tenantB = new TenantId(Guid.NewGuid().ToString());
+        Assert.NotEqual(tenantA.Value, tenantB.Value);
+        var keyA = devices.Register("dev-a", "MA").DeviceKey;
+        var keyB = devices.Register("dev-b", "MB").DeviceKey;
+        devices.SetAccountBinding("dev-a", "sub-alice", tenantA.Value);
+        devices.SetAccountBinding("dev-b", "sub-bob", tenantB.Value);
+
+        var store = new PushedSessionStore(() => DateTime.UtcNow);
+        var registry = new GatewayStreamRegistry();
+        var hubA = NewHub("conn-a", keyA, boundary, store, registry);
+        var hubB = NewHub("conn-b", keyB, boundary, store, registry);
+
+        // Both Hellos declare the SAME Director id and BOTH must bind - the id is not unique across accounts,
+        // and if B's bind were rejected the refusal below would prove nothing about ownership.
+        hubA.Hello(new DirectorStreamHello { DirectorId = sharedDirectorId, Version = "t" });
+        hubB.Hello(new DirectorStreamHello { DirectorId = sharedDirectorId, Version = "t" });
+        Assert.Equal(new[] { "sess-a" }, PushAndRead(hubA, store, tenantA, "sess-a"));
+        Assert.Equal(new[] { "sess-b" }, PushAndRead(hubB, store, tenantB, "sess-b"));
+
+        // ---- POSITIVE CONTROL: tenant A's own write to its own stream lands. ----
+        var sink = new RecordingSink();
+        registry.Register("shared-id-stream", new StreamOwner(tenantA, sharedDirectorId), sink);
+        await hubA.StreamUp("shared-id-stream", Frames("shared-id-stream", 0xC1));
+        AssertFramesArrived(sink, "shared-id-stream", 0xC1);
+
+        // ---- THE ATTACK: a DIFFERENT ACCOUNT whose Director carries the SAME id. ----
+        // The Director halves are equal here, so only tenant equality can refuse this.
+        var victimSink = new RecordingSink();
+        registry.Register("shared-id-victim", new StreamOwner(tenantA, sharedDirectorId), victimSink);
+
+        var denied = await Assert.ThrowsAsync<HubException>(
+            () => hubB.StreamUp("shared-id-victim", Frames("shared-id-victim", 0xCB)));
+        Assert.Contains("shared-id-victim", denied.Message);
+        Assert.Empty(victimSink.Frames);
+        Assert.False(victimSink.Completed);
+        Assert.Equal(1, registry.LiveStreamCount);
+
+        // ---- DESTRUCTIBILITY CONTROL: the owner writes to THAT SAME sink and it lands. ----
+        await hubA.StreamUp("shared-id-victim", Frames("shared-id-victim", 0xC2));
+        AssertFramesArrived(victimSink, "shared-id-victim", 0xC2);
+        Assert.DoesNotContain(victimSink.Frames, f => f.Data is { Length: > 0 } d && d[0] == 0xCB);
+    }
+
     // ------------------------------------------------------------------- self-host is unchanged ----
 
     [Fact]
@@ -152,6 +215,11 @@ public sealed class StreamOwnershipTests : IDisposable
     {
         // The owner is the PAIR. One account can run many Directors, and one of its Directors has no business
         // writing into a stream opened on another - the id is still not a capability.
+        //
+        // This is the DIRECTOR-HALF detector, the twin of Hosted_TwoTenantsUsingTheSameDirectorId_...: the
+        // tenants are equal here, so only the Director comparison can refuse. Between the two, each half of the
+        // composite key has a test that fails when THAT half alone is deleted, which is what lets three
+        // separate one-primitive mutation runs attribute a red to the clause that caused it.
         var tenant = new TenantId(Guid.NewGuid().ToString());
         var registry = new GatewayStreamRegistry();
         var sink = new RecordingSink();

--- a/src/CcDirector.Gateway.Tests/StreamOwnershipTests.cs
+++ b/src/CcDirector.Gateway.Tests/StreamOwnershipTests.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Stats;
+using CcDirector.Gateway.Streaming;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1923 - CROSS-TENANT STREAM INJECTION. The Director-facing StreamUp method proved WHO the caller was
+/// (the Hello binding) but never that the caller OWNED the stream it named, and the stream registry recorded
+/// no owner at all: its entries were keyed on the bare stream id. Any authenticated account that learned or
+/// guessed another account's live stream id could therefore WRITE frames into that account's terminal, file,
+/// or screenshot sink, claim the stream before the real Director, or tear it down. Note the direction: this is
+/// INJECTION (a write into what another customer sees), not disclosure.
+///
+/// The fix authorizes rather than denies: the stream is tenant-attributable, so the entry now carries its
+/// owner (the tenant whose request opened it, plus the Director the open command was sent to) and every
+/// StreamUp is checked against it and REFUSED on a mismatch.
+///
+/// These tests are built to the proof bar, and the bar's two hardest items are the reason for their shape:
+///  - "Absence proved twice, presence never" is a reject. A refusal assertion is worthless on its own - a
+///    no-op stream would satisfy it perfectly. So every refusal here is BRACKETED by a permitted write on the
+///    SAME registry that genuinely lands frames on the sink: a positive control BEFORE the attempt (the
+///    mechanism works) and a destructibility control AFTER it (the very sink that "received nothing" was
+///    alive and writable the whole time - the guard is what stopped the write, not a dead stream).
+///  - The hosted/self-host mode is SET here and asserted (<see cref="HostedTenantBoundary.IsHosted"/>), never
+///    inherited from whatever the test runner happened to default to.
+/// </summary>
+public sealed class StreamOwnershipTests : IDisposable
+{
+    private readonly string _devPath = Path.Combine(Path.GetTempPath(), $"strown-dev-{Guid.NewGuid():N}.json");
+    private readonly string _tempDir = Path.Combine(Path.GetTempPath(), $"strown-{Guid.NewGuid():N}");
+
+    public StreamOwnershipTests() => Directory.CreateDirectory(_tempDir);
+
+    public void Dispose()
+    {
+        if (File.Exists(_devPath)) File.Delete(_devPath);
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    // ---------------------------------------------------------------- THE cross-tenant proof ----
+
+    [Fact]
+    public async Task Hosted_TenantB_StreamingIntoTenantAsStream_IsRefused_AndAsSinkReceivesNothing()
+    {
+        // HOSTED MODE IS SET HERE, NOT INHERITED: the ambient (async-local) tenant context is what makes the
+        // boundary hosted, so construct it explicitly and assert the mode actually took effect before relying
+        // on anything below. A boundary that silently came up self-host would make every account Local and
+        // this whole test would prove nothing.
+        var devices = new DeviceRegistry(_devPath);
+        var boundary = new HostedTenantBoundary(new AsyncLocalTenantContext(), devices);
+        Assert.True(boundary.IsHosted);
+
+        // Two accounts, two tenants, two authenticated device keys - exactly the production enrollment shape.
+        var tenantA = new TenantId(Guid.NewGuid().ToString());
+        var tenantB = new TenantId(Guid.NewGuid().ToString());
+        Assert.NotEqual(tenantA.Value, tenantB.Value);
+        var keyA = devices.Register("dev-a", "MA").DeviceKey;
+        var keyB = devices.Register("dev-b", "MB").DeviceKey;
+        devices.SetAccountBinding("dev-a", "sub-alice", tenantA.Value);
+        devices.SetAccountBinding("dev-b", "sub-bob", tenantB.Value);
+
+        // ONE Gateway, ONE stream registry (the production singleton), two Directors bound to different
+        // tenants. Both Hellos must bind, or the "refusal" below could just be an unbound connection.
+        var store = new PushedSessionStore(() => DateTime.UtcNow);
+        var registry = new GatewayStreamRegistry();
+        var hubA = NewHub("conn-a", keyA, boundary, store, registry);
+        var hubB = NewHub("conn-b", keyB, boundary, store, registry);
+        hubA.Hello(new DirectorStreamHello { DirectorId = "dir-a", Version = "t" });
+        hubB.Hello(new DirectorStreamHello { DirectorId = "dir-b", Version = "t" });
+        Assert.Equal(new[] { "sess-a" }, PushAndRead(hubA, store, tenantA, "sess-a"));
+        Assert.Equal(new[] { "sess-b" }, PushAndRead(hubB, store, tenantB, "sess-b"));
+
+        // ---- POSITIVE CONTROL, BEFORE the attempt: the permitted path genuinely delivers frames. ----
+        // Without this, a refusal assertion could pass on a registry that never delivers anything at all.
+        var controlSink = new RecordingSink();
+        registry.Register("stream-a-control", new StreamOwner(tenantA, "dir-a"), controlSink);
+        await hubA.StreamUp("stream-a-control", Frames("stream-a-control", 0xA1));
+        AssertFramesArrived(controlSink, "stream-a-control", 0xA1);
+
+        // ---- The attack: tenant B streams up under a stream id minted for tenant A. ----
+        var victimSink = new RecordingSink();
+        registry.Register("stream-a", new StreamOwner(tenantA, "dir-a"), victimSink);
+
+        var denied = await Assert.ThrowsAsync<HubException>(
+            () => hubB.StreamUp("stream-a", Frames("stream-a", 0xBB)));
+        // A REFUSAL, not a silent drop: the caller is told, so this can never be mistaken in a log for the
+        // legitimate "the browser already left" no-op.
+        Assert.Contains("stream-a", denied.Message);
+
+        // Nothing of B's reached A's sink...
+        Assert.Empty(victimSink.Frames);
+        // ...and B could not deny A service either: the stream was neither claimed nor torn down.
+        Assert.False(victimSink.Completed);
+        Assert.Equal(1, registry.LiveStreamCount);
+
+        // ---- DESTRUCTIBILITY CONTROL, AFTER the attempt: that same sink IS writable. ----
+        // This is what makes "victimSink.Frames is empty" mean something. The owner now streams into the very
+        // stream B was refused, and the frames land - so the emptiness above was the ownership check, not a
+        // stream that was dead, closed, or incapable of receiving anything.
+        await hubA.StreamUp("stream-a", Frames("stream-a", 0xA2));
+        AssertFramesArrived(victimSink, "stream-a", 0xA2);
+        // And still nothing of B's is in there - the refused frames were never buffered and replayed.
+        Assert.DoesNotContain(victimSink.Frames, f => f.Data is { Length: > 0 } d && d[0] == 0xBB);
+    }
+
+    // ------------------------------------------------------------------- self-host is unchanged ----
+
+    [Fact]
+    public async Task SelfHost_TheSingleTenantsDirector_StreamsUpUnchanged()
+    {
+        // SELF-HOST MODE IS SET HERE, NOT INHERITED: the single-tenant context makes the boundary inert.
+        // Assert the mode took effect - this is the control that says the fix costs the self-host install
+        // nothing, and it is worthless if the boundary silently came up hosted.
+        var devices = new DeviceRegistry(_devPath);
+        var boundary = new HostedTenantBoundary(new SingleTenantContext(), devices);
+        Assert.False(boundary.IsHosted);
+
+        var store = new PushedSessionStore(() => DateTime.UtcNow);
+        var registry = new GatewayStreamRegistry();
+        var hub = NewHub("conn-local", deviceKey: "any-key-self-host-does-not-check", boundary, store, registry);
+        hub.Hello(new DirectorStreamHello { DirectorId = "dir-1", Version = "t" });
+
+        var sink = new RecordingSink();
+        registry.Register("s-local", new StreamOwner(TenantId.Local, "dir-1"), sink);
+        await hub.StreamUp("s-local", Frames("s-local", 0x5A));
+
+        AssertFramesArrived(sink, "s-local", 0x5A);
+        Assert.Equal(0, registry.LiveStreamCount); // torn down on the Closed frame, exactly as before
+    }
+
+    // ------------------------------------------------------- registry-level ownership behaviour ----
+
+    [Fact]
+    public async Task SameTenant_DifferentDirector_IsAlsoRefused()
+    {
+        // The owner is the PAIR. One account can run many Directors, and one of its Directors has no business
+        // writing into a stream opened on another - the id is still not a capability.
+        var tenant = new TenantId(Guid.NewGuid().ToString());
+        var registry = new GatewayStreamRegistry();
+        var sink = new RecordingSink();
+        registry.Register("s", new StreamOwner(tenant, "dir-owner"), sink);
+
+        await Assert.ThrowsAsync<StreamOwnershipDeniedException>(
+            () => registry.ConsumeAsync("s", new StreamOwner(tenant, "dir-other"), Frames("s", 0x11), CancellationToken.None));
+        Assert.Empty(sink.Frames);
+
+        // Destructibility control: the rightful Director's write DOES land on that same sink.
+        await registry.ConsumeAsync("s", new StreamOwner(tenant, "dir-owner"), Frames("s", 0x22), CancellationToken.None);
+        AssertFramesArrived(sink, "s", 0x22);
+    }
+
+    [Fact]
+    public async Task SameOwner_DirectorIdCaseDiffers_IsStillTheOwner()
+    {
+        // Director ids are compared case-insensitively everywhere else on this connection (Hello's re-claim
+        // check), so a case difference must not turn the rightful owner into an intruder.
+        var tenant = new TenantId(Guid.NewGuid().ToString());
+        var registry = new GatewayStreamRegistry();
+        var sink = new RecordingSink();
+        registry.Register("s", new StreamOwner(tenant, "Dir-Owner"), sink);
+
+        await registry.ConsumeAsync("s", new StreamOwner(tenant, "dir-owner"), Frames("s", 0x33), CancellationToken.None);
+        AssertFramesArrived(sink, "s", 0x33);
+    }
+
+    [Fact]
+    public async Task UnknownStreamId_IsStillTheSilentNoOp_NotARefusal()
+    {
+        // The two outcomes MUST stay distinguishable. An unknown id is the legitimate lifecycle race (the
+        // browser left before the frames arrived) and stays a quiet no-op; a KNOWN id with the wrong owner is
+        // an authorization failure and throws. Collapsing them is exactly what would hide an injection attempt.
+        var registry = new GatewayStreamRegistry();
+        var owner = new StreamOwner(TenantId.Local, "dir-1");
+        var sink = new RecordingSink();
+        registry.Register("gone", owner, sink);
+        registry.Close("gone");
+
+        await registry.ConsumeAsync("gone", owner, Frames("gone", 0x44), CancellationToken.None);
+        Assert.Empty(sink.Frames);
+    }
+
+    [Fact]
+    public void Register_WithoutAnOwner_FailsLoud()
+    {
+        // A stream whose owner is unknown must never be opened - recording a blank owner would authorize
+        // nobody at best and anybody at worst.
+        var registry = new GatewayStreamRegistry();
+        Assert.Throws<ArgumentException>(() => registry.Register("s", default, new RecordingSink()));
+        Assert.Throws<ArgumentException>(() => registry.Register("s", new StreamOwner(TenantId.Local, ""), new RecordingSink()));
+        Assert.Equal(0, registry.LiveStreamCount);
+    }
+
+    // ------------------------------------------------------------------------------- helpers ----
+
+    /// <summary>
+    /// Assert the frames actually ARRIVED, checking the FORMAT FACTS before reading anything out of them: the
+    /// count, then each frame's kind, then the marker byte. A bare "the list is not empty" would pass on
+    /// frames that carried none of this payload.
+    /// </summary>
+    private static void AssertFramesArrived(RecordingSink sink, string streamId, byte marker)
+    {
+        Assert.Equal(2, sink.Frames.Count);
+        Assert.Equal(DirectorStreamFrameType.Binary, sink.Frames[0].Kind);
+        Assert.Equal(streamId, sink.Frames[0].StreamId);
+        Assert.NotNull(sink.Frames[0].Data);
+        Assert.Single(sink.Frames[0].Data!);
+        Assert.Equal(marker, sink.Frames[0].Data![0]);
+        Assert.Equal(DirectorStreamFrameType.Closed, sink.Frames[1].Kind);
+        Assert.True(sink.Completed);
+    }
+
+    private static async IAsyncEnumerable<DirectorStreamFrame> Frames(
+        string streamId, byte marker, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return new DirectorStreamFrame { StreamId = streamId, Kind = DirectorStreamFrameType.Binary, Data = new[] { marker } };
+        await Task.Yield();
+        yield return new DirectorStreamFrame { StreamId = streamId, Kind = DirectorStreamFrameType.Closed, Reason = "eof" };
+    }
+
+    private static string[] PushAndRead(DirectorHub hub, PushedSessionStore store, TenantId tenant, string sessionId)
+    {
+        hub.PushDelta(1, new SessionDto { SessionId = sessionId });
+        return store.SnapshotFresh(tenant, TimeSpan.FromMinutes(5)).Select(x => x.Session.SessionId).OrderBy(s => s).ToArray();
+    }
+
+    private DirectorHub NewHub(string connId, string deviceKey, HostedTenantBoundary boundary,
+        PushedSessionStore store, GatewayStreamRegistry streams)
+    {
+        var http = new DefaultHttpContext();
+        http.Items[AuthMiddleware.DeviceKeyItemKey] = deviceKey;
+        var directors = new DirectorRegistry(_tempDir);
+        var inputStats = new GatewayInputStatsAggregator(Path.Combine(_tempDir, $"stats-{Guid.NewGuid():N}.db"));
+        return new DirectorHub(store, directors, inputStats, streams, tenantBoundary: boundary)
+        {
+            Context = new FakeHubCtx(connId, http),
+        };
+    }
+
+    private sealed class RecordingSink : IStreamSink
+    {
+        public List<DirectorStreamFrame> Frames { get; } = new();
+        public bool Completed { get; private set; }
+
+        public Task WriteFrameAsync(DirectorStreamFrame frame, CancellationToken cancellationToken)
+        {
+            Frames.Add(frame);
+            return Task.CompletedTask;
+        }
+
+        public Task CompleteAsync(string? reason)
+        {
+            Completed = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeHubCtx : HubCallerContext
+    {
+        public FakeHubCtx(string connectionId, HttpContext http)
+        {
+            ConnectionId = connectionId;
+            Features.Set<Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature>(new HttpContextFeatureImpl { HttpContext = http });
+        }
+
+        public override string ConnectionId { get; }
+        public override string? UserIdentifier => null;
+        public override System.Security.Claims.ClaimsPrincipal? User => null;
+        public override IDictionary<object, object?> Items { get; } = new Dictionary<object, object?>();
+        public override IFeatureCollection Features { get; } = new FeatureCollection();
+        public override CancellationToken ConnectionAborted => CancellationToken.None;
+        public override void Abort() { }
+
+        private sealed class HttpContextFeatureImpl : Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature
+        {
+            public HttpContext? HttpContext { get; set; }
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TunnelMechanismProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelMechanismProofTests.cs
@@ -10,6 +10,7 @@ using System.Text.Json.Nodes;
 using CcDirector.ControlApi;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Sessions;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Streaming;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -277,7 +278,9 @@ public sealed class TunnelMechanismProofTests : IAsyncLifetime
         var sink = new StallingSink(gate);
         var yielded = 0;
 
-        _gateway.StreamRegistry.Register(streamId, sink);
+        // Issue #1923: the stream is owned by the tenant and Director this test's real hub connection is
+        // bound to (self-host -> Local, Hello -> DirectorId), so the StreamUp below is the PERMITTED path.
+        _gateway.StreamRegistry.Register(streamId, new StreamOwner(TenantId.Local, DirectorId), sink);
 
         async IAsyncEnumerable<DirectorStreamFrame> Produce([EnumeratorCancellation] CancellationToken ct = default)
         {

--- a/src/CcDirector.Gateway.Tests/TunnelStreamLegsTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelStreamLegsTests.cs
@@ -8,6 +8,7 @@ using CcDirector.Gateway.Streaming;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Xunit;
+using CcDirector.Core.Tenancy;
 
 namespace CcDirector.Gateway.Tests;
 
@@ -37,7 +38,7 @@ public sealed class TunnelStreamLegsTests
             {
                 case "read-file":
                     var req = JsonSerializer.Deserialize<OpenStreamRequest>(command.PayloadJson, Json)!;
-                    _ = registry.ConsumeAsync(req.StreamId, FileFrames(req.StreamId, fileBytes), CancellationToken.None);
+                    _ = registry.ConsumeAsync(req.StreamId, new StreamOwner(TenantId.Local, "dir1"), FileFrames(req.StreamId, fileBytes), CancellationToken.None);
                     return Ok(new OpenReadResponse { TotalBytes = fileBytes.Length, ContentType = "text/plain" });
                 case "close-stream":
                     closeStreamSent.Add(JsonSerializer.Deserialize<CloseStreamRequest>(command.PayloadJson, Json)!.StreamId);
@@ -50,7 +51,7 @@ public sealed class TunnelStreamLegsTests
         var legs = new TunnelStreamLegs(registry, send);
         var (ctx, body) = NewHttpContext();
 
-        var handled = await legs.TryServeFileAsync(ctx, Guid.NewGuid().ToString(), "dir1", "/some/abs/path.txt");
+        var handled = await legs.TryServeFileAsync(ctx, Guid.NewGuid().ToString(), TenantId.Local, "dir1", "/some/abs/path.txt");
 
         Assert.True(handled);
         Assert.Equal("text/plain", ctx.Response.ContentType);
@@ -69,7 +70,7 @@ public sealed class TunnelStreamLegsTests
         var legs = new TunnelStreamLegs(registry, send);
         var (ctx, _) = NewHttpContext();
 
-        var handled = await legs.TryServeFileAsync(ctx, Guid.NewGuid().ToString(), "dir1", "/missing");
+        var handled = await legs.TryServeFileAsync(ctx, Guid.NewGuid().ToString(), TenantId.Local, "dir1", "/missing");
 
         Assert.True(handled);
         Assert.Equal(StatusCodes.Status404NotFound, ctx.Response.StatusCode);
@@ -84,7 +85,7 @@ public sealed class TunnelStreamLegsTests
         var legs = new TunnelStreamLegs(registry, send);
         var (ctx, body) = NewHttpContext();
 
-        var handled = await legs.TryServeFileAsync(ctx, Guid.NewGuid().ToString(), "dir1", "/x");
+        var handled = await legs.TryServeFileAsync(ctx, Guid.NewGuid().ToString(), TenantId.Local, "dir1", "/x");
 
         Assert.False(handled); // caller falls back to the HTTP proxy path
         Assert.Empty(body.ToArray());
@@ -103,7 +104,7 @@ public sealed class TunnelStreamLegsTests
         var stub = new StubServerWebSocket();
         var ctx = NewWebSocketContext(stub);
 
-        await legs.ServeTerminalAsync(ctx, Guid.NewGuid().ToString(), "dir1");
+        await legs.ServeTerminalAsync(ctx, Guid.NewGuid().ToString(), TenantId.Local, "dir1");
 
         Assert.Contains(stub.SentText, t => t.Contains("\"type\":\"closed\"") && t.Contains("session not found"));
         Assert.Equal(0, registry.LiveStreamCount);
@@ -124,7 +125,7 @@ public sealed class TunnelStreamLegsTests
                     var req = JsonSerializer.Deserialize<OpenStreamRequest>(command.PayloadJson, Json)!;
                     _ = Task.Run(async () =>
                     {
-                        try { await registry.ConsumeAsync(req.StreamId, TerminalForever(req.StreamId), CancellationToken.None); }
+                        try { await registry.ConsumeAsync(req.StreamId, new StreamOwner(TenantId.Local, "dir1"), TerminalForever(req.StreamId), CancellationToken.None); }
                         finally { producerEnded.TrySetResult(); }
                     });
                     return Ok();
@@ -140,7 +141,7 @@ public sealed class TunnelStreamLegsTests
         var stub = new StubServerWebSocket();
         var ctx = NewWebSocketContext(stub);
 
-        var serve = legs.ServeTerminalAsync(ctx, Guid.NewGuid().ToString(), "dir1");
+        var serve = legs.ServeTerminalAsync(ctx, Guid.NewGuid().ToString(), TenantId.Local, "dir1");
 
         await WaitUntil(() => stub.SentBinaryCount > 0, TimeSpan.FromSeconds(3));
         Assert.Equal(1, registry.LiveStreamCount);

--- a/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
@@ -65,7 +65,7 @@ internal static class SessionWsProxyEndpoints
             if (reqTenant is null) return;
             if (pushedSessions.TryLocate(reqTenant.Value, sid, stale) is { } loc)
             {
-                await tunnel.ServeTerminalAsync(ctx, sid, loc.DirectorId);
+                await tunnel.ServeTerminalAsync(ctx, sid, reqTenant.Value, loc.DirectorId);
                 return;
             }
             await RejectAsync(ctx, sid, "stream");
@@ -80,7 +80,7 @@ internal static class SessionWsProxyEndpoints
             if (pushedSessions.TryLocate(reqTenant.Value, sid, stale) is { } loc)
             {
                 ctx.Response.Headers["X-Content-Type-Options"] = "nosniff";
-                if (await tunnel.TryServeFileAsync(ctx, sid, loc.DirectorId, ctx.Request.Query["path"].ToString()))
+                if (await tunnel.TryServeFileAsync(ctx, sid, reqTenant.Value, loc.DirectorId, ctx.Request.Query["path"].ToString()))
                     return;
             }
             await RejectAsync(ctx, sid, "file");
@@ -107,7 +107,7 @@ internal static class SessionWsProxyEndpoints
             }
             ctx.Response.Headers["Access-Control-Allow-Origin"] = "*";
             ctx.Response.Headers["Cache-Control"] = "public, max-age=3600";
-            if (!await tunnel.TryServeScreenshotAsync(ctx, sid, loc.DirectorId, ctx.Request.Query["name"].ToString()))
+            if (!await tunnel.TryServeScreenshotAsync(ctx, sid, reqTenant.Value, loc.DirectorId, ctx.Request.Query["name"].ToString()))
                 await RejectAsync(ctx, sid, "shot");
         });
 

--- a/src/CcDirector.Gateway/Api/TunnelStreamLegs.cs
+++ b/src/CcDirector.Gateway/Api/TunnelStreamLegs.cs
@@ -1,4 +1,5 @@
 using System.Net.WebSockets;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Streaming;
@@ -40,7 +41,7 @@ internal sealed class TunnelStreamLegs
     /// upgrade is accepted (the caller already committed to the tunnel because the owner is stream-connected);
     /// an open failure closes the socket with a reason and the browser reconnects.
     /// </summary>
-    public async Task ServeTerminalAsync(HttpContext ctx, string sid, string directorId)
+    public async Task ServeTerminalAsync(HttpContext ctx, string sid, TenantId tenant, string directorId)
     {
         if (!ctx.WebSockets.IsWebSocketRequest)
         {
@@ -55,7 +56,9 @@ internal sealed class TunnelStreamLegs
 
         var streamId = Guid.NewGuid().ToString("N");
         var sink = new WebSocketStreamSink(ws);
-        var teardown = _registry.Register(streamId, sink);
+        // Issue #1923: record WHO owns this stream - the tenant that located the session and the Director the
+        // open command below is sent to. Only that identity may stream frames back up under this id.
+        var teardown = _registry.Register(streamId, new StreamOwner(tenant, directorId), sink);
 
         // The browser is "gone" when the request aborts OR the keystroke receive loop ends (a close frame or a
         // socket fault). Either tears the stream down and sends close-stream.
@@ -143,22 +146,25 @@ internal sealed class TunnelStreamLegs
     /// (streamed, or answered 404/400); false ONLY when nothing was written and the caller should fall back to
     /// the HTTP proxy path (the owning Director's stream was lost between resolution and open).
     /// </summary>
-    public Task<bool> TryServeFileAsync(HttpContext ctx, string sid, string directorId, string? path) =>
-        TryServeReadAsync(ctx, sid, directorId, "read-file", new OpenStreamRequest { StreamId = "", Path = path }, "file");
+    public Task<bool> TryServeFileAsync(HttpContext ctx, string sid, TenantId tenant, string directorId, string? path) =>
+        TryServeReadAsync(ctx, sid, tenant, directorId, "read-file", new OpenStreamRequest { StreamId = "", Path = path }, "file");
 
     /// <summary>
     /// Serve <c>GET /sessions/{sid}/screenshots/file?name=...</c> over the tunnel (screenshot-file). Same
     /// contract as <see cref="TryServeFileAsync"/>.
     /// </summary>
-    public Task<bool> TryServeScreenshotAsync(HttpContext ctx, string sid, string directorId, string? name) =>
-        TryServeReadAsync(ctx, sid, directorId, "screenshot-file", new OpenStreamRequest { StreamId = "", ScreenshotId = name }, "screenshot");
+    public Task<bool> TryServeScreenshotAsync(HttpContext ctx, string sid, TenantId tenant, string directorId, string? name) =>
+        TryServeReadAsync(ctx, sid, tenant, directorId, "screenshot-file", new OpenStreamRequest { StreamId = "", ScreenshotId = name }, "screenshot");
 
-    private async Task<bool> TryServeReadAsync(HttpContext ctx, string sid, string directorId, string verb, OpenStreamRequest req, string label)
+    private async Task<bool> TryServeReadAsync(HttpContext ctx, string sid, TenantId tenant, string directorId, string verb, OpenStreamRequest req, string label)
     {
         var streamId = Guid.NewGuid().ToString("N");
         req.StreamId = streamId;
         var sink = new HttpResponseStreamSink(ctx.Response);
-        var teardown = _registry.Register(streamId, sink);
+        // Issue #1923: same ownership record as the terminal leg - the finite reads are the same primitive and
+        // are injectable in exactly the same way (a screenshot or file body written into another account's
+        // response), so they carry the same owner.
+        var teardown = _registry.Register(streamId, new StreamOwner(tenant, directorId), sink);
 
         FileLog.Write($"[TunnelStreamLegs] {label} open sid={sid} director={directorId} stream={streamId}");
         DirectorCommandResult? open;

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -65,12 +65,31 @@ public sealed class DirectorHub : Hub
     /// sink with pull-then-forward backpressure, so a slow browser blocks the pull, which - with a small
     /// StreamBufferCapacity - blocks the Director's producer. One primitive serves both the live terminal and a
     /// finite file/screenshot read (keyed by the stream id). Requires the connection be bound first (Hello).
+    ///
+    /// Issue #1923: binding proves WHO is calling; it does not prove the caller owns THIS stream. The bound
+    /// identity (tenant resolved from the authenticated device key at Hello, plus the bound Director id) is
+    /// handed to the registry, which authorizes it against the owner recorded when the stream was opened and
+    /// REFUSES a caller that does not match. Without that, any authenticated account that learned or guessed a
+    /// live stream id could write frames into another account's terminal, claim the stream ahead of the real
+    /// Director, or tear it down.
     /// </summary>
-    public Task StreamUp(string streamId, IAsyncEnumerable<DirectorStreamFrame> frames)
+    public async Task StreamUp(string streamId, IAsyncEnumerable<DirectorStreamFrame> frames)
     {
         var directorId = RequireBoundDirector();
+        var caller = new StreamOwner(RequireBoundTenant(), directorId);
         FileLog.Write($"[DirectorHub] StreamUp: director={directorId}, stream={streamId}, conn={Short(Context.ConnectionId)}");
-        return _streamRegistry.ConsumeAsync(streamId, frames, Context.ConnectionAborted);
+        try
+        {
+            await _streamRegistry.ConsumeAsync(streamId, caller, frames, Context.ConnectionAborted);
+        }
+        catch (StreamOwnershipDeniedException ex)
+        {
+            // Surface the refusal to the calling Director as a hub error (HubException is the one exception
+            // type SignalR relays verbatim). A refusal is never swallowed: an operator reading either side's
+            // log must be able to tell a cross-account injection attempt from an ordinary closed-stream race.
+            FileLog.Write($"[DirectorHub] StreamUp REFUSED: director={directorId}, stream={streamId}, conn={Short(Context.ConnectionId)}");
+            throw new HubException(ex.Message);
+        }
     }
 
     /// <summary>Bind this connection to a Director. Must be the first message; aborts the connection on a bad id.</summary>

--- a/src/CcDirector.Gateway/Streaming/GatewayStreamRegistry.cs
+++ b/src/CcDirector.Gateway/Streaming/GatewayStreamRegistry.cs
@@ -27,6 +27,14 @@ public sealed class GatewayStreamRegistry
     {
         public required IStreamSink Sink { get; init; }
         public required CancellationTokenSource Cts { get; init; }
+        /// <summary>
+        /// Issue #1923: the identity allowed to stream frames into this sink - the tenant that opened the
+        /// stream and the Director the open command was sent to. Recorded at registration; checked on every
+        /// claim/write. Without it the bare stream id was the only key, so any authenticated caller that
+        /// learned or guessed another account's id could WRITE into that account's terminal, claim the stream
+        /// before the real Director, or tear it down.
+        /// </summary>
+        public required StreamOwner Owner { get; init; }
         public Timer? OpenTimeout { get; set; }
         public int Claimed;
     }
@@ -52,18 +60,28 @@ public sealed class GatewayStreamRegistry
     /// StreamUp-never-arrives timeout. Returns a token that fires when the stream is torn down (a browser
     /// disconnect via <see cref="Close"/>, the timeout, or natural completion) so the caller can stop waiting.
     /// A duplicate stream id is a fail-loud error (ids are fresh Guids and must be unique).
+    ///
+    /// Issue #1923: the caller MUST supply the <paramref name="owner"/> - the tenant whose request opened this
+    /// stream and the Director the open command is being sent to. That pair is recorded on the entry and is
+    /// what <see cref="ConsumeAsync"/> authorizes every incoming StreamUp against, so a stream can only ever be
+    /// claimed, written, or ended by the Director it was opened on, inside the account that opened it.
     /// </summary>
-    public CancellationToken Register(string streamId, IStreamSink sink)
+    public CancellationToken Register(string streamId, StreamOwner owner, IStreamSink sink)
     {
         if (string.IsNullOrEmpty(streamId)) throw new ArgumentException("streamId is required", nameof(streamId));
         if (sink is null) throw new ArgumentNullException(nameof(sink));
+        // Fail loud on an unusable owner rather than recording one that would authorize nobody (or, worse,
+        // anybody). An invalid tenant or a blank Director id means the caller does not actually know who owns
+        // this stream, and a stream whose owner is unknown must never be opened.
+        if (!owner.Tenant.IsValid) throw new ArgumentException("stream owner tenant is required", nameof(owner));
+        if (string.IsNullOrWhiteSpace(owner.DirectorId)) throw new ArgumentException("stream owner directorId is required", nameof(owner));
 
-        var entry = new Entry { Sink = sink, Cts = new CancellationTokenSource() };
+        var entry = new Entry { Sink = sink, Cts = new CancellationTokenSource(), Owner = owner };
         if (!_streams.TryAdd(streamId, entry))
             throw new InvalidOperationException($"stream id already registered (ids must be fresh and unique): {streamId}");
 
         entry.OpenTimeout = new Timer(_ => TimeoutUnclaimed(streamId), null, _openTimeout, Timeout.InfiniteTimeSpan);
-        FileLog.Write($"[GatewayStreamRegistry] registered stream {streamId} (live={_streams.Count})");
+        FileLog.Write($"[GatewayStreamRegistry] registered stream {streamId} ({owner.ToLogString()}, live={_streams.Count})");
         return entry.Cts.Token;
     }
 
@@ -83,8 +101,15 @@ public sealed class GatewayStreamRegistry
     /// on the Closed frame, natural completion, cancellation (a browser disconnect via <see cref="Close"/>), or
     /// the hub connection aborting. If no sink is registered for this id the frames are dropped and the method
     /// returns at once (StreamUp-after-sink-gone: the browser is already gone).
+    ///
+    /// Issue #1923 - AUTHORIZATION, not just authentication. <paramref name="caller"/> is the identity the hub
+    /// resolved for the connection sending these frames (its bound tenant and its bound Director id). It is
+    /// checked against the owner recorded at <see cref="Register"/>, and a mismatch REFUSES the call by
+    /// throwing - the frames never reach the sink, the stream is not claimed, and it is not torn down. Proving
+    /// WHO the caller is (which the hub's Hello binding already does) is not proving the caller owns THIS
+    /// stream; this method is where the second question is answered.
     /// </summary>
-    public async Task ConsumeAsync(string streamId, IAsyncEnumerable<DirectorStreamFrame> frames, CancellationToken hubCancellation)
+    public async Task ConsumeAsync(string streamId, StreamOwner caller, IAsyncEnumerable<DirectorStreamFrame> frames, CancellationToken hubCancellation)
     {
         if (frames is null) throw new ArgumentNullException(nameof(frames));
 
@@ -94,6 +119,16 @@ public sealed class GatewayStreamRegistry
             // is nothing to pump into; return immediately so the Director's producer is not consumed further.
             FileLog.Write($"[GatewayStreamRegistry] StreamUp for unknown/closed stream {streamId}; dropping (sink already gone)");
             return;
+        }
+
+        if (!entry.Owner.Matches(caller))
+        {
+            // REFUSE - loudly. A silent drop here would be indistinguishable from the legitimate no-op above,
+            // which is exactly what would let a cross-account injection attempt look like an ordinary race in
+            // the log. Nothing is claimed and nothing is torn down: the real owner's stream is untouched, so a
+            // wrong caller cannot deny it service either.
+            FileLog.Write($"[GatewayStreamRegistry] StreamUp REFUSED for stream {streamId}: caller ({caller.ToLogString()}) does not own it (owner {entry.Owner.ToLogString()})");
+            throw new StreamOwnershipDeniedException($"stream {streamId} is not owned by the calling Director");
         }
 
         Interlocked.Exchange(ref entry.Claimed, 1);
@@ -127,7 +162,18 @@ public sealed class GatewayStreamRegistry
         }
     }
 
-    /// <summary>Tear a stream down from the browser-facing side (the browser disconnected). Idempotent.</summary>
+    /// <summary>
+    /// Tear a stream down from the BROWSER-FACING side (the browser disconnected). Idempotent.
+    ///
+    /// Issue #1923 - why this one takes no owner. Every caller of this method is the Gateway leg that called
+    /// <see cref="Register"/> for that very stream id, inside the same request (see
+    /// <c>TunnelStreamLegs</c>); the id never leaves that method's local scope on this side. No Director,
+    /// device, or browser can reach it - the Director-facing surface is the hub, whose only stream method is
+    /// StreamUp, and the Director's own "close-stream" travels the OTHER way (Gateway to Director) and never
+    /// re-enters this registry. So there is no untrusted caller to authorize here. The teardown that IS
+    /// reachable by a Director runs in <see cref="ConsumeAsync"/>'s finally, behind the ownership check above.
+    /// If a caller-supplied close is ever added, it must carry and check an owner exactly as ConsumeAsync does.
+    /// </summary>
     public void Close(string streamId) => Teardown(streamId, "closed");
 
     private void Teardown(string streamId, string? reason)

--- a/src/CcDirector.Gateway/Streaming/StreamOwner.cs
+++ b/src/CcDirector.Gateway/Streaming/StreamOwner.cs
@@ -1,0 +1,47 @@
+using CcDirector.Core.Tenancy;
+
+namespace CcDirector.Gateway.Streaming;
+
+/// <summary>
+/// Issue #1923: the identity that OWNS a registered up-stream - the tenant whose browser request opened it,
+/// paired with the Director the Gateway sent the open command to.
+///
+/// Why this pair, and not one or the other. The tenant alone is not enough on a self-host install (everything
+/// is <see cref="TenantId.Local"/>, so it would authorize nothing), and the Director id alone is not enough on
+/// hosted, because a Director id is chosen by the client in its Hello message and the Director registry is
+/// keyed on (tenant, director id) - two accounts can each own a Director calling itself the same thing. The
+/// PAIR is the identity that is both server-resolved on the receiving side (the tenant comes from the
+/// authenticated device key at Hello, never from client input) and known on the registering side (the request
+/// tenant that located the session, and that session's owning Director).
+/// </summary>
+/// <param name="Tenant">The isolation boundary the stream belongs to.</param>
+/// <param name="DirectorId">The Director the stream was opened on, and the only one allowed to stream it up.</param>
+public readonly record struct StreamOwner(TenantId Tenant, string DirectorId)
+{
+    /// <summary>
+    /// True when <paramref name="caller"/> is the same identity as this owner. The Director id is compared
+    /// case-insensitively, matching how <c>DirectorHub.Hello</c> compares a re-claim of a bound id; the tenant
+    /// is compared exactly (tenant values are canonical, never case-folded).
+    /// </summary>
+    public bool Matches(StreamOwner caller) =>
+        Tenant.IsValid
+        && caller.Tenant.IsValid
+        && string.Equals(Tenant.Value, caller.Tenant.Value, StringComparison.Ordinal)
+        && !string.IsNullOrEmpty(DirectorId)
+        && string.Equals(DirectorId, caller.DirectorId, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>A log-safe rendering: the tenant is hashed (never raw), the Director id is shortened.</summary>
+    public string ToLogString() =>
+        $"tenant={Tenant.ToLogString()}, director={(string.IsNullOrEmpty(DirectorId) ? "(none)" : DirectorId)}";
+}
+
+/// <summary>
+/// Issue #1923: thrown when a caller tries to stream frames into an up-stream it does not own. This is a
+/// REFUSAL, not a silent drop: a drop would be indistinguishable from the legitimate "the stream id is
+/// unknown because the browser already left" no-op, and it would hide a real misconfiguration from operators.
+/// The hub turns this into a hub error the calling Director sees.
+/// </summary>
+public sealed class StreamOwnershipDeniedException : Exception
+{
+    public StreamOwnershipDeniedException(string message) : base(message) { }
+}


### PR DESCRIPTION
Fixes #1923.

## The defect

`DirectorHub.StreamUp` proved WHO the caller was - the Hello binding - but never that the caller OWNED the stream it named, and `GatewayStreamRegistry` recorded no owner at all: its entries were keyed on the bare stream id string. Any authenticated account that learned or guessed another account's live stream id could therefore write frames into that account's terminal, file, or screenshot sink, claim the stream ahead of the real Director, or tear it down.

The direction matters: this is INJECTION - a write into what another customer sees - plus a denial of service against their streams. It is not disclosure, and a fix that only prevented reading would not have touched it.

## The fix: authorize, do not deny

This is a live product path, and the stream is tenant-attributable, so the entry carries its owner rather than the path being denied.

`Register` now records a `StreamOwner` - the tenant whose request located the session, paired with the Director the open command is being sent to - and `ConsumeAsync` authorizes the calling identity against it and refuses on a mismatch.

**Why the pair, and why not the connection id.** The tenant alone authorizes nothing on self-host, where everything is the single local tenant. The Director id alone is not enough either: it is declared by the client in its Hello message, and the Director registry is keyed on tenant plus Director id, so two accounts can each own a Director calling itself the same thing. Separately, a Director id is re-usable across connections within one tenant - the Hello re-claim guard is per-connection - which means one of an account's own machines could name itself as another of that account's Directors. That is bounded to a single customer and is not a charge blocker, but it is exactly why the tenant half of the pair is load-bearing rather than decorative.

The SignalR connection id was considered and rejected: the Gateway does not hold it at registration time - it routes the open command by Director id - so recording it would have meant inventing a lookup rather than recording a fact.

**A refusal, never a silent drop.** A drop would be indistinguishable from the legitimate "the stream id is unknown because the browser already left" no-op, and it would hide a real misconfiguration from operators. The unknown-id no-op is preserved unchanged and a test pins the two outcomes apart.

## Every public registry member, checked or cleared

| Member | Check? | Why |
|---|---|---|
| constructor | No | No caller identity involved. |
| `LiveStreamCount` | No | Gateway-internal diagnostic count; not reachable by a Director, device, or browser. |
| `Register` | Records the owner | The source of the authorization fact. Fails loud on an invalid tenant or blank Director id - a stream whose owner is unknown must never be opened. |
| `ConsumeAsync` | Yes, added | The write leg, the claim leg, and a teardown leg all at once: the claim flag is set inside it and teardown runs in its `finally`, so one guard at the entry covers all three. On refusal nothing is claimed and nothing is torn down, so a wrong caller cannot deny the real owner service either. |
| `Close` | No, and documented in code | Every caller is the same leg that called `Register` for that id, in the same request; the id never leaves that local scope. The Director-facing surface is the hub, whose only stream method is `StreamUp`, and the Director's own close-stream travels Gateway to Director and never re-enters this registry. The doc comment tells the next person to carry and check an owner if a caller-supplied close is ever added. |

## Proof

Full Gateway suite, one primitive mutated, run on this exact commit.

- **Baseline:** 3005 passed, 0 failed, 10 skipped (Postgres-gated).
- **Reverted** (the ownership block deleted outright): 3003 passed, 2 failed. Both predicted reds appeared by name and as assertions, not crashes:
  - `Hosted_TenantB_StreamingIntoTenantAsStream_IsRefused_AndAsSinkReceivesNothing` - `Assert.Throws() Failure: No exception was thrown. Expected: typeof(Microsoft.AspNetCore.SignalR.HubException)`
  - `SameTenant_DifferentDirector_IsAlsoRefused` - `Assert.Throws() Failure: No exception was thrown. Expected: typeof(CcDirector.Gateway.Streaming.StreamOwnershipDeniedException)`
- **Restored:** 3005 passed, 0 failed. Reconciliation computed: 3003 + 2 = 3005.
- The other six test projects are green: Core 3306, Avalonia 247, HostedAgent 86, Engine 62, Launcher 27, Terminal.Avalonia 21.

The cross-tenant test is deliberately bracketed, because a refusal assertion over a stream that never worked would prove nothing:

1. **Positive control first** - tenant A streams to its own stream id over the real hub and the frames genuinely arrive, with the format facts asserted before the payload is read.
2. **The attack** - tenant B calls `StreamUp` with a stream id minted for tenant A: refused, tenant A's sink receives nothing, is not completed, and the stream is still live.
3. **Destructibility control after** - tenant A then streams into that very same refused stream and the frames land, proving the sink was alive and writable throughout. So the emptiness in step 2 was the ownership check, not a dead stream.

Both hosted and self-host modes are set explicitly in the tests and asserted, never inherited from the runner's default. Self-host is the control and its behaviour is unchanged.
