### PR TITLE
feat(tenancy): the tenant-scoped session key and its key-accepting collection (state half of the session-identifier unit)

### DIFF
--- a/src/CcDirector.Core.Tests/Tenancy/TenantSessionKeyTests.cs
+++ b/src/CcDirector.Core.Tests/Tenancy/TenantSessionKeyTests.cs
@@ -1,0 +1,159 @@
+using System;
+using CcDirector.Core.Tenancy;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Tenancy;
+
+/// <summary>
+/// The derivation contract for <see cref="TenantSessionKey"/>: the same raw session identifier under two
+/// tenants derives two different internal keys, the same tenant derives the same key every time, the RAW
+/// identifier survives untouched for external protocols, the raw tenant identifier never appears in the
+/// key or in a log rendering, and an identifier that cannot be namespaced is refused rather than escaped.
+/// </summary>
+public sealed class TenantSessionKeyTests
+{
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+    private const string SharedSessionId = "sess-abc123";
+
+    [Fact]
+    public void TwoTenants_SameRawSessionId_DeriveDifferentKeys()
+    {
+        var a = TenantSessionKey.For(TenantA, SharedSessionId);
+        var b = TenantSessionKey.For(TenantB, SharedSessionId);
+
+        Assert.NotEqual(a, b);
+        Assert.NotEqual(a.Value, b.Value);
+    }
+
+    [Fact]
+    public void SameTenant_SameRawSessionId_DerivesTheSameKeyEveryTime()
+    {
+        // Every write, read, removal, expiry pass and disconnect path must be able to derive the IDENTICAL
+        // key, or a partition that holds on the write side strands state on the read side.
+        var first = TenantSessionKey.For(TenantA, SharedSessionId);
+        var second = TenantSessionKey.For(TenantA, SharedSessionId);
+
+        Assert.Equal(first, second);
+        Assert.Equal(first.Value, second.Value);
+    }
+
+    [Fact]
+    public void RawSessionIdentifier_SurvivesUnchanged()
+    {
+        // Rule four of the map: external protocols keep the raw identifier. Route parameters, links, tunnel
+        // commands, deletion, dictation progress, governance history and brief file paths all read this.
+        var key = TenantSessionKey.For(TenantA, SharedSessionId);
+
+        Assert.Equal(SharedSessionId, key.SessionId);
+    }
+
+    [Fact]
+    public void Value_IsDomainTagged_AndCarriesTheRawIdentifierLast()
+    {
+        var key = TenantSessionKey.For(TenantA, SharedSessionId);
+        var parts = key.Value.Split(TenantSessionKey.Separator);
+
+        Assert.Equal(3, parts.Length);
+        Assert.Equal(TenantSessionKey.Domain, parts[1]);
+        Assert.Equal(SharedSessionId, parts[2]);
+        Assert.Equal(64, parts[0].Length); // a Secure Hash Algorithm 256 digest as hex
+    }
+
+    [Fact]
+    public void Value_NeverContainsTheRawTenantIdentifier()
+    {
+        var key = TenantSessionKey.For(TenantA, SharedSessionId);
+
+        Assert.DoesNotContain(TenantA.Value, key.Value, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ToString_IsLogSafe_AndNeitherRawTenantNorFullHash()
+    {
+        var key = TenantSessionKey.For(TenantA, SharedSessionId);
+        var rendered = key.ToString();
+
+        Assert.DoesNotContain(TenantA.Value, rendered, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(key.Value.Split(TenantSessionKey.Separator)[0], rendered, StringComparison.Ordinal);
+        Assert.Contains(TenantA.ToLogString(), rendered, StringComparison.Ordinal);
+        Assert.Contains(SharedSessionId, rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LocalTenant_StillDerivesAKey_SoSelfHostIsUnchangedInShape()
+    {
+        var key = TenantSessionKey.For(TenantId.Local, SharedSessionId);
+
+        Assert.True(key.IsValid);
+        Assert.Equal(SharedSessionId, key.SessionId);
+    }
+
+    [Fact]
+    public void InvalidTenant_IsDenied_NotDefaulted()
+    {
+        Assert.Throws<ArgumentException>(() => TenantSessionKey.For(default, SharedSessionId));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptySessionIdentifier_IsRefused(string sessionId)
+    {
+        Assert.Throws<ArgumentException>(() => TenantSessionKey.For(TenantA, sessionId));
+    }
+
+    [Theory]
+    [InlineData("has|separator")]
+    [InlineData("has/slash")]
+    [InlineData("has\\backslash")]
+    [InlineData("..")]
+    [InlineData(".")]
+    public void UnusableSessionIdentifier_IsRefused_NotEscaped(string sessionId)
+    {
+        // Refusing rather than sanitizing keeps ONE canonical form. Two different identifiers must never be
+        // escaped into the same key, and a key later used as a directory name must not climb out.
+        Assert.Throws<ArgumentException>(() => TenantSessionKey.For(TenantA, sessionId));
+    }
+
+    [Theory]
+    [InlineData((char)0)]
+    [InlineData((char)9)]
+    [InlineData((char)10)]
+    [InlineData((char)13)]
+    public void ControlCharacterInSessionIdentifier_IsRefused(char control)
+    {
+        // Given by character code rather than as an escaped literal, so no control character sits in source.
+        Assert.Throws<ArgumentException>(() => TenantSessionKey.For(TenantA, "has" + control + "control"));
+    }
+
+    [Fact]
+    public void SeparatorInjection_CannotForgeAnotherTenantsKey()
+    {
+        // The attack the domain tag and the refusal together close: a caller choosing a session identifier
+        // that LOOKS like a whole namespaced key for another tenant.
+        var victim = TenantSessionKey.For(TenantB, SharedSessionId);
+
+        Assert.Throws<ArgumentException>(() => TenantSessionKey.For(TenantA, victim.Value));
+    }
+
+    [Fact]
+    public void TryFor_YieldsAnInvalidKey_RatherThanThrowing()
+    {
+        Assert.False(TenantSessionKey.TryFor(TenantA, null, out var fromNull));
+        Assert.False(fromNull.IsValid);
+
+        Assert.False(TenantSessionKey.TryFor(default, SharedSessionId, out var fromNoTenant));
+        Assert.False(fromNoTenant.IsValid);
+
+        Assert.True(TenantSessionKey.TryFor(TenantA, SharedSessionId, out var good));
+        Assert.Equal(TenantSessionKey.For(TenantA, SharedSessionId), good);
+    }
+
+    [Fact]
+    public void DefaultKey_IsNotValid()
+    {
+        Assert.False(default(TenantSessionKey).IsValid);
+        Assert.Equal("<invalid-session-key>", default(TenantSessionKey).ToString());
+    }
+}

--- a/src/CcDirector.Core.Tests/Tenancy/TenantSessionKeyTests.cs
+++ b/src/CcDirector.Core.Tests/Tenancy/TenantSessionKeyTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using CcDirector.Core.Tenancy;
 using Xunit;
 
@@ -125,6 +126,67 @@ public sealed class TenantSessionKeyTests
     {
         // Given by character code rather than as an escaped literal, so no control character sits in source.
         Assert.Throws<ArgumentException>(() => TenantSessionKey.For(TenantA, "has" + control + "control"));
+    }
+
+    // ===== SAME-TENANT IDENTITY =====
+    // The tenancy dimension is only half the job. Within ONE tenant this type must keep distinct raw
+    // identifiers distinct, or the partition it builds merges the very things it exists to separate.
+
+    [Theory]
+    [InlineData(" leading")]
+    [InlineData("trailing ")]
+    [InlineData(" both ")]
+    public void SurroundingWhitespace_IsRefused_NotTrimmed(string sessionId)
+    {
+        // Trimming would map "x", " x" and "x " onto ONE entry, so a write for one would overwrite,
+        // suppress or delete another. Refusal keeps the injectivity promise instead of tidying input.
+        Assert.Throws<ArgumentException>(() => TenantSessionKey.For(TenantA, sessionId));
+        Assert.False(TenantSessionKey.TryFor(TenantA, sessionId, out _));
+    }
+
+    [Fact]
+    public void SameTenant_NearMissIdentifiers_AreNeverMergedIntoOneKey()
+    {
+        // The three that a trim would collapse. Exactly one of them is a valid identifier; the other two
+        // are refused. What must NOT happen is all three arriving at one key.
+        const string bare = "sess-near-miss";
+
+        var accepted = TenantSessionKey.For(TenantA, bare);
+
+        Assert.Throws<ArgumentException>(() => TenantSessionKey.For(TenantA, " " + bare));
+        Assert.Throws<ArgumentException>(() => TenantSessionKey.For(TenantA, bare + " "));
+        Assert.Equal(bare, accepted.SessionId);
+    }
+
+    [Fact]
+    public void SameTenant_DistinctIdentifiers_AlwaysDeriveDistinctKeys()
+    {
+        // The injectivity property stated directly: not-equal in, never-equal out. Deliberately includes
+        // pairs a normalizing implementation would fold - case, an inner space, a trailing digit.
+        var identifiers = new[]
+        {
+            "sess-1", "sess-2", "sess-10", "sess_1", "Sess-1", "SESS-1",
+            "sess 1", "sess  1", "a", "aa", "sess-1-", "-sess-1",
+        };
+
+        var keys = identifiers.Select(id => TenantSessionKey.For(TenantA, id)).ToList();
+
+        Assert.Equal(identifiers.Length, keys.Select(k => k.Value).Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(identifiers.Length, keys.Distinct().Count());
+        Assert.Equal(identifiers.Length, keys.Select(k => k.SessionId).Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public void SessionIdentifier_IsStoredByteForByte_WithNoNormalization()
+    {
+        // An inner space is legitimate and must survive: it is neither leading nor trailing, so it is not
+        // the collision case, and altering it would change the identifier every external protocol carries.
+        const string inner = "sess with inner space";
+
+        var key = TenantSessionKey.For(TenantA, inner);
+
+        Assert.Equal(inner, key.SessionId);
+        Assert.EndsWith(inner, key.Value, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Tenancy/TenantSessionMapTests.cs
+++ b/src/CcDirector.Core.Tests/Tenancy/TenantSessionMapTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CcDirector.Core.Tenancy;
 using Xunit;
@@ -240,6 +241,126 @@ public sealed class TenantSessionMapTests
 
         Assert.True(map.ContainsKey(KeyA));
         Assert.Equal("tenant A value", map.GetValueOrDefault(KeyA));
+    }
+
+    // ===== SAME-TENANT IDENTITY =====
+    // The tenancy dimension is only half of what a keyed collection owes. Inside ONE tenant, two sessions
+    // must not share an entry either.
+
+    [Fact]
+    public void SameTenant_DistinctSessions_AreSeparateEntries()
+    {
+        var map = new TenantSessionMap<string>();
+        var one = TenantSessionKey.For(TenantA, "sess-1");
+        var two = TenantSessionKey.For(TenantA, "sess-2");
+
+        map.Set(one, "first");
+        map.Set(two, "second");
+
+        Assert.Equal("first", map.GetValueOrDefault(one));
+        Assert.Equal("second", map.GetValueOrDefault(two));
+        Assert.True(map.TryRemove(one, out _));
+        Assert.Equal("second", map.GetValueOrDefault(two));
+    }
+
+    // ===== CONCURRENCY ON ONE KEY =====
+    // Both tests below carry a WITNESS assertion that the race actually interleaved. A concurrency test
+    // that never interleaves is dead coverage that reads as a pass, so a run that failed to produce the
+    // contended condition fails loudly rather than reporting success.
+
+    [Fact]
+    public async Task Contend_UpdateRacingRemoval_NeverResurrectsTheRemovedEntry()
+    {
+        // TryUpdateExisting promises to keep a live mark alive and NEVER to bring a cleared one back. A
+        // check-then-assign implementation breaks that promise: a removal landing between the check and
+        // the assignment turns the assignment into an insert. This drives that exact interleaving.
+        const int rounds = 4000;
+        var map = new TenantSessionMap<string>();
+        var key = TenantSessionKey.For(TenantA, "sess-race");
+
+        using var barrier = new Barrier(2);
+        var resurrections = 0;
+        var bothSucceeded = 0;
+        var removeResult = false;
+        var updateResult = false;
+
+        var remover = Task.Run(() =>
+        {
+            for (var i = 0; i < rounds; i++)
+            {
+                map.Set(key, "live");
+                barrier.SignalAndWait();
+                removeResult = map.TryRemove(key, out _);
+                barrier.SignalAndWait();
+
+                if (removeResult && updateResult) bothSucceeded++;
+                if (removeResult && map.ContainsKey(key)) resurrections++;
+                map.Remove(key); // reset for the next round regardless of outcome
+                barrier.SignalAndWait();
+            }
+        });
+
+        var updater = Task.Run(() =>
+        {
+            for (var i = 0; i < rounds; i++)
+            {
+                barrier.SignalAndWait();
+                updateResult = map.TryUpdateExisting(key, "updated");
+                barrier.SignalAndWait();
+                barrier.SignalAndWait();
+            }
+        });
+
+        await Task.WhenAll(remover, updater);
+
+        Assert.True(bothSucceeded > 0,
+            "the update and the removal never both succeeded in one round, so the interleaving under test " +
+            "never occurred and this test proved nothing");
+        Assert.Equal(0, resurrections);
+    }
+
+    [Fact]
+    public async Task Contend_GetOrAddOnOneKey_HasExactlyOneWinnerPerRound()
+    {
+        // The first-seen / seed marker contract: exactly one caller is told it created the entry. Using the
+        // concurrent dictionary's own get-or-add with a flag set inside the factory breaks this, because it
+        // may run the factory in several racing callers while keeping only one value - so several callers
+        // are told they were first.
+        const int rounds = 500;
+        var workers = Math.Max(4, Environment.ProcessorCount);
+        var map = new TenantSessionMap<int>();
+        var key = TenantSessionKey.For(TenantA, "sess-seed");
+
+        using var barrier = new Barrier(workers);
+        var winners = new int[rounds];
+        var factoryRuns = new int[rounds];
+
+        var tasks = Enumerable.Range(0, workers).Select(worker => Task.Run(() =>
+        {
+            for (var round = 0; round < rounds; round++)
+            {
+                barrier.SignalAndWait();
+                map.GetOrAdd(key, _ =>
+                {
+                    Interlocked.Increment(ref factoryRuns[round]);
+                    return worker;
+                }, out var added);
+                if (added) Interlocked.Increment(ref winners[round]);
+                barrier.SignalAndWait();
+
+                if (worker == 0) map.Remove(key); // reset for the next round
+                barrier.SignalAndWait();
+            }
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        // The witness: at least one round genuinely contended, meaning more than one caller reached the
+        // factory. Without this, a serialized run would report a clean pass having tested nothing.
+        Assert.True(factoryRuns.Any(runs => runs > 1),
+            "no round ever ran the value factory more than once, so the callers never actually contended " +
+            "for the same key and this test proved nothing");
+        Assert.All(winners, w => Assert.Equal(1, w));
     }
 
     // ===== DENY BY DEFAULT =====

--- a/src/CcDirector.Core.Tests/Tenancy/TenantSessionMapTests.cs
+++ b/src/CcDirector.Core.Tests/Tenancy/TenantSessionMapTests.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Tenancy;
+
+/// <summary>
+/// THE test the unsafe-collection ingestion map demands: two authenticated tenants using the SAME raw
+/// session identifier, proving one cannot READ, MUTATE, SUPPRESS, DELETE or CONTEND with the other's state.
+/// Each of those five verbs gets its own test, because each is a distinct way the fourteen session-keyed
+/// Gateway collections are used today and a partition can hold for one while failing for another.
+///
+/// Every test uses the SAME raw session identifier for both tenants. That is the whole point: on a hosted
+/// Gateway two Directors are free to choose the same session identifier, and it is exactly that collision
+/// the bare-string key could not survive.
+/// </summary>
+public sealed class TenantSessionMapTests
+{
+    private static readonly TenantId TenantA = new("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly TenantId TenantB = new("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private const string SharedSessionId = "sess-collide";
+
+    private static TenantSessionKey KeyA => TenantSessionKey.For(TenantA, SharedSessionId);
+    private static TenantSessionKey KeyB => TenantSessionKey.For(TenantB, SharedSessionId);
+
+    // ===== READ =====
+
+    [Fact]
+    public void Read_OneTenantCannotSeeTheOthersValue()
+    {
+        var map = new TenantSessionMap<string>();
+        map.Set(KeyA, "tenant A secret");
+
+        Assert.False(map.TryGetValue(KeyB, out _));
+        Assert.False(map.ContainsKey(KeyB));
+        Assert.Null(map.GetValueOrDefault(KeyB));
+
+        // The control: tenant A still reads its own.
+        Assert.True(map.TryGetValue(KeyA, out var mine));
+        Assert.Equal("tenant A secret", mine);
+    }
+
+    [Fact]
+    public void Read_PerTenantEnumerationReturnsOnlyThatTenantsEntries()
+    {
+        // The expiry passes, roster folds and statistics reads all enumerate. An enumeration that crossed
+        // the boundary would disclose everything a keyed read does not.
+        var map = new TenantSessionMap<int>();
+        map.Set(KeyA, 1);
+        map.Set(TenantSessionKey.For(TenantA, "sess-a-only"), 2);
+        map.Set(KeyB, 99);
+
+        var aKeys = map.KeysFor(TenantA);
+        var bKeys = map.KeysFor(TenantB);
+
+        Assert.Equal(2, aKeys.Count);
+        Assert.All(aKeys, k => Assert.Equal(TenantA, k.Tenant));
+        Assert.Single(bKeys);
+        Assert.All(bKeys, k => Assert.Equal(TenantB, k.Tenant));
+
+        Assert.Equal(new[] { 1, 2 }, map.SnapshotFor(TenantA).Select(p => p.Value).OrderBy(v => v));
+        Assert.Equal(new[] { 99 }, map.SnapshotFor(TenantB).Select(p => p.Value));
+    }
+
+    [Fact]
+    public void Read_CountIsPerTenant_NeverAProcessWideTotal()
+    {
+        // Census row 65 is the current-session concurrency set: a shared count is itself the disclosure.
+        var map = new TenantSessionMap<byte>();
+        map.Set(KeyA, 1);
+        map.Set(TenantSessionKey.For(TenantA, "sess-a-only"), 1);
+        map.Set(KeyB, 1);
+
+        Assert.Equal(2, map.CountFor(TenantA));
+        Assert.Equal(1, map.CountFor(TenantB));
+    }
+
+    [Fact]
+    public void Read_AnUnknownTenantSeesNothing_RatherThanEveryoneElse()
+    {
+        var map = new TenantSessionMap<string>();
+        map.Set(KeyA, "tenant A secret");
+
+        var stranger = new TenantId("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+        Assert.Equal(0, map.CountFor(stranger));
+        Assert.Empty(map.KeysFor(stranger));
+        Assert.Empty(map.SnapshotFor(stranger));
+    }
+
+    // ===== MUTATE =====
+
+    [Fact]
+    public void Mutate_OneTenantsWriteDoesNotOverwriteTheOthers()
+    {
+        var map = new TenantSessionMap<string>();
+        map.Set(KeyA, "tenant A value");
+
+        map.Set(KeyB, "tenant B value");
+
+        Assert.Equal("tenant A value", map.GetValueOrDefault(KeyA));
+        Assert.Equal("tenant B value", map.GetValueOrDefault(KeyB));
+    }
+
+    [Fact]
+    public void Mutate_UpdateOfAnExistingEntryDoesNotReachTheOtherTenant()
+    {
+        // The transcribing marker's progress refresh: bump a LIVE mark only. Tenant B has no mark, so its
+        // refresh must fail - and must certainly not bump tenant A's.
+        var map = new TenantSessionMap<int>();
+        map.Set(KeyA, 10);
+
+        Assert.False(map.TryUpdateExisting(KeyB, 20));
+        Assert.Equal(10, map.GetValueOrDefault(KeyA));
+        Assert.False(map.ContainsKey(KeyB));
+
+        // The control: tenant A's own refresh does land.
+        Assert.True(map.TryUpdateExisting(KeyA, 30));
+        Assert.Equal(30, map.GetValueOrDefault(KeyA));
+    }
+
+    // ===== SUPPRESS =====
+
+    [Fact]
+    public void Suppress_OneTenantCannotConsumeTheOthersFirstSeenMarker()
+    {
+        // The seed / first-seen shape (census rows 51 and 53, and the needs-you clock's entry stamp): the
+        // FIRST writer is told it created the entry, and a later writer is not. If the partition failed,
+        // tenant B writing first would silently steal tenant A's "first" and suppress its accounting.
+        var map = new TenantSessionMap<string>();
+
+        map.GetOrAdd(KeyB, _ => "B first", out var bCreated);
+        map.GetOrAdd(KeyA, _ => "A first", out var aCreated);
+
+        Assert.True(bCreated);
+        Assert.True(aCreated); // NOT suppressed by B having gone first
+        Assert.Equal("A first", map.GetValueOrDefault(KeyA));
+        Assert.Equal("B first", map.GetValueOrDefault(KeyB));
+    }
+
+    [Fact]
+    public void Suppress_HoldingAnEntryDoesNotHoldTheOtherTenants()
+    {
+        // The hold half of entry/hold: a second GetOrAdd for the same tenant reports created=false and keeps
+        // the original value, while the OTHER tenant's first call still reports created=true.
+        var map = new TenantSessionMap<string>();
+
+        map.GetOrAdd(KeyA, _ => "A original", out var firstA);
+        map.GetOrAdd(KeyA, _ => "A replacement", out var secondA);
+        map.GetOrAdd(KeyB, _ => "B original", out var firstB);
+
+        Assert.True(firstA);
+        Assert.False(secondA);
+        Assert.True(firstB);
+        Assert.Equal("A original", map.GetValueOrDefault(KeyA));
+    }
+
+    // ===== DELETE =====
+
+    [Fact]
+    public void Delete_OneTenantCannotRemoveTheOthersEntry()
+    {
+        var map = new TenantSessionMap<string>();
+        map.Set(KeyA, "tenant A value");
+
+        Assert.False(map.TryRemove(KeyB, out _));
+        Assert.True(map.ContainsKey(KeyA));
+        Assert.Equal("tenant A value", map.GetValueOrDefault(KeyA));
+    }
+
+    [Fact]
+    public void Delete_RemovingOnesOwnEntryLeavesTheOthersStanding()
+    {
+        var map = new TenantSessionMap<string>();
+        map.Set(KeyA, "tenant A value");
+        map.Set(KeyB, "tenant B value");
+
+        Assert.True(map.TryRemove(KeyA, out var removed));
+
+        Assert.Equal("tenant A value", removed);
+        Assert.False(map.ContainsKey(KeyA));
+        Assert.Equal("tenant B value", map.GetValueOrDefault(KeyB));
+    }
+
+    [Fact]
+    public void Delete_TenantTeardownDropsOnlyThatTenantsPartition()
+    {
+        var map = new TenantSessionMap<string>();
+        map.Set(KeyA, "tenant A value");
+        map.Set(TenantSessionKey.For(TenantA, "sess-a-only"), "tenant A second");
+        map.Set(KeyB, "tenant B value");
+
+        Assert.Equal(2, map.RemoveAllFor(TenantA));
+
+        Assert.Equal(0, map.CountFor(TenantA));
+        Assert.Equal("tenant B value", map.GetValueOrDefault(KeyB));
+    }
+
+    // ===== CONTEND =====
+
+    [Fact]
+    public async Task Contend_ConcurrentWritersOnTheSameRawIdentifierNeverMeet()
+    {
+        // The collision under load. Both tenants hammer the SAME raw session identifier; each must end
+        // holding exactly its own value and see exactly one entry.
+        var map = new TenantSessionMap<string>();
+        const int iterations = 2000;
+
+        var writeA = Task.Run(() =>
+        {
+            for (var i = 0; i < iterations; i++) map.Set(KeyA, "A");
+        });
+        var writeB = Task.Run(() =>
+        {
+            for (var i = 0; i < iterations; i++) map.Set(KeyB, "B");
+        });
+        await Task.WhenAll(writeA, writeB);
+
+        Assert.Equal("A", map.GetValueOrDefault(KeyA));
+        Assert.Equal("B", map.GetValueOrDefault(KeyB));
+        Assert.Equal(1, map.CountFor(TenantA));
+        Assert.Equal(1, map.CountFor(TenantB));
+    }
+
+    [Fact]
+    public async Task Contend_OneTenantsRemovalStormCannotClearTheOthersEntry()
+    {
+        // The suppression race in its sharpest form: B removes the shared raw identifier as fast as it can
+        // while A holds a single entry. A's entry must survive untouched.
+        var map = new TenantSessionMap<string>();
+        map.Set(KeyA, "tenant A value");
+
+        var removeB = Task.Run(() =>
+        {
+            for (var i = 0; i < 5000; i++) map.TryRemove(KeyB, out _);
+        });
+        await removeB;
+
+        Assert.True(map.ContainsKey(KeyA));
+        Assert.Equal("tenant A value", map.GetValueOrDefault(KeyA));
+    }
+
+    // ===== DENY BY DEFAULT =====
+
+    [Fact]
+    public void ADefaultKeyIsRefusedOnEveryMember_NotTreatedAsAMiss()
+    {
+        // A default key is the only way to hold one without having resolved a tenant. A quiet miss is how an
+        // unpartitioned access survives review, so every member fails loud instead.
+        var map = new TenantSessionMap<string>();
+
+        Assert.Throws<ArgumentException>(() => map.Set(default, "x"));
+        Assert.Throws<ArgumentException>(() => map.TryAdd(default, "x"));
+        Assert.Throws<ArgumentException>(() => map.TryGetValue(default, out _));
+        Assert.Throws<ArgumentException>(() => map.GetValueOrDefault(default));
+        Assert.Throws<ArgumentException>(() => map.ContainsKey(default));
+        Assert.Throws<ArgumentException>(() => map.GetOrAdd(default, _ => "x", out _));
+        Assert.Throws<ArgumentException>(() => map.TryUpdateExisting(default, "x"));
+        Assert.Throws<ArgumentException>(() => map.TryRemove(default, out _));
+        Assert.Throws<ArgumentException>(() => map.Remove(default));
+    }
+
+    [Fact]
+    public void AnUnresolvedTenantIsRefusedOnEveryTenantWideMember()
+    {
+        var map = new TenantSessionMap<string>();
+
+        Assert.Throws<ArgumentException>(() => map.CountFor(default));
+        Assert.Throws<ArgumentException>(() => map.KeysFor(default));
+        Assert.Throws<ArgumentException>(() => map.SnapshotFor(default));
+        Assert.Throws<ArgumentException>(() => map.RemoveAllFor(default));
+    }
+
+    [Fact]
+    public void SelfHostIsUnchangedInBehaviour_OneTenantBehavesLikeAPlainMap()
+    {
+        // The control for the whole change: on self-host every key is Local, so the map must behave exactly
+        // as the bare dictionary it replaces.
+        var map = new TenantSessionMap<string>();
+        var one = TenantSessionKey.For(TenantId.Local, "sess-1");
+        var two = TenantSessionKey.For(TenantId.Local, "sess-2");
+
+        map.Set(one, "first");
+        map.Set(two, "second");
+
+        Assert.Equal("first", map.GetValueOrDefault(one));
+        Assert.Equal("second", map.GetValueOrDefault(two));
+        Assert.Equal(2, map.CountFor(TenantId.Local));
+        Assert.True(map.TryRemove(one, out _));
+        Assert.Equal(1, map.CountFor(TenantId.Local));
+    }
+}

--- a/src/CcDirector.Core/Tenancy/TenantSessionKey.cs
+++ b/src/CcDirector.Core/Tenancy/TenantSessionKey.cs
@@ -83,6 +83,13 @@ public readonly record struct TenantSessionKey
     /// Derive the canonical key for one tenant's session. Fails loud on an invalid tenant or an unusable
     /// session identifier rather than carrying a half-scoped key forward - an unresolved tenant is denied,
     /// never defaulted.
+    ///
+    /// THE INJECTIVITY PROPERTY, which is the whole job of a partition key: within one tenant, two raw
+    /// identifiers that are not equal NEVER produce one key. Nothing here normalizes the identifier -
+    /// there is no trimming, no case folding, no substitution - because every normalization is a rule for
+    /// merging two distinct things, and merging is precisely the failure this type exists to prevent. An
+    /// identifier that is not in usable form is REFUSED, exactly as one containing a separator is, so
+    /// there is one canonical form and it is the caller's own.
     /// </summary>
     /// <param name="tenant">The tenant from authenticated request state or bound-connection state. Never
     /// from the payload.</param>
@@ -91,33 +98,32 @@ public readonly record struct TenantSessionKey
     {
         if (!tenant.IsValid)
             throw new ArgumentException("A TenantSessionKey needs a valid tenant; an unresolved tenant is denied, not defaulted.", nameof(tenant));
-        if (string.IsNullOrWhiteSpace(sessionId))
+        if (string.IsNullOrEmpty(sessionId))
             throw new ArgumentException("A TenantSessionKey needs a non-empty session identifier.", nameof(sessionId));
 
-        var raw = sessionId.Trim();
-        var rejected = FirstUnusableReason(raw);
+        var rejected = FirstUnusableReason(sessionId);
         if (rejected is not null)
             throw new ArgumentException($"This session identifier cannot be namespaced: {rejected}.", nameof(sessionId));
 
-        var value = string.Concat(NamespaceHash(tenant.Value), Separator, Domain, Separator, raw);
-        return new TenantSessionKey(tenant, raw, value);
+        var value = string.Concat(NamespaceHash(tenant.Value), Separator, Domain, Separator, sessionId);
+        return new TenantSessionKey(tenant, sessionId, value);
     }
 
     /// <summary>
     /// The non-throwing form, for the observation paths that today silently ignore an empty session
     /// identifier and must keep doing so. Returns false and yields an invalid key rather than throwing.
+    /// It refuses exactly what <see cref="For"/> refuses - it is not a lenient variant.
     /// </summary>
     public static bool TryFor(TenantId tenant, string? sessionId, out TenantSessionKey key)
     {
         key = default;
-        if (!tenant.IsValid || string.IsNullOrWhiteSpace(sessionId))
+        if (!tenant.IsValid || string.IsNullOrEmpty(sessionId))
             return false;
 
-        var raw = sessionId.Trim();
-        if (FirstUnusableReason(raw) is not null)
+        if (FirstUnusableReason(sessionId) is not null)
             return false;
 
-        key = new TenantSessionKey(tenant, raw, string.Concat(NamespaceHash(tenant.Value), Separator, Domain, Separator, raw));
+        key = new TenantSessionKey(tenant, sessionId, string.Concat(NamespaceHash(tenant.Value), Separator, Domain, Separator, sessionId));
         return true;
     }
 
@@ -131,13 +137,20 @@ public readonly record struct TenantSessionKey
 
     /// <summary>
     /// Why this identifier cannot be namespaced, or null when it is usable. Rejecting rather than escaping
-    /// keeps one canonical form: two identifiers can never be sanitized into the same key, and a key that is
-    /// later used as a directory name cannot climb out of its parent.
+    /// or normalizing keeps one canonical form: two identifiers can never be reduced to the same key, and a
+    /// key that is later used as a directory name cannot climb out of its parent.
+    ///
+    /// SURROUNDING WHITESPACE IS REFUSED, not trimmed. Trimming would map "s", " s" and "s " onto ONE
+    /// partition entry, so a write for one would overwrite, suppress or delete another - the exact
+    /// collision this type exists to make impossible, reintroduced under the guise of tidying input. An
+    /// identifier with surrounding whitespace is not a valid identifier; it is not one to be cleaned.
     /// </summary>
     private static string? FirstUnusableReason(string raw)
     {
         if (raw is "." or "..")
             return "it is a relative-path element";
+        if (char.IsWhiteSpace(raw[0]) || char.IsWhiteSpace(raw[^1]))
+            return "it has leading or trailing whitespace, which is refused rather than trimmed so that two distinct identifiers can never become one key";
         foreach (var c in raw)
         {
             if (c == Separator) return "it contains the key separator";

--- a/src/CcDirector.Core/Tenancy/TenantSessionKey.cs
+++ b/src/CcDirector.Core/Tenancy/TenantSessionKey.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace CcDirector.Core.Tenancy;
+
+/// <summary>
+/// THE canonical internal key for any retained Gateway state that is addressed by a session identifier.
+///
+/// WHY THIS TYPE EXISTS. Fourteen retained Gateway collections are keyed by a bare session identifier that
+/// a Director chose - the needs-you clock, both transcribing markers, the governance state emitter, the
+/// turn-end watcher, five session-keyed statistics indexes, the current-session concurrency set, and both
+/// turn-brief caches. On a hosted Gateway two accounts can present the SAME raw session identifier, so a
+/// bare-identifier key lets one account read, overwrite, suppress, delete, or contend with the other's
+/// entry. Keying by (tenant, session) instead makes naming another tenant's entry structurally impossible
+/// rather than merely refused - the same shape this codebase already adopted for
+/// <c>DirectorRegistry.DirectorKey</c> and for the composite tenant primary keys in the database.
+///
+/// WHERE THE TENANT COMES FROM. Always from authenticated request state or bound-connection state, and
+/// NEVER from the payload: <c>DirectorHub.RequireBoundTenant()</c> for anything arriving on a Director
+/// stream, and <c>GatewayEndpoints.ResolveReadTenant(ctx, boundary)</c> for anything arriving on an HTTP
+/// request. This type cannot be built from a raw string, so a caller cannot conjure a key without first
+/// holding a <see cref="TenantId"/> that one of those resolvers produced.
+///
+/// THE RAW IDENTIFIER SURVIVES. Only internal storage receives the namespaced key. Session identifiers
+/// appear in route parameters, browser links, tunnel commands, deletion, dictation progress, governance
+/// history and brief file paths, and every one of those keeps the raw value - which is why
+/// <see cref="SessionId"/> is carried alongside and is what any external protocol must emit.
+///
+/// PRIVACY. The raw account tenant identifier is never rendered. <see cref="Value"/> carries a one-way
+/// Secure Hash Algorithm 256 of the tenant, exactly as <c>HostedEnrollmentEndpoint.Enroll</c> namespaces a
+/// caller device identifier before it reaches <c>DeviceRegistry</c>. The tenant hash is an INTERNAL
+/// partition key only: it must never reach a user-facing surface, and <see cref="ToString"/> is the
+/// log-safe rendering (short tag) rather than the storage key.
+///
+/// NOTE on <c>default(TenantSessionKey)</c>: like any struct, a default value bypasses construction and is
+/// NOT a valid key. Check <see cref="IsValid"/> when a value's provenance is uncertain; the collections in
+/// <see cref="TenantSessionMap{TValue}"/> reject it outright rather than storing under a null partition.
+/// </summary>
+public readonly record struct TenantSessionKey
+{
+    /// <summary>The domain tag placed between the tenant hash and the raw identifier, so a session key can
+    /// never collide with a differently-scoped key (an upload key, a machine key) that happens to share a
+    /// tenant and a string.</summary>
+    public const string Domain = "session";
+
+    /// <summary>The separator between the three parts, matching the enrollment template's
+    /// <c>tenant hash | caller identifier</c> shape.</summary>
+    public const char Separator = '|';
+
+    private TenantSessionKey(TenantId tenant, string sessionId, string value)
+    {
+        Tenant = tenant;
+        SessionId = sessionId;
+        Value = value;
+    }
+
+    /// <summary>The owning tenant. Present so a partitioned store can route by tenant without re-parsing
+    /// <see cref="Value"/>. Never render this on a user-facing surface.</summary>
+    public TenantId Tenant { get; }
+
+    /// <summary>The RAW session identifier, unchanged. This - never <see cref="Value"/> - is what goes into
+    /// route parameters, links, tunnel commands, data-transfer objects, and file paths.</summary>
+    public string SessionId { get; }
+
+    /// <summary>
+    /// The domain-tagged internal key, <c>tenant hash | session | raw identifier</c>, for stores whose key
+    /// must be a single flat string. In-memory dictionaries should prefer the typed key itself (see
+    /// <see cref="TenantSessionMap{TValue}"/>), which is partitioned and therefore cannot be addressed
+    /// across tenants at all.
+    ///
+    /// This is a KEY, not a path segment. <see cref="For"/> rejects a session identifier containing a
+    /// separator, a path separator, a relative-path element, or a control character, so a later use as a
+    /// directory name cannot be made to escape its parent - but the intended use remains a dictionary key.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>True when this key came through <see cref="For"/> and carries a partition. A
+    /// <c>default(TenantSessionKey)</c> is false and must never be stored under.</summary>
+    public bool IsValid => Tenant.IsValid && !string.IsNullOrEmpty(Value);
+
+    /// <summary>
+    /// Derive the canonical key for one tenant's session. Fails loud on an invalid tenant or an unusable
+    /// session identifier rather than carrying a half-scoped key forward - an unresolved tenant is denied,
+    /// never defaulted.
+    /// </summary>
+    /// <param name="tenant">The tenant from authenticated request state or bound-connection state. Never
+    /// from the payload.</param>
+    /// <param name="sessionId">The raw session identifier as the Director or the route supplied it.</param>
+    public static TenantSessionKey For(TenantId tenant, string sessionId)
+    {
+        if (!tenant.IsValid)
+            throw new ArgumentException("A TenantSessionKey needs a valid tenant; an unresolved tenant is denied, not defaulted.", nameof(tenant));
+        if (string.IsNullOrWhiteSpace(sessionId))
+            throw new ArgumentException("A TenantSessionKey needs a non-empty session identifier.", nameof(sessionId));
+
+        var raw = sessionId.Trim();
+        var rejected = FirstUnusableReason(raw);
+        if (rejected is not null)
+            throw new ArgumentException($"This session identifier cannot be namespaced: {rejected}.", nameof(sessionId));
+
+        var value = string.Concat(NamespaceHash(tenant.Value), Separator, Domain, Separator, raw);
+        return new TenantSessionKey(tenant, raw, value);
+    }
+
+    /// <summary>
+    /// The non-throwing form, for the observation paths that today silently ignore an empty session
+    /// identifier and must keep doing so. Returns false and yields an invalid key rather than throwing.
+    /// </summary>
+    public static bool TryFor(TenantId tenant, string? sessionId, out TenantSessionKey key)
+    {
+        key = default;
+        if (!tenant.IsValid || string.IsNullOrWhiteSpace(sessionId))
+            return false;
+
+        var raw = sessionId.Trim();
+        if (FirstUnusableReason(raw) is not null)
+            return false;
+
+        key = new TenantSessionKey(tenant, raw, string.Concat(NamespaceHash(tenant.Value), Separator, Domain, Separator, raw));
+        return true;
+    }
+
+    /// <summary>
+    /// A LOG-SAFE rendering. It reuses <see cref="TenantId.ToLogString"/>, so a real account tenant becomes
+    /// a short one-way tag and neither the raw tenant identifier nor the full namespace hash reaches a log.
+    /// Never write <see cref="Value"/> to a log, and never render either on a user-facing surface.
+    /// </summary>
+    public override string ToString() =>
+        IsValid ? string.Concat(Tenant.ToLogString(), Separator, Domain, Separator, SessionId) : "<invalid-session-key>";
+
+    /// <summary>
+    /// Why this identifier cannot be namespaced, or null when it is usable. Rejecting rather than escaping
+    /// keeps one canonical form: two identifiers can never be sanitized into the same key, and a key that is
+    /// later used as a directory name cannot climb out of its parent.
+    /// </summary>
+    private static string? FirstUnusableReason(string raw)
+    {
+        if (raw is "." or "..")
+            return "it is a relative-path element";
+        foreach (var c in raw)
+        {
+            if (c == Separator) return "it contains the key separator";
+            if (c is '/' or '\\') return "it contains a path separator";
+            if (char.IsControl(c)) return "it contains a control character";
+        }
+        return null;
+    }
+
+    /// <summary>A one-way Secure Hash Algorithm 256 hex hash, so the raw tenant identifier never becomes
+    /// part of a stored key. Identical in construction to the hash
+    /// <c>HostedEnrollmentEndpoint.Enroll</c> uses to namespace a caller device identifier.</summary>
+    private static string NamespaceHash(string value) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
+}

--- a/src/CcDirector.Core/Tenancy/TenantSessionMap.cs
+++ b/src/CcDirector.Core/Tenancy/TenantSessionMap.cs
@@ -62,33 +62,62 @@ public sealed class TenantSessionMap<TValue>
 
     /// <summary>
     /// Read this session's value, creating it from <paramref name="factory"/> when absent.
-    /// <paramref name="added"/> reports whether THIS call created it - the entry/hold distinction the
-    /// needs-you clock and the statistics seed markers both turn on.
+    /// <paramref name="added"/> reports whether THIS call is the one that INSERTED it - the entry/hold
+    /// distinction the needs-you clock and the statistics seed markers both turn on.
+    ///
+    /// EXACTLY ONE WINNER, even under contention. This deliberately does not use
+    /// <c>ConcurrentDictionary.GetOrAdd</c> with a flag set inside the factory: that dictionary may run
+    /// the factory in several racing callers while keeping only one value, so every one of them would be
+    /// told it created the entry. For a first-seen or seed marker that is not a cosmetic difference - it
+    /// is several callers each believing they own the first sighting, which is the accounting the marker
+    /// exists to make unique. Insertion is decided by <see cref="ConcurrentDictionary{TKey,TValue}.TryAdd"/>,
+    /// which has one winner by construction.
+    ///
+    /// The factory MAY run more than once under contention; the losers' values are discarded. Keep it free
+    /// of side effects - a timestamp, a counter seed, an empty record.
     /// </summary>
     public TValue GetOrAdd(TenantSessionKey key, Func<TenantSessionKey, TValue> factory, out bool added)
     {
         if (factory is null) throw new ArgumentNullException(nameof(factory));
-        var created = false;
-        var value = Writable(Require(key)).GetOrAdd(key.SessionId, _ =>
+        var partition = Writable(Require(key));
+        while (true)
         {
-            created = true;
-            return factory(key);
-        });
-        added = created;
-        return value;
+            if (partition.TryGetValue(key.SessionId, out var existing))
+            {
+                added = false;
+                return existing;
+            }
+
+            var candidate = factory(key);
+            if (partition.TryAdd(key.SessionId, candidate))
+            {
+                added = true;
+                return candidate;
+            }
+        }
     }
 
     /// <summary>
     /// Replace this session's value ONLY if it already has one. False when the session is absent. This is
     /// the "keep a live mark alive, never resurrect a cleared one" operation - an unconditional write in
     /// its place lets a progress update race a clear and re-create what the clear just removed.
+    ///
+    /// THE TEST-THEN-WRITE IS NOT ENOUGH. Checking presence and then assigning through the indexer is two
+    /// operations, and a removal landing between them makes the assignment an INSERT - so the entry the
+    /// clear just deleted comes straight back, which is the one thing this method promises never to do.
+    /// The update is therefore a compare-and-swap retry loop: it can only ever replace a value that was
+    /// still there at the instant of the swap.
     /// </summary>
     public bool TryUpdateExisting(TenantSessionKey key, TValue value)
     {
         if (Readable(Require(key)) is not { } partition) return false;
-        if (!partition.ContainsKey(key.SessionId)) return false;
-        partition[key.SessionId] = value;
-        return true;
+        while (partition.TryGetValue(key.SessionId, out var current))
+        {
+            if (partition.TryUpdate(key.SessionId, value, current))
+                return true;
+            // The value moved under us. Re-read: if the entry is gone, the loop exits and reports false.
+        }
+        return false;
     }
 
     /// <summary>Remove this session's value, yielding what was removed.</summary>

--- a/src/CcDirector.Core/Tenancy/TenantSessionMap.cs
+++ b/src/CcDirector.Core/Tenancy/TenantSessionMap.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CcDirector.Core.Tenancy;
+
+/// <summary>
+/// THE key-accepting collection for retained state addressed by a session identifier: a drop-in
+/// replacement for the <c>ConcurrentDictionary&lt;string, TValue&gt;</c> that the fourteen unsafe
+/// session-keyed Gateway collections declare today, which accepts ONLY a <see cref="TenantSessionKey"/>.
+///
+/// WHY A TYPE AND NOT A CONVENTION. A prefixing convention is bypassable one call site at a time, and the
+/// bypass is invisible: a writer that forgets the prefix compiles, runs, and silently shares a partition
+/// with another tenant. Here there is no un-namespaced key to express - every member takes the typed key,
+/// there is no string overload and no implicit conversion, so a call site that has not resolved a tenant
+/// does not compile. That is the difference between a partition that is enforced and one that is merely
+/// intended.
+///
+/// THE PARTITION IS PHYSICAL. Entries live in a per-tenant inner dictionary, exactly as
+/// <c>PushedSessionStore._byTenant</c> does (census row 16, clean). A lookup routes by
+/// <see cref="TenantSessionKey.Tenant"/> before the session identifier is ever compared, so one tenant's
+/// raw session identifier cannot reach another tenant's entry even if the two strings are identical. It
+/// also gives the per-tenant enumeration that the expiry passes, roster folds and statistics reads need,
+/// which a single flat namespaced dictionary could only do by scanning every tenant's keys.
+///
+/// DENY BY DEFAULT. An invalid key - a <c>default(TenantSessionKey)</c>, which is the only way to hold one
+/// without having resolved a tenant - throws on EVERY member, read and write alike. It is never quietly
+/// treated as a miss, because a quiet miss is how an unpartitioned access survives review.
+///
+/// CONCURRENCY. Individual operations are thread-safe. <see cref="RemoveAllFor"/> is a tenant TEARDOWN
+/// operation: a write racing a teardown of its OWN tenant may land in the discarded partition and be lost.
+/// It can never land in another tenant's partition, which is the property under proof here.
+/// </summary>
+/// <typeparam name="TValue">The stored value - a timestamp, a marker, a counter, a cached brief.</typeparam>
+public sealed class TenantSessionMap<TValue>
+{
+    private readonly ConcurrentDictionary<TenantId, ConcurrentDictionary<string, TValue>> _byTenant = new();
+
+    /// <summary>Store or replace this session's value.</summary>
+    public void Set(TenantSessionKey key, TValue value) => Writable(Require(key))[key.SessionId] = value;
+
+    /// <summary>Store this session's value only if it has none yet. True when this call stored it.</summary>
+    public bool TryAdd(TenantSessionKey key, TValue value) => Writable(Require(key)).TryAdd(key.SessionId, value);
+
+    /// <summary>Read this session's value.</summary>
+    public bool TryGetValue(TenantSessionKey key, out TValue value)
+    {
+        if (Readable(Require(key)) is { } partition)
+            return partition.TryGetValue(key.SessionId, out value!);
+        value = default!;
+        return false;
+    }
+
+    /// <summary>Read this session's value, or the default when it has none.</summary>
+    public TValue? GetValueOrDefault(TenantSessionKey key) =>
+        TryGetValue(key, out var value) ? value : default;
+
+    /// <summary>Whether this session has a value.</summary>
+    public bool ContainsKey(TenantSessionKey key) =>
+        Readable(Require(key)) is { } partition && partition.ContainsKey(key.SessionId);
+
+    /// <summary>
+    /// Read this session's value, creating it from <paramref name="factory"/> when absent.
+    /// <paramref name="added"/> reports whether THIS call created it - the entry/hold distinction the
+    /// needs-you clock and the statistics seed markers both turn on.
+    /// </summary>
+    public TValue GetOrAdd(TenantSessionKey key, Func<TenantSessionKey, TValue> factory, out bool added)
+    {
+        if (factory is null) throw new ArgumentNullException(nameof(factory));
+        var created = false;
+        var value = Writable(Require(key)).GetOrAdd(key.SessionId, _ =>
+        {
+            created = true;
+            return factory(key);
+        });
+        added = created;
+        return value;
+    }
+
+    /// <summary>
+    /// Replace this session's value ONLY if it already has one. False when the session is absent. This is
+    /// the "keep a live mark alive, never resurrect a cleared one" operation - an unconditional write in
+    /// its place lets a progress update race a clear and re-create what the clear just removed.
+    /// </summary>
+    public bool TryUpdateExisting(TenantSessionKey key, TValue value)
+    {
+        if (Readable(Require(key)) is not { } partition) return false;
+        if (!partition.ContainsKey(key.SessionId)) return false;
+        partition[key.SessionId] = value;
+        return true;
+    }
+
+    /// <summary>Remove this session's value, yielding what was removed.</summary>
+    public bool TryRemove(TenantSessionKey key, out TValue value)
+    {
+        if (Readable(Require(key)) is { } partition)
+            return partition.TryRemove(key.SessionId, out value!);
+        value = default!;
+        return false;
+    }
+
+    /// <summary>Remove this session's value.</summary>
+    public bool Remove(TenantSessionKey key) => TryRemove(key, out _);
+
+    /// <summary>How many sessions this tenant holds. The per-tenant count a concurrency or statistics read
+    /// must report - never a process-wide total.</summary>
+    public int CountFor(TenantId tenant) =>
+        Readable(RequireTenant(tenant)) is { } partition ? partition.Count : 0;
+
+    /// <summary>This tenant's keys, as a point-in-time copy safe to enumerate while others write. The input
+    /// to an expiry pass, a roster fold, or a per-tenant statistics read.</summary>
+    public IReadOnlyList<TenantSessionKey> KeysFor(TenantId tenant)
+    {
+        var t = RequireTenant(tenant);
+        if (Readable(t) is not { } partition) return Array.Empty<TenantSessionKey>();
+        return partition.Keys.Select(sid => TenantSessionKey.For(t, sid)).ToList();
+    }
+
+    /// <summary>This tenant's entries, as a point-in-time copy safe to enumerate while others write.</summary>
+    public IReadOnlyList<KeyValuePair<TenantSessionKey, TValue>> SnapshotFor(TenantId tenant)
+    {
+        var t = RequireTenant(tenant);
+        if (Readable(t) is not { } partition) return Array.Empty<KeyValuePair<TenantSessionKey, TValue>>();
+        return partition
+            .Select(pair => new KeyValuePair<TenantSessionKey, TValue>(TenantSessionKey.For(t, pair.Key), pair.Value))
+            .ToList();
+    }
+
+    /// <summary>Drop this tenant's whole partition, returning how many entries went. Tenant teardown only -
+    /// no ordinary path removes another tenant's state.</summary>
+    public int RemoveAllFor(TenantId tenant) =>
+        _byTenant.TryRemove(RequireTenant(tenant), out var partition) ? partition.Count : 0;
+
+    /// <summary>How many tenants currently hold state. Diagnostics only - it is not an answer to a
+    /// client, and it must never surface a tenant identity.</summary>
+    public int TenantCount => _byTenant.Count;
+
+    private static TenantSessionKey Require(TenantSessionKey key) =>
+        key.IsValid ? key : throw new ArgumentException(
+            "This key was never derived from a resolved tenant, so it addresses no partition. Derive it with " +
+            "TenantSessionKey.For from the tenant bound to the connection or the request.", nameof(key));
+
+    private static TenantId RequireTenant(TenantId tenant) =>
+        tenant.IsValid ? tenant : throw new ArgumentException(
+            "An unresolved tenant addresses no partition; it is denied, not defaulted.", nameof(tenant));
+
+    private ConcurrentDictionary<string, TValue>? Readable(TenantSessionKey key) =>
+        _byTenant.TryGetValue(key.Tenant, out var partition) ? partition : null;
+
+    private ConcurrentDictionary<string, TValue>? Readable(TenantId tenant) =>
+        _byTenant.TryGetValue(tenant, out var partition) ? partition : null;
+
+    private ConcurrentDictionary<string, TValue> Writable(TenantSessionKey key) =>
+        _byTenant.GetOrAdd(key.Tenant, _ => new ConcurrentDictionary<string, TValue>(StringComparer.Ordinal));
+}


### PR DESCRIPTION
## What this is

The **state half** of the session-identifier work unit from the hosted Gateway unsafe-collection
ingestion map - census rows 1, 3, 4, 5, 11, 26, 49-53, 65, 92 and 93, fourteen rows.

It adds the derivation helper and the key-accepting collection, and **converts no route and no
collection call site**. Two reasons, both deliberate:

1. **State before route.** Partition the state before converting the route that reads it. Converting a
   route first starts writing into a store that is still shared - that arms a cross-tenant path instead
   of closing one.
2. **Collision with live work.** The session identifier enters through, among others,
   `GatewayDictationEndpoint.Map` and `DirectorHub`, both of which are being changed right now by
   pull requests #1900 and #1930 under mutation proof at pinned heads. Converting those call sites now
   would invalidate proofs that are mid-flight.

The conversion of the fourteen collections and their call sites follows as its own unit.

## What it adds

**`TenantSessionKey`** (`src/CcDirector.Core/Tenancy/TenantSessionKey.cs`) - the one canonical
derivation, meeting the map's four conditions:

1. The tenant comes from authenticated request or bound-connection state. The type cannot be built
   from a raw string, so a caller must first hold a `TenantId` that `DirectorHub.RequireBoundTenant()`
   or `GatewayEndpoints.ResolveReadTenant(ctx, boundary)` produced. Nothing reads a tenant from a payload.
2. One helper derives the domain-tagged internal key, `tenant hash | session | raw identifier`. The
   tenant is hashed with Secure Hash Algorithm 256, exactly as `HostedEnrollmentEndpoint.Enroll`
   namespaces a caller device identifier before it reaches `DeviceRegistry` (census row 45, clean).
3. Derivation is pure and total, so every write, read, removal, expiry pass and disconnect path can
   derive the identical key. The enumeration below is the checklist for making them do so.
4. The raw identifier survives on `SessionId`, unchanged, for every external protocol.

An identifier that cannot be namespaced - containing the separator, a path separator, a
relative-path element, or a control character - is **refused, not escaped**, so two identifiers can
never be sanitized into one key and a key later used as a directory name cannot climb out of its parent.

The tenant hash is an **internal partition key only**. `ToString()` is the log-safe rendering (it reuses
`TenantId.ToLogString`), and nothing here is intended for, or reachable from, a user-facing surface.

**`TenantSessionMap<TValue>`** (`src/CcDirector.Core/Tenancy/TenantSessionMap.cs`) - the collection the
fourteen declarations move to. It accepts only the typed key, and entries live in a per-tenant inner
dictionary, as `PushedSessionStore._byTenant` already does (census row 16, clean). It offers exactly the
operations the fourteen rows use today: set, add-if-absent, read, contains, get-or-add reporting whether
this call created the entry, update-only-if-present, remove, per-tenant count, per-tenant key and entry
enumeration, and tenant teardown.

## The bypass: what is structurally impossible and what is not

**Structurally impossible: expressing an un-namespaced key.** There is no string overload, no implicit
conversion, and no public constructor. A call site that has not resolved a tenant does not compile. This
is what reduced the mutation count - the per-member routing collapses into two shared private helpers,
so the isolation property is carried by two lines rather than by thirteen members each able to be
individually wrong.

**NOT structurally impossible: naming the WRONG tenant.** A caller can still pass `TenantId.Local` on
hosted. That is precisely the defect class issue #1869 hit, where twenty-three per-session routes passed
a literal `TenantId.Local` and read the empty partition. This layer cannot close it; the route-conversion
unit must, by taking the request or the hub connection rather than a tenant argument - the shape
`LocateSessionForRequestAsync` already uses. Stating it plainly rather than claiming a stronger property
than was built.

## Enumeration for the follow-up unit

Every production path, at `f5bb926f`, that must derive this key. A single-path prefix is a partition that
holds and that nothing uses, so this list - not one converted writer - is what makes the follow-up
completable. **Thirty production call sites**, plus two upstream ingestion points and one exposed handle.

| Row | Declaring state | Path | Kind |
| ---: | --- | --- | --- |
| 1 | `BroadcastGovernor._sends` | `Api/GatewayEndpoints.cs:2488` `TryRecordSend(req.FromSessionId)` on `POST /fanout` | write + read + in-place window expiry |
| 3 | `NeedsYouClock._since` | `GatewayHost.cs:796` `needsYouStampFor` in the display-state push fold | write + removal |
| 3 | `NeedsYouClock._since` | `GatewayHost.cs:1639` `needsYouStampFor` in the `/sessions` roster fold | write + removal |
| 4 | `TranscribingSessions._lastProgress` | `Api/GatewayDictationEndpoint.cs:107` `Begin` | write |
| 4 | | `Api/GatewayDictationEndpoint.cs:128` `Refresh` (chunk stored) | update-if-present |
| 4 | | `Api/GatewayDictationEndpoint.cs:148` `Refresh` (completion attempt) | update-if-present |
| 4 | | `Api/GatewayDictationEndpoint.cs:511` `End` | removal |
| 4 | | `Api/GatewayEndpoints.cs:1513` `Begin` on `POST /sessions/{sid}/transcribing` | write |
| 4 | | `Api/GatewayEndpoints.cs:1515` `End` on the same route | removal |
| 4 | | `GatewayHost.cs:499` `IsTranscribing` in the push fold | read + idle expiry |
| 4 | | `GatewayHost.cs:1642` `transcribingFor` in the roster fold | read + idle expiry |
| 5 | `TranscribingSessions._activelyTranscribing` | `Api/GatewayDictationEndpoint.cs:365` `MarkActivelyTranscribing` | write |
| 5 | | `Api/GatewayDictationEndpoint.cs:262` `ClearActivelyTranscribing` | removal |
| 5 | | `Api/GatewayDictationEndpoint.cs:505` `ClearActivelyTranscribing` (the finally) | removal |
| 5 | | `GatewayHost.cs:497` `IsActivelyTranscribing` | read |
| 11 | `SessionStateEventEmitter._lastState` | `GatewayHost.cs:1607` `Observe` | write + removal on exit |
| 26 | `TurnEndWatcher._lastActivity` | `GatewayHost.cs:1600` `Observe` | write |
| 26 | | `Briefing/TurnEndWatcher.cs` `SweepAsync` reconcile pass | read, currently pinned to `TenantId.Local` |
| 49-53 | `GatewayInputStatsAggregator` five session-keyed indexes | `Streaming/DirectorHub.cs:132` `ObserveSnapshot` | write |
| 49-53 | | `Streaming/DirectorHub.cs:168` `Observe` | write |
| 49-53 | | `Streaming/DirectorHub.cs:203` `Forget` in `RemoveSession` | removal / disconnect |
| 49-53 | | `Api/GatewayEndpoints.cs:995` `ObserveSnapshot` in the roster fold - the second aggregation seam the map names | write |
| 65 | `GatewaySessionConcurrencyStats._curSessions` | `Api/GatewayEndpoints.cs:1002` `Observe(all, now)` | write |
| 65 | | `Stats/StatsPageEndpoint.cs:89` and `GatewayHost.cs:2105` `Snapshot` | read |
| 92 | `GatewayTurnBriefStore._latest` | `Api/TurnBriefGatewayEndpoints.cs:57` `Latest` | read-through cache write |
| 92 | | `GatewayHost.cs:1696` `Latest` (interrupted-session enrichment) | read-through cache write |
| 92 | | `GatewayHost.cs:2070` `Latest` (brief presence) | read-through cache write |
| 92 | | `Briefing/GatewayTurnBriefStore.cs:76` `Append` - no production caller today, reachable through the exposed handle | write |
| 93 | `GatewayTurnBriefStore._packages` | `Api/TurnBriefGatewayEndpoints.cs:84` `SaveFeedback` calling `LoadPackage` | read-through cache write |
| 93 | | `Briefing/GatewayTurnBriefStore.cs:92` `SavePackage` - no production caller today, reachable through the exposed handle | write |

Also required, and easy to miss:

- **Two upstream ingestion points** feed the state funnel that drives rows 11 and 26:
  `Api/GatewayEndpoints.cs:585` (the heartbeat snapshot) and `Api/GatewayEndpoints.cs:608` (the doorbell).
  Both must carry the resolved tenant into `onSessionState`, or the funnel's two consumers get a
  tenant the route never authenticated.
- **One exposed handle:** `GatewayHost.cs:1238` `public GatewayTurnBriefStore TurnBriefs`. Left as it
  is, it hands out a store whose raw-identifier methods remain callable, which is a bypass of the whole
  conversion.
- `Briefing/TurnEndWatcher.cs` already carries a written BLOCKED ON note naming this exact partition
  as the reason its reconcile sweep serves `TenantId.Local`. That note comes out with the conversion.
- Rows 92 and 93 are read-through caches: their **reads are the writes**. Converting the writers alone
  leaves them unpartitioned.

## Pre-registered mutations

Not yet run - see below. Registered now so a predicted red that fails to appear is a finding rather than
something explained away afterwards. One primitive per full-suite run, never combined. **Fourteen runs.**

| # | Mutation | Predicted red, by name | Predicted to stay green (control) |
| ---: | --- | --- | --- |
| 1 | `TenantSessionKey.For` omits the tenant hash from `Value` | `TwoTenants_SameRawSessionId_DeriveDifferentKeys`, `Value_IsDomainTagged_AndCarriesTheRawIdentifierLast` | every `TenantSessionMap` test (the typed key is unaffected) |
| 2 | `For` omits the domain tag | `Value_IsDomainTagged_AndCarriesTheRawIdentifierLast` | `TwoTenants_SameRawSessionId_DeriveDifferentKeys` |
| 3 | `For` uses the raw tenant value instead of the hash | `Value_NeverContainsTheRawTenantIdentifier` | `ToString_IsLogSafe_AndNeitherRawTenantNorFullHash` (a separate rendering) |
| 4 | Drop the separator rejection in `FirstUnusableReason` | `UnusableSessionIdentifier_IsRefused_NotEscaped` for the separator case, `SeparatorInjection_CannotForgeAnotherTenantsKey` | the path and control-character cases |
| 5 | Drop the path-separator and relative-element rejection | `UnusableSessionIdentifier_IsRefused_NotEscaped` for the slash, backslash, dot and double-dot cases | the separator case |
| 6 | Drop the control-character rejection | `ControlCharacterInSessionIdentifier_IsRefused` (all four codes) | `UnusableSessionIdentifier_IsRefused_NotEscaped` |
| 7 | `For` accepts an invalid tenant | `InvalidTenant_IsDenied_NotDefaulted`, `TryFor_YieldsAnInvalidKey_RatherThanThrowing` | the `Value` shape tests |
| 8 | `TenantSessionMap` `Writable` and `Readable(key)` route every key to one fixed partition | `Read_OneTenantCannotSeeTheOthersValue`, `Read_AnUnknownTenantSeesNothing_RatherThanEveryoneElse`, `Read_PerTenantEnumerationReturnsOnlyThatTenantsEntries`, `Read_CountIsPerTenant_NeverAProcessWideTotal`, `Mutate_OneTenantsWriteDoesNotOverwriteTheOthers`, `Mutate_UpdateOfAnExistingEntryDoesNotReachTheOtherTenant`, `Suppress_OneTenantCannotConsumeTheOthersFirstSeenMarker`, `Suppress_HoldingAnEntryDoesNotHoldTheOtherTenants`, `Delete_OneTenantCannotRemoveTheOthersEntry`, `Delete_RemovingOnesOwnEntryLeavesTheOthersStanding`, `Contend_ConcurrentWritersOnTheSameRawIdentifierNeverMeet`, `Contend_OneTenantsRemovalStormCannotClearTheOthersEntry` | `SelfHostIsUnchangedInBehaviour_OneTenantBehavesLikeAPlainMap`, both deny-by-default tests |
| 9 | Only the tenant-wide `Readable(TenantId)` returns the first partition regardless of tenant | `Read_PerTenantEnumerationReturnsOnlyThatTenantsEntries`, `Read_CountIsPerTenant_NeverAProcessWideTotal`, `Read_AnUnknownTenantSeesNothing_RatherThanEveryoneElse` | every keyed read, mutate, delete and contend test |
| 10 | `RemoveAllFor` clears the whole map | `Delete_TenantTeardownDropsOnlyThatTenantsPartition` | everything else |
| 11 | `Require(key)` returns an invalid key instead of throwing | `ADefaultKeyIsRefusedOnEveryMember_NotTreatedAsAMiss` | `AnUnresolvedTenantIsRefusedOnEveryTenantWideMember` |
| 12 | `RequireTenant` returns an invalid tenant instead of throwing | `AnUnresolvedTenantIsRefusedOnEveryTenantWideMember` | `ADefaultKeyIsRefusedOnEveryMember_NotTreatedAsAMiss` |
| 13 | `TryUpdateExisting` writes unconditionally | `Mutate_UpdateOfAnExistingEntryDoesNotReachTheOtherTenant` | `Mutate_OneTenantsWriteDoesNotOverwriteTheOthers` |
| 14 | `GetOrAdd` always reports that it created the entry | `Suppress_HoldingAnEntryDoesNotHoldTheOtherTenants` | `Suppress_OneTenantCannotConsumeTheOthersFirstSeenMarker` |

Runs 8, 9 and 10 are separate because the three routing sites can each be individually wrong while the
others stay correct and isolation still breaks. Overlap does not exempt them.

## What has and has not been run

- `dotnet build src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj` - succeeded, 0 warnings, 0 errors
  (the project treats warnings as errors).
- `dotnet build src/CcDirector.Gateway/CcDirector.Gateway.csproj` - succeeded, 0 warnings, 0 errors.
- **No test suite has been run.** The machine's test lane is held by another worker, and a concurrent run
  kills the test host and produces failures in untouched areas. The baseline and the fourteen mutation
  runs are pending admission. Nothing in this description claims a test result.

The change is additive - four new files, no existing file touched - so it cannot redden an existing test
by construction of the diff, but that is a statement about the diff, not a substitute for the baseline.

## Note for the record

The two specification documents live on `origin/docs/hosted-gateway-collection-census`, not on
`origin/main`. Anyone verifying this work against `origin/main` will not find them.
