### PR TITLE
fix(gateway): partition car-mode telemetry by device credential

### DIFF
--- a/src/CcDirector.Gateway.Tests/AuthenticatedCredentialStashTests.cs
+++ b/src/CcDirector.Gateway.Tests/AuthenticatedCredentialStashTests.cs
@@ -1,0 +1,158 @@
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The authentication gate resolves the caller's identity ONCE and passes it forward:
+/// <see cref="AuthMiddleware.AuthenticatedCredentialItemKey"/> carries THE EXACT CREDENTIAL STRING THE GATE
+/// ACCEPTED, for every accepted credential shape.
+///
+/// Anything needing a per-caller identity - a storage partition, a per-device context key - must read that,
+/// instead of reading the raw request a second time and reaching its own conclusion. The gate accepts a
+/// request if ANY presented credential is valid (it tries the Bearer, then every raw cc-gateway-token
+/// cookie), so a second reader with its own preference order will disagree with it: authenticated on the
+/// cookie, identified by an attacker-chosen Bearer. These tests pin the stash for each shape, including the
+/// two disagreement shapes, so that mechanism cannot quietly stop being available.
+/// </summary>
+public sealed class AuthenticatedCredentialStashTests : IDisposable
+{
+    private const string SharedToken = "shared-machine-token-stash-tests";
+
+    private readonly string _registryPath = Path.Combine(Path.GetTempPath(), $"cc-gw-stash-devices-{Guid.NewGuid():N}.json");
+    private readonly DeviceRegistry _devices;
+    private readonly string _deviceKey;
+
+    public AuthenticatedCredentialStashTests()
+    {
+        _devices = new DeviceRegistry(_registryPath);
+        _deviceKey = _devices.Register("device-one", "PHONE-ONE", "android", "phone").DeviceKey;
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_registryPath)) File.Delete(_registryPath);
+    }
+
+    private static string? StashedCredential(HttpContext ctx)
+        => ctx.Items.TryGetValue(AuthMiddleware.AuthenticatedCredentialItemKey, out var v) ? v as string : null;
+
+    private bool Authenticate(HttpContext ctx)
+        => AuthMiddleware.HasValidToken(ctx, SharedToken, _devices);
+
+    private static HttpContext WithBearer(string value)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Headers.Authorization = $"Bearer {value}";
+        return ctx;
+    }
+
+    private static HttpContext WithRawCookieHeader(string cookieHeader)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Headers.Cookie = cookieHeader;
+        return ctx;
+    }
+
+    [Fact]
+    public void BearerDeviceKey_StashesThatDeviceKey()
+    {
+        var ctx = WithBearer(_deviceKey);
+
+        Assert.True(Authenticate(ctx)); // positive control: this credential really did authenticate
+        Assert.Equal(_deviceKey, StashedCredential(ctx));
+    }
+
+    [Fact]
+    public void BearerSharedToken_StashesTheSharedToken()
+    {
+        // The shared machine token is accepted on a branch that stashes NO device key, so this is the shape
+        // most easily left with no identity at all.
+        var ctx = WithBearer(SharedToken);
+
+        Assert.True(Authenticate(ctx));
+        Assert.Equal(SharedToken, StashedCredential(ctx));
+    }
+
+    [Fact]
+    public void CookieDeviceKey_StashesThatDeviceKey()
+    {
+        var ctx = WithRawCookieHeader($"{AuthMiddleware.CookieName}={_deviceKey}");
+
+        Assert.True(Authenticate(ctx));
+        Assert.Equal(_deviceKey, StashedCredential(ctx));
+    }
+
+    [Fact]
+    public void CookieSharedToken_StashesTheSharedToken()
+    {
+        var ctx = WithRawCookieHeader($"{AuthMiddleware.CookieName}={SharedToken}");
+
+        Assert.True(Authenticate(ctx));
+        Assert.Equal(SharedToken, StashedCredential(ctx));
+    }
+
+    [Fact]
+    public void ChosenBearerBesideAValidCookie_StashesTheCOOKIE_TheOneThatAuthenticated()
+    {
+        // The disagreement shape. The Bearer is rejected and the cookie is what let the request in, so the
+        // identity is the cookie's. A reader that preferred the Bearer would be identifying the caller by a
+        // value nothing ever validated.
+        const string chosenBearer = "attacker-chosen-value-9001";
+        var ctx = WithRawCookieHeader($"{AuthMiddleware.CookieName}={_deviceKey}");
+        ctx.Request.Headers.Authorization = $"Bearer {chosenBearer}";
+
+        Assert.True(Authenticate(ctx));
+        Assert.Equal(_deviceKey, StashedCredential(ctx));
+        Assert.NotEqual(chosenBearer, StashedCredential(ctx));
+    }
+
+    [Fact]
+    public void DuplicateCookies_StashTheVALIDATEDOne_NotTheFirstOne()
+    {
+        // The gate tolerates a stale duplicate cc-gateway-token and accepts on whichever value is valid.
+        const string stale = "stale-duplicate-value-9002";
+        var ctx = WithRawCookieHeader($"{AuthMiddleware.CookieName}={stale}; {AuthMiddleware.CookieName}={_deviceKey}");
+
+        Assert.True(Authenticate(ctx));
+        Assert.Equal(_deviceKey, StashedCredential(ctx));
+        Assert.NotEqual(stale, StashedCredential(ctx));
+    }
+
+    [Fact]
+    public void ARejectedRequest_StashesNothing()
+    {
+        // No credential was authenticated, so there is no identity to pass forward. Absent must stay absent:
+        // it is the signal that there is nothing to partition by, not an invitation to go and read the
+        // headers.
+        var ctx = WithBearer("not-a-valid-credential-at-all");
+
+        Assert.False(Authenticate(ctx));
+        Assert.Null(StashedCredential(ctx));
+    }
+
+    [Fact]
+    public void TheSharedToken_DoesNotStashADeviceKey()
+    {
+        // The pre-existing device-key stash keeps its meaning: absent means "shared machine token, no
+        // device", which hosted tenant resolution depends on. The new credential stash is separate.
+        var ctx = WithBearer(SharedToken);
+
+        Assert.True(Authenticate(ctx));
+        Assert.False(ctx.Items.ContainsKey(AuthMiddleware.DeviceKeyItemKey));
+        Assert.Equal(SharedToken, StashedCredential(ctx));
+    }
+
+    [Fact]
+    public void ADeviceKey_StillStashesTheDeviceKey()
+    {
+        // The other half of the control above: the device-key stash is untouched by the new one.
+        var ctx = WithBearer(_deviceKey);
+
+        Assert.True(Authenticate(ctx));
+        Assert.Equal(_deviceKey, ctx.Items[AuthMiddleware.DeviceKeyItemKey]);
+        Assert.Equal(_deviceKey, StashedCredential(ctx));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/CarModeTelemetryEndpointPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeTelemetryEndpointPartitionTests.cs
@@ -143,8 +143,9 @@ public sealed class CarModeTelemetryEndpointPartitionTests : IAsyncLifetime
     private Dictionary<string, string> StoredPartitions()
     {
         using var doc = JsonDocument.Parse(File.ReadAllText(_storePath));
-        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
-        return doc.RootElement.EnumerateArray()
+        // The store persists a versioned envelope: an object with a Version and a Records array.
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+        return doc.RootElement.GetProperty("Records").EnumerateArray()
             .ToDictionary(
                 r => r.GetProperty("TurnId").GetString() ?? "",
                 r => r.GetProperty("DeviceHash").GetString() ?? "");
@@ -205,6 +206,49 @@ public sealed class CarModeTelemetryEndpointPartitionTests : IAsyncLifetime
         Assert.Equal(new[] { "turn-from-b" }, readB.TurnIds);
         Assert.DoesNotContain("turn-from-b", readA.TurnIds);
         Assert.DoesNotContain("turn-from-a", readB.TurnIds);
+    }
+
+    [Fact]
+    public async Task SameTurnId_UnderTwoCredentials_DoesNotCross()
+    {
+        // The requested colliding-key proof, on the wire behind the gate: the SAME Car Mode key (an identical
+        // TurnId) written under two DIFFERENT authenticated device credentials must land in two partitions,
+        // never one. Distinguishable payloads (a different brainMs on each side) make "each side reads its
+        // OWN record" a real assertion rather than a turn-id match that a merge would also satisfy.
+        const string sharedTurn = "same-turn-id-under-both";
+        using var client = Client();
+
+        var writeA = new HttpRequestMessage(HttpMethod.Post, "/carmode/telemetry")
+        { Content = JsonContent.Create(new { turnId = sharedTurn, totalTurnMs = 2500.0, brainMs = 111.0 }) };
+        Bearer(_keyA)(writeA);
+        var respA = await client.SendAsync(writeA);
+        Assert.Equal(HttpStatusCode.OK, respA.StatusCode);
+
+        var writeB = new HttpRequestMessage(HttpMethod.Post, "/carmode/telemetry")
+        { Content = JsonContent.Create(new { turnId = sharedTurn, totalTurnMs = 2500.0, brainMs = 222.0 }) };
+        Bearer(_keyB)(writeB);
+        var respB = await client.SendAsync(writeB);
+        Assert.Equal(HttpStatusCode.OK, respB.StatusCode);
+
+        // Positive read on each side, plus the cross-credential exclusion: each device holds exactly ONE
+        // record for the colliding key - its own - not two.
+        var readA = await ReadTurnsAsync(client, Bearer(_keyA));
+        var readB = await ReadTurnsAsync(client, Bearer(_keyB));
+        Assert.Equal(new[] { sharedTurn }, readA.TurnIds);
+        Assert.Equal(new[] { sharedTurn }, readB.TurnIds);
+        Assert.Equal(1, readA.Held);
+        Assert.Equal(1, readB.Held);
+
+        // And at rest: the colliding key exists as TWO records, one per partition, with the two payloads kept
+        // apart - so nothing was overwritten or merged when the keys collided.
+        using var stored = JsonDocument.Parse(File.ReadAllText(_storePath));
+        var records = stored.RootElement.GetProperty("Records").EnumerateArray()
+            .Where(r => r.GetProperty("TurnId").GetString() == sharedTurn)
+            .Select(r => (Hash: r.GetProperty("DeviceHash").GetString(), Brain: r.GetProperty("BrainMs").GetDouble()))
+            .ToArray();
+        Assert.Equal(2, records.Length);
+        Assert.Contains(records, r => r.Hash == CarModeDeviceHash.Of(_keyA) && r.Brain == 111.0);
+        Assert.Contains(records, r => r.Hash == CarModeDeviceHash.Of(_keyB) && r.Brain == 222.0);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/CarModeTelemetryEndpointPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeTelemetryEndpointPartitionTests.cs
@@ -5,6 +5,8 @@ using System.Net.Sockets;
 using System.Text.Json;
 using CcDirector.Gateway.Api;
 using CcDirector.Gateway.CarMode;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Util;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -12,34 +14,47 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// The Car Mode telemetry routes over the WIRE, with two callers holding DIFFERENT device credentials
-/// (hosted-Gateway collection census row 40). Boots the real <see cref="CarModeEndpoint"/> route map on an
-/// ephemeral port over a temp-file store, so these drive the shipped handlers, not a stand-in.
+/// The Car Mode telemetry routes over the WIRE, BEHIND THE REAL AUTHENTICATION GATE, with two callers
+/// holding different enrolled device keys (hosted-Gateway collection census row 40). The pipeline is the
+/// shipped one: <see cref="AuthMiddleware.Run"/> over a real <see cref="DeviceRegistry"/>, then the real
+/// <see cref="CarModeEndpoint"/> route map, on an ephemeral port over a temp-file store.
 ///
-/// The two facts are asserted SEPARATELY:
-///   1. the WRITE records the partition - proven from the stored document itself, so it cannot be satisfied
-///      by a read filter alone (a read-only filter is a deferred leak: records would keep accumulating
-///      unpartitioned behind it);
-///   2. the READ filters by the partition - neither caller's data read returns the other's records or
-///      counts them.
+/// THE GATE IS IN THE PIPELINE ON PURPOSE. An earlier version of these tests mapped the routes with no
+/// authentication and treated any Bearer string as accepted, and that is precisely why they could not see
+/// the defect they were meant to guard: the partition was resolved by a SECOND reading of the raw request,
+/// which could disagree with the reading the gate had just done. A test that skips authentication cannot
+/// observe a disagreement between authentication and the partition, because it only ever runs one of them.
+/// <see cref="NoCredential_IsRejected_SoTheseTestsReallyRunBehindTheGate"/> keeps that honest.
 ///
-/// Every cross-device assertion carries a positive control in the same test - the caller reading its OWN
-/// record back on the same route - so an empty answer can never pass for isolation when it was really a
-/// failed seed. Status code and media type are asserted BEFORE any body is parsed, because parsing is
-/// itself an assertion about format and a parse failure would arrive as a crash rather than a verdict.
+/// The two facts are asserted SEPARATELY: the WRITE records the partition (proven from the stored document,
+/// so a read filter alone could not satisfy it) and the READS filter by it. Every cross-device assertion
+/// carries a positive control in the same test - the caller reading its OWN record back on the same route -
+/// so an empty answer cannot pass for isolation when it was really a failed seed. Status code and media
+/// type are asserted BEFORE any body is parsed, because parsing is itself an assertion about format.
 /// </summary>
 public sealed class CarModeTelemetryEndpointPartitionTests : IAsyncLifetime
 {
-    private const string CredentialA = "device-a-credential-0000000000";
-    private const string CredentialB = "device-b-credential-1111111111";
+    private const string SharedMachineToken = "shared-machine-token-for-this-test";
 
-    private readonly string _path = Path.Combine(Path.GetTempPath(), $"carmode-telemetry-http-{Guid.NewGuid():N}.json");
+    private readonly string _storePath = Path.Combine(Path.GetTempPath(), $"carmode-telemetry-http-{Guid.NewGuid():N}.json");
+    private readonly string _registryPath = Path.Combine(Path.GetTempPath(), $"carmode-devices-{Guid.NewGuid():N}.json");
+
     private WebApplication _app = null!;
     private string _baseAddress = "";
 
+    /// <summary>Device A's enrolled per-device key - a real key minted by the real registry.</summary>
+    private string _keyA = "";
+
+    /// <summary>Device B's enrolled per-device key.</summary>
+    private string _keyB = "";
+
     public async Task InitializeAsync()
     {
-        var telemetry = new CarModeTelemetryStore(_path, _ => { });
+        var devices = new DeviceRegistry(_registryPath);
+        _keyA = devices.Register("device-a", "PHONE-A", "android", "phone").DeviceKey;
+        _keyB = devices.Register("device-b", "PHONE-B", "android", "phone").DeviceKey;
+
+        var telemetry = new CarModeTelemetryStore(_storePath, _ => { });
         var brain = new CarModeBrain(
             new UnusedChat(),
             new UnusedFleet(),
@@ -57,6 +72,11 @@ public sealed class CarModeTelemetryEndpointPartitionTests : IAsyncLifetime
         _app = builder.Build();
         var port = AllocateFreePort();
         _app.Urls.Add($"http://127.0.0.1:{port}");
+
+        // The real host-wide gate, exactly as GatewayHost installs it.
+        var requireToken = new AuthMiddleware.RequireToken { Token = SharedMachineToken, Devices = devices };
+        _app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, requireToken, next));
+
         CarModeEndpoint.Map(_app, brain, new CarModeTurnCache(_ => { }), telemetry, warmup);
         await _app.StartAsync();
         _baseAddress = $"http://127.0.0.1:{port}";
@@ -66,7 +86,8 @@ public sealed class CarModeTelemetryEndpointPartitionTests : IAsyncLifetime
     {
         await _app.StopAsync();
         await _app.DisposeAsync();
-        if (File.Exists(_path)) File.Delete(_path);
+        if (File.Exists(_storePath)) File.Delete(_storePath);
+        if (File.Exists(_registryPath)) File.Delete(_registryPath);
     }
 
     private static int AllocateFreePort()
@@ -78,31 +99,32 @@ public sealed class CarModeTelemetryEndpointPartitionTests : IAsyncLifetime
         return port;
     }
 
-    private HttpClient ClientFor(string credential)
-    {
-        var client = new HttpClient { BaseAddress = new Uri(_baseAddress) };
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", credential);
-        return client;
-    }
+    private HttpClient Client() => new() { BaseAddress = new Uri(_baseAddress) };
 
-    /// <summary>Post one telemetry record as this caller, asserting the wire contract before any parse.</summary>
-    private static async Task PostTurnAsync(HttpClient client, string turnId)
+    /// <summary>Post one telemetry record with whatever credentials <paramref name="present"/> attaches,
+    ///  asserting the wire contract before any parse.</summary>
+    private async Task PostTurnAsync(HttpClient client, string turnId, Action<HttpRequestMessage> present)
     {
-        var response = await client.PostAsJsonAsync("/carmode/telemetry", new
+        var request = new HttpRequestMessage(HttpMethod.Post, "/carmode/telemetry")
         {
-            turnId,
-            totalTurnMs = 2500.0,
-            brainMs = 1200.0,
-        });
+            Content = JsonContent.Create(new { turnId, totalTurnMs = 2500.0, brainMs = 1200.0 }),
+        };
+        present(request);
+
+        var response = await client.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
     }
 
-    /// <summary>Read this caller's telemetry, asserting status and media type BEFORE parsing the body.</summary>
-    private static async Task<(int Held, string[] TurnIds)> ReadTurnsAsync(HttpClient client)
+    /// <summary>Read telemetry with whatever credentials <paramref name="present"/> attaches, asserting
+    ///  status and media type BEFORE parsing the body.</summary>
+    private async Task<(int Held, string[] TurnIds)> ReadTurnsAsync(HttpClient client, Action<HttpRequestMessage> present)
     {
-        var response = await client.GetAsync("/carmode/telemetry/data");
+        var request = new HttpRequestMessage(HttpMethod.Get, "/carmode/telemetry/data");
+        present(request);
+
+        var response = await client.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
@@ -116,22 +138,71 @@ public sealed class CarModeTelemetryEndpointPartitionTests : IAsyncLifetime
         return (held, ids);
     }
 
+    /// <summary>Every device hash present in the stored document, keyed by turn id. Read straight from the
+    ///  file so the write is proven without going through the read filter.</summary>
+    private Dictionary<string, string> StoredPartitions()
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(_storePath));
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+        return doc.RootElement.EnumerateArray()
+            .ToDictionary(
+                r => r.GetProperty("TurnId").GetString() ?? "",
+                r => r.GetProperty("DeviceHash").GetString() ?? "");
+    }
+
+    /// <summary>Authenticate the way an enrolled phone does: the device key as the Bearer.</summary>
+    private static Action<HttpRequestMessage> Bearer(string key)
+        => request => request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+
+    /// <summary>Authenticate the way a browser does: the device key in the cc-gateway-token cookie.</summary>
+    private static Action<HttpRequestMessage> Cookie(string key)
+        => request => request.Headers.Add("Cookie", $"{AuthMiddleware.CookieName}={key}");
+
+    /// <summary>The attack shape: a valid cookie (which is what the gate will accept) presented ALONGSIDE a
+    ///  Bearer value the caller chose and the gate will reject.</summary>
+    private static Action<HttpRequestMessage> CookiePlusChosenBearer(string cookieKey, string chosenBearer)
+        => request =>
+        {
+            request.Headers.Add("Cookie", $"{AuthMiddleware.CookieName}={cookieKey}");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", chosenBearer);
+        };
+
+    /// <summary>The duplicate-cookie shape the gate explicitly tolerates: a stale first cc-gateway-token
+    ///  that Request.Cookies exposes, and the valid one second, which is the one the gate validates.</summary>
+    private static Action<HttpRequestMessage> StaleThenValidCookie(string staleValue, string validKey)
+        => request => request.Headers.Add(
+            "Cookie", $"{AuthMiddleware.CookieName}={staleValue}; {AuthMiddleware.CookieName}={validKey}");
+
+    // ---- The gate really is in front of these routes ----
+
+    [Fact]
+    public async Task NoCredential_IsRejected_SoTheseTestsReallyRunBehindTheGate()
+    {
+        using var client = Client();
+
+        var write = await client.PostAsJsonAsync("/carmode/telemetry", new { turnId = "no-credential" });
+        var read = await client.GetAsync("/carmode/telemetry/data");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, write.StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, read.StatusCode);
+    }
+
+    // ---- Two authenticated devices ----
+
     [Fact]
     public async Task TwoDevices_NeitherDataReadReturnsTheOthersRecords()
     {
-        using var a = ClientFor(CredentialA);
-        using var b = ClientFor(CredentialB);
-        await PostTurnAsync(a, "turn-from-a");
-        await PostTurnAsync(b, "turn-from-b");
+        using var client = Client();
+        await PostTurnAsync(client, "turn-from-a", Bearer(_keyA));
+        await PostTurnAsync(client, "turn-from-b", Bearer(_keyB));
 
-        var readA = await ReadTurnsAsync(a);
-        var readB = await ReadTurnsAsync(b);
+        var readA = await ReadTurnsAsync(client, Bearer(_keyA));
+        var readB = await ReadTurnsAsync(client, Bearer(_keyB));
 
-        // Positive control on each side first: each caller reads its OWN record back on this very route, so
+        // Positive control on each side first: each device reads its OWN record back on this very route, so
         // an empty result cannot be mistaken for isolation.
         Assert.Equal(new[] { "turn-from-a" }, readA.TurnIds);
         Assert.Equal(new[] { "turn-from-b" }, readB.TurnIds);
-        // The isolation assertion itself.
         Assert.DoesNotContain("turn-from-b", readA.TurnIds);
         Assert.DoesNotContain("turn-from-a", readB.TurnIds);
     }
@@ -139,62 +210,128 @@ public sealed class CarModeTelemetryEndpointPartitionTests : IAsyncLifetime
     [Fact]
     public async Task TwoDevices_TheHeldCountIsPerDevice_NotTheProcessWideTotal()
     {
-        using var a = ClientFor(CredentialA);
-        using var b = ClientFor(CredentialB);
-        await PostTurnAsync(a, "a-one");
-        await PostTurnAsync(b, "b-one");
-        await PostTurnAsync(b, "b-two");
+        using var client = Client();
+        await PostTurnAsync(client, "a-one", Bearer(_keyA));
+        await PostTurnAsync(client, "b-one", Bearer(_keyB));
+        await PostTurnAsync(client, "b-two", Bearer(_keyB));
 
-        var readA = await ReadTurnsAsync(a);
-        var readB = await ReadTurnsAsync(b);
+        var readA = await ReadTurnsAsync(client, Bearer(_keyA));
+        var readB = await ReadTurnsAsync(client, Bearer(_keyB));
 
-        Assert.Equal(1, readA.Held); // positive control: A's own turn is counted
-        Assert.Equal(2, readB.Held); // positive control: B's own turns are counted
+        Assert.Equal(1, readA.Held);
+        Assert.Equal(2, readB.Held);
     }
 
     [Fact]
     public async Task TheWriteRecordsThePartition_ProvenFromTheStoredDocument()
     {
         // Fact 1, proven WITHOUT going through the read filter: the record on disk carries the writing
-        // device's own hash, so the two callers' records are separated at rest, not just when served.
-        using var a = ClientFor(CredentialA);
-        using var b = ClientFor(CredentialB);
-        await PostTurnAsync(a, "stored-by-a");
-        await PostTurnAsync(b, "stored-by-b");
+        // device's own hash, so the callers' records are separated at rest, not only when served.
+        using var client = Client();
+        await PostTurnAsync(client, "stored-by-a", Bearer(_keyA));
+        await PostTurnAsync(client, "stored-by-b", Bearer(_keyB));
 
-        using var doc = JsonDocument.Parse(File.ReadAllText(_path));
+        var stored = StoredPartitions();
 
-        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
-        var stored = doc.RootElement.EnumerateArray()
-            .ToDictionary(r => r.GetProperty("TurnId").GetString() ?? "", r => r.GetProperty("DeviceHash").GetString() ?? "");
-        Assert.Equal(CarModeDeviceHash.Of(CredentialA), stored["stored-by-a"]);
-        Assert.Equal(CarModeDeviceHash.Of(CredentialB), stored["stored-by-b"]);
+        Assert.Equal(CarModeDeviceHash.Of(_keyA), stored["stored-by-a"]);
+        Assert.Equal(CarModeDeviceHash.Of(_keyB), stored["stored-by-b"]);
         Assert.NotEqual(stored["stored-by-a"], stored["stored-by-b"]);
     }
 
     [Fact]
     public async Task ThePostedBodyCannotChooseThePartition()
     {
-        // A caller-supplied value is never the discriminator: caller A posts a body claiming B's hash and a
-        // turn id shaped like B's, and it still lands in A's partition only.
-        using var a = ClientFor(CredentialA);
-        using var b = ClientFor(CredentialB);
-        await PostTurnAsync(b, "really-b");
+        using var client = Client();
+        await PostTurnAsync(client, "really-b", Bearer(_keyB));
 
-        var response = await a.PostAsJsonAsync("/carmode/telemetry", new
+        var request = new HttpRequestMessage(HttpMethod.Post, "/carmode/telemetry")
         {
-            turnId = "claimed-by-a",
-            deviceHash = CarModeDeviceHash.Of(CredentialB),
-            totalTurnMs = 1000.0,
-        });
+            Content = JsonContent.Create(new { turnId = "claimed-by-a", deviceHash = CarModeDeviceHash.Of(_keyB), totalTurnMs = 1000.0 }),
+        };
+        Bearer(_keyA)(request);
+        var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
 
-        var readA = await ReadTurnsAsync(a);
-        var readB = await ReadTurnsAsync(b);
+        var readA = await ReadTurnsAsync(client, Bearer(_keyA));
+        var readB = await ReadTurnsAsync(client, Bearer(_keyB));
 
-        Assert.Equal(new[] { "claimed-by-a" }, readA.TurnIds); // positive control: it was recorded, under A
+        Assert.Equal(new[] { "claimed-by-a" }, readA.TurnIds); // positive control: recorded, under A
         Assert.Equal(new[] { "really-b" }, readB.TurnIds);     // and B's view is untouched by the claim
+    }
+
+    // ---- The partition follows the credential that AUTHENTICATED, not one presented alongside it ----
+
+    [Fact]
+    public async Task ChosenBearerBesideAValidCookie_WritesIntoTheCookiesPartition_NotTheChosenOne()
+    {
+        // The gate tries the Bearer, rejects it, then accepts the request on the cookie. The partition must
+        // therefore be the cookie's. While the route did its own reading of the request it preferred the
+        // Bearer, so a caller could name their own partition on a write.
+        const string chosenBearer = "attacker-chosen-partition-key-0001";
+        using var client = Client();
+        await PostTurnAsync(client, "a-normal", Cookie(_keyA));
+
+        await PostTurnAsync(client, "a-with-chosen-bearer", CookiePlusChosenBearer(_keyA, chosenBearer));
+
+        var stored = StoredPartitions();
+        Assert.Equal(CarModeDeviceHash.Of(_keyA), stored["a-normal"]);              // positive control
+        Assert.Equal(CarModeDeviceHash.Of(_keyA), stored["a-with-chosen-bearer"]);
+        Assert.DoesNotContain(CarModeDeviceHash.Of(chosenBearer), stored.Values);
+    }
+
+    [Fact]
+    public async Task ChosenBearerBesideAValidCookie_ReadsTheCookiesPartition_NotTheChosenOne()
+    {
+        // The same mismatch on the READ path: the answer is the authenticating cookie's records.
+        const string chosenBearer = "attacker-chosen-partition-key-0002";
+        using var client = Client();
+        await PostTurnAsync(client, "a-one", Cookie(_keyA));
+        await PostTurnAsync(client, "b-one", Bearer(_keyB));
+
+        var mismatched = await ReadTurnsAsync(client, CookiePlusChosenBearer(_keyA, chosenBearer));
+
+        Assert.Equal(new[] { "a-one" }, mismatched.TurnIds); // positive control AND the isolation fact
+        Assert.Equal(1, mismatched.Held);
+        Assert.DoesNotContain("b-one", mismatched.TurnIds);
+    }
+
+    [Fact]
+    public async Task DuplicateCookies_PartitionOnTheCookieTheGateValidated_NotTheFirstOne()
+    {
+        // The gate explicitly tolerates a stale duplicate cc-gateway-token and accepts the request on
+        // whichever value is valid. The partition must follow that same value, not the one a single-cookie
+        // reading of the request would have picked up first.
+        const string stale = "stale-duplicate-cookie-value-0003";
+        using var client = Client();
+
+        await PostTurnAsync(client, "written-with-duplicates", StaleThenValidCookie(stale, _keyA));
+
+        var readA = await ReadTurnsAsync(client, Bearer(_keyA));
+        Assert.Equal(new[] { "written-with-duplicates" }, readA.TurnIds); // positive control
+
+        var stored = StoredPartitions();
+        Assert.Equal(CarModeDeviceHash.Of(_keyA), stored["written-with-duplicates"]);
+        Assert.DoesNotContain(CarModeDeviceHash.Of(stale), stored.Values);
+    }
+
+    [Fact]
+    public async Task TheSharedMachineToken_IsItsOwnPartition_AndNotADevices()
+    {
+        // The shared machine token is an accepted credential shape too, and it is accepted on a code path
+        // that stashes no device key. It must still be partitioned as itself - neither merged into a
+        // device's records nor left with no partition at all.
+        using var client = Client();
+        await PostTurnAsync(client, "by-device-a", Bearer(_keyA));
+
+        await PostTurnAsync(client, "by-shared-token", Bearer(SharedMachineToken));
+
+        var readShared = await ReadTurnsAsync(client, Bearer(SharedMachineToken));
+        var readA = await ReadTurnsAsync(client, Bearer(_keyA));
+
+        Assert.Equal(new[] { "by-shared-token" }, readShared.TurnIds); // positive control
+        Assert.Equal(new[] { "by-device-a" }, readA.TurnIds);          // positive control
+        Assert.DoesNotContain("anonymous", StoredPartitions().Values);  // and never the credential-free bucket
     }
 
     /// <summary>The brain is never called by these tests - the telemetry routes do not touch it. It throws

--- a/src/CcDirector.Gateway.Tests/CarModeTelemetryEndpointPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeTelemetryEndpointPartitionTests.cs
@@ -1,0 +1,224 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.CarMode;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The Car Mode telemetry routes over the WIRE, with two callers holding DIFFERENT device credentials
+/// (hosted-Gateway collection census row 40). Boots the real <see cref="CarModeEndpoint"/> route map on an
+/// ephemeral port over a temp-file store, so these drive the shipped handlers, not a stand-in.
+///
+/// The two facts are asserted SEPARATELY:
+///   1. the WRITE records the partition - proven from the stored document itself, so it cannot be satisfied
+///      by a read filter alone (a read-only filter is a deferred leak: records would keep accumulating
+///      unpartitioned behind it);
+///   2. the READ filters by the partition - neither caller's data read returns the other's records or
+///      counts them.
+///
+/// Every cross-device assertion carries a positive control in the same test - the caller reading its OWN
+/// record back on the same route - so an empty answer can never pass for isolation when it was really a
+/// failed seed. Status code and media type are asserted BEFORE any body is parsed, because parsing is
+/// itself an assertion about format and a parse failure would arrive as a crash rather than a verdict.
+/// </summary>
+public sealed class CarModeTelemetryEndpointPartitionTests : IAsyncLifetime
+{
+    private const string CredentialA = "device-a-credential-0000000000";
+    private const string CredentialB = "device-b-credential-1111111111";
+
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"carmode-telemetry-http-{Guid.NewGuid():N}.json");
+    private WebApplication _app = null!;
+    private string _baseAddress = "";
+
+    public async Task InitializeAsync()
+    {
+        var telemetry = new CarModeTelemetryStore(_path, _ => { });
+        var brain = new CarModeBrain(
+            new UnusedChat(),
+            new UnusedFleet(),
+            new CarModeConversationStore(_ => { }),
+            new CarModePendingStore(_ => { }),
+            new CarModeSubjectStore(_ => { }),
+            _ => { });
+        var warmup = new CarModeWarmup(
+            () => ("http://127.0.0.1:1", "model", "key"),
+            () => ("http://127.0.0.1:1", "voice", "model", "key"),
+            log: _ => { });
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        _app = builder.Build();
+        var port = AllocateFreePort();
+        _app.Urls.Add($"http://127.0.0.1:{port}");
+        CarModeEndpoint.Map(_app, brain, new CarModeTurnCache(_ => { }), telemetry, warmup);
+        await _app.StartAsync();
+        _baseAddress = $"http://127.0.0.1:{port}";
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+        if (File.Exists(_path)) File.Delete(_path);
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private HttpClient ClientFor(string credential)
+    {
+        var client = new HttpClient { BaseAddress = new Uri(_baseAddress) };
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", credential);
+        return client;
+    }
+
+    /// <summary>Post one telemetry record as this caller, asserting the wire contract before any parse.</summary>
+    private static async Task PostTurnAsync(HttpClient client, string turnId)
+    {
+        var response = await client.PostAsJsonAsync("/carmode/telemetry", new
+        {
+            turnId,
+            totalTurnMs = 2500.0,
+            brainMs = 1200.0,
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    /// <summary>Read this caller's telemetry, asserting status and media type BEFORE parsing the body.</summary>
+    private static async Task<(int Held, string[] TurnIds)> ReadTurnsAsync(HttpClient client)
+    {
+        var response = await client.GetAsync("/carmode/telemetry/data");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var held = doc.RootElement.GetProperty("held").GetInt32();
+        var ids = doc.RootElement.GetProperty("records")
+            .EnumerateArray()
+            .Select(r => r.GetProperty("turnId").GetString() ?? "")
+            .ToArray();
+        return (held, ids);
+    }
+
+    [Fact]
+    public async Task TwoDevices_NeitherDataReadReturnsTheOthersRecords()
+    {
+        using var a = ClientFor(CredentialA);
+        using var b = ClientFor(CredentialB);
+        await PostTurnAsync(a, "turn-from-a");
+        await PostTurnAsync(b, "turn-from-b");
+
+        var readA = await ReadTurnsAsync(a);
+        var readB = await ReadTurnsAsync(b);
+
+        // Positive control on each side first: each caller reads its OWN record back on this very route, so
+        // an empty result cannot be mistaken for isolation.
+        Assert.Equal(new[] { "turn-from-a" }, readA.TurnIds);
+        Assert.Equal(new[] { "turn-from-b" }, readB.TurnIds);
+        // The isolation assertion itself.
+        Assert.DoesNotContain("turn-from-b", readA.TurnIds);
+        Assert.DoesNotContain("turn-from-a", readB.TurnIds);
+    }
+
+    [Fact]
+    public async Task TwoDevices_TheHeldCountIsPerDevice_NotTheProcessWideTotal()
+    {
+        using var a = ClientFor(CredentialA);
+        using var b = ClientFor(CredentialB);
+        await PostTurnAsync(a, "a-one");
+        await PostTurnAsync(b, "b-one");
+        await PostTurnAsync(b, "b-two");
+
+        var readA = await ReadTurnsAsync(a);
+        var readB = await ReadTurnsAsync(b);
+
+        Assert.Equal(1, readA.Held); // positive control: A's own turn is counted
+        Assert.Equal(2, readB.Held); // positive control: B's own turns are counted
+    }
+
+    [Fact]
+    public async Task TheWriteRecordsThePartition_ProvenFromTheStoredDocument()
+    {
+        // Fact 1, proven WITHOUT going through the read filter: the record on disk carries the writing
+        // device's own hash, so the two callers' records are separated at rest, not just when served.
+        using var a = ClientFor(CredentialA);
+        using var b = ClientFor(CredentialB);
+        await PostTurnAsync(a, "stored-by-a");
+        await PostTurnAsync(b, "stored-by-b");
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(_path));
+
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+        var stored = doc.RootElement.EnumerateArray()
+            .ToDictionary(r => r.GetProperty("TurnId").GetString() ?? "", r => r.GetProperty("DeviceHash").GetString() ?? "");
+        Assert.Equal(CarModeDeviceHash.Of(CredentialA), stored["stored-by-a"]);
+        Assert.Equal(CarModeDeviceHash.Of(CredentialB), stored["stored-by-b"]);
+        Assert.NotEqual(stored["stored-by-a"], stored["stored-by-b"]);
+    }
+
+    [Fact]
+    public async Task ThePostedBodyCannotChooseThePartition()
+    {
+        // A caller-supplied value is never the discriminator: caller A posts a body claiming B's hash and a
+        // turn id shaped like B's, and it still lands in A's partition only.
+        using var a = ClientFor(CredentialA);
+        using var b = ClientFor(CredentialB);
+        await PostTurnAsync(b, "really-b");
+
+        var response = await a.PostAsJsonAsync("/carmode/telemetry", new
+        {
+            turnId = "claimed-by-a",
+            deviceHash = CarModeDeviceHash.Of(CredentialB),
+            totalTurnMs = 1000.0,
+        });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        var readA = await ReadTurnsAsync(a);
+        var readB = await ReadTurnsAsync(b);
+
+        Assert.Equal(new[] { "claimed-by-a" }, readA.TurnIds); // positive control: it was recorded, under A
+        Assert.Equal(new[] { "really-b" }, readB.TurnIds);     // and B's view is untouched by the claim
+    }
+
+    /// <summary>The brain is never called by these tests - the telemetry routes do not touch it. It throws
+    ///  loudly rather than returning a plausible answer if that assumption ever breaks.</summary>
+    private sealed class UnusedChat : ICarModeChat
+    {
+        public Task<CarModeAssistantTurn> CompleteAsync(string messagesJson, string toolsJson, CancellationToken ct)
+            => throw new InvalidOperationException("The telemetry routes must not call the model.");
+    }
+
+    private sealed class UnusedFleet : ICarModeFleet
+    {
+        private static InvalidOperationException Unexpected()
+            => new("The telemetry routes must not call the fleet.");
+
+        public Task<IReadOnlyList<CarModeSessionInfo>> ListSessionsAsync(CancellationToken ct) => throw Unexpected();
+        public Task<CarModeActivity?> GetSessionActivityAsync(string sessionReference, CancellationToken ct) => throw Unexpected();
+        public Task<CarModeSessionInfo?> ResolveSessionAsync(string sessionReference, CancellationToken ct) => throw Unexpected();
+        public Task<string> StartSessionAsync(string repo, CancellationToken ct) => throw Unexpected();
+        public Task MessageSessionAsync(string sessionId, string message, CancellationToken ct) => throw Unexpected();
+        public Task ApproveSessionAsync(string sessionId, CancellationToken ct) => throw Unexpected();
+        public Task DeleteSessionAsync(string sessionId, CancellationToken ct) => throw Unexpected();
+        public Task<CarModeExplain> ExplainSessionAsync(string sessionId, CancellationToken ct) => throw Unexpected();
+        public Task SwitchVoiceModeAsync(string sessionId, bool enabled, CancellationToken ct) => throw Unexpected();
+        public Task SnoozeSessionAsync(string sessionId, CancellationToken ct) => throw Unexpected();
+    }
+}

--- a/src/CcDirector.Gateway.Tests/CarModeTelemetryPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeTelemetryPartitionTests.cs
@@ -85,9 +85,11 @@ public sealed class CarModeTelemetryPartitionTests : IDisposable
 
         using var doc = JsonDocument.Parse(File.ReadAllText(_path));
 
-        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
-        Assert.Equal(1, doc.RootElement.GetArrayLength());
-        Assert.Equal(DeviceA, doc.RootElement[0].GetProperty("DeviceHash").GetString());
+        // The store persists a versioned envelope: an object carrying a Version and the Records array.
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+        var records = doc.RootElement.GetProperty("Records");
+        Assert.Equal(1, records.GetArrayLength());
+        Assert.Equal(DeviceA, records[0].GetProperty("DeviceHash").GetString());
     }
 
     [Fact]
@@ -172,29 +174,73 @@ public sealed class CarModeTelemetryPartitionTests : IDisposable
 
     // ---- Records already on disk ----
 
+    /// <summary>Build a VERSIONED store document on disk - the current envelope shape - from raw record JSON
+    ///  fragments, so a load test exercises trusted (v2+) records rather than a quarantined legacy array.</summary>
+    private void WriteVersionedFile(int version, params string[] recordJson)
+        => File.WriteAllText(_path, $"{{\"Version\":{version},\"Records\":[{string.Join(",", recordJson)}]}}");
+
+    private static string RecordJson(string turnId, string deviceHash, DateTime receivedAtUtc)
+        => $"{{\"TurnId\":\"{turnId}\",\"ReceivedAtUtc\":\"{receivedAtUtc:o}\",\"DeviceHash\":\"{deviceHash}\"}}";
+
     [Fact]
-    public void Load_ExistingRecordsKeepTheirRecordedDevice_SoNoAttributionIsInvented()
+    public void Load_VersionedRecordsKeepTheirRecordedDevice_SoNoAttributionIsInvented()
     {
-        // Records written before this partition existed already carry the device hash the SERVER stamped on
-        // them, so partitioning the reads attributes nothing that was not already recorded - no migration.
-        var legacy = $"[{{\"TurnId\":\"legacy-a\",\"ReceivedAtUtc\":\"{DateTime.UtcNow:o}\",\"DeviceHash\":\"{DeviceA}\"}},"
-                   + $"{{\"TurnId\":\"legacy-b\",\"ReceivedAtUtc\":\"{DateTime.UtcNow:o}\",\"DeviceHash\":\"{DeviceB}\"}}]";
+        // Records persisted by this store (a versioned envelope) carry the device hash the AUTH GATE accepted,
+        // so partitioning the reads attributes nothing that was not already recorded from trusted context.
+        WriteVersionedFile(2,
+            RecordJson("v2-a", DeviceA, DateTime.UtcNow),
+            RecordJson("v2-b", DeviceB, DateTime.UtcNow));
+
+        var store = new CarModeTelemetryStore(_path, _ => { });
+
+        Assert.Equal(new[] { "v2-a" }, store.Recent(DeviceA, 10).Select(r => r.TurnId).ToArray());
+        Assert.Equal(new[] { "v2-b" }, store.Recent(DeviceB, 10).Select(r => r.TurnId).ToArray());
+    }
+
+    [Fact]
+    public void Load_LegacyUnversionedDocument_IsQuarantined_NotServedAcrossCredentials()
+    {
+        // A pre-version document is a BARE ARRAY of records. Its DeviceHash values were stamped before the
+        // store partitioned on the authenticated credential - by an endpoint that reparsed raw request
+        // credentials and could disagree with the gate - so a nonblank legacy hash is NOT a trustworthy
+        // partition key. The whole document must be quarantined and NOTHING served, or one credential's turns
+        // could be handed to another. Blank-only cleanup would leave exactly these nonblank rows exposed.
+        var legacy = $"[{RecordJson("legacy-a", DeviceA, DateTime.UtcNow)},{RecordJson("legacy-b", DeviceB, DateTime.UtcNow)}]";
         File.WriteAllText(_path, legacy);
 
         var store = new CarModeTelemetryStore(_path, _ => { });
 
-        Assert.Equal(new[] { "legacy-a" }, store.Recent(DeviceA, 10).Select(r => r.TurnId).ToArray());
-        Assert.Equal(new[] { "legacy-b" }, store.Recent(DeviceB, 10).Select(r => r.TurnId).ToArray());
+        // Not one legacy record is exposed under any partition.
+        Assert.Empty(store.Recent(DeviceA, 10));
+        Assert.Empty(store.Recent(DeviceB, 10));
+        // The untrusted document was moved aside (quarantined), not deleted or trusted.
+        var corrupt = Directory.GetFiles(Path.GetDirectoryName(_path)!, Path.GetFileName(_path) + ".corrupt-*");
+        Assert.Single(corrupt);
+    }
+
+    [Fact]
+    public void Load_OlderVersionedDocument_IsQuarantined_NotTrusted()
+    {
+        // An envelope from a version BELOW the current one is untrusted for the same reason: its records
+        // predate the trust boundary. It is quarantined whole, not partially trusted.
+        WriteVersionedFile(1, RecordJson("v1-a", DeviceA, DateTime.UtcNow));
+
+        var store = new CarModeTelemetryStore(_path, _ => { });
+
+        Assert.Empty(store.Recent(DeviceA, 10));
+        var corrupt = Directory.GetFiles(Path.GetDirectoryName(_path)!, Path.GetFileName(_path) + ".corrupt-*");
+        Assert.Single(corrupt);
     }
 
     [Fact]
     public void Load_PurgesRecordsThatCarryNoDevice_RatherThanGuessingAnOwner()
     {
-        // A record with no recorded device has no attribution at all. Inventing one would be the forbidden
-        // half-partition, so it is purged; the attributed record beside it is untouched.
-        var mixed = $"[{{\"TurnId\":\"orphan\",\"ReceivedAtUtc\":\"{DateTime.UtcNow:o}\",\"DeviceHash\":\"\"}},"
-                  + $"{{\"TurnId\":\"owned\",\"ReceivedAtUtc\":\"{DateTime.UtcNow:o}\",\"DeviceHash\":\"{DeviceA}\"}}]";
-        File.WriteAllText(_path, mixed);
+        // Even inside a trusted (versioned) document, a record with no recorded device has no attribution at
+        // all. Inventing one would be the forbidden half-partition, so it is purged; the attributed record
+        // beside it is untouched.
+        WriteVersionedFile(2,
+            RecordJson("orphan", "", DateTime.UtcNow),
+            RecordJson("owned", DeviceA, DateTime.UtcNow));
 
         var store = new CarModeTelemetryStore(_path, _ => { });
 
@@ -204,7 +250,7 @@ public sealed class CarModeTelemetryPartitionTests : IDisposable
         // it would pass just as happily against a purge that only ever removed the record from memory and
         // left it in the file until some future turn arrived.
         using var doc = JsonDocument.Parse(File.ReadAllText(_path));
-        var storedTurnIds = doc.RootElement.EnumerateArray().Select(r => r.GetProperty("TurnId").GetString()).ToArray();
+        var storedTurnIds = doc.RootElement.GetProperty("Records").EnumerateArray().Select(r => r.GetProperty("TurnId").GetString()).ToArray();
         Assert.Equal(new[] { "owned" }, storedTurnIds);
 
         // And a second store reading that same file agrees, with the surviving record still attributed.
@@ -219,14 +265,14 @@ public sealed class CarModeTelemetryPartitionTests : IDisposable
     {
         // Same guarantee for the age sweep: an aged-out record must leave the FILE at load, not linger there
         // until a later turn happens to flush it. Nothing in this test writes to the store.
-        var aged = $"[{{\"TurnId\":\"ancient\",\"ReceivedAtUtc\":\"{DateTime.UtcNow.AddDays(-120):o}\",\"DeviceHash\":\"{DeviceA}\"}},"
-                 + $"{{\"TurnId\":\"recent\",\"ReceivedAtUtc\":\"{DateTime.UtcNow:o}\",\"DeviceHash\":\"{DeviceA}\"}}]";
-        File.WriteAllText(_path, aged);
+        WriteVersionedFile(2,
+            RecordJson("ancient", DeviceA, DateTime.UtcNow.AddDays(-120)),
+            RecordJson("recent", DeviceA, DateTime.UtcNow));
 
         var store = new CarModeTelemetryStore(_path, _ => { });
 
         using var doc = JsonDocument.Parse(File.ReadAllText(_path));
-        var storedTurnIds = doc.RootElement.EnumerateArray().Select(r => r.GetProperty("TurnId").GetString()).ToArray();
+        var storedTurnIds = doc.RootElement.GetProperty("Records").EnumerateArray().Select(r => r.GetProperty("TurnId").GetString()).ToArray();
         Assert.Equal(new[] { "recent" }, storedTurnIds);
         Assert.Equal(new[] { "recent" }, store.Recent(DeviceA, 10).Select(r => r.TurnId).ToArray()); // positive control
     }
@@ -236,8 +282,7 @@ public sealed class CarModeTelemetryPartitionTests : IDisposable
     {
         // The control for the two tests above: load only rewrites the file when it actually removed
         // something, so a plain restart is not a write.
-        var clean = $"[{{\"TurnId\":\"owned\",\"ReceivedAtUtc\":\"{DateTime.UtcNow:o}\",\"DeviceHash\":\"{DeviceA}\"}}]";
-        File.WriteAllText(_path, clean);
+        WriteVersionedFile(2, RecordJson("owned", DeviceA, DateTime.UtcNow));
         var before = File.ReadAllText(_path);
 
         var store = new CarModeTelemetryStore(_path, _ => { });
@@ -246,13 +291,46 @@ public sealed class CarModeTelemetryPartitionTests : IDisposable
         Assert.Single(store.Recent(DeviceA, 10)); // positive control: it really did load the record
     }
 
+    // ---- Colliding key: the SAME TurnId under two devices must not cross ----
+
+    [Fact]
+    public void CollidingTurnId_UnderTwoDevices_StaysInTwoPartitions_WithAMutationRevertProof()
+    {
+        // The requested colliding-key proof at the store: the SAME car-mode key (an identical TurnId) written
+        // under two DIFFERENT trusted partitions must stay separated, with distinguishable payloads so "each
+        // side reads its OWN record" is a real assertion. It also carries a MUTATION/REVERT proof - the two
+        // assertions that go red the moment the read filter is removed - so it cannot silently rot into a
+        // test that passes against an un-partitioned store.
+        const string shared = "same-turn-id";
+        var store = new CarModeTelemetryStore(_path, _ => { });
+        store.Add(DeviceA, Record(shared) with { BrainMs = 111 });
+        store.Add(DeviceB, Record(shared) with { BrainMs = 222 });
+
+        var a = store.Recent(DeviceA, 100);
+        var b = store.Recent(DeviceB, 100);
+
+        // Positive control: each device sees exactly its OWN record for the colliding key, with its own payload.
+        Assert.Single(a);
+        Assert.Single(b);
+        Assert.Equal(shared, a[0].TurnId);
+        Assert.Equal(shared, b[0].TurnId);
+        Assert.Equal(111, a[0].BrainMs);
+        Assert.Equal(222, b[0].BrainMs);
+        // Cross-credential exclusion: the mutation/revert proof. If the read filter were dropped, each side
+        // would return BOTH records (count 2) and the neighbour's payload would appear - these go red.
+        Assert.Equal(1, store.Count(DeviceA));
+        Assert.Equal(1, store.Count(DeviceB));
+        Assert.DoesNotContain(a, r => r.BrainMs == 222);
+        Assert.DoesNotContain(b, r => r.BrainMs == 111);
+    }
+
     // ---- Contention: one device must not push another device's records out ----
 
     [Fact]
-    public void GrowthGuard_EvictsFromTheBusiestDevice_NeverFromAQuietOne()
+    public void GrowthGuard_CapsEachPartitionWithinItself_NeverAcrossDevices()
     {
-        // The file cap is a size guard, not a licence to delete a neighbour's data. A device that floods the
-        // store may only evict its own records while it is the largest partition.
+        // The cap is PER DEVICE, so a flooding device only ever evicts its OWN oldest records down to the cap,
+        // and a quiet neighbour keeps everything it has.
         var store = new CarModeTelemetryStore(_path, _ => { }, maxRecords: 5);
         store.Add(DeviceA, Record("a-keep"));
 
@@ -261,6 +339,28 @@ public sealed class CarModeTelemetryPartitionTests : IDisposable
         var a = store.Recent(DeviceA, 100);
         Assert.Single(a);                                  // the quiet device kept its record
         Assert.Equal("a-keep", a[0].TurnId);
-        Assert.Equal(4, store.Count(DeviceB));             // the flooder absorbed the whole eviction
+        Assert.Equal(5, store.Count(DeviceB));             // the flooder is capped to its OWN per-device cap
+    }
+
+    [Fact]
+    public void GrowthGuard_AQuietWritesAddCannotEvictALargerNeighboursRows()
+    {
+        // The blocker this rework fixes: with a PROCESS-WIDE cap, a quiet writer A crossing the global cap by
+        // one would trip an eviction that deleted a LARGER neighbour B's record - a cross-partition deletion.
+        // With a per-partition cap, B fills to the cap and A's later single write leaves every one of B's
+        // records intact, because A only ever prunes its own partition. This assertion is RED on the old
+        // process-wide cap (B would drop to 2) and GREEN here.
+        var store = new CarModeTelemetryStore(_path, _ => { }, maxRecords: 3);
+        store.Add(DeviceB, Record("b-0"));
+        store.Add(DeviceB, Record("b-1"));
+        store.Add(DeviceB, Record("b-2"));
+        Assert.Equal(3, store.Count(DeviceB)); // B is exactly at the cap
+
+        store.Add(DeviceA, Record("a-keep")); // a single write by the QUIET device
+
+        // B lost nothing - not even its oldest - to A's write, and B's oldest record is still present.
+        Assert.Equal(3, store.Count(DeviceB));
+        Assert.Contains(store.Recent(DeviceB, 100), r => r.TurnId == "b-0");
+        Assert.Equal(new[] { "a-keep" }, store.Recent(DeviceA, 100).Select(r => r.TurnId).ToArray()); // positive control
     }
 }

--- a/src/CcDirector.Gateway.Tests/CarModeTelemetryPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeTelemetryPartitionTests.cs
@@ -197,16 +197,53 @@ public sealed class CarModeTelemetryPartitionTests : IDisposable
         File.WriteAllText(_path, mixed);
 
         var store = new CarModeTelemetryStore(_path, _ => { });
-        store.Add(DeviceA, Record("fresh")); // any write persists the store, so the purge reaches the file
 
-        Assert.Equal(new[] { "fresh", "owned" }, store.Recent(DeviceA, 10).Select(r => r.TurnId).ToArray()); // positive control
-        Assert.Empty(store.Recent(DeviceB, 10));
-
-        // The orphan is GONE from the stored document - not merely filtered out of one read path, where it
-        // would sit forever consuming the growth-guard budget and waiting for a future unfiltered reader.
+        // The orphan is GONE FROM THE DURABLE FILE, and nothing in this test wrote to the store to make that
+        // happen: the file is inspected IMMEDIATELY after construction. A test that added a record first
+        // would be performing the flush itself and then crediting the purge with it - it could not fail, and
+        // it would pass just as happily against a purge that only ever removed the record from memory and
+        // left it in the file until some future turn arrived.
         using var doc = JsonDocument.Parse(File.ReadAllText(_path));
         var storedTurnIds = doc.RootElement.EnumerateArray().Select(r => r.GetProperty("TurnId").GetString()).ToArray();
-        Assert.Equal(new[] { "owned", "fresh" }, storedTurnIds);
+        Assert.Equal(new[] { "owned" }, storedTurnIds);
+
+        // And a second store reading that same file agrees, with the surviving record still attributed.
+        var reopened = new CarModeTelemetryStore(_path, _ => { });
+        Assert.Equal(new[] { "owned" }, reopened.Recent(DeviceA, 10).Select(r => r.TurnId).ToArray()); // positive control
+        Assert.Empty(reopened.Recent(DeviceB, 10));
+        Assert.Equal(new[] { "owned" }, store.Recent(DeviceA, 10).Select(r => r.TurnId).ToArray());
+    }
+
+    [Fact]
+    public void Load_PersistsTheRetentionPrune_WithoutWaitingForTheNextWrite()
+    {
+        // Same guarantee for the age sweep: an aged-out record must leave the FILE at load, not linger there
+        // until a later turn happens to flush it. Nothing in this test writes to the store.
+        var aged = $"[{{\"TurnId\":\"ancient\",\"ReceivedAtUtc\":\"{DateTime.UtcNow.AddDays(-120):o}\",\"DeviceHash\":\"{DeviceA}\"}},"
+                 + $"{{\"TurnId\":\"recent\",\"ReceivedAtUtc\":\"{DateTime.UtcNow:o}\",\"DeviceHash\":\"{DeviceA}\"}}]";
+        File.WriteAllText(_path, aged);
+
+        var store = new CarModeTelemetryStore(_path, _ => { });
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(_path));
+        var storedTurnIds = doc.RootElement.EnumerateArray().Select(r => r.GetProperty("TurnId").GetString()).ToArray();
+        Assert.Equal(new[] { "recent" }, storedTurnIds);
+        Assert.Equal(new[] { "recent" }, store.Recent(DeviceA, 10).Select(r => r.TurnId).ToArray()); // positive control
+    }
+
+    [Fact]
+    public void Load_WithNothingToRemove_LeavesTheFileAlone()
+    {
+        // The control for the two tests above: load only rewrites the file when it actually removed
+        // something, so a plain restart is not a write.
+        var clean = $"[{{\"TurnId\":\"owned\",\"ReceivedAtUtc\":\"{DateTime.UtcNow:o}\",\"DeviceHash\":\"{DeviceA}\"}}]";
+        File.WriteAllText(_path, clean);
+        var before = File.ReadAllText(_path);
+
+        var store = new CarModeTelemetryStore(_path, _ => { });
+
+        Assert.Equal(before, File.ReadAllText(_path));
+        Assert.Single(store.Recent(DeviceA, 10)); // positive control: it really did load the record
     }
 
     // ---- Contention: one device must not push another device's records out ----

--- a/src/CcDirector.Gateway.Tests/CarModeTelemetryPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeTelemetryPartitionTests.cs
@@ -1,0 +1,229 @@
+using System.Text.Json;
+using CcDirector.Gateway.CarMode;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Car Mode telemetry is PARTITIONED BY DEVICE CREDENTIAL (hosted-Gateway collection census row 40). These
+/// tests hold the store to the two facts that make the partition real, and they are deliberately kept as
+/// TWO SEPARATE FACTS rather than one end-to-end assertion:
+///
+///   1. THE WRITE RECORDS THE PARTITION. The stored record's device hash is the trusted, credential-derived
+///      one the caller was given, never anything the caller put in the body. A read-only filter would be a
+///      deferred leak - unpartitioned records would keep piling up behind it - so the write is proven on
+///      its own, by reading back what was actually stored.
+///   2. THE READS FILTER BY THE PARTITION. Neither the record list nor the count ever returns another
+///      device's data.
+///
+/// Every cross-device assertion carries a POSITIVE CONTROL in the same test: the device reads its OWN
+/// record back on the same call. Without it, a failed seed would produce an empty answer that looks exactly
+/// like isolation.
+/// </summary>
+public sealed class CarModeTelemetryPartitionTests : IDisposable
+{
+    private const string DeviceA = "aaaa11112222";
+    private const string DeviceB = "bbbb33334444";
+
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"carmode-telemetry-part-{Guid.NewGuid():N}.json");
+
+    public void Dispose()
+    {
+        if (File.Exists(_path)) File.Delete(_path);
+        foreach (var f in Directory.GetFiles(Path.GetDirectoryName(_path)!, Path.GetFileName(_path) + ".corrupt-*"))
+            File.Delete(f);
+    }
+
+    private static CarModeTelemetryRecord Record(string turnId, string? claimedDeviceHash = null) => new()
+    {
+        TurnId = turnId,
+        ReceivedAtUtc = DateTime.UtcNow.ToString("o"),
+        DeviceHash = claimedDeviceHash ?? "",
+        GatewayVersion = "1.0.0+test",
+        TotalTurnMs = 2500,
+    };
+
+    // ---- Fact 1: the WRITE records the partition ----
+
+    [Fact]
+    public void Add_StoresTheTrustedPartition_NotTheOneTheRecordCarried()
+    {
+        // The caller's record claims to belong to device B. The write must file it under the trusted
+        // partition it was called with (device A) and nowhere else.
+        var store = new CarModeTelemetryStore(_path, _ => { });
+
+        store.Add(DeviceA, Record("claims-b", claimedDeviceHash: DeviceB));
+
+        var mine = store.Recent(DeviceA, 10);
+        Assert.Single(mine);                              // positive control: A really did seed a record
+        Assert.Equal("claims-b", mine[0].TurnId);
+        Assert.Equal(DeviceA, mine[0].DeviceHash);        // the STORED partition is the trusted one
+        Assert.Empty(store.Recent(DeviceB, 10));          // and the claimed device got nothing
+    }
+
+    [Fact]
+    public void Add_PersistsTheTrustedPartitionToDisk_SoItSurvivesARestart()
+    {
+        // The partition must be RECORDED, not merely applied in memory: a reload of the file must still
+        // attribute the record to the writing device only.
+        new CarModeTelemetryStore(_path, _ => { }).Add(DeviceA, Record("persisted", claimedDeviceHash: DeviceB));
+
+        var reopened = new CarModeTelemetryStore(_path, _ => { });
+
+        var mine = reopened.Recent(DeviceA, 10);
+        Assert.Single(mine);                              // positive control after the reload
+        Assert.Equal(DeviceA, mine[0].DeviceHash);
+        Assert.Empty(reopened.Recent(DeviceB, 10));
+    }
+
+    [Fact]
+    public void Add_RawJsonOnDisk_CarriesTheWritingDevice()
+    {
+        // Read the stored document directly, not through the store's own reader, so the write is proven by
+        // the artifact rather than by the same code path that filters.
+        new CarModeTelemetryStore(_path, _ => { }).Add(DeviceA, Record("on-disk", claimedDeviceHash: DeviceB));
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(_path));
+
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+        Assert.Equal(1, doc.RootElement.GetArrayLength());
+        Assert.Equal(DeviceA, doc.RootElement[0].GetProperty("DeviceHash").GetString());
+    }
+
+    [Fact]
+    public void Add_BlankPartition_Throws_RatherThanWritingAnUnpartitionedRecord()
+    {
+        var store = new CarModeTelemetryStore(_path, _ => { });
+
+        Assert.Throws<ArgumentException>(() => store.Add("", Record("no-owner")));
+        Assert.Throws<ArgumentException>(() => store.Add("   ", Record("no-owner")));
+    }
+
+    // ---- Fact 2: the READS filter by the partition ----
+
+    [Fact]
+    public void Recent_ReturnsOnlyTheCallingDevicesRecords()
+    {
+        var store = new CarModeTelemetryStore(_path, _ => { });
+        store.Add(DeviceA, Record("a-one"));
+        store.Add(DeviceB, Record("b-one"));
+        store.Add(DeviceA, Record("a-two"));
+
+        var a = store.Recent(DeviceA, 100);
+        var b = store.Recent(DeviceB, 100);
+
+        // Positive control on each side: each device sees its OWN turns, so an empty answer could not
+        // masquerade as isolation.
+        Assert.Equal(new[] { "a-two", "a-one" }, a.Select(r => r.TurnId).ToArray());
+        Assert.Equal(new[] { "b-one" }, b.Select(r => r.TurnId).ToArray());
+        // And neither side sees the other's.
+        Assert.DoesNotContain(a, r => r.TurnId.StartsWith("b-", StringComparison.Ordinal));
+        Assert.DoesNotContain(b, r => r.TurnId.StartsWith("a-", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Count_IsThisDevicesCount_NotTheProcessWideTotal()
+    {
+        var store = new CarModeTelemetryStore(_path, _ => { });
+        store.Add(DeviceA, Record("a-one"));
+        store.Add(DeviceB, Record("b-one"));
+        store.Add(DeviceB, Record("b-two"));
+
+        Assert.Equal(1, store.Count(DeviceA)); // positive control: A's own count is visible
+        Assert.Equal(2, store.Count(DeviceB)); // positive control: B's own count is visible
+    }
+
+    [Fact]
+    public void Add_ReturnsThisDevicesHeldCount_NotTheProcessWideTotal()
+    {
+        var store = new CarModeTelemetryStore(_path, _ => { });
+        store.Add(DeviceB, Record("b-one"));
+        store.Add(DeviceB, Record("b-two"));
+
+        var heldForA = store.Add(DeviceA, Record("a-one"));
+
+        Assert.Equal(1, heldForA); // A holds one, even though the store holds three
+    }
+
+    [Fact]
+    public void Recent_ALimitNeverBorrowsFromAnotherDevice()
+    {
+        // A limit must be applied AFTER the partition, never before it: filling the slice from the global
+        // tail would hand a quiet device its neighbour's turns.
+        var store = new CarModeTelemetryStore(_path, _ => { });
+        store.Add(DeviceA, Record("a-one"));
+        for (var i = 0; i < 5; i++) store.Add(DeviceB, Record($"b-{i}"));
+
+        var a = store.Recent(DeviceA, 3);
+
+        Assert.Single(a);                    // positive control: A's own record is returned
+        Assert.Equal("a-one", a[0].TurnId);
+    }
+
+    [Fact]
+    public void Recent_BlankPartition_Throws_RatherThanReturningEveryDevice()
+    {
+        var store = new CarModeTelemetryStore(_path, _ => { });
+        store.Add(DeviceA, Record("a-one"));
+
+        Assert.Throws<ArgumentException>(() => store.Recent("", 100));
+        Assert.Throws<ArgumentException>(() => store.Count(" "));
+    }
+
+    // ---- Records already on disk ----
+
+    [Fact]
+    public void Load_ExistingRecordsKeepTheirRecordedDevice_SoNoAttributionIsInvented()
+    {
+        // Records written before this partition existed already carry the device hash the SERVER stamped on
+        // them, so partitioning the reads attributes nothing that was not already recorded - no migration.
+        var legacy = $"[{{\"TurnId\":\"legacy-a\",\"ReceivedAtUtc\":\"{DateTime.UtcNow:o}\",\"DeviceHash\":\"{DeviceA}\"}},"
+                   + $"{{\"TurnId\":\"legacy-b\",\"ReceivedAtUtc\":\"{DateTime.UtcNow:o}\",\"DeviceHash\":\"{DeviceB}\"}}]";
+        File.WriteAllText(_path, legacy);
+
+        var store = new CarModeTelemetryStore(_path, _ => { });
+
+        Assert.Equal(new[] { "legacy-a" }, store.Recent(DeviceA, 10).Select(r => r.TurnId).ToArray());
+        Assert.Equal(new[] { "legacy-b" }, store.Recent(DeviceB, 10).Select(r => r.TurnId).ToArray());
+    }
+
+    [Fact]
+    public void Load_PurgesRecordsThatCarryNoDevice_RatherThanGuessingAnOwner()
+    {
+        // A record with no recorded device has no attribution at all. Inventing one would be the forbidden
+        // half-partition, so it is purged; the attributed record beside it is untouched.
+        var mixed = $"[{{\"TurnId\":\"orphan\",\"ReceivedAtUtc\":\"{DateTime.UtcNow:o}\",\"DeviceHash\":\"\"}},"
+                  + $"{{\"TurnId\":\"owned\",\"ReceivedAtUtc\":\"{DateTime.UtcNow:o}\",\"DeviceHash\":\"{DeviceA}\"}}]";
+        File.WriteAllText(_path, mixed);
+
+        var store = new CarModeTelemetryStore(_path, _ => { });
+        store.Add(DeviceA, Record("fresh")); // any write persists the store, so the purge reaches the file
+
+        Assert.Equal(new[] { "fresh", "owned" }, store.Recent(DeviceA, 10).Select(r => r.TurnId).ToArray()); // positive control
+        Assert.Empty(store.Recent(DeviceB, 10));
+
+        // The orphan is GONE from the stored document - not merely filtered out of one read path, where it
+        // would sit forever consuming the growth-guard budget and waiting for a future unfiltered reader.
+        using var doc = JsonDocument.Parse(File.ReadAllText(_path));
+        var storedTurnIds = doc.RootElement.EnumerateArray().Select(r => r.GetProperty("TurnId").GetString()).ToArray();
+        Assert.Equal(new[] { "owned", "fresh" }, storedTurnIds);
+    }
+
+    // ---- Contention: one device must not push another device's records out ----
+
+    [Fact]
+    public void GrowthGuard_EvictsFromTheBusiestDevice_NeverFromAQuietOne()
+    {
+        // The file cap is a size guard, not a licence to delete a neighbour's data. A device that floods the
+        // store may only evict its own records while it is the largest partition.
+        var store = new CarModeTelemetryStore(_path, _ => { }, maxRecords: 5);
+        store.Add(DeviceA, Record("a-keep"));
+
+        for (var i = 0; i < 20; i++) store.Add(DeviceB, Record($"b-{i}"));
+
+        var a = store.Recent(DeviceA, 100);
+        Assert.Single(a);                                  // the quiet device kept its record
+        Assert.Equal("a-keep", a[0].TurnId);
+        Assert.Equal(4, store.Count(DeviceB));             // the flooder absorbed the whole eviction
+    }
+}

--- a/src/CcDirector.Gateway.Tests/CarModeTelemetryPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeTelemetryPartitionTests.cs
@@ -363,4 +363,59 @@ public sealed class CarModeTelemetryPartitionTests : IDisposable
         Assert.Contains(store.Recent(DeviceB, 100), r => r.TurnId == "b-0");
         Assert.Equal(new[] { "a-keep" }, store.Recent(DeviceA, 100).Select(r => r.TurnId).ToArray()); // positive control
     }
+
+    // ---- Age retention: one device's Add must not age-prune ANOTHER device's expired rows ----
+
+    /// <summary>Place a record straight into the store's backing list, past every prune path. A unit test has
+    ///  no clock seam, and both <see cref="CarModeTelemetryStore.Add"/> and startup Load prune expired rows -
+    ///  the very behaviour under test - so an already-aged row that is present in memory but has NOT yet been
+    ///  swept (a quiet device on a long-lived Gateway that has not restarted) can only be staged this way.</summary>
+    private static void SeedRawRecord(CarModeTelemetryStore store, CarModeTelemetryRecord record)
+    {
+        var field = typeof(CarModeTelemetryStore).GetField("_records",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var list = (List<CarModeTelemetryRecord>)field.GetValue(store)!;
+        list.Add(record);
+    }
+
+    private static CarModeTelemetryRecord AgedRecord(string turnId, string deviceHash, int daysOld)
+        => Record(turnId, claimedDeviceHash: deviceHash) with { ReceivedAtUtc = DateTime.UtcNow.AddDays(-daysOld).ToString("o") };
+
+    [Fact]
+    public void Add_ByOneDevice_DoesNotAgePruneAnotherDevicesExpiredRows()
+    {
+        // THE RESIDUAL THIS REWORK FIXES: the age prune was global, so credential A's write deleted EXPIRED
+        // rows belonging to credential B - a caller's Add mutating a partition that is not its own. A caller's
+        // Add must NEVER remove another device's rows, not by the growth cap AND not by age. B's rows have
+        // aged past the 90-day window but its Gateway has not restarted (no load-time global sweep), so they
+        // are still in memory when an UNRELATED device A posts one fresh turn.
+        var store = new CarModeTelemetryStore(_path, _ => { });
+        SeedRawRecord(store, AgedRecord("b-old-1", DeviceB, daysOld: 120));
+        SeedRawRecord(store, AgedRecord("b-old-2", DeviceB, daysOld: 200));
+
+        store.Add(DeviceA, Record("a-fresh")); // a different credential's write
+
+        // B's expired rows are UNTOUCHED - A's Add pruned only A's own partition. On the reverted (global)
+        // age prune, A's Add would delete both of B's expired rows and this drops to 0: revert-proof.
+        Assert.Equal(2, store.Count(DeviceB));
+        var b = store.Recent(DeviceB, 100);
+        Assert.Contains(b, r => r.TurnId == "b-old-1");
+        Assert.Contains(b, r => r.TurnId == "b-old-2");
+        Assert.Equal(new[] { "a-fresh" }, store.Recent(DeviceA, 100).Select(r => r.TurnId).ToArray()); // positive control
+    }
+
+    [Fact]
+    public void Add_ByTheOwningDevice_StillAgePrunesItsOwnExpiredRows()
+    {
+        // The control for the test above: per-partition age retention is still LIVE, not disabled. When the
+        // owning device B writes, ITS OWN expired row is aged out - proving the seeded row really is past the
+        // window (so the test above is not vacuously green) and that the fix narrowed the prune's scope
+        // without switching retention off.
+        var store = new CarModeTelemetryStore(_path, _ => { });
+        SeedRawRecord(store, AgedRecord("b-old", DeviceB, daysOld: 120));
+
+        store.Add(DeviceB, Record("b-fresh")); // the owning device's own write ages its own partition
+
+        Assert.Equal(new[] { "b-fresh" }, store.Recent(DeviceB, 100).Select(r => r.TurnId).ToArray());
+    }
 }

--- a/src/CcDirector.Gateway.Tests/CarModeTelemetryStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeTelemetryStoreTests.cs
@@ -20,6 +20,9 @@ public sealed class CarModeTelemetryStoreTests : IDisposable
             File.Delete(f);
     }
 
+    /// <summary>The device partition these single-device tests write and read under.</summary>
+    private const string Device = "abc123def456";
+
     private static CarModeTelemetryRecord Record(string turnId, string receivedAtUtc, double totalTurnMs = 2500) => new()
     {
         TurnId = turnId,
@@ -36,25 +39,25 @@ public sealed class CarModeTelemetryStoreTests : IDisposable
     public void Add_ThenRecent_ReturnsNewestFirst()
     {
         var store = new CarModeTelemetryStore(_path, _ => { });
-        store.Add(Record("t1", DateTime.UtcNow.AddMinutes(-2).ToString("o")));
-        store.Add(Record("t2", DateTime.UtcNow.AddMinutes(-1).ToString("o")));
+        store.Add(Device, Record("t1", DateTime.UtcNow.AddMinutes(-2).ToString("o")));
+        store.Add(Device, Record("t2", DateTime.UtcNow.AddMinutes(-1).ToString("o")));
 
-        var recent = store.Recent(10);
+        var recent = store.Recent(Device, 10);
 
         Assert.Equal(2, recent.Count);
         Assert.Equal("t2", recent[0].TurnId); // newest first
         Assert.Equal("t1", recent[1].TurnId);
-        Assert.Equal(2, store.Count());
+        Assert.Equal(2, store.Count(Device));
     }
 
     [Fact]
     public void Prune_DropsRecordsOlderThanNinetyDays_KeepsRecent()
     {
         var store = new CarModeTelemetryStore(_path, _ => { });
-        store.Add(Record("old", DateTime.UtcNow.AddDays(-120).ToString("o")));
-        store.Add(Record("fresh", DateTime.UtcNow.AddDays(-1).ToString("o")));
+        store.Add(Device, Record("old", DateTime.UtcNow.AddDays(-120).ToString("o")));
+        store.Add(Device, Record("fresh", DateTime.UtcNow.AddDays(-1).ToString("o")));
 
-        var recent = store.Recent(10);
+        var recent = store.Recent(Device, 10);
 
         Assert.Single(recent);
         Assert.Equal("fresh", recent[0].TurnId);
@@ -64,21 +67,21 @@ public sealed class CarModeTelemetryStoreTests : IDisposable
     public void Prune_KeepsRecordWithUnparseableStamp_RatherThanDiscardIt()
     {
         var store = new CarModeTelemetryStore(_path, _ => { });
-        store.Add(Record("weird", "not-a-date"));
+        store.Add(Device, Record("weird", "not-a-date"));
 
-        Assert.Equal(1, store.Count());
+        Assert.Equal(1, store.Count(Device));
     }
 
     [Fact]
     public void Load_RestoresPersistedRecords_AcrossInstances()
     {
         var first = new CarModeTelemetryStore(_path, _ => { });
-        first.Add(Record("t1", DateTime.UtcNow.ToString("o")));
+        first.Add(Device, Record("t1", DateTime.UtcNow.ToString("o")));
 
         var second = new CarModeTelemetryStore(_path, _ => { });
 
-        Assert.Equal(1, second.Count());
-        Assert.Equal("t1", second.Recent(1)[0].TurnId);
+        Assert.Equal(1, second.Count(Device));
+        Assert.Equal("t1", second.Recent(Device, 1)[0].TurnId);
     }
 
     [Fact]
@@ -95,9 +98,9 @@ public sealed class CarModeTelemetryStoreTests : IDisposable
             Completed = false,
             ReplyChars = 180,
         };
-        store.Add(cutOff);
+        store.Add(Device, cutOff);
 
-        var reloaded = new CarModeTelemetryStore(_path, _ => { }).Recent(1)[0];
+        var reloaded = new CarModeTelemetryStore(_path, _ => { }).Recent(Device, 1)[0];
 
         Assert.False(reloaded.Completed); // the reply did not play to its end
         Assert.Equal(1, reloaded.Chunks);
@@ -123,9 +126,9 @@ public sealed class CarModeTelemetryStoreTests : IDisposable
             MicReacquiredDuringPlayback = true, // the mic was re-opened while the reply "played"
             SpeakingPollCount = 2,
         };
-        store.Add(turn);
+        store.Add(Device, turn);
 
-        var reloaded = new CarModeTelemetryStore(_path, _ => { }).Recent(1)[0];
+        var reloaded = new CarModeTelemetryStore(_path, _ => { }).Recent(Device, 1)[0];
 
         Assert.Equal(4, reloaded.TranscribeAttempts);
         Assert.Equal(5200, reloaded.ClipDurationMs);
@@ -142,7 +145,7 @@ public sealed class CarModeTelemetryStoreTests : IDisposable
 
         var store = new CarModeTelemetryStore(_path, _ => { });
 
-        Assert.Equal(0, store.Count());
+        Assert.Equal(0, store.Count(Device));
         var corrupt = Directory.GetFiles(Path.GetDirectoryName(_path)!, Path.GetFileName(_path) + ".corrupt-*");
         Assert.Single(corrupt);
     }

--- a/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
@@ -23,6 +23,10 @@ namespace CcDirector.Gateway.Api;
 ///   GET  /carmode/telemetry       - a self-contained HTML dashboard of recent turns and aggregates.
 ///   GET  /carmode/telemetry/data  - the raw records as JSON, which the dashboard fetches.
 ///
+/// Telemetry is stored and served PER DEVICE. The write files the record under the device hash the server
+/// derives from the caller's own credential, and the data read returns only that same device's records, so
+/// one caller's turn timings are never disclosed to another.
+///
 /// Auth: the routes are not on the public allow-list and are not under /m/, so the host-wide auth gate
 /// already requires the caller's per-device key (or the shared token), per the Gateway auth rule. The
 /// caller's own credential also keys the server-side conversation context, so multi-turn works per device
@@ -140,16 +144,22 @@ internal static class CarModeEndpoint
         // the server timing it received in the turn response; the SERVER fills the received-at time, the
         // device hash (from its own credential extraction, never trusting the client), and the Gateway
         // build, so those cannot be spoofed. A malformed body is a clear 400, never a silent drop.
+        //
+        // The device hash the server derives here is also the STORAGE PARTITION: the write files the record
+        // under this device and the reads below return only this device's records. Nothing from the posted
+        // body is ever used as the discriminator - a caller-supplied value (the turn id in particular) is
+        // not trusted, and the partition is recorded at write time so records can never accumulate
+        // unpartitioned behind a read filter.
         app.MapPost("/carmode/telemetry", (HttpContext ctx, CarModeTelemetryPost? req) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.TurnId))
                 return Results.Json(new { error = "turnId is required" }, statusCode: StatusCodes.Status400BadRequest);
 
+            var deviceHash = DevicePartition(ctx);
             var record = new CarModeTelemetryRecord
             {
                 TurnId = req.TurnId,
                 ReceivedAtUtc = DateTime.UtcNow.ToString("o"),
-                DeviceHash = CarModeDeviceHash.Of(ExtractCallerCredential(ctx)),
                 GatewayVersion = AppVersion.Full,
                 PauseToTranscribeMs = req.PauseToTranscribeMs,
                 TranscodeMs = req.TranscodeMs,
@@ -183,22 +193,29 @@ internal static class CarModeEndpoint
                 ActionsCount = req.ActionsCount,
                 PendingConfirmation = req.PendingConfirmation,
             };
-            var held = telemetry.Add(record);
+            var held = telemetry.Add(deviceHash, record);
             return Results.Json(new { recorded = true, held });
         });
 
+        // The dashboard's data read. It is scoped to the CALLER'S OWN device partition, derived from the
+        // caller's credential exactly as the write derives it, so one device's turns are never handed to
+        // another. The held count is this device's count too - a process-wide total would disclose other
+        // devices' activity as an aggregate.
         app.MapGet("/carmode/telemetry/data", (HttpContext ctx) =>
         {
+            var deviceHash = DevicePartition(ctx);
             var limit = 200;
             if (int.TryParse(ctx.Request.Query["limit"], out var q) && q > 0) limit = Math.Min(q, 2000);
             return Results.Json(new
             {
                 generatedAtUtc = DateTime.UtcNow,
-                held = telemetry.Count(),
-                records = telemetry.Recent(limit),
+                held = telemetry.Count(deviceHash),
+                records = telemetry.Recent(deviceHash, limit),
             });
         });
 
+        // The dashboard page itself is a static, record-free document: it carries no telemetry, it fetches
+        // /carmode/telemetry/data in the browser, and that read is partitioned above.
         app.MapGet("/carmode/telemetry", (HttpContext ctx) =>
         {
             ctx.Response.Headers.CacheControl = "no-cache";
@@ -206,6 +223,12 @@ internal static class CarModeEndpoint
             return ctx.Response.WriteAsync(CarModeTelemetryPage.Html);
         });
     }
+
+    /// <summary>THE storage partition for Car Mode telemetry: a one-way hash of the caller's OWN credential.
+    ///  Both the write and the data read derive it here, from this one helper, so the write can never file a
+    ///  record under a partition the read would not ask for. It is derived from the request, never from the
+    ///  posted body or a query parameter - a caller-supplied value is not a trusted discriminator.</summary>
+    private static string DevicePartition(HttpContext ctx) => CarModeDeviceHash.Of(ExtractCallerCredential(ctx));
 
     /// <summary>The caller's own credential (Bearer header, else the cc-gateway-token cookie), used only as
     ///  the opaque per-device conversation key and the one-way device hash. Empty when the auth gate is off

--- a/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
@@ -28,10 +28,12 @@ namespace CcDirector.Gateway.Api;
 /// one caller's turn timings are never disclosed to another.
 ///
 /// Auth: the routes are not on the public allow-list and are not under /m/, so the host-wide auth gate
-/// already requires the caller's per-device key (or the shared token), per the Gateway auth rule. The
-/// caller's own credential also keys the server-side conversation context, so multi-turn works per device
-/// without any history crossing the wire. The credential is used only as an opaque key and a one-way
-/// device hash, and is never logged (DT-05).
+/// already requires the caller's per-device key (or the shared token), per the Gateway auth rule. THE
+/// CREDENTIAL THE GATE ACCEPTED - not this file's own reading of the request - keys the server-side
+/// conversation context and the telemetry partition, so multi-turn works per device without any history
+/// crossing the wire and a caller cannot be authenticated as one identity while being partitioned as
+/// another. The credential is used only as an opaque key and a one-way device hash, and is never
+/// logged (DT-05).
 /// </summary>
 internal static class CarModeEndpoint
 {
@@ -74,7 +76,10 @@ internal static class CarModeEndpoint
             if (req is null || string.IsNullOrWhiteSpace(req.Text))
                 return Results.Json(new { error = "text is required" }, statusCode: StatusCodes.Status400BadRequest);
 
-            var deviceKey = ExtractCallerCredential(ctx);
+            // The per-device conversation key is the SAME authenticated credential the telemetry partition
+            // uses. It was read from the raw headers here too, which had the same flaw: a caller could be
+            // authenticated on one credential and given another device's conversation context.
+            var deviceKey = AuthenticatedCredential(ctx);
             var text = req.Text.Trim();
             // Offline resilience Phase 4b (issue #1427): the client sends its durable command-audio record id
             // as the Idempotency-Key so an already-sent turn whose result was lost in a dead zone auto-retries
@@ -224,28 +229,35 @@ internal static class CarModeEndpoint
         });
     }
 
-    /// <summary>THE storage partition for Car Mode telemetry: a one-way hash of the caller's OWN credential.
-    ///  Both the write and the data read derive it here, from this one helper, so the write can never file a
-    ///  record under a partition the read would not ask for. It is derived from the request, never from the
-    ///  posted body or a query parameter - a caller-supplied value is not a trusted discriminator.</summary>
-    private static string DevicePartition(HttpContext ctx) => CarModeDeviceHash.Of(ExtractCallerCredential(ctx));
+    /// <summary>
+    /// THE ONE caller identity in this file: THE EXACT CREDENTIAL THE AUTHENTICATION GATE ACCEPTED, which
+    /// <see cref="AuthMiddleware.HasValidToken"/> stashes on the request. It is the storage partition for
+    /// telemetry and the per-device conversation key for a turn.
+    ///
+    /// This route deliberately does NOT read the Authorization header or the cookies itself. It used to, and
+    /// that was the defect: the gate accepts a request if ANY presented credential is valid - it tries the
+    /// Bearer value and then EVERY raw cc-gateway-token cookie - while a second reader here always preferred
+    /// the Bearer. A caller presenting an attacker-chosen Bearer alongside their valid device cookie would
+    /// therefore be authenticated on the cookie and partitioned on the Bearer, letting them read and write a
+    /// partition that was not theirs. Duplicate cookies opened the same gap. Two independent readings of one
+    /// request are two authentication decisions with different rules, and the disagreement between them IS
+    /// the vulnerability. The identity is resolved once, by the gate whose job that is, and passed forward.
+    ///
+    /// Absent means no credential was authenticated at all (the host-wide gate is off in local debug). That
+    /// is not an identity, so it maps to ONE shared anonymous bucket - exactly what a credential-free request
+    /// got before - and never to a second reading of the headers. Never logged.
+    /// </summary>
+    private static string AuthenticatedCredential(HttpContext ctx)
+        => ctx.Items.TryGetValue(AuthMiddleware.AuthenticatedCredentialItemKey, out var credential)
+            ? credential as string ?? ""
+            : "";
 
-    /// <summary>The caller's own credential (Bearer header, else the cc-gateway-token cookie), used only as
-    ///  the opaque per-device conversation key and the one-way device hash. Empty when the auth gate is off
-    ///  (debug), which the store maps to one shared anonymous context. Never logged.</summary>
-    private static string ExtractCallerCredential(HttpContext ctx)
-    {
-        if (ctx.Request.Headers.TryGetValue("Authorization", out var header))
-        {
-            var raw = header.ToString();
-            const string prefix = "Bearer ";
-            if (raw.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-                return raw[prefix.Length..].Trim();
-        }
-        if (ctx.Request.Cookies.TryGetValue(AuthMiddleware.CookieName, out var cookie) && !string.IsNullOrWhiteSpace(cookie))
-            return cookie;
-        return "";
-    }
+    /// <summary>The telemetry storage partition: a one-way hash of the credential that authenticated this
+    ///  request. Both the write and the data read derive it here, from this one helper, so the write can
+    ///  never file a record under a partition the read would not ask for, and neither can be steered by
+    ///  anything the caller supplies - not the posted body, not a query parameter, and not an unvalidated
+    ///  credential presented alongside the one that actually authenticated.</summary>
+    private static string DevicePartition(HttpContext ctx) => CarModeDeviceHash.Of(AuthenticatedCredential(ctx));
 
     /// <summary>The client's idempotency key for this turn (the durable command-audio record id), from the
     ///  standard <c>Idempotency-Key</c> header. Empty when absent (a legacy caller), which the handler maps

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetryStore.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetryStore.cs
@@ -18,6 +18,21 @@ namespace CcDirector.Gateway.CarMode;
 /// exactly like <see cref="Stats.GatewayInputStatsAggregator"/>.
 ///
 /// Only timings and small counts are ever kept - never the text of what was said or heard.
+///
+/// PARTITIONED BY DEVICE CREDENTIAL. Every record belongs to exactly one device partition - the short
+/// one-way hash of the caller's own credential that <see cref="CarModeDeviceHash"/> derives from the
+/// request, never from the posted body. The device credential is the safe discriminator here for three
+/// reasons: it is trusted (the Gateway derives it from the authenticated request), the other Car Mode
+/// stores - conversation, pending action, subject - are already keyed the same way, so this is consistent
+/// rather than novel, and telemetry is per-device operational data (a turn's timings describe THAT phone's
+/// microphone, transcode, and playback). Making telemetry follow a person across their devices is a
+/// PRODUCT question, not this security partition, and is deliberately not built here.
+///
+/// Both the write and the reads take the partition: <see cref="Add"/> stamps the trusted hash onto the
+/// record it stores (so a record can never be filed under a partition the caller chose), and
+/// <see cref="Recent"/> and <see cref="Count"/> return only that partition. A read-only filter would be a
+/// deferred leak - unpartitioned records would keep accumulating behind it - so the write records the
+/// partition too. The caller-supplied <c>TurnId</c> is never used as a discriminator.
 /// </summary>
 public sealed class CarModeTelemetryStore
 {
@@ -27,12 +42,14 @@ public sealed class CarModeTelemetryStore
     private const int RetentionDays = 90;
 
     /// <summary>An unbounded-growth guard only - far above any realistic 90-day volume. When the store
-    ///  somehow exceeds this, the oldest records are dropped first so the newest are always kept.</summary>
+    ///  somehow exceeds this, records are evicted from the LARGEST device partition first (see
+    ///  <see cref="PruneLocked"/>), so one busy device can never push another device's records out.</summary>
     private const int MaxRecords = 10000;
 
     private readonly string _path;
     private readonly object _lock = new();
     private readonly Action<string> _log;
+    private readonly int _maxRecords;
 
     // Newest last (append order). Reads hand back a newest-first copy for the dashboard.
     private readonly List<CarModeTelemetryRecord> _records = new();
@@ -41,47 +58,87 @@ public sealed class CarModeTelemetryStore
     ///  storage root, beside the other Gateway stores.</param>
     /// <param name="log">Log sink; <see cref="FileLog.Write"/> when null.</param>
     public CarModeTelemetryStore(string? path = null, Action<string>? log = null)
+        : this(path, log, MaxRecords)
     {
+    }
+
+    /// <summary>Test seam: the same store with a small growth-guard cap, so the partition-fair eviction can
+    ///  be driven with a handful of records instead of ten thousand.</summary>
+    internal CarModeTelemetryStore(string? path, Action<string>? log, int maxRecords)
+    {
+        if (maxRecords <= 0) throw new ArgumentOutOfRangeException(nameof(maxRecords));
         _path = string.IsNullOrWhiteSpace(path)
             ? Path.Combine(CcStorage.Root(), "carmode-telemetry.json")
             : path!;
         _log = log ?? FileLog.Write;
+        _maxRecords = maxRecords;
         Load();
     }
 
-    /// <summary>Record one turn's timing, then prune by age (and the growth-guard cap) and persist. A null
-    ///  record is ignored. The stored count after the add is returned so the endpoint can log it.</summary>
-    public int Add(CarModeTelemetryRecord? record)
+    /// <summary>Record one turn's timing INTO <paramref name="deviceHash"/>'s partition, then prune by age
+    ///  (and the growth-guard cap) and persist. The stored record's device hash is taken from
+    ///  <paramref name="deviceHash"/> and nothing else, so the write always records the partition and a
+    ///  caller can never file a record under another device. A null record is ignored. The count held for
+    ///  THAT device after the add is returned so the endpoint can report it.</summary>
+    /// <param name="deviceHash">The trusted, credential-derived partition from
+    ///  <see cref="CarModeDeviceHash.Of"/>. Blank is a programming error and throws - it is never quietly
+    ///  turned into a shared bucket, because that would silently un-partition the write.</param>
+    public int Add(string deviceHash, CarModeTelemetryRecord? record)
     {
-        if (record is null) return Count();
+        if (string.IsNullOrWhiteSpace(deviceHash))
+            throw new ArgumentException("A telemetry write needs the caller's device partition.", nameof(deviceHash));
+        if (record is null) return Count(deviceHash);
+        var owned = record with { DeviceHash = deviceHash };
         lock (_lock)
         {
-            _records.Add(record);
+            _records.Add(owned);
             PruneLocked(DateTime.UtcNow);
             Save();
-            _log($"[CarModeTelemetry] recorded turn {record.TurnId}: total={record.TotalTurnMs:F0}ms, brain={record.BrainMs:F0}ms, "
-                + $"fleetReads={record.FleetReadCount}, models={record.ModelCallCount}; store now holds {_records.Count}");
-            return _records.Count;
+            var held = MineNewestFirstLocked(deviceHash).Count;
+            _log($"[CarModeTelemetry] recorded turn {owned.TurnId}: total={owned.TotalTurnMs:F0}ms, brain={owned.BrainMs:F0}ms, "
+                + $"fleetReads={owned.FleetReadCount}, models={owned.ModelCallCount}; this device now holds {held} of {_records.Count}");
+            return held;
         }
     }
 
-    /// <summary>The most recent <paramref name="limit"/> records, newest first, for the dashboard.</summary>
-    public IReadOnlyList<CarModeTelemetryRecord> Recent(int limit)
+    /// <summary>The most recent <paramref name="limit"/> records BELONGING TO <paramref name="deviceHash"/>,
+    ///  newest first, for the dashboard. Another device's records are never returned.</summary>
+    /// <param name="deviceHash">The trusted, credential-derived partition from
+    ///  <see cref="CarModeDeviceHash.Of"/>. Blank is a programming error and throws, so a missing partition
+    ///  can never widen the read to every device.</param>
+    public IReadOnlyList<CarModeTelemetryRecord> Recent(string deviceHash, int limit)
     {
+        if (string.IsNullOrWhiteSpace(deviceHash))
+            throw new ArgumentException("A telemetry read needs the caller's device partition.", nameof(deviceHash));
         if (limit <= 0) limit = 100;
         lock (_lock)
         {
-            var start = Math.Max(0, _records.Count - limit);
-            var slice = _records.GetRange(start, _records.Count - start);
-            slice.Reverse();
-            return slice;
+            var mine = MineNewestFirstLocked(deviceHash);
+            return mine.Count <= limit ? mine : mine.GetRange(0, limit);
         }
     }
 
-    /// <summary>How many records are held right now.</summary>
-    public int Count()
+    /// <summary>How many records <paramref name="deviceHash"/> holds right now. Deliberately per-device:
+    ///  a process-wide total is another device's data, disclosed as an aggregate.</summary>
+    public int Count(string deviceHash)
     {
-        lock (_lock) return _records.Count;
+        if (string.IsNullOrWhiteSpace(deviceHash))
+            throw new ArgumentException("A telemetry read needs the caller's device partition.", nameof(deviceHash));
+        lock (_lock) return MineNewestFirstLocked(deviceHash).Count;
+    }
+
+    /// <summary>THE ONE PLACE a device's records are selected. Every read - the record list and the count -
+    ///  goes through this single filter, so the partition cannot be right in one read and wrong in another,
+    ///  and there is exactly one line to get right. Newest first. Caller holds the lock.</summary>
+    private List<CarModeTelemetryRecord> MineNewestFirstLocked(string deviceHash)
+    {
+        var mine = new List<CarModeTelemetryRecord>();
+        for (var i = _records.Count - 1; i >= 0; i--)
+        {
+            if (string.Equals(_records[i].DeviceHash, deviceHash, StringComparison.Ordinal))
+                mine.Add(_records[i]);
+        }
+        return mine;
     }
 
     // Drop records older than the retention window, then, only if still over the growth-guard cap, drop the
@@ -93,12 +150,42 @@ public sealed class CarModeTelemetryStore
         if (removedByAge > 0)
             _log($"[CarModeTelemetry] pruned {removedByAge} record(s) older than {RetentionDays} days");
 
-        if (_records.Count > MaxRecords)
+        // Growth guard, partition-fair. The cap is on the FILE, but the eviction is never allowed to let one
+        // device push another device's records out - that would be suppression across the partition, not just
+        // a size guard. So each eviction takes the OLDEST record of whichever device currently holds the MOST
+        // records: a device can only lose a record while it is the largest partition, which is exactly the
+        // device that is over its share. Ties break on the device hash so the choice is deterministic.
+        var evicted = 0;
+        while (_records.Count > _maxRecords)
         {
-            var overflow = _records.Count - MaxRecords;
-            _records.RemoveRange(0, overflow);
-            _log($"[CarModeTelemetry] growth guard: dropped {overflow} oldest record(s) to stay at {MaxRecords}");
+            var largest = LargestPartitionLocked();
+            var index = _records.FindIndex(r => string.Equals(r.DeviceHash, largest, StringComparison.Ordinal));
+            if (index < 0) break; // unreachable: the largest partition has at least one record.
+            _records.RemoveAt(index);
+            evicted++;
         }
+        if (evicted > 0)
+            _log($"[CarModeTelemetry] growth guard: dropped {evicted} record(s) from the largest device partition(s) to stay at {_maxRecords}");
+    }
+
+    // The device hash holding the most records right now. Caller holds the lock.
+    private string LargestPartitionLocked()
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var r in _records)
+            counts[r.DeviceHash] = counts.TryGetValue(r.DeviceHash, out var n) ? n + 1 : 1;
+
+        var bestKey = "";
+        var bestCount = -1;
+        foreach (var pair in counts)
+        {
+            if (pair.Value > bestCount || (pair.Value == bestCount && string.CompareOrdinal(pair.Key, bestKey) < 0))
+            {
+                bestKey = pair.Key;
+                bestCount = pair.Value;
+            }
+        }
+        return bestKey;
     }
 
     /// <summary>True when a record's received-at stamp is at or after the cutoff. A record with an
@@ -135,6 +222,17 @@ public sealed class CarModeTelemetryStore
         }
 
         _records.AddRange(parsed);
+
+        // Records already on disk carry the device hash the SERVER stamped on them when they were written -
+        // it has been a server-filled field since the store shipped - so partitioning the reads attributes
+        // nothing that was not already recorded. There is no migration to run and nothing to invent.
+        // A record with a BLANK hash is the one case with no recorded attribution: it belongs to no device,
+        // no partitioned read could ever return it, and guessing an owner for it would be exactly the
+        // invented attribution we refuse. Those are purged here rather than kept as unreachable residue.
+        var unattributed = _records.RemoveAll(r => string.IsNullOrWhiteSpace(r.DeviceHash));
+        if (unattributed > 0)
+            _log($"[CarModeTelemetry] Load: purged {unattributed} record(s) with no device partition (unattributable; never disclosed)");
+
         PruneLocked(DateTime.UtcNow);
         _log($"[CarModeTelemetry] Load: restored {_records.Count} record(s) from {_path}");
     }

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetryStore.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetryStore.cs
@@ -11,11 +11,25 @@ namespace CcDirector.Gateway.CarMode;
 /// foundation the owner asked for - a real per-stage breakdown of where a Car Mode turn spends its time.
 ///
 /// Retention is by AGE (drop records older than <see cref="RetentionDays"/> days, the owner's stated
-/// 90-day intent), with a generous hard cap (<see cref="MaxRecords"/>) ONLY as an unbounded-growth guard so
-/// the file can never grow without bound if the owner walks-and-talks far more than expected in a window.
-/// Persisted as a single JSON document with an atomic temp-write + rename (a concurrent reader or a crash
-/// mid-write never sees a half-written store); a corrupt file is quarantined and the store starts empty,
-/// exactly like <see cref="Stats.GatewayInputStatsAggregator"/>.
+/// 90-day intent), with a generous PER-PARTITION hard cap (<see cref="MaxRecords"/> records per device) ONLY
+/// as an unbounded-growth guard so the file can never grow without bound if the owner walks-and-talks far
+/// more than expected in a window. The cap is per device on purpose: a process-wide cap would let one
+/// credential's write trip an eviction that deletes ANOTHER credential's rows, which is a cross-partition
+/// deletion. A write only ever prunes the caller's OWN partition; startup prunes every partition within
+/// itself. Persisted as a single VERSIONED JSON document (a <see cref="StoreDocument"/> envelope) with an
+/// atomic temp-write + rename (a concurrent reader or a crash mid-write never sees a half-written store); a
+/// corrupt file is quarantined and the store starts empty, exactly like
+/// <see cref="Stats.GatewayInputStatsAggregator"/>.
+///
+/// THE DOCUMENT IS VERSIONED, AND A PRE-VERSION DOCUMENT IS NOT TRUSTED. Before this store was partitioned
+/// on the authenticated credential, an earlier endpoint stamped each record's DeviceHash by independently
+/// reparsing the raw request credentials and preferring any Bearer value - even when the gate had REJECTED
+/// that Bearer and authenticated a cookie instead. A nonblank hash on one of those legacy records is
+/// therefore NOT a trustworthy partition key: serving it under the partitioned reads could hand one
+/// credential's turns to another. So a legacy (unversioned) or older-version document is quarantined whole
+/// on load and the store starts empty - blank-only cleanup is not enough, because the untrustworthy case is
+/// precisely a NONBLANK legacy hash. Only records this store wrote at <see cref="StoreVersion"/> or above,
+/// whose DeviceHash <see cref="Add"/> stamped from the gate's own accepted credential, are trusted.
 ///
 /// Only timings and small counts are ever kept - never the text of what was said or heard.
 ///
@@ -42,12 +56,18 @@ public sealed class CarModeTelemetryStore
 {
     private static readonly JsonSerializerOptions FileJsonOptions = new() { WriteIndented = false };
 
+    /// <summary>The persisted document format version. Bumped to 2 when the store began partitioning on the
+    ///  AUTHENTICATED credential; a document written before that (unversioned, or any version below this) is
+    ///  quarantined on load rather than trusted, because its per-record attribution predates the fix. Bump
+    ///  this again if a future change ever invalidates the trust in an existing record's DeviceHash.</summary>
+    private const int StoreVersion = 2;
+
     /// <summary>Keep records for this many days (the owner asked specifically for 90 days).</summary>
     private const int RetentionDays = 90;
 
-    /// <summary>An unbounded-growth guard only - far above any realistic 90-day volume. When the store
-    ///  somehow exceeds this, records are evicted from the LARGEST device partition first (see
-    ///  <see cref="PruneLocked"/>), so one busy device can never push another device's records out.</summary>
+    /// <summary>An unbounded-growth guard only, applied PER DEVICE PARTITION - far above any realistic 90-day
+    ///  volume for a single device. When a device's own partition exceeds this, ITS OWN oldest records are
+    ///  evicted (see <see cref="PruneLocked"/>); one device's writes never touch another device's partition.</summary>
     private const int MaxRecords = 10000;
 
     private readonly string _path;
@@ -66,8 +86,8 @@ public sealed class CarModeTelemetryStore
     {
     }
 
-    /// <summary>Test seam: the same store with a small growth-guard cap, so the partition-fair eviction can
-    ///  be driven with a handful of records instead of ten thousand.</summary>
+    /// <summary>Test seam: the same store with a small PER-PARTITION growth-guard cap, so the per-device
+    ///  eviction can be driven with a handful of records per device instead of ten thousand.</summary>
     internal CarModeTelemetryStore(string? path, Action<string>? log, int maxRecords)
     {
         if (maxRecords <= 0) throw new ArgumentOutOfRangeException(nameof(maxRecords));
@@ -96,7 +116,10 @@ public sealed class CarModeTelemetryStore
         lock (_lock)
         {
             _records.Add(owned);
-            PruneLocked(DateTime.UtcNow);
+            // A write prunes ONLY the caller's own partition for the growth cap - never another device's -
+            // so one credential's Add can never delete another credential's rows. (Age retention below is a
+            // deterministic time policy, not attributable suppression, so it stays global.)
+            PruneLocked(DateTime.UtcNow, capPartition: deviceHash);
             Save();
             var held = MineNewestFirstLocked(deviceHash).Count;
             _log($"[CarModeTelemetry] recorded turn {owned.TurnId}: total={owned.TotalTurnMs:F0}ms, brain={owned.BrainMs:F0}ms, "
@@ -145,54 +168,67 @@ public sealed class CarModeTelemetryStore
         return mine;
     }
 
-    // Drop records older than the retention window, then, only if still over the growth-guard cap, drop the
-    // oldest until under it. Returns HOW MANY records were removed, so a caller that is not already going to
-    // persist (Load) knows it must. Caller holds the lock.
-    private int PruneLocked(DateTime nowUtc)
+    // Drop records older than the retention window (global, by age), then enforce the PER-PARTITION growth
+    // cap. When capPartition is set (a write), only THAT device's partition is capped, so a write can never
+    // evict another device's rows. When capPartition is null (load), every partition is capped WITHIN ITSELF.
+    // Returns HOW MANY records were removed, so a caller that is not already going to persist (Load) knows it
+    // must. Caller holds the lock.
+    private int PruneLocked(DateTime nowUtc, string? capPartition)
     {
         var cutoff = nowUtc.AddDays(-RetentionDays);
         var removedByAge = _records.RemoveAll(r => !WithinRetention(r.ReceivedAtUtc, cutoff));
         if (removedByAge > 0)
             _log($"[CarModeTelemetry] pruned {removedByAge} record(s) older than {RetentionDays} days");
 
-        // Growth guard, partition-fair. The cap is on the FILE, but the eviction is never allowed to let one
-        // device push another device's records out - that would be suppression across the partition, not just
-        // a size guard. So each eviction takes the OLDEST record of whichever device currently holds the MOST
-        // records: a device can only lose a record while it is the largest partition, which is exactly the
-        // device that is over its share. Ties break on the device hash so the choice is deterministic.
+        // Growth guard, strictly partition-local. The cap is PER DEVICE: a partition over its cap loses its
+        // OWN oldest records and nothing else. On a write we cap only the writer's partition, so a write can
+        // never delete another device's data; on load we cap each partition within itself. There is no
+        // cross-partition comparison and therefore no way for one device to push another device's records out.
         var evicted = 0;
-        while (_records.Count > _maxRecords)
+        if (capPartition is null)
         {
-            var largest = LargestPartitionLocked();
-            var index = _records.FindIndex(r => string.Equals(r.DeviceHash, largest, StringComparison.Ordinal));
-            if (index < 0) break; // unreachable: the largest partition has at least one record.
-            _records.RemoveAt(index);
-            evicted++;
+            foreach (var hash in DistinctPartitionsLocked())
+                evicted += EvictOldestOfPartitionLocked(hash);
+        }
+        else
+        {
+            evicted += EvictOldestOfPartitionLocked(capPartition);
         }
         if (evicted > 0)
-            _log($"[CarModeTelemetry] growth guard: dropped {evicted} record(s) from the largest device partition(s) to stay at {_maxRecords}");
+            _log($"[CarModeTelemetry] growth guard: dropped {evicted} record(s), each from its own device partition, to keep every partition at or under {_maxRecords}");
 
         return removedByAge + evicted;
     }
 
-    // The device hash holding the most records right now. Caller holds the lock.
-    private string LargestPartitionLocked()
+    // Evict the OLDEST records of ONE device's partition until it is at or under the per-partition cap. Never
+    // touches any other partition. Returns how many it removed. Caller holds the lock.
+    private int EvictOldestOfPartitionLocked(string deviceHash)
     {
-        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var count = 0;
         foreach (var r in _records)
-            counts[r.DeviceHash] = counts.TryGetValue(r.DeviceHash, out var n) ? n + 1 : 1;
+            if (string.Equals(r.DeviceHash, deviceHash, StringComparison.Ordinal)) count++;
 
-        var bestKey = "";
-        var bestCount = -1;
-        foreach (var pair in counts)
+        var evicted = 0;
+        while (count > _maxRecords)
         {
-            if (pair.Value > bestCount || (pair.Value == bestCount && string.CompareOrdinal(pair.Key, bestKey) < 0))
-            {
-                bestKey = pair.Key;
-                bestCount = pair.Value;
-            }
+            // FindIndex returns the LOWEST index, which is the oldest record of this partition (append order).
+            var index = _records.FindIndex(r => string.Equals(r.DeviceHash, deviceHash, StringComparison.Ordinal));
+            if (index < 0) break; // unreachable: count > cap >= 1 means this partition has a record.
+            _records.RemoveAt(index);
+            count--;
+            evicted++;
         }
-        return bestKey;
+        return evicted;
+    }
+
+    // Each distinct device hash present right now. Caller holds the lock.
+    private List<string> DistinctPartitionsLocked()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var order = new List<string>();
+        foreach (var r in _records)
+            if (seen.Add(r.DeviceHash)) order.Add(r.DeviceHash);
+        return order;
     }
 
     /// <summary>True when a record's received-at stamp is at or after the cutoff. A record with an
@@ -212,35 +248,65 @@ public sealed class CarModeTelemetryStore
             return;
         }
 
-        List<CarModeTelemetryRecord>? parsed;
+        var text = File.ReadAllText(_path);
+
+        // Inspect the root shape first. A pre-version document is a BARE ARRAY of records; the current
+        // document is an OBJECT envelope with a Version. A legacy array (or an older-version envelope) is
+        // NOT trusted - its per-record DeviceHash predates partitioning on the authenticated credential and
+        // may have been stamped from a credential the gate rejected - so it is quarantined whole and the
+        // store starts empty. Trusting a nonblank legacy hash is exactly the cross-credential leak we refuse;
+        // blank-only cleanup would not catch it.
+        JsonValueKind rootKind;
         try
         {
-            parsed = JsonSerializer.Deserialize<List<CarModeTelemetryRecord>>(File.ReadAllText(_path), FileJsonOptions);
+            using var probe = JsonDocument.Parse(text);
+            rootKind = probe.RootElement.ValueKind;
         }
         catch (JsonException ex)
         {
             Quarantine(ex.Message);
             return;
         }
-        if (parsed is null)
+
+        if (rootKind == JsonValueKind.Array)
+        {
+            Quarantine("legacy unversioned store (records predate partitioning on the authenticated credential); attribution not trustworthy");
+            return;
+        }
+
+        StoreDocument? doc;
+        try
+        {
+            doc = JsonSerializer.Deserialize<StoreDocument>(text, FileJsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            Quarantine(ex.Message);
+            return;
+        }
+        if (doc is null)
         {
             Quarantine("file deserialized to null (no store document)");
             return;
         }
+        if (doc.Version < StoreVersion)
+        {
+            Quarantine($"store version {doc.Version} predates the authenticated-credential partition (need v{StoreVersion}); attribution not trustworthy");
+            return;
+        }
 
-        _records.AddRange(parsed);
+        _records.AddRange(doc.Records ?? new List<CarModeTelemetryRecord>());
 
-        // Records already on disk carry the device hash the SERVER stamped on them when they were written -
-        // it has been a server-filled field since the store shipped - so partitioning the reads attributes
-        // nothing that was not already recorded. There is no migration to run and nothing to invent.
-        // A record with a BLANK hash is the one case with no recorded attribution: it belongs to no device,
-        // no partitioned read could ever return it, and guessing an owner for it would be exactly the
-        // invented attribution we refuse. Those are purged here rather than kept as unreachable residue.
+        // Every surviving record was written at this store version or above, where Add stamps the DeviceHash
+        // from the credential THE GATE ACCEPTED, so its attribution is trusted. A record with a BLANK hash is
+        // the one case with no recorded attribution: it belongs to no device, no partitioned read could ever
+        // return it, and guessing an owner for it would be exactly the invented attribution we refuse. Those
+        // are purged here rather than kept as unreachable residue.
         var unattributed = _records.RemoveAll(r => string.IsNullOrWhiteSpace(r.DeviceHash));
         if (unattributed > 0)
             _log($"[CarModeTelemetry] Load: purged {unattributed} record(s) with no device partition (unattributable; never disclosed)");
 
-        var pruned = PruneLocked(DateTime.UtcNow);
+        var pruned = PruneLocked(DateTime.UtcNow, capPartition: null);
 
         // The purge and the retention prune are GUARANTEES, so they happen on their own terms: whatever load
         // removes is written back to the durable file IMMEDIATELY. Removing it from memory only and waiting
@@ -275,7 +341,7 @@ public sealed class CarModeTelemetryStore
             if (!string.IsNullOrEmpty(dir))
                 Directory.CreateDirectory(dir);
 
-            var json = JsonSerializer.Serialize(_records, FileJsonOptions);
+            var json = JsonSerializer.Serialize(new StoreDocument(StoreVersion, _records), FileJsonOptions);
             var tmp = _path + ".tmp";
             File.WriteAllText(tmp, json);
             File.Move(tmp, _path, overwrite: true);
@@ -286,4 +352,9 @@ public sealed class CarModeTelemetryStore
             throw;
         }
     }
+
+    /// <summary>The persisted envelope: a version stamp plus the records. The version is what lets load
+    ///  distinguish records written under the authenticated-credential partition (trusted) from a pre-version
+    ///  document (quarantined). A bare record array on disk is a pre-version document by definition.</summary>
+    private sealed record StoreDocument(int Version, List<CarModeTelemetryRecord> Records);
 }

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetryStore.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetryStore.cs
@@ -116,9 +116,10 @@ public sealed class CarModeTelemetryStore
         lock (_lock)
         {
             _records.Add(owned);
-            // A write prunes ONLY the caller's own partition for the growth cap - never another device's -
-            // so one credential's Add can never delete another credential's rows. (Age retention below is a
-            // deterministic time policy, not attributable suppression, so it stays global.)
+            // A write prunes ONLY the caller's own partition - never another device's - for BOTH the age
+            // retention AND the growth cap, so one credential's Add can never mutate or delete another
+            // credential's rows (not by cap, and not by age either). Other partitions' expired rows are aged
+            // on the next startup Load (which ages every partition within itself), never by a foreign caller.
             PruneLocked(DateTime.UtcNow, capPartition: deviceHash);
             Save();
             var held = MineNewestFirstLocked(deviceHash).Count;
@@ -168,15 +169,23 @@ public sealed class CarModeTelemetryStore
         return mine;
     }
 
-    // Drop records older than the retention window (global, by age), then enforce the PER-PARTITION growth
-    // cap. When capPartition is set (a write), only THAT device's partition is capped, so a write can never
-    // evict another device's rows. When capPartition is null (load), every partition is capped WITHIN ITSELF.
-    // Returns HOW MANY records were removed, so a caller that is not already going to persist (Load) knows it
-    // must. Caller holds the lock.
+    // Drop records older than the retention window, then enforce the growth cap. BOTH steps are strictly
+    // partition-local when capPartition is set (a write): only THAT device's partition is aged and capped, so
+    // a write can never remove another device's rows - not by cap, and not by age. A caller's Add must NEVER
+    // mutate, prune, or delete a row outside its own partition. When capPartition is null (load, which is not
+    // attributable to any credential), every partition is aged and capped WITHIN ITSELF. Returns HOW MANY
+    // records were removed, so a caller that is not already going to persist (Load) knows it must. Caller
+    // holds the lock.
     private int PruneLocked(DateTime nowUtc, string? capPartition)
     {
         var cutoff = nowUtc.AddDays(-RetentionDays);
-        var removedByAge = _records.RemoveAll(r => !WithinRetention(r.ReceivedAtUtc, cutoff));
+        // Age retention. On a write, age ONLY the writer's own partition - a foreign caller aging (and thus
+        // deleting) another device's expired rows is exactly the cross-partition mutation this store forbids.
+        // On load, age every partition.
+        int removedByAge = capPartition is null
+            ? _records.RemoveAll(r => !WithinRetention(r.ReceivedAtUtc, cutoff))
+            : _records.RemoveAll(r => string.Equals(r.DeviceHash, capPartition, StringComparison.Ordinal)
+                                      && !WithinRetention(r.ReceivedAtUtc, cutoff));
         if (removedByAge > 0)
             _log($"[CarModeTelemetry] pruned {removedByAge} record(s) older than {RetentionDays} days");
 

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetryStore.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetryStore.cs
@@ -28,6 +28,10 @@ namespace CcDirector.Gateway.CarMode;
 /// microphone, transcode, and playback). Making telemetry follow a person across their devices is a
 /// PRODUCT question, not this security partition, and is deliberately not built here.
 ///
+/// The hash is derived from THE CREDENTIAL THE AUTHENTICATION GATE ACCEPTED, which the endpoint reads from
+/// the request the gate stamped it on - never from a second reading of the raw headers, which would be a
+/// second authentication decision that can disagree with the first.
+///
 /// Both the write and the reads take the partition: <see cref="Add"/> stamps the trusted hash onto the
 /// record it stores (so a record can never be filed under a partition the caller chose), and
 /// <see cref="Recent"/> and <see cref="Count"/> return only that partition. A read-only filter would be a
@@ -142,8 +146,9 @@ public sealed class CarModeTelemetryStore
     }
 
     // Drop records older than the retention window, then, only if still over the growth-guard cap, drop the
-    // oldest until under it. Caller holds the lock.
-    private void PruneLocked(DateTime nowUtc)
+    // oldest until under it. Returns HOW MANY records were removed, so a caller that is not already going to
+    // persist (Load) knows it must. Caller holds the lock.
+    private int PruneLocked(DateTime nowUtc)
     {
         var cutoff = nowUtc.AddDays(-RetentionDays);
         var removedByAge = _records.RemoveAll(r => !WithinRetention(r.ReceivedAtUtc, cutoff));
@@ -166,6 +171,8 @@ public sealed class CarModeTelemetryStore
         }
         if (evicted > 0)
             _log($"[CarModeTelemetry] growth guard: dropped {evicted} record(s) from the largest device partition(s) to stay at {_maxRecords}");
+
+        return removedByAge + evicted;
     }
 
     // The device hash holding the most records right now. Caller holds the lock.
@@ -233,7 +240,20 @@ public sealed class CarModeTelemetryStore
         if (unattributed > 0)
             _log($"[CarModeTelemetry] Load: purged {unattributed} record(s) with no device partition (unattributable; never disclosed)");
 
-        PruneLocked(DateTime.UtcNow);
+        var pruned = PruneLocked(DateTime.UtcNow);
+
+        // The purge and the retention prune are GUARANTEES, so they happen on their own terms: whatever load
+        // removes is written back to the durable file IMMEDIATELY. Removing it from memory only and waiting
+        // for the next write to flush is not cleanup - it is cleanup as a side effect of unrelated activity,
+        // which works whenever something happens to write and never happens on a Gateway where no further
+        // turn arrives. The unattributed record would then sit in the file indefinitely, waiting for a future
+        // unfiltered reader, while the log line claimed it had been purged.
+        if (unattributed + pruned > 0)
+        {
+            Save();
+            _log($"[CarModeTelemetry] Load: rewrote {_path} after removing {unattributed + pruned} record(s)");
+        }
+
         _log($"[CarModeTelemetry] Load: restored {_records.Count} record(s) from {_path}");
     }
 

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -70,6 +70,27 @@ internal static class AuthMiddleware
     public const string DeviceKeyItemKey = "cc.auth.DeviceKey";
 
     /// <summary>
+    /// HttpContext.Items key under which <see cref="HasValidToken"/> stashes THE EXACT CREDENTIAL STRING IT
+    /// ACCEPTED, for every accepted credential shape - the shared machine token as well as a per-device key,
+    /// arriving as a Bearer header or as any one of possibly several cookies.
+    ///
+    /// This exists so that anything which needs a per-caller identity - a storage partition, a per-device
+    /// context key - uses the credential this gate actually validated, instead of reading the raw request a
+    /// SECOND time and reaching its own conclusion. Re-deriving an identity from raw headers is re-doing the
+    /// authentication decision in a second place with different rules, and two independent parsers of the
+    /// same request eventually disagree: the gate accepts on a valid cookie while the second parser resolves
+    /// on an attacker-chosen Bearer, and the gap between them is a partition the caller can choose. Resolve
+    /// the identity once, here, and pass it forward.
+    ///
+    /// Absent means NO credential was authenticated on this request (the host-wide gate is off), which is
+    /// not an identity and must never be quietly replaced by re-reading the headers.
+    ///
+    /// It is deliberately SEPARATE from <see cref="DeviceKeyItemKey"/>, whose absence means "the shared
+    /// machine token, no device" and is load-bearing for hosted tenant resolution.
+    /// </summary>
+    public const string AuthenticatedCredentialItemKey = "cc.auth.Credential";
+
+    /// <summary>
     /// The desktop Cockpit's sign-in route (issue #1088): the shared client-core enrollment screen a
     /// signed-out browser navigation is redirected to. Must match the route in apps/cockpit/src/main.tsx.
     /// </summary>
@@ -249,18 +270,12 @@ internal static class AuthMiddleware
                 // MH-2: the shared machine token authenticates with no device (no tenant), so it is refused on
                 // hosted - the per-device key below is the only accepted credential there.
                 if (!rejectSharedToken && string.Equals(provided, token, StringComparison.Ordinal))
-                    return true;
+                    return Accept(ctx, provided, deviceType: null);
                 // Issue #469: a unique per-device key issued at enrollment is equally valid. DevThrottle
-                // Stats: stash the matched device's type so a remote prompt can be tagged with its surface.
+                // Stats: record the matched device's type so a remote prompt can be tagged with its surface.
                 var deviceType = devices?.DeviceTypeForKey(provided);
                 if (deviceType is not null)
-                {
-                    ctx.Items[DeviceTypeItemKey] = deviceType;
-                    // Hosted Multi-Tenancy increment 1: stash the authenticated key so the tenant boundary can
-                    // resolve this request's tenant from the same verified credential.
-                    ctx.Items[DeviceKeyItemKey] = provided;
-                    return true;
-                }
+                    return Accept(ctx, provided, deviceType);
             }
         }
 
@@ -278,21 +293,38 @@ internal static class AuthMiddleware
         {
             // MH-2: same as the Bearer branch - the shared machine token cookie is not accepted on hosted.
             if (!rejectSharedToken && string.Equals(cookieValue, token, StringComparison.Ordinal))
-                return true;
-            // DevThrottle Stats: same device-key surface stash as the Bearer branch (the live terminal
+                return Accept(ctx, cookieValue, deviceType: null);
+            // DevThrottle Stats: same device-key surface record as the Bearer branch (the live terminal
             // stream authenticates via this cookie).
             var cookieDeviceType = devices?.DeviceTypeForKey(cookieValue);
             if (cookieDeviceType is not null)
-            {
-                ctx.Items[DeviceTypeItemKey] = cookieDeviceType;
-                // Hosted Multi-Tenancy increment 1: same authenticated-key stash as the Bearer branch (the
-                // live terminal stream authenticates via this cookie).
-                ctx.Items[DeviceKeyItemKey] = cookieValue;
-                return true;
-            }
+                return Accept(ctx, cookieValue, cookieDeviceType);
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// THE ONE PLACE a request is accepted. Every accepted credential shape - the shared machine token or a
+    /// per-device key, arriving as a Bearer or as any one of several cookies - returns through here, so the
+    /// authenticated identity is recorded on the request exactly once, in one line, for all of them. A shape
+    /// that returned true on its own would be an authenticated caller with no identity to pass forward, and
+    /// whatever needed one would go and read the raw request again - which is the second authentication
+    /// decision this whole mechanism exists to prevent.
+    /// </summary>
+    /// <param name="credential">The exact credential string that was validated.</param>
+    /// <param name="deviceType">The matched device's type, or null for the shared machine token (no device).
+    ///  Null deliberately leaves <see cref="DeviceKeyItemKey"/> absent, which hosted tenant resolution reads
+    ///  as "shared token, no device".</param>
+    private static bool Accept(HttpContext ctx, string credential, string? deviceType)
+    {
+        ctx.Items[AuthenticatedCredentialItemKey] = credential;
+        if (deviceType is not null)
+        {
+            ctx.Items[DeviceTypeItemKey] = deviceType;
+            ctx.Items[DeviceKeyItemKey] = credential;
+        }
+        return true;
     }
 
     private static IEnumerable<string> CookieValues(HttpContext ctx, string name)


### PR DESCRIPTION
Census row 40 / ingestion map work unit "Car-mode telemetry record with no storage key". `POST /carmode/telemetry` appended every caller's record to one process-global list, and both telemetry reads returned that whole list, so any authenticated caller could read every other caller's turn timings.

## The discriminator

Partitioned by DEVICE CREDENTIAL, as ruled. It is trusted (the Gateway derives it from the authenticated request, never the payload), the other Car Mode stores - conversation, pending action, subject - are already keyed the same way, so this is consistent rather than novel, and telemetry is per-device operational data. Telemetry following a person across their devices is a product question and is deliberately not built here.

## What I found in the existing records, and what I did with them

The stored document already carries a server-stamped `DeviceHash` on every record - it has been a server-filled field since the store shipped. I read the live store on this machine: **36 records, every one carrying a non-blank credential-derived hash across three devices (30 / 5 / 1), zero blank, zero anonymous.**

So there is nothing to migrate and nothing to invent: filtering the reads by the recorded hash attributes each existing record to exactly the device that wrote it. The purge ruling from the sibling diagnostic unit does not transfer here, because the attribution that unit lacked is present in this one.

The one case with no recorded attribution is a record with a blank hash. It belongs to no device, no partitioned read can return it, and guessing an owner would be exactly the half-partition we refuse - so those are purged on load rather than left as unreachable residue consuming the growth-guard budget. On today's file that purge removes nothing; it is proven against a crafted file.

## The change

- `CarModeTelemetryStore.Add(deviceHash, record)` stamps the trusted partition onto the record it stores, so a record can never be filed under a partition the caller chose. Blank throws rather than becoming a shared bucket.
- `Recent(deviceHash, limit)` and `Count(deviceHash)` both go through ONE private selection method, so the filter cannot be right in one read and wrong in another. The limit is applied after the partition, so a quiet device's slice never borrows from a busy one. `Count` is per-device: a process-wide total is other devices' activity disclosed as an aggregate.
- Both routes derive the partition from ONE helper, `DevicePartition(ctx)`, on the request credential. Never the posted body, never a query parameter. The caller-supplied turn id is not used as a discriminator anywhere.
- The HTML dashboard page is static and record-free; it fetches the data route, which is partitioned.
- The growth guard now evicts from the LARGEST device partition instead of the oldest record overall, so a busy device cannot push a quiet device's records out (the census completion predicate covers suppression and contention, not only disclosure).

Consequence the Architect should note: the dashboard now shows the records of the device you are viewing from, which is the ruled per-device behaviour.

## Proof design

Write-partition and read-filter are asserted as TWO SEPARATE FACTS. The write is proven from the stored JSON document directly, not through the read path, so a read-only filter could not satisfy it. Every cross-device assertion carries a positive control in the same test - each caller reading its OWN record back on the same route - so an empty answer cannot pass for isolation when it was really a failed seed. In the wire tests, status code and media type are asserted BEFORE any body is parsed.

New tests:
- `CarModeTelemetryEndpointPartitionTests` - the real `CarModeEndpoint` route map on an ephemeral port, two callers with different Bearer credentials: neither data read returns the other's records, the held count is per-device, the write records the partition (proven from the stored document), and a posted body claiming another device's hash still lands in the caller's own partition.
- `CarModeTelemetryPartitionTests` - store level: the trusted partition is stored and persisted, blank partition throws on write and on read, reads and counts are per-device, a limit never borrows across devices, existing records keep their recorded device, blank-hash records are purged from the stored document, and the growth guard evicts from the busiest device only.

## Pre-registered mutations (five runs, one primitive each)

| # | Mutation | Predicted reds |
| --- | --- | --- |
| 1 | `Add`: store `record` instead of `record with { DeviceHash = deviceHash }` | every test in `CarModeTelemetryPartitionTests` and all four endpoint tests; the single-device `CarModeTelemetryStoreTests` stay GREEN as controls |
| 2 | `MineNewestFirstLocked`: drop the device comparison, return every record | all cross-device tests in both new files; `Add_RawJsonOnDisk_CarriesTheWritingDevice` stays GREEN as a control (it does not use the read path) |
| 3 | `DevicePartition(ctx)`: return a constant instead of the credential hash | all four endpoint tests; every store test stays GREEN as a control |
| 4 | `Load`: remove the blank-hash purge | `Load_PurgesRecordsThatCarryNoDevice_RatherThanGuessingAnOwner` only |
| 5 | growth guard: evict the oldest record overall instead of from the largest partition | `GrowthGuard_EvictsFromTheBusiestDevice_NeverFromAQuietOne` only |

A predicted red that does not appear is a finding, not something to explain away.

## Not run

The Gateway test suite has NOT been run - the test lane is held by another worker. Full solution builds clean (0 warnings, 0 errors). Awaiting admission for the baseline plus the five mutation runs.
