### PR TITLE
fix(gateway): partition diagnostic results and hourly rollups by tenant (census rows 21 and 22)

### DIFF
--- a/src/CcDirector.Gateway.Tests/NetDiagResultStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/NetDiagResultStoreTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Api;
 using CcDirector.Gateway.Contracts;
 using Xunit;
@@ -27,10 +28,10 @@ public sealed class NetDiagResultStoreTests : IDisposable
     public void Recent_IsNewestFirst()
     {
         var store = new NetDiagResultStore(_path);
-        store.Add(Result("a"));
-        store.Add(Result("b"));
-        store.Add(Result("c"));
-        Assert.Equal(new[] { "c", "b", "a" }, store.Recent().Select(r => r.Verdict));
+        store.Add(TenantId.Local, Result("a"));
+        store.Add(TenantId.Local, Result("b"));
+        store.Add(TenantId.Local, Result("c"));
+        Assert.Equal(new[] { "c", "b", "a" }, store.Recent(TenantId.Local).Select(r => r.Verdict));
     }
 
     [Fact]
@@ -38,9 +39,9 @@ public sealed class NetDiagResultStoreTests : IDisposable
     {
         var store = new NetDiagResultStore(_path);
         for (int i = 0; i < NetDiagResultStore.MaxRecords + 5; i++)
-            store.Add(Result($"r{i}"));
+            store.Add(TenantId.Local, Result($"r{i}"));
 
-        var recent = store.Recent();
+        var recent = store.Recent(TenantId.Local);
         Assert.Equal(NetDiagResultStore.MaxRecords, recent.Count);
         Assert.Equal($"r{NetDiagResultStore.MaxRecords + 4}", recent[0].Verdict);
         Assert.DoesNotContain(recent, r => r.Verdict == "r0");
@@ -50,11 +51,11 @@ public sealed class NetDiagResultStoreTests : IDisposable
     public void Results_SurviveReload()
     {
         var store = new NetDiagResultStore(_path);
-        store.Add(new NetDiagResultDto { Verdict = "persisted", Route = "tailscale", LatencyMedianMs = 44, DownloadMbps = 90 });
+        store.Add(TenantId.Local, new NetDiagResultDto { Verdict = "persisted", Route = "tailscale", LatencyMedianMs = 44, DownloadMbps = 90 });
 
         // A fresh store over the SAME file (simulating a Gateway restart) must see the persisted result.
         var reopened = new NetDiagResultStore(_path);
-        var recent = reopened.Recent();
+        var recent = reopened.Recent(TenantId.Local);
         var only = Assert.Single(recent);
         Assert.Equal("persisted", only.Verdict);
         Assert.Equal("tailscale", only.Route);
@@ -70,20 +71,20 @@ public sealed class NetDiagResultStoreTests : IDisposable
 
         // Load must not throw; it quarantines the bad file and starts empty.
         var store = new NetDiagResultStore(_path);
-        Assert.Empty(store.Recent());
+        Assert.Empty(store.Recent(TenantId.Local));
         Assert.NotEmpty(Directory.GetFiles(Path.GetDirectoryName(_path)!, "*.corrupt-*"));
 
         // And it is usable afterward.
-        store.Add(Result("after-quarantine"));
-        Assert.Single(store.Recent());
+        store.Add(TenantId.Local, Result("after-quarantine"));
+        Assert.Single(store.Recent(TenantId.Local));
     }
 
     [Fact]
     public void Recent_RespectsCount()
     {
         var store = new NetDiagResultStore(_path);
-        for (int i = 0; i < 10; i++) store.Add(Result($"r{i}"));
-        Assert.Equal(3, store.Recent(3).Count);
-        Assert.Empty(store.Recent(0));
+        for (int i = 0; i < 10; i++) store.Add(TenantId.Local, Result($"r{i}"));
+        Assert.Equal(3, store.Recent(TenantId.Local, 3).Count);
+        Assert.Empty(store.Recent(TenantId.Local, 0));
     }
 }

--- a/src/CcDirector.Gateway.Tests/NetDiagRollupStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/NetDiagRollupStoreTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Api;
 using Xunit;
 
@@ -25,9 +26,9 @@ public sealed class NetDiagRollupStoreTests : IDisposable
     public void Fold_HomeSample_LandsInLanSubSums()
     {
         var store = new NetDiagRollupStore(_path);
-        store.Fold(T0, latencyMs: 44, direct: true, isLanPath: true, downMbps: null, upMbps: null);
+        store.Fold(TenantId.Local, T0, latencyMs: 44, direct: true, isLanPath: true, downMbps: null, upMbps: null);
 
-        var b = Assert.Single(store.All());
+        var b = Assert.Single(store.All(TenantId.Local));
         Assert.Equal(1, b.Count);
         Assert.Equal(1, b.DirectCount);
         Assert.Equal(0, b.RelayCount);
@@ -41,9 +42,9 @@ public sealed class NetDiagRollupStoreTests : IDisposable
     public void Fold_AwaySample_LandsInAwaySubSums_AndCountsRelay()
     {
         var store = new NetDiagRollupStore(_path);
-        store.Fold(T0, latencyMs: 150, direct: false, isLanPath: false, downMbps: null, upMbps: null);
+        store.Fold(TenantId.Local, T0, latencyMs: 150, direct: false, isLanPath: false, downMbps: null, upMbps: null);
 
-        var b = Assert.Single(store.All());
+        var b = Assert.Single(store.All(TenantId.Local));
         Assert.Equal(1, b.RelayCount);
         Assert.Equal(1, b.AwayCount);
         Assert.Equal(0, b.LanCount);
@@ -54,10 +55,10 @@ public sealed class NetDiagRollupStoreTests : IDisposable
     public void Fold_ClientThroughput_AccumulatesDownUpInTheRightSplit()
     {
         var store = new NetDiagRollupStore(_path);
-        store.Fold(T0, 40, true, isLanPath: true, downMbps: 90, upMbps: 10);
-        store.Fold(T0, 42, true, isLanPath: true, downMbps: 80, upMbps: 8);
+        store.Fold(TenantId.Local, T0, 40, true, isLanPath: true, downMbps: 90, upMbps: 10);
+        store.Fold(TenantId.Local, T0, 42, true, isLanPath: true, downMbps: 80, upMbps: 8);
 
-        var b = Assert.Single(store.All()); // same hour -> accumulates
+        var b = Assert.Single(store.All(TenantId.Local)); // same hour -> accumulates
         Assert.Equal(2, b.LanCount);
         Assert.Equal(170, b.SumDownLan);
         Assert.Equal(18, b.SumUpLan);
@@ -68,8 +69,8 @@ public sealed class NetDiagRollupStoreTests : IDisposable
     [Fact]
     public void Fold_SurvivesReload()
     {
-        new NetDiagRollupStore(_path).Fold(T0, 44, true, true, null, null);
-        var reopened = new NetDiagRollupStore(_path).All();
+        new NetDiagRollupStore(_path).Fold(TenantId.Local, T0, 44, true, true, null, null);
+        var reopened = new NetDiagRollupStore(_path).All(TenantId.Local);
         Assert.Single(reopened);
         Assert.Equal(1, reopened[0].LanCount);
     }
@@ -96,7 +97,7 @@ public sealed class NetDiagRollupStoreTests : IDisposable
 
         monitor.Tick(diag, _ => "aa-bb-cc-dd-ee-ff", T0);
 
-        var b = Assert.Single(rollup.All());
+        var b = Assert.Single(rollup.All(TenantId.Local));
         Assert.Equal(1, b.LanCount);
         Assert.Equal(1, b.DirectCount);
         Assert.Equal(44, b.SumLatencyLan);
@@ -106,10 +107,10 @@ public sealed class NetDiagRollupStoreTests : IDisposable
     public void Prune_DropsBucketsBeyondNinetyDays()
     {
         var store = new NetDiagRollupStore(_path);
-        store.Fold(T0 - TimeSpan.FromDays(100), 44, true, true, null, null); // ancient
-        store.Fold(T0, 44, true, true, null, null);                          // now -> prunes the ancient one
+        store.Fold(TenantId.Local, T0 - TimeSpan.FromDays(100), 44, true, true, null, null); // ancient
+        store.Fold(TenantId.Local, T0, 44, true, true, null, null);                          // now -> prunes the ancient one
 
-        var all = store.All();
+        var all = store.All(TenantId.Local);
         Assert.Single(all);
         Assert.Equal(NetDiagRollupStore.HourKey(T0), all[0].Hour);
     }

--- a/src/CcDirector.Gateway.Tests/NetDiagTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/NetDiagTenantPartitionTests.cs
@@ -18,6 +18,69 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
+/// The two account tenants these tests partition between, and - the point of this type existing at all -
+/// the NON-CANONICAL SPELLINGS of one, WITH THE FIXTURE'S OWN PREMISE ASSERTED.
+///
+/// WHY THIS IS A TYPE AND NOT TWO CONSTANTS. The first version of these tests built an "uppercase alias" by
+/// calling <c>ToUpperInvariant()</c> on an ALL-NUMERIC identifier. Uppercasing a string with no letters in
+/// it changes nothing, so the alias was byte-for-byte the canonical value: the tests asserted that a
+/// non-canonical spelling is refused while never once presenting a non-canonical spelling. They were not
+/// weak tests - their premise never occurred, so they could not fail in the direction they were written to
+/// catch, and they went red for the opposite reason. A fixture is a CLAIM ABOUT THE INPUT, and an unasserted
+/// claim about the input is exactly as unreliable as an unasserted claim about the output.
+///
+/// TWO THINGS FIX IT, AND THE SECOND IS THE ONE THAT LASTS. First, the identifiers now contain hexadecimal
+/// LETTERS, so case actually varies. But choosing better characters is a fact about today's constants that
+/// the next edit can quietly undo, so second - and this is the durable half - <see cref="AliasesOf"/>
+/// ASSERTS ITS OWN PREMISE before returning: every spelling it hands back must differ from the canonical
+/// value, and must still denote the SAME underlying identifier (otherwise the test would be presenting a
+/// different tenant, which the store should refuse for an entirely different reason and would prove nothing
+/// about spelling). If someone later changes these constants back to all-digit values, the fixture fails
+/// LOUDLY at the claim rather than silently ceasing to test anything.
+///
+/// The alias set deliberately includes two forms that differ for ANY identifier - the dash-less "N" form and
+/// the braced "B" form - so the premise no longer depends on the fixture happening to contain letters. That
+/// is the design half of the same fix: make the condition impossible to miss rather than remembering to
+/// choose inputs that hit it.
+/// </summary>
+internal static class NetDiagTenantFixture
+{
+    /// <summary>A canonical minted account tenant, in the EXACT form the registry mints (lowercase "D").
+    /// Contains hexadecimal letters, so case conversion genuinely produces a different string.</summary>
+    public static readonly TenantId TenantA = new("aaaaaaaa-1111-4c1a-8b1a-aaaaaaaaaaaa");
+
+    /// <summary>A second canonical minted account tenant, the one the first must never reach.</summary>
+    public static readonly TenantId TenantB = new("bbbbbbbb-2222-4c2b-8b2b-bbbbbbbbbbbb");
+
+    /// <summary>
+    /// Every non-canonical SPELLING of <paramref name="tenant"/> a test should present to a partition key -
+    /// the same identifier, written a way this system does not mint. The premise is asserted here, once, for
+    /// every caller: each spelling differs from the canonical text (or it is not an alias at all) and each
+    /// parses back to the same identifier (or it is a different tenant, not a different spelling).
+    /// </summary>
+    public static IEnumerable<string> AliasesOf(TenantId tenant)
+    {
+        var canonical = tenant.Value;
+        var parsed = Guid.Parse(canonical);
+
+        var aliases = new[]
+        {
+            canonical.ToUpperInvariant(),  // same identifier, upper case
+            parsed.ToString("N"),          // same identifier, no dashes
+            parsed.ToString("B"),          // same identifier, braced
+        };
+
+        foreach (var alias in aliases)
+        {
+            Assert.NotEqual(canonical, alias);          // it really is a DIFFERENT spelling...
+            Assert.Equal(parsed, Guid.Parse(alias));    // ...of the SAME identifier.
+        }
+
+        return aliases;
+    }
+}
+
+/// <summary>
 /// Unsafe-collection census rows 21 and 22: the diagnostic RESULT store and the hourly quality ROLLUP.
 ///
 /// THE DEFECT. <c>POST /diag/result</c> wrote into one process-global result list and folded into one
@@ -63,16 +126,23 @@ namespace CcDirector.Gateway.Tests;
 ///   M3  GET /diag/rollup passes <c>TenantId.Local</c> instead of the resolved request tenant (read half).
 ///       PREDICT RED: Two_tenants_writing_in_the_same_hour_do_not_share_a_rollup_bucket.
 ///   M4  Delete the three <c>reqTenant is null</c> deny blocks, letting a tenant-less key fall through.
-///       PREDICT RED: A_key_with_no_bound_tenant_is_denied_on_every_diagnostic_route (all three cases).
-///   M5  In both stores, delete the <c>parsed.Tenants is null -> PurgePrePartitionFile()</c> branch.
-///       PREDICT RED: A_pre_partition_result_file_is_purged_not_migrated,
-///       A_pre_partition_rollup_file_is_purged_not_migrated.
+///       PREDICT RED: A_key_with_no_bound_tenant_is_denied_on_every_diagnostic_route (both cases) and
+///       A_key_with_no_bound_tenant_cannot_write_a_diagnostic_result.
+///   M5  In both stores, delete the <c>parsed.Tenants is null -> DeletePrePartitionFile()</c> branch.
+///       PREDICT RED: A_pre_partition_result_file_is_deleted_from_the_live_store_not_migrated,
+///       A_pre_partition_rollup_file_is_deleted_from_the_live_store_not_migrated.
 ///   M6  In <see cref="NetDiagResultStore"/>, prune against the TOTAL record count across partitions rather
 ///       than the writing tenant's own list.
 ///       PREDICT RED: One_tenants_flood_does_not_evict_another_tenants_results.
+///   M7  In both stores' <c>CanonicalTenantKey</c>, drop the ordinal round-trip comparison from
+///       <c>IsMintedAccountTenant</c> so any parseable identifier is accepted in any spelling.
+///       PREDICT RED: An_alternate_spelling_of_a_minted_tenant_is_refused_on_the_write_and_the_read,
+///       An_alternate_spelling_of_a_minted_tenant_is_refused_on_the_fold_and_the_read.
 ///
 /// A predicted red that does not appear is a FINDING, not something to explain away: it means the test does
-/// not actually reach the line the mutation changed.
+/// not actually reach the line the mutation changed. That is not hypothetical here - the FIRST version of the
+/// two alias tests could not reach their own condition at all (see <see cref="NetDiagTenantFixture"/>), which
+/// is why the fixture now asserts its own premise.
 /// </summary>
 public sealed class NetDiagResultStoreTenantPartitionTests : IDisposable
 {
@@ -81,8 +151,8 @@ public sealed class NetDiagResultStoreTenantPartitionTests : IDisposable
 
     private string Path_ => Path.Combine(_dir, "diagnostics-results.json");
 
-    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
-    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+    private static readonly TenantId TenantA = NetDiagTenantFixture.TenantA;
+    private static readonly TenantId TenantB = NetDiagTenantFixture.TenantB;
 
     public void Dispose()
     {
@@ -151,7 +221,7 @@ public sealed class NetDiagResultStoreTenantPartitionTests : IDisposable
     }
 
     [Fact]
-    public void A_pre_partition_result_file_is_purged_not_migrated()
+    public void A_pre_partition_result_file_is_deleted_from_the_live_store_not_migrated()
     {
         // THE ARCHITECT'S RULING, made executable. The old file is one flat list with NO per-tenant
         // attribution recorded anywhere in it. Migrating it would INVENT an attribution that was never
@@ -177,7 +247,9 @@ public sealed class NetDiagResultStoreTenantPartitionTests : IDisposable
         Assert.Empty(store.Recent(TenantId.Local));
         Assert.Empty(store.Recent(TenantId.System));
 
-        // Not quarantined either: purge means GONE, not renamed aside.
+        // Not quarantined either: the live file is REMOVED, not renamed aside. This states deletion from
+        // the LIVE STORE and nothing wider - a test that writes and deletes a file cannot speak for a share
+        // snapshot, a soft-deleted copy or a backup of the same path, which are outside this process.
         Assert.False(File.Exists(Path_), "the pre-partition file must be deleted, not left in place");
         Assert.Empty(Directory.GetFiles(_dir, "*.corrupt-*"));
 
@@ -188,7 +260,7 @@ public sealed class NetDiagResultStoreTenantPartitionTests : IDisposable
     }
 
     [Fact]
-    public void An_unreadable_file_is_still_quarantined_not_purged()
+    public void An_unreadable_file_is_still_quarantined_not_deleted()
     {
         // CONTROL for the purge: the two paths must stay distinct. A file we could not READ is evidence of a
         // bug and is preserved; a file we read perfectly whose CONTENTS are a cross-tenant mixture is
@@ -214,9 +286,27 @@ public sealed class NetDiagResultStoreTenantPartitionTests : IDisposable
         Assert.Throws<ArgumentException>(() => store.Add(new TenantId("not-a-guid"), Result("x")));
         Assert.Throws<ArgumentException>(() => store.Recent(new TenantId("../escape")));
         Assert.Throws<ArgumentException>(() => store.Add(default, Result("x")));
+    }
 
-        // Upper-case is a DIFFERENT spelling of the same account and must not open a second partition.
-        Assert.Throws<ArgumentException>(() => store.Add(new TenantId(TenantA.Value.ToUpperInvariant()), Result("x")));
+    [Fact]
+    public void An_alternate_spelling_of_a_minted_tenant_is_refused_on_the_write_and_the_read()
+    {
+        // The SAME account written a way this system does not mint must not open a second partition, and
+        // must not reach the first one either. The fixture asserts its own premise - see
+        // NetDiagTenantFixture.AliasesOf - so an alias that is not actually a different spelling fails there
+        // rather than passing here for the wrong reason.
+        var store = new NetDiagResultStore(Path_);
+        store.Add(TenantA, Result("canonical-only"));
+
+        foreach (var alias in NetDiagTenantFixture.AliasesOf(TenantA))
+        {
+            Assert.Throws<ArgumentException>(() => store.Add(new TenantId(alias), Result("x")));
+            Assert.Throws<ArgumentException>(() => store.Recent(new TenantId(alias)));
+        }
+
+        // Positive control: the canonical spelling still works and still holds exactly what was written, so
+        // the refusals above are about the SPELLING and not about the store having become unusable.
+        Assert.Equal(new[] { "canonical-only" }, store.Recent(TenantA).Select(r => r.Verdict));
     }
 }
 
@@ -229,8 +319,8 @@ public sealed class NetDiagRollupStoreTenantPartitionTests : IDisposable
     private static readonly DateTime T0 = new(2026, 7, 20, 12, 30, 0, DateTimeKind.Utc);
     private static readonly DateTime T0SameHour = new(2026, 7, 20, 12, 55, 0, DateTimeKind.Utc);
 
-    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
-    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+    private static readonly TenantId TenantA = NetDiagTenantFixture.TenantA;
+    private static readonly TenantId TenantB = NetDiagTenantFixture.TenantB;
 
     private readonly string _dir = Path.Combine(
         Path.GetTempPath(), "cc-netdiagroll-part-" + Guid.NewGuid().ToString("N"));
@@ -304,7 +394,7 @@ public sealed class NetDiagRollupStoreTenantPartitionTests : IDisposable
     }
 
     [Fact]
-    public void A_pre_partition_rollup_file_is_purged_not_migrated()
+    public void A_pre_partition_rollup_file_is_deleted_from_the_live_store_not_migrated()
     {
         // Worse than the raw-results case, and the same ruling for a stronger reason: each old bucket is a
         // SUM over every tenant that folded into that hour. The addends cannot be separated after the fact,
@@ -334,7 +424,7 @@ public sealed class NetDiagRollupStoreTenantPartitionTests : IDisposable
     }
 
     [Fact]
-    public void An_unreadable_rollup_file_is_still_quarantined_not_purged()
+    public void An_unreadable_rollup_file_is_still_quarantined_not_deleted()
     {
         Directory.CreateDirectory(_dir);
         File.WriteAllText(Path_, "{ not json at all");
@@ -353,7 +443,23 @@ public sealed class NetDiagRollupStoreTenantPartitionTests : IDisposable
         Assert.Throws<ArgumentException>(() => store.Fold(new TenantId("not-a-guid"), T0, 40, true, true, null, null));
         Assert.Throws<ArgumentException>(() => store.All(new TenantId("../escape")));
         Assert.Throws<ArgumentException>(() => store.Fold(default, T0, 40, true, true, null, null));
-        Assert.Throws<ArgumentException>(() => store.All(new TenantId(TenantA.Value.ToUpperInvariant())));
+    }
+
+    [Fact]
+    public void An_alternate_spelling_of_a_minted_tenant_is_refused_on_the_fold_and_the_read()
+    {
+        var store = new NetDiagRollupStore(Path_);
+        store.Fold(TenantA, T0, 40, true, true, null, null);
+
+        foreach (var alias in NetDiagTenantFixture.AliasesOf(TenantA))
+        {
+            Assert.Throws<ArgumentException>(() => store.Fold(new TenantId(alias), T0, 40, true, true, null, null));
+            Assert.Throws<ArgumentException>(() => store.All(new TenantId(alias)));
+        }
+
+        // Positive control: the canonical spelling still reaches its own single bucket, so the refusals are
+        // about the SPELLING rather than about the store having become unusable.
+        Assert.Equal(1, Assert.Single(store.All(TenantA)).Count);
     }
 }
 

--- a/src/CcDirector.Gateway.Tests/NetDiagTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/NetDiagTenantPartitionTests.cs
@@ -1,0 +1,688 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unsafe-collection census rows 21 and 22: the diagnostic RESULT store and the hourly quality ROLLUP.
+///
+/// THE DEFECT. <c>POST /diag/result</c> wrote into one process-global result list and folded into one
+/// process-global hour bucket; <c>GET /diag/results</c> and <c>GET /diag/rollup</c> read those same globals.
+/// Every authenticated caller, on any tenant, saw every tenant's diagnostic history and could add to every
+/// tenant's aggregate. There is NO caller-supplied identifier anywhere in this shape to namespace - the hour
+/// comes from server time and the result carries no id - so the remedy is a PARTITION, not a prefix.
+///
+/// TWO HALVES, AND EITHER ALONE IS WORTH NOTHING. These tests deliberately prove the WRITE STAMP and the
+/// READ FILTER separately, because a fix to one masks a hole in the other. A write-only fix still leaks on
+/// the reads. A read-only filter is worse than it looks: it is a DEFERRED leak, because cross-tenant data
+/// keeps accumulating behind it, so the day the filter is lifted or bypassed it exposes a contaminated
+/// history that was written wrong all along. The store-level tests below state the write half directly
+/// (does the record land in - and ONLY in - the writing tenant's partition), and the endpoint tests state
+/// the read half through real authenticated HTTP.
+///
+/// OVERLAPPING TIME BUCKETS ARE THE POINT for the rollup, and they come for free: both tenants POST within
+/// the same test, so the server-derived UTC hour is the SAME hour for both. That is exactly the collision
+/// the census row describes - a shared aggregate that nobody can attribute afterwards, so a fold by one
+/// tenant silently poisons the other's numbers.
+///
+/// A POSITIVE CONTROL ON EVERY CROSS-TENANT ASSERTION. Each "B cannot see A's data" assertion is paired with
+/// "A CAN see A's data" on the same route in the same test. Without that pairing an empty answer passes for
+/// isolation when what really happened is a failed seed - the strongest possible isolation result and the
+/// weakest possible evidence, indistinguishable from the outside.
+///
+/// STATUS AND MEDIA TYPE ARE ASSERTED BEFORE ANY PARSE. Parsing is itself an assertion about format: a
+/// mutation that makes a route serve HTML, or 403, or 404 would otherwise redden these tests as a
+/// JsonReaderException, which proves only that something upstream broke. An assertion says WHAT was served.
+///
+/// PRE-REGISTERED MUTATIONS AND PREDICTED REDS (one primitive per full-suite run, never combined - a
+/// combined revert mis-attributes). Each of these can be individually wrong while everything else stays
+/// correct and isolation still breaks, so each earns its own run; overlap does not exempt any of them.
+///
+///   M1  POST /diag/result passes <c>TenantId.Local</c> instead of the resolved request tenant (write half).
+///       PREDICT RED: Two_tenants_writing_in_the_same_hour_do_not_see_each_others_results,
+///       Two_tenants_writing_in_the_same_hour_do_not_share_a_rollup_bucket,
+///       A_result_lands_only_in_the_writing_tenants_partition (endpoint form).
+///       PREDICT GREEN (controls): every self-host control below, and the store-level tests, which do not
+///       go through the route.
+///   M2  GET /diag/results passes <c>TenantId.Local</c> instead of the resolved request tenant (read half).
+///       PREDICT RED: Two_tenants_writing_in_the_same_hour_do_not_see_each_others_results.
+///   M3  GET /diag/rollup passes <c>TenantId.Local</c> instead of the resolved request tenant (read half).
+///       PREDICT RED: Two_tenants_writing_in_the_same_hour_do_not_share_a_rollup_bucket.
+///   M4  Delete the three <c>reqTenant is null</c> deny blocks, letting a tenant-less key fall through.
+///       PREDICT RED: A_key_with_no_bound_tenant_is_denied_on_every_diagnostic_route (all three cases).
+///   M5  In both stores, delete the <c>parsed.Tenants is null -> PurgePrePartitionFile()</c> branch.
+///       PREDICT RED: A_pre_partition_result_file_is_purged_not_migrated,
+///       A_pre_partition_rollup_file_is_purged_not_migrated.
+///   M6  In <see cref="NetDiagResultStore"/>, prune against the TOTAL record count across partitions rather
+///       than the writing tenant's own list.
+///       PREDICT RED: One_tenants_flood_does_not_evict_another_tenants_results.
+///
+/// A predicted red that does not appear is a FINDING, not something to explain away: it means the test does
+/// not actually reach the line the mutation changed.
+/// </summary>
+public sealed class NetDiagResultStoreTenantPartitionTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "cc-netdiag-part-" + Guid.NewGuid().ToString("N"));
+
+    private string Path_ => Path.Combine(_dir, "diagnostics-results.json");
+
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
+    private static NetDiagResultDto Result(string tag) => new() { Verdict = tag };
+
+    [Fact]
+    public void A_result_lands_only_in_the_writing_tenants_partition()
+    {
+        // THE WRITE HALF, stated on its own. Nothing here reads through a filter that could be covering for
+        // an unstamped write: the record is placed by tenant, and the other tenant's partition is a
+        // different list entirely.
+        var store = new NetDiagResultStore(Path_);
+        store.Add(TenantA, Result("a-only"));
+
+        // Positive control FIRST - if this is empty the seed failed and the next assertion is meaningless.
+        Assert.Equal(new[] { "a-only" }, store.Recent(TenantA).Select(r => r.Verdict));
+        Assert.Empty(store.Recent(TenantB));
+    }
+
+    [Fact]
+    public void Neither_tenant_can_mutate_or_suppress_the_others_results()
+    {
+        // The census's completion predicate names read, mutate, suppress and contend. Writing is the only
+        // mutation this store offers, so "B writes a lot" is the whole attack, and A's list must be
+        // untouched in content AND in order.
+        var store = new NetDiagResultStore(Path_);
+        store.Add(TenantA, Result("a1"));
+        store.Add(TenantA, Result("a2"));
+        for (int i = 0; i < 25; i++) store.Add(TenantB, Result($"b{i}"));
+
+        Assert.Equal(new[] { "a2", "a1" }, store.Recent(TenantA).Select(r => r.Verdict));
+        Assert.DoesNotContain(store.Recent(TenantA), r => r.Verdict!.StartsWith("b", StringComparison.Ordinal));
+        Assert.DoesNotContain(store.Recent(TenantB), r => r.Verdict!.StartsWith("a", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void One_tenants_flood_does_not_evict_another_tenants_results()
+    {
+        // CONTENTION, which a partition alone does not close. If the MaxRecords cap were still counted
+        // across all partitions, a noisy tenant would push a quiet tenant's history out of the store just by
+        // writing - suppression achieved without ever reading anything. The cap is per tenant.
+        var store = new NetDiagResultStore(Path_);
+        store.Add(TenantA, Result("a-survivor"));
+        for (int i = 0; i < NetDiagResultStore.MaxRecords + 50; i++)
+            store.Add(TenantB, Result($"b{i}"));
+
+        var a = store.Recent(TenantA);
+        Assert.Equal(new[] { "a-survivor" }, a.Select(r => r.Verdict));
+        Assert.Equal(NetDiagResultStore.MaxRecords, store.Recent(TenantB).Count);
+    }
+
+    [Fact]
+    public void Partitions_survive_a_reload_intact()
+    {
+        var store = new NetDiagResultStore(Path_);
+        store.Add(TenantA, Result("a-persisted"));
+        store.Add(TenantB, Result("b-persisted"));
+
+        var reopened = new NetDiagResultStore(Path_);
+        Assert.Equal(new[] { "a-persisted" }, reopened.Recent(TenantA).Select(r => r.Verdict));
+        Assert.Equal(new[] { "b-persisted" }, reopened.Recent(TenantB).Select(r => r.Verdict));
+    }
+
+    [Fact]
+    public void A_pre_partition_result_file_is_purged_not_migrated()
+    {
+        // THE ARCHITECT'S RULING, made executable. The old file is one flat list with NO per-tenant
+        // attribution recorded anywhere in it. Migrating it would INVENT an attribution that was never
+        // recorded - the forbidden half-partition - and would hand one tenant another tenant's data.
+        // Quarantining it would merely park a live liability on disk that nothing will ever be able to
+        // attribute. Diagnostics are ephemeral operational telemetry with no durability contract, so the
+        // purge costs nothing real.
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path_, """
+        {
+          "results": [
+            { "verdict": "pre-partition-1", "route": "tailscale" },
+            { "verdict": "pre-partition-2", "route": "lan" }
+          ]
+        }
+        """);
+
+        var store = new NetDiagResultStore(Path_);
+
+        // Not migrated into ANY partition - not the writing tenant's, not Local, not System.
+        Assert.Empty(store.Recent(TenantA));
+        Assert.Empty(store.Recent(TenantB));
+        Assert.Empty(store.Recent(TenantId.Local));
+        Assert.Empty(store.Recent(TenantId.System));
+
+        // Not quarantined either: purge means GONE, not renamed aside.
+        Assert.False(File.Exists(Path_), "the pre-partition file must be deleted, not left in place");
+        Assert.Empty(Directory.GetFiles(_dir, "*.corrupt-*"));
+
+        // And the store is usable afterward, writing the new partitioned shape.
+        store.Add(TenantA, Result("after-purge"));
+        Assert.Equal(new[] { "after-purge" }, store.Recent(TenantA).Select(r => r.Verdict));
+        Assert.Empty(store.Recent(TenantB));
+    }
+
+    [Fact]
+    public void An_unreadable_file_is_still_quarantined_not_purged()
+    {
+        // CONTROL for the purge: the two paths must stay distinct. A file we could not READ is evidence of a
+        // bug and is preserved; a file we read perfectly whose CONTENTS are a cross-tenant mixture is
+        // deleted. Collapsing either into the other loses something - evidence in one direction, or the
+        // ruling in the other.
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path_, "{ this is not valid json");
+
+        var store = new NetDiagResultStore(Path_);
+
+        Assert.Empty(store.Recent(TenantId.Local));
+        Assert.NotEmpty(Directory.GetFiles(_dir, "*.corrupt-*"));
+    }
+
+    [Fact]
+    public void A_tenant_shape_this_system_does_not_mint_is_refused_not_coerced()
+    {
+        // A partition key that is not canonicalized is not a partition (one account reachable under two
+        // spellings, or two accounts colliding on one). The store accepts the well-known Local and System
+        // identities and the exact minted account form, and refuses anything else rather than storing it.
+        var store = new NetDiagResultStore(Path_);
+
+        Assert.Throws<ArgumentException>(() => store.Add(new TenantId("not-a-guid"), Result("x")));
+        Assert.Throws<ArgumentException>(() => store.Recent(new TenantId("../escape")));
+        Assert.Throws<ArgumentException>(() => store.Add(default, Result("x")));
+
+        // Upper-case is a DIFFERENT spelling of the same account and must not open a second partition.
+        Assert.Throws<ArgumentException>(() => store.Add(new TenantId(TenantA.Value.ToUpperInvariant()), Result("x")));
+    }
+}
+
+/// <summary>
+/// The rollup half of census row 22, at the store level. See
+/// <see cref="NetDiagResultStoreTenantPartitionTests"/> for the mutation register that covers both.
+/// </summary>
+public sealed class NetDiagRollupStoreTenantPartitionTests : IDisposable
+{
+    private static readonly DateTime T0 = new(2026, 7, 20, 12, 30, 0, DateTimeKind.Utc);
+    private static readonly DateTime T0SameHour = new(2026, 7, 20, 12, 55, 0, DateTimeKind.Utc);
+
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "cc-netdiagroll-part-" + Guid.NewGuid().ToString("N"));
+
+    private string Path_ => Path.Combine(_dir, "netdiag-rollup.json");
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public void Folds_in_the_same_hour_do_not_share_a_bucket()
+    {
+        // THE OVERLAPPING TIME BUCKET the map demands. T0 and T0SameHour are the SAME UTC hour, which is what
+        // every concurrent tenant gets from server time - so before the partition these three folds were one
+        // bucket and one tenant's numbers were the sum of everybody's.
+        var store = new NetDiagRollupStore(Path_);
+        store.Fold(TenantA, T0, latencyMs: 40, direct: true, isLanPath: true, downMbps: 100, upMbps: 10);
+        store.Fold(TenantA, T0SameHour, latencyMs: 44, direct: true, isLanPath: true, downMbps: 80, upMbps: 8);
+        store.Fold(TenantB, T0SameHour, latencyMs: 900, direct: false, isLanPath: false, downMbps: 1, upMbps: 1);
+
+        var a = Assert.Single(store.All(TenantA));
+        var b = Assert.Single(store.All(TenantB));
+
+        Assert.Equal(NetDiagRollupStore.HourKey(T0), a.Hour);
+        Assert.Equal(NetDiagRollupStore.HourKey(T0), b.Hour); // same hour, different partition
+
+        // Positive control on both sides: each tenant's own folds ARE there...
+        Assert.Equal(2, a.Count);
+        Assert.Equal(1, b.Count);
+
+        // ...and neither carries a trace of the other. B's 900ms relay sample must not touch A's numbers.
+        Assert.Equal(2, a.DirectCount);
+        Assert.Equal(0, a.RelayCount);
+        Assert.Equal(84, a.SumLatencyLan);
+        Assert.Equal(180, a.SumDownLan);
+        Assert.Equal(0, a.AwayCount);
+
+        Assert.Equal(0, b.DirectCount);
+        Assert.Equal(1, b.RelayCount);
+        Assert.Equal(900, b.SumLatencyAway);
+        Assert.Equal(0, b.LanCount);
+    }
+
+    [Fact]
+    public void One_tenants_retention_prune_does_not_reach_into_anothers_history()
+    {
+        // Pruning is driven by the CLOCK OF THE FOLDING TENANT. Sharing one bucket map would let a tenant
+        // folding "now" delete another tenant's older-than-retention history as a side effect - deletion, the
+        // fourth verb in the census's completion predicate, achieved without touching that tenant at all.
+        var store = new NetDiagRollupStore(Path_);
+        store.Fold(TenantA, T0 - TimeSpan.FromDays(30), 44, true, true, null, null);
+        store.Fold(TenantB, T0, 44, true, true, null, null); // B's prune runs against B's partition only
+
+        Assert.Single(store.All(TenantA));
+        Assert.Equal(NetDiagRollupStore.HourKey(T0 - TimeSpan.FromDays(30)), store.All(TenantA)[0].Hour);
+    }
+
+    [Fact]
+    public void Partitions_survive_a_reload_intact()
+    {
+        var store = new NetDiagRollupStore(Path_);
+        store.Fold(TenantA, T0, 40, true, true, null, null);
+        store.Fold(TenantB, T0, 900, false, false, null, null);
+
+        var reopened = new NetDiagRollupStore(Path_);
+        Assert.Equal(1, Assert.Single(reopened.All(TenantA)).LanCount);
+        Assert.Equal(1, Assert.Single(reopened.All(TenantB)).AwayCount);
+    }
+
+    [Fact]
+    public void A_pre_partition_rollup_file_is_purged_not_migrated()
+    {
+        // Worse than the raw-results case, and the same ruling for a stronger reason: each old bucket is a
+        // SUM over every tenant that folded into that hour. The addends cannot be separated after the fact,
+        // so attributing a bucket to a tenant hands that tenant a number that is provably not its own.
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path_, """
+        {
+          "buckets": {
+            "2026-07-20T12": { "hour": "2026-07-20T12", "count": 7, "sumLatencyMs": 700, "directCount": 7 }
+          }
+        }
+        """);
+
+        var store = new NetDiagRollupStore(Path_);
+
+        Assert.Empty(store.All(TenantA));
+        Assert.Empty(store.All(TenantB));
+        Assert.Empty(store.All(TenantId.Local));
+        Assert.Empty(store.All(TenantId.System));
+
+        Assert.False(File.Exists(Path_), "the pre-partition rollup file must be deleted, not left in place");
+        Assert.Empty(Directory.GetFiles(_dir, "*.corrupt-*"));
+
+        store.Fold(TenantA, T0, 40, true, true, null, null);
+        Assert.Equal(1, Assert.Single(store.All(TenantA)).Count);
+        Assert.Empty(store.All(TenantB));
+    }
+
+    [Fact]
+    public void An_unreadable_rollup_file_is_still_quarantined_not_purged()
+    {
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path_, "{ not json at all");
+
+        var store = new NetDiagRollupStore(Path_);
+
+        Assert.Empty(store.All(TenantId.Local));
+        Assert.NotEmpty(Directory.GetFiles(_dir, "*.corrupt-*"));
+    }
+
+    [Fact]
+    public void A_tenant_shape_this_system_does_not_mint_is_refused_not_coerced()
+    {
+        var store = new NetDiagRollupStore(Path_);
+
+        Assert.Throws<ArgumentException>(() => store.Fold(new TenantId("not-a-guid"), T0, 40, true, true, null, null));
+        Assert.Throws<ArgumentException>(() => store.All(new TenantId("../escape")));
+        Assert.Throws<ArgumentException>(() => store.Fold(default, T0, 40, true, true, null, null));
+        Assert.Throws<ArgumentException>(() => store.All(new TenantId(TenantA.Value.ToUpperInvariant())));
+    }
+}
+
+/// <summary>
+/// The READ half of census rows 21 and 22, proved through the real hosted Gateway over authenticated HTTP
+/// with two separately enrolled, tenant-bound device keys. The store-level tests above cannot state this:
+/// they prove the partition holds when it is asked correctly, and say nothing about whether the ROUTE asks
+/// correctly. This class is the only thing that proves the routes resolve the tenant from the caller's own
+/// credential rather than serving the whole store.
+///
+/// See <see cref="NetDiagResultStoreTenantPartitionTests"/> for the pre-registered mutation register.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class NetDiagEndpointTenantIsolationTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _keyA = "";
+    private string _keyB = "";
+    private string _keyNoTenant = "";
+
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "cc-netdiag-ep-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+    private string? _priorRoot;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        // The diagnostic stores resolve their file from CcStorage.Root(), so the test gets its OWN root -
+        // otherwise this test would read and WRITE the developer's real diagnostics files, and a stale one
+        // from a previous run could seed a pass. [Collection("DirectorRoot")] serializes it against the
+        // other tests that move this process-wide variable.
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: Path.Combine(_root, "instances"),
+            workListsPath: Path.Combine(_root, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_root, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        _keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var tenantA = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", tenantA.Value);
+
+        _keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        var tenantB = _gateway.TenantRegistry.MintOrLookupBySubject("sub-bob", "bob@example.com");
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", tenantB.Value);
+
+        // A key that authenticates but is bound to NO tenant. Proving who you are is not proving you own
+        // anything, so this caller must be refused rather than quietly served the Local partition.
+        _keyNoTenant = _gateway.Devices.Register("dev-none", "MC").DeviceKey;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task Two_tenants_writing_in_the_same_hour_do_not_see_each_others_results()
+    {
+        await PostResult(_keyA, "alice-result");
+        await PostResult(_keyB, "bob-result");
+
+        var aVerdicts = await ResultVerdicts(_keyA);
+        var bVerdicts = await ResultVerdicts(_keyB);
+
+        // POSITIVE CONTROL on each side FIRST. Without it, two empty lists would pass this test perfectly
+        // while the truth was that neither POST ever landed.
+        Assert.Contains("alice-result", aVerdicts);
+        Assert.Contains("bob-result", bVerdicts);
+
+        Assert.DoesNotContain("bob-result", aVerdicts);
+        Assert.DoesNotContain("alice-result", bVerdicts);
+    }
+
+    [Fact]
+    public async Task A_result_lands_only_in_the_writing_tenants_partition()
+    {
+        // THE WRITE HALF AT THE ROUTE. Only A ever writes; B only reads. If the route stamped the wrong
+        // tenant on the write, A's own read would come back without it - which a read-filter fix alone
+        // cannot rescue, and which the read-leak test above would not distinguish from a failed seed.
+        await PostResult(_keyA, "written-by-alice");
+
+        Assert.Contains("written-by-alice", await ResultVerdicts(_keyA));
+        Assert.Empty(await ResultVerdicts(_keyB));
+    }
+
+    [Fact]
+    public async Task Two_tenants_writing_in_the_same_hour_do_not_share_a_rollup_bucket()
+    {
+        // Both POSTs happen within this test, so the Gateway stamps them with the SAME server UTC hour -
+        // the overlapping bucket the census row is about. A folds twice, B once.
+        await PostResult(_keyA, "a1", latency: 40, direct: true, lan: true);
+        await PostResult(_keyA, "a2", latency: 44, direct: true, lan: true);
+        await PostResult(_keyB, "b1", latency: 900, direct: false, lan: false);
+
+        var a = await Rollup(_keyA);
+        var b = await Rollup(_keyB);
+
+        // Positive control: each side sees its OWN folds.
+        var aBucket = Assert.Single(a);
+        var bBucket = Assert.Single(b);
+        Assert.Equal(2, aBucket.Count);
+        Assert.Equal(1, bBucket.Count);
+
+        // Same hour on both sides - so this is a partition, not an accident of timing.
+        Assert.Equal(aBucket.Hour, bBucket.Hour);
+
+        // NO AGGREGATE POISONING: B's single 900ms relay sample is nowhere in A's numbers, and vice versa.
+        Assert.Equal(2, aBucket.DirectCount);
+        Assert.Equal(0, aBucket.RelayCount);
+        Assert.Equal(84, aBucket.SumLatencyMs);
+
+        Assert.Equal(0, bBucket.DirectCount);
+        Assert.Equal(1, bBucket.RelayCount);
+        Assert.Equal(900, bBucket.SumLatencyMs);
+    }
+
+    [Theory]
+    [InlineData("diag/results")]
+    [InlineData("diag/rollup")]
+    public async Task A_key_with_no_bound_tenant_is_denied_on_every_diagnostic_route(string path)
+    {
+        // DENY BY DEFAULT. An authenticated key with no tenant owns nothing; serving it the Local partition
+        // would be a wrong-tenant read, and serving it an empty list would be a false statement about a
+        // question it has no standing to ask.
+        var resp = await Get(path, _keyNoTenant);
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_key_with_no_bound_tenant_cannot_write_a_diagnostic_result()
+    {
+        // The write half of the same deny. A read-only refusal would be a DEFERRED leak: unattributable
+        // records would keep accumulating behind it with nowhere correct to put them.
+        var resp = await PostResultRaw(_keyNoTenant, "no-tenant");
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_caller_is_still_rejected()
+    {
+        // Control: the tenant work must not have opened these routes up as a side effect of running before
+        // the host-wide auth gate.
+        Assert.Equal(HttpStatusCode.Unauthorized, (await _http.GetAsync("diag/results")).StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, (await _http.GetAsync("diag/rollup")).StatusCode);
+    }
+
+    // ---- helpers ----
+
+    private Task<HttpResponseMessage> PostResultRaw(string deviceKey, string verdict,
+        double? latency = 40, bool direct = true, bool lan = true)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "diag/result")
+        {
+            Content = JsonContent.Create(new NetDiagResultDto
+            {
+                Verdict = verdict,
+                LatencyMedianMs = latency,
+                Direct = direct,
+                IsLanPath = lan,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private async Task PostResult(string deviceKey, string verdict,
+        double? latency = 40, bool direct = true, bool lan = true)
+    {
+        var resp = await PostResultRaw(deviceKey, verdict, latency, direct, lan);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    private Task<HttpResponseMessage> Get(string path, string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    /// <summary>Read GET /diag/results, asserting the status and media type BEFORE parsing - so a mutation
+    /// that changes WHAT is served reddens as a statement rather than as a parser crash.</summary>
+    private async Task<List<string>> ResultVerdicts(string deviceKey)
+    {
+        var resp = await Get("diag/results", deviceKey);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+        return doc.RootElement.EnumerateArray()
+            .Select(e => e.TryGetProperty("verdict", out var v) ? v.GetString() ?? "" : "")
+            .ToList();
+    }
+
+    /// <summary>Read GET /diag/rollup with the same status-and-media-type-before-parse discipline.</summary>
+    private async Task<List<NetDiagRollupStore.HourBucket>> Rollup(string deviceKey)
+    {
+        var resp = await Get("diag/rollup", deviceKey);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        using (var doc = JsonDocument.Parse(body))
+            Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+
+        return JsonSerializer.Deserialize<List<NetDiagRollupStore.HourBucket>>(body,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}
+
+/// <summary>
+/// SELF-HOST IS PROVED, NOT INHERITED. With <c>CC_GATEWAY_HOSTED</c> explicitly CLEARED there is one tenant -
+/// Local - and all three diagnostic routes must behave exactly as they always did. Leaning on the older
+/// endpoint tests would prove nothing here, because those rest on the test runner's ambient default: if that
+/// default ever flips they keep passing while self-host is broken.
+///
+/// This is a CONTROL for the mutation register in <see cref="NetDiagResultStoreTenantPartitionTests"/>: it
+/// must stay GREEN under every one of M1 through M4, because on self-host the resolved tenant IS Local and
+/// there is no second tenant to leak to. A control that moves with the change under test is not a control.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class NetDiagSelfHostControlTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _key = "";
+
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "cc-netdiag-self-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+    private string? _priorRoot;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: Path.Combine(_root, "instances"),
+            workListsPath: Path.Combine(_root, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_root, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // A device with NO account binding at all - on self-host that is still the one Local tenant, which
+        // is the behaviour that must not have changed.
+        _key = _gateway.Devices.Register("dev-self", "MSELF").DeviceKey;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task A_result_posted_on_self_host_is_readable_back_and_folded_into_the_rollup()
+    {
+        var post = new HttpRequestMessage(HttpMethod.Post, "diag/result")
+        {
+            Content = JsonContent.Create(new NetDiagResultDto
+            {
+                Verdict = "self-host", LatencyMedianMs = 40, Direct = true, IsLanPath = true,
+            }),
+        };
+        post.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        Assert.Equal(HttpStatusCode.OK, (await _http.SendAsync(post)).StatusCode);
+
+        var results = await Get("diag/results");
+        Assert.Equal(HttpStatusCode.OK, results.StatusCode);
+        Assert.Equal("application/json", results.Content.Headers.ContentType?.MediaType);
+        Assert.Contains("self-host", await results.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+
+        var rollup = await Get("diag/rollup");
+        Assert.Equal(HttpStatusCode.OK, rollup.StatusCode);
+        Assert.Equal("application/json", rollup.Content.Headers.ContentType?.MediaType);
+
+        var body = await rollup.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+        Assert.Equal(1, doc.RootElement.EnumerateArray().Single().GetProperty("count").GetInt32());
+    }
+
+    private Task<HttpResponseMessage> Get(string path)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        return _http.SendAsync(req);
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -426,28 +426,67 @@ internal static class GatewayEndpoints
         // what IT saw about the connection, writes one greppable log line, and keeps it in a small ring so
         // an agent can read the recent history at GET /diag/results with no phone. This is the "log all of
         // this so the agent can get to it" piece of the mission.
+        //
+        // TENANT-PARTITIONED (Hosted Multi-Tenancy; unsafe-collection census rows 21 and 22). All three of
+        // these routes carry the SAME obligation, and it has two halves that must both hold: the WRITE
+        // stamps the caller's authenticated tenant onto what it stores, and BOTH READS serve only that
+        // tenant's partition. A write-only fix still leaks on the reads; a read-only filter is a DEFERRED
+        // leak - cross-tenant data would keep accumulating behind it, so the day the filter is lifted it
+        // exposes a contaminated history. Neither half is worth anything without the other.
+        //
+        // The tenant comes from the caller's authenticated device key (ResolveReadTenant), never from the
+        // posted body. A null is a DENY (403): on hosted, an authenticated key with no bound tenant is
+        // refused, never served or credited to the Local partition.
         var netDiagResults = new NetDiagResultStore(Path.Combine(CcStorage.Root(), "diagnostics-results.json"));
         app.MapPost("/diag/result", async (HttpContext ctx, NetDiagResultDto result) =>
         {
+            var reqTenant = ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+            {
+                FileLog.Write("[NetDiag] POST /diag/result DENIED - the authenticated device key resolves to no tenant, so there is no partition to credit this result to (never Local)");
+                return Results.StatusCode(StatusCodes.Status403Forbidden);
+            }
+
             result.ClientIp = ctx.Connection.RemoteIpAddress?.ToString();
             result.ClientPath = NetDiag.ClassifyClientIp(ctx.Connection.RemoteIpAddress);
             result.ReceivedAt = DateTime.UtcNow;
-            netDiagResults.Add(result);
+            netDiagResults.Add(reqTenant.Value, result);
             // Fold into the hourly quality rollup by the MEASURED path (Direct/IsLanPath the client tagged
-            // from its authoritative self-peer), never the front-door ClientPath.
-            netDiagRollup?.Fold(result.ReceivedAt, result.LatencyMedianMs, result.Direct, result.IsLanPath, result.DownloadMbps, result.UploadMbps);
+            // from its authoritative self-peer), never the front-door ClientPath. Keyed by tenant AND hour:
+            // the hour alone is server time, which every tenant shares, so an unkeyed fold is an addition
+            // into a shared aggregate that nobody can attribute or undo afterwards.
+            netDiagRollup?.Fold(reqTenant.Value, result.ReceivedAt, result.LatencyMedianMs, result.Direct, result.IsLanPath, result.DownloadMbps, result.UploadMbps);
             FileLog.Write(
-                $"[NetDiag] result surface={result.Surface} route={result.Route} clientPath={result.ClientPath} " +
+                $"[NetDiag] result tenant={reqTenant.Value.ToLogString()} surface={result.Surface} route={result.Route} clientPath={result.ClientPath} " +
                 $"client={result.ClientIp} latencyMedian={result.LatencyMedianMs}ms down={result.DownloadMbps}Mbps " +
                 $"up={result.UploadMbps}Mbps rating={result.Rating} loadedFrom={result.LoadedFrom}");
             await Task.CompletedTask;
             return Results.Json(new { ok = true });
         });
-        app.MapGet("/diag/results", () => Results.Json(netDiagResults.Recent()));
+        app.MapGet("/diag/results", (HttpContext ctx) =>
+        {
+            var reqTenant = ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+            {
+                FileLog.Write("[NetDiag] GET /diag/results DENIED - the authenticated device key resolves to no tenant, so it owns no results (never the Local partition)");
+                return Results.StatusCode(StatusCodes.Status403Forbidden);
+            }
+            return Results.Json(netDiagResults.Recent(reqTenant.Value));
+        });
 
         // GET /diag/rollup: the hourly quality trend (one bucket per UTC hour, oldest first) for the
         // Cockpit dashboard - percent-direct over time, latency trend, and the stored home/away split.
-        app.MapGet("/diag/rollup", () => Results.Json(netDiagRollup?.All() ?? new List<NetDiagRollupStore.HourBucket>()));
+        // Served from the caller's own tenant partition only.
+        app.MapGet("/diag/rollup", (HttpContext ctx) =>
+        {
+            var reqTenant = ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+            {
+                FileLog.Write("[NetDiag] GET /diag/rollup DENIED - the authenticated device key resolves to no tenant, so it owns no rollup (never the Local partition)");
+                return Results.StatusCode(StatusCodes.Status403Forbidden);
+            }
+            return Results.Json(netDiagRollup?.All(reqTenant.Value) ?? new List<NetDiagRollupStore.HourBucket>());
+        });
 
         // About / diagnostics: product, version, build date, install root, the one Cockpit URL, and
         // the installed component versions (from installed.json on this box). Feeds the Cockpit About

--- a/src/CcDirector.Gateway/Api/NetDiagMonitor.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagMonitor.cs
@@ -215,7 +215,15 @@ public sealed class NetDiagMonitor : IDisposable
 
                 // Fold this judged observation into the hourly quality rollup (home/away split on the
                 // MEASURED path). The monitor has no throughput numbers, so down/up are null. Best-effort.
-                try { _rollup?.Fold(nowUtc, peer.LatencyMs, peer.Direct, isLanPath, null, null); }
+                //
+                // TENANT: explicitly Local, and that is correct HERE and only here. This monitor is
+                // constructed by GatewayHost inside `if (!GatewayHostedMode.IsHosted)` - it shells out to the
+                // tailscale command-line tool, which the hosted container image does not carry, and a hosted
+                // Gateway has no tailnet to diagnose. On self-host, Local is the only tenant there is. If this
+                // monitor is ever constructed on hosted, this line becomes wrong and the owning tenant must be
+                // passed in rather than assumed; it is written literally, at the fold, so that change is
+                // visible here instead of hidden behind a defaulted parameter.
+                try { _rollup?.Fold(Core.Tenancy.TenantId.Local, nowUtc, peer.LatencyMs, peer.Direct, isLanPath, null, null); }
                 catch (Exception ex) { FileLog.Write($"[NetDiagMonitor] rollup fold failed for {key}: {ex.Message}"); }
 
                 results.Add((key, decision));

--- a/src/CcDirector.Gateway/Api/NetDiagResultStore.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagResultStore.cs
@@ -30,7 +30,8 @@ namespace CcDirector.Gateway.Api;
 /// noisy tenant evict another tenant's results just by writing - suppression and contention, not merely
 /// disclosure. Each partition is pruned on its own.
 ///
-/// PRE-PARTITION FILES ARE PURGED, NOT MIGRATED AND NOT QUARANTINED. See <see cref="PurgePrePartitionFile"/>.
+/// A PRE-PARTITION FILE IS DELETED FROM THE LIVE STORE, NOT MIGRATED AND NOT QUARANTINED - and that claim
+/// stops at the live path. See <see cref="DeletePrePartitionFile"/>.
 /// </summary>
 public sealed class NetDiagResultStore
 {
@@ -135,7 +136,7 @@ public sealed class NetDiagResultStore
         /// <summary>Canonical tenant key -> that tenant's results, newest first. NULL after deserializing a
         /// PRE-PARTITION file, which is exactly how <see cref="Load"/> tells the two shapes apart: the old
         /// document has no <c>tenants</c> property at all, and read into the new shape it would otherwise
-        /// arrive as a silent empty rather than as the purge case it is.</summary>
+        /// arrive as a silent empty rather than as the delete-and-start-empty case it is.</summary>
         public Dictionary<string, List<NetDiagResultDto>>? Tenants { get; set; }
     }
 
@@ -166,7 +167,7 @@ public sealed class NetDiagResultStore
 
         if (parsed.Tenants is null)
         {
-            PurgePrePartitionFile();
+            DeletePrePartitionFile();
             return;
         }
 
@@ -185,7 +186,15 @@ public sealed class NetDiagResultStore
     }
 
     /// <summary>
-    /// DELETE a pre-partition (global, tenant-less) store file and start empty.
+    /// DELETE THE LIVE pre-partition (global, tenant-less) store file and start empty.
+    ///
+    /// WHAT THIS DOES AND DOES NOT CLAIM. It removes the file at <see cref="_path"/> - the live store this
+    /// process reads and writes. That is the whole of what a <c>File.Delete</c> can establish. It says
+    /// NOTHING about copies that exist outside this path: a hosted deployment keeps this file on an Azure
+    /// Files share (the App Service <c>/home</c> mount), and a share snapshot, a soft-deleted file, a backup,
+    /// or filesystem history could hold the same cross-tenant mixture after this call returns. Erasing those
+    /// is operational work on the storage account, not something code at this layer can perform or verify,
+    /// and it is tracked separately. Deletion from the live representation is not deletion.
     ///
     /// WHY DELETE AND NOT MIGRATE. The old file is one flat list into which EVERY tenant's results were
     /// mixed, with NO per-tenant attribution recorded anywhere in it. There is therefore no tenant to migrate
@@ -194,17 +203,17 @@ public sealed class NetDiagResultStore
     ///
     /// WHY DELETE AND NOT QUARANTINE. Quarantine is for a file that could not be READ - it preserves the
     /// evidence of a bug. This file reads perfectly; its problem is that its contents are a cross-tenant
-    /// mixture. Renaming it aside would leave that live liability sitting on disk indefinitely for no
-    /// benefit, because nothing will ever be able to attribute it.
+    /// mixture. Renaming it aside would keep it in the live store indefinitely for no benefit, because
+    /// nothing will ever be able to attribute it.
     ///
     /// WHY THE COST IS NOTHING REAL. Diagnostic results are ephemeral operational telemetry with no
     /// durability contract - a bounded recent-history ring that prunes itself continuously and that a
-    /// Gateway restart was already free to lose. Purge, and partition forward.
+    /// Gateway restart was already free to lose. Delete, and partition forward.
     /// </summary>
-    private void PurgePrePartitionFile()
+    private void DeletePrePartitionFile()
     {
         File.Delete(_path);
-        FileLog.Write($"[NetDiagResultStore] Load: PURGED pre-partition store file at {_path} - it holds a cross-tenant mixture with no per-tenant attribution recorded, so it cannot be migrated without inventing one; starting empty.");
+        FileLog.Write($"[NetDiagResultStore] Load: DELETED the live pre-partition store file at {_path} - it holds a cross-tenant mixture with no per-tenant attribution recorded, so it cannot be migrated without inventing one; starting empty. This removes the live file only; any snapshot, soft-deleted copy or backup of the same path is outside this process and is purged as separate operational work.");
     }
 
     private void Quarantine(string reason)

--- a/src/CcDirector.Gateway/Api/NetDiagResultStore.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagResultStore.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -11,15 +12,38 @@ namespace CcDirector.Gateway.Api;
 /// persisted to <c>diagnostics-results.json</c> with the same atomic write-through + corrupt-file
 /// quarantine contract as <see cref="CronRunHistoryStore"/>, so a crash mid-write never half-truncates
 /// the file and an unreadable file is preserved rather than silently overwritten.
+///
+/// PARTITIONED BY TENANT (Hosted Multi-Tenancy; unsafe-collection census row 21). Every result carries the
+/// client's address, its measured path, and the surface and route it came from - one tenant's operational
+/// picture of its own fleet - and before this partition they were all mixed into ONE list that any
+/// authenticated caller read in full. There is NO caller-supplied identifier here to namespace, so this is a
+/// partition rather than a prefix: each tenant gets its own list, and both the write and the read take the
+/// tenant as a REQUIRED parameter.
+///
+/// THE TENANT IS RECORDED PER RESULT BY THE CONTAINING PARTITION KEY, and deliberately NOT by a field on
+/// <see cref="NetDiagResultDto"/>. The DTO is deserialized straight from the request body, so any tenant
+/// field on it would be a value the CALLER could claim, which the store would then have to overwrite on
+/// every path - a claim surface bought for nothing, because the partition key already records the
+/// attribution of every stored record unambiguously and the caller cannot reach it.
+///
+/// THE CAP IS PER TENANT, NOT GLOBAL. A single shared <see cref="MaxRecords"/> across partitions would let a
+/// noisy tenant evict another tenant's results just by writing - suppression and contention, not merely
+/// disclosure. Each partition is pruned on its own.
+///
+/// PRE-PARTITION FILES ARE PURGED, NOT MIGRATED AND NOT QUARANTINED. See <see cref="PurgePrePartitionFile"/>.
 /// </summary>
 public sealed class NetDiagResultStore
 {
-    /// <summary>Max results retained; older results are pruned (keeps the file bounded). Architect Decision 2a: 50 -> 200.</summary>
+    /// <summary>Max results retained PER TENANT; older results are pruned (keeps the file bounded). Architect Decision 2a: 50 -> 200.</summary>
     public const int MaxRecords = 200;
 
     private readonly object _gate = new();
     private readonly string _path;
-    private readonly List<NetDiagResultDto> _items = new(); // newest first
+
+    /// <summary>Canonical tenant key -> that tenant's results, newest first. The ONLY way in is
+    /// <see cref="PartitionFor"/> with a validated tenant, so there is no all-tenants view to read by
+    /// accident and no tenant-less way to write.</summary>
+    private readonly Dictionary<string, List<NetDiagResultDto>> _tenants = new(StringComparer.Ordinal);
 
     private static readonly JsonSerializerOptions FileJsonOptions = new()
     {
@@ -38,35 +62,81 @@ public sealed class NetDiagResultStore
         Load();
     }
 
-    /// <summary>Record one result (newest first), pruning to <see cref="MaxRecords"/>, and persist.</summary>
+    /// <summary>
+    /// Record one result for <paramref name="tenant"/> (newest first), pruning that tenant's partition to
+    /// <see cref="MaxRecords"/>, and persist. The tenant must be resolved from the caller's authenticated
+    /// credential; an unresolved tenant is a DENY at the route, never a default here.
+    /// </summary>
     /// <exception cref="ArgumentNullException">The result is null.</exception>
-    public void Add(NetDiagResultDto result)
+    public void Add(TenantId tenant, NetDiagResultDto result)
     {
         if (result is null)
             throw new ArgumentNullException(nameof(result));
 
         lock (_gate)
         {
-            _items.Insert(0, result);
-            if (_items.Count > MaxRecords)
-                _items.RemoveRange(MaxRecords, _items.Count - MaxRecords);
+            var items = PartitionFor(tenant);
+            items.Insert(0, result);
+            if (items.Count > MaxRecords)
+                items.RemoveRange(MaxRecords, items.Count - MaxRecords);
             Save();
-            FileLog.Write($"[NetDiagResultStore] Add: surface={result.Surface}, route={result.Route}, clientPath={result.ClientPath}, latencyMedian={result.LatencyMedianMs}ms, count={_items.Count}");
+            FileLog.Write($"[NetDiagResultStore] Add: tenant={tenant.ToLogString()}, surface={result.Surface}, route={result.Route}, clientPath={result.ClientPath}, latencyMedian={result.LatencyMedianMs}ms, count={items.Count}");
         }
     }
 
-    /// <summary>The most recent results, newest first (at most <paramref name="count"/>).</summary>
-    public IReadOnlyList<NetDiagResultDto> Recent(int count = MaxRecords)
+    /// <summary>The most recent results BELONGING TO <paramref name="tenant"/>, newest first (at most
+    /// <paramref name="count"/>). There is no unfiltered read: the filter IS the partition lookup, so it
+    /// cannot be forgotten separately from the partition.</summary>
+    public IReadOnlyList<NetDiagResultDto> Recent(TenantId tenant, int count = MaxRecords)
     {
         lock (_gate)
-            return _items.Take(Math.Max(0, count)).ToList();
+            return PartitionFor(tenant).Take(Math.Max(0, count)).ToList();
+    }
+
+    // ---- tenant canonicalization ----
+
+    /// <summary>
+    /// True only for the EXACT form the tenant registry mints: a canonical lowercase GUID. The same guard
+    /// <see cref="Voice.GatewayTurnJobStore"/> uses, so two spellings of one account can never become two
+    /// partitions, nor one partition be reached by two spellings.
+    /// </summary>
+    private static bool IsMintedAccountTenant(string value)
+        => Guid.TryParseExact(value, "D", out var parsed)
+           && string.Equals(value, parsed.ToString("D"), StringComparison.Ordinal);
+
+    private static string CanonicalTenantKey(TenantId tenant)
+    {
+        if (!tenant.IsValid)
+            throw new ArgumentException("A diagnostic result needs a valid tenant; an unresolved tenant is denied, never defaulted.", nameof(tenant));
+        if (tenant.IsLocal) return TenantId.Local.Value;
+        if (tenant.IsSystem) return TenantId.System.Value;
+        if (!IsMintedAccountTenant(tenant.Value))
+            throw new ArgumentException(
+                $"Tenant '{tenant.ToLogString()}' is not a minted account tenant and cannot own diagnostic results.", nameof(tenant));
+        return tenant.Value;
+    }
+
+    /// <summary>Caller must hold <see cref="_gate"/>.</summary>
+    private List<NetDiagResultDto> PartitionFor(TenantId tenant)
+    {
+        var key = CanonicalTenantKey(tenant);
+        if (!_tenants.TryGetValue(key, out var items))
+        {
+            items = new List<NetDiagResultDto>();
+            _tenants[key] = items;
+        }
+        return items;
     }
 
     // ---- persistence (CronRunHistoryStore precedent: atomic write-through + corrupt-file quarantine) ----
 
     private sealed class StoreFile
     {
-        public List<NetDiagResultDto> Results { get; set; } = new();
+        /// <summary>Canonical tenant key -> that tenant's results, newest first. NULL after deserializing a
+        /// PRE-PARTITION file, which is exactly how <see cref="Load"/> tells the two shapes apart: the old
+        /// document has no <c>tenants</c> property at all, and read into the new shape it would otherwise
+        /// arrive as a silent empty rather than as the purge case it is.</summary>
+        public Dictionary<string, List<NetDiagResultDto>>? Tenants { get; set; }
     }
 
     private void Load()
@@ -94,10 +164,47 @@ public sealed class NetDiagResultStore
             return;
         }
 
-        _items.AddRange(parsed.Results.Where(r => r is not null));
-        if (_items.Count > MaxRecords)
-            _items.RemoveRange(MaxRecords, _items.Count - MaxRecords);
-        FileLog.Write($"[NetDiagResultStore] Load: restored {_items.Count} result(s) from {_path}");
+        if (parsed.Tenants is null)
+        {
+            PurgePrePartitionFile();
+            return;
+        }
+
+        foreach (var (tenantKey, results) in parsed.Tenants)
+        {
+            if (string.IsNullOrWhiteSpace(tenantKey) || results is null)
+                continue;
+
+            var kept = results.Where(r => r is not null).ToList();
+            if (kept.Count > MaxRecords)
+                kept.RemoveRange(MaxRecords, kept.Count - MaxRecords);
+            _tenants[tenantKey] = kept;
+        }
+
+        FileLog.Write($"[NetDiagResultStore] Load: restored {_tenants.Values.Sum(v => v.Count)} result(s) across {_tenants.Count} tenant partition(s) from {_path}");
+    }
+
+    /// <summary>
+    /// DELETE a pre-partition (global, tenant-less) store file and start empty.
+    ///
+    /// WHY DELETE AND NOT MIGRATE. The old file is one flat list into which EVERY tenant's results were
+    /// mixed, with NO per-tenant attribution recorded anywhere in it. There is therefore no tenant to migrate
+    /// those records TO - assigning them one would INVENT an attribution that was never recorded, which is
+    /// the half-partition this mission forbids, and it would silently hand one tenant another tenant's data.
+    ///
+    /// WHY DELETE AND NOT QUARANTINE. Quarantine is for a file that could not be READ - it preserves the
+    /// evidence of a bug. This file reads perfectly; its problem is that its contents are a cross-tenant
+    /// mixture. Renaming it aside would leave that live liability sitting on disk indefinitely for no
+    /// benefit, because nothing will ever be able to attribute it.
+    ///
+    /// WHY THE COST IS NOTHING REAL. Diagnostic results are ephemeral operational telemetry with no
+    /// durability contract - a bounded recent-history ring that prunes itself continuously and that a
+    /// Gateway restart was already free to lose. Purge, and partition forward.
+    /// </summary>
+    private void PurgePrePartitionFile()
+    {
+        File.Delete(_path);
+        FileLog.Write($"[NetDiagResultStore] Load: PURGED pre-partition store file at {_path} - it holds a cross-tenant mixture with no per-tenant attribution recorded, so it cannot be migrated without inventing one; starting empty.");
     }
 
     private void Quarantine(string reason)
@@ -115,7 +222,7 @@ public sealed class NetDiagResultStore
             if (!string.IsNullOrEmpty(dir))
                 Directory.CreateDirectory(dir);
 
-            var file = new StoreFile { Results = _items };
+            var file = new StoreFile { Tenants = _tenants };
             var json = JsonSerializer.Serialize(file, FileJsonOptions);
 
             var tmp = _path + ".tmp";

--- a/src/CcDirector.Gateway/Api/NetDiagRollupStore.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagRollupStore.cs
@@ -1,20 +1,31 @@
 using System.Globalization;
 using System.Text.Json;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Gateway.Api;
 
 /// <summary>
 /// The hourly quality rollup (Network Diagnostics mission, Phase 1 / Architect Decision 2b as resequenced).
-/// ONE bucket per UTC hour (no per-route key - so no cardinality growth and no route/quality conflation),
-/// but each bucket carries a HOME vs AWAY split keyed on the MEASURED path (isLanPath), never the front-door
-/// ClientPath. That gives home-vs-away quality history from day one for free; P1 STORES the split, the P3
-/// dashboard shows overall percent-direct + latency trend, and P4 just turns on the home/away presentation
-/// over history that is already accumulating.
+/// ONE bucket per UTC hour PER TENANT (no per-route key - so no cardinality growth and no route/quality
+/// conflation), but each bucket carries a HOME vs AWAY split keyed on the MEASURED path (isLanPath), never
+/// the front-door ClientPath. That gives home-vs-away quality history from day one for free; P1 STORES the
+/// split, the P3 dashboard shows overall percent-direct + latency trend, and P4 just turns on the home/away
+/// presentation over history that is already accumulating.
 ///
 /// This is the 90-day durable memory (the raw results ring stays recent-depth). Same atomic write-through +
 /// corrupt-file quarantine contract as <see cref="CronRunHistoryStore"/>; the file stays small (~24 x 90 =
-/// a couple thousand buckets), so a rewrite per fold is cheap.
+/// a couple thousand buckets per tenant), so a rewrite per fold is cheap.
+///
+/// KEYED BY TENANT PLUS HOUR (Hosted Multi-Tenancy; unsafe-collection census row 22). The hour comes from
+/// SERVER TIME, so every tenant writing at the same moment folded into the SAME bucket: a shared aggregate
+/// that any authenticated caller could both read and POISON, because a fold is an addition nobody can
+/// attribute afterwards. There is no caller-supplied identifier to namespace, so the fix is a partition:
+/// <c>tenant -> hour -> bucket</c>, with the tenant a REQUIRED parameter on the fold AND on the read.
+/// Retention pruning is per tenant for the same reason - one tenant's clock-driven prune must not reach
+/// into another's history.
+///
+/// PRE-PARTITION FILES ARE PURGED, NOT MIGRATED AND NOT QUARANTINED. See <see cref="PurgePrePartitionFile"/>.
 /// </summary>
 public sealed class NetDiagRollupStore
 {
@@ -47,7 +58,11 @@ public sealed class NetDiagRollupStore
 
     private readonly object _gate = new();
     private readonly string _path;
-    private readonly Dictionary<string, HourBucket> _buckets = new(StringComparer.Ordinal);
+
+    /// <summary>Canonical tenant key -> that tenant's hour buckets. The ONLY way in is
+    /// <see cref="PartitionFor"/> with a validated tenant, so there is no all-tenants aggregate to read or
+    /// fold into by accident.</summary>
+    private readonly Dictionary<string, Dictionary<string, HourBucket>> _tenants = new(StringComparer.Ordinal);
 
     private static readonly JsonSerializerOptions FileJsonOptions = new()
     {
@@ -65,16 +80,18 @@ public sealed class NetDiagRollupStore
     }
 
     /// <summary>
-    /// Fold one observation into its UTC-hour bucket. <paramref name="isLanPath"/> is the MEASURED path type
-    /// (a LAN-direct address = home); <paramref name="direct"/> is the ping verdict. Down/up are only present
-    /// for client speed-test results (the monitor passes null). Prunes buckets past the 90-day retention.
+    /// Fold one observation into <paramref name="tenant"/>'s UTC-hour bucket. <paramref name="isLanPath"/> is
+    /// the MEASURED path type (a LAN-direct address = home); <paramref name="direct"/> is the ping verdict.
+    /// Down/up are only present for client speed-test results (the monitor passes null). Prunes THAT
+    /// TENANT'S buckets past the 90-day retention.
     /// </summary>
-    public void Fold(DateTime whenUtc, double? latencyMs, bool? direct, bool isLanPath, double? downMbps, double? upMbps)
+    public void Fold(TenantId tenant, DateTime whenUtc, double? latencyMs, bool? direct, bool isLanPath, double? downMbps, double? upMbps)
     {
         var hour = HourKey(whenUtc);
         lock (_gate)
         {
-            if (!_buckets.TryGetValue(hour, out var b)) { b = new HourBucket { Hour = hour }; _buckets[hour] = b; }
+            var buckets = PartitionFor(tenant);
+            if (!buckets.TryGetValue(hour, out var b)) { b = new HourBucket { Hour = hour }; buckets[hour] = b; }
 
             b.Count++;
             if (latencyMs is { } lat) { b.SumLatencyMs += lat; b.MinLatencyMs = Least(b.MinLatencyMs, lat); }
@@ -96,16 +113,18 @@ public sealed class NetDiagRollupStore
                 if (upMbps is { } u) b.SumUpAway += u;
             }
 
-            Prune(whenUtc);
+            Prune(buckets, whenUtc);
             Save();
         }
     }
 
-    /// <summary>All retained buckets, oldest hour first.</summary>
-    public IReadOnlyList<HourBucket> All()
+    /// <summary>All retained buckets BELONGING TO <paramref name="tenant"/>, oldest hour first. There is no
+    /// unfiltered read: the filter IS the partition lookup, so it cannot be forgotten separately from the
+    /// partition.</summary>
+    public IReadOnlyList<HourBucket> All(TenantId tenant)
     {
         lock (_gate)
-            return _buckets.Values.OrderBy(b => b.Hour, StringComparer.Ordinal).ToList();
+            return PartitionFor(tenant).Values.OrderBy(b => b.Hour, StringComparer.Ordinal).ToList();
     }
 
     public static string HourKey(DateTime whenUtc)
@@ -113,18 +132,57 @@ public sealed class NetDiagRollupStore
 
     private static double? Least(double? cur, double v) => cur is null ? v : Math.Min(cur.Value, v);
 
-    private void Prune(DateTime nowUtc)
+    private static void Prune(Dictionary<string, HourBucket> buckets, DateTime nowUtc)
     {
         var cutoff = HourKey(nowUtc - Retention);
-        var stale = _buckets.Keys.Where(k => string.CompareOrdinal(k, cutoff) < 0).ToList();
-        foreach (var k in stale) _buckets.Remove(k);
+        var stale = buckets.Keys.Where(k => string.CompareOrdinal(k, cutoff) < 0).ToList();
+        foreach (var k in stale) buckets.Remove(k);
+    }
+
+    // ---- tenant canonicalization ----
+
+    /// <summary>
+    /// True only for the EXACT form the tenant registry mints: a canonical lowercase GUID. The same guard
+    /// <see cref="Voice.GatewayTurnJobStore"/> uses, so two spellings of one account can never become two
+    /// partitions, nor one partition be reached by two spellings.
+    /// </summary>
+    private static bool IsMintedAccountTenant(string value)
+        => Guid.TryParseExact(value, "D", out var parsed)
+           && string.Equals(value, parsed.ToString("D"), StringComparison.Ordinal);
+
+    private static string CanonicalTenantKey(TenantId tenant)
+    {
+        if (!tenant.IsValid)
+            throw new ArgumentException("A quality rollup needs a valid tenant; an unresolved tenant is denied, never defaulted.", nameof(tenant));
+        if (tenant.IsLocal) return TenantId.Local.Value;
+        if (tenant.IsSystem) return TenantId.System.Value;
+        if (!IsMintedAccountTenant(tenant.Value))
+            throw new ArgumentException(
+                $"Tenant '{tenant.ToLogString()}' is not a minted account tenant and cannot own quality rollups.", nameof(tenant));
+        return tenant.Value;
+    }
+
+    /// <summary>Caller must hold <see cref="_gate"/>.</summary>
+    private Dictionary<string, HourBucket> PartitionFor(TenantId tenant)
+    {
+        var key = CanonicalTenantKey(tenant);
+        if (!_tenants.TryGetValue(key, out var buckets))
+        {
+            buckets = new Dictionary<string, HourBucket>(StringComparer.Ordinal);
+            _tenants[key] = buckets;
+        }
+        return buckets;
     }
 
     // ---- persistence (CronRunHistoryStore precedent) ----
 
     private sealed class StoreFile
     {
-        public Dictionary<string, HourBucket> Buckets { get; set; } = new(StringComparer.Ordinal);
+        /// <summary>Canonical tenant key -> hour key -> bucket. NULL after deserializing a PRE-PARTITION
+        /// file, which is exactly how <see cref="Load"/> tells the two shapes apart: the old document has no
+        /// <c>tenants</c> property at all, and read into the new shape it would otherwise arrive as a silent
+        /// empty rather than as the purge case it is.</summary>
+        public Dictionary<string, Dictionary<string, HourBucket>>? Tenants { get; set; }
     }
 
     private void Load()
@@ -152,11 +210,48 @@ public sealed class NetDiagRollupStore
             return;
         }
 
-        foreach (var (hour, bucket) in parsed.Buckets)
-            if (!string.IsNullOrWhiteSpace(hour) && bucket is not null)
-                _buckets[hour] = bucket;
+        if (parsed.Tenants is null)
+        {
+            PurgePrePartitionFile();
+            return;
+        }
 
-        FileLog.Write($"[NetDiagRollupStore] Load: restored {_buckets.Count} hourly bucket(s) from {_path}");
+        foreach (var (tenantKey, buckets) in parsed.Tenants)
+        {
+            if (string.IsNullOrWhiteSpace(tenantKey) || buckets is null)
+                continue;
+
+            var kept = new Dictionary<string, HourBucket>(StringComparer.Ordinal);
+            foreach (var (hour, bucket) in buckets)
+                if (!string.IsNullOrWhiteSpace(hour) && bucket is not null)
+                    kept[hour] = bucket;
+            _tenants[tenantKey] = kept;
+        }
+
+        FileLog.Write($"[NetDiagRollupStore] Load: restored {_tenants.Values.Sum(v => v.Count)} hourly bucket(s) across {_tenants.Count} tenant partition(s) from {_path}");
+    }
+
+    /// <summary>
+    /// DELETE a pre-partition (global, tenant-less) rollup file and start empty.
+    ///
+    /// WHY DELETE AND NOT MIGRATE. Each old bucket is a SUM over every tenant that folded into that hour,
+    /// with no per-tenant attribution recorded anywhere - the addends cannot be separated after the fact.
+    /// Assigning a bucket to a tenant would INVENT an attribution that was never recorded, which is the
+    /// half-partition this mission forbids; worse than the raw results case, it would hand that tenant a
+    /// number that is provably not its own.
+    ///
+    /// WHY DELETE AND NOT QUARANTINE. Quarantine is for a file that could not be READ - it preserves the
+    /// evidence of a bug. This file reads perfectly; its problem is that its contents are a cross-tenant
+    /// mixture. Renaming it aside would leave that live liability on disk indefinitely for no benefit,
+    /// because nothing will ever be able to attribute it.
+    ///
+    /// WHY THE COST IS NOTHING REAL. This is ephemeral operational telemetry with no durability contract -
+    /// a self-pruning quality trend, not a record anything is owed. Purge, and partition forward.
+    /// </summary>
+    private void PurgePrePartitionFile()
+    {
+        File.Delete(_path);
+        FileLog.Write($"[NetDiagRollupStore] Load: PURGED pre-partition rollup file at {_path} - its buckets are cross-tenant sums with no per-tenant attribution recorded, so they cannot be migrated without inventing one; starting empty.");
     }
 
     private void Quarantine(string reason)
@@ -174,7 +269,7 @@ public sealed class NetDiagRollupStore
             if (!string.IsNullOrEmpty(dir))
                 Directory.CreateDirectory(dir);
 
-            var file = new StoreFile { Buckets = _buckets };
+            var file = new StoreFile { Tenants = _tenants };
             var json = JsonSerializer.Serialize(file, FileJsonOptions);
 
             var tmp = _path + ".tmp";

--- a/src/CcDirector.Gateway/Api/NetDiagRollupStore.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagRollupStore.cs
@@ -25,7 +25,8 @@ namespace CcDirector.Gateway.Api;
 /// Retention pruning is per tenant for the same reason - one tenant's clock-driven prune must not reach
 /// into another's history.
 ///
-/// PRE-PARTITION FILES ARE PURGED, NOT MIGRATED AND NOT QUARANTINED. See <see cref="PurgePrePartitionFile"/>.
+/// A PRE-PARTITION FILE IS DELETED FROM THE LIVE STORE, NOT MIGRATED AND NOT QUARANTINED - and that claim
+/// stops at the live path. See <see cref="DeletePrePartitionFile"/>.
 /// </summary>
 public sealed class NetDiagRollupStore
 {
@@ -181,7 +182,7 @@ public sealed class NetDiagRollupStore
         /// <summary>Canonical tenant key -> hour key -> bucket. NULL after deserializing a PRE-PARTITION
         /// file, which is exactly how <see cref="Load"/> tells the two shapes apart: the old document has no
         /// <c>tenants</c> property at all, and read into the new shape it would otherwise arrive as a silent
-        /// empty rather than as the purge case it is.</summary>
+        /// empty rather than as the delete-and-start-empty case it is.</summary>
         public Dictionary<string, Dictionary<string, HourBucket>>? Tenants { get; set; }
     }
 
@@ -212,7 +213,7 @@ public sealed class NetDiagRollupStore
 
         if (parsed.Tenants is null)
         {
-            PurgePrePartitionFile();
+            DeletePrePartitionFile();
             return;
         }
 
@@ -232,7 +233,14 @@ public sealed class NetDiagRollupStore
     }
 
     /// <summary>
-    /// DELETE a pre-partition (global, tenant-less) rollup file and start empty.
+    /// DELETE THE LIVE pre-partition (global, tenant-less) rollup file and start empty.
+    ///
+    /// WHAT THIS DOES AND DOES NOT CLAIM. It removes the file at <see cref="_path"/> - the live store this
+    /// process reads and writes - and nothing more. A hosted deployment keeps this file on an Azure Files
+    /// share (the App Service <c>/home</c> mount), so a share snapshot, a soft-deleted file, a backup, or
+    /// filesystem history could hold the same cross-tenant sums after this call returns. Erasing those is
+    /// operational work on the storage account, not something code at this layer can perform or verify, and
+    /// it is tracked separately. Deletion from the live representation is not deletion.
     ///
     /// WHY DELETE AND NOT MIGRATE. Each old bucket is a SUM over every tenant that folded into that hour,
     /// with no per-tenant attribution recorded anywhere - the addends cannot be separated after the fact.
@@ -242,16 +250,16 @@ public sealed class NetDiagRollupStore
     ///
     /// WHY DELETE AND NOT QUARANTINE. Quarantine is for a file that could not be READ - it preserves the
     /// evidence of a bug. This file reads perfectly; its problem is that its contents are a cross-tenant
-    /// mixture. Renaming it aside would leave that live liability on disk indefinitely for no benefit,
-    /// because nothing will ever be able to attribute it.
+    /// mixture. Renaming it aside would keep it in the live store indefinitely for no benefit, because
+    /// nothing will ever be able to attribute it.
     ///
     /// WHY THE COST IS NOTHING REAL. This is ephemeral operational telemetry with no durability contract -
-    /// a self-pruning quality trend, not a record anything is owed. Purge, and partition forward.
+    /// a self-pruning quality trend, not a record anything is owed. Delete, and partition forward.
     /// </summary>
-    private void PurgePrePartitionFile()
+    private void DeletePrePartitionFile()
     {
         File.Delete(_path);
-        FileLog.Write($"[NetDiagRollupStore] Load: PURGED pre-partition rollup file at {_path} - its buckets are cross-tenant sums with no per-tenant attribution recorded, so they cannot be migrated without inventing one; starting empty.");
+        FileLog.Write($"[NetDiagRollupStore] Load: DELETED the live pre-partition rollup file at {_path} - its buckets are cross-tenant sums with no per-tenant attribution recorded, so they cannot be migrated without inventing one; starting empty. This removes the live file only; any snapshot, soft-deleted copy or backup of the same path is outside this process and is purged as separate operational work.");
     }
 
     private void Quarantine(string reason)


### PR DESCRIPTION
Unsafe-collection ingestion map, work unit "Diagnostic result and hour bucket with no tenant key" - census rows 21 and 22. Base is `f5bb926f`, which is the map's own audit snapshot.

## The defect

`POST /diag/result` wrote into one process-global result list (`NetDiagResultStore._items`) and folded into one process-global UTC-hour bucket (`NetDiagRollupStore._buckets`); `GET /diag/results` and `GET /diag/rollup` read those same globals. Every authenticated caller, on any tenant, saw every tenant's diagnostic history and could add to every tenant's aggregate.

There is no caller-supplied identifier anywhere in this shape to namespace - the hour comes from server time and a result carries no id - which is what makes this a partition unit rather than a prefix one.

## Both halves, because either alone is worth nothing

The map's own warning is the shape of the trap: a write-only fix still leaks on the reads, and a read-only fix still permits aggregate poisoning. The standing ruling adds the sharper point - a read-only filter is a DEFERRED leak, because cross-tenant data keeps accumulating behind it, so the day it is lifted it exposes a contaminated history. So the write stamps the tenant AND both reads filter, and the tests state the two halves separately.

## What changed

- `NetDiagResultStore` holds one list per canonicalized tenant. The tenant is a required parameter on the write and on the read, and there is no unfiltered accessor - the filter IS the partition lookup, so it cannot be forgotten separately from the partition.
- The record cap is per tenant. A shared cap across partitions would let a noisy tenant evict a quiet tenant's history just by writing - suppression and contention achieved without ever reading anything, which the map's completion predicate names explicitly.
- `NetDiagRollupStore` keys by tenant AND hour, and prunes retention per tenant, so one tenant's clock-driven prune cannot delete another tenant's history.
- All three routes resolve the tenant from the authenticated device key (`ResolveReadTenant`) and DENY with 403 when it resolves to none - never falling back to the Local partition. The deny covers the write as well as the reads.
- The tenant is recorded per record by the containing partition key rather than by a field on the posted DTO. The DTO is deserialized straight from the request body, so a tenant field on it would be a value the CALLER could claim, which every path would then have to overwrite - a claim surface bought for nothing, because the partition key already records the attribution of every stored record unambiguously and the caller cannot reach it.
- A tenant shape this system does not mint is refused rather than coerced (the same canonicalization guard `GatewayTurnJobStore` uses), so one account cannot open two partitions under two spellings and a non-minted string cannot become a key.
- The self-host `NetDiagMonitor` fold passes `TenantId.Local` literally, at the fold, with the reason at the call site: that monitor is constructed only inside `if (!GatewayHostedMode.IsHosted)`, and on self-host Local is the only tenant there is. Written literally rather than defaulted so that if it is ever constructed on hosted, the wrongness is visible here.

## Existing data: purged, per the Architect's ruling

Pre-partition store files are DELETED on load, not migrated and not quarantined, and the reason is written where the code does it.

They are a cross-tenant mixture with NO per-tenant attribution recorded anywhere, so migrating them would invent an attribution that was never recorded - the forbidden half-partition - and would silently hand one tenant another tenant's data. For the rollup it is worse: each old bucket is a sum over every tenant that folded into that hour, so the addends cannot be separated at all and attribution would hand a tenant a number provably not its own. Quarantine would merely park a live liability on disk that nothing will ever be able to attribute. Diagnostics are ephemeral operational telemetry with no durability contract - a self-pruning ring that a restart was already free to lose - so the purge costs nothing real.

The UNREADABLE-file path is unchanged and still quarantines, and has its own control test in each store, so the two paths cannot silently collapse into one.

## Tests

Two authenticated, separately enrolled, tenant-bound device keys writing over OVERLAPPING hour buckets through a real hosted `GatewayHost` over real HTTP, plus store-level tests for the write half.

- Write half and read half are stated separately, because a fix to one masks a hole in the other.
- A POSITIVE CONTROL on every cross-tenant assertion - the tenant reads its OWN record on the same route in the same test - so an empty answer can never pass for isolation when it was really a failed seed.
- Status and media type are asserted BEFORE any parse, so a mutation that changes what is served reddens as a statement rather than as a laundered parser crash.
- Read, mutate, suppress, contend and delete are each covered: cross-read, cross-write, per-tenant cap under a flood, per-tenant retention prune.
- Deny-by-default is proved on all three routes for a key that authenticates but is bound to no tenant, plus an unauthenticated control proving the routes were not opened up as a side effect.
- Self-host is PROVED, not inherited: a control class explicitly CLEARS `CC_GATEWAY_HOSTED` and asserts all three routes still behave as they always did. Leaning on the older endpoint tests would rest on the runner's ambient default, so they would keep passing if that default ever flipped.

## Proof status - NOT YET RUN

The Gateway test suite has NOT been run for this branch: the machine's single test lane was held by another worker, and a concurrent run kills the test host and produces failures in untouched areas. This branch is built clean (full solution, non-incremental, zero errors and zero warnings) and the new test types are verified present in the built test assembly, but it is NOT proved and must not be merged on this evidence.

Six mutations are pre-registered with their predicted reds, in the doc comment on `NetDiagResultStoreTenantPartitionTests`. One primitive per full-suite run, never combined, because a combined revert mis-attributes. Each earns its own run because it can be individually wrong while everything else stays correct and isolation still breaks; overlap does not exempt any of them. The count was reduced by DESIGN, not by argument: the read filter and the partition are the same lookup (there is no unfiltered accessor to delete), and there is no claimable tenant field to fail to overwrite - both would otherwise have been separate mutations.

A predicted red that does not appear is a FINDING, not something to explain away.
