### PR TITLE
test: refuse to start a mutation-proof baseline or arm on a contaminated tree

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,6 +40,26 @@
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
     <Compile Include="$(MSBuildThisFileDirectory)src\TestInfrastructure\MutationProofPinGuard.cs"
              Link="TestInfrastructure\MutationProofPinGuard.cs" />
+    <!--
+      The per-assembly sentinel, and ONLY the sentinel. Every assembly must prove its own copy of the
+      module initializer woke up, because one that silently does not run leaves no trace and every other
+      test in the assembly still passes.
+
+      The guard's BEHAVIOURAL suite is deliberately NOT here - it builds real git repositories and launches
+      real processes, and running that seven times buys no coverage while changing the load and the test
+      scheduling in assemblies that have nothing to do with this mechanism. See
+      MutationProofPinGuardArmedTests for the incident that prompted the split.
+    -->
+    <Compile Include="$(MSBuildThisFileDirectory)src\TestInfrastructure\MutationProofPinGuardArmedTests.cs"
+             Link="TestInfrastructure\MutationProofPinGuardArmedTests.cs" />
+  </ItemGroup>
+
+  <!--
+    The guard's behavioural suite, compiled into exactly one assembly. Core.Tests because it is the
+    fastest of the seven to build and run, has no user-interface threading requirements, and is where
+    this unit's proofs have been driven throughout.
+  -->
+  <ItemGroup Condition="'$(MSBuildProjectName)' == 'CcDirector.Core.Tests'">
     <Compile Include="$(MSBuildThisFileDirectory)src\TestInfrastructure\MutationProofPinGuardTests.cs"
              Link="TestInfrastructure\MutationProofPinGuardTests.cs" />
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,4 +18,29 @@
   <PropertyGroup>
     <Version>1.8.4</Version>
   </PropertyGroup>
+
+  <!--
+    THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.
+
+    It refuses to START a run that has been declared part of a mutation proof - a baseline or a mutation
+    arm - when the working tree is not exactly what that proof pinned, and it records what it verified to a
+    ledger that outlives the working tree. Every other run is admitted untouched. The full reasoning, and
+    the incident that produced it, are at the top of MutationProofPinGuard.cs; read that before changing
+    anything here.
+
+    WHY IT IS LINKED FROM HERE RATHER THAN LISTED IN EACH TEST PROJECT: so a test project added next year
+    is covered without anybody remembering. The guard exists because a rule that has to be remembered is
+    not a mechanism, and wiring that has to be remembered is the same mistake one level down.
+
+    WHY THE CONDITION IS ON THE PROJECT NAME AND NOT ON IsTestProject: one of the seven existing test
+    projects (CcDirector.Terminal.Avalonia.Tests) does not set IsTestProject, so keying on that flag would
+    have silently skipped it - and a guard that silently covers six of seven assemblies looks exactly like
+    a guard that covers all of them.
+  -->
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+    <Compile Include="$(MSBuildThisFileDirectory)src\TestInfrastructure\MutationProofPinGuard.cs"
+             Link="TestInfrastructure\MutationProofPinGuard.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)src\TestInfrastructure\MutationProofPinGuardTests.cs"
+             Link="TestInfrastructure\MutationProofPinGuardTests.cs" />
+  </ItemGroup>
 </Project>

--- a/docs/testing/mutation-proof-pin.md
+++ b/docs/testing/mutation-proof-pin.md
@@ -41,7 +41,8 @@ working tree is checked - the baseline, the arm, and any re-run of either.
 
 #    Run the suite. Record the numbers against the pinned head it printed.
 
-# 2. Apply the mutation, then re-declare as the arm, naming what it touches.
+# 2. Apply the mutation, then declare the arm, naming what it touches. This does NOT re-pin: it carries
+#    the baseline's head forward, and refuses if the tree has moved off it.
 ./scripts/mutation-proof-pin.ps1 set -Phase arm -Mutates src/CcDirector.Gateway/Api/GatewayEndpoints.cs
 
 #    Run the suite again. Reconcile.
@@ -65,10 +66,38 @@ declared changes:
 
 A baseline is simply an arm that declares no mutations, so one rule runs both phases.
 
-**With no pin, the guard has no opinion at all.** A worker mid-rework is legitimately dirty and must be able
-to run whatever it likes. This is deliberate and is not an oversight to be tidied up later: a blanket
-refusal on any dirty tree would be switched off within a day, and a guard that gets switched off protects
-nothing.
+**With no pin, no run is ever refused.** A worker mid-rework is legitimately dirty and must be able to run
+whatever it likes. This is deliberate and is not an oversight to be tidied up later: a blanket refusal on
+any dirty tree would be switched off within a day, and a guard that gets switched off protects nothing.
+
+### The pinned head never moves, and that is enforced twice
+
+A proof's pinned head is its identity. A baseline and its arm must be taken at the same commit, or the
+reconciliation compares two different programs and the arithmetic means nothing while still adding up.
+
+The first version of this tool got that wrong in the most dangerous possible way: every `set` recomputed
+`git rev-parse HEAD`, so the documented baseline-to-arm transition silently **re-pinned** to the new head
+whenever HEAD had moved between the two runs. The guard then compared the arm against the new head, found
+an exact match, and admitted it. The supported happy path walked into the exact event the guard exists to
+refuse.
+
+Two mechanisms now hold it:
+
+1. `set -Phase arm` **carries the baseline's head forward** and never recomputes it. If the tree has moved
+   off the pinned head it refuses, naming both. Setting an arm with no baseline refuses too, and pinning a
+   baseline over an existing pin refuses - re-pinning requires an explicit `release`, which is loud and
+   discards the old proof identity along with its numbers.
+2. The pin carries a **proof identity**, and every run records it to the ledger with the head it measured.
+   If any earlier run of the same proof was measured against a different head, the run is refused - however
+   the pin file came to say what it says. That covers a hand-edited pin, a copied file, and a future change
+   to this script. Fixing the script fixes the instance; this covers the class.
+
+### What an unpinned run costs
+
+It is not free, and an earlier version of this document wrongly said it was. Every run of every test
+assembly invokes git twice and appends one line to a log outside the tree - roughly a fifth of a second per
+assembly against a suite measured in minutes. That is the deliberate price of the ledger below: it is the
+entire reason a **forgotten** pin is still answerable afterwards.
 
 ## The second job: the record outlives the tree
 
@@ -80,7 +109,15 @@ Those proofs were run in worktrees, and the worktrees were removed after merging
 hygiene, and it destroyed the only artifact that could have answered the question. Those four are recorded
 as unknown and will stay unknown.
 
-So every run appends a line to a ledger that lives **outside every working tree**, under the per-user local
+The **pin** lives in the repository's git directory, found by asking `git rev-parse --absolute-git-dir` -
+the same question the guard asks, so there is no second derivation to disagree with. (There used to be one,
+computed from the working tree path in both PowerShell and C#, and the two copies did not agree off
+Windows: the tool printed `PINNED` while the guard read nothing at all. Continuous integration runs on
+Linux.) That location is per-worktree by construction, is invisible to `git status` so the pin cannot dirty
+the tree it guards, and survives `git clean -xdf`.
+
+The **ledger** has the opposite requirement - it must outlive the tree - so every run appends a line to a
+file **outside every working tree**, under the per-user local
 application data directory alongside the suite lock's own state. `git worktree remove`, `git clean -xdf`,
 and deleting the whole checkout cannot reach it.
 

--- a/docs/testing/mutation-proof-pin.md
+++ b/docs/testing/mutation-proof-pin.md
@@ -99,6 +99,25 @@ assembly invokes git twice and appends one line to a log outside the tree - roug
 assembly against a suite measured in minutes. That is the deliberate price of the ledger below: it is the
 entire reason a **forgotten** pin is still answerable afterwards.
 
+## Two kinds of mechanism here, and one is easy to delete by mistake
+
+Some of this **prevents** a failure: the refusal on an undeclared change, the refusal on a moved pin. Those
+either work or they do not.
+
+The rest **cannot prevent anything**, and is not meant to. The ledger does not stop a bad proof; it records
+what each run verified so the question can be answered later. Requiring the pinned commit to exist on a
+remote does not stop a stashed repair; it makes the commit fetchable so a reader can see what was in it.
+
+The honest sentence is that they **convert a private failure into a public one**. A contaminated proof
+nobody can detect afterwards lives on one machine and dies with it. The same failure recorded in a ledger,
+or attributed to a commit anyone can fetch, is still a failure — but one a second person can find without
+being told where to look. That matters here more than it would elsewhere, because this whole proof
+structure rests on somebody else being able to re-derive a claim.
+
+So do not remove the ledger or the publication requirement on the grounds that they "do not stop
+anything". They are not supposed to. The question to answer first is whether the failure each one makes
+visible has any other way of being seen.
+
 ## The second job: the record outlives the tree
 
 Refusing a bad run is only half of it.

--- a/docs/testing/mutation-proof-pin.md
+++ b/docs/testing/mutation-proof-pin.md
@@ -1,0 +1,113 @@
+# The mutation-proof pin: how to take a baseline and a mutation arm that mean something
+
+## What a mutation proof is, and the one way it lies
+
+We prove a security guard is real by mutating the one primitive it depends on, running the whole suite
+again, and reconciling the arithmetic: the tests that pass plus the tests that fail under the mutation must
+add up to the tests that passed under the restored run. If they add up, the suite is held to have observed
+the primitive.
+
+There is exactly one failure that reconciliation cannot see, and it is the one that matters most.
+
+Suppose the baseline is taken on a working tree where a security guard block has **already been silently
+deleted and left uncommitted**. That is not a hypothetical - it is what a killed run leaves behind, because
+a process that is killed skips its cleanup. The tree still compiles. The suite still runs. The baseline
+still looks green and complete. Then the mutation arm runs on that same contaminated tree, and the two runs
+reconcile **perfectly** - because they agree with each other, not because either one measured anything.
+
+The cheapest detector we own passes while measuring nothing, and nothing anywhere in the process says so.
+
+On 2026-07-19 a worker found exactly that on disk in its own worktree. A sweep of the mission's working
+trees that night found four dirty trees.
+
+## Why telling people to check their tree does not work
+
+The worker who **inherits** a contaminated tree is, by definition, the one who does not know there is a
+mutation in it. It looks clean to them: it compiles, and the tests pass.
+
+This is the same shape as the concurrent-suite problem the per-user test-suite lock was built for. Four
+workers were each told not to run two suites at once; each complied with everything it could observe; four
+suites ran concurrently anyway. A rule that requires global knowledge cannot be obeyed by an actor holding
+only local knowledge. That one was solved by a mechanism rather than a briefing, and so is this.
+
+## How to run a proof
+
+Set the pin once, before the baseline. From that moment until you release it, **every** test run in that
+working tree is checked - the baseline, the arm, and any re-run of either.
+
+```
+# 1. Before the baseline. Refuses if the tree is already dirty.
+./scripts/mutation-proof-pin.ps1 set -Phase baseline -Note "tenant isolation guard, issue 1901"
+
+#    Run the suite. Record the numbers against the pinned head it printed.
+
+# 2. Apply the mutation, then re-declare as the arm, naming what it touches.
+./scripts/mutation-proof-pin.ps1 set -Phase arm -Mutates src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+
+#    Run the suite again. Reconcile.
+
+# 3. Restore the mutation and release the pin.
+./scripts/mutation-proof-pin.ps1 release
+```
+
+`status` shows the current pin and the tree beside it. `ledger` prints every proof run ever recorded on
+this machine.
+
+## What the guard refuses, and what it never touches
+
+With a pin active it requires the head to be the pinned head, and the working tree to carry **exactly** the
+declared changes:
+
+- **more** than was declared is a contaminated run, and is refused naming each undeclared file;
+- **less** than was declared is refused too, and that half matters as much: an arm with no mutation in it
+  is a second baseline wearing an arm's name, and it reconciles perfectly against the first while proving
+  nothing.
+
+A baseline is simply an arm that declares no mutations, so one rule runs both phases.
+
+**With no pin, the guard has no opinion at all.** A worker mid-rework is legitimately dirty and must be able
+to run whatever it likes. This is deliberate and is not an oversight to be tidied up later: a blanket
+refusal on any dirty tree would be switched off within a day, and a guard that gets switched off protects
+nothing.
+
+## The second job: the record outlives the tree
+
+Refusing a bad run is only half of it.
+
+Somebody was asked whether four **already-merged** security proofs had been taken on contaminated trees. The
+answer could not be given - not because the evidence was hard to find, but because it no longer existed.
+Those proofs were run in worktrees, and the worktrees were removed after merging. That removal is correct
+hygiene, and it destroyed the only artifact that could have answered the question. Those four are recorded
+as unknown and will stay unknown.
+
+So every run appends a line to a ledger that lives **outside every working tree**, under the per-user local
+application data directory alongside the suite lock's own state. `git worktree remove`, `git clean -xdf`,
+and deleting the whole checkout cannot reach it.
+
+The ledger writes on **admission** as well as refusal, and an admission line states which head was verified
+and that the tree matched it. That is the point: a log written only when something goes wrong cannot
+afterwards distinguish "verified clean" from "the guard never ran". Both are silence, and silence reads as
+success.
+
+Unpinned runs are recorded too - never refused. That is what makes a **forgotten** pin recoverable: when a
+proof's numbers are questioned later, the record still says whether the tree was dirty at the moment the
+baseline ran.
+
+## Where it lives
+
+- `src/TestInfrastructure/MutationProofPinGuard.cs` - the mechanism. Read the comment at the top before
+  changing it.
+- `src/TestInfrastructure/MutationProofPinGuardTests.cs` - the proof that it fires, with both controls.
+- `Directory.Build.props` - links both into every project whose name ends in `.Tests`, so a test project
+  added next year is covered without anybody remembering. It keys on the project name rather than the
+  `IsTestProject` flag because one of the seven existing test projects does not set that flag.
+- `scripts/mutation-proof-pin.ps1` - set, status, release, ledger.
+
+## The one thing that is not automatic
+
+A worker can still forget to set the pin at all, and then nothing is checked. That limit is the price of
+the scope gate, and it is stated here rather than papered over.
+
+Two things narrow it. The pin is the only place the pinned head is written down, so a proof that skipped it
+has no pinned head to cite and is not a proof anybody can write up. And the ledger records unpinned runs
+anyway, so a forgotten pin leaves evidence instead of a hole.

--- a/scripts/mutation-proof-pin.ps1
+++ b/scripts/mutation-proof-pin.ps1
@@ -155,6 +155,7 @@ switch ($Verb) {
                 throw "A baseline declares no mutations. A run that carries a mutation is an arm."
             }
             if ($null -ne $existing) {
+                # CONTROL (preventing). Test: TheScriptRefusesToPinABaselineOverAnActivePin.
                 Write-Host "CANNOT PIN A BASELINE: this working tree already has an active pin." -ForegroundColor Red
                 Write-Host ("    proof:       " + $existing['proofId'])
                 Write-Host ("    phase:       " + $existing['phase'])
@@ -169,6 +170,7 @@ switch ($Verb) {
             if ($changes.Count -gt 0) {
                 # Refused HERE as well as at run time, because pinning a contaminated tree would record a
                 # false starting point and the run-time refusal would then look like a mystery.
+                # CONTROL (preventing). Test: TheScriptRefusesToPinABaselineOnADirtyTree.
                 Write-Host "CANNOT PIN A BASELINE: this working tree already carries uncommitted changes." -ForegroundColor Red
                 $changes | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
                 Write-Host ""
@@ -189,6 +191,7 @@ switch ($Verb) {
                 # An arm with no baseline before it has nothing to be compared against. Minting a fresh pin
                 # here would create a proof whose "baseline" was never taken - and it would look identical
                 # to a correct one.
+                # CONTROL (preventing). Test: TheScriptRefusesAnArmWithNoBaselineBeforeIt.
                 Write-Host "CANNOT SET AN ARM: this working tree has no active baseline pin." -ForegroundColor Red
                 Write-Host ""
                 Write-Host "A mutation arm only means something next to a baseline taken at the same commit. Pin the"
@@ -198,6 +201,7 @@ switch ($Verb) {
             }
 
             if ($existing['pinnedHead'] -ne $currentHead) {
+                # CONTROL (preventing). Test: TheScriptRefusesAnArmTransitionAfterTheHeadMoves_AndLeavesThePinOnTheBaselineHead.
                 Write-Host "CANNOT SET AN ARM: the head has moved since this proof's baseline was pinned." -ForegroundColor Red
                 Write-Host ("    proof:        " + $existing['proofId'])
                 Write-Host ("    pinned head:  " + $existing['pinnedHead'] + "   (what the baseline measured)")

--- a/scripts/mutation-proof-pin.ps1
+++ b/scripts/mutation-proof-pin.ps1
@@ -1,0 +1,211 @@
+<#
+.SYNOPSIS
+    Declares this working tree to be part of a mutation proof, so every test run in it is checked against
+    the head the proof pinned.
+
+.DESCRIPTION
+    We prove a security guard is real by mutating the one primitive it depends on, running the whole suite
+    again, and reconciling the arithmetic: passed plus failed under the mutation must equal passed under the
+    restored run.
+
+    That reconciliation has one failure it cannot see. If the BASELINE is taken on a tree where a guard block
+    has already been silently deleted and left uncommitted - which is what a KILLED run leaves behind, because
+    a killed process skips its cleanup - the tree still compiles, the baseline still looks green and complete,
+    and the two runs reconcile PERFECTLY. They agree with each other rather than measuring anything. The
+    cheapest detector we own passes while measuring nothing.
+
+    This script writes the declaration that arms the guard. From the moment a pin is set until it is released,
+    EVERY test run in this working tree is checked: the head must be the pinned head, and the working tree must
+    carry exactly the declared changes - no more (a contaminated tree) and no less (an "arm" with no mutation
+    in it, which is a second baseline in disguise and reconciles perfectly against the first).
+
+    A run with no pin is never touched. A worker mid-rework is legitimately dirty and must be able to run
+    whatever it likes; only a baseline and an arm carry a meaning that depends on the tree being exact.
+
+    The pin, and the ledger of what each proof run verified, live under the per-user local application data
+    directory - OUTSIDE every working tree. That is deliberate: removing a worktree after merging is correct
+    hygiene, and it is also what destroyed the only evidence for four already-merged proofs, which can now
+    never be shown to have been taken on clean trees.
+
+.EXAMPLE
+    # Before the baseline run:
+    ./scripts/mutation-proof-pin.ps1 set -Phase baseline -Note "tenant isolation guard, issue 1901"
+
+.EXAMPLE
+    # Before the mutation arm, after applying the mutation:
+    ./scripts/mutation-proof-pin.ps1 set -Phase arm -Mutates src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+
+.EXAMPLE
+    # When the proof is finished:
+    ./scripts/mutation-proof-pin.ps1 release
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidateSet('set', 'status', 'release', 'ledger')]
+    [string] $Verb,
+
+    [ValidateSet('baseline', 'arm')]
+    [string] $Phase,
+
+    [string[]] $Mutates = @(),
+
+    [string] $Note = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-WorkingTreeRoot {
+    $root = (git rev-parse --show-toplevel 2>$null)
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($root)) {
+        throw "Not inside a git working tree. Run this from the tree the proof will be run in."
+    }
+    return ($root -replace '\\', '/').TrimEnd('/')
+}
+
+function Get-PinsDirectory {
+    $local = [Environment]::GetFolderPath('LocalApplicationData')
+    if ([string]::IsNullOrWhiteSpace($local)) {
+        throw "Cannot locate the per-user local application data directory, so the pin has no environment-independent home."
+    }
+    return (Join-Path (Join-Path $local 'cc-director') 'mutation-proof-pins')
+}
+
+function Get-PinPath([string] $root) {
+    # Must match MutationProofPinGuard.ComputePinFilePath EXACTLY, or the script writes a pin the guard
+    # never reads and the whole mechanism is inert while appearing to work. The C# side of this derivation
+    # is frozen by a golden value in MutationProofPinGuardTests
+    # (ThePinFileNameIsAGoldenValue_BecauseAScriptDerivesTheSameNameSeparately) - if you change either
+    # side, run that test and reconcile both, because a silent divergence here disarms the guard.
+    #
+    # SHA256::Create rather than SHA256::HashData: HashData does not exist on Windows PowerShell 5.1, which
+    # is the shell this repository's scripts are driven from.
+    $normalized = $root.ToLowerInvariant()
+    $hasher = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $sha = $hasher.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($normalized))
+    }
+    finally {
+        $hasher.Dispose()
+    }
+    $digest = ([System.BitConverter]::ToString($sha) -replace '-', '').ToLowerInvariant()
+
+    $leafSource = Split-Path -Leaf $normalized
+    $leaf = -join ($leafSource.ToCharArray() | ForEach-Object {
+        if ([char]::IsLetterOrDigit($_) -or $_ -eq '-' -or $_ -eq '_') { $_ } else { '-' }
+    })
+    if ($leaf.Length -gt 40) { $leaf = $leaf.Substring(0, 40) }
+
+    return (Join-Path (Get-PinsDirectory) ("$leaf-" + $digest.Substring(0, 16) + '.pin'))
+}
+
+function Get-WorkingTreeChanges([string] $root) {
+    $status = (git -C $root --no-optional-locks status --porcelain=v1 --untracked-files=normal)
+    if ([string]::IsNullOrWhiteSpace($status)) { return @() }
+    return @($status -split "`n" | Where-Object { $_.Trim().Length -gt 0 })
+}
+
+$root = Get-WorkingTreeRoot
+$pinPath = Get-PinPath $root
+
+switch ($Verb) {
+
+    'set' {
+        if ([string]::IsNullOrWhiteSpace($Phase)) {
+            throw "Specify -Phase baseline (the tree must be unmodified) or -Phase arm (the tree must carry exactly the declared mutation)."
+        }
+
+        $head = (git -C $root rev-parse HEAD).Trim().ToLowerInvariant()
+        $changes = Get-WorkingTreeChanges $root
+
+        if ($Phase -eq 'baseline') {
+            if ($Mutates.Count -gt 0) {
+                throw "A baseline declares no mutations. A run that carries a mutation is an arm."
+            }
+            if ($changes.Count -gt 0) {
+                # Refused HERE as well as at run time, because pinning a contaminated tree would record a
+                # false starting point and the run-time refusal would then look like a mystery.
+                Write-Host "CANNOT PIN A BASELINE: this working tree already carries uncommitted changes." -ForegroundColor Red
+                $changes | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
+                Write-Host ""
+                Write-Host "A baseline taken over uncommitted changes measures those changes as if they were the committed program."
+                Write-Host "If a security guard has been deleted here and left behind - which is what a killed mutation run leaves -"
+                Write-Host "the baseline is green, complete, and reconciles perfectly against its own arm while proving nothing."
+                Write-Host ""
+                Write-Host "Commit these changes, or revert them, then pin again."
+                exit 1
+            }
+        }
+        else {
+            if ($Mutates.Count -eq 0) {
+                throw "An arm must declare which paths its mutation touches (-Mutates src/...). An arm that declares nothing would admit any tree at all."
+            }
+        }
+
+        New-Item -ItemType Directory -Force -Path (Get-PinsDirectory) | Out-Null
+
+        $lines = @(
+            "# Written by scripts/mutation-proof-pin.ps1. Read MutationProofPinGuard.cs before editing by hand.",
+            "phase=$Phase",
+            "pinnedHead=$head",
+            "pinnedUtc=" + [DateTime]::UtcNow.ToString('o'),
+            "tree=$root"
+        )
+        foreach ($m in $Mutates) { $lines += ("mutates=" + ($m -replace '\\', '/').Trim()) }
+        if (-not [string]::IsNullOrWhiteSpace($Note)) { $lines += "note=$Note" }
+
+        Set-Content -Path $pinPath -Value $lines -Encoding utf8
+
+        Write-Host "PINNED. Every test run in this working tree is now checked until the pin is released." -ForegroundColor Green
+        Write-Host "    tree:        $root"
+        Write-Host "    phase:       $Phase"
+        Write-Host "    pinned head: $head"
+        if ($Mutates.Count -gt 0) { Write-Host ("    mutates:     " + ($Mutates -join ', ')) }
+        Write-Host "    pin file:    $pinPath"
+        Write-Host ""
+        Write-Host "CITE THAT PINNED HEAD IN THE PROOF WRITE-UP. It is the commit the numbers belong to."
+        Write-Host "Release the pin when the proof is finished: ./scripts/mutation-proof-pin.ps1 release"
+    }
+
+    'status' {
+        Write-Host "tree:     $root"
+        Write-Host "pin file: $pinPath"
+        if (-not (Test-Path $pinPath)) {
+            Write-Host "NO PIN. Test runs in this tree are not checked, and are not this guard's business." -ForegroundColor Yellow
+            exit 0
+        }
+
+        Write-Host "PIN ACTIVE:" -ForegroundColor Green
+        Get-Content $pinPath | ForEach-Object { Write-Host "    $_" }
+        Write-Host ""
+        Write-Host "working tree now:"
+        $changes = Get-WorkingTreeChanges $root
+        if ($changes.Count -eq 0) { Write-Host "    (clean)" }
+        else { $changes | ForEach-Object { Write-Host "    $_" } }
+        Write-Host ("head now: " + (git -C $root rev-parse HEAD).Trim())
+    }
+
+    'release' {
+        if (-not (Test-Path $pinPath)) {
+            Write-Host "No pin was set for this working tree; nothing to release."
+            exit 0
+        }
+        Remove-Item $pinPath -Force
+        Write-Host "Pin released. Test runs in this tree are no longer checked." -ForegroundColor Green
+        Write-Host "The ledger of what each proof run verified is kept, and outlives this working tree:"
+        Write-Host ("    " + (Join-Path (Get-PinsDirectory) 'mutation-proof-ledger.log'))
+    }
+
+    'ledger' {
+        $ledger = Join-Path (Get-PinsDirectory) 'mutation-proof-ledger.log'
+        if (-not (Test-Path $ledger)) {
+            Write-Host "No proof runs have been recorded on this machine yet: $ledger"
+            exit 0
+        }
+        Write-Host "Every declared proof run recorded on this machine, and whether its tree was verified:"
+        Write-Host "    $ledger"
+        Write-Host ""
+        Get-Content $ledger
+    }
+}

--- a/scripts/mutation-proof-pin.ps1
+++ b/scripts/mutation-proof-pin.ps1
@@ -64,40 +64,54 @@ function Get-WorkingTreeRoot {
     return ($root -replace '\\', '/').TrimEnd('/')
 }
 
-function Get-PinsDirectory {
+function Get-LedgerDirectory {
     $local = [Environment]::GetFolderPath('LocalApplicationData')
     if ([string]::IsNullOrWhiteSpace($local)) {
-        throw "Cannot locate the per-user local application data directory, so the pin has no environment-independent home."
+        throw "Cannot locate the per-user local application data directory, so the ledger has no home."
     }
     return (Join-Path (Join-Path $local 'cc-director') 'mutation-proof-pins')
 }
 
+# The pin file's name. This ONE string is all the script and the guard have to agree on, and the test
+# TheScriptAndTheGuardAgreeOnThePinFileName reads this very line and compares it against the guard's
+# constant - so a change to either side reddens a test instead of silently disarming the guard.
+$script:PinFileName = 'cc-director-mutation-proof.pin'
+
 function Get-PinPath([string] $root) {
-    # Must match MutationProofPinGuard.ComputePinFilePath EXACTLY, or the script writes a pin the guard
-    # never reads and the whole mechanism is inert while appearing to work. The C# side of this derivation
-    # is frozen by a golden value in MutationProofPinGuardTests
-    # (ThePinFileNameIsAGoldenValue_BecauseAScriptDerivesTheSameNameSeparately) - if you change either
-    # side, run that test and reconcile both, because a silent divergence here disarms the guard.
+    # ASK GIT, DO NOT DERIVE. The first version of this script computed the pin's location from the working
+    # tree path with a hash and a per-user directory, and the guard computed it again in C#. A reviewer
+    # found the two copies did not agree on non-Windows platforms: this script printed "PINNED" while the
+    # guard looked elsewhere, found nothing, and admitted contaminated baselines. Armed by its own output,
+    # inert in fact - and continuous integration runs on Linux.
     #
-    # SHA256::Create rather than SHA256::HashData: HashData does not exist on Windows PowerShell 5.1, which
-    # is the shell this repository's scripts are driven from.
-    $normalized = $root.ToLowerInvariant()
-    $hasher = [System.Security.Cryptography.SHA256]::Create()
-    try {
-        $sha = $hasher.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($normalized))
+    # Aligning the two derivations would have fixed that instance and kept the class. There is now no
+    # derivation to diverge: one question to git, one answer, both sides. In a worktree this returns
+    # .git/worktrees/<name>, so trees are separated with nothing to key on; the git directory is outside
+    # "git status" so the pin cannot dirty the tree it guards; and "git clean -xdf" does not reach it.
+    $gitDir = (git -C $root --no-optional-locks rev-parse --absolute-git-dir 2>$null)
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($gitDir)) {
+        throw "git could not name its own directory for '$root', so the pin has nowhere to live."
     }
-    finally {
-        $hasher.Dispose()
+    return (Join-Path $gitDir.Trim() $script:PinFileName)
+}
+
+function Read-Pin([string] $path) {
+    if (-not (Test-Path $path)) { return $null }
+    $fields = @{}
+    foreach ($line in (Get-Content $path)) {
+        $trimmed = $line.Trim()
+        if ($trimmed.Length -eq 0 -or $trimmed.StartsWith('#')) { continue }
+        $split = $trimmed.IndexOf('=')
+        if ($split -le 0) { continue }
+        $key = $trimmed.Substring(0, $split).Trim()
+        $value = $trimmed.Substring($split + 1).Trim()
+        if ($key -eq 'mutates') {
+            if (-not $fields.ContainsKey('mutates')) { $fields['mutates'] = @() }
+            $fields['mutates'] += $value
+        }
+        else { $fields[$key] = $value }
     }
-    $digest = ([System.BitConverter]::ToString($sha) -replace '-', '').ToLowerInvariant()
-
-    $leafSource = Split-Path -Leaf $normalized
-    $leaf = -join ($leafSource.ToCharArray() | ForEach-Object {
-        if ([char]::IsLetterOrDigit($_) -or $_ -eq '-' -or $_ -eq '_') { $_ } else { '-' }
-    })
-    if ($leaf.Length -gt 40) { $leaf = $leaf.Substring(0, 40) }
-
-    return (Join-Path (Get-PinsDirectory) ("$leaf-" + $digest.Substring(0, 16) + '.pin'))
+    return $fields
 }
 
 function Get-WorkingTreeChanges([string] $root) {
@@ -116,12 +130,41 @@ switch ($Verb) {
             throw "Specify -Phase baseline (the tree must be unmodified) or -Phase arm (the tree must carry exactly the declared mutation)."
         }
 
-        $head = (git -C $root rev-parse HEAD).Trim().ToLowerInvariant()
+        $currentHead = (git -C $root rev-parse HEAD).Trim().ToLowerInvariant()
         $changes = Get-WorkingTreeChanges $root
+        $existing = Read-Pin $pinPath
+
+        # ------------------------------------------------------------------------------------------------
+        # THE PINNED HEAD IS WRITTEN ONCE, WHEN THE BASELINE IS PINNED, AND IS NEVER RECOMPUTED AFTERWARDS.
+        #
+        # This is the defect a reviewer found in the first version, and it defeated the guard rather than
+        # weakening it. Every "set" recomputed "git rev-parse HEAD" and overwrote the pinned head - so the
+        # documented workflow, which is "set -Phase baseline, run, set -Phase arm, run", silently re-pinned
+        # to the new head whenever HEAD had moved between the two runs. The guard then compared the arm
+        # against the NEW head, found an exact match, and admitted it. The baseline and the arm had measured
+        # two different programs, which is precisely the condition this guard exists to refuse, and the
+        # supported happy path walked straight into it.
+        #
+        # A proof's pinned head is its identity. Changing it is not a correction, it is a different proof.
+        # So the arm transition CARRIES the baseline's head forward and refuses if the tree has moved off
+        # it; re-pinning requires an explicit release, which is loud and throws the old numbers away.
+        # ------------------------------------------------------------------------------------------------
 
         if ($Phase -eq 'baseline') {
             if ($Mutates.Count -gt 0) {
                 throw "A baseline declares no mutations. A run that carries a mutation is an arm."
+            }
+            if ($null -ne $existing) {
+                Write-Host "CANNOT PIN A BASELINE: this working tree already has an active pin." -ForegroundColor Red
+                Write-Host ("    proof:       " + $existing['proofId'])
+                Write-Host ("    phase:       " + $existing['phase'])
+                Write-Host ("    pinned head: " + $existing['pinnedHead'])
+                Write-Host ""
+                Write-Host "Overwriting it would start a second proof at a possibly different commit while the numbers"
+                Write-Host "already collected still claim to belong to this one. If that proof is finished or abandoned,"
+                Write-Host "say so explicitly and the old identity is retired:"
+                Write-Host "    ./scripts/mutation-proof-pin.ps1 release"
+                exit 1
             }
             if ($changes.Count -gt 0) {
                 # Refused HERE as well as at run time, because pinning a contaminated tree would record a
@@ -141,12 +184,45 @@ switch ($Verb) {
             if ($Mutates.Count -eq 0) {
                 throw "An arm must declare which paths its mutation touches (-Mutates src/...). An arm that declares nothing would admit any tree at all."
             }
+
+            if ($null -eq $existing) {
+                # An arm with no baseline before it has nothing to be compared against. Minting a fresh pin
+                # here would create a proof whose "baseline" was never taken - and it would look identical
+                # to a correct one.
+                Write-Host "CANNOT SET AN ARM: this working tree has no active baseline pin." -ForegroundColor Red
+                Write-Host ""
+                Write-Host "A mutation arm only means something next to a baseline taken at the same commit. Pin the"
+                Write-Host "baseline first and run it, then set the arm:"
+                Write-Host "    ./scripts/mutation-proof-pin.ps1 set -Phase baseline"
+                exit 1
+            }
+
+            if ($existing['pinnedHead'] -ne $currentHead) {
+                Write-Host "CANNOT SET AN ARM: the head has moved since this proof's baseline was pinned." -ForegroundColor Red
+                Write-Host ("    proof:        " + $existing['proofId'])
+                Write-Host ("    pinned head:  " + $existing['pinnedHead'] + "   (what the baseline measured)")
+                Write-Host ("    current head: " + $currentHead + "   (what an arm would measure now)")
+                Write-Host ""
+                Write-Host "The pinned head is NOT being updated to the current one. That is the whole point: a baseline"
+                Write-Host "and its arm must be taken at the same commit, or the reconciliation compares two different"
+                Write-Host "programs and the arithmetic means nothing while still adding up."
+                Write-Host ""
+                Write-Host "Either return the tree to the pinned commit and set the arm again, or abandon this proof"
+                Write-Host "and start over:  ./scripts/mutation-proof-pin.ps1 release"
+                exit 1
+            }
         }
 
-        New-Item -ItemType Directory -Force -Path (Get-PinsDirectory) | Out-Null
+        # Carried forward, never recomputed, for anything other than a brand-new baseline.
+        $proofId = if ($null -ne $existing) { $existing['proofId'] } else { [Guid]::NewGuid().ToString('N') }
+        $head = if ($null -ne $existing) { $existing['pinnedHead'] } else { $currentHead }
+        $pinnedUtc = if ($null -ne $existing) { $existing['pinnedUtc'] } else { [DateTime]::UtcNow.ToString('o') }
+
+        New-Item -ItemType Directory -Force -Path (Get-LedgerDirectory) | Out-Null
 
         $lines = @(
             "# Written by scripts/mutation-proof-pin.ps1. Read MutationProofPinGuard.cs before editing by hand.",
+            "proofId=$proofId",
             "phase=$Phase",
             "pinnedHead=$head",
             # Parenthesised deliberately: in PowerShell the comma binds tighter than "+", so without these
@@ -154,7 +230,7 @@ switch ($Verb) {
             # lands on a line of its own. The guard then refuses the whole proof as a malformed pin, which
             # is the correct behaviour and is exactly how this defect was found - but it is not what was
             # meant, and it would have stopped the first proof anybody tried to run.
-            ("pinnedUtc=" + [DateTime]::UtcNow.ToString('o')),
+            ("pinnedUtc=" + $pinnedUtc),
             "tree=$root"
         )
         foreach ($m in $Mutates) { $lines += ("mutates=" + ($m -replace '\\', '/').Trim()) }
@@ -164,6 +240,7 @@ switch ($Verb) {
 
         Write-Host "PINNED. Every test run in this working tree is now checked until the pin is released." -ForegroundColor Green
         Write-Host "    tree:        $root"
+        Write-Host "    proof:       $proofId"
         Write-Host "    phase:       $Phase"
         Write-Host "    pinned head: $head"
         if ($Mutates.Count -gt 0) { Write-Host ("    mutates:     " + ($Mutates -join ', ')) }
@@ -199,11 +276,11 @@ switch ($Verb) {
         Remove-Item $pinPath -Force
         Write-Host "Pin released. Test runs in this tree are no longer checked." -ForegroundColor Green
         Write-Host "The ledger of what each proof run verified is kept, and outlives this working tree:"
-        Write-Host ("    " + (Join-Path (Get-PinsDirectory) 'mutation-proof-ledger.log'))
+        Write-Host ("    " + (Join-Path (Get-LedgerDirectory) 'mutation-proof-ledger.log'))
     }
 
     'ledger' {
-        $ledger = Join-Path (Get-PinsDirectory) 'mutation-proof-ledger.log'
+        $ledger = Join-Path (Get-LedgerDirectory) 'mutation-proof-ledger.log'
         if (-not (Test-Path $ledger)) {
             Write-Host "No proof runs have been recorded on this machine yet: $ledger"
             exit 0

--- a/scripts/mutation-proof-pin.ps1
+++ b/scripts/mutation-proof-pin.ps1
@@ -149,7 +149,12 @@ switch ($Verb) {
             "# Written by scripts/mutation-proof-pin.ps1. Read MutationProofPinGuard.cs before editing by hand.",
             "phase=$Phase",
             "pinnedHead=$head",
-            "pinnedUtc=" + [DateTime]::UtcNow.ToString('o'),
+            # Parenthesised deliberately: in PowerShell the comma binds tighter than "+", so without these
+            # brackets this element parses as "pinnedUtc=" + (<timestamp>, "tree=...") and the timestamp
+            # lands on a line of its own. The guard then refuses the whole proof as a malformed pin, which
+            # is the correct behaviour and is exactly how this defect was found - but it is not what was
+            # meant, and it would have stopped the first proof anybody tried to run.
+            ("pinnedUtc=" + [DateTime]::UtcNow.ToString('o')),
             "tree=$root"
         )
         foreach ($m in $Mutates) { $lines += ("mutates=" + ($m -replace '\\', '/').Trim()) }

--- a/src/TestInfrastructure/MutationProofPinGuard.cs
+++ b/src/TestInfrastructure/MutationProofPinGuard.cs
@@ -338,6 +338,7 @@ internal static class MutationProofPinGuard
 
         if (pin.Pin is null)
         {
+            // CONTROL (preventing) - defensive; should be unreachable. Test: AnActiveProofWithNoPinAttachedRefuses.
             return new Verdict(
                 false,
                 "The mutation-proof pin guard reports an active proof with no pin attached, which it "
@@ -1005,6 +1006,7 @@ internal static class MutationProofPinGuard
                     }
                     catch (Exception ex)
                     {
+                        // CONTROL (preventing). Test: ARepositoryMarkerThatExistsButCannotBeReadIsIndeterminate.
                         return new PinLocation(
                             PinLocationOutcome.Indeterminate, null, null,
                             "the repository marker " + marker + " exists but could not be read, so the "
@@ -1414,6 +1416,7 @@ internal static class MutationProofPinGuard
         {
             // The git directory was confirmed moments ago, so its disappearance now is a change underneath
             // this run, not a settled absence.
+            // CONTROL (preventing). Test: APinWhoseDirectoryHasVanishedIsIndeterminate_NotAbsent.
             return PinReading.Indeterminate(
                 "the pin file " + path + " could not be read because its directory is gone: " + ex.Message);
         }

--- a/src/TestInfrastructure/MutationProofPinGuard.cs
+++ b/src/TestInfrastructure/MutationProofPinGuard.cs
@@ -690,6 +690,70 @@ internal static class MutationProofPinGuard
     /// The pin dying with "git worktree remove" is correct: a proof in a removed worktree is over. The
     /// LEDGER is what must outlive the tree, and it lives elsewhere - see <see cref="LedgerDirectory"/>.
     /// </summary>
+    /// <summary>What a filesystem probe established about one path.</summary>
+    internal enum ProbeOutcome
+    {
+        /// <summary>The path is there.</summary>
+        Exists,
+
+        /// <summary>The path is definitely NOT there - the operating system said so by name.</summary>
+        DoesNotExist,
+
+        /// <summary>The question could not be answered. Never treated as absence.</summary>
+        CouldNotTell,
+    }
+
+    internal readonly record struct Probe(ProbeOutcome Outcome, bool IsDirectory, string? Problem);
+
+    /// <summary>
+    /// Establishes whether a path is there by ATTEMPTING AN OPERATION, never by asking a predicate.
+    ///
+    /// THIS IS THE FLOOR UNDER THE THREE-STATE OUTCOME, and it was missing. A reviewer put it exactly:
+    /// a three-state type is only as good as the narrowest source feeding it. The guard had been given a
+    /// proper place for uncertainty to live - NoPinPresent, PinActive, CouldNotDetermine - and was then
+    /// POPULATING it from File.Exists and Directory.Exists, which return FALSE for an access failure, an
+    /// invalid path, or an input-output error exactly as they do for a file that genuinely is not there.
+    /// By the time the value reached the enum, "could not look" and "there is nothing there" were already
+    /// the same boolean, and no amount of downstream typing can recover what the predicate threw away.
+    ///
+    /// The collapse this guard was built to prevent had therefore been re-introduced inside the guard's own
+    /// constructor - in the one place nobody would look for it, because the type signature now promises
+    /// three states. The surrounding try/catch blocks were no help: those APIs are documented to RETURN
+    /// FALSE rather than throw, so there was nothing for a catch to see.
+    ///
+    /// PREDICATES DESTROY ERROR INFORMATION; OPERATIONS PRESERVE IT. "Does this exist" yields a boolean
+    /// that cannot say why it answered no. Attempting to read the attributes yields a success, a specific
+    /// not-found, or a specific failure - each distinguishable, which is the whole requirement.
+    ///
+    /// So ONLY a genuine not-found - the operating system naming the file or the directory as missing -
+    /// counts as absence. Everything else is CouldNotTell, and CouldNotTell refuses.
+    /// </summary>
+    internal static Probe ProbePath(string path)
+    {
+        try
+        {
+            var attributes = File.GetAttributes(path);
+            return new Probe(
+                ProbeOutcome.Exists, (attributes & FileAttributes.Directory) != 0, null);
+        }
+        catch (FileNotFoundException)
+        {
+            return new Probe(ProbeOutcome.DoesNotExist, false, null);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return new Probe(ProbeOutcome.DoesNotExist, false, null);
+        }
+        catch (Exception ex)
+        {
+            // Access denied, an invalid path, a device that is not responding, a name too long. Every one
+            // of these makes File.Exists answer "false", which is how an unreadable pin used to read as a
+            // proven absence and admit the run.
+            return new Probe(
+                ProbeOutcome.CouldNotTell, false, ex.GetType().Name + ": " + ex.Message);
+        }
+    }
+
     /// <summary>Whether the pin location could be established, and if not, why.</summary>
     internal enum PinLocationOutcome
     {
@@ -703,7 +767,19 @@ internal static class MutationProofPinGuard
         Indeterminate,
     }
 
-    internal sealed record PinLocation(PinLocationOutcome Outcome, string? PinFilePath, string? Problem);
+    /// <summary>
+    /// THE ONE LOOKUP. Carries the working tree root as well as the pin path, so that nothing else in this
+    /// file has to walk the filesystem for itself and independently decide that nothing is there.
+    ///
+    /// A reviewer found that <c>Check</c> did exactly that: a separate root walk, with its own boolean
+    /// probes, whose null answer was turned straight into the admitting state without ever consulting this
+    /// lookup. Two walks meant two places to get it wrong and only one of them was being repaired.
+    /// </summary>
+    internal sealed record PinLocation(
+        PinLocationOutcome Outcome,
+        string? WorkingTreeRoot,
+        string? PinFilePath,
+        string? Problem);
 
     /// <summary>
     /// Works out where the pin lives WITHOUT LAUNCHING GIT.
@@ -725,7 +801,18 @@ internal static class MutationProofPinGuard
     /// than the guard looking for a pin in the wrong place, not finding one, and admitting. Agreement with
     /// git own answer is pinned by tests against a real repository and a real worktree.
     /// </summary>
-    internal static PinLocation LocatePin(string startDirectory)
+    internal static PinLocation LocatePin(string startDirectory) => LocatePin(startDirectory, ProbePath);
+
+    /// <summary>
+    /// The same, against a nominated filesystem probe.
+    ///
+    /// Injected so the CouldNotTell branch can be driven deterministically on any machine. Proving that
+    /// branch on a real filesystem needs a path the operating system refuses to describe, which cannot be
+    /// created portably; and a branch that only executes on someone else's machine is a branch nobody has
+    /// seen work. The probe is a parameter rather than a global because these assemblies run tests in
+    /// parallel.
+    /// </summary>
+    internal static PinLocation LocatePin(string startDirectory, Func<string, Probe> probe)
     {
         try
         {
@@ -733,21 +820,44 @@ internal static class MutationProofPinGuard
             while (directory is not null)
             {
                 var marker = Path.Combine(directory.FullName, ".git");
+                var found = probe(marker);
 
-                if (Directory.Exists(marker))
-                    return VerifyGitDirectory(marker, marker);
-
-                if (File.Exists(marker))
+                if (found.Outcome == ProbeOutcome.CouldNotTell)
                 {
+                    // The marker may well be RIGHT THERE and simply unreadable. Walking past it would end
+                    // at "no repository", which is the admitting state - a live proof silently skipped.
+                    return new PinLocation(
+                        PinLocationOutcome.Indeterminate, null, null,
+                        "the repository marker " + marker + " could not be examined, so whether this is a "
+                        + "repository is unknown: " + found.Problem);
+                }
+
+                if (found.Outcome == ProbeOutcome.Exists)
+                {
+                    if (found.IsDirectory)
+                        return VerifyGitDirectory(directory.FullName, marker, marker, probe);
+
                     // A worktree, a submodule, or any other linked checkout. The file names the real git
                     // directory, and the path it names may be relative to the directory holding the file.
-                    var text = File.ReadAllText(marker).Trim();
+                    string text;
+                    try
+                    {
+                        text = File.ReadAllText(marker).Trim();
+                    }
+                    catch (Exception ex)
+                    {
+                        return new PinLocation(
+                            PinLocationOutcome.Indeterminate, null, null,
+                            "the repository marker " + marker + " exists but could not be read, so the "
+                            + "real git directory is unknown: " + ex.GetType().Name + ": " + ex.Message);
+                    }
+
                     const string prefix = "gitdir:";
 
                     if (!text.StartsWith(prefix, StringComparison.Ordinal))
                     {
                         return new PinLocation(
-                            PinLocationOutcome.Indeterminate, null,
+                            PinLocationOutcome.Indeterminate, null, null,
                             "the repository marker " + marker + " is a file that does not begin with "
                             + "gitdir:, so the real git directory - and therefore the pin - cannot be "
                             + "located.");
@@ -758,22 +868,23 @@ internal static class MutationProofPinGuard
                         ? named
                         : Path.GetFullPath(Path.Combine(directory.FullName, named));
 
-                    return VerifyGitDirectory(resolved, marker);
+                    return VerifyGitDirectory(directory.FullName, resolved, marker, probe);
                 }
 
                 directory = directory.Parent;
             }
 
-            // Walked to the top of the filesystem without finding a repository. A COMPLETED search, not a
-            // failure: no repository means no pin can exist, so admitting is correct.
-            return new PinLocation(PinLocationOutcome.NotInARepository, null, null);
+            // Walked to the top of the filesystem and every probe answered a definite NOT THERE. This is
+            // the only completed, error-free search in the file, and therefore the only walk that may
+            // conclude there is no repository - which is the one honest absence.
+            return new PinLocation(PinLocationOutcome.NotInARepository, null, null, null);
         }
         catch (Exception ex)
         {
-            // The walk touched the filesystem and it refused. Nothing is known, so nothing is claimed -
-            // and "nothing is known" refuses.
+            // The walk itself failed. Nothing is known, so nothing is claimed - and "nothing is known"
+            // refuses.
             return new PinLocation(
-                PinLocationOutcome.Indeterminate, null,
+                PinLocationOutcome.Indeterminate, null, null,
                 "the repository could not be located from " + startDirectory + ": "
                 + ex.GetType().Name + ": " + ex.Message);
         }
@@ -784,26 +895,33 @@ internal static class MutationProofPinGuard
     /// wrong answer here would send the guard looking for a pin somewhere no pin is ever written, where it
     /// would find nothing and admit - the failure this whole repair is about.
     /// </summary>
-    private static PinLocation VerifyGitDirectory(string gitDirectory, string marker)
+    private static PinLocation VerifyGitDirectory(
+        string workingTreeRoot, string gitDirectory, string marker, Func<string, Probe> probe)
     {
-        if (!Directory.Exists(gitDirectory))
+        var directory = probe(gitDirectory);
+
+        if (directory.Outcome != ProbeOutcome.Exists || !directory.IsDirectory)
         {
             return new PinLocation(
-                PinLocationOutcome.Indeterminate, null,
+                PinLocationOutcome.Indeterminate, null, null,
                 "the repository marker " + marker + " names a git directory at " + gitDirectory
-                + " which does not exist, so the pin cannot be located.");
+                + " which could not be confirmed to be one ("
+                + (directory.Problem ?? directory.Outcome.ToString()) + "), so the pin cannot be located.");
         }
 
-        if (!File.Exists(Path.Combine(gitDirectory, "HEAD")))
+        var head = probe(Path.Combine(gitDirectory, "HEAD"));
+
+        if (head.Outcome != ProbeOutcome.Exists)
         {
             return new PinLocation(
-                PinLocationOutcome.Indeterminate, null,
-                gitDirectory + " does not contain a HEAD file, so it is not the git directory this guard "
-                + "expected and the pin location cannot be trusted.");
+                PinLocationOutcome.Indeterminate, null, null,
+                gitDirectory + " could not be confirmed as a git directory - its HEAD reference is "
+                + (head.Problem ?? head.Outcome.ToString())
+                + " - so the pin location cannot be trusted.");
         }
 
         return new PinLocation(
-            PinLocationOutcome.Located, Path.Combine(gitDirectory, PinFileName), null);
+            PinLocationOutcome.Located, workingTreeRoot, Path.Combine(gitDirectory, PinFileName), null);
     }
 
     /// <summary>
@@ -987,43 +1105,23 @@ internal static class MutationProofPinGuard
         // to proceed. A reviewer reported the same shape in the pin lookup; these two were the same defect
         // in a different place, which is why the repair is structural rather than a patch at the reported
         // site.
-        string root;
-        try
-        {
-            var located = FindWorkingTreeRoot(AppContext.BaseDirectory);
+        // ONE LOOKUP. Check no longer walks the filesystem for itself.
+        //
+        // It used to: a separate root walk with its own boolean probes, whose null answer was turned
+        // straight into the admitting state without consulting the pin lookup at all. Two walks meant two
+        // places to get this wrong, and repairing one of them left the other manufacturing the same
+        // admission. The lookup now carries the working tree root as well as the pin path, so there is one
+        // search, one classification, and one route to "no pin".
+        var location = LocatePin(AppContext.BaseDirectory);
+        var pin = ReadPin(location);
 
-            if (located is null)
-            {
-                // A COMPLETED search: walked to the top of the filesystem and found no repository. No
-                // repository means no pin can exist, so this is a genuine absence and admits.
-                Finish(
-                    AppContext.BaseDirectory,
-                    PinReading.NoPin(),
-                    new TreeReading(false, "", Array.Empty<ChangedPath>(), "not inside a repository"),
-                    new Verdict(true, "This run is not inside a git working tree, so no mutation proof "
-                        + "can be active for it."));
-                return;
-            }
-
-            root = located;
-        }
-        catch (Exception ex)
-        {
-            // The walk touched the filesystem and it refused, so whether a proof is active is UNKNOWN.
-            // Unknown refuses. This used to admit "loudly", which is a contradiction in terms: the run
-            // went ahead regardless of how loudly it said so.
-            var unknown = PinReading.Indeterminate(
-                "the working tree root could not be located from " + AppContext.BaseDirectory + ": "
-                + ex.GetType().Name + ": " + ex.Message);
-            var unreadable = new TreeReading(false, "", Array.Empty<ChangedPath>(), ex.Message);
-
-            Finish(AppContext.BaseDirectory, unknown, unreadable,
-                Decide(unknown, unreadable, Array.Empty<string>()));
-            return;
-        }
-
-        var pin = ReadPinFor(root);
-        var tree = ReadTree(root);
+        // Only meaningful when the lookup found a repository. Where it did not, the tree is unreadable and
+        // says so - and the verdict comes from the pin state, not from this.
+        var root = location.WorkingTreeRoot ?? AppContext.BaseDirectory;
+        var tree = location.WorkingTreeRoot is null
+            ? new TreeReading(false, "", Array.Empty<ChangedPath>(),
+                location.Problem ?? "this run is not inside a git working tree")
+            : ReadTree(root);
 
         // Read only when a pin is active. An unpinned run has no proof identity to compare against, and
         // reading the ledger on every ordinary run would be cost for nothing.
@@ -1091,13 +1189,27 @@ internal static class MutationProofPinGuard
 
     internal static PinReading ReadPinFor(string workingTreeRoot)
     {
-        var location = LocatePin(workingTreeRoot);
+        return ReadPin(LocatePin(workingTreeRoot));
+    }
 
+    /// <summary>
+    /// Reads the pin at an already-established location.
+    ///
+    /// THE READ IS AN OPERATION, NOT A PREDICATE, and this is the last place the collapse could hide. The
+    /// previous version asked File.Exists first and returned "no pin" when it said false - but that API
+    /// answers false for an unreadable, inaccessible or otherwise unexaminable file just as it does for a
+    /// missing one, so a live pin that could not be opened became a proven absence, which admits. The
+    /// surrounding catch never saw it, because there was nothing thrown to catch.
+    ///
+    /// Now the file is simply OPENED. Only the operating system naming it as missing - FileNotFound -
+    /// counts as absence. Every other outcome is indeterminate and refuses.
+    /// </summary>
+    internal static PinReading ReadPin(PinLocation location)
+    {
         switch (location.Outcome)
         {
             case PinLocationOutcome.NotInARepository:
-                // A completed search: no repository, so no pin can exist. This is the one failure-shaped
-                // input that is genuinely an ABSENCE rather than an unknown.
+                // The one honest absence: a completed, error-free walk that found no repository at all.
                 return PinReading.NoPin();
 
             case PinLocationOutcome.Indeterminate:
@@ -1113,20 +1225,34 @@ internal static class MutationProofPinGuard
 
         var path = location.PinFilePath!;
 
+        string text;
         try
         {
-            if (!File.Exists(path))
-                return PinReading.NoPin();
-
-            return ParsePin(File.ReadAllText(path), path);
+            text = File.ReadAllText(path);
+        }
+        catch (FileNotFoundException)
+        {
+            // The operating system named it: there is no pin here. The ONLY absence this method can
+            // produce, and the only route to the admitting state once a repository has been found.
+            return PinReading.NoPin();
+        }
+        catch (DirectoryNotFoundException ex)
+        {
+            // The git directory was confirmed moments ago, so its disappearance now is a change underneath
+            // this run, not a settled absence.
+            return PinReading.Indeterminate(
+                "the pin file " + path + " could not be read because its directory is gone: " + ex.Message);
         }
         catch (Exception ex)
         {
-            // A pin file that EXISTS but cannot be read is a refusal, not an absence. Treating it as an
-            // absence would disarm the guard for exactly the proof that most needs it.
+            // Access denied, a directory sitting at the pin path, a device failure. Each of these makes
+            // File.Exists answer "false" - which is precisely how an unreadable pin used to admit.
             return PinReading.Indeterminate(
-                "the pin file '" + path + "' could not be read: " + ex.Message);
+                "the pin file " + path + " could not be read, so whether a proof is active here is "
+                + "unknown: " + ex.GetType().Name + ": " + ex.Message);
         }
+
+        return ParsePin(text, path);
     }
 
     /// <summary>The name of the ledger every pinned run in every working tree appends to.</summary>

--- a/src/TestInfrastructure/MutationProofPinGuard.cs
+++ b/src/TestInfrastructure/MutationProofPinGuard.cs
@@ -187,11 +187,50 @@ internal static class MutationProofPinGuard
         string PinFilePath);
 
     /// <summary>
-    /// The result of looking for a pin. A pin that EXISTS but cannot be understood is not the same as no
-    /// pin, and must never be treated as one - a typo in a pin file would otherwise silently disarm the
-    /// guard for the whole proof.
+    /// What the guard KNOWS about this working tree's pin. Three states, not two, and the third is the
+    /// whole point.
+    ///
+    /// "There is no pin" and "I could not find out whether there is a pin" are different facts, and
+    /// collapsing them is how this guard failed open. The first version had a boolean: a pin was Found or
+    /// it was not. Every way of FAILING TO LOOK - git missing from the path, a timeout, an unreadable
+    /// directory - had to be expressed as NOT FOUND, and not-found meant ADMIT. So a machine without git
+    /// would run a contaminated proof to completion while the pin file sat in the git directory the whole
+    /// time, and nothing said a word.
+    ///
+    /// A guard's two failure directions are not symmetric. Refusing wrongly is loud, visible and
+    /// self-correcting: somebody complains within the hour. Admitting wrongly is silent and
+    /// self-concealing, and it is worse precisely because the guard's existence stops everyone else
+    /// checking. So the type makes the dangerous direction unreachable: <see cref="PinOutcome.NoPinPresent"/>
+    /// is only constructible after LOOKING AND FINDING NOTHING, and it is the only state
+    /// <see cref="Decide"/> will admit.
     /// </summary>
-    internal sealed record PinReading(bool Found, ProofPin? Pin, string? Problem);
+    internal enum PinOutcome
+    {
+        /// <summary>Looked, and there is definitely no pin. The ONLY state that admits.</summary>
+        NoPinPresent,
+
+        /// <summary>A pin was found and understood.</summary>
+        PinActive,
+
+        /// <summary>Could not establish either way. Refuses - see the remarks above.</summary>
+        CouldNotDetermine,
+    }
+
+    /// <summary>
+    /// The result of looking for a pin. Built through the factories below rather than directly, so a
+    /// failure cannot be spelled as an absence.
+    /// </summary>
+    internal sealed record PinReading(PinOutcome Outcome, ProofPin? Pin, string? Problem)
+    {
+        /// <summary>Looked, found nothing. Only reachable from a completed search.</summary>
+        internal static PinReading NoPin() => new(PinOutcome.NoPinPresent, null, null);
+
+        internal static PinReading Active(ProofPin pin) => new(PinOutcome.PinActive, pin, null);
+
+        /// <summary>Could not establish whether a proof is active. Refuses.</summary>
+        internal static PinReading Indeterminate(string reason) =>
+            new(PinOutcome.CouldNotDetermine, null, reason);
+    }
 
     /// <summary>
     /// What git says about the working tree. Reading can fail - git missing from the path, a corrupt
@@ -218,22 +257,52 @@ internal static class MutationProofPinGuard
     /// </summary>
     internal static Verdict Decide(PinReading pin, TreeReading tree, IReadOnlyList<string> priorLedgerLines)
     {
-        if (pin.Problem is not null)
+        // THE ONLY ADMIT IN THIS METHOD IS THE ONE BELOW, AND IT IS REACHABLE FROM ONE STATE.
+        //
+        // Everything else - a pin that cannot be parsed, a location that cannot be resolved, a state this
+        // switch does not recognise - lands on a refusal. That is deliberate, and it is the repair for a
+        // defect a reviewer found: the guard used to admit whenever it FAILED TO LOOK, because failing to
+        // look and finding nothing were the same value.
+        switch (pin.Outcome)
+        {
+            case PinOutcome.NoPinPresent:
+                // The ordinary case, and the scope limit the whole design turns on: no pin, no opinion. A
+                // worker mid-rework is legitimately dirty and is not this guard's business. Reachable only
+                // after a completed search - see PinOutcome.
+                return new Verdict(true, "No mutation-proof pin is active for this working tree.");
+
+            case PinOutcome.CouldNotDetermine:
+                return new Verdict(
+                    false,
+                    "CANNOT ESTABLISH WHETHER A MUTATION PROOF IS ACTIVE IN THIS WORKING TREE: "
+                    + (pin.Problem ?? "(no detail)")
+                    + Environment.NewLine
+                    + "    This is NOT the same as there being no pin, and is deliberately not treated as "
+                    + "one. If a proof IS active, admitting this run would let a baseline or a mutation arm "
+                    + "execute against an unverified tree and report numbers nobody could trust - "
+                    + "silently, because a guard that admits wrongly leaves no trace and stops everyone "
+                    + "else checking." + Environment.NewLine
+                    + "    Fix the cause above, or release the pin if no proof is running: "
+                    + "powershell -File scripts/mutation-proof-pin.ps1 release");
+
+            case PinOutcome.PinActive:
+                break;
+
+            default:
+                // Unreachable today. Present so that ADDING a state cannot silently create a new way to
+                // admit: an unhandled outcome refuses rather than falling through.
+                return new Verdict(
+                    false,
+                    "The mutation-proof pin guard does not recognise the pin state '" + pin.Outcome
+                    + "', so it cannot say whether a proof is active and refuses rather than guessing.");
+        }
+
+        if (pin.Pin is null)
         {
             return new Verdict(
                 false,
-                "A mutation-proof pin file exists for this working tree but cannot be understood: "
-                + pin.Problem
-                + " A pin that cannot be read is NOT the same as no pin, and is not treated as one - "
-                + "a proof whose declaration is unreadable has declared nothing. Fix or release the pin "
-                + "(scripts/mutation-proof-pin.ps1 release) and start the proof again.");
-        }
-
-        if (!pin.Found || pin.Pin is null)
-        {
-            // The ordinary case, and the scope limit the whole design turns on: no pin, no opinion. A
-            // worker mid-rework is legitimately dirty and is not this guard's business.
-            return new Verdict(true, "No mutation-proof pin is active for this working tree.");
+                "The mutation-proof pin guard reports an active proof with no pin attached, which it "
+                + "cannot check. Refusing rather than admitting an unverifiable run.");
         }
 
         var active = pin.Pin;
@@ -537,16 +606,19 @@ internal static class MutationProofPinGuard
                 + "history. Release this pin and set it again with the current script.");
         }
 
-        return new PinReading(
-            true,
+        return PinReading.Active(
             new ProofPin(
                 proofId, phase, head.ToLowerInvariant(), pinnedUtc ?? "(not recorded)",
-                mutations, note, pinFilePath),
-            null);
+                mutations, note, pinFilePath));
     }
 
+    /// <summary>
+    /// A pin file that EXISTS but cannot be understood. Indeterminate, never absent: a proof whose
+    /// declaration is unreadable has declared nothing, and reading that as "no pin" would disarm the guard
+    /// for exactly the proof that most needs it.
+    /// </summary>
     private static PinReading Malformed(string pinFilePath, string detail) =>
-        new(true, null, "the pin file '" + pinFilePath + "' is not usable - " + detail);
+        PinReading.Indeterminate("the pin file '" + pinFilePath + "' is not usable - " + detail);
 
     private static bool LooksLikeCommitId(string value) =>
         value.Length == 40 && value.All(Uri.IsHexDigit);
@@ -618,22 +690,129 @@ internal static class MutationProofPinGuard
     /// The pin dying with "git worktree remove" is correct: a proof in a removed worktree is over. The
     /// LEDGER is what must outlive the tree, and it lives elsewhere - see <see cref="LedgerDirectory"/>.
     /// </summary>
-    internal static string? ResolveGitDirectory(string workingTreeRoot)
+    /// <summary>Whether the pin location could be established, and if not, why.</summary>
+    internal enum PinLocationOutcome
     {
-        var result = RunGit(workingTreeRoot, "--no-optional-locks rev-parse --absolute-git-dir");
-        if (result.ExitCode != 0)
-            return null;
+        /// <summary>The pin path is known. It may or may not exist on disk.</summary>
+        Located,
 
-        var path = result.Output.Trim();
-        return path.Length == 0 ? null : path;
+        /// <summary>There is no repository above the starting point, so no pin can exist.</summary>
+        NotInARepository,
+
+        /// <summary>A repository marker exists but the location could not be worked out. Refuses.</summary>
+        Indeterminate,
     }
 
-    /// <summary>The pin file for the working tree rooted at the given path, or null when git cannot say.</summary>
-    internal static string? ResolvePinFilePath(string workingTreeRoot)
+    internal sealed record PinLocation(PinLocationOutcome Outcome, string? PinFilePath, string? Problem);
+
+    /// <summary>
+    /// Works out where the pin lives WITHOUT LAUNCHING GIT.
+    ///
+    /// This replaced a call to "git rev-parse --absolute-git-dir", and the reason is the defect that call
+    /// produced. Launching a subprocess can fail for reasons that have nothing to do with whether a proof
+    /// is running - git missing from the path, a timeout under load, a broken installation - and every one
+    /// of those failures was reported as "no pin", which ADMITTED the run. The safety-critical question
+    /// "is a proof active here" was being answered by the least reliable mechanism in the file.
+    ///
+    /// So the question is now answered by reading what git has already WRITTEN, which is what the
+    /// subprocess would have gone and read anyway. The on-disk format is git own and is stable: ".git" is
+    /// either the directory itself, or - in a worktree, which is how every mission here runs - a file
+    /// whose contents name the real git directory.
+    ///
+    /// THE RESOLVED DIRECTORY IS THEN VERIFIED, by requiring it to contain a HEAD file. That check is what
+    /// stops this from becoming a second, drifting derivation of the location the script computes: if this
+    /// ever resolves somewhere git would not, the answer is INDETERMINATE and the run is refused - rather
+    /// than the guard looking for a pin in the wrong place, not finding one, and admitting. Agreement with
+    /// git own answer is pinned by tests against a real repository and a real worktree.
+    /// </summary>
+    internal static PinLocation LocatePin(string startDirectory)
     {
-        var gitDirectory = ResolveGitDirectory(workingTreeRoot);
-        return gitDirectory is null ? null : Path.Combine(gitDirectory, PinFileName);
+        try
+        {
+            var directory = new DirectoryInfo(startDirectory);
+            while (directory is not null)
+            {
+                var marker = Path.Combine(directory.FullName, ".git");
+
+                if (Directory.Exists(marker))
+                    return VerifyGitDirectory(marker, marker);
+
+                if (File.Exists(marker))
+                {
+                    // A worktree, a submodule, or any other linked checkout. The file names the real git
+                    // directory, and the path it names may be relative to the directory holding the file.
+                    var text = File.ReadAllText(marker).Trim();
+                    const string prefix = "gitdir:";
+
+                    if (!text.StartsWith(prefix, StringComparison.Ordinal))
+                    {
+                        return new PinLocation(
+                            PinLocationOutcome.Indeterminate, null,
+                            "the repository marker " + marker + " is a file that does not begin with "
+                            + "gitdir:, so the real git directory - and therefore the pin - cannot be "
+                            + "located.");
+                    }
+
+                    var named = text[prefix.Length..].Trim();
+                    var resolved = Path.IsPathRooted(named)
+                        ? named
+                        : Path.GetFullPath(Path.Combine(directory.FullName, named));
+
+                    return VerifyGitDirectory(resolved, marker);
+                }
+
+                directory = directory.Parent;
+            }
+
+            // Walked to the top of the filesystem without finding a repository. A COMPLETED search, not a
+            // failure: no repository means no pin can exist, so admitting is correct.
+            return new PinLocation(PinLocationOutcome.NotInARepository, null, null);
+        }
+        catch (Exception ex)
+        {
+            // The walk touched the filesystem and it refused. Nothing is known, so nothing is claimed -
+            // and "nothing is known" refuses.
+            return new PinLocation(
+                PinLocationOutcome.Indeterminate, null,
+                "the repository could not be located from " + startDirectory + ": "
+                + ex.GetType().Name + ": " + ex.Message);
+        }
     }
+
+    /// <summary>
+    /// Requires the resolved directory to look like a git directory before a pin path is built from it. A
+    /// wrong answer here would send the guard looking for a pin somewhere no pin is ever written, where it
+    /// would find nothing and admit - the failure this whole repair is about.
+    /// </summary>
+    private static PinLocation VerifyGitDirectory(string gitDirectory, string marker)
+    {
+        if (!Directory.Exists(gitDirectory))
+        {
+            return new PinLocation(
+                PinLocationOutcome.Indeterminate, null,
+                "the repository marker " + marker + " names a git directory at " + gitDirectory
+                + " which does not exist, so the pin cannot be located.");
+        }
+
+        if (!File.Exists(Path.Combine(gitDirectory, "HEAD")))
+        {
+            return new PinLocation(
+                PinLocationOutcome.Indeterminate, null,
+                gitDirectory + " does not contain a HEAD file, so it is not the git directory this guard "
+                + "expected and the pin location cannot be trusted.");
+        }
+
+        return new PinLocation(
+            PinLocationOutcome.Located, Path.Combine(gitDirectory, PinFileName), null);
+    }
+
+    /// <summary>
+    /// The pin file for a working tree, or null when its location could not be established. Retained for
+    /// tests and callers that only need the happy path; anything making a SAFETY decision must use
+    /// <see cref="LocatePin"/> so it can tell "no pin" from "could not tell".
+    /// </summary>
+    internal static string? ResolvePinFilePath(string workingTreeRoot) =>
+        LocatePin(workingTreeRoot).PinFilePath;
 
     /// <summary>
     /// Where the LEDGER lives - deliberately NOT in the git directory, because it has the opposite
@@ -673,9 +852,21 @@ internal static class MutationProofPinGuard
     /// business contending for the index lock. The porcelain format is requested explicitly with a version
     /// number, because the default format is documented as subject to change and this parser is not.
     /// </summary>
-    internal static TreeReading ReadTree(string workingTreeRoot)
+    internal static TreeReading ReadTree(string workingTreeRoot) => ReadTree(workingTreeRoot, GitExecutable);
+
+    /// <summary>
+    /// The same, with the git program named explicitly.
+    ///
+    /// Parameterised so a test can run the guard with git GENUINELY UNAVAILABLE and observe what it does,
+    /// rather than construct a "tree could not be read" value by hand and assert about that. The
+    /// difference is not cosmetic: the fail-open defect lived in the wiring BETWEEN the pin lookup and the
+    /// decision, so a test that hands Decide its inputs cannot see it. A parameter rather than a settable
+    /// global, because these assemblies run tests in parallel and a global would let one test change
+    /// another test git.
+    /// </summary>
+    internal static TreeReading ReadTree(string workingTreeRoot, string gitExecutable)
     {
-        var head = RunGit(workingTreeRoot, "--no-optional-locks rev-parse HEAD");
+        var head = RunGit(workingTreeRoot, "--no-optional-locks rev-parse HEAD", gitExecutable);
         if (head.ExitCode != 0)
         {
             return new TreeReading(
@@ -684,7 +875,9 @@ internal static class MutationProofPinGuard
         }
 
         var status = RunGit(
-            workingTreeRoot, "--no-optional-locks status --porcelain=v1 --untracked-files=normal -z");
+            workingTreeRoot,
+            "--no-optional-locks status --porcelain=v1 --untracked-files=normal -z",
+            gitExecutable);
         if (status.ExitCode != 0)
         {
             return new TreeReading(
@@ -740,12 +933,15 @@ internal static class MutationProofPinGuard
 
     private readonly record struct GitResult(int ExitCode, string Output, string Error);
 
-    private static GitResult RunGit(string workingTreeRoot, string arguments)
+    /// <summary>The git program. A constant in production; a parameter so tests can remove it.</summary>
+    internal const string GitExecutable = "git";
+
+    private static GitResult RunGit(string workingTreeRoot, string arguments, string gitExecutable)
     {
         try
         {
             using var process = new Process();
-            process.StartInfo = new ProcessStartInfo("git")
+            process.StartInfo = new ProcessStartInfo(gitExecutable)
             {
                 Arguments = "-C \"" + workingTreeRoot + "\" " + arguments,
                 RedirectStandardOutput = true,
@@ -784,25 +980,45 @@ internal static class MutationProofPinGuard
     {
         HasRun = true;
 
-        string? root;
+        // NOTHING RETURNS EARLY WITH AN ADMISSION. Every path reaches Decide, which has exactly one admit.
+        //
+        // This method used to hold two admissions of its own: a failure to locate the working tree root
+        // admitted, and so did a null root. Both were written as though "I could not look" were a reason
+        // to proceed. A reviewer reported the same shape in the pin lookup; these two were the same defect
+        // in a different place, which is why the repair is structural rather than a patch at the reported
+        // site.
+        string root;
         try
         {
-            root = FindWorkingTreeRoot(AppContext.BaseDirectory);
+            var located = FindWorkingTreeRoot(AppContext.BaseDirectory);
+
+            if (located is null)
+            {
+                // A COMPLETED search: walked to the top of the filesystem and found no repository. No
+                // repository means no pin can exist, so this is a genuine absence and admits.
+                Finish(
+                    AppContext.BaseDirectory,
+                    PinReading.NoPin(),
+                    new TreeReading(false, "", Array.Empty<ChangedPath>(), "not inside a repository"),
+                    new Verdict(true, "This run is not inside a git working tree, so no mutation proof "
+                        + "can be active for it."));
+                return;
+            }
+
+            root = located;
         }
         catch (Exception ex)
         {
-            // Walking to the root touched the file system and it refused. There is no pin this run can be
-            // measured against, so it is admitted - but it is admitted LOUDLY, because a guard that goes
-            // quiet on an unexpected input is how a guard stops guarding without anybody noticing.
-            LastVerdictSummary = "admitted: the working tree root could not be located (" + ex.Message + ")";
-            Say("[mutation-proof-pin] Could not locate the working tree root, so no mutation-proof pin "
-                + "could be checked for this run: " + ex.Message);
-            return;
-        }
+            // The walk touched the filesystem and it refused, so whether a proof is active is UNKNOWN.
+            // Unknown refuses. This used to admit "loudly", which is a contradiction in terms: the run
+            // went ahead regardless of how loudly it said so.
+            var unknown = PinReading.Indeterminate(
+                "the working tree root could not be located from " + AppContext.BaseDirectory + ": "
+                + ex.GetType().Name + ": " + ex.Message);
+            var unreadable = new TreeReading(false, "", Array.Empty<ChangedPath>(), ex.Message);
 
-        if (root is null)
-        {
-            LastVerdictSummary = "admitted: this run is not inside a git working tree";
+            Finish(AppContext.BaseDirectory, unknown, unreadable,
+                Decide(unknown, unreadable, Array.Empty<string>()));
             return;
         }
 
@@ -811,22 +1027,35 @@ internal static class MutationProofPinGuard
 
         // Read only when a pin is active. An unpinned run has no proof identity to compare against, and
         // reading the ledger on every ordinary run would be cost for nothing.
-        var priorLedgerLines = pin.Found ? ReadLedger() : Array.Empty<string>();
+        var priorLedgerLines = pin.Outcome == PinOutcome.NoPinPresent
+            ? Array.Empty<string>()
+            : ReadLedger();
 
-        var verdict = Decide(pin, tree, priorLedgerLines);
+        Finish(root, pin, tree, Decide(pin, tree, priorLedgerLines));
+    }
 
+    /// <summary>
+    /// THE ONE EXIT. Records the run, then either returns or stops the process.
+    ///
+    /// Every path through <see cref="Check"/> ends here, so there is no way to reach the end of the guard
+    /// without a verdict having been recorded and enforced. That is the structural half of the repair: the
+    /// previous version let two paths return early, and an early return is an admission that never appears
+    /// in the ledger either - invisible twice over.
+    /// </summary>
+    private static void Finish(string workingTreeRoot, PinReading pin, TreeReading tree, Verdict verdict)
+    {
         LastVerdictSummary = (verdict.Admitted ? "admitted" : "refused") + ": " + verdict.Message;
 
         // Recorded for EVERY run, admitted or refused, pinned or not - see the remarks on the ledger. An
         // admission is the fact worth keeping; a log that only writes on refusal cannot afterwards tell
         // "verified clean" from "the guard never ran".
-        Record(root, pin, tree, verdict);
+        Record(workingTreeRoot, pin, tree, verdict);
 
         if (verdict.Admitted)
         {
             // An unpinned run says nothing at all. There are thousands of them and they are not this
             // guard's business; a line of output on each one is how a mechanism trains people to ignore it.
-            if (pin.Found)
+            if (pin.Outcome != PinOutcome.NoPinPresent)
                 Say("[mutation-proof-pin] " + verdict.Message);
 
             return;
@@ -853,23 +1082,41 @@ internal static class MutationProofPinGuard
     /// evidence, being prose in a pull request, cannot notice.
     /// </summary>
     internal static Verdict Evaluate(string workingTreeRoot, IReadOnlyList<string> priorLedgerLines) =>
-        Decide(ReadPinFor(workingTreeRoot), ReadTree(workingTreeRoot), priorLedgerLines);
+        Evaluate(workingTreeRoot, priorLedgerLines, GitExecutable);
+
+    /// <summary>The same, with the git program named - see <see cref="ReadTree(string, string)"/>.</summary>
+    internal static Verdict Evaluate(
+        string workingTreeRoot, IReadOnlyList<string> priorLedgerLines, string gitExecutable) =>
+        Decide(ReadPinFor(workingTreeRoot), ReadTree(workingTreeRoot, gitExecutable), priorLedgerLines);
 
     internal static PinReading ReadPinFor(string workingTreeRoot)
     {
-        var path = ResolvePinFilePath(workingTreeRoot);
-        if (path is null)
+        var location = LocatePin(workingTreeRoot);
+
+        switch (location.Outcome)
         {
-            // Git could not name its own directory. There is no pin to find and no way to know whether one
-            // exists, so nothing is claimed - the run is admitted, and the ledger records that this run
-            // verified nothing rather than that it was clean.
-            return new PinReading(false, null, null);
+            case PinLocationOutcome.NotInARepository:
+                // A completed search: no repository, so no pin can exist. This is the one failure-shaped
+                // input that is genuinely an ABSENCE rather than an unknown.
+                return PinReading.NoPin();
+
+            case PinLocationOutcome.Indeterminate:
+                return PinReading.Indeterminate(location.Problem ?? "the pin location is unknown.");
+
+            case PinLocationOutcome.Located:
+                break;
+
+            default:
+                return PinReading.Indeterminate(
+                    "the pin location outcome " + location.Outcome + " is not one this guard handles.");
         }
+
+        var path = location.PinFilePath!;
 
         try
         {
             if (!File.Exists(path))
-                return new PinReading(false, null, null);
+                return PinReading.NoPin();
 
             return ParsePin(File.ReadAllText(path), path);
         }
@@ -877,7 +1124,8 @@ internal static class MutationProofPinGuard
         {
             // A pin file that EXISTS but cannot be read is a refusal, not an absence. Treating it as an
             // absence would disarm the guard for exactly the proof that most needs it.
-            return new PinReading(true, null, "the pin file '" + path + "' could not be read: " + ex.Message);
+            return PinReading.Indeterminate(
+                "the pin file '" + path + "' could not be read: " + ex.Message);
         }
     }
 
@@ -1057,7 +1305,7 @@ internal static class MutationProofPinGuard
             TrimIfLarge(allRuns);
             Append(allRuns, line);
 
-            if (pin.Found)
+            if (pin.Outcome != PinOutcome.NoPinPresent)
             {
                 // Never trimmed. It only grows by one line per proof run, and a ledger that discards its
                 // oldest entries is exactly useless for the question it exists to answer, which is always

--- a/src/TestInfrastructure/MutationProofPinGuard.cs
+++ b/src/TestInfrastructure/MutationProofPinGuard.cs
@@ -1,0 +1,922 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+
+namespace CcDirector.TestInfrastructure;
+
+/// <summary>
+/// Refuses to START a test run that has been declared part of a mutation proof - a BASELINE run or a
+/// MUTATION ARM run - when the working tree is not exactly what that proof pinned. Every other run is
+/// admitted untouched.
+///
+/// WHY THIS EXISTS - READ THIS BEFORE YOU DELETE IT OR WIDEN IT.
+///
+/// We prove a security guard is real by mutating the one primitive it depends on, running the whole suite
+/// again, and reconciling the arithmetic: the tests that pass plus the tests that fail under the mutation
+/// must add up to the tests that passed under the restored run. If they add up, the suite is held to have
+/// observed the primitive.
+///
+/// That reconciliation has one failure it cannot see by itself, and it is the failure that matters most.
+/// Suppose the BASELINE is taken on a tree where a security guard block has ALREADY been silently deleted
+/// and left uncommitted. The tree still compiles. The suite still runs. The baseline still looks green and
+/// complete. Then the mutation arm runs on that same contaminated tree, and the two runs reconcile
+/// PERFECTLY - because they agree with each other, not because either one measured anything. The cheapest
+/// detector we own passes while measuring nothing, and every conclusion drawn from it is worthless with
+/// nothing anywhere in the process saying so.
+///
+/// This is not hypothetical. On 2026-07-19 a worker found exactly that on disk: a security guard block that
+/// a KILLED run had deleted and never restored, because a process that is killed skips its cleanup. A sweep
+/// of the mission's working trees that night found four dirty trees.
+///
+/// AND IT IS AN INSTRUCTION THAT CANNOT BIND. Telling every worker "check your tree is clean before you
+/// take a baseline" does not work, and the reason is the whole design argument for this file: the worker
+/// who INHERITS a contaminated tree is, by definition, the one who does not know there is a mutation in it.
+/// It looks clean to them because it compiles and the tests pass. This is the same shape as the problem the
+/// per-user suite lock in this repository was built for: a rule that requires global knowledge cannot be
+/// obeyed by an actor holding only local knowledge. Four workers were each told not to run two suites at
+/// once, each complied with everything it could observe, and four suites ran concurrently anyway. That one
+/// was solved by a mechanism rather than a briefing, and so is this.
+///
+/// WHAT IT IS DELIBERATELY NOT: A BLANKET REFUSAL ON ANY DIRTY TREE.
+///
+/// A worker halfway through a rework is legitimately dirty and must be able to run whatever it likes,
+/// whenever it likes. Only a baseline and a mutation arm carry a MEANING that depends on the tree being
+/// exactly the pinned head. A blanket guard would be switched off inside a day, and a guard that gets
+/// switched off protects nothing at all. So the guard is inert - it does not even invoke git - unless the
+/// tree has an active pin.
+///
+/// HOW A RUN DECLARES ITSELF PART OF A PROOF, AND WHY THAT IS HARD TO FORGET.
+///
+/// The declaration is made ONCE PER PROOF, not once per run, by writing a pin for the working tree
+/// (scripts/mutation-proof-pin.ps1). From that moment until the pin is released, EVERY test run in that
+/// tree is checked - the baseline, the arm, and any re-run of either. So the only moment a worker can
+/// forget is the moment before the proof starts, and at that moment forgetting means something visible:
+/// the pin is the only place the pinned head is written down, and a mutation proof with no recorded pinned
+/// head is not a proof anybody can write up. The un-guarded path is not "skip a flag on the command line",
+/// it is "have no pinned head at all".
+///
+/// It is not, and cannot honestly be claimed to be, impossible to forget - see the RUN RECORD below, which
+/// is what closes the remainder.
+///
+/// THE ARM IS CHECKED TOO, AND AGAINST A TIGHTER RULE THAN THE BASELINE.
+///
+/// A mutation arm is SUPPOSED to be dirty - that is what a mutation is. So the arm's pin declares which
+/// paths the mutation touches, and the guard requires the working tree to carry EXACTLY those changes:
+///
+///   - a change to a path the pin did not declare is refused, which is the contaminated-arm case, and
+///   - a declared path that is NOT modified is refused, which is the case where the mutation was never
+///     applied or was already restored. That one matters as much as the first: an arm run with no mutation
+///     in it is a second baseline wearing an arm's name, and it reconciles perfectly against the first.
+///
+/// A baseline is simply an arm that declares no mutations, so both phases run one rule.
+///
+/// THE SECOND JOB: MAKE THE TREE'S STATE AT RUN TIME OUTLIVE THE TREE.
+///
+/// Refusing a contaminated run is only half of what this mechanism is for. On 2026-07-19 somebody was asked
+/// whether four ALREADY-MERGED security proofs had been taken on contaminated trees. The answer could not be
+/// given - not because the evidence was hard to find, but because it no longer existed. Those proofs were
+/// run in worktrees, and the worktrees were removed after merging, which is correct hygiene and also
+/// destroyed the only artifact that could have answered the question. Those four are recorded as unknown
+/// and will stay unknown forever.
+///
+/// So every run appends a line to a LEDGER that lives outside every working tree, in the same per-user
+/// neighbourhood as the suite lock, and therefore survives "git worktree remove", "git clean -xdf", and the
+/// deletion of the whole checkout. Six months from now the question "was that proof taken on a clean tree at
+/// the pinned head" is answered by reading a file, not by reconstructing a directory that is gone.
+///
+/// THE LEDGER STATES A POSITIVE FACT, NOT THE ABSENCE OF A COMPLAINT. It writes on ADMISSION as well as on
+/// refusal, and an admission line says which head was verified and that the tree matched it. A log written
+/// only when something goes wrong cannot afterwards distinguish "verified clean" from "the guard never
+/// ran" - both are silence, and silence reads as success. That is the same principle the firing tests are
+/// built on: an instrument that cannot observe its subject reports the subject's absence.
+///
+/// UNPINNED RUNS ARE OBSERVED, NEVER REFUSED. They are recorded too - head, and the tree's changed paths -
+/// which is what makes a FORGOTTEN pin recoverable: when a proof's numbers are later questioned, the record
+/// says whether the tree was dirty at the moment the baseline ran, even though no pin was ever written.
+/// Recording NEVER refuses and NEVER fails a run; a diagnostic that can break a run is worse than no
+/// diagnostic.
+///
+/// WHERE THE PIN LIVES: OUTSIDE THE WORKING TREE.
+///
+/// Two reasons, both load-bearing. A pin file inside the tree would itself be a working-tree change, so the
+/// guard would trip over its own declaration or would need an exemption - and an exemption is a hole. And a
+/// pin inside the tree is removed by "git clean -xdf", which is exactly the sort of housekeeping a worker
+/// runs in the middle of a proof. So pins live under the per-user local application data directory, keyed
+/// by the working tree's path, alongside the suite lock's home.
+///
+/// WHY A MODULE INITIALIZER. It runs on assembly load, before any test, under every runner, and there is no
+/// call site for anybody to forget. It is the same form the per-user suite lock and the storage-root
+/// redirect already use in this repository. This file is linked into EVERY project whose name ends in
+/// ".Tests" by Directory.Build.props, so a test project added next year is covered without anybody
+/// remembering - keying on the project name rather than on the IsTestProject flag was deliberate, because
+/// one of the seven existing test projects does not set that flag.
+///
+/// It is pinned by MutationProofPinGuardTests, because a guard that silently fails to run leaves no trace
+/// and looks exactly like a guard that works.
+/// </summary>
+internal static class MutationProofPinGuard
+{
+    /// <summary>Exit code used when this run refuses to start because the tree is not what the proof pinned.</summary>
+    internal const int ContaminatedTreeExitCode = 97;
+
+    /// <summary>The phase name for a run whose tree must carry no changes at all.</summary>
+    internal const string BaselinePhase = "baseline";
+
+    /// <summary>The phase name for a run whose tree must carry exactly the declared mutation and nothing else.</summary>
+    internal const string ArmPhase = "arm";
+
+    /// <summary>How long to let a git invocation run before treating it as unusable.</summary>
+    private static readonly TimeSpan GitTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>Trim the run record back to this many lines once it passes <see cref="RunRecordMaxBytes"/>.</summary>
+    private const int RunRecordKeepLines = 500;
+
+    /// <summary>Size at which the run record is trimmed, so a long-lived tree cannot grow it without bound.</summary>
+    private const long RunRecordMaxBytes = 1024 * 1024;
+
+    /// <summary>True once the module initializer has run in this process. Pinned by the tests, because a
+    /// module initializer that silently does not run is invisible.</summary>
+    internal static bool HasRun { get; private set; }
+
+    /// <summary>What the guard decided in this process, for the tests to read.</summary>
+    internal static string LastVerdictSummary { get; private set; } = "(the guard has not run)";
+
+    // ---------------------------------------------------------------------------------------------------
+    // The decision. A pure function of its arguments so it can be driven directly, including down the paths
+    // that only occur on a contaminated tree - which is the whole point, since those are the paths that
+    // must be shown to FIRE rather than merely to exist.
+    // ---------------------------------------------------------------------------------------------------
+
+    /// <summary>One entry from the working tree's change list: the two-letter git status code and the path.</summary>
+    internal readonly record struct ChangedPath(string StatusCode, string Path)
+    {
+        public override string ToString() => StatusCode + " " + Path;
+    }
+
+    /// <summary>A proof's declaration for one working tree.</summary>
+    internal sealed record ProofPin(
+        string Phase,
+        string PinnedHead,
+        string PinnedUtc,
+        IReadOnlyList<string> DeclaredMutations,
+        string Note,
+        string PinFilePath);
+
+    /// <summary>
+    /// The result of looking for a pin. A pin that EXISTS but cannot be understood is not the same as no
+    /// pin, and must never be treated as one - a typo in a pin file would otherwise silently disarm the
+    /// guard for the whole proof.
+    /// </summary>
+    internal sealed record PinReading(bool Found, ProofPin? Pin, string? Problem);
+
+    /// <summary>
+    /// What git says about the working tree. Reading can fail - git missing from the path, a corrupt
+    /// repository - and when a pin is active that failure REFUSES, because a proof that cannot verify its
+    /// own tree has not verified anything.
+    /// </summary>
+    internal sealed record TreeReading(bool Read, string Head, IReadOnlyList<ChangedPath> Changes, string? Problem);
+
+    /// <summary>Admitted, or refused with the reason a human needs in order to fix it.</summary>
+    internal sealed record Verdict(bool Admitted, string Message);
+
+    /// <summary>
+    /// The rule, in one place. Collects EVERY problem rather than stopping at the first, so a worker fixes
+    /// the tree in one pass instead of discovering the second fault after another nine-minute run.
+    /// </summary>
+    internal static Verdict Decide(PinReading pin, TreeReading tree)
+    {
+        if (pin.Problem is not null)
+        {
+            return new Verdict(
+                false,
+                "A mutation-proof pin file exists for this working tree but cannot be understood: "
+                + pin.Problem
+                + " A pin that cannot be read is NOT the same as no pin, and is not treated as one - "
+                + "a proof whose declaration is unreadable has declared nothing. Fix or release the pin "
+                + "(scripts/mutation-proof-pin.ps1 release) and start the proof again.");
+        }
+
+        if (!pin.Found || pin.Pin is null)
+        {
+            // The ordinary case, and the scope limit the whole design turns on: no pin, no opinion. A
+            // worker mid-rework is legitimately dirty and is not this guard's business.
+            return new Verdict(true, "No mutation-proof pin is active for this working tree.");
+        }
+
+        var active = pin.Pin;
+
+        if (!tree.Read)
+        {
+            return new Verdict(
+                false,
+                "This run is declared part of a mutation proof (" + Describe(active) + "), but the state of "
+                + "the working tree could not be read, so there is no way to know whether the tree is the "
+                + "one the proof pinned: " + (tree.Problem ?? "(no detail)")
+                + " A proof run that cannot verify its own tree has verified nothing, so it stops rather "
+                + "than producing numbers nobody can trust.");
+        }
+
+        var problems = new List<string>();
+
+        if (!string.Equals(active.PinnedHead, tree.Head, StringComparison.OrdinalIgnoreCase))
+        {
+            problems.Add(
+                "THE HEAD HAS MOVED. This proof pinned " + active.PinnedHead + ", and the working tree is "
+                + "now at " + tree.Head + ". A baseline and its mutation arm must be taken at the same "
+                + "commit or the arithmetic compares two different programs. Either return the tree to the "
+                + "pinned commit, or release the pin and start the proof again from the head you mean.");
+        }
+
+        var declared = active.DeclaredMutations
+            .Select(NormalizePath)
+            .Where(p => p.Length > 0)
+            .ToList();
+
+        var changedPaths = tree.Changes.Select(c => NormalizePath(c.Path)).ToList();
+
+        var undeclared = tree.Changes
+            .Where(c => !declared.Contains(NormalizePath(c.Path), StringComparer.Ordinal))
+            .ToList();
+
+        if (undeclared.Count > 0)
+        {
+            problems.Add(
+                "THE WORKING TREE CARRIES " + undeclared.Count.ToString(CultureInfo.InvariantCulture)
+                + " CHANGE(S) THIS PROOF DID NOT DECLARE:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, undeclared.Select(c => "    " + c.StatusCode + "  " + c.Path))
+                + Environment.NewLine
+                + "    An uncommitted change that nobody declared is how a contaminated baseline happens: "
+                + "a security guard deleted by a killed run still compiles, still runs green, and then "
+                + "reconciles perfectly against its own mutation arm while measuring nothing. Commit these "
+                + "changes, revert them, or declare them - but do not run a proof over them.");
+        }
+
+        var missing = declared
+            .Where(d => !changedPaths.Contains(d, StringComparer.Ordinal))
+            .ToList();
+
+        if (missing.Count > 0)
+        {
+            problems.Add(
+                "THE DECLARED MUTATION IS NOT IN THE WORKING TREE:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, missing.Select(m => "    " + m))
+                + Environment.NewLine
+                + "    This run was declared a mutation arm, so those paths were expected to be modified. "
+                + "An arm with no mutation in it is a SECOND BASELINE wearing an arm's name, and it "
+                + "reconciles perfectly against the first while proving nothing. Apply the mutation, or "
+                + "correct the declared path - the tree currently carries: "
+                + (changedPaths.Count == 0
+                    ? "(no changes at all)"
+                    : string.Join(", ", changedPaths))
+                + ".");
+        }
+
+        if (problems.Count == 0)
+        {
+            return new Verdict(
+                true,
+                "This run is declared part of a mutation proof (" + Describe(active)
+                + ") and the working tree matches what the proof pinned.");
+        }
+
+        return new Verdict(
+            false,
+            "*** REFUSING TO RUN. NO TESTS WILL RUN. ***" + Environment.NewLine
+            + "This run is declared part of a mutation proof (" + Describe(active) + "), and the working "
+            + "tree is not the tree that proof pinned. A mutation proof compares a baseline against a "
+            + "mutation arm and reconciles the counts; if the tree carries changes nobody declared, both "
+            + "runs agree with each other rather than measuring anything, and the proof passes while "
+            + "proving nothing." + Environment.NewLine
+            + string.Join(Environment.NewLine + Environment.NewLine, problems.Select(p => "  - " + p))
+            + Environment.NewLine + Environment.NewLine
+            + "  Pin file: " + active.PinFilePath + Environment.NewLine
+            + "  If this run is NOT part of the proof, release the pin: "
+            + "powershell -File scripts/mutation-proof-pin.ps1 release");
+    }
+
+    private static string Describe(ProofPin pin)
+    {
+        var mutations = pin.DeclaredMutations.Count == 0
+            ? "no declared mutations"
+            : "declared mutations: " + string.Join(", ", pin.DeclaredMutations);
+
+        return "phase " + pin.Phase + ", pinned head " + pin.PinnedHead + ", pinned at " + pin.PinnedUtc
+            + ", " + mutations
+            + (string.IsNullOrWhiteSpace(pin.Note) ? "" : ", note: " + pin.Note);
+    }
+
+    /// <summary>Git reports forward-slash relative paths; a hand-written pin may not. Compare like for like.</summary>
+    internal static string NormalizePath(string path) =>
+        path.Replace('\\', '/').Trim().TrimStart('.', '/').Trim();
+
+    // ---------------------------------------------------------------------------------------------------
+    // Reading the pin. Every rejection here REFUSES rather than falling through to "no pin", because the
+    // fall-through is silent and this file exists to stop silent failures.
+    // ---------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Parses a pin file's text. Separated from the file system so the malformed cases can be driven
+    /// directly - they are the cases that must not degrade into "no pin found".
+    /// </summary>
+    internal static PinReading ParsePin(string text, string pinFilePath)
+    {
+        string? phase = null;
+        string? head = null;
+        string? pinnedUtc = null;
+        var note = "";
+        var mutations = new List<string>();
+
+        foreach (var raw in text.Split('\n'))
+        {
+            var line = raw.Trim();
+            if (line.Length == 0 || line.StartsWith('#'))
+                continue;
+
+            var split = line.IndexOf('=');
+            if (split <= 0)
+                return Malformed(pinFilePath, "the line '" + line + "' is not a key=value pair.");
+
+            var key = line[..split].Trim();
+            var value = line[(split + 1)..].Trim();
+
+            switch (key)
+            {
+                case "phase":
+                    phase = value;
+                    break;
+                case "pinnedHead":
+                    head = value;
+                    break;
+                case "pinnedUtc":
+                    pinnedUtc = value;
+                    break;
+                case "mutates":
+                    if (value.Length > 0)
+                        mutations.Add(value);
+                    break;
+                case "note":
+                    note = value;
+                    break;
+                case "tree":
+                    break; // diagnostic only
+                default:
+                    // Refuse rather than ignore. An ignored key is how "mutate=" instead of "mutates="
+                    // would quietly drop a declaration - and the guard would then blame the worker for a
+                    // change the worker did declare.
+                    return Malformed(pinFilePath, "the key '" + key + "' is not one this guard understands.");
+            }
+        }
+
+        if (phase is null)
+            return Malformed(pinFilePath, "it declares no phase.");
+
+        if (phase != BaselinePhase && phase != ArmPhase)
+        {
+            return Malformed(
+                pinFilePath,
+                "the phase '" + phase + "' is neither '" + BaselinePhase + "' nor '" + ArmPhase + "'.");
+        }
+
+        if (head is null || !LooksLikeCommitId(head))
+        {
+            return Malformed(
+                pinFilePath,
+                "the pinned head '" + (head ?? "(absent)") + "' is not a full forty-character commit id.");
+        }
+
+        if (phase == BaselinePhase && mutations.Count > 0)
+        {
+            return Malformed(
+                pinFilePath,
+                "it is a baseline yet declares mutations (" + string.Join(", ", mutations)
+                + "). A baseline is taken on an unmodified tree by definition; a run that carries a "
+                + "mutation is an arm.");
+        }
+
+        if (phase == ArmPhase && mutations.Count == 0)
+        {
+            return Malformed(
+                pinFilePath,
+                "it is a mutation arm yet declares no mutation. An arm that declares nothing would admit "
+                + "any tree at all, which is the opposite of what this guard is for.");
+        }
+
+        return new PinReading(
+            true,
+            new ProofPin(phase, head.ToLowerInvariant(), pinnedUtc ?? "(not recorded)", mutations, note, pinFilePath),
+            null);
+    }
+
+    private static PinReading Malformed(string pinFilePath, string detail) =>
+        new(true, null, "the pin file '" + pinFilePath + "' is not usable - " + detail);
+
+    private static bool LooksLikeCommitId(string value) =>
+        value.Length == 40 && value.All(Uri.IsHexDigit);
+
+    // ---------------------------------------------------------------------------------------------------
+    // Locating things.
+    // ---------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Walks up from a starting directory to the working tree root - the directory holding ".git". In a git
+    /// worktree ".git" is a FILE rather than a directory, which is the normal case for this repository's
+    /// mission work, so both are accepted.
+    ///
+    /// Returns null when there is no repository above the starting point. That is the honest answer for a
+    /// test assembly copied somewhere else entirely, and it means the guard has nothing to key on; it is
+    /// stated here rather than papered over because it is the one way a proof run could sidestep the guard.
+    /// </summary>
+    internal static string? FindWorkingTreeRoot(string startDirectory)
+    {
+        var directory = new DirectoryInfo(startDirectory);
+        while (directory is not null)
+        {
+            var marker = Path.Combine(directory.FullName, ".git");
+            if (Directory.Exists(marker) || File.Exists(marker))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The pin file for one working tree. The key is a hash of the tree's path so that two working trees of
+    /// the same repository - which is how every mission here is run - hold independent pins.
+    ///
+    /// SHA-256 rather than a runtime hash code, because this name is written to disk and must mean the same
+    /// thing in the next process. The leaf directory name is kept in front of the hash so a human reading
+    /// the pins directory can tell at a glance which tree each pin belongs to.
+    /// </summary>
+    internal static string ComputePinFilePath(string pinsDirectory, string workingTreeRoot)
+    {
+        var normalized = workingTreeRoot.Replace('\\', '/').TrimEnd('/').ToLowerInvariant();
+        var digest = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)))
+            .ToLowerInvariant();
+
+        var leaf = new string(Path.GetFileName(normalized.TrimEnd('/'))
+            .Select(c => char.IsLetterOrDigit(c) || c is '-' or '_' ? c : '-')
+            .ToArray());
+
+        if (leaf.Length > 40)
+            leaf = leaf[..40];
+
+        return Path.Combine(pinsDirectory, leaf + "-" + digest[..16] + ".pin");
+    }
+
+    /// <summary>
+    /// Where pins live: beside the per-user suite lock, under the per-user local application data
+    /// directory, and NOT anywhere the process environment can move - for the same reason the suite lock
+    /// is derived that way. A pin the launching environment can relocate is a pin two runs of the same
+    /// proof would not share.
+    /// </summary>
+    internal static string ComputePinsDirectory(bool isWindows, string localApplicationDataFolder, string userName)
+    {
+        if (!isWindows)
+        {
+            // Built by hand: the separator belongs to the target platform, not the running one.
+            return "/tmp/cc-director-" + userName + "-mutation-proof-pins";
+        }
+
+        if (string.IsNullOrWhiteSpace(localApplicationDataFolder))
+        {
+            throw new InvalidOperationException(
+                "Cannot locate the per-user local application data directory, so mutation-proof pins have "
+                + "no environment-independent home. Every alternative location is settable by whoever "
+                + "launched the run, which would let the baseline and the mutation arm read different "
+                + "pins. See MutationProofPinGuard.");
+        }
+
+        return Path.Combine(localApplicationDataFolder, "cc-director", "mutation-proof-pins");
+    }
+
+    private static string PinsDirectory => ComputePinsDirectory(
+        OperatingSystem.IsWindows(),
+        Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify),
+        Environment.UserName);
+
+    // ---------------------------------------------------------------------------------------------------
+    // Reading the tree, via git.
+    // ---------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Asks git for the head commit and the working tree's changes.
+    ///
+    /// "--no-optional-locks" because several agents run in this repository at once and a status call has no
+    /// business contending for the index lock. The porcelain format is requested explicitly with a version
+    /// number, because the default format is documented as subject to change and this parser is not.
+    /// </summary>
+    internal static TreeReading ReadTree(string workingTreeRoot)
+    {
+        var head = RunGit(workingTreeRoot, "--no-optional-locks rev-parse HEAD");
+        if (head.ExitCode != 0)
+        {
+            return new TreeReading(
+                false, "", Array.Empty<ChangedPath>(),
+                "'git rev-parse HEAD' failed in '" + workingTreeRoot + "': " + Describe(head));
+        }
+
+        var status = RunGit(
+            workingTreeRoot, "--no-optional-locks status --porcelain=v1 --untracked-files=normal -z");
+        if (status.ExitCode != 0)
+        {
+            return new TreeReading(
+                false, "", Array.Empty<ChangedPath>(),
+                "'git status' failed in '" + workingTreeRoot + "': " + Describe(status));
+        }
+
+        return new TreeReading(
+            true,
+            head.Output.Trim().ToLowerInvariant(),
+            ParsePorcelainZ(status.Output),
+            null);
+    }
+
+    private static string Describe(GitResult result) =>
+        "exit code " + result.ExitCode.ToString(CultureInfo.InvariantCulture)
+        + (string.IsNullOrWhiteSpace(result.Error) ? "" : ", " + result.Error.Trim());
+
+    /// <summary>
+    /// Parses the NUL-separated porcelain v1 format.
+    ///
+    /// NUL-separated rather than line-separated on purpose: in the line format git QUOTES and escapes paths
+    /// containing unusual characters, so a path with a space or a non-ASCII character comes back in a shape
+    /// this parser would mis-read - and mis-reading a path means naming the wrong file in a refusal, or
+    /// failing to match a declared mutation. In the NUL format paths are always literal.
+    ///
+    /// Rename and copy entries carry a SECOND path (the origin) as its own field, which must be consumed or
+    /// every subsequent entry is shifted by one.
+    /// </summary>
+    internal static IReadOnlyList<ChangedPath> ParsePorcelainZ(string output)
+    {
+        var fields = output.Split('\0');
+        var changes = new List<ChangedPath>();
+
+        for (var i = 0; i < fields.Length; i++)
+        {
+            var entry = fields[i];
+            if (entry.Length < 4)
+                continue; // the trailing empty field, and anything too short to be an entry
+
+            var code = entry[..2];
+            var path = entry[3..];
+
+            changes.Add(new ChangedPath(code, path));
+
+            // 'R' is a rename, 'C' a copy; either way the origin path follows in its own field.
+            if (code[0] is 'R' or 'C' || code[1] is 'R' or 'C')
+                i++;
+        }
+
+        return changes;
+    }
+
+    private readonly record struct GitResult(int ExitCode, string Output, string Error);
+
+    private static GitResult RunGit(string workingTreeRoot, string arguments)
+    {
+        try
+        {
+            using var process = new Process();
+            process.StartInfo = new ProcessStartInfo("git")
+            {
+                Arguments = "-C \"" + workingTreeRoot + "\" " + arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+
+            if (!process.WaitForExit((int)GitTimeout.TotalMilliseconds))
+            {
+                return new GitResult(
+                    -1, "", "git did not finish within " + GitTimeout.TotalSeconds + " seconds.");
+            }
+
+            return new GitResult(process.ExitCode, output, error);
+        }
+        catch (Exception ex)
+        {
+            // Deliberately reported rather than swallowed. When a pin is active this becomes a refusal,
+            // because a proof that cannot read its own tree has proved nothing; when no pin is active the
+            // caller ignores it, and the run proceeds untouched.
+            return new GitResult(-1, "", ex.GetType().Name + ": " + ex.Message);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The entry point.
+    // ---------------------------------------------------------------------------------------------------
+
+    [ModuleInitializer]
+    internal static void Check()
+    {
+        HasRun = true;
+
+        string? root;
+        try
+        {
+            root = FindWorkingTreeRoot(AppContext.BaseDirectory);
+        }
+        catch (Exception ex)
+        {
+            // Walking to the root touched the file system and it refused. There is no pin this run can be
+            // measured against, so it is admitted - but it is admitted LOUDLY, because a guard that goes
+            // quiet on an unexpected input is how a guard stops guarding without anybody noticing.
+            LastVerdictSummary = "admitted: the working tree root could not be located (" + ex.Message + ")";
+            Say("[mutation-proof-pin] Could not locate the working tree root, so no mutation-proof pin "
+                + "could be checked for this run: " + ex.Message);
+            return;
+        }
+
+        if (root is null)
+        {
+            LastVerdictSummary = "admitted: this run is not inside a git working tree";
+            return;
+        }
+
+        var pin = ReadPinFor(root);
+        var tree = ReadTree(root);
+        var verdict = Decide(pin, tree);
+
+        LastVerdictSummary = (verdict.Admitted ? "admitted" : "refused") + ": " + verdict.Message;
+
+        // Recorded for EVERY run, admitted or refused, pinned or not - see the remarks on the ledger. An
+        // admission is the fact worth keeping; a log that only writes on refusal cannot afterwards tell
+        // "verified clean" from "the guard never ran".
+        Record(root, pin, tree, verdict);
+
+        if (verdict.Admitted)
+        {
+            // An unpinned run says nothing at all. There are thousands of them and they are not this
+            // guard's business; a line of output on each one is how a mechanism trains people to ignore it.
+            if (pin.Found)
+                Say("[mutation-proof-pin] " + verdict.Message);
+
+            return;
+        }
+
+        Say("[mutation-proof-pin] " + verdict.Message);
+
+        // Environment.Exit rather than an exception, for the same reason the suite lock does it: an
+        // exception thrown from a module initializer surfaces as a type-initialization failure on whichever
+        // test happened to touch this type first, and reads as an unrelated test failure. Stopping the
+        // process is unambiguous - no test ran, and the reason is the last thing on the console.
+        Console.Out.Flush();
+        Console.Error.Flush();
+        Environment.Exit(ContaminatedTreeExitCode);
+    }
+
+    private static PinReading ReadPinFor(string workingTreeRoot)
+    {
+        string path;
+        try
+        {
+            path = ComputePinFilePath(PinsDirectory, workingTreeRoot);
+        }
+        catch (Exception ex)
+        {
+            return new PinReading(true, null, "the pins directory could not be located: " + ex.Message);
+        }
+
+        try
+        {
+            if (!File.Exists(path))
+                return new PinReading(false, null, null);
+
+            return ParsePin(File.ReadAllText(path), path);
+        }
+        catch (Exception ex)
+        {
+            // A pin file that EXISTS but cannot be read is a refusal, not an absence. Treating it as an
+            // absence would disarm the guard for exactly the proof that most needs it.
+            return new PinReading(true, null, "the pin file '" + path + "' could not be read: " + ex.Message);
+        }
+    }
+
+    /// <summary>The name of the ledger every pinned run in every working tree appends to.</summary>
+    internal const string ProofLedgerFileName = "mutation-proof-ledger.log";
+
+    /// <summary>
+    /// Everything about one run that a person reading the ledger in six months needs, gathered as VALUES so
+    /// the line can be produced and asserted without a repository, a clock, or a file system.
+    /// </summary>
+    internal readonly record struct RunRecord(
+        string WhenUtc,
+        int ProcessId,
+        string Assembly,
+        string WorkingTreeRoot,
+        string SessionIdentifier,
+        PinReading Pin,
+        TreeReading Tree,
+        Verdict Verdict);
+
+    /// <summary>
+    /// Renders one ledger line.
+    ///
+    /// It states a POSITIVE FACT on admission - which head was verified, and that the tree matched it -
+    /// rather than merely failing to complain. That distinction is the whole value of the ledger: a record
+    /// written only on refusal cannot afterwards distinguish a proof that was verified clean from a proof
+    /// where this guard never ran at all. Both would be silence.
+    ///
+    /// One line per run, key=value, so it can be read by eye and grepped by anybody, and so a partially
+    /// written line from an interrupted process cannot corrupt its neighbours.
+    /// </summary>
+    internal static string FormatRunRecord(RunRecord record)
+    {
+        var pin = record.Pin.Pin;
+
+        var phase = record.Pin.Problem is not null
+            ? "unreadable-pin"
+            : pin is null ? "unpinned" : pin.Phase;
+
+        var pinnedHead = pin?.PinnedHead ?? "(none)";
+        var observedHead = record.Tree.Read ? record.Tree.Head : "(unreadable)";
+
+        var headVerified = pin is not null
+            && record.Tree.Read
+            && string.Equals(pin.PinnedHead, record.Tree.Head, StringComparison.OrdinalIgnoreCase);
+
+        var changes = !record.Tree.Read
+            ? "(unreadable: " + (record.Tree.Problem ?? "no detail") + ")"
+            : record.Tree.Changes.Count == 0
+                ? "none"
+                : string.Join(" | ", record.Tree.Changes.Select(c => c.StatusCode + " " + c.Path));
+
+        // The positive statement, spelled out in words a person can read without knowing this format. It is
+        // deliberately a sentence rather than a flag, because whoever reads this in six months will be
+        // deciding whether to trust a merged proof, and a bare "ok=1" is not an answer to that question.
+        var finding = record.Verdict.Admitted
+            ? pin is null
+                ? "NOT PART OF A PROOF - this run was not declared a baseline or a mutation arm, so nothing "
+                  + "was verified about its tree; the observed state is recorded above for later reference."
+                : "VERIFIED - the working tree was checked against pinned head " + pinnedHead
+                  + " and MATCHED it, carrying exactly the declared changes for phase '" + phase
+                  + "'. This run's results were produced on that tree."
+            : "REFUSED - the working tree did NOT match what the proof pinned, and NO TESTS RAN in this "
+              + "process. Any numbers attributed to this run are not from this run.";
+
+        return string.Join("  ", new[]
+        {
+            record.WhenUtc,
+            "verdict=" + (record.Verdict.Admitted ? "admitted" : "refused"),
+            "phase=" + phase,
+            "pinnedHead=" + pinnedHead,
+            "observedHead=" + observedHead,
+            "headVerified=" + (headVerified ? "yes" : "no"),
+            "declaredMutations=" + (pin is null || pin.DeclaredMutations.Count == 0
+                ? "(none)"
+                : string.Join(",", pin.DeclaredMutations)),
+            "observedChanges=" + changes,
+            "tree=" + record.WorkingTreeRoot,
+            "assembly=" + record.Assembly,
+            "pid=" + record.ProcessId.ToString(CultureInfo.InvariantCulture),
+            "session=" + record.SessionIdentifier,
+            "finding=" + finding,
+        });
+    }
+
+    /// <summary>
+    /// Appends this run to the ledger, and to a per-tree record beside it.
+    ///
+    /// TWO FILES ON PURPOSE. The per-tree record carries the high-volume traffic - every ordinary
+    /// unpinned run - and is where you look when a FORGOTTEN pin has to be reconstructed for one tree. The
+    /// ledger carries only runs that declared themselves part of a proof, so it stays small enough that the
+    /// question "show me every proof run ever taken on this machine, and whether each one was verified" is
+    /// answered by reading one file top to bottom. Mixing them would bury the second in the first.
+    ///
+    /// BOTH LIVE OUTSIDE EVERY WORKING TREE, which is the point: "git worktree remove" is correct hygiene
+    /// and it is also what destroyed the evidence for four already-merged proofs. Nothing here is stored
+    /// anywhere that removal can reach.
+    ///
+    /// It can never fail a run. Every failure is swallowed, because a channel whose only job is to explain
+    /// a problem must never be able to cause one.
+    /// </summary>
+    private static void Record(string workingTreeRoot, PinReading pin, TreeReading tree, Verdict verdict)
+    {
+        try
+        {
+            var line = FormatRunRecord(new RunRecord(
+                WhenUtc: DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture),
+                ProcessId: Environment.ProcessId,
+                Assembly: Path.GetFileName(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar)),
+                WorkingTreeRoot: workingTreeRoot,
+                SessionIdentifier: SessionIdentifier(),
+                Pin: pin,
+                Tree: tree,
+                Verdict: verdict));
+
+            var directory = PinsDirectory;
+            Directory.CreateDirectory(directory);
+
+            var perTree = ComputePinFilePath(directory, workingTreeRoot) + ".runs.log";
+            TrimIfLarge(perTree);
+            Append(perTree, line);
+
+            if (pin.Found)
+            {
+                // Never trimmed. It only grows by one line per proof run, and a ledger that discards its
+                // oldest entries is exactly useless for the question it exists to answer, which is always
+                // about something that happened a while ago.
+                Append(Path.Combine(directory, ProofLedgerFileName), line);
+            }
+        }
+        catch (Exception)
+        {
+            // Diagnostics only. See the remarks above: this must never be able to break a run.
+        }
+    }
+
+    /// <summary>
+    /// Appends one line, retrying briefly around the sharing conflicts that happen when several test
+    /// assemblies start at once. A lost ledger line is a lost fact, so it is worth a few attempts - but
+    /// never worth failing the run, so the attempts are bounded and the last failure is swallowed by the
+    /// caller.
+    /// </summary>
+    private static void Append(string path, string line)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                File.AppendAllText(path, line + Environment.NewLine);
+                return;
+            }
+            catch (IOException) when (attempt < 10)
+            {
+                Thread.Sleep(25);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Identifies the run for whoever reads the ledger later. Every fleet-launched session carries
+    /// CC_SESSION_ID, which is the case that matters - it names the session whose proof this was. A run
+    /// started outside the fleet says so rather than inventing an identity.
+    /// </summary>
+    private static string SessionIdentifier()
+    {
+        var id = Environment.GetEnvironmentVariable("CC_SESSION_ID");
+        return string.IsNullOrWhiteSpace(id) ? "(none)" : id;
+    }
+
+    private static void TrimIfLarge(string recordPath)
+    {
+        var info = new FileInfo(recordPath);
+        if (!info.Exists || info.Length <= RunRecordMaxBytes)
+            return;
+
+        var lines = File.ReadAllLines(recordPath);
+        File.WriteAllLines(recordPath, lines.Skip(Math.Max(0, lines.Length - RunRecordKeepLines)));
+    }
+
+    /// <summary>
+    /// Says it on standard output, standard error, and the attached terminal.
+    ///
+    /// Three channels for the reason the suite lock documents: "dotnet test" launches the test host as a
+    /// child with its standard streams redirected and, at the default console verbosity, relays none of
+    /// that output. A refusal nobody sees is indistinguishable from a crash, and somebody will go looking
+    /// for the wrong fault.
+    /// </summary>
+    private static void Say(string message)
+    {
+        var stamped = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)
+            + " pid " + Environment.ProcessId.ToString(CultureInfo.InvariantCulture) + ": " + message;
+
+        Console.Out.WriteLine(stamped);
+        Console.Out.Flush();
+        Console.Error.WriteLine(stamped);
+        Console.Error.Flush();
+
+        var device = OperatingSystem.IsWindows() ? "CONOUT$" : "/dev/tty";
+        try
+        {
+            using var terminal = new StreamWriter(
+                new FileStream(device, FileMode.Open, FileAccess.Write, FileShare.ReadWrite));
+            terminal.WriteLine(stamped);
+            terminal.Flush();
+        }
+        catch (Exception)
+        {
+            // No terminal is attached (a scheduled run, a continuous-integration agent, a redirected pipe
+            // with no console). The standard streams above already carry the message.
+        }
+    }
+}

--- a/src/TestInfrastructure/MutationProofPinGuard.cs
+++ b/src/TestInfrastructure/MutationProofPinGuard.cs
@@ -51,8 +51,15 @@ namespace CcDirector.TestInfrastructure;
 /// A worker halfway through a rework is legitimately dirty and must be able to run whatever it likes,
 /// whenever it likes. Only a baseline and a mutation arm carry a MEANING that depends on the tree being
 /// exactly the pinned head. A blanket guard would be switched off inside a day, and a guard that gets
-/// switched off protects nothing at all. So the guard is inert - it does not even invoke git - unless the
-/// tree has an active pin.
+/// switched off protects nothing at all. So an unpinned run is never REFUSED, whatever state its tree is in.
+///
+/// WHAT AN UNPINNED RUN DOES COST, stated plainly because an earlier version of this comment claimed the
+/// guard was "inert" and did "not even invoke git" unless pinned, and that was simply untrue. Every run of
+/// every test assembly invokes git twice - once for the head, once for the working tree's changes - and
+/// appends one line to a log outside the tree. That is roughly a fifth of a second per assembly against a
+/// suite measured in minutes, and it is deliberate: it is the entire reason a FORGOTTEN pin is still
+/// answerable afterwards. But it is a real cost on every ordinary run, it is not nothing, and anybody
+/// weighing this mechanism should weigh what it actually does.
 ///
 /// HOW A RUN DECLARES ITSELF PART OF A PROOF, AND WHY THAT IS HARD TO FORGET.
 ///
@@ -162,8 +169,16 @@ internal static class MutationProofPinGuard
         public override string ToString() => StatusCode + " " + Path;
     }
 
-    /// <summary>A proof's declaration for one working tree.</summary>
+    /// <summary>
+    /// A proof's declaration for one working tree.
+    ///
+    /// <c>ProofId</c> is the proof's identity, minted once when the baseline is pinned and CARRIED
+    /// UNCHANGED through the phase transition to the arm. It exists so that the one property this whole
+    /// design rests on - that the pinned head does not move for the life of a proof - can be CHECKED rather
+    /// than assumed. See <see cref="DetectMovedPin"/>.
+    /// </summary>
     internal sealed record ProofPin(
+        string ProofId,
         string Phase,
         string PinnedHead,
         string PinnedUtc,
@@ -189,10 +204,19 @@ internal static class MutationProofPinGuard
     internal sealed record Verdict(bool Admitted, string Message);
 
     /// <summary>
+    /// Convenience for the many cases where no proof has run before, so there is no history to check.
+    /// </summary>
+    internal static Verdict Decide(PinReading pin, TreeReading tree) =>
+        Decide(pin, tree, Array.Empty<string>());
+
+    /// <summary>
     /// The rule, in one place. Collects EVERY problem rather than stopping at the first, so a worker fixes
     /// the tree in one pass instead of discovering the second fault after another nine-minute run.
+    ///
+    /// <paramref name="priorLedgerLines"/> is this machine's record of every earlier proof run. It is what
+    /// lets the guard check its own foundation - see <see cref="DetectMovedPin"/>.
     /// </summary>
-    internal static Verdict Decide(PinReading pin, TreeReading tree)
+    internal static Verdict Decide(PinReading pin, TreeReading tree, IReadOnlyList<string> priorLedgerLines)
     {
         if (pin.Problem is not null)
         {
@@ -226,6 +250,10 @@ internal static class MutationProofPinGuard
         }
 
         var problems = new List<string>();
+
+        var moved = DetectMovedPin(active, priorLedgerLines);
+        if (moved is not null)
+            problems.Add(moved);
 
         if (!string.Equals(active.PinnedHead, tree.Head, StringComparison.OrdinalIgnoreCase))
         {
@@ -305,6 +333,86 @@ internal static class MutationProofPinGuard
             + "powershell -File scripts/mutation-proof-pin.ps1 release");
     }
 
+    /// <summary>
+    /// Checks the one property this entire design rests on: THAT THE PINNED HEAD DOES NOT MOVE FOR THE LIFE
+    /// OF A PROOF.
+    ///
+    /// WHY THIS EXISTS, AND WHY IT IS NOT A RESTATEMENT OF THE SCRIPT'S BEHAVIOUR.
+    ///
+    /// A pinned head is what makes a baseline and its arm comparable. Everything else here - the refusal on
+    /// an undeclared change, the refusal on a missing mutation - is worthless if the pin itself can shift
+    /// underneath the proof, because then the two runs are simply measured against whatever each happened
+    /// to see.
+    ///
+    /// That property was the one thing nothing checked, and the reason it was missed is worth writing down:
+    /// the pin not moving is the PREMISE, so no test was aimed at it. The property that justifies a design
+    /// is the property nothing exercises, precisely because the whole design assumes it. A reviewer then
+    /// found that the supported workflow BROKE it - "set -Phase arm" recomputed the head, so a head that
+    /// moved between the baseline and the arm was silently re-pinned and the arm ADMITTED. The guard's
+    /// documented happy path walked into the exact event the guard exists to refuse.
+    ///
+    /// The script is fixed. This is the SECOND mechanism, and it is here because fixing the script only
+    /// fixes the instance. This one holds no matter how the pin file came to say what it says - a future
+    /// edit to the script, a hand-edited pin, a copied file, a tool nobody has written yet. The identity is
+    /// the proof id; the ledger is the memory. If any earlier run of THIS proof was measured against a
+    /// different head, this proof's foundation moved, and every number it produced is incomparable.
+    ///
+    /// It fails CLOSED on a malformed prior line: a ledger entry that names this proof but whose head
+    /// cannot be read is treated as a mismatch, because the alternative is to skip the check on exactly the
+    /// input that is already wrong.
+    /// </summary>
+    internal static string? DetectMovedPin(ProofPin pin, IReadOnlyList<string> priorLedgerLines)
+    {
+        if (string.IsNullOrWhiteSpace(pin.ProofId))
+            return null;
+
+        foreach (var line in priorLedgerLines)
+        {
+            var proofId = ReadLedgerField(line, "proofId");
+            if (proofId is null || !string.Equals(proofId, pin.ProofId, StringComparison.Ordinal))
+                continue;
+
+            var earlierHead = ReadLedgerField(line, "pinnedHead");
+            if (earlierHead is not null
+                && string.Equals(earlierHead, pin.PinnedHead, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            return "THIS PROOF'S PINNED HEAD HAS MOVED SINCE AN EARLIER RUN OF THE SAME PROOF. Proof "
+                + pin.ProofId + " was measured against " + (earlierHead ?? "(a head this ledger line does "
+                + "not record)") + " at " + (ReadLedgerField(line, "when") ?? "an earlier run")
+                + ", and the pin now says " + pin.PinnedHead + "."
+                + Environment.NewLine
+                + "    A proof's pinned head is its identity: a baseline and its mutation arm must be taken "
+                + "at the SAME commit or the reconciliation compares two different programs and means "
+                + "nothing. Re-pinning midway is not a correction, it is a new proof - so the numbers "
+                + "already collected under this proof id cannot be reconciled against anything collected "
+                + "now." + Environment.NewLine
+                + "    Start again: release the pin, return the tree to the head you intend to measure, and "
+                + "pin a fresh baseline.";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reads one key from a ledger line. The line is key=value pairs joined by two spaces, so a value may
+    /// contain single spaces (paths do) but never two - which is what makes this readable by eye and
+    /// parseable without quoting.
+    /// </summary>
+    internal static string? ReadLedgerField(string line, string key)
+    {
+        foreach (var field in line.Split("  ", StringSplitOptions.RemoveEmptyEntries))
+        {
+            var split = field.IndexOf('=');
+            if (split > 0 && string.Equals(field[..split].Trim(), key, StringComparison.Ordinal))
+                return field[(split + 1)..].Trim();
+        }
+
+        return null;
+    }
+
     private static string Describe(ProofPin pin)
     {
         var mutations = pin.DeclaredMutations.Count == 0
@@ -334,6 +442,7 @@ internal static class MutationProofPinGuard
         string? phase = null;
         string? head = null;
         string? pinnedUtc = null;
+        string? proofId = null;
         var note = "";
         var mutations = new List<string>();
 
@@ -360,6 +469,9 @@ internal static class MutationProofPinGuard
                     break;
                 case "pinnedUtc":
                     pinnedUtc = value;
+                    break;
+                case "proofId":
+                    proofId = value;
                     break;
                 case "mutates":
                     if (value.Length > 0)
@@ -412,9 +524,24 @@ internal static class MutationProofPinGuard
                 + "any tree at all, which is the opposite of what this guard is for.");
         }
 
+        if (string.IsNullOrWhiteSpace(proofId))
+        {
+            // Required, and a refusal rather than a default, because the proof id is what lets the guard
+            // check that this proof's head never moved. Inventing one here would mint a NEW identity on
+            // every run, and the moved-pin check would then never fire while appearing to be in force -
+            // the guard would be reporting on a proof that, as far as it could tell, had just begun.
+            return Malformed(
+                pinFilePath,
+                "it declares no proofId. That identity is what lets the guard detect a pinned head that "
+                + "moved midway through a proof, so a pin without one cannot be checked against its own "
+                + "history. Release this pin and set it again with the current script.");
+        }
+
         return new PinReading(
             true,
-            new ProofPin(phase, head.ToLowerInvariant(), pinnedUtc ?? "(not recorded)", mutations, note, pinFilePath),
+            new ProofPin(
+                proofId, phase, head.ToLowerInvariant(), pinnedUtc ?? "(not recorded)",
+                mutations, note, pinFilePath),
             null);
     }
 
@@ -453,60 +580,87 @@ internal static class MutationProofPinGuard
     }
 
     /// <summary>
-    /// The pin file for one working tree. The key is a hash of the tree's path so that two working trees of
-    /// the same repository - which is how every mission here is run - hold independent pins.
-    ///
-    /// SHA-256 rather than a runtime hash code, because this name is written to disk and must mean the same
-    /// thing in the next process. The leaf directory name is kept in front of the hash so a human reading
-    /// the pins directory can tell at a glance which tree each pin belongs to.
+    /// The pin file's name inside the repository's git directory. Read by this guard, WRITTEN by
+    /// scripts/mutation-proof-pin.ps1, and therefore the one string the two must agree on - which is why
+    /// TheScriptAndTheGuardAgreeOnThePinFileName reads the script's own text and compares it against this
+    /// constant.
     /// </summary>
-    internal static string ComputePinFilePath(string pinsDirectory, string workingTreeRoot)
+    internal const string PinFileName = "cc-director-mutation-proof.pin";
+
+    /// <summary>
+    /// The pin lives inside the repository's GIT DIRECTORY, and both the writer and this reader locate it
+    /// by asking git the same question.
+    ///
+    /// THIS REPLACED A DERIVATION, AND THE REASON IS THE BUG IT REMOVES. The first version computed the
+    /// pin's location from the working tree path - a per-user directory, a sanitized leaf name and a
+    /// SHA-256 - which meant the PowerShell writer and this C# reader each carried their own copy of that
+    /// derivation. A reviewer found that the two copies did not agree: the writer used one location on
+    /// every platform while this reader used a different one on Linux and macOS, so on those platforms the
+    /// supported tooling printed "PINNED" while the guard read no pin at all and admitted contaminated
+    /// baselines. Armed according to its own output, inert in fact.
+    ///
+    /// Aligning the two derivations would have fixed that instance and left the CLASS in place: any future
+    /// edit to either copy re-opens it, and the failure is silent in the direction that matters, because a
+    /// guard reading a pin that is not there looks exactly like a guard with nothing to do.
+    ///
+    /// So there is no derivation left to diverge. "git rev-parse --absolute-git-dir" is one question with
+    /// one answer, asked by both sides, on every platform. Four properties come free with it:
+    ///
+    ///   - PER WORKING TREE, BY CONSTRUCTION. In a git worktree this returns .git/worktrees/&lt;name&gt;, so two
+    ///     worktrees of one repository hold independent pins with no hashing and nothing to key.
+    ///   - OUTSIDE THE WORKING TREE. The git directory is not part of "git status", so the pin cannot dirty
+    ///     the tree it is guarding, and needs no exemption from its own rule - an exemption would be a hole.
+    ///   - BEYOND "git clean -xdf", which does not touch the git directory. That is housekeeping a worker
+    ///     runs in the middle of a proof.
+    ///   - NOT MOVABLE BY THE ENVIRONMENT. The answer belongs to the repository, not to whoever launched
+    ///     the run - the property the per-user suite lock had to be repaired to obtain.
+    ///
+    /// The pin dying with "git worktree remove" is correct: a proof in a removed worktree is over. The
+    /// LEDGER is what must outlive the tree, and it lives elsewhere - see <see cref="LedgerDirectory"/>.
+    /// </summary>
+    internal static string? ResolveGitDirectory(string workingTreeRoot)
     {
-        var normalized = workingTreeRoot.Replace('\\', '/').TrimEnd('/').ToLowerInvariant();
-        var digest = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)))
-            .ToLowerInvariant();
+        var result = RunGit(workingTreeRoot, "--no-optional-locks rev-parse --absolute-git-dir");
+        if (result.ExitCode != 0)
+            return null;
 
-        var leaf = new string(Path.GetFileName(normalized.TrimEnd('/'))
-            .Select(c => char.IsLetterOrDigit(c) || c is '-' or '_' ? c : '-')
-            .ToArray());
+        var path = result.Output.Trim();
+        return path.Length == 0 ? null : path;
+    }
 
-        if (leaf.Length > 40)
-            leaf = leaf[..40];
-
-        return Path.Combine(pinsDirectory, leaf + "-" + digest[..16] + ".pin");
+    /// <summary>The pin file for the working tree rooted at the given path, or null when git cannot say.</summary>
+    internal static string? ResolvePinFilePath(string workingTreeRoot)
+    {
+        var gitDirectory = ResolveGitDirectory(workingTreeRoot);
+        return gitDirectory is null ? null : Path.Combine(gitDirectory, PinFileName);
     }
 
     /// <summary>
-    /// Where pins live: beside the per-user suite lock, under the per-user local application data
-    /// directory, and NOT anywhere the process environment can move - for the same reason the suite lock
-    /// is derived that way. A pin the launching environment can relocate is a pin two runs of the same
-    /// proof would not share.
+    /// Where the LEDGER lives - deliberately NOT in the git directory, because it has the opposite
+    /// requirement to the pin: it must survive "git worktree remove", which is exactly what destroyed the
+    /// evidence for four already-merged proofs.
+    ///
+    /// ONE RULE ON EVERY PLATFORM, and no branch on the operating system. The branch is what the reviewer
+    /// caught in the pin path, and it is not worth keeping here for a different reason: the framework's
+    /// local-application-data folder is defined on every platform this runs on, and both this reader and
+    /// the script obtain it by calling that same framework method rather than by each spelling out a
+    /// platform's convention.
     /// </summary>
-    internal static string ComputePinsDirectory(bool isWindows, string localApplicationDataFolder, string userName)
+    internal static string ComputeLedgerDirectory(string localApplicationDataFolder)
     {
-        if (!isWindows)
-        {
-            // Built by hand: the separator belongs to the target platform, not the running one.
-            return "/tmp/cc-director-" + userName + "-mutation-proof-pins";
-        }
-
         if (string.IsNullOrWhiteSpace(localApplicationDataFolder))
         {
             throw new InvalidOperationException(
-                "Cannot locate the per-user local application data directory, so mutation-proof pins have "
-                + "no environment-independent home. Every alternative location is settable by whoever "
-                + "launched the run, which would let the baseline and the mutation arm read different "
-                + "pins. See MutationProofPinGuard.");
+                "Cannot locate the per-user local application data directory, so the mutation-proof ledger "
+                + "has no home. See MutationProofPinGuard.");
         }
 
         return Path.Combine(localApplicationDataFolder, "cc-director", "mutation-proof-pins");
     }
 
-    private static string PinsDirectory => ComputePinsDirectory(
-        OperatingSystem.IsWindows(),
+    private static string LedgerDirectory => ComputeLedgerDirectory(
         Environment.GetFolderPath(
-            Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify),
-        Environment.UserName);
+            Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify));
 
     // ---------------------------------------------------------------------------------------------------
     // Reading the tree, via git.
@@ -654,7 +808,12 @@ internal static class MutationProofPinGuard
 
         var pin = ReadPinFor(root);
         var tree = ReadTree(root);
-        var verdict = Decide(pin, tree);
+
+        // Read only when a pin is active. An unpinned run has no proof identity to compare against, and
+        // reading the ledger on every ordinary run would be cost for nothing.
+        var priorLedgerLines = pin.Found ? ReadLedger() : Array.Empty<string>();
+
+        var verdict = Decide(pin, tree, priorLedgerLines);
 
         LastVerdictSummary = (verdict.Admitted ? "admitted" : "refused") + ": " + verdict.Message;
 
@@ -686,14 +845,13 @@ internal static class MutationProofPinGuard
 
     private static PinReading ReadPinFor(string workingTreeRoot)
     {
-        string path;
-        try
+        var path = ResolvePinFilePath(workingTreeRoot);
+        if (path is null)
         {
-            path = ComputePinFilePath(PinsDirectory, workingTreeRoot);
-        }
-        catch (Exception ex)
-        {
-            return new PinReading(true, null, "the pins directory could not be located: " + ex.Message);
+            // Git could not name its own directory. There is no pin to find and no way to know whether one
+            // exists, so nothing is claimed - the run is admitted, and the ledger records that this run
+            // verified nothing rather than that it was clean.
+            return new PinReading(false, null, null);
         }
 
         try
@@ -713,6 +871,49 @@ internal static class MutationProofPinGuard
 
     /// <summary>The name of the ledger every pinned run in every working tree appends to.</summary>
     internal const string ProofLedgerFileName = "mutation-proof-ledger.log";
+
+    /// <summary>
+    /// Every run, pinned or not - the high-volume record, trimmed. This is where a FORGOTTEN pin is
+    /// reconstructed from: it says whether the tree was dirty when a baseline ran even though nobody
+    /// declared that run a baseline.
+    /// </summary>
+    internal const string AllRunsFileName = "mutation-proof-all-runs.log";
+
+    /// <summary>
+    /// This machine's record of every proof run, oldest first.
+    ///
+    /// Read with full sharing, because several test assemblies start at once and one of them may be
+    /// appending. An unreadable ledger returns nothing rather than throwing: it must never break a run, and
+    /// the moved-pin check it feeds is an ADDITIONAL mechanism - the head comparison against the working
+    /// tree still runs regardless.
+    /// </summary>
+    private static IReadOnlyList<string> ReadLedger()
+    {
+        try
+        {
+            var path = Path.Combine(LedgerDirectory, ProofLedgerFileName);
+            if (!File.Exists(path))
+                return Array.Empty<string>();
+
+            using var stream = new FileStream(
+                path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var reader = new StreamReader(stream);
+
+            var lines = new List<string>();
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                if (line.Length > 0)
+                    lines.Add(line);
+            }
+
+            return lines;
+        }
+        catch (Exception)
+        {
+            return Array.Empty<string>();
+        }
+    }
 
     /// <summary>
     /// Everything about one run that a person reading the ledger in six months needs, gathered as VALUES so
@@ -775,8 +976,11 @@ internal static class MutationProofPinGuard
 
         return string.Join("  ", new[]
         {
-            record.WhenUtc,
+            "when=" + record.WhenUtc,
             "verdict=" + (record.Verdict.Admitted ? "admitted" : "refused"),
+            // The proof's identity, and the reason the ledger is more than a diary: it is what a later run
+            // of the SAME proof compares its pinned head against, so a head that moved midway is caught.
+            "proofId=" + (pin?.ProofId ?? "(none)"),
             "phase=" + phase,
             "pinnedHead=" + pinnedHead,
             "observedHead=" + observedHead,
@@ -823,12 +1027,16 @@ internal static class MutationProofPinGuard
                 Tree: tree,
                 Verdict: verdict));
 
-            var directory = PinsDirectory;
+            var directory = LedgerDirectory;
             Directory.CreateDirectory(directory);
 
-            var perTree = ComputePinFilePath(directory, workingTreeRoot) + ".runs.log";
-            TrimIfLarge(perTree);
-            Append(perTree, line);
+            // Every run, pinned or not, in one file. It used to be split per working tree by a hashed file
+            // name; that hash was the derivation the PowerShell writer had to reproduce, and reproducing it
+            // is what diverged. Every line already carries "tree=", so the split bought nothing that a
+            // search does not, and removing it removed a whole class of disagreement.
+            var allRuns = Path.Combine(directory, AllRunsFileName);
+            TrimIfLarge(allRuns);
+            Append(allRuns, line);
 
             if (pin.Found)
             {

--- a/src/TestInfrastructure/MutationProofPinGuard.cs
+++ b/src/TestInfrastructure/MutationProofPinGuard.cs
@@ -843,7 +843,19 @@ internal static class MutationProofPinGuard
         Environment.Exit(ContaminatedTreeExitCode);
     }
 
-    private static PinReading ReadPinFor(string workingTreeRoot)
+    /// <summary>
+    /// Everything the module initializer does to reach a verdict, minus stopping the process: find the pin
+    /// on disk, read the working tree, and decide against the given history.
+    ///
+    /// This exists so the proofs can be TESTS instead of a sequence somebody drove by hand once. The
+    /// end-to-end refusals were originally demonstrated by hand on one machine, which proves the mechanism
+    /// worked that day and protects nothing afterwards - a script or a path can regress and the hand-run
+    /// evidence, being prose in a pull request, cannot notice.
+    /// </summary>
+    internal static Verdict Evaluate(string workingTreeRoot, IReadOnlyList<string> priorLedgerLines) =>
+        Decide(ReadPinFor(workingTreeRoot), ReadTree(workingTreeRoot), priorLedgerLines);
+
+    internal static PinReading ReadPinFor(string workingTreeRoot)
     {
         var path = ResolvePinFilePath(workingTreeRoot);
         if (path is null)
@@ -887,11 +899,18 @@ internal static class MutationProofPinGuard
     /// the moved-pin check it feeds is an ADDITIONAL mechanism - the head comparison against the working
     /// tree still runs regardless.
     /// </summary>
-    private static IReadOnlyList<string> ReadLedger()
+    private static IReadOnlyList<string> ReadLedger() => ReadLedger(LedgerDirectory);
+
+    /// <summary>
+    /// The ledger in a nominated directory. Parameterised so the whole on-disk path - a real pin file, a
+    /// real working tree, a real ledger - can be driven by a test rather than only by a person following a
+    /// sequence by hand. A proof nobody can re-run is not a regression test.
+    /// </summary>
+    internal static IReadOnlyList<string> ReadLedger(string ledgerDirectory)
     {
         try
         {
-            var path = Path.Combine(LedgerDirectory, ProofLedgerFileName);
+            var path = Path.Combine(ledgerDirectory, ProofLedgerFileName);
             if (!File.Exists(path))
                 return Array.Empty<string>();
 

--- a/src/TestInfrastructure/MutationProofPinGuard.cs
+++ b/src/TestInfrastructure/MutationProofPinGuard.cs
@@ -310,6 +310,7 @@ internal static class MutationProofPinGuard
                 return new Verdict(true, "No mutation-proof pin is active for this working tree.");
 
             case PinOutcome.CouldNotDetermine:
+                // CONTROL (preventing) - pinned state unknown. Test: OnlyASettledAbsenceAdmits.
                 return new Verdict(
                     false,
                     "CANNOT ESTABLISH WHETHER A MUTATION PROOF IS ACTIVE IN THIS WORKING TREE: "
@@ -347,6 +348,8 @@ internal static class MutationProofPinGuard
 
         if (!tree.Read)
         {
+            // CONTROL (preventing) - a pinned run whose tree cannot be read. Test:
+            // AnActivePinIsNeverTreatedAsAbsentWhenGitIsUnavailable, APinnedRunThatCannotReadTheTreeIsRefused.
             return new Verdict(
                 false,
                 "This run is declared part of a mutation proof (" + Describe(active) + "), but the state of "
@@ -360,6 +363,8 @@ internal static class MutationProofPinGuard
 
         if (!ledger.Read)
         {
+            // CONTROL (preventing) - protects the moved-pin control below, which cannot run without a
+            // history. Test: AProofHistoryThatCannotBeReadRefuses_RatherThanReadingAsNoHistory.
             // The history is what proves this proof's pinned head has not moved. Without it that check
             // cannot run, and an unreadable history silently disabling a safety mechanism is exactly the
             // shape this guard exists to refuse.
@@ -375,6 +380,9 @@ internal static class MutationProofPinGuard
         switch (publication.Outcome)
         {
             case HeadPublication.NotPublished:
+                // CONTROL (VISIBILITY, not preventing) - does NOT stop a stashed repair; makes the commit
+                // the numbers are attributed to fetchable, so a missing repair is visible in the record
+                // rather than only on this machine. Test: APinnedCommitThatWasNeverPushedIsRefused.
                 problems.Add(
                     "THE PINNED COMMIT HAS NOT BEEN PUSHED, so the numbers this run produces would be "
                     + "attributed to a commit nobody else can fetch or read."
@@ -408,12 +416,17 @@ internal static class MutationProofPinGuard
                 break;
         }
 
+        // CONTROL (preventing) - the second mechanism, catching a pin that names a different head
+        // however it came to say so. Test: AProofWhoseHeadMovedSinceAnEarlierRunOfTheSameProofIsRefused,
+        // APinReWrittenToANewHeadIsRefusedFromDisk_EvenThoughTheTreeMatchesItExactly.
         var moved = DetectMovedPin(active, priorLedgerLines);
         if (moved is not null)
             problems.Add(moved);
 
         if (!string.Equals(active.PinnedHead, tree.Head, StringComparison.OrdinalIgnoreCase))
         {
+            // CONTROL (preventing) - baseline and arm must be the same commit. Test:
+            // ABaselineOnATreeWhoseHeadHasMovedIsRefused_AndNamesBothHeads.
             problems.Add(
                 "THE HEAD HAS MOVED. This proof pinned " + active.PinnedHead + ", and the working tree is "
                 + "now at " + tree.Head + ". A baseline and its mutation arm must be taken at the same "
@@ -434,6 +447,8 @@ internal static class MutationProofPinGuard
 
         if (undeclared.Count > 0)
         {
+            // CONTROL (preventing) - the 2026-07-19 event. Test:
+            // ABaselineOverAnUncommittedlyDeletedGuardBlockIsRefused_AndTheRefusalNamesTheFile.
             problems.Add(
                 "THE WORKING TREE CARRIES " + undeclared.Count.ToString(CultureInfo.InvariantCulture)
                 + " CHANGE(S) THIS PROOF DID NOT DECLARE:"
@@ -452,6 +467,8 @@ internal static class MutationProofPinGuard
 
         if (missing.Count > 0)
         {
+            // CONTROL (preventing) - an arm with no mutation is a second baseline. Test:
+            // AnArmWhoseDeclaredMutationIsAbsentIsRefused_BecauseItIsASecondBaselineInDisguise.
             problems.Add(
                 "THE DECLARED MUTATION IS NOT IN THE WORKING TREE:"
                 + Environment.NewLine
@@ -1599,6 +1616,11 @@ internal static class MutationProofPinGuard
     /// </summary>
     private static void Record(string workingTreeRoot, PinReading pin, TreeReading tree, Verdict verdict)
     {
+        // CONTROL (VISIBILITY, not preventing) - stops nothing; makes what each run verified answerable
+        // afterwards, by someone else, once this working tree is gone. Judge it by whether the failure it
+        // exposes has another way of being seen, not by whether it prevents one. Tests:
+        // AnAdmittedBaselineIsRecordedAsAPositiveVerifiedFact_NotAsAnAbsenceOfComplaint,
+        // TheLedgerLivesOutsideEveryWorkingTree_SoWorktreeRemovalCannotDestroyIt.
         try
         {
             var line = FormatRunRecord(new RunRecord(

--- a/src/TestInfrastructure/MutationProofPinGuard.cs
+++ b/src/TestInfrastructure/MutationProofPinGuard.cs
@@ -248,6 +248,10 @@ internal static class MutationProofPinGuard
     internal static Verdict Decide(PinReading pin, TreeReading tree) =>
         Decide(pin, tree, Array.Empty<string>());
 
+    /// <summary>The same, given a history that was read successfully.</summary>
+    internal static Verdict Decide(PinReading pin, TreeReading tree, IReadOnlyList<string> priorLedgerLines) =>
+        Decide(pin, tree, LedgerReading.Of(priorLedgerLines));
+
     /// <summary>
     /// The rule, in one place. Collects EVERY problem rather than stopping at the first, so a worker fixes
     /// the tree in one pass instead of discovering the second fault after another nine-minute run.
@@ -255,8 +259,14 @@ internal static class MutationProofPinGuard
     /// <paramref name="priorLedgerLines"/> is this machine's record of every earlier proof run. It is what
     /// lets the guard check its own foundation - see <see cref="DetectMovedPin"/>.
     /// </summary>
-    internal static Verdict Decide(PinReading pin, TreeReading tree, IReadOnlyList<string> priorLedgerLines)
+    internal static Verdict Decide(PinReading pin, TreeReading tree, LedgerReading ledger) =>
+        Decide(pin, tree, ledger, new HeadPublicationReading(HeadPublication.NoRemoteConfigured, null));
+
+    /// <summary>The whole rule, including whether the pinned commit is one anybody else can read.</summary>
+    internal static Verdict Decide(
+        PinReading pin, TreeReading tree, LedgerReading ledger, HeadPublicationReading publication)
     {
+        var priorLedgerLines = ledger.Lines;
         // THE ONLY ADMIT IN THIS METHOD IS THE ONE BELOW, AND IT IS REACHABLE FROM ONE STATE.
         //
         // Everything else - a pin that cannot be parsed, a location that cannot be resolved, a state this
@@ -319,6 +329,56 @@ internal static class MutationProofPinGuard
         }
 
         var problems = new List<string>();
+
+        if (!ledger.Read)
+        {
+            // The history is what proves this proof's pinned head has not moved. Without it that check
+            // cannot run, and an unreadable history silently disabling a safety mechanism is exactly the
+            // shape this guard exists to refuse.
+            problems.Add(
+                "THE PROOF HISTORY COULD NOT BE READ, so this run cannot be checked against earlier runs "
+                + "of the same proof: " + (ledger.Problem ?? "(no detail)")
+                + Environment.NewLine
+                + "    That check is the only thing that catches a pinned head which moved midway through "
+                + "a proof, so proceeding without it would mean running with one of this guard's two "
+                + "mechanisms silently switched off.");
+        }
+
+        switch (publication.Outcome)
+        {
+            case HeadPublication.NotPublished:
+                problems.Add(
+                    "THE PINNED COMMIT HAS NOT BEEN PUSHED, so the numbers this run produces would be "
+                    + "attributed to a commit nobody else can fetch or read."
+                    + Environment.NewLine
+                    + "    This guard can verify that the tree matches the pinned head. It cannot know "
+                    + "what that head was SUPPOSED to contain - so a repair that was stashed rather than "
+                    + "committed leaves a perfectly clean tree at exactly the pinned head, and the arm "
+                    + "measures unrepaired source while every count reconciles. Requiring a published "
+                    + "commit does not close that gap, but it makes it visible to somebody else: the "
+                    + "commit can be fetched and the missing repair seen."
+                    + Environment.NewLine
+                    + "    Commit and push the work this proof is about, then pin a fresh baseline.");
+                break;
+
+            case HeadPublication.CouldNotTell:
+                problems.Add(
+                    "WHETHER THE PINNED COMMIT HAS BEEN PUBLISHED COULD NOT BE ESTABLISHED: "
+                    + (publication.Problem ?? "(no detail)")
+                    + Environment.NewLine
+                    + "    Unknown is not the same as published, and is not treated as it.");
+                break;
+
+            case HeadPublication.Published:
+            case HeadPublication.NoRemoteConfigured:
+                break;
+
+            default:
+                problems.Add(
+                    "The publication state " + publication.Outcome + " is not one this guard recognises, "
+                    + "so it cannot say whether the pinned commit is readable by anyone else.");
+                break;
+        }
 
         var moved = DetectMovedPin(active, priorLedgerLines);
         if (moved is not null)
@@ -628,30 +688,6 @@ internal static class MutationProofPinGuard
     // ---------------------------------------------------------------------------------------------------
 
     /// <summary>
-    /// Walks up from a starting directory to the working tree root - the directory holding ".git". In a git
-    /// worktree ".git" is a FILE rather than a directory, which is the normal case for this repository's
-    /// mission work, so both are accepted.
-    ///
-    /// Returns null when there is no repository above the starting point. That is the honest answer for a
-    /// test assembly copied somewhere else entirely, and it means the guard has nothing to key on; it is
-    /// stated here rather than papered over because it is the one way a proof run could sidestep the guard.
-    /// </summary>
-    internal static string? FindWorkingTreeRoot(string startDirectory)
-    {
-        var directory = new DirectoryInfo(startDirectory);
-        while (directory is not null)
-        {
-            var marker = Path.Combine(directory.FullName, ".git");
-            if (Directory.Exists(marker) || File.Exists(marker))
-                return directory.FullName;
-
-            directory = directory.Parent;
-        }
-
-        return null;
-    }
-
-    /// <summary>
     /// The pin file's name inside the repository's git directory. Read by this guard, WRITTEN by
     /// scripts/mutation-proof-pin.ps1, and therefore the one string the two must agree on - which is why
     /// TheScriptAndTheGuardAgreeOnThePinFileName reads the script's own text and compares it against this
@@ -690,6 +726,84 @@ internal static class MutationProofPinGuard
     /// The pin dying with "git worktree remove" is correct: a proof in a removed worktree is over. The
     /// LEDGER is what must outlive the tree, and it lives elsewhere - see <see cref="LedgerDirectory"/>.
     /// </summary>
+    /// <summary>Whether the commit a proof is pinned to has been published to a remote.</summary>
+    internal enum HeadPublication
+    {
+        /// <summary>The pinned commit exists on a remote, so anyone can fetch and read it.</summary>
+        Published,
+
+        /// <summary>The commit is local only. Refuses.</summary>
+        NotPublished,
+
+        /// <summary>No remote is configured, so publication is not a meaningful question here.</summary>
+        NoRemoteConfigured,
+
+        /// <summary>Could not establish either way. Refuses.</summary>
+        CouldNotTell,
+    }
+
+    internal readonly record struct HeadPublicationReading(HeadPublication Outcome, string? Problem);
+
+    /// <summary>
+    /// Establishes whether the pinned commit exists on a remote.
+    ///
+    /// WHY A PROOF SHOULD ONLY BE TAKEN AT A PUBLISHED COMMIT. This came from another unit on this mission,
+    /// which built the same precondition independently and flagged the overlap rather than shipping a
+    /// duplicate. Its case is the one below, and it is a real gap in what this guard could otherwise
+    /// promise.
+    ///
+    /// This guard verifies that the working tree is exactly the pinned head. A reader will hear something
+    /// stronger - "this arm measured the code under review" - and those are different sentences. The gap
+    /// between them is a STASH: a worker who stashes an uncommitted repair presents a perfectly clean tree
+    /// at exactly the pinned head, this guard admits, and the arm runs on unrepaired source while every
+    /// count reconciles beautifully. That unit nearly lost its tree to a stash the same night.
+    ///
+    /// BE PRECISE ABOUT WHAT THIS DOES AND DOES NOT FIX. It cannot close that gap, because nothing here can
+    /// know what a repair was SUPPOSED to contain. What it does is make the claim CHECKABLE BY SOMEBODY
+    /// ELSE: if the pinned commit must exist on a remote, then the head every number is attributed to is
+    /// one a reviewer can fetch and read, and a stashed repair becomes visible as absent from that commit
+    /// rather than invisible on one machine. It also catches the common shape directly, since a stash
+    /// usually leaves the tree on a local commit that was never pushed.
+    ///
+    /// A COPY restores a snapshot, a CHECKOUT restores the last commit, a STASH restores an index state,
+    /// and none of them restores the state before one mutation. Committing first closes all three - and it
+    /// is also what makes an admission here mean anything.
+    /// </summary>
+    internal static HeadPublicationReading ReadHeadPublication(string workingTreeRoot, string gitExecutable)
+    {
+        var remotes = RunGit(workingTreeRoot, "--no-optional-locks remote", gitExecutable);
+        if (remotes.ExitCode != 0)
+        {
+            return new HeadPublicationReading(
+                HeadPublication.CouldNotTell,
+                "the configured remotes could not be listed: " + Describe(remotes));
+        }
+
+        if (remotes.Output.Trim().Length == 0)
+        {
+            // A repository with nowhere to publish to - a scratch clone, a fixture, an offline experiment.
+            // Publication is not a question that has an answer here, so it is not held against the run.
+            return new HeadPublicationReading(HeadPublication.NoRemoteConfigured, null);
+        }
+
+        var containing = RunGit(
+            workingTreeRoot, "--no-optional-locks branch --remotes --contains HEAD", gitExecutable);
+
+        if (containing.ExitCode != 0)
+        {
+            return new HeadPublicationReading(
+                HeadPublication.CouldNotTell,
+                "whether the pinned commit exists on a remote could not be established: "
+                + Describe(containing));
+        }
+
+        return new HeadPublicationReading(
+            containing.Output.Trim().Length > 0
+                ? HeadPublication.Published
+                : HeadPublication.NotPublished,
+            null);
+    }
+
     /// <summary>What a filesystem probe established about one path.</summary>
     internal enum ProbeOutcome
     {
@@ -1125,11 +1239,17 @@ internal static class MutationProofPinGuard
 
         // Read only when a pin is active. An unpinned run has no proof identity to compare against, and
         // reading the ledger on every ordinary run would be cost for nothing.
-        var priorLedgerLines = pin.Outcome == PinOutcome.NoPinPresent
-            ? Array.Empty<string>()
+        var ledger = pin.Outcome == PinOutcome.NoPinPresent
+            ? LedgerReading.Of(Array.Empty<string>())
             : ReadLedger();
 
-        Finish(root, pin, tree, Decide(pin, tree, priorLedgerLines));
+        // Only asked for a run that is actually part of a proof - it costs two git calls, and an
+        // ordinary run has no claim to make about the commit it sits on.
+        var publication = pin.Outcome == PinOutcome.PinActive && location.WorkingTreeRoot is not null
+            ? ReadHeadPublication(root, GitExecutable)
+            : new HeadPublicationReading(HeadPublication.NoRemoteConfigured, null);
+
+        Finish(root, pin, tree, Decide(pin, tree, ledger, publication));
     }
 
     /// <summary>
@@ -1180,12 +1300,21 @@ internal static class MutationProofPinGuard
     /// evidence, being prose in a pull request, cannot notice.
     /// </summary>
     internal static Verdict Evaluate(string workingTreeRoot, IReadOnlyList<string> priorLedgerLines) =>
-        Evaluate(workingTreeRoot, priorLedgerLines, GitExecutable);
+        Evaluate(workingTreeRoot, LedgerReading.Of(priorLedgerLines), GitExecutable);
+
+    /// <summary>The same, given a history that may or may not have been readable.</summary>
+    internal static Verdict Evaluate(string workingTreeRoot, LedgerReading ledger) =>
+        Evaluate(workingTreeRoot, ledger, GitExecutable);
 
     /// <summary>The same, with the git program named - see <see cref="ReadTree(string, string)"/>.</summary>
     internal static Verdict Evaluate(
         string workingTreeRoot, IReadOnlyList<string> priorLedgerLines, string gitExecutable) =>
-        Decide(ReadPinFor(workingTreeRoot), ReadTree(workingTreeRoot, gitExecutable), priorLedgerLines);
+        Evaluate(workingTreeRoot, LedgerReading.Of(priorLedgerLines), gitExecutable);
+
+    /// <summary>The same, with the git program named - see <see cref="ReadTree(string, string)"/>.</summary>
+    internal static Verdict Evaluate(
+        string workingTreeRoot, LedgerReading ledger, string gitExecutable) =>
+        Decide(ReadPinFor(workingTreeRoot), ReadTree(workingTreeRoot, gitExecutable), ledger);
 
     internal static PinReading ReadPinFor(string workingTreeRoot)
     {
@@ -1273,21 +1402,43 @@ internal static class MutationProofPinGuard
     /// the moved-pin check it feeds is an ADDITIONAL mechanism - the head comparison against the working
     /// tree still runs regardless.
     /// </summary>
-    private static IReadOnlyList<string> ReadLedger() => ReadLedger(LedgerDirectory);
+    /// <summary>
+    /// The proof history, and whether it could actually be read.
+    ///
+    /// TYPED FOR THE SAME REASON THE PIN IS. An earlier version returned a bare list and swallowed every
+    /// failure into an empty one, which silently disabled <see cref="DetectMovedPin"/> - the second
+    /// mechanism, the one that exists precisely to catch what the first cannot. A proof whose history
+    /// cannot be read is not a proof with no history.
+    ///
+    /// I found this by applying to my own code the rule a reviewer had just taught me about someone
+    /// else's: the try/catch around it made the failure look handled while converting it into silence.
+    /// </summary>
+    internal sealed record LedgerReading(bool Read, IReadOnlyList<string> Lines, string? Problem)
+    {
+        /// <summary>A successfully read history - including a genuinely empty one.</summary>
+        internal static LedgerReading Of(IReadOnlyList<string> lines) => new(true, lines, null);
+
+        internal static LedgerReading Unreadable(string problem) =>
+            new(false, Array.Empty<string>(), problem);
+    }
+
+    private static LedgerReading ReadLedger() => ReadLedger(LedgerDirectory);
 
     /// <summary>
     /// The ledger in a nominated directory. Parameterised so the whole on-disk path - a real pin file, a
     /// real working tree, a real ledger - can be driven by a test rather than only by a person following a
     /// sequence by hand. A proof nobody can re-run is not a regression test.
+    ///
+    /// Opened rather than tested for existence, for the reason the pin read is: only the operating system
+    /// naming the file as missing means "no history yet". Everything else is unreadable, and unreadable is
+    /// not empty.
     /// </summary>
-    internal static IReadOnlyList<string> ReadLedger(string ledgerDirectory)
+    internal static LedgerReading ReadLedger(string ledgerDirectory)
     {
+        var path = Path.Combine(ledgerDirectory, ProofLedgerFileName);
+
         try
         {
-            var path = Path.Combine(ledgerDirectory, ProofLedgerFileName);
-            if (!File.Exists(path))
-                return Array.Empty<string>();
-
             using var stream = new FileStream(
                 path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             using var reader = new StreamReader(stream);
@@ -1300,11 +1451,23 @@ internal static class MutationProofPinGuard
                     lines.Add(line);
             }
 
-            return lines;
+            return LedgerReading.Of(lines);
         }
-        catch (Exception)
+        catch (FileNotFoundException)
         {
-            return Array.Empty<string>();
+            // No proof has ever run on this machine. A genuine, completed absence.
+            return LedgerReading.Of(Array.Empty<string>());
+        }
+        catch (DirectoryNotFoundException)
+        {
+            // Likewise: the ledger directory is created on first write.
+            return LedgerReading.Of(Array.Empty<string>());
+        }
+        catch (Exception ex)
+        {
+            return LedgerReading.Unreadable(
+                "the proof ledger " + path + " could not be read: "
+                + ex.GetType().Name + ": " + ex.Message);
         }
     }
 

--- a/src/TestInfrastructure/MutationProofPinGuard.cs
+++ b/src/TestInfrastructure/MutationProofPinGuard.cs
@@ -86,6 +86,34 @@ namespace CcDirector.TestInfrastructure;
 ///
 /// A baseline is simply an arm that declares no mutations, so both phases run one rule.
 ///
+/// TWO KINDS OF MECHANISM LIVE IN THIS FILE, AND JUDGING ONE BY THE OTHER'S STANDARD GETS IT DELETED.
+///
+/// Some of what follows PREVENTS a failure. The refusal on an undeclared change prevents a contaminated
+/// baseline from running. The refusal on a moved pin prevents an arm being compared against a different
+/// program. Those either work or they do not, and a test can show which.
+///
+/// The rest CANNOT PREVENT ANYTHING. The ledger does not stop a bad proof; it records what each run
+/// verified, so the question can be answered afterwards. The requirement that the pinned commit exist on a
+/// remote does not stop a stashed repair; it makes the commit fetchable, so a reader can see for
+/// themselves what was and was not in it. Neither of these is a preventer, and measuring them as though
+/// they were makes them look like failures - which is exactly how a future reader talks themselves into
+/// removing them.
+///
+/// THE HONEST SENTENCE IS THAT THEY CONVERT A PRIVATE FAILURE INTO A PUBLIC ONE. A contaminated proof that
+/// nobody can detect afterwards is a private failure: it lives on one machine, in one worktree, and it
+/// dies with them. The same failure recorded in a ledger, or attributed to a commit anybody can fetch, is
+/// a public one - still a failure, but now something a second person can find without being told where to
+/// look.
+///
+/// That matters here more than it would elsewhere, because this entire proof structure rests on somebody
+/// ELSE being able to re-derive a claim. Four already-merged proofs cannot now be shown to have been taken
+/// on clean trees, and that is not because a preventer failed - it is because nothing made the failure
+/// visible to anyone but the machine it happened on.
+///
+/// So: do not delete the ledger or the publication requirement because they "do not stop anything". They
+/// are not supposed to. If you want to remove one, the question to answer is whether the failure it makes
+/// visible has some other way of being seen.
+///
 /// THE SECOND JOB: MAKE THE TREE'S STATE AT RUN TIME OUTLIVE THE TREE.
 ///
 /// Refusing a contaminated run is only half of what this mechanism is for. On 2026-07-19 somebody was asked

--- a/src/TestInfrastructure/MutationProofPinGuardArmedTests.cs
+++ b/src/TestInfrastructure/MutationProofPinGuardArmedTests.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+using Xunit;
+
+namespace CcDirector.TestInfrastructure;
+
+/// <summary>
+/// The per-assembly sentinel: proves the mutation-proof pin guard's module initializer actually RAN in
+/// this test process.
+///
+/// WHY THIS IS SEPARATE FROM THE REST OF THE GUARD'S TESTS.
+///
+/// The guard is linked into every test assembly, so every assembly needs its own proof that the mechanism
+/// fired there - a module initializer that silently does not run leaves no trace at all, and the assembly
+/// would go back to admitting contaminated proofs with every other test still green.
+///
+/// But the guard's BEHAVIOURAL tests do not need to run seven times. They build real git repositories and
+/// launch real processes, and duplicating that into six assemblies buys no coverage while adding load and
+/// changing test scheduling in assemblies that have nothing to do with this mechanism. One of those
+/// assemblies contains tests that read Avalonia styled properties, which throw unless they run on the
+/// dispatcher thread; a continuous-integration run reddened there on a head where the only change was to
+/// this guard's own tests. That was not traced to a cause and may be unrelated - but a mechanism has no
+/// business changing the conditions other suites run under, and the cheapest way to stop being a suspect
+/// is to stop being present.
+///
+/// So: the GUARD goes everywhere, because that is the mechanism. This SENTINEL goes everywhere, because
+/// each assembly must prove its own copy woke up. The behavioural suite lives in one assembly.
+/// </summary>
+public sealed class MutationProofPinGuardArmedTests
+{
+    [Fact]
+    public void TheGuardRanInThisProcess()
+    {
+        Assert.True(
+            MutationProofPinGuard.HasRun,
+            "The mutation-proof pin guard's module initializer did not run in this test process, so "
+            + "nothing checked whether this run's working tree is the tree a proof pinned. Every other "
+            + "test in this assembly would still pass. See MutationProofPinGuard.");
+
+        Assert.NotEqual("(the guard has not run)", MutationProofPinGuard.LastVerdictSummary);
+    }
+}

--- a/src/TestInfrastructure/MutationProofPinGuardTests.cs
+++ b/src/TestInfrastructure/MutationProofPinGuardTests.cs
@@ -867,6 +867,82 @@ public sealed class MutationProofPinGuardTests
         Assert.True(verdict.Admitted, verdict.Message);
     }
 
+    // -------------------------------------------------------------------------------------------------
+    // THE SCRIPT'S OTHER REFUSALS.
+    //
+    // Found by auditing this unit's controls one at a time rather than reading its own summary. The script
+    // has four refusal branches; only one of them had a test. The other three were enforcement nobody had
+    // ever watched work - which is the same failure shape as an untested guard, and would let a future
+    // edit remove them silently while the pull request still described them.
+    // -------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void TheScriptRefusesToPinABaselineOverAnActivePin()
+    {
+        var shell = RequirePowerShell();
+        var script = RequirePinScript();
+
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        Assert.Equal(0, RunScript(shell, script, repository.Root, "set -Phase baseline").ExitCode);
+
+        var second = RunScript(shell, script, repository.Root, "set -Phase baseline");
+
+        Assert.False(
+            second.ExitCode == 0,
+            "A second baseline was pinned over a live one. That silently starts a new proof at a possibly "
+            + "different commit while the numbers already collected still claim to belong to the first. "
+            + second.Output + second.Error);
+        Assert.Contains("already has an active pin", second.Output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TheScriptRefusesToPinABaselineOnADirtyTree()
+    {
+        var shell = RequirePowerShell();
+        var script = RequirePinScript();
+
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        // The 2026-07-19 event, present before the baseline is even taken.
+        repository.Write("src/RequestHandler.cs", FileWithTheGuardBlockDeleted);
+
+        var result = RunScript(shell, script, repository.Root, "set -Phase baseline");
+
+        Assert.False(
+            result.ExitCode == 0,
+            "A baseline was pinned over uncommitted changes, which records a false starting point and "
+            + "leaves the run-time refusal looking like a mystery. " + result.Output + result.Error);
+        Assert.Contains("uncommitted changes", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("src/RequestHandler.cs", result.Output, StringComparison.Ordinal);
+
+        // And it must not have written a pin on its way out.
+        Assert.False(File.Exists(MutationProofPinGuard.ResolvePinFilePath(repository.Root)!));
+    }
+
+    [Fact]
+    public void TheScriptRefusesAnArmWithNoBaselineBeforeIt()
+    {
+        var shell = RequirePowerShell();
+        var script = RequirePinScript();
+
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        var result = RunScript(
+            shell, script, repository.Root, "set -Phase arm -Mutates src/RequestHandler.cs");
+
+        Assert.False(
+            result.ExitCode == 0,
+            "An arm was declared with no baseline before it. That mints a proof whose baseline was never "
+            + "taken, and it looks identical to a correct one. " + result.Output + result.Error);
+        Assert.Contains("no active baseline pin", result.Output, StringComparison.OrdinalIgnoreCase);
+
+        Assert.False(File.Exists(MutationProofPinGuard.ResolvePinFilePath(repository.Root)!));
+    }
+
     /// <summary>
     /// The arming check, driven through the real script rather than by reproducing its algorithm: a pin the
     /// SCRIPT wrote must be found and understood by the GUARD. This is the property that was false off

--- a/src/TestInfrastructure/MutationProofPinGuardTests.cs
+++ b/src/TestInfrastructure/MutationProofPinGuardTests.cs
@@ -1505,6 +1505,91 @@ public sealed class MutationProofPinGuardTests
             MutationProofPinGuard.LedgerReading.Of(Array.Empty<string>()),
             new MutationProofPinGuard.HeadPublicationReading(publication, null));
 
+    // -------------------------------------------------------------------------------------------------
+    // THE REMAINDER OF THE SITE-BY-SITE AUDIT.
+    //
+    // Having just criticised this unit's own script for controls that were right but never watched, these
+    // close the same state in the guard. Each is a refusal that existed and had no test naming it - one
+    // edit away from not happening, with nothing going red on the way. None of them found a bug; they
+    // convert four claims into four facts, which is the whole point of the exercise.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A marker file that exists but cannot be read must be indeterminate. Under a predicate this looked
+    /// like any other unreadable path; the danger is that failing to read it and concluding "no repository"
+    /// lands on the admitting state.
+    /// </summary>
+    [Fact]
+    public void ARepositoryMarkerThatExistsButCannotBeReadIsIndeterminate()
+    {
+        using var scratch = new TemporaryDirectory();
+        var deep = Path.Combine(scratch.Path, "a", "b");
+        Directory.CreateDirectory(deep);
+
+        // The probe reports a marker FILE that is not actually on disk, so the read that follows fails -
+        // which is the shape of a marker that exists and refuses to be read.
+        var located = MutationProofPinGuard.LocatePin(
+            deep,
+            path => path.EndsWith(".git", StringComparison.Ordinal)
+                ? new MutationProofPinGuard.Probe(MutationProofPinGuard.ProbeOutcome.Exists, false, null)
+                : MutationProofPinGuard.ProbePath(path));
+
+        Assert.Equal(MutationProofPinGuard.PinLocationOutcome.Indeterminate, located.Outcome);
+        Assert.Contains("could not be read", located.Problem!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A pin whose directory has vanished between locating it and reading it is a change underneath the
+    /// run, not a settled absence.
+    /// </summary>
+    [Fact]
+    public void APinWhoseDirectoryHasVanishedIsIndeterminate_NotAbsent()
+    {
+        using var scratch = new TemporaryDirectory();
+
+        var reading = MutationProofPinGuard.ReadPin(
+            new MutationProofPinGuard.PinLocation(
+                MutationProofPinGuard.PinLocationOutcome.Located,
+                scratch.Path,
+                Path.Combine(scratch.Path, "a-directory-that-is-not-there", MutationProofPinGuard.PinFileName),
+                null));
+
+        Assert.Equal(MutationProofPinGuard.PinOutcome.CouldNotDetermine, reading.Outcome);
+    }
+
+    /// <summary>
+    /// The defensive branch: an active proof with no pin attached cannot be checked, so it refuses. It
+    /// should be unreachable, and an unreachable refusal that was never exercised is indistinguishable
+    /// from one that admits.
+    /// </summary>
+    [Fact]
+    public void AnActiveProofWithNoPinAttachedRefuses()
+    {
+        var verdict = MutationProofPinGuard.Decide(
+            new MutationProofPinGuard.PinReading(MutationProofPinGuard.PinOutcome.PinActive, null, null),
+            CleanTreeAt("1111111111111111111111111111111111111111"),
+            MutationProofPinGuard.LedgerReading.Of(Array.Empty<string>()));
+
+        Assert.False(verdict.Admitted, verdict.Message);
+        Assert.Contains("no pin attached", verdict.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The probe's other not-found shape: a missing intermediate DIRECTORY rather than a missing file. It
+    /// raises a different exception, and it must classify the same way or a path under a directory that
+    /// does not exist would read as unknown and refuse every ordinary run beneath it.
+    /// </summary>
+    [Fact]
+    public void TheProbeTreatsAMissingIntermediateDirectoryAsNotFound()
+    {
+        using var scratch = new TemporaryDirectory();
+
+        var probe = MutationProofPinGuard.ProbePath(
+            Path.Combine(scratch.Path, "no-such-directory", "no-such-file"));
+
+        Assert.Equal(MutationProofPinGuard.ProbeOutcome.DoesNotExist, probe.Outcome);
+    }
+
     /// <summary>A git that is certainly not installed, so the run genuinely cannot reach git.</summary>
     private const string GitThatDoesNotExist = "git-not-installed-on-this-machine-b6f2a1";
 

--- a/src/TestInfrastructure/MutationProofPinGuardTests.cs
+++ b/src/TestInfrastructure/MutationProofPinGuardTests.cs
@@ -1,0 +1,849 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace CcDirector.TestInfrastructure;
+
+/// <summary>
+/// Proves the mutation-proof pin guard CAN FIRE, not merely that it is present.
+///
+/// This is the point of the whole file, so it is worth being blunt about why. A guard that never fires
+/// looks exactly like a guard that works: both are silent, and both let every run through. An instrument
+/// that cannot observe its subject reports the subject's absence, and absence reads as success. So each
+/// refusal below is paired with a CONTROL that must be admitted, because a guard which refused everything
+/// would sail through the refusal tests on its own.
+///
+/// Four properties are pinned, and the last two are the controls:
+///
+///   1. A baseline on a tree carrying an uncommitted modification is REFUSED, and the refusal names the
+///      file. The case is built by REPLAYING the event of 2026-07-19 against a real git repository: a
+///      security guard block deleted from a source file and left uncommitted. The deletion leaves a
+///      brace-balanced file, which is asserted here, because a detector that could only see a
+///      syntactically broken tree would not have caught the real event and would be worthless.
+///   2. A baseline on a tree whose head has moved off the pinned head is REFUSED, naming both heads.
+///   3. CONTROL: a clean tree at the pinned head is ADMITTED.
+///   4. CONTROL FOR SCOPE: a mid-rework run with NO pin is ADMITTED however dirty the tree is. This is what
+///      proves the guard the Architect ruled for was built - gated to baselines and arms - rather than a
+///      blanket refusal on any dirty tree. A blanket guard would be switched off within a day, and a guard
+///      that gets switched off protects nothing.
+///
+/// The refusal cases and the admission cases are driven through the SAME repository, differing only by the
+/// contamination under test, so nothing here can pass because the two arms were set up differently.
+/// </summary>
+public sealed class MutationProofPinGuardTests
+{
+    // -------------------------------------------------------------------------------------------------
+    // The guard on the guard.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A module initializer that silently does not run leaves no trace whatsoever - the suite would go
+    /// straight back to admitting contaminated baselines and every test here would still pass, because
+    /// every test here drives the decision directly. So the fact that the mechanism actually executed in
+    /// this process is asserted separately from the decision it makes.
+    /// </summary>
+    [Fact]
+    public void TheGuardRanInThisProcess()
+    {
+        Assert.True(
+            MutationProofPinGuard.HasRun,
+            "The mutation-proof pin guard's module initializer did not run in this test process, so "
+            + "nothing checked whether this run's working tree is the tree a proof pinned. See "
+            + "MutationProofPinGuard.");
+
+        Assert.NotEqual("(the guard has not run)", MutationProofPinGuard.LastVerdictSummary);
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // 1. The event of 2026-07-19, replayed against a real git repository.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The source file as it is committed: a security guard block inside a request handler.
+    /// </summary>
+    private const string FileWithTheGuardBlock =
+        """
+        namespace Example;
+
+        public static class RequestHandler
+        {
+            public static string Handle(string tenantId, string callerTenantId)
+            {
+                if (tenantId != callerTenantId)
+                {
+                    throw new UnauthorizedAccessException("Cross-tenant read refused.");
+                }
+
+                return Read(tenantId);
+            }
+
+            private static string Read(string tenantId) => tenantId;
+        }
+        """;
+
+    /// <summary>
+    /// The same file with the guard block deleted, which is precisely what a killed mutation-arm run leaves
+    /// behind when it never gets to restore what it removed. It COMPILES. That is the whole danger: the
+    /// baseline taken over this file is green, complete, and measures nothing.
+    /// </summary>
+    private const string FileWithTheGuardBlockDeleted =
+        """
+        namespace Example;
+
+        public static class RequestHandler
+        {
+            public static string Handle(string tenantId, string callerTenantId)
+            {
+                return Read(tenantId);
+            }
+
+            private static string Read(string tenantId) => tenantId;
+        }
+        """;
+
+    [Fact]
+    public void ABaselineOverAnUncommittedlyDeletedGuardBlockIsRefused_AndTheRefusalNamesTheFile()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        var pin = BaselinePinAt(repository.Head());
+
+        // THE OTHER ARM, taken first and from the same repository: before the contamination, this exact
+        // baseline is admitted. Without this, a guard that refused unconditionally would pass the assertion
+        // below and nobody would learn anything.
+        var beforeContamination = MutationProofPinGuard.Decide(pin, MutationProofPinGuard.ReadTree(repository.Root));
+        Assert.True(
+            beforeContamination.Admitted,
+            "A clean tree at the pinned head must be admitted, or the refusal below proves nothing. "
+            + beforeContamination.Message);
+
+        // The event: the guard block is deleted and left uncommitted. Nothing else changes.
+        repository.Write("src/RequestHandler.cs", FileWithTheGuardBlockDeleted);
+
+        var afterContamination = MutationProofPinGuard.Decide(pin, MutationProofPinGuard.ReadTree(repository.Root));
+
+        Assert.False(
+            afterContamination.Admitted,
+            "A baseline was admitted over a working tree in which a security guard block had been deleted "
+            + "and left uncommitted. That baseline would look green and complete and would reconcile "
+            + "perfectly against its own mutation arm while measuring nothing. " + afterContamination.Message);
+
+        Assert.Contains("src/RequestHandler.cs", afterContamination.Message, StringComparison.Ordinal);
+        Assert.Contains("NO TESTS WILL RUN", afterContamination.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The property that makes the case above a real reconstruction rather than a convenient one: the
+    /// mutation leaves a file the compiler still accepts. If the only trees this guard could detect were
+    /// syntactically broken ones, it would not have caught the event it was built for - the broken tree
+    /// announces itself with a build failure and needs no guard at all.
+    /// </summary>
+    [Fact]
+    public void TheReplayedMutationLeavesAFileThatStillCompiles_OtherwiseItWouldNotBeTheRealEvent()
+    {
+        Assert.NotEqual(FileWithTheGuardBlock, FileWithTheGuardBlockDeleted);
+
+        Assert.Equal(
+            FileWithTheGuardBlock.Count(c => c == '{'),
+            FileWithTheGuardBlock.Count(c => c == '}'));
+
+        Assert.Equal(
+            FileWithTheGuardBlockDeleted.Count(c => c == '{'),
+            FileWithTheGuardBlockDeleted.Count(c => c == '}'));
+
+        // The security decision is gone; everything the compiler needs is still there.
+        Assert.Contains("UnauthorizedAccessException", FileWithTheGuardBlock, StringComparison.Ordinal);
+        Assert.DoesNotContain("UnauthorizedAccessException", FileWithTheGuardBlockDeleted, StringComparison.Ordinal);
+        Assert.Contains("return Read(tenantId);", FileWithTheGuardBlockDeleted, StringComparison.Ordinal);
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // 2. The head has moved.
+    // -------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ABaselineOnATreeWhoseHeadHasMovedIsRefused_AndNamesBothHeads()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        var pinnedHead = repository.Head();
+        var pin = BaselinePinAt(pinnedHead);
+
+        // Clean tree, different commit - the arm this test exists to separate from a dirty tree. A baseline
+        // and its mutation arm taken at different commits compare two different programs, and the
+        // reconciliation arithmetic silently means nothing.
+        repository.WriteAndCommit("src/Other.cs", "namespace Example; public static class Other { }", "unrelated work");
+        var movedHead = repository.Head();
+
+        Assert.NotEqual(pinnedHead, movedHead);
+        Assert.Empty(MutationProofPinGuard.ReadTree(repository.Root).Changes);
+
+        var verdict = MutationProofPinGuard.Decide(pin, MutationProofPinGuard.ReadTree(repository.Root));
+
+        Assert.False(verdict.Admitted, verdict.Message);
+        Assert.Contains(pinnedHead, verdict.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(movedHead, verdict.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // 3. CONTROL: the guard does not refuse everything.
+    // -------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void CONTROL_ACleanTreeAtThePinnedHeadIsAdmitted()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        var verdict = MutationProofPinGuard.Decide(
+            BaselinePinAt(repository.Head()),
+            MutationProofPinGuard.ReadTree(repository.Root));
+
+        Assert.True(
+            verdict.Admitted,
+            "A clean tree at the pinned head was refused. A guard that refuses everything would pass every "
+            + "other test in this file while stopping all proof work, and would be removed within the day. "
+            + verdict.Message);
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // 4. CONTROL FOR SCOPE: an unpinned run is never this guard's business.
+    // -------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void CONTROL_AMidReworkRunWithNoPinIsAdmittedHoweverDirtyTheTreeIs()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        // As dirty as a working tree gets mid-rework: a modified file, a deleted file, and a new one.
+        repository.Write("src/RequestHandler.cs", FileWithTheGuardBlockDeleted);
+        repository.WriteAndCommit("src/Doomed.cs", "namespace Example; public static class Doomed { }", "add");
+        repository.Delete("src/Doomed.cs");
+        repository.Write("src/Scratch.cs", "namespace Example; public static class Scratch { }");
+
+        var tree = MutationProofPinGuard.ReadTree(repository.Root);
+        Assert.True(tree.Changes.Count >= 3, "the tree under test must actually be dirty for this control to mean anything");
+
+        var noPin = new MutationProofPinGuard.PinReading(false, null, null);
+        var verdict = MutationProofPinGuard.Decide(noPin, tree);
+
+        Assert.True(
+            verdict.Admitted,
+            "A run with no mutation-proof pin was refused because the tree was dirty. That is a BLANKET "
+            + "guard, which the Architect ruled against: a worker mid-rework is legitimately dirty, and a "
+            + "guard that blocks ordinary work is switched off within a day, after which it protects "
+            + "nothing. " + verdict.Message);
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // The mutation arm. An arm is SUPPOSED to be dirty, so it is checked against a tighter rule than a
+    // baseline: exactly the declared change, no more and no less.
+    // -------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void AnArmCarryingExactlyItsDeclaredMutationIsAdmitted()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+        var pin = ArmPinAt(repository.Head(), "src/RequestHandler.cs");
+
+        repository.Write("src/RequestHandler.cs", FileWithTheGuardBlockDeleted);
+
+        var verdict = MutationProofPinGuard.Decide(pin, MutationProofPinGuard.ReadTree(repository.Root));
+
+        Assert.True(
+            verdict.Admitted,
+            "A mutation arm carrying exactly the mutation it declared was refused, which would make the "
+            + "guard impossible to use for the arm half of every proof. " + verdict.Message);
+    }
+
+    [Fact]
+    public void AnArmCarryingAnUndeclaredChangeAsWellIsRefused_AndNamesOnlyTheUndeclaredFile()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+        repository.WriteAndCommit("src/OtherGuard.cs", FileWithTheGuardBlock.Replace("RequestHandler", "OtherGuard"), "add another guard");
+
+        var pin = ArmPinAt(repository.Head(), "src/RequestHandler.cs");
+
+        repository.Write("src/RequestHandler.cs", FileWithTheGuardBlockDeleted);
+
+        // The contaminated-arm case: the intended mutation PLUS a leftover somebody else's killed run left
+        // behind. The counts would still reconcile, because both runs carry the leftover.
+        repository.Write("src/OtherGuard.cs", FileWithTheGuardBlockDeleted.Replace("RequestHandler", "OtherGuard"));
+
+        var verdict = MutationProofPinGuard.Decide(pin, MutationProofPinGuard.ReadTree(repository.Root));
+
+        Assert.False(verdict.Admitted, verdict.Message);
+        Assert.Contains("src/OtherGuard.cs", verdict.Message, StringComparison.Ordinal);
+        Assert.Contains("THIS PROOF DID NOT DECLARE", verdict.Message, StringComparison.Ordinal);
+
+        // Only the undeclared one. Naming the declared mutation here would train a worker to ignore the
+        // list, which is the same as not printing it.
+        Assert.DoesNotContain("    src/RequestHandler.cs", verdict.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The mirror image, and the one most likely to be dismissed as unnecessary: an arm run on a tree where
+    /// the mutation was never applied, or was already restored, is a SECOND BASELINE wearing an arm's name.
+    /// It reconciles perfectly against the first baseline - passed plus zero failed equals passed - and the
+    /// proof reads as a clean pass.
+    /// </summary>
+    [Fact]
+    public void AnArmWhoseDeclaredMutationIsAbsentIsRefused_BecauseItIsASecondBaselineInDisguise()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        var pin = ArmPinAt(repository.Head(), "src/RequestHandler.cs");
+
+        // No mutation applied at all.
+        var verdict = MutationProofPinGuard.Decide(pin, MutationProofPinGuard.ReadTree(repository.Root));
+
+        Assert.False(verdict.Admitted, verdict.Message);
+        Assert.Contains("src/RequestHandler.cs", verdict.Message, StringComparison.Ordinal);
+        Assert.Contains("SECOND BASELINE", verdict.Message, StringComparison.Ordinal);
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // A pin that cannot be understood must REFUSE, never quietly become "no pin".
+    // -------------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("pinnedHead=0123456789abcdef0123456789abcdef01234567", "declares no phase")]
+    [InlineData("phase=baseline", "not a full forty-character commit id")]
+    [InlineData("phase=warmup\npinnedHead=0123456789abcdef0123456789abcdef01234567", "is neither")]
+    [InlineData("phase=arm\npinnedHead=0123456789abcdef0123456789abcdef01234567", "declares no mutation")]
+    [InlineData("phase=baseline\npinnedHead=0123456789abcdef0123456789abcdef01234567\nmutates=src/A.cs", "yet declares mutations")]
+    [InlineData("phase=baseline\npinnedHead=0123456789abcdef0123456789abcdef01234567\nmutate=src/A.cs", "is not one this guard understands")]
+    public void APinThatCannotBeUnderstoodRefuses_ItDoesNotDegradeIntoNoPin(string text, string expectedDetail)
+    {
+        var reading = MutationProofPinGuard.ParsePin(text, "C:/pins/example.pin");
+
+        Assert.True(reading.Found, "a pin file that exists must never be reported as absent");
+        Assert.Null(reading.Pin);
+        Assert.NotNull(reading.Problem);
+        Assert.Contains(expectedDetail, reading.Problem!, StringComparison.Ordinal);
+
+        var verdict = MutationProofPinGuard.Decide(
+            reading,
+            new MutationProofPinGuard.TreeReading(true, "0123456789abcdef0123456789abcdef01234567", Array.Empty<MutationProofPinGuard.ChangedPath>(), null));
+
+        Assert.False(
+            verdict.Admitted,
+            "A pin file that exists but cannot be read was treated as no pin at all, which disarms the "
+            + "guard for exactly the proof that most needs it. " + verdict.Message);
+    }
+
+    /// <summary>
+    /// A typo of "mutates" is worth its own case because it is the failure that would look like the
+    /// guard working: the arm would be refused for carrying an undeclared change, the worker would edit the
+    /// pin, and nobody would learn that the pin format had silently dropped a key.
+    /// </summary>
+    [Fact]
+    public void AGoodPinParsesEverythingItWasGiven()
+    {
+        var reading = MutationProofPinGuard.ParsePin(
+            "# a comment\n"
+            + "phase=arm\n"
+            + "pinnedHead=0123456789ABCDEF0123456789abcdef01234567\n"
+            + "pinnedUtc=2026-07-20T00:00:00.0000000Z\n"
+            + "tree=D:/ReposFred/_wt/example\n"
+            + "mutates=src/A.cs\n"
+            + "mutates=src/B.cs\n"
+            + "note=removing the tenant comparison\n",
+            "C:/pins/example.pin");
+
+        Assert.Null(reading.Problem);
+        Assert.NotNull(reading.Pin);
+        Assert.Equal(MutationProofPinGuard.ArmPhase, reading.Pin!.Phase);
+        Assert.Equal("0123456789abcdef0123456789abcdef01234567", reading.Pin.PinnedHead);
+        Assert.Equal(new[] { "src/A.cs", "src/B.cs" }, reading.Pin.DeclaredMutations);
+        Assert.Equal("removing the tenant comparison", reading.Pin.Note);
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // A pinned run that cannot read its own tree must stop, not proceed.
+    // -------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void APinnedRunThatCannotReadTheTreeIsRefused()
+    {
+        var pin = BaselinePinAt("0123456789abcdef0123456789abcdef01234567");
+        var unreadable = new MutationProofPinGuard.TreeReading(
+            false, "", Array.Empty<MutationProofPinGuard.ChangedPath>(), "git is not on the path");
+
+        var verdict = MutationProofPinGuard.Decide(pin, unreadable);
+
+        Assert.False(verdict.Admitted, verdict.Message);
+        Assert.Contains("git is not on the path", verdict.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CONTROL_AnUnpinnedRunThatCannotReadTheTreeIsStillAdmitted()
+    {
+        var noPin = new MutationProofPinGuard.PinReading(false, null, null);
+        var unreadable = new MutationProofPinGuard.TreeReading(
+            false, "", Array.Empty<MutationProofPinGuard.ChangedPath>(), "git is not on the path");
+
+        Assert.True(
+            MutationProofPinGuard.Decide(noPin, unreadable).Admitted,
+            "An ordinary run was blocked because git could not be invoked. The guard must be inert for "
+            + "unpinned runs even when its own inputs are unavailable.");
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // Parsing what git actually emits.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A rename entry carries a SECOND path in its own field. Consuming it is not cosmetic: miss it and
+    /// every subsequent entry is shifted by one, so the guard names the wrong file in its refusal - which
+    /// is worse than not refusing, because somebody acts on the name.
+    /// </summary>
+    [Fact]
+    public void RenameEntriesDoNotShiftEverySubsequentPath()
+    {
+        var output = "R  src/New.cs\0src/Old.cs\0 M src/Changed.cs\0?? src/Untracked.cs\0";
+
+        var changes = MutationProofPinGuard.ParsePorcelainZ(output);
+
+        Assert.Equal(
+            new[] { "src/New.cs", "src/Changed.cs", "src/Untracked.cs" },
+            changes.Select(c => c.Path));
+    }
+
+    [Fact]
+    public void PathsWithSpacesSurviveParsing()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/a file with spaces.cs", "namespace Example; public static class A { }", "add");
+        repository.Write("src/a file with spaces.cs", "namespace Example; public static class A { public const int X = 1; }");
+
+        var tree = MutationProofPinGuard.ReadTree(repository.Root);
+
+        Assert.Contains("src/a file with spaces.cs", tree.Changes.Select(c => c.Path));
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // Where the pin lives.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Two working trees of the same repository - which is how every mission here runs - must hold
+    /// independent pins. A shared pin would mean one worker's proof declaration silently governing another
+    /// worker's tree.
+    /// </summary>
+    [Fact]
+    public void TwoWorkingTreesOfOneRepositoryGetDifferentPins()
+    {
+        var first = MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:/ReposFred/_wt/w-alpha");
+        var second = MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:/ReposFred/_wt/w-beta");
+
+        Assert.NotEqual(first, second);
+    }
+
+    /// <summary>
+    /// The same tree must resolve to the same pin however its path was spelled, or the run that WRITES the
+    /// pin and the run that READS it can miss each other and the guard silently does nothing.
+    /// </summary>
+    [Fact]
+    public void OneWorkingTreeResolvesToOnePinHoweverItsPathIsSpelled()
+    {
+        var canonical = MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:/ReposFred/_wt/w-alpha");
+
+        Assert.Equal(canonical, MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:\\ReposFred\\_wt\\w-alpha"));
+        Assert.Equal(canonical, MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:/ReposFred/_wt/w-alpha/"));
+        Assert.Equal(canonical, MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:/ReposFred/_WT/W-Alpha"));
+    }
+
+    /// <summary>
+    /// A GOLDEN VALUE, and the reason it is worth freezing: scripts/mutation-proof-pin.ps1 derives this
+    /// same file name INDEPENDENTLY, in another language, because it has to write the pin the guard will
+    /// later read. If the two derivations ever drift apart the script writes a pin nothing reads, and the
+    /// guard is inert while every command still reports success - the exact failure shape this whole file
+    /// exists to prevent, reproduced in its own plumbing.
+    ///
+    /// A change here is not wrong, but it is never one-sided: change this value and the script's
+    /// Get-PinPath together, and re-derive both.
+    /// </summary>
+    [Fact]
+    public void ThePinFileNameIsAGoldenValue_BecauseAScriptDerivesTheSameNameSeparately()
+    {
+        Assert.Equal(
+            Path.Combine("C:/pins", "w-example-d324397e599abb89.pin"),
+            MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:/ReposFred/_wt/w-example"));
+    }
+
+    /// <summary>
+    /// The pins directory must not be movable by whoever launched the run - the same defect the per-user
+    /// suite lock was repaired for. If the baseline run and the arm run compute different homes, each reads
+    /// its own pin and the guard serializes nothing.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ThePinsDirectoryIsNotRelocatableByWhoeverLaunchesTheRun(bool isWindows)
+    {
+        var directory = MutationProofPinGuard.ComputePinsDirectory(
+            isWindows, "C:/Users/example/AppData/Local", "example");
+
+        Assert.DoesNotContain("relocated", directory, StringComparison.Ordinal);
+
+        if (isWindows)
+            Assert.StartsWith("C:/Users/example/AppData/Local", directory, StringComparison.Ordinal);
+        else
+            Assert.StartsWith("/tmp/cc-director-example", directory, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WithNoLocalApplicationDataFolder_ItRefusesRatherThanFallingBack()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => MutationProofPinGuard.ComputePinsDirectory(isWindows: true, "", "example"));
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // Finding the working tree root.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// In a git worktree - how every mission in this repository is run - ".git" is a FILE, not a directory.
+    /// A root-finder that only accepted a directory would find nothing in exactly the trees this guard
+    /// exists to protect, and would then admit every proof run silently.
+    /// </summary>
+    [Fact]
+    public void TheWorkingTreeRootIsFoundWhenDotGitIsAFile()
+    {
+        using var scratch = new TemporaryDirectory();
+        var root = Path.Combine(scratch.Path, "tree");
+        var deep = Path.Combine(root, "src", "Project", "bin", "Debug", "net10.0");
+        Directory.CreateDirectory(deep);
+        File.WriteAllText(Path.Combine(root, ".git"), "gitdir: ../.git/worktrees/tree");
+
+        Assert.Equal(root, MutationProofPinGuard.FindWorkingTreeRoot(deep));
+    }
+
+    [Fact]
+    public void OutsideAnyRepositoryThereIsNoWorkingTreeRoot()
+    {
+        using var scratch = new TemporaryDirectory();
+        var deep = Path.Combine(scratch.Path, "a", "b");
+        Directory.CreateDirectory(deep);
+
+        // A temporary directory is not inside this repository, so the walk reaches the drive root and
+        // stops. If some ancestor of the temporary directory ever is a repository this would find it, so
+        // the assertion is on the shape of the answer rather than on a specific null.
+        var found = MutationProofPinGuard.FindWorkingTreeRoot(deep);
+        Assert.True(
+            found is null || !found.StartsWith(scratch.Path, StringComparison.OrdinalIgnoreCase),
+            "no repository was created under the scratch directory, so none may be reported from inside it");
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // The ledger: the tree's state at run time, recorded as a fact that outlives the tree.
+    //
+    // Four already-merged security proofs cannot now be shown to have been taken on clean trees, because
+    // their worktrees were removed after merging and that removal destroyed the only evidence. These pin
+    // the properties that stop the fifth one joining them.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// An ADMITTED baseline must leave a POSITIVE statement behind - which head was verified, and that the
+    /// tree matched it. This is the property the Manager's finding turns on: a ledger that only writes on
+    /// refusal cannot afterwards distinguish "verified clean" from "the guard never ran", because both are
+    /// silence, and silence reads as success.
+    /// </summary>
+    [Fact]
+    public void AnAdmittedBaselineIsRecordedAsAPositiveVerifiedFact_NotAsAnAbsenceOfComplaint()
+    {
+        const string head = "0123456789abcdef0123456789abcdef01234567";
+
+        var pin = BaselinePinAt(head);
+        var tree = new MutationProofPinGuard.TreeReading(
+            true, head, Array.Empty<MutationProofPinGuard.ChangedPath>(), null);
+        var verdict = MutationProofPinGuard.Decide(pin, tree);
+
+        Assert.True(verdict.Admitted, verdict.Message);
+
+        var line = MutationProofPinGuard.FormatRunRecord(new MutationProofPinGuard.RunRecord(
+            "2026-07-20T01:02:03.0000000Z", 4242, "net10.0", "D:/ReposFred/_wt/w-example",
+            "cj_example", pin, tree, verdict));
+
+        Assert.Contains("verdict=admitted", line, StringComparison.Ordinal);
+        Assert.Contains("headVerified=yes", line, StringComparison.Ordinal);
+        Assert.Contains("pinnedHead=" + head, line, StringComparison.Ordinal);
+        Assert.Contains("VERIFIED", line, StringComparison.Ordinal);
+        Assert.Contains("MATCHED it", line, StringComparison.Ordinal);
+
+        // The identity that ties the record to the run it admitted, so the record still means something
+        // once the tree it describes has been removed.
+        Assert.Contains("tree=D:/ReposFred/_wt/w-example", line, StringComparison.Ordinal);
+        Assert.Contains("session=cj_example", line, StringComparison.Ordinal);
+        Assert.Contains("pid=4242", line, StringComparison.Ordinal);
+
+        // One line per run: a partially written record from an interrupted process must not be able to
+        // corrupt its neighbours, and the file must stay greppable.
+        Assert.DoesNotContain('\n', line);
+    }
+
+    /// <summary>
+    /// The refusal arm of the same record, so the ledger distinguishes the three outcomes rather than two:
+    /// verified, refused, and never checked. A refused run's line must say that no tests ran, because
+    /// somebody reading a proof's numbers later needs to know they did not come from this process.
+    /// </summary>
+    [Fact]
+    public void ARefusedRunIsRecordedAsRefused_AndSaysItsNumbersAreNotItsOwn()
+    {
+        const string pinnedHead = "0123456789abcdef0123456789abcdef01234567";
+
+        var pin = BaselinePinAt(pinnedHead);
+        var tree = new MutationProofPinGuard.TreeReading(
+            true,
+            pinnedHead,
+            new[] { new MutationProofPinGuard.ChangedPath(" M", "src/RequestHandler.cs") },
+            null);
+        var verdict = MutationProofPinGuard.Decide(pin, tree);
+
+        Assert.False(verdict.Admitted, verdict.Message);
+
+        var line = MutationProofPinGuard.FormatRunRecord(new MutationProofPinGuard.RunRecord(
+            "2026-07-20T01:02:03.0000000Z", 4242, "net10.0", "D:/ReposFred/_wt/w-example",
+            "cj_example", pin, tree, verdict));
+
+        Assert.Contains("verdict=refused", line, StringComparison.Ordinal);
+        Assert.Contains("NO TESTS RAN", line, StringComparison.Ordinal);
+        Assert.Contains("src/RequestHandler.cs", line, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The third outcome, and the one that must never be confused with the first: a run nobody declared
+    /// part of a proof verified NOTHING. Recording it as a bland success would manufacture exactly the
+    /// false reassurance this ledger exists to prevent.
+    /// </summary>
+    [Fact]
+    public void AnUnpinnedRunIsRecordedAsHavingVerifiedNothing_NotAsVerified()
+    {
+        var noPin = new MutationProofPinGuard.PinReading(false, null, null);
+        var tree = new MutationProofPinGuard.TreeReading(
+            true,
+            "0123456789abcdef0123456789abcdef01234567",
+            new[] { new MutationProofPinGuard.ChangedPath(" M", "src/InProgress.cs") },
+            null);
+        var verdict = MutationProofPinGuard.Decide(noPin, tree);
+
+        Assert.True(verdict.Admitted, verdict.Message);
+
+        var line = MutationProofPinGuard.FormatRunRecord(new MutationProofPinGuard.RunRecord(
+            "2026-07-20T01:02:03.0000000Z", 4242, "net10.0", "D:/ReposFred/_wt/w-example",
+            "cj_example", noPin, tree, verdict));
+
+        Assert.Contains("headVerified=no", line, StringComparison.Ordinal);
+        Assert.Contains("NOT PART OF A PROOF", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("VERIFIED - ", line, StringComparison.Ordinal);
+
+        // The observed state is still kept, which is what makes a FORGOTTEN pin answerable after the fact.
+        Assert.Contains("src/InProgress.cs", line, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The record must not live where the evidence died last time. A worktree is removed after its work
+    /// merges - correct hygiene - and anything stored inside it goes with it.
+    /// </summary>
+    [Fact]
+    public void TheLedgerLivesOutsideEveryWorkingTree_SoWorktreeRemovalCannotDestroyIt()
+    {
+        const string workingTree = "D:/ReposFred/_wt/w-example";
+
+        var directory = MutationProofPinGuard.ComputePinsDirectory(
+            isWindows: true, "C:/Users/example/AppData/Local", "example");
+        var ledger = Path.Combine(directory, MutationProofPinGuard.ProofLedgerFileName);
+        var perTree = MutationProofPinGuard.ComputePinFilePath(directory, workingTree);
+
+        foreach (var path in new[] { ledger, perTree })
+        {
+            Assert.DoesNotContain(
+                workingTree,
+                path.Replace('\\', '/'),
+                StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("_wt", path.Replace('\\', '/'), StringComparison.OrdinalIgnoreCase);
+        }
+
+        // And it is one file for the whole machine, so "every proof run ever taken here" is one read
+        // rather than a hunt through directories that no longer exist. Compared with separators
+        // normalized, because the directory is spelled with the separator the caller supplied and the
+        // combine uses the platform's.
+        Assert.Equal(
+            directory.Replace('\\', '/'),
+            Path.GetDirectoryName(ledger)!.Replace('\\', '/'));
+    }
+
+    /// <summary>
+    /// The ledger's identity must not move with whoever launched the run, for the same reason the per-user
+    /// suite lock's did not: a baseline and its arm writing to two different ledgers would each look like
+    /// the only run that ever happened.
+    /// </summary>
+    [Fact]
+    public void TheLedgerDoesNotMoveWithTheWorkingTreeThatWroteToIt()
+    {
+        var directory = MutationProofPinGuard.ComputePinsDirectory(
+            isWindows: true, "C:/Users/example/AppData/Local", "example");
+
+        Assert.Equal(
+            Path.Combine(directory, MutationProofPinGuard.ProofLedgerFileName),
+            Path.Combine(
+                MutationProofPinGuard.ComputePinsDirectory(
+                    isWindows: true, "C:/Users/example/AppData/Local", "example"),
+                MutationProofPinGuard.ProofLedgerFileName));
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // Helpers.
+    // -------------------------------------------------------------------------------------------------
+
+    private static MutationProofPinGuard.PinReading BaselinePinAt(string head) =>
+        new(
+            true,
+            new MutationProofPinGuard.ProofPin(
+                MutationProofPinGuard.BaselinePhase, head, "2026-07-20T00:00:00Z",
+                Array.Empty<string>(), "test", "C:/pins/example.pin"),
+            null);
+
+    private static MutationProofPinGuard.PinReading ArmPinAt(string head, params string[] mutations) =>
+        new(
+            true,
+            new MutationProofPinGuard.ProofPin(
+                MutationProofPinGuard.ArmPhase, head, "2026-07-20T00:00:00Z",
+                mutations, "test", "C:/pins/example.pin"),
+            null);
+
+    /// <summary>A scratch directory that removes itself.</summary>
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "cc-mutation-pin-tests", Guid.NewGuid().ToString("N"));
+
+        public TemporaryDirectory() => Directory.CreateDirectory(Path);
+
+        public void Dispose() => DeleteTree(Path);
+
+        /// <summary>
+        /// Git marks its object files read-only, which makes a plain recursive delete throw on Windows, so
+        /// the attributes are cleared first. Failure to clean up is swallowed: a leftover directory under
+        /// the temporary path is untidy, whereas a test that fails during cleanup reports a defect that is
+        /// not there.
+        /// </summary>
+        internal static void DeleteTree(string path)
+        {
+            try
+            {
+                if (!Directory.Exists(path))
+                    return;
+
+                foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+                    File.SetAttributes(file, FileAttributes.Normal);
+
+                Directory.Delete(path, recursive: true);
+            }
+            catch (Exception)
+            {
+                // Cleanup only. See the remarks above.
+            }
+        }
+    }
+
+    /// <summary>
+    /// A real git repository in a scratch directory.
+    ///
+    /// Real, rather than a hand-written status string, because the properties under test are properties of
+    /// what GIT actually reports - the exact status codes, the exact path spelling, the difference between
+    /// a modification and a move of the head. A fixture built from what the author believed git emits would
+    /// test the author's belief.
+    /// </summary>
+    private sealed class TemporaryGitRepository : IDisposable
+    {
+        private readonly TemporaryDirectory _scratch;
+
+        public string Root { get; }
+
+        private TemporaryGitRepository(TemporaryDirectory scratch)
+        {
+            _scratch = scratch;
+            Root = Path.Combine(scratch.Path, "tree");
+            Directory.CreateDirectory(Root);
+        }
+
+        public static TemporaryGitRepository Create()
+        {
+            var repository = new TemporaryGitRepository(new TemporaryDirectory());
+            repository.Git("init --initial-branch=main");
+            repository.Git("config user.email tests@example.invalid");
+            repository.Git("config user.name Tests");
+            repository.Git("config commit.gpgsign false");
+            return repository;
+        }
+
+        public void Write(string relativePath, string content)
+        {
+            var full = Path.Combine(Root, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+            File.WriteAllText(full, content);
+        }
+
+        public void Delete(string relativePath) =>
+            File.Delete(Path.Combine(Root, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+
+        /// <summary>
+        /// Stages ONLY the named path. An earlier draft used "git add --all", which quietly committed
+        /// whatever else the test had already left in the tree - so the mid-rework control ended up
+        /// asserting against a tree far cleaner than the one it meant to build. A fixture that tidies up
+        /// behind the test destroys the condition under test.
+        /// </summary>
+        public void WriteAndCommit(string relativePath, string content, string message)
+        {
+            Write(relativePath, content);
+            Git("add -- \"" + relativePath + "\"");
+            Git("commit -m \"" + message + "\"");
+        }
+
+        public string Head() => Git("rev-parse HEAD").Trim().ToLowerInvariant();
+
+        private string Git(string arguments)
+        {
+            using var process = new Process();
+            process.StartInfo = new ProcessStartInfo("git")
+            {
+                Arguments = "-C \"" + Root + "\" " + arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    "git " + arguments + " failed in the test repository with exit code "
+                    + process.ExitCode + ": " + error);
+            }
+
+            return output;
+        }
+
+        public void Dispose() => _scratch.Dispose();
+    }
+}

--- a/src/TestInfrastructure/MutationProofPinGuardTests.cs
+++ b/src/TestInfrastructure/MutationProofPinGuardTests.cs
@@ -1130,6 +1130,153 @@ public sealed class MutationProofPinGuardTests
         Assert.True(verdict.Admitted, verdict.Message);
     }
 
+    // -------------------------------------------------------------------------------------------------
+    // ONLY A COMPLETED, ERROR-FREE NOT-FOUND MAY CONSTRUCT THE ADMITTING STATE.
+    //
+    // The three-state outcome was necessary and not sufficient. A reviewer found the collapse it was meant
+    // to end still happening one level down: absence was being ESTABLISHED with File.Exists and
+    // Directory.Exists, which answer false for an access failure, an invalid path or an input-output error
+    // exactly as they do for a file that genuinely is not there. By the time the value reached the enum,
+    // "could not look" and "there is nothing there" were already the same boolean - and no downstream
+    // typing can recover what a predicate threw away. The surrounding try/catch blocks saw nothing,
+    // because those APIs are documented to return false rather than throw.
+    //
+    // A three-state type is only as good as the narrowest source feeding it. Predicates destroy error
+    // information; operations preserve it. These pin the repair at the level where it now lives.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A pin path that cannot be READ but is certainly there, on a real filesystem: a DIRECTORY sitting
+    /// where the pin file belongs.
+    ///
+    /// This is the reviewer finding made concrete without needing permissions or an injected filesystem.
+    /// File.Exists answers FALSE for a directory, so the old lookup concluded "no pin" and ADMITTED, while
+    /// opening it raises an access error that says plainly that something is there and unreadable.
+    /// </summary>
+    [Fact]
+    public void APinPathThatCannotBeReadIsIndeterminate_NotAProvenAbsence()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        var pinPath = MutationProofPinGuard.ResolvePinFilePath(repository.Root)!;
+        Directory.CreateDirectory(pinPath);
+
+        // The predicate the old code trusted says there is no pin here.
+        Assert.False(File.Exists(pinPath));
+
+        var reading = MutationProofPinGuard.ReadPinFor(repository.Root);
+
+        Assert.Equal(MutationProofPinGuard.PinOutcome.CouldNotDetermine, reading.Outcome);
+
+        var verdict = MutationProofPinGuard.Decide(
+            reading,
+            MutationProofPinGuard.ReadTree(repository.Root),
+            Array.Empty<string>());
+
+        Assert.False(
+            verdict.Admitted,
+            "An unreadable pin path was treated as a proven absence and the run was ADMITTED. File.Exists "
+            + "answers false for an inaccessible path exactly as it does for a missing one, which is how "
+            + "a live proof can be skipped silently. " + verdict.Message);
+    }
+
+    /// <summary>
+    /// CONTROL. The same repository with a genuinely missing pin must still admit, or the test above is
+    /// satisfied by refusing every unpinned run - which is the blanket behaviour the Architect ruled out.
+    /// </summary>
+    [Fact]
+    public void CONTROL_AGenuinelyMissingPinIsAnAbsenceAndAdmits()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        var reading = MutationProofPinGuard.ReadPinFor(repository.Root);
+
+        Assert.Equal(MutationProofPinGuard.PinOutcome.NoPinPresent, reading.Outcome);
+        Assert.True(
+            MutationProofPinGuard.Decide(
+                reading, MutationProofPinGuard.ReadTree(repository.Root), Array.Empty<string>()).Admitted);
+    }
+
+    /// <summary>
+    /// A repository marker that cannot be EXAMINED must not be walked past.
+    ///
+    /// Walking past it ends at "no repository", which is the admitting state - so an unreadable `.git`
+    /// would silently skip a live proof. The probe is injected because a path the operating system refuses
+    /// to describe cannot be created portably, and a branch that only runs on someone else's machine is a
+    /// branch nobody has watched work.
+    /// </summary>
+    [Fact]
+    public void ARepositoryMarkerThatCannotBeExaminedIsIndeterminate_NotAbsent()
+    {
+        using var scratch = new TemporaryDirectory();
+        var deep = Path.Combine(scratch.Path, "a", "b");
+        Directory.CreateDirectory(deep);
+
+        var located = MutationProofPinGuard.LocatePin(
+            deep,
+            path => path.EndsWith(".git", StringComparison.Ordinal)
+                ? new MutationProofPinGuard.Probe(
+                    MutationProofPinGuard.ProbeOutcome.CouldNotTell, false, "access is denied")
+                : MutationProofPinGuard.ProbePath(path));
+
+        Assert.Equal(MutationProofPinGuard.PinLocationOutcome.Indeterminate, located.Outcome);
+
+        Assert.Equal(
+            MutationProofPinGuard.PinOutcome.CouldNotDetermine,
+            MutationProofPinGuard.ReadPin(located).Outcome);
+    }
+
+    /// <summary>
+    /// CONTROL for the probe. When every probe answers a definite NOT THERE, the walk completes and the
+    /// answer is a genuine absence - otherwise the test above would be satisfied by a lookup that never
+    /// concludes anything, and no ordinary run outside a repository could proceed.
+    /// </summary>
+    [Fact]
+    public void CONTROL_AWalkWhereEveryProbeSaysNotThereIsACompletedSearch()
+    {
+        using var scratch = new TemporaryDirectory();
+        var deep = Path.Combine(scratch.Path, "a", "b");
+        Directory.CreateDirectory(deep);
+
+        var located = MutationProofPinGuard.LocatePin(
+            deep,
+            _ => new MutationProofPinGuard.Probe(
+                MutationProofPinGuard.ProbeOutcome.DoesNotExist, false, null));
+
+        Assert.Equal(MutationProofPinGuard.PinLocationOutcome.NotInARepository, located.Outcome);
+        Assert.Equal(
+            MutationProofPinGuard.PinOutcome.NoPinPresent,
+            MutationProofPinGuard.ReadPin(located).Outcome);
+    }
+
+    /// <summary>
+    /// The probe itself must distinguish the two, on the real filesystem of whatever machine runs this.
+    /// Everything above rests on it.
+    /// </summary>
+    [Fact]
+    public void TheProbeTellsAMissingPathFromOneItCannotDescribe()
+    {
+        using var scratch = new TemporaryDirectory();
+
+        var missing = MutationProofPinGuard.ProbePath(Path.Combine(scratch.Path, "nothing-here"));
+        Assert.Equal(MutationProofPinGuard.ProbeOutcome.DoesNotExist, missing.Outcome);
+
+        var directory = MutationProofPinGuard.ProbePath(scratch.Path);
+        Assert.Equal(MutationProofPinGuard.ProbeOutcome.Exists, directory.Outcome);
+        Assert.True(directory.IsDirectory);
+
+        var file = Path.Combine(scratch.Path, "a-file");
+        File.WriteAllText(file, "x");
+        var probedFile = MutationProofPinGuard.ProbePath(file);
+        Assert.Equal(MutationProofPinGuard.ProbeOutcome.Exists, probedFile.Outcome);
+        Assert.False(probedFile.IsDirectory);
+
+        // An input the operating system will not describe at all. It must NOT come back as "not there".
+        Assert.Equal(MutationProofPinGuard.ProbeOutcome.CouldNotTell, MutationProofPinGuard.ProbePath("").Outcome);
+    }
+
     /// <summary>A git that is certainly not installed, so the run genuinely cannot reach git.</summary>
     private const string GitThatDoesNotExist = "git-not-installed-on-this-machine-b6f2a1";
 

--- a/src/TestInfrastructure/MutationProofPinGuardTests.cs
+++ b/src/TestInfrastructure/MutationProofPinGuardTests.cs
@@ -48,17 +48,8 @@ public sealed class MutationProofPinGuardTests
     /// every test here drives the decision directly. So the fact that the mechanism actually executed in
     /// this process is asserted separately from the decision it makes.
     /// </summary>
-    [Fact]
-    public void TheGuardRanInThisProcess()
-    {
-        Assert.True(
-            MutationProofPinGuard.HasRun,
-            "The mutation-proof pin guard's module initializer did not run in this test process, so "
-            + "nothing checked whether this run's working tree is the tree a proof pinned. See "
-            + "MutationProofPinGuard.");
-
-        Assert.NotEqual("(the guard has not run)", MutationProofPinGuard.LastVerdictSummary);
-    }
+    // The per-assembly sentinel lives in MutationProofPinGuardArmedTests, which is linked into every
+    // test assembly. See that file for why the behavioural suite below is not.
 
     // -------------------------------------------------------------------------------------------------
     // 1. The event of 2026-07-19, replayed against a real git repository.

--- a/src/TestInfrastructure/MutationProofPinGuardTests.cs
+++ b/src/TestInfrastructure/MutationProofPinGuardTests.cs
@@ -1277,6 +1277,158 @@ public sealed class MutationProofPinGuardTests
         Assert.Equal(MutationProofPinGuard.ProbeOutcome.CouldNotTell, MutationProofPinGuard.ProbePath("").Outcome);
     }
 
+    // -------------------------------------------------------------------------------------------------
+    // A HISTORY THAT CANNOT BE READ IS NOT A HISTORY WITH NOTHING IN IT.
+    //
+    // Found by applying to my own code the rule a reviewer had just applied to it: the try/catch around
+    // the ledger read made failure look handled while turning it into an empty list - which silently
+    // disabled DetectMovedPin, the second mechanism, the one built to catch what the first cannot.
+    // -------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void AProofHistoryThatCannotBeReadRefuses_RatherThanReadingAsNoHistory()
+    {
+        var verdict = MutationProofPinGuard.Decide(
+            BaselinePinAt("1111111111111111111111111111111111111111"),
+            new MutationProofPinGuard.TreeReading(
+                true, "1111111111111111111111111111111111111111",
+                Array.Empty<MutationProofPinGuard.ChangedPath>(), null),
+            MutationProofPinGuard.LedgerReading.Unreadable("access is denied"));
+
+        Assert.False(
+            verdict.Admitted,
+            "A proof ran with its history unreadable, which silently switches off the check that catches a "
+            + "pinned head moving midway through a proof. " + verdict.Message);
+        Assert.Contains("PROOF HISTORY COULD NOT BE READ", verdict.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// CONTROL. A genuinely EMPTY history - the first proof ever run on a machine - must admit, or no
+    /// proof could ever start.
+    /// </summary>
+    [Fact]
+    public void CONTROL_AnEmptyProofHistoryIsFineAndAdmits()
+    {
+        var verdict = MutationProofPinGuard.Decide(
+            BaselinePinAt("1111111111111111111111111111111111111111"),
+            new MutationProofPinGuard.TreeReading(
+                true, "1111111111111111111111111111111111111111",
+                Array.Empty<MutationProofPinGuard.ChangedPath>(), null),
+            MutationProofPinGuard.LedgerReading.Of(Array.Empty<string>()));
+
+        Assert.True(verdict.Admitted, verdict.Message);
+    }
+
+    /// <summary>A missing ledger is an empty history, not an unreadable one - the first run on a machine.</summary>
+    [Fact]
+    public void AMissingLedgerReadsAsAnEmptyHistory_NotAnUnreadableOne()
+    {
+        using var scratch = new TemporaryDirectory();
+
+        var reading = MutationProofPinGuard.ReadLedger(Path.Combine(scratch.Path, "never-written"));
+
+        Assert.True(reading.Read);
+        Assert.Empty(reading.Lines);
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // THE PINNED COMMIT MUST BE ONE SOMEBODY ELSE CAN READ.
+    //
+    // From another unit on this mission, which built the same precondition independently and flagged the
+    // overlap rather than shipping a duplicate. This guard verifies the tree matches the pinned head; a
+    // reader hears "this arm measured the code under review", and the gap between those two sentences is
+    // a STASH - a stashed repair leaves a perfectly clean tree at exactly the pinned head.
+    //
+    // Requiring a published commit does not close that gap; nothing here can know what a head was SUPPOSED
+    // to contain. It makes the claim checkable by somebody else, and catches the common shape, where the
+    // stash leaves the tree on a local commit that was never pushed.
+    // -------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void APinnedCommitThatWasNeverPushedIsRefused()
+    {
+        var verdict = DecideWithPublication(MutationProofPinGuard.HeadPublication.NotPublished);
+
+        Assert.False(verdict.Admitted, verdict.Message);
+        Assert.Contains("HAS NOT BEEN PUSHED", verdict.Message, StringComparison.Ordinal);
+        Assert.Contains("stashed", verdict.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void APublicationStateThatCannotBeEstablishedIsRefused()
+    {
+        var verdict = MutationProofPinGuard.Decide(
+            BaselinePinAt("1111111111111111111111111111111111111111"),
+            CleanTreeAt("1111111111111111111111111111111111111111"),
+            MutationProofPinGuard.LedgerReading.Of(Array.Empty<string>()),
+            new MutationProofPinGuard.HeadPublicationReading(
+                MutationProofPinGuard.HeadPublication.CouldNotTell, "the remote could not be listed"));
+
+        Assert.False(verdict.Admitted, verdict.Message);
+        Assert.Contains("COULD NOT BE ESTABLISHED", verdict.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// CONTROL. A published commit admits - otherwise the check above would refuse every proof, which is
+    /// the same blanket failure the Architect ruled out in the original scope.
+    /// </summary>
+    [Fact]
+    public void CONTROL_APublishedPinnedCommitIsAdmitted()
+    {
+        Assert.True(
+            DecideWithPublication(MutationProofPinGuard.HeadPublication.Published).Admitted);
+    }
+
+    /// <summary>
+    /// CONTROL. A repository with no remote at all - a scratch clone, a fixture, an offline experiment -
+    /// has no publication question to answer, and must not be blocked by one.
+    /// </summary>
+    [Fact]
+    public void CONTROL_ARepositoryWithNoRemoteIsNotHeldToPublication()
+    {
+        Assert.True(
+            DecideWithPublication(MutationProofPinGuard.HeadPublication.NoRemoteConfigured).Admitted);
+    }
+
+    /// <summary>
+    /// The real reader, against a real repository with no remote configured - the case every temporary
+    /// fixture in this file is in, so this is also what stops the new check breaking them all.
+    /// </summary>
+    [Fact]
+    public void ARepositoryWithNoRemoteReportsNoRemoteConfigured()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        var reading = MutationProofPinGuard.ReadHeadPublication(
+            repository.Root, MutationProofPinGuard.GitExecutable);
+
+        Assert.Equal(MutationProofPinGuard.HeadPublication.NoRemoteConfigured, reading.Outcome);
+    }
+
+    /// <summary>With git unreachable, publication is unknown - and unknown is never read as published.</summary>
+    [Fact]
+    public void WithGitUnreachableThePublicationStateIsUnknown()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        var reading = MutationProofPinGuard.ReadHeadPublication(repository.Root, GitThatDoesNotExist);
+
+        Assert.Equal(MutationProofPinGuard.HeadPublication.CouldNotTell, reading.Outcome);
+    }
+
+    private static MutationProofPinGuard.TreeReading CleanTreeAt(string head) =>
+        new(true, head, Array.Empty<MutationProofPinGuard.ChangedPath>(), null);
+
+    private static MutationProofPinGuard.Verdict DecideWithPublication(
+        MutationProofPinGuard.HeadPublication publication) =>
+        MutationProofPinGuard.Decide(
+            BaselinePinAt("1111111111111111111111111111111111111111"),
+            CleanTreeAt("1111111111111111111111111111111111111111"),
+            MutationProofPinGuard.LedgerReading.Of(Array.Empty<string>()),
+            new MutationProofPinGuard.HeadPublicationReading(publication, null));
+
     /// <summary>A git that is certainly not installed, so the run genuinely cannot reach git.</summary>
     private const string GitThatDoesNotExist = "git-not-installed-on-this-machine-b6f2a1";
 
@@ -1418,28 +1570,38 @@ public sealed class MutationProofPinGuardTests
     [Fact]
     public void TheWorkingTreeRootIsFoundWhenDotGitIsAFile()
     {
-        using var scratch = new TemporaryDirectory();
-        var root = Path.Combine(scratch.Path, "tree");
-        var deep = Path.Combine(root, "src", "Project", "bin", "Debug", "net10.0");
-        Directory.CreateDirectory(deep);
-        File.WriteAllText(Path.Combine(root, ".git"), "gitdir: ../.git/worktrees/tree");
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
 
-        Assert.Equal(root, MutationProofPinGuard.FindWorkingTreeRoot(deep));
+        // A real worktree, where ".git" is a FILE naming somewhere else - how every mission here runs.
+        var worktree = Path.Combine(repository.ScratchPath, "linked-worktree");
+        repository.Git("worktree add \"" + worktree + "\" -b linked");
+
+        var deep = Path.Combine(worktree, "src", "Project", "bin", "Debug", "net10.0");
+        Directory.CreateDirectory(deep);
+
+        var located = MutationProofPinGuard.LocatePin(deep);
+
+        Assert.Equal(MutationProofPinGuard.PinLocationOutcome.Located, located.Outcome);
+        Assert.Equal(Path.GetFullPath(worktree), Path.GetFullPath(located.WorkingTreeRoot!));
     }
 
     [Fact]
-    public void OutsideAnyRepositoryThereIsNoWorkingTreeRoot()
+    public void OutsideAnyRepositoryTheLookupSaysNotInARepository()
     {
         using var scratch = new TemporaryDirectory();
         var deep = Path.Combine(scratch.Path, "a", "b");
         Directory.CreateDirectory(deep);
 
-        // A temporary directory is not inside this repository, so the walk reaches the drive root and
-        // stops. If some ancestor of the temporary directory ever is a repository this would find it, so
-        // the assertion is on the shape of the answer rather than on a specific null.
-        var found = MutationProofPinGuard.FindWorkingTreeRoot(deep);
+        var located = MutationProofPinGuard.LocatePin(deep);
+
+        // If some ancestor of the temporary directory ever were a repository the walk would legitimately
+        // find it, so the assertion forbids only the answer that matters: it must never be Indeterminate,
+        // and it must never report a root inside the scratch directory, where none was created.
+        Assert.NotEqual(MutationProofPinGuard.PinLocationOutcome.Indeterminate, located.Outcome);
         Assert.True(
-            found is null || !found.StartsWith(scratch.Path, StringComparison.OrdinalIgnoreCase),
+            located.WorkingTreeRoot is null
+            || !located.WorkingTreeRoot.StartsWith(scratch.Path, StringComparison.OrdinalIgnoreCase),
             "no repository was created under the scratch directory, so none may be reported from inside it");
     }
 

--- a/src/TestInfrastructure/MutationProofPinGuardTests.cs
+++ b/src/TestInfrastructure/MutationProofPinGuardTests.cs
@@ -696,6 +696,324 @@ public sealed class MutationProofPinGuardTests
         Assert.NotNull(problem);
     }
 
+    // -------------------------------------------------------------------------------------------------
+    // THE PROOFS THAT WERE ONCE DRIVEN BY HAND.
+    //
+    // The two refusals below were first demonstrated as a sequence typed at a terminal on one machine on
+    // one night. That proves the mechanism worked that day and protects nothing afterwards: a script, a
+    // path or a parser can regress, and hand-run evidence - being prose in a pull request - cannot notice.
+    // Worse, the hand run happened on Windows only, which is the same blind spot that produced the
+    // platform divergence a reviewer had to find: I could only ever see the arm that worked.
+    //
+    // These drive the REAL pin file, the REAL working tree and the REAL ledger, so they re-run on every
+    // push. See the pull request for what this does and does not close about the platform question.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The whole ledger-memory refusal, on disk, with no hand-typed steps.
+    ///
+    /// This is the case the script fix alone cannot catch, and therefore the one worth mechanising most: a
+    /// pin that names the wrong head, where the working tree matches that wrong head EXACTLY. Every other
+    /// check in the guard passes. Only the proof's own history says the foundation moved.
+    /// </summary>
+    [Fact]
+    public void APinReWrittenToANewHeadIsRefusedFromDisk_EvenThoughTheTreeMatchesItExactly()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        using var ledger = new TemporaryDirectory();
+
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+        var headTheBaselineMeasured = repository.Head();
+
+        var pinPath = MutationProofPinGuard.ResolvePinFilePath(repository.Root)!;
+        WritePin(pinPath, "proof-99", MutationProofPinGuard.BaselinePhase, headTheBaselineMeasured);
+
+        // The baseline runs and is admitted, and the ledger remembers the head it measured.
+        var baseline = MutationProofPinGuard.Evaluate(
+            repository.Root, MutationProofPinGuard.ReadLedger(ledger.Path));
+
+        Assert.True(baseline.Admitted, "the baseline itself must be admitted. " + baseline.Message);
+        AppendLedger(ledger.Path, LedgerLine("proof-99", headTheBaselineMeasured));
+
+        // The head moves, and the pin is REWRITTEN to the new head - what the old script did by itself,
+        // and what a hand edit or a future script regression would do again.
+        repository.WriteAndCommit("src/Other.cs", "namespace Example; public static class Other { }", "later work");
+        var headThePinNowClaims = repository.Head();
+        Assert.NotEqual(headTheBaselineMeasured, headThePinNowClaims);
+
+        WritePin(pinPath, "proof-99", MutationProofPinGuard.BaselinePhase, headThePinNowClaims);
+
+        // The tree is clean and sits exactly on the re-pinned head, so the head comparison AGREES.
+        var tree = MutationProofPinGuard.ReadTree(repository.Root);
+        Assert.Empty(tree.Changes);
+        Assert.Equal(headThePinNowClaims, tree.Head);
+
+        var verdict = MutationProofPinGuard.Evaluate(
+            repository.Root, MutationProofPinGuard.ReadLedger(ledger.Path));
+
+        Assert.False(
+            verdict.Admitted,
+            "A proof was admitted after its pinned head was rewritten to a later commit. The tree matches "
+            + "the new pin exactly, so every other check in this guard passes - the ledger's memory of the "
+            + "baseline is the only thing that can catch it. " + verdict.Message);
+
+        Assert.Contains(headTheBaselineMeasured, verdict.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(headThePinNowClaims, verdict.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// CONTROL for the test above, and it is not optional: without it, a guard that refused every run whose
+    /// ledger was non-empty would pass. Same repository, same ledger, same proof - the pin simply is not
+    /// rewritten.
+    /// </summary>
+    [Fact]
+    public void CONTROL_AProofWhosePinWasNotRewrittenIsAdmittedFromDisk()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        using var ledger = new TemporaryDirectory();
+
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+        var head = repository.Head();
+
+        WritePin(
+            MutationProofPinGuard.ResolvePinFilePath(repository.Root)!,
+            "proof-99", MutationProofPinGuard.BaselinePhase, head);
+
+        AppendLedger(ledger.Path, LedgerLine("proof-99", head));
+
+        var verdict = MutationProofPinGuard.Evaluate(
+            repository.Root, MutationProofPinGuard.ReadLedger(ledger.Path));
+
+        Assert.True(verdict.Admitted, verdict.Message);
+    }
+
+    /// <summary>
+    /// The arm transition, driven through the REAL script.
+    ///
+    /// This is the bypass a reviewer found: "set -Phase arm" recomputed the head, so a head that moved
+    /// between the baseline and the arm was silently re-pinned and the arm admitted. Asserting the script's
+    /// behaviour by reading its source would test my belief about PowerShell; running it tests PowerShell.
+    ///
+    /// Two things are asserted, and the second matters more: the transition is REFUSED, and the pin file
+    /// still names the BASELINE's head afterwards. A refusal that had already overwritten the pin would
+    /// leave the next run to be measured against the wrong commit.
+    /// </summary>
+    [Fact]
+    public void TheScriptRefusesAnArmTransitionAfterTheHeadMoves_AndLeavesThePinOnTheBaselineHead()
+    {
+        var shell = RequirePowerShell();
+        var script = RequirePinScript();
+
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        var baselineHead = repository.Head();
+
+        var pinned = RunScript(shell, script, repository.Root, "set -Phase baseline -Note \"transition test\"");
+        Assert.True(pinned.ExitCode == 0, "pinning the baseline failed: " + pinned.Output + pinned.Error);
+
+        // The head moves between the baseline run and the arm - the whole condition under test.
+        repository.WriteAndCommit("src/Other.cs", "namespace Example; public static class Other { }", "later work");
+        var movedHead = repository.Head();
+        Assert.NotEqual(baselineHead, movedHead);
+
+        var arm = RunScript(
+            shell, script, repository.Root, "set -Phase arm -Mutates src/RequestHandler.cs");
+
+        Assert.False(
+            arm.ExitCode == 0,
+            "The script accepted an arm transition after the head had moved. That silently re-pins the "
+            + "proof to the new head, and the guard then finds an exact match and admits an arm that "
+            + "measured a different program from its own baseline. Output: " + arm.Output + arm.Error);
+
+        Assert.Contains("the head has moved", arm.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(baselineHead, arm.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(movedHead, arm.Output, StringComparison.OrdinalIgnoreCase);
+
+        // And the pin was NOT quietly updated on the way out.
+        var pinText = File.ReadAllText(MutationProofPinGuard.ResolvePinFilePath(repository.Root)!);
+        Assert.Contains("pinnedHead=" + baselineHead, pinText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("pinnedHead=" + movedHead, pinText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// CONTROL. The same transition, with the head left alone, must SUCCEED - otherwise the refusal above
+    /// would be satisfied by a script that refuses every arm, which would make the tool unusable for the
+    /// arm half of every proof and would be discovered only by whoever tried to run one.
+    /// </summary>
+    [Fact]
+    public void CONTROL_TheScriptAcceptsAnArmTransitionAtTheBaselineHead()
+    {
+        var shell = RequirePowerShell();
+        var script = RequirePinScript();
+
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+        var head = repository.Head();
+
+        RunScript(shell, script, repository.Root, "set -Phase baseline");
+
+        // Apply the mutation, exactly as a real arm would, then declare it.
+        repository.Write("src/RequestHandler.cs", FileWithTheGuardBlockDeleted);
+
+        var arm = RunScript(shell, script, repository.Root, "set -Phase arm -Mutates src/RequestHandler.cs");
+
+        Assert.True(
+            arm.ExitCode == 0,
+            "A legitimate arm transition at the pinned head was refused. Output: " + arm.Output + arm.Error);
+
+        var pinText = File.ReadAllText(MutationProofPinGuard.ResolvePinFilePath(repository.Root)!);
+        Assert.Contains("phase=arm", pinText, StringComparison.Ordinal);
+        Assert.Contains("pinnedHead=" + head, pinText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("mutates=src/RequestHandler.cs", pinText, StringComparison.Ordinal);
+
+        // And the guard admits the run that follows, which is the point of the whole transition.
+        using var ledger = new TemporaryDirectory();
+        var verdict = MutationProofPinGuard.Evaluate(
+            repository.Root, MutationProofPinGuard.ReadLedger(ledger.Path));
+
+        Assert.True(verdict.Admitted, verdict.Message);
+    }
+
+    /// <summary>
+    /// The arming check, driven through the real script rather than by reproducing its algorithm: a pin the
+    /// SCRIPT wrote must be found and understood by the GUARD. This is the property that was false off
+    /// Windows, and running the actual writer is the only way to test the actual writer.
+    /// </summary>
+    [Fact]
+    public void APinWrittenByTheRealScriptIsFoundAndUnderstoodByTheGuard()
+    {
+        var shell = RequirePowerShell();
+        var script = RequirePinScript();
+
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        var result = RunScript(shell, script, repository.Root, "set -Phase baseline -Note \"arming check\"");
+        Assert.True(result.ExitCode == 0, result.Output + result.Error);
+
+        var reading = MutationProofPinGuard.ReadPinFor(repository.Root);
+
+        Assert.True(
+            reading.Found,
+            "The script reported success but the guard cannot find the pin it wrote. That is the exact "
+            + "shape of the platform divergence a reviewer found: armed according to its own output, inert "
+            + "in fact.");
+        Assert.Null(reading.Problem);
+        Assert.Equal(repository.Head(), reading.Pin!.PinnedHead, ignoreCase: true);
+    }
+
+    private static void WritePin(string path, string proofId, string phase, string head, params string[] mutations)
+    {
+        var text = "proofId=" + proofId + "\nphase=" + phase + "\npinnedHead=" + head + "\n"
+            + string.Concat(mutations.Select(m => "mutates=" + m + "\n"));
+        File.WriteAllText(path, text);
+    }
+
+    private static void AppendLedger(string ledgerDirectory, string line) =>
+        File.AppendAllText(
+            Path.Combine(ledgerDirectory, MutationProofPinGuard.ProofLedgerFileName),
+            line + Environment.NewLine);
+
+    /// <summary>
+    /// The script host, or a LOUD FAILURE.
+    ///
+    /// Deliberately not a silent skip. A skipped test is invisible in a summary line and looks exactly like
+    /// a test that ran - which is the failure mode this entire unit exists to end, reproduced in its own
+    /// test suite. The tests run on Windows, which always has a PowerShell host, and the hosted Linux
+    /// images carry pwsh; a machine with neither cannot check the writer at all, and should be told so
+    /// rather than quietly reassured.
+    /// </summary>
+    private static string RequirePowerShell() =>
+        FindPowerShell()
+        ?? throw new InvalidOperationException(
+            "No PowerShell host (pwsh or powershell) could be executed on this machine, so the pin script "
+            + "cannot be run and the writer half of this mechanism cannot be checked here. This is reported "
+            + "as a failure rather than skipped on purpose: a silent skip would leave the suite looking "
+            + "green while the script that WRITES pins went unchecked.");
+
+    private static string RequirePinScript() =>
+        FindPinScriptPath()
+        ?? throw new InvalidOperationException(
+            "scripts/mutation-proof-pin.ps1 was not found above " + AppContext.BaseDirectory
+            + ", so the writer half of this mechanism cannot be checked. Reported rather than skipped for "
+            + "the same reason as the missing-host case above.");
+
+    private static string? FindPinScriptPath()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, "scripts", "mutation-proof-pin.ps1");
+            if (File.Exists(candidate))
+                return candidate;
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// pwsh first, because it is the cross-platform host and is present on the hosted Linux images;
+    /// powershell second, because Windows always has it. Resolved by running it, not by probing a path -
+    /// a name on the path that cannot execute is not a host.
+    /// </summary>
+    private static string? FindPowerShell()
+    {
+        foreach (var candidate in new[] { "pwsh", "powershell" })
+        {
+            try
+            {
+                using var probe = new Process();
+                probe.StartInfo = new ProcessStartInfo(candidate)
+                {
+                    Arguments = "-NoProfile -Command \"exit 0\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                };
+
+                probe.Start();
+                probe.StandardOutput.ReadToEnd();
+                probe.StandardError.ReadToEnd();
+
+                if (probe.WaitForExit(30_000) && probe.ExitCode == 0)
+                    return candidate;
+            }
+            catch (Exception)
+            {
+                // Not present on this machine; try the next.
+            }
+        }
+
+        return null;
+    }
+
+    private readonly record struct ScriptResult(int ExitCode, string Output, string Error);
+
+    private static ScriptResult RunScript(string shell, string scriptPath, string workingDirectory, string arguments)
+    {
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo(shell)
+        {
+            Arguments = "-NoProfile -ExecutionPolicy Bypass -File \"" + scriptPath + "\" " + arguments,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        process.Start();
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit(120_000);
+
+        return new ScriptResult(process.ExitCode, output, error);
+    }
+
     private static string LedgerLine(string proofId, string pinnedHead) =>
         "when=2026-07-20T00:00:00.0000000Z  verdict=admitted  proofId=" + proofId
         + "  phase=baseline  pinnedHead=" + pinnedHead + "  observedHead=" + pinnedHead

--- a/src/TestInfrastructure/MutationProofPinGuardTests.cs
+++ b/src/TestInfrastructure/MutationProofPinGuardTests.cs
@@ -354,6 +354,7 @@ public sealed class MutationProofPinGuardTests
     {
         var reading = MutationProofPinGuard.ParsePin(
             "# a comment\n"
+            + "proofId=7f3c\n"
             + "phase=arm\n"
             + "pinnedHead=0123456789ABCDEF0123456789abcdef01234567\n"
             + "pinnedUtc=2026-07-20T00:00:00.0000000Z\n"
@@ -365,7 +366,8 @@ public sealed class MutationProofPinGuardTests
 
         Assert.Null(reading.Problem);
         Assert.NotNull(reading.Pin);
-        Assert.Equal(MutationProofPinGuard.ArmPhase, reading.Pin!.Phase);
+        Assert.Equal("7f3c", reading.Pin!.ProofId);
+        Assert.Equal(MutationProofPinGuard.ArmPhase, reading.Pin.Phase);
         Assert.Equal("0123456789abcdef0123456789abcdef01234567", reading.Pin.PinnedHead);
         Assert.Equal(new[] { "src/A.cs", "src/B.cs" }, reading.Pin.DeclaredMutations);
         Assert.Equal("removing the tenant comparison", reading.Pin.Note);
@@ -438,78 +440,275 @@ public sealed class MutationProofPinGuardTests
     // Where the pin lives.
     // -------------------------------------------------------------------------------------------------
 
-    /// <summary>
-    /// Two working trees of the same repository - which is how every mission here runs - must hold
-    /// independent pins. A shared pin would mean one worker's proof declaration silently governing another
-    /// worker's tree.
-    /// </summary>
-    [Fact]
-    public void TwoWorkingTreesOfOneRepositoryGetDifferentPins()
-    {
-        var first = MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:/ReposFred/_wt/w-alpha");
-        var second = MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:/ReposFred/_wt/w-beta");
-
-        Assert.NotEqual(first, second);
-    }
-
-    /// <summary>
-    /// The same tree must resolve to the same pin however its path was spelled, or the run that WRITES the
-    /// pin and the run that READS it can miss each other and the guard silently does nothing.
-    /// </summary>
-    [Fact]
-    public void OneWorkingTreeResolvesToOnePinHoweverItsPathIsSpelled()
-    {
-        var canonical = MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:/ReposFred/_wt/w-alpha");
-
-        Assert.Equal(canonical, MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:\\ReposFred\\_wt\\w-alpha"));
-        Assert.Equal(canonical, MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:/ReposFred/_wt/w-alpha/"));
-        Assert.Equal(canonical, MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:/ReposFred/_WT/W-Alpha"));
-    }
+    // -------------------------------------------------------------------------------------------------
+    // IS THE GUARD ACTUALLY ARMED ON THE PLATFORM IT IS RUNNING ON?
+    //
+    // A reviewer found that it was not, on Linux and macOS. The pin's location was DERIVED twice - once in
+    // PowerShell to write it, once in C# to read it - and the two derivations disagreed off Windows. The
+    // script printed "PINNED" while the guard looked somewhere else, found nothing, and admitted
+    // contaminated baselines. Armed according to its own output, inert in fact. Continuous integration runs
+    // on Linux, so the platform where it was dead is the platform nobody watches.
+    //
+    // These run on WHATEVER PLATFORM executes them, so the Linux answer is checked by the Linux run rather
+    // than reasoned about from Windows.
+    // -------------------------------------------------------------------------------------------------
 
     /// <summary>
-    /// A GOLDEN VALUE, and the reason it is worth freezing: scripts/mutation-proof-pin.ps1 derives this
-    /// same file name INDEPENDENTLY, in another language, because it has to write the pin the guard will
-    /// later read. If the two derivations ever drift apart the script writes a pin nothing reads, and the
-    /// guard is inert while every command still reports success - the exact failure shape this whole file
-    /// exists to prevent, reproduced in its own plumbing.
+    /// The end-to-end arming check: a pin placed where the SCRIPT puts it must be found by the GUARD, here,
+    /// on this operating system.
     ///
-    /// A change here is not wrong, but it is never one-sided: change this value and the script's
-    /// Get-PinPath together, and re-derive both.
+    /// The script's location is reproduced the way the script gets it - by asking git, in this process, in
+    /// a real repository - rather than by restating a path. That is the whole repair: there is no longer a
+    /// derivation on either side to disagree about, only one question with one answer.
     /// </summary>
     [Fact]
-    public void ThePinFileNameIsAGoldenValue_BecauseAScriptDerivesTheSameNameSeparately()
+    public void TheGuardFindsAPinWrittenWhereTheScriptWritesIt_OnThisPlatform()
     {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        // Exactly what scripts/mutation-proof-pin.ps1 does to find the pin's home.
+        var asTheScriptResolvesIt = Path.Combine(
+            repository.Git("rev-parse --absolute-git-dir").Trim(),
+            MutationProofPinGuard.PinFileName);
+
+        var asTheGuardResolvesIt = MutationProofPinGuard.ResolvePinFilePath(repository.Root);
+
+        Assert.NotNull(asTheGuardResolvesIt);
         Assert.Equal(
-            Path.Combine("C:/pins", "w-example-d324397e599abb89.pin"),
-            MutationProofPinGuard.ComputePinFilePath("C:/pins", "D:/ReposFred/_wt/w-example"));
+            Path.GetFullPath(asTheScriptResolvesIt),
+            Path.GetFullPath(asTheGuardResolvesIt!));
+
+        // And a pin written there is genuinely readable as a pin, rather than merely landing at a matching
+        // path. A path that agrees but content that does not parse would be the same silence.
+        File.WriteAllText(
+            asTheScriptResolvesIt,
+            "proofId=abc123\nphase=baseline\npinnedHead=" + repository.Head() + "\n");
+
+        var reading = MutationProofPinGuard.ParsePin(
+            File.ReadAllText(asTheGuardResolvesIt!), asTheGuardResolvesIt!);
+
+        Assert.Null(reading.Problem);
+        Assert.Equal("abc123", reading.Pin!.ProofId);
     }
 
     /// <summary>
-    /// The pins directory must not be movable by whoever launched the run - the same defect the per-user
-    /// suite lock was repaired for. If the baseline run and the arm run compute different homes, each reads
-    /// its own pin and the guard serializes nothing.
+    /// The pin must not sit anywhere "git status" can see, or the guard would trip over its own
+    /// declaration and need an exemption - and an exemption is a hole.
     /// </summary>
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void ThePinsDirectoryIsNotRelocatableByWhoeverLaunchesTheRun(bool isWindows)
+    [Fact]
+    public void ThePinDoesNotDirtyTheTreeItGuards()
     {
-        var directory = MutationProofPinGuard.ComputePinsDirectory(
-            isWindows, "C:/Users/example/AppData/Local", "example");
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
 
-        Assert.DoesNotContain("relocated", directory, StringComparison.Ordinal);
+        File.WriteAllText(
+            MutationProofPinGuard.ResolvePinFilePath(repository.Root)!,
+            "proofId=abc123\nphase=baseline\npinnedHead=" + repository.Head() + "\n");
 
-        if (isWindows)
-            Assert.StartsWith("C:/Users/example/AppData/Local", directory, StringComparison.Ordinal);
-        else
-            Assert.StartsWith("/tmp/cc-director-example", directory, StringComparison.Ordinal);
+        Assert.Empty(MutationProofPinGuard.ReadTree(repository.Root).Changes);
+    }
+
+    /// <summary>
+    /// Two worktrees of one repository - how every mission here runs - must hold independent pins. A shared
+    /// pin would mean one worker's proof declaration silently governing another worker's tree. This is now
+    /// a property of git's own answer rather than of a hash we maintain, so it is checked against a REAL
+    /// second worktree.
+    /// </summary>
+    [Fact]
+    public void TwoWorktreesOfOneRepositoryGetDifferentPins()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        var secondRoot = Path.Combine(repository.ScratchPath, "second-worktree");
+        repository.Git("worktree add \"" + secondRoot + "\" -b second");
+
+        var first = MutationProofPinGuard.ResolvePinFilePath(repository.Root);
+        var second = MutationProofPinGuard.ResolvePinFilePath(secondRoot);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.NotEqual(Path.GetFullPath(first!), Path.GetFullPath(second!));
+    }
+
+    /// <summary>
+    /// The one string the script and the guard still have to agree on, checked by reading the script's own
+    /// text. The previous version froze a golden file NAME while the two sides disagreed about the
+    /// DIRECTORY, which is precisely the gap the reviewer walked through - so this asserts the location
+    /// primitive as well, not just the name.
+    /// </summary>
+    [Fact]
+    public void TheScriptAndTheGuardAgreeOnThePinFileName()
+    {
+        var script = ReadPinScript();
+        if (script is null)
+            return; // Not run from a checkout that carries the script; the arming test above still applies.
+
+        Assert.Contains(
+            "$script:PinFileName = '" + MutationProofPinGuard.PinFileName + "'",
+            script,
+            StringComparison.Ordinal);
+
+        // Both sides must locate the pin by asking git the same question. If either ever goes back to
+        // deriving a path, this is the line that should stop it.
+        Assert.Contains("rev-parse --absolute-git-dir", script, StringComparison.Ordinal);
+    }
+
+    private static string? ReadPinScript()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, "scripts", "mutation-proof-pin.ps1");
+            if (File.Exists(candidate))
+                return File.ReadAllText(candidate);
+
+            directory = directory.Parent;
+        }
+
+        return null;
     }
 
     [Fact]
-    public void WithNoLocalApplicationDataFolder_ItRefusesRatherThanFallingBack()
+    public void WithNoLocalApplicationDataFolder_TheLedgerRefusesRatherThanFallingBack()
     {
         Assert.Throws<InvalidOperationException>(
-            () => MutationProofPinGuard.ComputePinsDirectory(isWindows: true, "", "example"));
+            () => MutationProofPinGuard.ComputeLedgerDirectory(""));
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // THE PROPERTY THAT JUSTIFIES THE WHOLE DESIGN: THE PINNED HEAD DOES NOT MOVE.
+    //
+    // Nothing tested this in the first round, and the reason is worth keeping: the pin being fixed is the
+    // PREMISE, so no test was aimed at it. A reviewer then found the supported workflow broke it - every
+    // "set", including the baseline-to-arm transition, recomputed HEAD and overwrote the pin, so a head
+    // that moved between the two runs was silently re-pinned and the arm ADMITTED. The documented happy
+    // path walked into the exact event the guard exists to refuse.
+    //
+    // The script is fixed. These pin the SECOND mechanism, which holds however the pin file came to say
+    // what it says: a hand edit, a copied file, a future script change, a tool nobody has written yet.
+    // -------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void AProofWhoseHeadMovedSinceAnEarlierRunOfTheSameProofIsRefused()
+    {
+        const string headTheBaselineMeasured = "1111111111111111111111111111111111111111";
+        const string headThePinNowClaims = "2222222222222222222222222222222222222222";
+
+        var priorBaselineRun = LedgerLine("proof-42", headTheBaselineMeasured);
+
+        // The arm, at a tree that exactly matches the RE-PINNED head - so every other check in this guard
+        // passes. Only the proof's own history shows that its foundation moved.
+        var pin = ArmPinAt(headThePinNowClaims, "src/RequestHandler.cs");
+        var tree = new MutationProofPinGuard.TreeReading(
+            true,
+            headThePinNowClaims,
+            new[] { new MutationProofPinGuard.ChangedPath(" M", "src/RequestHandler.cs") },
+            null);
+
+        var verdict = MutationProofPinGuard.Decide(pin, tree, new[] { priorBaselineRun });
+
+        Assert.False(
+            verdict.Admitted,
+            "A proof was admitted whose pinned head had moved since its own baseline ran. Every other check "
+            + "passes in this state - the tree matches the new pin exactly - so this is the only thing "
+            + "standing between a silently re-pinned proof and a clean-looking result. " + verdict.Message);
+
+        Assert.Contains(headTheBaselineMeasured, verdict.Message, StringComparison.Ordinal);
+        Assert.Contains(headThePinNowClaims, verdict.Message, StringComparison.Ordinal);
+        Assert.Contains("PINNED HEAD HAS MOVED", verdict.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// CONTROL. The same proof, run again at the same head, must be admitted - otherwise the check above
+    /// would pass by refusing every second run of every proof, and the mechanism would be discarded.
+    /// </summary>
+    [Fact]
+    public void CONTROL_AProofRunAgainAtItsOwnPinnedHeadIsAdmitted()
+    {
+        const string head = "1111111111111111111111111111111111111111";
+
+        var verdict = MutationProofPinGuard.Decide(
+            ArmPinAt(head, "src/RequestHandler.cs"),
+            new MutationProofPinGuard.TreeReading(
+                true, head,
+                new[] { new MutationProofPinGuard.ChangedPath(" M", "src/RequestHandler.cs") }, null),
+            new[] { LedgerLine("proof-42", head), LedgerLine("proof-42", head) });
+
+        Assert.True(verdict.Admitted, verdict.Message);
+    }
+
+    /// <summary>
+    /// CONTROL. A DIFFERENT proof at a different head is somebody else's business. Without this, the check
+    /// could pass by refusing any run that followed any earlier proof, which would stop the second proof
+    /// ever run on a machine.
+    /// </summary>
+    [Fact]
+    public void CONTROL_AnEarlierUnRELATEDProofAtAnotherHeadDoesNotRefuseThisOne()
+    {
+        const string head = "1111111111111111111111111111111111111111";
+
+        var verdict = MutationProofPinGuard.Decide(
+            BaselinePinAt(head),
+            new MutationProofPinGuard.TreeReading(
+                true, head, Array.Empty<MutationProofPinGuard.ChangedPath>(), null),
+            new[]
+            {
+                LedgerLine("some-other-proof", "9999999999999999999999999999999999999999"),
+                LedgerLine("another-proof", "8888888888888888888888888888888888888888"),
+            });
+
+        Assert.True(verdict.Admitted, verdict.Message);
+    }
+
+    /// <summary>
+    /// A pin with no proof identity cannot be checked against its own history at all, so it is refused
+    /// outright rather than admitted with the moved-head check quietly skipped. Minting an identity here
+    /// instead would be worse than doing nothing: every run would look like the first run of a brand-new
+    /// proof, and the mechanism would report itself in force while never firing.
+    /// </summary>
+    [Fact]
+    public void APinWithNoProofIdentityIsRefused_RatherThanCheckedAgainstNothing()
+    {
+        var reading = MutationProofPinGuard.ParsePin(
+            "phase=baseline\npinnedHead=1111111111111111111111111111111111111111\n",
+            "C:/pins/example.pin");
+
+        Assert.NotNull(reading.Problem);
+        Assert.Contains("declares no proofId", reading.Problem!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A prior run that names this proof but whose head cannot be read is treated as a MISMATCH. Skipping
+    /// it would mean the check is skipped on exactly the input that is already wrong.
+    /// </summary>
+    [Fact]
+    public void AProofsHistoryThatCannotBeReadIsTreatedAsAMismatch_NotAsAgreement()
+    {
+        var problem = MutationProofPinGuard.DetectMovedPin(
+            new MutationProofPinGuard.ProofPin(
+                "proof-42", MutationProofPinGuard.BaselinePhase,
+                "1111111111111111111111111111111111111111", "when",
+                Array.Empty<string>(), "", "C:/pins/example.pin"),
+            new[] { "when=2026-07-20T00:00:00Z  verdict=admitted  proofId=proof-42  phase=baseline" });
+
+        Assert.NotNull(problem);
+    }
+
+    private static string LedgerLine(string proofId, string pinnedHead) =>
+        "when=2026-07-20T00:00:00.0000000Z  verdict=admitted  proofId=" + proofId
+        + "  phase=baseline  pinnedHead=" + pinnedHead + "  observedHead=" + pinnedHead
+        + "  headVerified=yes  tree=D:/ReposFred/_wt/w-example";
+
+    [Fact]
+    public void LedgerFieldsAreReadableEvenWhenAValueContainsSpaces()
+    {
+        const string line = "when=2026-07-20T00:00:00Z  proofId=proof-42  observedChanges= M src/a file.cs  tree=D:/x";
+
+        Assert.Equal("proof-42", MutationProofPinGuard.ReadLedgerField(line, "proofId"));
+        Assert.Equal("M src/a file.cs", MutationProofPinGuard.ReadLedgerField(line, "observedChanges"));
+        Assert.Null(MutationProofPinGuard.ReadLedgerField(line, "absent"));
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -664,18 +863,21 @@ public sealed class MutationProofPinGuardTests
     {
         const string workingTree = "D:/ReposFred/_wt/w-example";
 
-        var directory = MutationProofPinGuard.ComputePinsDirectory(
-            isWindows: true, "C:/Users/example/AppData/Local", "example");
+        var directory = MutationProofPinGuard.ComputeLedgerDirectory("C:/Users/example/AppData/Local");
         var ledger = Path.Combine(directory, MutationProofPinGuard.ProofLedgerFileName);
-        var perTree = MutationProofPinGuard.ComputePinFilePath(directory, workingTree);
+        var allRuns = Path.Combine(directory, MutationProofPinGuard.AllRunsFileName);
 
-        foreach (var path in new[] { ledger, perTree })
+        foreach (var path in new[] { ledger, allRuns })
         {
             Assert.DoesNotContain(
                 workingTree,
                 path.Replace('\\', '/'),
                 StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("_wt", path.Replace('\\', '/'), StringComparison.OrdinalIgnoreCase);
+
+            // And not in the git directory either, which is where the PIN lives. The pin is per-worktree
+            // and dies with it, correctly; the ledger has the opposite requirement and must not.
+            Assert.DoesNotContain(".git", path.Replace('\\', '/'), StringComparison.OrdinalIgnoreCase);
         }
 
         // And it is one file for the whole machine, so "every proof run ever taken here" is one read
@@ -695,15 +897,16 @@ public sealed class MutationProofPinGuardTests
     [Fact]
     public void TheLedgerDoesNotMoveWithTheWorkingTreeThatWroteToIt()
     {
-        var directory = MutationProofPinGuard.ComputePinsDirectory(
-            isWindows: true, "C:/Users/example/AppData/Local", "example");
-
+        // One rule on every platform, and no branch on the operating system - the branch is what diverged
+        // from the writer last time.
         Assert.Equal(
-            Path.Combine(directory, MutationProofPinGuard.ProofLedgerFileName),
-            Path.Combine(
-                MutationProofPinGuard.ComputePinsDirectory(
-                    isWindows: true, "C:/Users/example/AppData/Local", "example"),
-                MutationProofPinGuard.ProofLedgerFileName));
+            MutationProofPinGuard.ComputeLedgerDirectory("C:/Users/example/AppData/Local"),
+            MutationProofPinGuard.ComputeLedgerDirectory("C:/Users/example/AppData/Local"));
+
+        Assert.Contains(
+            "cc-director",
+            MutationProofPinGuard.ComputeLedgerDirectory("/home/example/.local/share").Replace('\\', '/'),
+            StringComparison.Ordinal);
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -714,7 +917,7 @@ public sealed class MutationProofPinGuardTests
         new(
             true,
             new MutationProofPinGuard.ProofPin(
-                MutationProofPinGuard.BaselinePhase, head, "2026-07-20T00:00:00Z",
+                "proof-42", MutationProofPinGuard.BaselinePhase, head, "2026-07-20T00:00:00Z",
                 Array.Empty<string>(), "test", "C:/pins/example.pin"),
             null);
 
@@ -722,7 +925,7 @@ public sealed class MutationProofPinGuardTests
         new(
             true,
             new MutationProofPinGuard.ProofPin(
-                MutationProofPinGuard.ArmPhase, head, "2026-07-20T00:00:00Z",
+                "proof-42", MutationProofPinGuard.ArmPhase, head, "2026-07-20T00:00:00Z",
                 mutations, "test", "C:/pins/example.pin"),
             null);
 
@@ -775,6 +978,9 @@ public sealed class MutationProofPinGuardTests
 
         public string Root { get; }
 
+        /// <summary>The directory holding the tree, so a second worktree can be created beside it.</summary>
+        public string ScratchPath => _scratch.Path;
+
         private TemporaryGitRepository(TemporaryDirectory scratch)
         {
             _scratch = scratch;
@@ -817,7 +1023,7 @@ public sealed class MutationProofPinGuardTests
 
         public string Head() => Git("rev-parse HEAD").Trim().ToLowerInvariant();
 
-        private string Git(string arguments)
+        public string Git(string arguments)
         {
             using var process = new Process();
             process.StartInfo = new ProcessStartInfo("git")

--- a/src/TestInfrastructure/MutationProofPinGuardTests.cs
+++ b/src/TestInfrastructure/MutationProofPinGuardTests.cs
@@ -233,7 +233,7 @@ public sealed class MutationProofPinGuardTests
         var tree = MutationProofPinGuard.ReadTree(repository.Root);
         Assert.True(tree.Changes.Count >= 3, "the tree under test must actually be dirty for this control to mean anything");
 
-        var noPin = new MutationProofPinGuard.PinReading(false, null, null);
+        var noPin = MutationProofPinGuard.PinReading.NoPin();
         var verdict = MutationProofPinGuard.Decide(noPin, tree);
 
         Assert.True(
@@ -329,7 +329,8 @@ public sealed class MutationProofPinGuardTests
     {
         var reading = MutationProofPinGuard.ParsePin(text, "C:/pins/example.pin");
 
-        Assert.True(reading.Found, "a pin file that exists must never be reported as absent");
+        Assert.NotEqual(MutationProofPinGuard.PinOutcome.NoPinPresent, reading.Outcome);
+        Assert.Equal(MutationProofPinGuard.PinOutcome.CouldNotDetermine, reading.Outcome);
         Assert.Null(reading.Pin);
         Assert.NotNull(reading.Problem);
         Assert.Contains(expectedDetail, reading.Problem!, StringComparison.Ordinal);
@@ -393,7 +394,7 @@ public sealed class MutationProofPinGuardTests
     [Fact]
     public void CONTROL_AnUnpinnedRunThatCannotReadTheTreeIsStillAdmitted()
     {
-        var noPin = new MutationProofPinGuard.PinReading(false, null, null);
+        var noPin = MutationProofPinGuard.PinReading.NoPin();
         var unreadable = new MutationProofPinGuard.TreeReading(
             false, "", Array.Empty<MutationProofPinGuard.ChangedPath>(), "git is not on the path");
 
@@ -894,14 +895,252 @@ public sealed class MutationProofPinGuardTests
 
         var reading = MutationProofPinGuard.ReadPinFor(repository.Root);
 
-        Assert.True(
-            reading.Found,
-            "The script reported success but the guard cannot find the pin it wrote. That is the exact "
-            + "shape of the platform divergence a reviewer found: armed according to its own output, inert "
-            + "in fact.");
+        Assert.Equal(MutationProofPinGuard.PinOutcome.PinActive, reading.Outcome);
         Assert.Null(reading.Problem);
         Assert.Equal(repository.Head(), reading.Pin!.PinnedHead, ignoreCase: true);
     }
+
+    // -------------------------------------------------------------------------------------------------
+    // FAILING OPEN: the guard must never admit because it FAILED TO LOOK.
+    //
+    // A reviewer found that it did. Resolving the pin's location launched git; any failure - git missing
+    // from the path, a timeout, a broken install - returned null, which became "no pin found", which
+    // ADMITTED. So on a machine without git a contaminated baseline ran to completion while the pin file
+    // sat in the git directory the whole time, silently.
+    //
+    // The two directions of a guard's failure are not symmetric. Refusing wrongly is loud and
+    // self-correcting; somebody complains within the hour. Admitting wrongly is silent and
+    // self-concealing, and it is worse precisely because the guard's existence stops everyone checking.
+    // These pin the repair, each against the control that stops it being satisfied by refusing everything.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The exact bypass, end to end: a REAL pin on disk, and git genuinely unavailable to the run.
+    ///
+    /// The pre-existing test for an unreadable tree could not catch this, and the reason is worth keeping:
+    /// it built a PinReading that was already "found" and called Decide directly. The defect lived in the
+    /// wiring BETWEEN the lookup and the decision, where an active pin never reached that state at all. A
+    /// test that hands a decision its inputs cannot test how those inputs are obtained.
+    /// </summary>
+    [Fact]
+    public void AnActivePinIsNeverTreatedAsAbsentWhenGitIsUnavailable()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        WritePin(
+            MutationProofPinGuard.ResolvePinFilePath(repository.Root)!,
+            "proof-77", MutationProofPinGuard.BaselinePhase, repository.Head());
+
+        // A contaminant, so that if this run were admitted it would be a genuinely corrupt baseline rather
+        // than a harmless one.
+        repository.Write("src/RequestHandler.cs", FileWithTheGuardBlockDeleted);
+
+        var verdict = MutationProofPinGuard.Evaluate(
+            repository.Root, Array.Empty<string>(), GitThatDoesNotExist);
+
+        Assert.False(
+            verdict.Admitted,
+            "A proof run was ADMITTED while a pin file sat in the git directory, because git could not be "
+            + "launched to locate it. That is the worst direction for this guard to fail in: the run "
+            + "proceeds, the numbers look complete, and nothing anywhere says the tree was never checked. "
+            + verdict.Message);
+    }
+
+    /// <summary>
+    /// THE CONTROL, and without it the test above is satisfied by a guard that refuses whenever git is
+    /// missing - which would be a blanket refusal on every ordinary run on such a machine, exactly the
+    /// scope the Architect ruled against. Same repository, same absent git, no pin.
+    /// </summary>
+    [Fact]
+    public void CONTROL_AnUnpinnedRunIsStillAdmittedWhenGitIsUnavailable()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        // Dirty, unpinned, and git unavailable: the mid-rework worker on a machine without git.
+        repository.Write("src/RequestHandler.cs", FileWithTheGuardBlockDeleted);
+
+        Assert.False(File.Exists(MutationProofPinGuard.ResolvePinFilePath(repository.Root)!));
+
+        var verdict = MutationProofPinGuard.Evaluate(
+            repository.Root, Array.Empty<string>(), GitThatDoesNotExist);
+
+        Assert.True(
+            verdict.Admitted,
+            "An ordinary unpinned run was refused because git was unavailable. The pin lookup must not "
+            + "need git at all, or every run on such a machine is blocked and the guard is switched off "
+            + "within a day. " + verdict.Message);
+    }
+
+    /// <summary>
+    /// The lookup answers from the filesystem, so "is a proof active here" no longer depends on launching
+    /// a subprocess. Asserted directly, because it is the property that makes the two tests above possible
+    /// rather than an implementation detail of them.
+    /// </summary>
+    [Fact]
+    public void ThePinLookupDoesNotNeedGitAtAll()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        WritePin(
+            MutationProofPinGuard.ResolvePinFilePath(repository.Root)!,
+            "proof-77", MutationProofPinGuard.BaselinePhase, repository.Head());
+
+        // No git executable is named here at all - this is a pure filesystem answer.
+        var reading = MutationProofPinGuard.ReadPinFor(repository.Root);
+
+        Assert.Equal(MutationProofPinGuard.PinOutcome.PinActive, reading.Outcome);
+        Assert.Equal("proof-77", reading.Pin!.ProofId);
+    }
+
+    /// <summary>
+    /// The filesystem answer must agree with git's own, in BOTH repository shapes - a plain checkout where
+    /// ".git" is a directory, and a worktree where it is a file naming somewhere else. This is what keeps
+    /// the lookup from becoming a second, drifting derivation of the location the pin script computes: the
+    /// script asks git, this reads what git wrote, and if they ever disagree this reddens.
+    /// </summary>
+    [Fact]
+    public void TheFileSystemLookupAgreesWithGitsOwnAnswer_InAPlainCheckoutAndInAWorktree()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.WriteAndCommit("src/RequestHandler.cs", FileWithTheGuardBlock, "add the tenant guard");
+
+        AssertLookupMatchesGit(repository, repository.Root);
+
+        var secondRoot = Path.Combine(repository.ScratchPath, "second-worktree");
+        repository.Git("worktree add \"" + secondRoot + "\" -b second");
+
+        AssertLookupMatchesGit(repository, secondRoot);
+    }
+
+    private static void AssertLookupMatchesGit(TemporaryGitRepository repository, string workingTreeRoot)
+    {
+        var asGitSaysIt = Path.Combine(
+            repository.GitIn(workingTreeRoot, "rev-parse --absolute-git-dir").Trim(),
+            MutationProofPinGuard.PinFileName);
+
+        var located = MutationProofPinGuard.LocatePin(workingTreeRoot);
+
+        Assert.Equal(MutationProofPinGuard.PinLocationOutcome.Located, located.Outcome);
+        Assert.Equal(Path.GetFullPath(asGitSaysIt), Path.GetFullPath(located.PinFilePath!));
+    }
+
+    /// <summary>
+    /// A repository marker that exists but cannot be understood is INDETERMINATE, and indeterminate
+    /// refuses. Under the old shape this resolved to "no pin" and admitted - the same collapse of "could
+    /// not look" into "nothing there".
+    /// </summary>
+    [Fact]
+    public void AnUnreadableRepositoryMarkerRefuses_RatherThanReadingAsNoPin()
+    {
+        using var scratch = new TemporaryDirectory();
+        var root = Path.Combine(scratch.Path, "tree");
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, ".git"), "this is not a gitdir pointer");
+
+        var located = MutationProofPinGuard.LocatePin(root);
+        Assert.Equal(MutationProofPinGuard.PinLocationOutcome.Indeterminate, located.Outcome);
+
+        var verdict = MutationProofPinGuard.Decide(
+            MutationProofPinGuard.ReadPinFor(root),
+            new MutationProofPinGuard.TreeReading(false, "", Array.Empty<MutationProofPinGuard.ChangedPath>(), "n/a"),
+            Array.Empty<string>());
+
+        Assert.False(verdict.Admitted, verdict.Message);
+        Assert.Contains("CANNOT ESTABLISH", verdict.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A marker naming a git directory that is not one must also refuse. Without the HEAD check the guard
+    /// would build a pin path under a wrong directory, find no pin there, and admit - looking in the wrong
+    /// place is indistinguishable from finding nothing.
+    /// </summary>
+    [Fact]
+    public void AMarkerNamingSomethingThatIsNotAGitDirectoryRefuses()
+    {
+        using var scratch = new TemporaryDirectory();
+        var root = Path.Combine(scratch.Path, "tree");
+        var decoy = Path.Combine(scratch.Path, "not-a-git-directory");
+        Directory.CreateDirectory(root);
+        Directory.CreateDirectory(decoy);
+        File.WriteAllText(Path.Combine(root, ".git"), "gitdir: " + decoy);
+
+        var located = MutationProofPinGuard.LocatePin(root);
+
+        Assert.Equal(MutationProofPinGuard.PinLocationOutcome.Indeterminate, located.Outcome);
+        Assert.Contains("HEAD", located.Problem!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// CONTROL for the two above: outside any repository there is no pin and no repository, which is a
+    /// COMPLETED search rather than a failure, and it admits. Without this the indeterminate cases could be
+    /// satisfied by refusing everything that is not a pristine repository.
+    /// </summary>
+    [Fact]
+    public void CONTROL_OutsideARepositoryTheAnswerIsNoPin_NotIndeterminate()
+    {
+        using var scratch = new TemporaryDirectory();
+        var deep = Path.Combine(scratch.Path, "a", "b");
+        Directory.CreateDirectory(deep);
+
+        var located = MutationProofPinGuard.LocatePin(deep);
+
+        // The scratch directory is not inside a repository. If some ancestor ever were one, the walk would
+        // legitimately find it, so the assertion allows that and forbids only the indeterminate answer.
+        Assert.NotEqual(MutationProofPinGuard.PinLocationOutcome.Indeterminate, located.Outcome);
+    }
+
+    /// <summary>
+    /// The structural claim, asserted rather than left to prose: every pin state OTHER than a settled
+    /// absence refuses. If a state is ever added, this fails until somebody decides what it means - which
+    /// is the point, since the defect being repaired was a new failure quietly reusing the admit path.
+    /// </summary>
+    [Fact]
+    public void OnlyASettledAbsenceAdmits()
+    {
+        // Enumerated rather than listed, so that ADDING a state is caught here instead of silently
+        // inheriting whatever the fall-through happens to do. That is precisely how the defect arose: a new
+        // way of failing reused the existing "not found" value, and "not found" admitted.
+        var everyOtherState = Enum.GetValues<MutationProofPinGuard.PinOutcome>()
+            .Where(o => o != MutationProofPinGuard.PinOutcome.NoPinPresent)
+            .ToList();
+
+        Assert.NotEmpty(everyOtherState);
+
+        foreach (var outcome in everyOtherState)
+        {
+            var verdict = MutationProofPinGuard.Decide(
+                new MutationProofPinGuard.PinReading(outcome, null, "unreadable for this test"),
+                new MutationProofPinGuard.TreeReading(
+                    true, "1111111111111111111111111111111111111111",
+                    Array.Empty<MutationProofPinGuard.ChangedPath>(), null),
+                Array.Empty<string>());
+
+            Assert.False(
+                verdict.Admitted,
+                "The pin state '" + outcome + "' ADMITTED. Only a settled absence may admit: every other "
+                + "state means the guard does not know whether a proof is active, and admitting on a "
+                + "not-known is how this guard failed open. " + verdict.Message);
+        }
+    }
+
+    [Fact]
+    public void CONTROL_ASettledAbsenceDoesAdmit()
+    {
+        var verdict = MutationProofPinGuard.Decide(
+            MutationProofPinGuard.PinReading.NoPin(),
+            new MutationProofPinGuard.TreeReading(
+                true, "1111111111111111111111111111111111111111",
+                Array.Empty<MutationProofPinGuard.ChangedPath>(), null),
+            Array.Empty<string>());
+
+        Assert.True(verdict.Admitted, verdict.Message);
+    }
+
+    /// <summary>A git that is certainly not installed, so the run genuinely cannot reach git.</summary>
+    private const string GitThatDoesNotExist = "git-not-installed-on-this-machine-b6f2a1";
 
     private static void WritePin(string path, string proofId, string phase, string head, params string[] mutations)
     {
@@ -1150,7 +1389,7 @@ public sealed class MutationProofPinGuardTests
     [Fact]
     public void AnUnpinnedRunIsRecordedAsHavingVerifiedNothing_NotAsVerified()
     {
-        var noPin = new MutationProofPinGuard.PinReading(false, null, null);
+        var noPin = MutationProofPinGuard.PinReading.NoPin();
         var tree = new MutationProofPinGuard.TreeReading(
             true,
             "0123456789abcdef0123456789abcdef01234567",
@@ -1232,20 +1471,16 @@ public sealed class MutationProofPinGuardTests
     // -------------------------------------------------------------------------------------------------
 
     private static MutationProofPinGuard.PinReading BaselinePinAt(string head) =>
-        new(
-            true,
+        MutationProofPinGuard.PinReading.Active(
             new MutationProofPinGuard.ProofPin(
                 "proof-42", MutationProofPinGuard.BaselinePhase, head, "2026-07-20T00:00:00Z",
-                Array.Empty<string>(), "test", "C:/pins/example.pin"),
-            null);
+                Array.Empty<string>(), "test", "C:/pins/example.pin"));
 
     private static MutationProofPinGuard.PinReading ArmPinAt(string head, params string[] mutations) =>
-        new(
-            true,
+        MutationProofPinGuard.PinReading.Active(
             new MutationProofPinGuard.ProofPin(
                 "proof-42", MutationProofPinGuard.ArmPhase, head, "2026-07-20T00:00:00Z",
-                mutations, "test", "C:/pins/example.pin"),
-            null);
+                mutations, "test", "C:/pins/example.pin"));
 
     /// <summary>A scratch directory that removes itself.</summary>
     private sealed class TemporaryDirectory : IDisposable
@@ -1340,6 +1575,33 @@ public sealed class MutationProofPinGuardTests
         }
 
         public string Head() => Git("rev-parse HEAD").Trim().ToLowerInvariant();
+
+        /// <summary>Runs git in a nominated working tree - used to ask git about a second worktree.</summary>
+        public string GitIn(string workingDirectory, string arguments)
+        {
+            using var process = new Process();
+            process.StartInfo = new ProcessStartInfo("git")
+            {
+                Arguments = "-C \"" + workingDirectory + "\" " + arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    "git " + arguments + " failed in '" + workingDirectory + "': " + error);
+            }
+
+            return output;
+        }
 
         public string Git(string arguments)
         {


### PR DESCRIPTION
## What this stops

A mutation proof works by mutating one primitive, running the whole suite, and reconciling the arithmetic: passed plus failed under the mutation must equal passed under the restored run. If they add up, the suite is held to have observed the primitive.

There is exactly one failure that reconciliation cannot see, and it is the one that matters most.

**If the baseline is taken on a tree where a security guard block has already been silently deleted and left uncommitted, the tree still compiles, the baseline still looks green and complete, and the mutation arm then reconciles PERFECTLY against it.** The two runs agree with each other rather than measuring anything. The cheapest detector we own passes while measuring nothing, and every conclusion drawn from it is worthless with nothing anywhere in the process saying so.

That is not hypothetical. On 2026-07-19 a worker found exactly that on disk in its own worktree: a guard block that a **killed** run had deleted and never restored, because a killed process skips its cleanup. A sweep of the mission's working trees that night found four dirty trees.

## Why an instruction could not close it

Telling every worker "check your tree is clean before you take a baseline" does not work. The worker who **inherits** a contaminated tree is, by definition, the one who does not know a mutation is there - it compiles, and the tests pass.

This is the same shape as the concurrent-suite problem the per-user test-suite lock was built for. Four workers were each told not to run two suites at once, each complied with everything it could observe, and four suites ran concurrently anyway. A rule that requires global knowledge cannot be obeyed by an actor holding only local knowledge. That one was solved by a mechanism rather than a briefing, and so is this: the guard acquires inside the test process, fires regardless of who started the run or what they knew, and names exactly what is wrong.

## It is gated, and that is deliberate - do not widen it

**With no pin, the guard has no opinion at all.** A worker mid-rework is legitimately dirty and must be able to run whatever it likes; only a baseline and a mutation arm carry a meaning that depends on the tree being exactly the pinned head.

If you are reading this in six months wondering whether to make it a blanket refusal on any dirty tree: **do not.** A blanket guard would be switched off within a day, and a guard that gets switched off protects nothing.

## The pinned head never moves, and that is enforced twice

A reviewer found that the first version broke this in the most dangerous possible way: every `set` recomputed `git rev-parse HEAD`, so the documented baseline-to-arm transition **silently re-pinned** whenever HEAD had moved between the two runs. The guard then compared the arm against the new head, matched exactly, and admitted it - the supported happy path reaching the exact event the guard exists to refuse.

Worth naming plainly, because it is the same shape this guard was built to catch: **that the pin is fixed is the property the whole design rests on, and it was the property nothing exercised** - precisely because it is the premise. I proved the guard fires on a contaminated tree and never asked whether the pin itself could move.

Two mechanisms now hold it, because fixing only the script fixes only the instance:

1. `set -Phase arm` carries the baseline's head forward and never recomputes it, refusing if the tree has moved off it and naming both heads. An arm with no baseline refuses; a baseline over a live pin refuses. Re-pinning requires an explicit `release`, which is loud and discards the old proof's numbers with its identity.
2. The pin carries a **proof identity**, recorded to the ledger with the head each run measured. A run whose pin names a head different from an earlier run of the same proof is refused - however the pin came to say what it says: a hand edit, a copied file, a future script change.

## How a run declares itself, and whether it can be forgotten

The declaration is made **once per proof, not once per run**, by pinning the working tree (`scripts/mutation-proof-pin.ps1 set -Phase baseline|arm`). From then until the pin is released, **every** run in that tree is checked - the baseline, the arm, and every re-run of either. So the only moment anybody can forget is before the proof starts, and at that moment forgetting means having no pinned head written down anywhere, which is not a proof anybody can write up.

Being honest about the limit: it is not impossible to forget. Two things narrow it. The pin is the only place the pinned head is recorded. And the ledger below records unpinned runs anyway, so a forgotten pin leaves evidence rather than a hole.

The arm is checked against a **tighter** rule than the baseline, because an arm is supposed to be dirty. Its pin declares which paths the mutation touches, and the tree must carry exactly those - no more (a contaminated arm) and no less. The "no less" half matters as much: an arm with no mutation in it is a second baseline wearing an arm's name, and it reconciles perfectly against the first while proving nothing.

## The second job: the record outlives the tree

Somebody was asked whether four **already-merged** security proofs had been taken on contaminated trees. The answer could not be given - not because the evidence was hard to find, but because it no longer existed. Those proofs ran in worktrees; the worktrees were removed after merging. That removal is correct hygiene, and it destroyed the only artifact that could have answered the question. Those four are recorded as unknown and will stay unknown.

So every run appends a line to a ledger under the per-user local application data directory, **outside every working tree** - beyond the reach of `git worktree remove`, `git clean -xdf`, and deleting the checkout.

The ledger writes on **admission** as well as refusal, and an admission states which head was verified and that the tree matched it. A log written only when something goes wrong cannot afterwards distinguish "verified clean" from "the guard never ran" - both are silence, and silence reads as success.

## Proof that the detector FIRES, not merely that it exists

A guard that never fires looks exactly like a guard that works: both are silent, and both let every run through. So every refusal below is paired with a control that must be admitted.

**Unit level (33 tests, real temporary git repositories, run in CcDirector.Core.Tests):**

- The 2026-07-19 event replayed: a guard block deleted and left uncommitted is REFUSED and the refusal names the file. The same repository is checked **before** the contamination in the same test and is admitted, so nothing passes because the two arms were set up differently.
- The mutation is asserted to leave a brace-balanced file. A detector that could only see a syntactically broken tree would not have caught the real event - a broken tree announces itself with a build failure and needs no guard.
- A head that has moved off the pinned head is REFUSED, naming both heads.
- CONTROL: a clean tree at the pinned head is ADMITTED.
- CONTROL FOR SCOPE: a mid-rework run with no pin is ADMITTED with three kinds of change in the tree.
- Plus: contaminated arm refused; arm with the mutation missing refused; a pin that cannot be parsed REFUSES rather than degrading into "no pin"; a pinned run that cannot read its tree refuses while an unpinned one still runs.

**End to end, against the real mechanism, in this worktree:**

| Arm | Tree | Pin | Result |
|---|---|---|---|
| Control | clean at the pinned head | baseline | ADMITTED, 33 passed; ledger records `headVerified=yes` and `VERIFIED ... MATCHED it` |
| **Firing** | a real cross-tenant partition filter deleted from `DirectorRegistry.ListDirectors`, uncommitted, **still compiles** | baseline | **REFUSED, exit code 1, "NO TESTS WILL RUN"**; ledger names the file |
| Scope control | the same contaminated tree | released | ADMITTED, 33 passed |

**The pinned head, end to end against the real script and the real guard:**

| Arm | Result |
|---|---|
| Pin baseline at A, commit B, `set -Phase arm` | **REFUSED**, naming A and B; the pin file still reads A afterwards |
| Run the suite at B with that pin | **REFUSED** by the guard |
| Hand-edit the pin's head to B (what a future script regression would do), tree clean and matching it exactly | **REFUSED** by the ledger's memory of this proof at A - the ledger line reads `headVerified=yes  verdict=refused`, so every other check passed and it was still stopped |
| Negative control: delete the `DetectMovedPin` call | exactly the moved-pin tests redden; their controls - same proof re-run at its own head, and an unrelated earlier proof at another head - stay green |
| Negative control: reintroduce the script's re-pin | exactly the transition test reddens; its control (arm accepted at the baseline head) stays green |

Those sequences are **tests**, not a walkthrough someone drove once: they run the real pin file, the real working tree, the real ledger and the real script on every push. Hand-run evidence is prose in a pull request and cannot notice a regression. The missing-PowerShell case fails rather than skipping, because a skipped test is invisible in a summary line and looks exactly like a test that ran.

The firing arm used a genuine security deletion, not a token edit: with that `.Where` gone, every caller receives the fleet-global director list. It was built and confirmed to compile first, because a mutation that fails the build is caught by the compiler and proves nothing about this guard.

This exercise also found a real defect in the pin script - PowerShell's comma binds tighter than `+`, so the timestamp landed on a line of its own and the guard refused the whole proof as a malformed pin. Correct behaviour, wrong cause; fixed in the second commit. It would have stopped the first proof anybody tried to run.

## One location, asked rather than derived

The pin's location used to be derived twice - once in PowerShell to write it, once in C# to read it - and a reviewer found the two disagreed off Windows: the tool printed `PINNED` while the guard read nothing and admitted contaminated baselines. Continuous integration runs on Linux, so the platform where it was dead is the one nobody watches.

Aligning the two would have fixed the instance and kept the class. There is no second derivation left: both sides ask git `rev-parse --absolute-git-dir`. That removes the hash, the per-user directory, the platform branch and the golden filename test, and brings four properties with it - per-worktree by construction, invisible to `git status` so the pin cannot dirty the tree it guards, beyond `git clean -xdf`, and not movable by the environment. The ledger had the same branch and now uses one rule on every platform, since it must survive `git worktree remove`.

New checks run on whatever platform executes them, so the Linux answer is checked by the Linux run: a pin written where the script writes it must be found and parsed by the guard here; two real worktrees get different pins; the pin does not dirty the tree; and the script's own text is read and compared against the guard's constant.

## Wiring

`Directory.Build.props` links the guard and its tests into every project whose name ends in `.Tests`, so a test project added next year is covered without anybody remembering. It keys on the project name rather than the `IsTestProject` flag deliberately: one of the seven existing test projects does not set that flag, and a guard that silently covers six of seven assemblies looks exactly like a guard that covers all of them. All seven build.

Documentation: `docs/testing/mutation-proof-pin.md`.

## It failed open, in three places, and one of them was documented as a design choice

A reviewer found that the guard **admitted a run whenever it failed to look**. Resolving the pin's location
launched git; any failure - git missing from the path, a timeout, a broken install - became "no pin found",
which admitted. A contaminated baseline would run to completion on such a machine while the pin file sat in
the git directory the whole time.

Asked whether that was one site or a class, I went and looked. It was three. Two were mine and unreported:
a failed working-tree-root lookup that admitted "loudly", and a null root that returned before the decision
ran at all. The same defect each time - **"I could not look" spelled as "there is nothing there."**

The detail worth keeping is the first one. My own comment at that site read:

> *"There is no pin to find and no way to know whether one exists, so nothing is claimed - the run is
> admitted."*

That is the defect written down, in a rationale, and not recognised as a defect. It is worse than an
undocumented bug: a comment confers authority, so the next reader finds a reason and stops looking. If you
are reading this file and a comment explains why something permissive is fine, that is exactly where to
look hardest.

**The two failure directions of a guard are not symmetric**, and this is the sentence to keep if only one
survives: refusing wrongly is loud, visible and self-correcting - somebody complains within the hour.
Admitting wrongly is silent and self-concealing, and it is worse precisely because the guard's existence
stops everyone else checking. This guard has now been found to admit wrongly twice, and both times the
mechanism was silence.

**Every ambiguous outcome in this guard now resolves to REFUSE, and that is structural rather than a
claim:**

- `PinOutcome` has three states, not two. `NoPinPresent` is only constructible from a *completed* search
  and is the only state that admits; a lookup failure is `CouldNotDetermine`, which refuses and cannot be
  spelled as an absence.
- `Decide` has exactly one admit, reachable from that one state, and an unrecognised state refuses - so
  adding a state cannot silently reuse the admit path, which is how this arose.
- Every path through the check ends at one exit that records and enforces. An early return was an admission
  that never reached the ledger either: invisible twice over.
- The lookup no longer launches git. It reads the `.git` marker git has already written and requires the
  resolved directory to contain `HEAD`, so resolving somewhere wrong refuses instead of finding no pin
  there and admitting. The safety-critical question is no longer answered by the least reliable mechanism
  in the file.

Controls, each paired so the fix cannot be satisfied by refusing everything: a real pin with git absent is
refused, while an unpinned run with git absent is still admitted; an unreadable marker and a marker naming
a non-git directory refuse, while outside a repository the answer is a settled absence and admits; and
`OnlyASettledAbsenceAdmits` enumerates every state except `NoPinPresent` and requires each to refuse.

Proven to fire: reproducing the reviewer's defect faithfully reddens exactly the git-absent test while its
control stays green. A first, weaker mutation reddened only the marker test - which told me the git-absent
test was not yet exercising the reported path. That red was available to write up and would have looked
like the guard firing; a red that reddens the wrong test is a proof you do not have.

## Two kinds of mechanism in here, and one is easy to delete by mistake

Some of this **prevents** a failure: the refusal on an undeclared change, the refusal on a moved pin. Those either work or they do not, and a test shows which.

The rest **cannot prevent anything**, and is not meant to. The ledger does not stop a bad proof; it records what each run verified so the question can be answered later. Requiring the pinned commit to exist on a remote does not stop a stashed repair; it makes the commit fetchable so a reader can see what was in it.

The honest sentence is that they **convert a private failure into a public one**. A contaminated proof nobody can detect afterwards lives on one machine and dies with it; the same failure recorded in a ledger, or attributed to a commit anyone can fetch, is still a failure but one a second person can find without being told where to look. That matters here more than it would elsewhere, because this whole proof structure rests on somebody else being able to re-derive a claim - and the four already-merged proofs that cannot now be shown to have been taken on clean trees were not a preventer failing, but nothing having made the failure visible beyond the machine it happened on.

If you are deciding whether to remove the ledger or the publication requirement because they do not stop anything: they are not supposed to. The question to answer first is whether the failure each one makes visible has any other way of being seen.

## What this guard promises, and the sentence a reader will hear instead

This is the limitation I most want on the record, because the two sentences are close enough to be
mistaken for each other.

**What it verifies:** this working tree is exactly the pinned head.
**What a reader will hear:** this arm measured the code under review.

The gap between them is a **stash**. A worker who stashes an uncommitted repair presents a perfectly clean
tree at exactly the pinned head — this guard admits, the arm runs on unrepaired source, and every count
reconciles beautifully. Another unit on this mission nearly lost its tree to a stash the same night, which
is how the case surfaced; it had independently built the same precondition and flagged the overlap rather
than shipping a duplicate, so it lands here once instead of drifting in two places.

Nothing here can close that gap, because nothing here can know what a head was *supposed* to contain. What
it now does is make the claim checkable by somebody else: **a proof must be pinned to a commit that exists
on a remote.** The head every number is attributed to can then be fetched and read, so a missing repair is
visible in the record rather than invisible on one machine — and it catches the common shape directly,
since a stash usually leaves the tree on a local commit that was never pushed. A repository with no remote
has no publication question and is not held to one.

That also completes a family worth naming: a **copy** restores a snapshot, a **checkout** restores the last
commit, a **stash** restores an index state, and none of them restores the state before one mutation.
Committing first closes all three — and it is what makes an admission here mean anything.

The whole source tree is checked, not just the project under test, for the reason that unit gave: a lost
test edit falsifies an arm as thoroughly as a lost production edit.

## The limit I am not claiming past

Every property of this guard is checked by tests on every push **on Windows only**. `.github/workflows/ci.yml` runs `dotnet test` exactly once, on `windows-latest`; the `ubuntu-latest` job is the JavaScript one and never touches .NET. So nothing executes this guard on Linux or macOS - the pin-path parity test would catch a recurrence of the platform divergence *if it were ever run there*, and today nothing runs it there.

That also corrects how finding 2 was framed: the divergence was real and the fix stands, but the exposure was to a person or agent working on Linux or macOS, not to CI, which never ran the guard there at all.

Closing it properly means a job on `ubuntu-latest` running these tests. I have not folded that into this change because I cannot verify from here that `CcDirector.Core.Tests` and its reference chain build on Linux - the product is a Windows application, and that chain is exactly where a Windows-only dependency would sit. That is a shared-CI change and deserves its own decision rather than being smuggled in here.

And a worker can still forget to pin at all. Unchanged, still recorded rather than refused.
