### PR TITLE
docs: land the hosted Gateway collection census and its remedy map

### DIFF
--- a/docs/architecture/hosted-gateway-process-global-collection-census-2026-07-20.md
+++ b/docs/architecture/hosted-gateway-process-global-collection-census-2026-07-20.md
@@ -1,0 +1,187 @@
+# Hosted Gateway process-global collection census
+
+**Audit snapshot:** `f5bb926f18c0023e86fc7b212ab02d425ff9cc50` (`origin/main` on 20 July 2026)  
+**Scope:** retained collection state declared by the Gateway, including singleton instance fields and static fields  
+**Status:** enumeration audit only; this document does not claim that the findings are fixed
+
+## Headline
+
+**Forty independently addressable rows are actively unsafe across hosted tenants.**
+
+This is a finite census, not a sample. It found 102 retained collection declarations in 54 declaring
+types. Applying the collapse rule below produces 94 independently addressable rows: 46 clean, seven
+latent, 40 actively cross-tenant unsafe, and one separately unsafe authorization-policy row.
+
+| Reconciliation | Count |
+| --- | ---: |
+| Raw retained collection declarations | 102 |
+| One-row reductions from the eight named collapses | -8 |
+| Independently addressable rows | 94 |
+| Clean rows | 46 |
+| Latent rows | 7 |
+| Active cross-tenant unsafe rows | 40 |
+| Authorization-policy unsafe rows | 1 |
+| Disposition total | 94 |
+
+## Counting rule
+
+Two collections collapse into one logical row only when no caller can address one without the other.
+Collections remain separate when a caller can arguably address, mutate, or observe either one without
+the other. This deliberately favors separate rows at an uncertain boundary.
+
+The dispositions mean:
+
+- **Clean:** the hosted path includes a trusted tenant discriminator, contains only server-owned
+  configuration, or cannot mix tenant-owned state in the inspected composition.
+- **Latent:** the collection has an unsafe global key shape, but its current hosted composition has no
+  producer, no consumer, or no construction path that can complete the cross-tenant interaction.
+- **Active unsafe:** a hosted path can currently cause one tenant to read, write, suppress, delete, or
+  contend with another tenant's state.
+- **Policy unsafe:** the isolation boundary is not crossed by the current lookup chain, but the
+  authorization object is ownerless or can be minted by a caller who should not have that authority.
+
+## Full census
+
+Paths in the source column are relative to `src/CcDirector.Gateway` at the audited snapshot.
+
+| # | Declaring state | Source | Lifetime | Effective address and supplier | Trusted tenant discriminator | Disposition and effect |
+| ---: | --- | --- | --- | --- | --- | --- |
+| 1 | `BroadcastGovernor._sends` | `Api/BroadcastGovernor.cs` | singleton | Bare sender session identifier from `POST /fanout` | No | **Active unsafe:** tenants sharing a session identifier share the send-rate budget and can deny one another broadcasts. |
+| 2 | `BroadcastGovernor._grants` | `Api/BroadcastGovernor.cs` | singleton | Server-minted grant token returned to any authenticated caller, then presented to `POST /fanout` | No owner is stored | **Policy unsafe:** the current target lookup remains tenant-scoped, but any authenticated caller can mint the supposedly human-only grant. |
+| 3 | `NeedsYouClock._since` | `Briefing/NeedsYouClock.cs` | singleton | Bare session identifier from the tenant roster; the Director originally supplies it | No | **Active unsafe:** one tenant can read or delete another tenant's derived needs-you timestamp through a colliding session identifier. |
+| 4 | `TranscribingSessions._lastProgress` | `Transcription/TranscribingSessions.cs` | singleton | Bare session identifier from transcription routes and Director session data | No | **Active unsafe:** progress from one tenant changes another tenant's presentation timestamp. |
+| 5 | `TranscribingSessions._activelyTranscribing` | `Transcription/TranscribingSessions.cs` | singleton | Bare session identifier from transcription routes and Director session data | No | **Active unsafe:** one tenant can set or clear another tenant's transcribing marker. |
+| 6 | `DirectorRegistry._directors` | `Discovery/DirectorRegistry.cs` | singleton | `DirectorKey`, formed from authenticated tenant plus Director identifier from `DirectorHub` hello | Yes | **Clean:** the primary Director registry is tenant-partitioned. |
+| 7 | `DirectorRegistry._everReachable` | `Discovery/DirectorRegistry.cs` | singleton | Bare Director identifier | No | **Latent:** removal code exists, but the audited snapshot has no completing producer and reader pair. |
+| 8 | `DirectorRegistry._stateReporting` | `Discovery/DirectorRegistry.cs` | singleton | Bare Director identifier from `DirectorHub` hello, heartbeat, and doorbell paths | No | **Latent:** writes exist, but the production reader is absent in the audited snapshot. |
+| 9 | `FleetRoleObserver._lastSent` | `Fleet/FleetRoleObserver.cs` | singleton | Bare pushed session identifier supplied by a Director | No | **Latent:** hosted construction receives only the local empty or no-operation snapshot. |
+| 10 | `FleetDisplayStateObserver._lastSent` | `Fleet/FleetDisplayStateObserver.cs` | singleton | Bare pushed session identifier supplied by a Director | No | **Latent:** hosted construction receives only the local empty or no-operation snapshot. |
+| 11 | `SessionStateEventEmitter._lastState` | `Governance/SessionStateEventEmitter.cs` | singleton | Bare session identifier from heartbeat and doorbell activity | No | **Active unsafe:** another tenant can suppress or remove a state transition and thereby suppress tenant-scoped durable history. |
+| 12 | `AutoDismissSweeper._closing` | `Running/AutoDismissSweeper.cs` | singleton | Explicit tenant plus session marker built from each tenant's own sweep | Yes | **Clean:** `MarkKey` includes the tenant. |
+| 13 | `CronEngine._inFlight` | `Running/CronEngine.cs` | singleton | Bare short job identifier from run-now and scheduled-job stores | No | **Active unsafe:** colliding six-hex-digit job identifiers share an overlap lock and can deny execution across tenants. |
+| 14 | `WorkListRunnerManager._activeByMachine` | `Running/WorkListRunnerManager.cs` | singleton | Bare machine name from list-run requests or the target Director | No | **Active unsafe:** tenants sharing a machine name share start, read, drain, and deletion state. |
+| 15 | `GatewayStreamRegistry._streams` | `Streaming/GatewayStreamRegistry.cs` | singleton | Bare server-minted stream identifier later supplied by the Director-side stream consumer | No owner is checked | **Active unsafe:** a tenant can claim, inject frames into, or tear down another tenant's colliding stream. |
+| 16 | `PushedSessionStore._byTenant` Director partition | `Streaming/PushedSessionStore.cs` | singleton | Authenticated tenant, then Director identifier from the Director hello | Yes | **Clean:** the outer partition is the authenticated tenant. |
+| 17 | `PushedSessionStore.DirectorEntry.Sessions` | `Streaming/PushedSessionStore.cs` | nested retained state | Authenticated tenant, Director identifier, then pushed session identifier | Yes | **Clean:** session access remains below the tenant and Director partitions. |
+| 18 | `GatewayDeviceRegistrationService._lastPublishedEndpointUrls` | `Account/GatewayDeviceRegistrationService.cs` | singleton | One unkeyed list supplied by server endpoint configuration | Not tenant data | **Clean:** it retains only the last published Gateway endpoint configuration. |
+| 19 | `GatewayDictationEndpoint._completes` | `Api/GatewayDictationEndpoint.cs` | static | Bare caller-supplied dictation upload identifier | No | **Active unsafe:** completion state can be read or overwritten across tenants. |
+| 20 | `GatewayDictationEndpoint._uploadSids` | `Api/GatewayDictationEndpoint.cs` | static | Bare caller-supplied upload identifier mapped to a bare session identifier | No | **Active unsafe:** one tenant can bind or observe another tenant's upload-to-session association. |
+| 21 | `NetDiagResultStore._items` | `Api/NetDiagResultStore.cs` | singleton | Unkeyed result list written and read by diagnostic routes | No | **Active unsafe:** diagnostic results from all tenants are mixed and disclosed. |
+| 22 | `NetDiagRollupStore._buckets` | `Api/NetDiagRollupStore.cs` | singleton | Coordinated Universal Time hour from diagnostic result monitoring | No | **Active unsafe:** tenants can poison and read a shared hourly aggregate. |
+| 23 | `DirectorEventLog._rings` | `Events/DirectorEventLog.cs` | singleton | Bare Director identifier from doorbell and event routes | No | **Active unsafe:** event rings collide across tenants. |
+| 24 | `FleetSessionNumberAllocator._bySession` plus `_inUse` | `Discovery/FleetSessionNumberAllocator.cs` | singleton | Bare session identifier, Director identifier, and observed number from roster and session-number routes | No | **Active unsafe:** allocation and reservation state is shared across tenants. |
+| 25 | `FleetRosterCache._byDirector` plus `Entry.Snapshot` | `Discovery/FleetRosterCache.cs` | singleton | Authenticated tenant plus Director identifier | Yes | **Clean:** the roster snapshot is below a tenant-aware Director key. |
+| 26 | `TurnEndWatcher._lastActivity` | `Briefing/TurnEndWatcher.cs` | singleton | Bare session identifier and activity from heartbeat and doorbell paths | No | **Active unsafe:** one tenant can advance another tenant's turn-end activity marker. |
+| 27 | `CarModeTurnCache._byKey` | `CarMode/CarModeTurnCache.cs` | singleton | Authenticated credential, separator, and caller idempotency key | Yes | **Clean:** the effective key includes the authenticated credential. |
+| 28 | `CarModeConversationStore._byDevice` plus `Conversation.Messages` | `CarMode/CarModeConversationStore.cs` | singleton | Device key derived from the authenticated credential | Yes | **Clean:** conversation history is credential-partitioned. |
+| 29 | `CarModePendingStore._byDevice` | `CarMode/CarModePendingStore.cs` | singleton | Device key derived from the authenticated credential | Yes | **Clean:** pending actions are credential-partitioned. |
+| 30 | `CarModeSubjectStore._byDevice` | `CarMode/CarModeSubjectStore.cs` | singleton | Device key derived from the authenticated credential | Yes | **Clean:** subject state is credential-partitioned. |
+| 31 | `LoopbackCarModeFleet._rosterCache` | `CarMode/LoopbackCarModeFleet.cs` | singleton | One unkeyed loopback roster loaded with the machine token | No | **Latent:** the hosted loopback path cannot currently populate this cache with tenant roster data. |
+| 32 | `NetDiagMonitor._devices` plus `DeviceState.Samples` | `Api/NetDiagMonitor.cs` | singleton when constructed | Tailscale device or address identity | No tenant field | **Clean:** this monitor is not constructed by the hosted composition at the audited snapshot. |
+| 33 | `NetDiagAlertService._emailedEpisode` | `Api/NetDiagAlertService.cs` | singleton when constructed | Tailscale device episode | No tenant field | **Clean:** this alert service is not constructed by the hosted composition at the audited snapshot. |
+| 34 | `NetDiagDeviceStore._devices` plus `PersistedDevice.Samples` | `Api/NetDiagDeviceStore.cs` | singleton when constructed | Tailscale device identity | No tenant field | **Clean:** this store is not constructed by the hosted composition at the audited snapshot. |
+| 35 | `TelemetryRetryQueue._events` | `Api/TelemetryRetryQueue.cs` | singleton | Unkeyed queue; each retained event carries its own bearer context | Per-event credential | **Clean:** callers cannot address another queued item by a shared key. |
+| 36 | `TunnelCatchAllDispatch.GetReads` | `Api/TunnelCatchAllDispatch.cs` | static immutable use | Server-owned route and verb literals | Not tenant data | **Clean:** dispatch configuration only. |
+| 37 | `TunnelCatchAllDispatch.BodyWrites` | `Api/TunnelCatchAllDispatch.cs` | static immutable use | Server-owned route and verb literals | Not tenant data | **Clean:** dispatch configuration only. |
+| 38 | `CarModeConfirm.Affirmatives` | `CarMode/CarModeConfirm.cs` | static immutable use | Server-owned phrase literals | Not tenant data | **Clean:** classifier configuration only. |
+| 39 | `CarModeConfirm.Negatives` | `CarMode/CarModeConfirm.cs` | static immutable use | Server-owned phrase literals | Not tenant data | **Clean:** classifier configuration only. |
+| 40 | `CarModeTelemetryStore._records` | `CarMode/CarModeTelemetryStore.cs` | singleton | One unkeyed list written and read by telemetry routes | No | **Active unsafe:** telemetry records from all tenants are mixed and disclosed. |
+| 41 | `CockpitReactApp.BrowserPageRoots` | `Cockpit/CockpitReactApp.cs` | static immutable use | Server-owned page-root literals | Not tenant data | **Clean:** browser application routing configuration only. |
+| 42 | `LauncherRegistry._launchers` | `Discovery/LauncherRegistry.cs` | singleton | Bare caller-supplied machine name from launcher routes | No | **Active unsafe:** registration, lookup, and removal collide across tenants. |
+| 43 | `SessionOwnerCache._ownerBySession` | `Discovery/SessionOwnerCache.cs` | singleton | Bare session identifier from roster and proxy writers | No | **Latent:** the audited production composition has no consumer of `OwnerOf`. |
+| 44 | `GovernanceAuditLog.ActorRequired` | `Governance/GovernanceAuditLog.cs` | static immutable use | Server-owned event-name literals | Not tenant data | **Clean:** validation configuration only. |
+| 45 | `DeviceRegistry._byDeviceId` | `Pairing/DeviceRegistry.cs` | singleton | One-way hash of authenticated tenant plus caller device identifier | Yes | **Clean:** hosted enrollment namespaces the caller identifier at ingestion. |
+| 46 | `WebPushNeedsYouNotifier.DotState.Announced` | `Push/WebPushNeedsYouNotifier.cs` | nested retained state | Bare roster session identifiers | No | **Latent:** the notifier is not constructed by the hosted composition at the audited snapshot. |
+| 47 | `WebPushNeedsYouNotifier.NoExpired` | `Push/WebPushNeedsYouNotifier.cs` | static immutable | Server-owned empty sentinel collection | Not tenant data | **Clean:** no caller-owned state. |
+| 48 | `SourceAdapters.BySource` | `Running/SourceAdapters.cs` | static immutable use | Server-owned source-name literals | Not tenant data | **Clean:** adapter configuration only. |
+| 49 | `GatewayInputStatsAggregator._highWater` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Bare session identifier plus modality and surface from Director statistics | No | **Active unsafe:** high-water counters collide across tenants. |
+| 50 | `GatewayInputStatsAggregator._agentDrivenHighWater` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Bare session identifier from Director statistics | No | **Active unsafe:** agent-driven high-water counters collide across tenants. |
+| 51 | `GatewayInputStatsAggregator._wingmanSessions` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Bare session identifier from Director statistics | No | **Active unsafe:** a tenant can suppress another tenant's first-seen wingman accounting. |
+| 52 | `GatewayInputStatsAggregator._tokenHighWater` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Bare session identifier from token statistics | No | **Active unsafe:** token high-water accounting collides across tenants. |
+| 53 | `GatewayInputStatsAggregator._agentsSeeded` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Bare session identifier used as the seed marker | No | **Active unsafe:** one tenant can suppress another tenant's initial agent seed. |
+| 54 | `GatewayInputStatsAggregator._repoIds` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Repository display value supplied through Director statistics | No | **Active unsafe:** repository identities are globally coalesced. |
+| 55 | `GatewayInputStatsAggregator._agentIds` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Agent display value supplied through Director statistics | No | **Active unsafe:** agent identities are globally coalesced. |
+| 56 | `GatewayInputStatsAggregator._modelIds` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Model display value supplied through Director statistics | No | **Active unsafe:** model identities are globally coalesced. |
+| 57 | `GatewayInputStatsAggregator._checkoutIds` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Checkout display value supplied through Director statistics | No | **Active unsafe:** checkout identities are globally coalesced. |
+| 58 | `GatewayInputStatsAggregator._repoDisplay` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Server database identity mapped back to caller-influenced repository display | No | **Active unsafe:** reverse identity display state is shared across tenants. |
+| 59 | `GatewayInputStatsAggregator._agentDisplay` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Server database identity mapped back to caller-influenced agent display | No | **Active unsafe:** reverse identity display state is shared across tenants. |
+| 60 | `GatewayInputStatsAggregator._modelDisplay` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Server database identity mapped back to caller-influenced model display | No | **Active unsafe:** reverse identity display state is shared across tenants. |
+| 61 | `GatewayInputStatsAggregator._checkoutDisplay` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Server database identity mapped back to caller-influenced checkout display | No | **Active unsafe:** reverse identity display state is shared across tenants. |
+| 62 | `GatewayInputStatsAggregator._repoSessions` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Repository database identity plus bare session identifier | No | **Active unsafe:** repository session membership is globally coalesced. |
+| 63 | `GatewayInputStatsAggregator._agentSessions` | `Stats/GatewayInputStatsAggregator.cs` | singleton | Agent database identity plus bare session identifier | No | **Active unsafe:** agent session membership is globally coalesced. |
+| 64 | `GatewaySessionConcurrencyStats._hours` | `Stats/GatewaySessionConcurrencyStats.cs` | singleton | Coordinated Universal Time hour from roster observations | No | **Active unsafe:** hourly concurrency aggregates mix all tenants. |
+| 65 | `GatewaySessionConcurrencyStats._curSessions` | `Stats/GatewaySessionConcurrencyStats.cs` | singleton | Bare session identifier from roster observations | No | **Active unsafe:** current session concurrency coalesces tenants. |
+| 66 | `GatewaySessionConcurrencyStats._curMachines` | `Stats/GatewaySessionConcurrencyStats.cs` | singleton | Bare machine name from roster observations | No | **Active unsafe:** current machine concurrency coalesces tenants. |
+| 67 | `GatewaySessionConcurrencyStats._curRepos` | `Stats/GatewaySessionConcurrencyStats.cs` | singleton | Bare repository name from roster observations | No | **Active unsafe:** current repository concurrency coalesces tenants. |
+| 68 | `StatsPageEndpoint.NotCaptured` | `Stats/StatsPageEndpoint.cs` | static immutable use | Server-owned explanatory text | Not tenant data | **Clean:** presentation configuration only. |
+| 69 | `LauncherConnectionRegistry._byMachine` | `Streaming/LauncherConnectionRegistry.cs` | singleton | Bare machine name from `LauncherHub` hello | No | **Active unsafe:** connection ownership collides across tenants. |
+| 70 | `AuthMiddleware.PublicPaths` | `Util/AuthMiddleware.cs` | static immutable use | Server-owned public route literals | Not tenant data | **Clean:** authentication configuration only. |
+| 71 | `GatewayTurnJobStore._tenants` plus `TenantJobs.Jobs` | `Voice/GatewayTurnJobStore.cs` | singleton | Validated canonical tenant plus server-minted turn identifier | Yes | **Clean:** turn jobs are below the tenant partition. |
+| 72 | `GatewayTurnJobStore._tenants` plus `TenantJobs.ByUpload` | `Voice/GatewayTurnJobStore.cs` | singleton | Validated canonical tenant plus caller upload identifier | Yes | **Clean:** upload lookup is below the tenant partition. |
+| 73 | `VoiceUploadStore._recordGates` | `Voice/VoiceUploadStore.cs` | static | Canonical record path derived from a bare caller upload identifier | No | **Active unsafe:** upload identifiers select shared record locks in an unpartitioned root. |
+| 74 | `WaitingScreenClassifier.ModeStatusAnchors` | `Wingman/WaitingScreenClassifier.cs` | static immutable use | Server-owned classifier literals | Not tenant data | **Clean:** classifier configuration only. |
+| 75 | `WaitingScreenClassifier.BorderOrSpace` | `Wingman/WaitingScreenClassifier.cs` | static immutable use | Server-owned character literals | Not tenant data | **Clean:** classifier configuration only. |
+| 76 | `WaitingScreenClassifier.BoxEdge` | `Wingman/WaitingScreenClassifier.cs` | static immutable use | Server-owned character literals | Not tenant data | **Clean:** classifier configuration only. |
+| 77 | `WaitingScreenClassifier.VerticalBorder` | `Wingman/WaitingScreenClassifier.cs` | static immutable use | Server-owned character literals | Not tenant data | **Clean:** classifier configuration only. |
+| 78 | `WingmanMenu.BorderPadding` | `Wingman/WingmanMenu.cs` | static immutable use | Server-owned character literals | Not tenant data | **Clean:** menu parsing configuration only. |
+| 79 | `WingmanMenu.NumberWords` | `Wingman/WingmanMenu.cs` | static immutable use | Server-owned number-word literals | Not tenant data | **Clean:** menu parsing configuration only. |
+| 80 | `WingmanVoiceService._tenants` plus `TenantVoiceState.VoiceSessions` | `Wingman/WingmanVoiceService.cs` | singleton | Validated tenant plus session identifier | Yes | **Clean:** voice-session markers are below the tenant partition. |
+| 81 | `WingmanVoiceService._tenants` plus `TenantVoiceState.Ready` | `Wingman/WingmanVoiceService.cs` | singleton | Validated tenant plus session identifier | Yes | **Clean:** ready audio is below the tenant partition. |
+| 82 | `WingmanVoiceService._tenants` plus `TenantVoiceState.Generating` | `Wingman/WingmanVoiceService.cs` | singleton | Validated tenant plus session identifier | Yes | **Clean:** generation markers are below the tenant partition. |
+| 83 | `WingmanVoiceService._tenants` plus `TenantVoiceState.Unavailable` | `Wingman/WingmanVoiceService.cs` | singleton | Validated tenant plus session identifier | Yes | **Clean:** unavailability state is below the tenant partition. |
+| 84 | `WingmanVoiceService._tenants` plus `TenantVoiceState.NothingToNarrate` | `Wingman/WingmanVoiceService.cs` | singleton | Validated tenant plus session identifier | Yes | **Clean:** narration state is below the tenant partition. |
+| 85 | `WingmanVoiceService._tenants` plus `TenantVoiceState.PreferBackupUntil` | `Wingman/WingmanVoiceService.cs` | singleton | Validated tenant plus session identifier | Yes | **Clean:** fallback deadlines are below the tenant partition. |
+| 86 | `WingmanVoiceService._tenants` plus `TenantVoiceState.InFlight` | `Wingman/WingmanVoiceService.cs` | singleton | Validated tenant plus session identifier | Yes | **Clean:** in-flight voice work is below the tenant partition. |
+| 87 | `BuiltInWorkflows.Definitions` | `Workflows/BuiltInWorkflows.cs` | static immutable use | Server-owned workflow definitions | Not tenant data | **Clean:** workflow configuration only. |
+| 88 | `WorkflowRunStore.LegalTransitions` | `Workflows/WorkflowRunStore.cs` | static immutable use | Server-owned status-transition literals | Not tenant data | **Clean:** workflow validation configuration only. |
+| 89 | `WorkflowRunStore.AcceptanceStatuses` | `Workflows/WorkflowRunStore.cs` | static immutable use | Server-owned status literals | Not tenant data | **Clean:** workflow validation configuration only. |
+| 90 | `WorkflowRunStore.CriterionStatuses` | `Workflows/WorkflowRunStore.cs` | static immutable use | Server-owned status literals | Not tenant data | **Clean:** workflow validation configuration only. |
+| 91 | `WorkflowValidation.AllowedFileExtensions` | `Workflows/WorkflowValidation.cs` | static immutable use | Server-owned file-extension literals | Not tenant data | **Clean:** workflow validation configuration only. |
+| 92 | `GatewayTurnBriefStore._latest` | `Briefing/GatewayTurnBriefStore.cs` | singleton | Bare session identifier from roster and turn-brief routes | No | **Active unsafe:** latest-brief cache entries collide across tenants. |
+| 93 | `GatewayTurnBriefStore._packages` | `Briefing/GatewayTurnBriefStore.cs` | singleton | Bare session identifier plus turn count | No | **Active unsafe:** turn packages collide across tenants. |
+| 94 | `CarModeHelp` cheat-sheet modes plus per-mode examples | `CarMode/CarModeHelp.cs` | static immutable use | Server-owned help configuration | Not tenant data | **Clean:** the mode and its examples are returned as one inseparable help unit. |
+
+## The eight named collapses
+
+Each collapse below reduces the raw declaration count by exactly one. The sixth and seventh retain
+multiple logical rows because the outer tenant collection is shared by multiple independently
+addressable inner collections.
+
+1. `NetDiagDeviceStore._devices` and `PersistedDevice.Samples` become row 34.
+2. `NetDiagMonitor._devices` and `DeviceState.Samples` become row 32.
+3. `CarModeConversationStore._byDevice` and `Conversation.Messages` become row 28.
+4. `FleetRosterCache._byDirector` and `Entry.Snapshot` become row 25.
+5. `FleetSessionNumberAllocator._bySession` and `_inUse` become row 24.
+6. `GatewayTurnJobStore._tenants` is folded into each inner index, producing rows 71 and 72 rather
+   than a third independently addressable row.
+7. `WingmanVoiceService._tenants` is folded into each of its seven inner state collections,
+   producing rows 80 through 86 rather than an eighth independently addressable row.
+8. `CarModeHelp` modes and each mode's examples become row 94.
+
+## Boundary exclusions
+
+The sweep examined and excluded these shapes because they are not retained, independently
+addressable Gateway collection state:
+
+- method-local accumulators;
+- request, response, and data-transfer objects;
+- containers used only while deserializing persisted files;
+- database context sets;
+- synchronization primitives;
+- byte-array payload values;
+- framework-owned internal collections.
+
+No collection-like keyed timers were found.
+
+## Count correction
+
+An intermediate tranche counted `WebPushNeedsYouNotifier.DotState.Initial` as row 47. It is a scalar
+sentinel whose value contains the already-counted `Announced` set, not an independently addressable
+collection. Removing it corrected that tranche's running total downward from 71 to 70. The separate
+`NoExpired` immutable empty collection remains row 47 in the final renumbered table.
+
+## What this census does and does not prove
+
+This closes finite-shape enumeration only, at the stated snapshot. It does not establish convergence.
+The 40 active rows still require fixes and proof. Open-ended shapes still require two clean dry rounds
+plus a list-completeness audit, and the instrumentation clause remains separate.

--- a/docs/architecture/hosted-gateway-process-global-collection-census-2026-07-20.md
+++ b/docs/architecture/hosted-gateway-process-global-collection-census-2026-07-20.md
@@ -1,7 +1,9 @@
 # Hosted Gateway process-global collection census
 
-**Audit snapshot:** `f5bb926f18c0023e86fc7b212ab02d425ff9cc50` (`origin/main` on 20 July 2026)  
-**Scope:** retained collection state declared by the Gateway, including singleton instance fields and static fields  
+**Audit snapshot:** `f5bb926f18c0023e86fc7b212ab02d425ff9cc50` (`origin/main` on 20 July 2026)
+
+**Scope:** retained collection state declared by the Gateway, including singleton instance fields and static fields
+
 **Status:** enumeration audit only; this document does not claim that the findings are fixed
 
 ## Headline

--- a/docs/architecture/hosted-gateway-unsafe-collection-ingestion-map-2026-07-20.md
+++ b/docs/architecture/hosted-gateway-unsafe-collection-ingestion-map-2026-07-20.md
@@ -1,0 +1,96 @@
+# Hosted Gateway unsafe-collection ingestion map
+
+**Audit snapshot:** `f5bb926f18c0023e86fc7b212ab02d425ff9cc50`
+
+**Parent census:** [Hosted Gateway process-global collection census](hosted-gateway-process-global-collection-census-2026-07-20.md), commit `a294d770`
+
+**Scope:** remedy regrouping for the census's 40 active cross-tenant unsafe rows
+
+**Status:** fix plan only; no row is declared fixed by this document
+
+## Result
+
+The 40 unsafe rows reduce to eleven identifier or no-identifier work units. The hoped-for single
+prefix boundary does not exist for every unit:
+
+- caller-supplied upload identifiers have one clean registration seam, provided every follow-up route
+  derives the same internal key;
+- statistics identity fields have one authoritative source family, but two aggregation call paths;
+- session identifiers, Director ring keys, and machine names enter through several independent paths;
+- job identifiers and stream identifiers are server-minted rather than caller-supplied;
+- session-number reservations, unkeyed diagnostic and car-mode lists, and hour-keyed concurrency state
+  cannot be made tenant-safe merely by prefixing a caller identifier.
+
+That distinction is the useful output of the regrouping. A blanket “prefix identifiers” change would
+leave active unsafe rows behind.
+
+## Proven pattern to extend
+
+`HostedEnrollmentEndpoint.Enroll` resolves the authenticated account to a tenant, hashes that tenant
+with Secure Hash Algorithm 256, and stores `tenant hash | caller device identifier` in `DeviceRegistry`.
+The raw device identifier never becomes a process-global key. Census row 45 is clean for that reason.
+
+The same mechanism is suitable where all of these are true:
+
+1. the tenant comes from authenticated request or bound-connection state, never the payload;
+2. one canonical helper derives a domain-tagged internal key such as
+   `tenant hash | session | raw identifier`;
+3. every write, read, removal, expiry pass, and disconnect path derives the identical key;
+4. external protocols keep the raw identifier, while only internal storage receives the namespaced key.
+
+The fourth rule prevents a storage repair from changing browser links, Director commands, idempotency
+tokens, or persisted user-facing identifiers.
+
+## Regrouping by identifier and ingestion point
+
+The row numbers refer to the parent census. Every active unsafe row appears exactly once.
+
+| Identifier or address family | Ingestion point where it enters the Gateway | Census rows covered | Boundary-prefix verdict | Blast radius if wrong or missed |
+| --- | --- | --- | --- | --- |
+| **Session identifier** | `DirectorHub.PushSnapshot`, `PushDelta`, and `RemoveSession`; `GatewayEndpoints` heartbeat and doorbell callbacks, `/fanout`, `/sessions/{sid}/transcribing`, roster folding, and session-number routes; `GatewayDictationEndpoint.Map`; `TurnBriefGatewayEndpoints.Map` | 1, 3, 4, 5, 11, 26, 49-53, 65, 92, 93 **(14)** | **No single clean ingestion point.** Introduce one `TenantSessionKey` derivation helper after `DirectorHub.RequireBoundTenant` or `GatewayEndpoints.ResolveReadTenant`, and require the affected collection methods to accept that internal key. Keep raw session identifiers in `SessionDto`, route parameters, links, and tunnel commands. | A missed writer preserves a cross-tenant collision. A mismatched read creates orphaned state. Mutating the raw identifier breaks session lookup, tunnel routing, deletion, dictation progress, governance history, brief file paths, and browser links. |
+| **Dictation upload identifier** | `GatewayDictationEndpoint.Map`, at `POST /dictation/upload`, after device authentication; the caller's `Idempotency-Key` reaches `VoiceUploadStore.Register`, and later chunk, complete, acknowledge, and abandon routes present it again | 19, 20, 73 **(3)** | **One clean registration seam, but all follow-up routes must normalize.** Keep the external globally unique identifier shape; use a `TenantUploadKey` for `_completes` and `_uploadSids`, and a tenant-specific record directory or gate key in `VoiceUploadStore`. | Inconsistent normalization loses resume and acknowledgement, splits chunks from completion, strands tombstones, permits duplicate prompt injection, or lets two tenants share a record lock. Changing the external identifier format also breaks the browser's durable idempotency record. |
+| **Director identifier or synthetic event-ring key** | `GatewayEndpoints` doorbell and event routes after tenant-aware `DirectorRegistry.Get`; `GatewayCronNotifier.NotifyRunCompletedAsync`; non-hosted `NetDiagAlertService` synthetic network ring | 23 **(1)** | **No single clean ingestion point.** Change `DirectorEventLog` to require tenant plus ring key. Background notifiers must carry the owning tenant explicitly; synthetic rings need a deliberate system or tenant scope. | A missed producer files an event into another tenant's ring. A mismatched reader makes notifications disappear. Cron failures and network alerts are especially easy to misfile because their fallback keys are not Director identifiers. |
+| **Machine name** | `LauncherHub.Hello`; `MachineEndpoints` launcher registration, heartbeat, removal, listing, and machine commands; `WorkListRunnerEndpoints` caller `machineKey` or resolved Director machine; Director-supplied `SessionDto.MachineName` in concurrency folding | 14, 42, 66, 69 **(4)** | **No single clean ingestion point.** Bind a tenant in `LauncherHub` as `DirectorHub` already does, introduce `TenantMachineKey`, and pass it through launcher registry, connection registry, list-run admission, and concurrency observation. | A mismatch can route a command to another tenant's launcher, disconnect the wrong connection, suppress a list drain, allow two drains on one tenant machine, or corrupt distinct-machine statistics. Prefixing only the registration path leaves command and disconnect paths unsafe. |
+| **Cron job identifier** | `CronJobStore.Create` mints `cj_` plus six hexadecimal digits under the ambient tenant; `CronRunEndpoints` later accepts the identifier; `CronEngine.EvaluateDueAsync` obtains it from the store | 13 **(1)** | **Not caller-prefixable.** Key `_inFlight` by tenant plus job identifier. The scheduled sweep must enumerate and enter tenant scopes rather than run without a tenant pass. | A collision suppresses another tenant's run. A wrong tenant on completion can release the wrong overlap slot. Fixing only run-now leaves scheduled execution wrong; changing the public job identifier breaks history and notification links. |
+| **Tunnel stream identifier** | `TunnelStreamLegs.ServeTerminalAsync` and the file-stream leg each mint a full globally unique identifier; `DirectorHub.StreamUp` later presents it from a tenant-bound Director connection | 15 **(1)** | **Not caller-prefixable.** Store tenant and expected Director ownership at registration and require the bound `DirectorHub` tenant and Director to match on every up-frame and close. A tenant-prefixed internal key is optional defense, not a substitute for the owner check. | A missed check permits frame injection, stream claim, or teardown. A wrong owner binding drops valid terminal or file frames, leaks sinks until timeout, or closes the wrong browser stream. |
+| **Fleet session-number compound state** | `POST /session-numbers/allocate`, `DELETE /session-numbers/{sessionId}`, roster-time `sessionNumbers.Adopt`, and `DirectorRegistry.OnDirectorRemoved` calling `ReleaseForDirector` | 24 **(1)** | **Not one identifier prefix.** The row couples session and Director identifiers to an integer reservation pool. Partition the allocator itself by tenant and require tenant on allocate, adopt, release, and Director removal. | Prefixing the session map alone leaves `_inUse` global. A missed release can free another tenant's number; a missed allocation can exhaust the shared pool or produce duplicates within one tenant. |
+| **Diagnostic result and hour bucket with no tenant key** | `GatewayEndpoints` `POST /diag/result` writes `NetDiagResultStore.Add` and `NetDiagRollupStore.Fold`; `GET /diag/results` and `GET /diag/rollup` read the same global stores | 21, 22 **(2)** | **No prefixable caller identifier.** Resolve the request tenant, stamp it on every result, partition the result store, and key rollups by tenant plus hour. Filter both reads by the authenticated tenant. | A write-only fix still leaks on reads; a read-only fix still permits aggregate poisoning. Persisted files need migration or quarantine rules, or old global data will be silently attributed to a tenant. |
+| **Car-mode telemetry record with no storage key** | `CarModeEndpoint` `POST /carmode/telemetry` derives `DeviceHash` from the caller credential and appends to one list; the two telemetry reads return the global list | 40 **(1)** | **No collection key to prefix.** The route already derives a caller credential hash, but the store and reads ignore it as a partition. Store a trusted tenant or device partition and filter both data and page reads. | Partitioning only new writes leaves old records globally visible. Filtering by caller-supplied `TurnId` is unsafe. A wrong device-versus-tenant choice can hide a user's telemetry when they switch devices or disclose another device's records. |
+| **Session statistics identity bundle: repository, agent, model, and checkout** | Authoritative values enter in `SessionDto` through `DirectorHub.PushSnapshot` and `PushDelta`; `GatewayInputStatsAggregator.ObserveSnapshot` and `Observe` fold them immediately, and the `/sessions` roster fold calls the aggregator and concurrency tracker again | 54-63, 67 **(11)** | **One source family, two aggregation seams.** Pass authenticated tenant into both aggregator call paths. Namespace internal identity keys or add tenant to their database and memory keys; preserve raw display strings. Row 62 belongs here rather than the session group because prefixing its session component leaves repository identity maps unsafe; row 63 is analogous for agents. | Incorrect namespacing double-counts high-water deltas, fragments one repository within a tenant, merges unrelated repositories, exposes tenant hashes in the user interface, or makes reverse identity maps disagree with forward maps. Legacy database and in-memory mirrors must migrate together. |
+| **Concurrency hour and process-wide scalar totals** | `GatewayEndpoints` calls `GatewaySessionConcurrencyStats.Observe` after assembling the authenticated tenant's `/sessions` roster; the store derives the hour from server time | 64 **(1)** | **No caller identifier.** Partition the entire tracker by tenant, not merely `_hours`. Its current and all-time scalar fields are also process-global but fell outside the collection-only census. | Prefixing only the hour key still shares current and all-time values. A partial migration produces plausible but wrong peaks, and a tenant-filtered read over a global scalar remains a disclosure. |
+
+## Coverage reconciliation
+
+| Work unit | Row count |
+| --- | ---: |
+| Session identifier | 14 |
+| Dictation upload identifier | 3 |
+| Director or synthetic event-ring key | 1 |
+| Machine name | 4 |
+| Cron job identifier | 1 |
+| Tunnel stream identifier | 1 |
+| Fleet session-number compound state | 1 |
+| Diagnostic result and hour bucket | 2 |
+| Car-mode telemetry | 1 |
+| Statistics identity bundle | 11 |
+| Concurrency hour and scalar totals | 1 |
+| **Total active unsafe rows covered** | **40** |
+
+The union is exact: the work units contain all 40 active unsafe row numbers from the census, with no
+duplicate assignment and no omission. The separate policy-unsafe broadcast-grant row 2 is not in this
+table because it has no current cross-tenant target lookup; it still needs authorization ownership work.
+
+## Completion predicate for the fix
+
+For the prefixable work units, the remedy is complete if and only if every named ingestion path derives
+the same tenant-scoped internal key, no affected collection API still accepts the raw identifier, and all
+reads, removals, expiry passes, disconnects, and background work use that same key.
+
+For the non-prefixable work units, completion instead requires the specific tenant partition or owner
+binding named in the table. Tests must exercise two authenticated tenants using the same raw identifier,
+the same machine name, the same short job identifier, and overlapping time buckets, then prove that one
+tenant cannot read, mutate, suppress, delete, or contend with the other's state.
+
+This map closes remedy coverage for the finite collection census. It does not assert that the remedies
+are implemented, that open-ended shapes have passed two clean dry rounds, or that instrumentation is
+complete.


### PR DESCRIPTION
Puts the hosted Gateway collection census and its remedy map onto main.

## Why this needs to land before more work is cut against it

These two documents are the specification for the eleven remedy units covering the
forty active cross-tenant unsafe rows. They have been driving worker briefs all
night. They have also been sitting on an unmerged branch the whole time.

Three separate workers independently reported the same problem: they were told to
read the specification from `origin/main`, and it is not there. Each had to go and
find it on the branch. One noted plainly that anyone verifying against main will
not find it.

That is the failure this repository has already learned once: an uncommitted design
is a question, not a specification. A worker cannot verify its work against a
document that is not on the branch it is told to trust, and a reviewer checking a
unit against "the map" has no single version to check against. Merged is the only
version a builder can rely on.

## What is in here

- **The census** (`a294d770`) - the finite enumeration, closed at 94 rows: 46 clean,
  7 latent, 40 active cross-tenant unsafe, 1 policy.
- **The ingestion map** (`ff63f85f`) - the regrouping of those 40 rows into eleven
  identifier or no-identifier work units, with the remedy for each chosen by the
  shape of the key: prefix at ingestion for a caller-supplied identifier, owner-bind
  for a server-minted one, explicit tenant partitioning where there is no caller
  identifier at all.

The map's own coverage reconciliation shows the union is exact: every one of the 40
active unsafe row numbers appears in exactly one work unit, with no duplicate
assignment and no omission.

## What this does not claim

Documentation only. No code changes. Neither document asserts that any remedy is
implemented, and the map says so about itself - it is a fix plan, and no row is
declared fixed by it. Landing this makes the specification citable; it does not
advance any unit.
