### PR TITLE
fix(gateway): deny the launcher and machine-control family on hosted (#1917)

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
@@ -185,7 +185,33 @@ namespace CcDirector.Gateway.Tests;
 /// THE RUN PLAN IS EXACTLY THREE FULL-SUITE RUNS, and the path actually taken is the path registered:
 /// baseline, arm, restore. There is no slice-then-full escalation and no separate canary gate here - all
 /// three arms are the FULL suite, so no ordering can slip a fourth run in behind the registered three. On a
-/// contended serial box a fourth run spends someone else's slot.
+/// contended serial box a fourth run spends someone else's slot. THAT COUNT WAS OBSERVED BY EXECUTING the
+/// driver against a counting stub, not by reading it: three test invocations, counted. Reading a driver has
+/// been wrong repeatedly tonight; executing it has not.
+///
+/// A FINDING THAT DOES NOT CHANGE THE VERDICT IS NOT A FINDING, IT IS A COMMENT. The first version of this
+/// unit's driver had EIGHT things that would have been described as controls and ZERO that could stop it:
+/// the clean-tree check printed, the mutation diff printed, the build exit codes were masked by pipes, and
+/// the reconciliation and red-classification existed only as prose. Every one of them reported into a void,
+/// because THE LOG IS WHAT NOBODY RE-READS ONCE THE EXIT CODE IS GREEN. Being confidently wrong about which
+/// checks can actually stop you is worse than having fewer checks. So the three questions, answered:
+///
+///   1. A PREDICTED RED THAT ARRIVES AS A CRASH DOES NOT COUNT TOWARD THE FIFTEEN, and the arm is NOT
+///      proven. Crediting a crash to the prediction - so a parse exception satisfies the expectation and
+///      keeps its row out of the not-reddened set - is precisely the laundering the arrival rule exists to
+///      prevent, happening inside the mechanism written to enforce it.
+///   2. A PREDICTED ROW THAT STAYS GREEN CHANGES THE VERDICT TO UNPROVEN. It does not become a line in a
+///      report filed beside a passing score. This is already registered for the four relay rows, where a
+///      green means the deny was indistinguishable from no-launcher-registered; the SAME rule covers all
+///      fifteen.
+///   3. A TOTAL THAT DOES NOT MATCH STOPS THE ARM BEING SCORED AT ALL. It is not mentioned alongside a score
+///      already formed. Reconcile FIRST; a short total is UNPROVEN-TRUNCATED, scored in NEITHER direction.
+///
+/// Those three, plus the controls-must-not-move check and the nothing-else-may-redden check, are five
+/// PREVENTING controls - each one validated by EXECUTING it against a synthetic arm built to trip it (a
+/// truncated arm, a crash-red arm, a stayed-green arm) and confirming it returns a distinct non-zero verdict,
+/// and against a clean arm to confirm it does not fire on the happy path. A detector that has only ever been
+/// read is another printout.
 /// </summary>
 public sealed class HostedLauncherMachineDenyTests : IAsyncLifetime
 {

--- a/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
@@ -106,7 +106,7 @@ namespace CcDirector.Gateway.Tests;
 ///       - ALL NINE theory rows.
 ///   HostedLauncherMachineDenyTests.The_launcher_listing_leaks_no_machine_on_hosted
 ///   HostedLauncherMachineDenyTests.The_refusal_is_not_an_empty_launcher_list
-///   HostedLauncherMachineExclusiveGroupTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own
+///   HostedLauncherMachineExclusiveGroupTests.A_body_bound_route_added_to_either_group_later_is_refused_on_hosted_with_no_binder_run
 ///   HostedLauncherMachineExclusiveGroupTests.A_refused_registration_writes_nothing_into_the_registry
 ///   HostedLauncherMachineExclusiveGroupTests.A_refused_spawn_never_reaches_the_resolver
 ///   HostedLauncherMachineExclusiveGroupTests.A_refused_launch_never_dials_the_launcher
@@ -461,7 +461,8 @@ internal sealed class MachineGroupProbeHost : IAsyncDisposable
     }
 
     public static async Task<MachineGroupProbeHost> StartAsync(
-        Action<HostedDenyGroup>? mapIntoGroup = null,
+        Action<HostedDenyGroup>? mapIntoMachineGroup = null,
+        Action<HostedDenyGroup>? mapIntoLauncherGroup = null,
         Action<IEndpointRouteBuilder>? mapOutsideGroup = null,
         bool withStubLauncher = false)
     {
@@ -506,11 +507,14 @@ internal sealed class MachineGroupProbeHost : IAsyncDisposable
             (directorId, req, ct) => Task.FromResult<(bool, SessionDto?, string?)>(
                 (true, new SessionDto { SessionId = SpawnedSessionId }, null)));
 
-        // The probe routes are /machines paths, so mapIntoGroup targets the MACHINE exclusive group. On hosted
-        // its handler is discarded and the group's catch-all refuses the path; off hosted the handler is mapped
-        // and served - which is exactly the future-route property both directions of the proof turn on.
-        var (_, machineGroup) = MachineEndpoints.Map(app, launchers, spawner, sendLauncherCommand: null);
-        mapIntoGroup?.Invoke(machineGroup);
+        // BOTH exclusive groups are handed back, because the family owns TWO prefixes and the future-route
+        // property has to be proved on EACH - a proof on /machines alone is silent on whether /launchers got
+        // the same coverage. On hosted a handler mapped into either group is discarded and that group's
+        // catch-all refuses the path; off hosted the handler is mapped and served. That is the future-route
+        // property both directions of the proof turn on, per prefix.
+        var (launcherGroup, machineGroup) = MachineEndpoints.Map(app, launchers, spawner, sendLauncherCommand: null);
+        mapIntoMachineGroup?.Invoke(machineGroup);
+        mapIntoLauncherGroup?.Invoke(launcherGroup);
         mapOutsideGroup?.Invoke(app);
 
         await app.StartAsync();
@@ -554,22 +558,46 @@ internal sealed class MachineGroupProbeHost : IAsyncDisposable
 /// exist today, which is precisely why it is dangerous - the difference only shows up on the route somebody
 /// adds NEXT, when it is open by default and nothing fails. On THIS family, "open by default" means
 /// cross-machine code execution. That difference is not observable by driving the nine routes that exist, so
-/// this class maps a BRAND-NEW probe route onto the group and asserts it is refused with no deny of its own
-/// written anywhere. Its mirror - the same probe path SERVED with hosted mode explicitly off - lives in
-/// <see cref="HostedLauncherMachineSelfHostControlTests"/>: one direction alone cannot tell a working gate
-/// apart from a brick.
+/// this class maps a BRAND-NEW body-bound probe route onto EACH exclusive group - <c>/launchers</c> and
+/// <c>/machines</c> - and asserts it is refused with no deny of its own written anywhere AND that no argument
+/// binder ran behind the refusal on any shape. Its mirror - the same probe path SERVED, and its binder RUN,
+/// with hosted mode explicitly off - lives in <see cref="HostedLauncherMachineSelfHostControlTests"/>: one
+/// direction alone cannot tell a working gate apart from a brick.
 /// </summary>
 public sealed class HostedLauncherMachineExclusiveGroupTests : IDisposable
 {
     internal const string ProbePayloadSentinel = "probe-payload-that-must-never-be-served-on-hosted";
 
-    /// <summary>The probe route mapped RELATIVE to the machine group prefix, so the full path is
-    /// <see cref="ProbeUrl"/>. It is mapped through the returned <see cref="HostedDenyGroup"/> handle, never
-    /// through the outer builder, which is what lets the future-route property be stated from a test.</summary>
+    /// <summary>The probe route mapped RELATIVE to each group prefix, so the full paths are
+    /// <see cref="ProbeUrl"/> (machine) and <see cref="LauncherProbeUrl"/> (launcher). It is mapped through the
+    /// returned <see cref="HostedDenyGroup"/> handles, never through the outer builder, which is what lets the
+    /// future-route property be stated from a test.</summary>
     internal const string ProbeRelativePath = "/added-after-the-deny-was-written";
 
-    /// <summary>The full URL the probe route answers on - the machine prefix plus <see cref="ProbeRelativePath"/>.</summary>
+    /// <summary>The full URL the probe route answers on under the MACHINE prefix - <see cref="ProbeRelativePath"/> mapped onto it.</summary>
     internal const string ProbeUrl = "/machines/added-after-the-deny-was-written";
+
+    /// <summary>
+    /// The full URL the probe route answers on under the LAUNCHER prefix. The family owns TWO exclusive
+    /// prefixes, so the future-route property is proved on each: a proof under only one prefix leaves the
+    /// other's catch-all untested and a regression there invisible.
+    /// </summary>
+    internal const string LauncherProbeUrl = "/launchers/added-after-the-deny-was-written";
+
+    /// <summary>
+    /// The SECOND canary route, mapped alongside the framework-body-bound one, taking a parameter with a
+    /// custom <see cref="FutureRouteBinding"/> binder. Its ONLY job is the no-binder-ran count: its
+    /// <c>BindAsync</c> records every invocation, so a bind behind the refusal reddens the count. The
+    /// malformed-body boundary is NOT proved through it - a custom binder ignores the body and never reaches
+    /// the framework's own 400, which is the whole reason the body-bound canary above exists separately.
+    /// </summary>
+    internal const string BinderProbeRelativePath = "/added-after-the-deny-was-written-binder";
+
+    /// <summary>The full URL the observable-binder canary answers on under the MACHINE prefix.</summary>
+    internal const string BinderProbeUrl = "/machines/added-after-the-deny-was-written-binder";
+
+    /// <summary>The full URL the observable-binder canary answers on under the LAUNCHER prefix.</summary>
+    internal const string LauncherBinderProbeUrl = "/launchers/added-after-the-deny-was-written-binder";
 
     private readonly string? _priorHosted;
 
@@ -583,24 +611,108 @@ public sealed class HostedLauncherMachineExclusiveGroupTests : IDisposable
     public void Dispose() => Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
 
     /// <summary>
-    /// A route that did not exist when the refusal was written is refused anyway. NOTHING in
-    /// <see cref="MachineEndpoints"/> mentions this path and no guard is written for it here - the only thing
-    /// standing between the caller and the probe payload is the exclusive-prefix catch-all refusal. Replace the
-    /// exclusive-group deny with per-handler guards and this test serves the probe payload with a 200, which is
-    /// the future-route hole stated out loud.
+    /// A BODY-BOUND route added to EITHER exclusive group later is refused on hosted, and - the load-bearing
+    /// claim - NO argument binder runs behind the refusal on any request shape. NOTHING in
+    /// <see cref="MachineEndpoints"/> mentions these paths and no guard is written for them here; the only
+    /// thing standing between the caller and the probe payload is each prefix's catch-all refusal.
+    ///
+    /// WHY A BODY-BOUND POST AND NOT A PARAMETERLESS GET. A parameterless GET is exactly the shape the removed
+    /// endpoint-filter deny could ALSO answer correctly - the filter ran after the framework had already
+    /// selected the endpoint and bound its arguments, so the one shape it could not be seen to miss is the one
+    /// with nothing to bind. A body-bound POST is where the difference shows: the exclusive catch-all is
+    /// verb-less and handler-less, so the discarded handler's parameter is never bound; a per-handler guard,
+    /// which runs AFTER binding, would have let the framework read and bind the body before the guard fired.
+    ///
+    /// TWO CANARIES, ONE PER CONCERN - AND WHY ONE ALONE CANNOT DO BOTH. This replicates the shared primitive's
+    /// own #1904 canary (<c>HostedRouteDenyTests</c>) exactly.
+    ///   * The FRAMEWORK-body-bound canary (<see cref="ProbeRelativePath"/>) takes a real record,
+    ///     <see cref="FutureRouteBody"/>, bound by the FRAMEWORK'S OWN model binding - NOT a custom binder. That
+    ///     is the whole point of the malformed-body row: only a genuine <c>[FromBody]</c> record reaches the
+    ///     framework's own 400 boundary, so a refusal that returns instead of that 400 proves the deny
+    ///     short-circuits BEFORE binding. A custom <c>BindAsync</c> ignores the body and never reaches that
+    ///     boundary, so a malformed-body assertion against one would be VACUOUS - the exact defect this fix
+    ///     closes. The undenied equivalent (this SAME route off hosted) is shown to answer the framework 400 in
+    ///     <see cref="HostedLauncherMachineSelfHostControlTests.A_body_bound_route_added_to_either_group_still_serves_and_binds_on_self_host"/>.
+    ///   * The OBSERVABLE-binder canary (<see cref="BinderProbeRelativePath"/>) exists ONLY to make the
+    ///     no-binder claim observable: framework body binding leaves no trace, so proving NO binder ran needs a
+    ///     parameter that records the fact it was bound. <see cref="FutureRouteBinding"/> records every bind, so
+    ///     a binder that ran anyway reddens the count here rather than leaking silently.
+    ///
+    /// BOTH PREFIXES. The family owns <c>/launchers</c> and <c>/machines</c> as separate exclusive groups, so
+    /// each has its own catch-all and each is proved independently - a proof under one prefix says nothing
+    /// about the other's future-route coverage.
+    ///
+    /// Replace the exclusive-group deny with per-handler guards (or delete it) and this test serves the probe
+    /// payload with a 200, answers the framework 400 on malformed JSON, AND records a bind - which is the
+    /// future-route + body-binding hole stated out loud.
     /// </summary>
     [Fact]
-    public async Task A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own()
+    public async Task A_body_bound_route_added_to_either_group_later_is_refused_on_hosted_with_no_binder_run()
     {
+        FutureRouteBinding.Reset();
+
         await using var probe = await MachineGroupProbeHost.StartAsync(
-            mapIntoGroup: group => group.MapGet(ProbeRelativePath, () => Results.Json(new { probe = ProbePayloadSentinel })));
+            mapIntoMachineGroup: MapBothCanaries(ProbePayloadSentinel),
+            mapIntoLauncherGroup: MapBothCanaries(ProbePayloadSentinel));
 
-        var resp = await probe.Http.GetAsync(ProbeUrl);
+        foreach (var (bodyBoundUrl, binderUrl) in new[]
+                 {
+                     (ProbeUrl, BinderProbeUrl),
+                     (LauncherProbeUrl, LauncherBinderProbeUrl),
+                 })
+        {
+            // THE FRAMEWORK-BODY-BOUND CANARY. A WELL-FORMED body: with the deny gone this route binds the body
+            // through the framework and serves the sentinel; the refusal short-circuits before that.
+            var wellFormed = await probe.Http.PostAsync(bodyBoundUrl,
+                HostedLauncherMachineDenyTests.JsonBody(new { text = "hello" }));
+            Assert.Equal(HttpStatusCode.NotFound, wellFormed.StatusCode);
+            Assert.DoesNotContain(ProbePayloadSentinel, await wellFormed.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+            await HostedLauncherMachineDenyTests.AssertBodyIsNothingButTheRefusal(wellFormed);
 
-        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
-        Assert.DoesNotContain(ProbePayloadSentinel, await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
-        await HostedLauncherMachineDenyTests.AssertBodyIsNothingButTheRefusal(resp);
+            // A MALFORMED body against that SAME framework-bound route. Its [FromBody] record makes the
+            // framework answer its OWN 400 off hosted (the undenied equivalent, proved in the self-host
+            // control); on hosted the refusal short-circuits before any binding, so this must meet the SAME
+            // refusal, not a framework 400. THIS is the row the custom-binder shape could never prove.
+            var malformed = await probe.Http.PostAsync(bodyBoundUrl,
+                new StringContent("{ not json", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.NotFound, malformed.StatusCode);
+            Assert.DoesNotContain(ProbePayloadSentinel, await malformed.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+            await HostedLauncherMachineDenyTests.AssertBodyIsNothingButTheRefusal(malformed);
+
+            // THE OBSERVABLE-BINDER CANARY, across shapes: the refusal must short-circuit before ANY argument
+            // binder runs. Its BindAsync records every invocation, so a bind behind the refusal reddens the
+            // count asserted below.
+            foreach (var shape in new[]
+                     {
+                         HostedLauncherMachineDenyTests.JsonBody(new { text = "hello" }),
+                         new StringContent("{ not json", Encoding.UTF8, "application/json"),
+                     })
+            {
+                var resp = await probe.Http.PostAsync(binderUrl, shape);
+                Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+                Assert.DoesNotContain(ProbePayloadSentinel, await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+                await HostedLauncherMachineDenyTests.AssertBodyIsNothingButTheRefusal(resp);
+            }
+        }
+
+        // THE CLAIM THAT SEPARATES A BEFORE-BINDING REFUSAL FROM AN AFTER-BINDING GUARD: not "the response was
+        // right" but that NO handler-bound code executed at all, on any shape, under either prefix. The
+        // observable binder was hit on both prefixes above and never once ran.
+        Assert.Equal(0, FutureRouteBinding.Count);
     }
+
+    /// <summary>
+    /// Maps BOTH canaries into a group: the framework-body-bound record route and the observable-binder route.
+    /// The <paramref name="payload"/> sentinel is what the framework-bound handler would serve if the deny
+    /// failed to short-circuit - so its ABSENCE from the response is the leak check.
+    /// </summary>
+    private static Action<HostedDenyGroup> MapBothCanaries(string payload) => group =>
+    {
+        group.MapPost(ProbeRelativePath,
+            (FutureRouteBody body) => Results.Json(new { probe = payload, echoed = body.Text }));
+        group.MapPost(BinderProbeRelativePath,
+            (FutureRouteBinding bound) => Results.Json(new { probe = payload, bound = bound.Value }));
+    };
 
     /// <summary>
     /// CONTROL: the deny is scoped to this group, not a blanket refusal on the whole application. A route
@@ -844,24 +956,107 @@ public sealed class HostedLauncherMachineSelfHostControlTests : IDisposable
     }
 
     /// <summary>
-    /// THE SECOND HALF OF THE FUTURE-ROUTE PROOF: the same probe path that
-    /// <see cref="HostedLauncherMachineExclusiveGroupTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own"/>
-    /// finds refused on hosted must be SERVED with hosted mode explicitly off, in both non-hosted forms.
-    /// Without this half, "the deny refuses everything, always" would pass every hosted assertion in this
-    /// file while having silently killed the family for self-host too.
+    /// THE SECOND HALF OF THE FUTURE-ROUTE PROOF: the same body-bound probe paths that
+    /// <see cref="HostedLauncherMachineExclusiveGroupTests.A_body_bound_route_added_to_either_group_later_is_refused_on_hosted_with_no_binder_run"/>
+    /// finds refused on hosted must be SERVED - and their binders actually RUN - with hosted mode explicitly
+    /// off, in both non-hosted forms and under BOTH prefixes. Without this half, "the deny refuses everything,
+    /// always" would pass every hosted assertion in this file while having silently killed the family for
+    /// self-host too; and a primitive that broke binding on every deployment would satisfy the hosted
+    /// no-binder assertion and nothing would notice.
+    ///
+    /// IT ALSO PINS THE UNDENIED 400 BOUNDARY THE HOSTED MALFORMED-BODY ROW IS MEASURED AGAINST. The
+    /// framework-body-bound canary here answers the framework's OWN 400 on malformed JSON off hosted - so the
+    /// hosted refusal returning instead of that 400 genuinely proves a short-circuit BEFORE binding, rather
+    /// than dodging a boundary that never existed. The bind count is the positive twin of the hosted
+    /// no-binder assertion.
     /// </summary>
     [Theory]
     [MemberData(nameof(NonHostedValues))]
-    public async Task A_route_added_to_the_group_still_serves_on_self_host(string? hostedValue)
+    public async Task A_body_bound_route_added_to_either_group_still_serves_and_binds_on_self_host(string? hostedValue)
     {
         DeclareSelfHost(hostedValue);
+        FutureRouteBinding.Reset();
+
         await using var probe = await MachineGroupProbeHost.StartAsync(
-            mapIntoGroup: group => group.MapGet(HostedLauncherMachineExclusiveGroupTests.ProbeRelativePath,
-                () => Results.Json(new { probe = "served" })));
+            mapIntoMachineGroup: MapBothServedCanaries(),
+            mapIntoLauncherGroup: MapBothServedCanaries());
 
-        var resp = await probe.Http.GetAsync(HostedLauncherMachineExclusiveGroupTests.ProbeUrl);
+        foreach (var (bodyBoundUrl, binderUrl) in new[]
+                 {
+                     (HostedLauncherMachineExclusiveGroupTests.ProbeUrl,
+                      HostedLauncherMachineExclusiveGroupTests.BinderProbeUrl),
+                     (HostedLauncherMachineExclusiveGroupTests.LauncherProbeUrl,
+                      HostedLauncherMachineExclusiveGroupTests.LauncherBinderProbeUrl),
+                 })
+        {
+            // The framework-bound canary serves a VALID body off hosted, binding the record through the
+            // framework...
+            var served = await probe.Http.PostAsync(bodyBoundUrl,
+                HostedLauncherMachineDenyTests.JsonBody(new { text = "hello" }));
+            Assert.Equal(HttpStatusCode.OK, served.StatusCode);
+            Assert.Contains("served", await served.Content.ReadAsStringAsync(), StringComparison.Ordinal);
 
-        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-        Assert.Contains("served", await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+            // ...and its [FromBody] record makes the FRAMEWORK answer its OWN 400 on malformed JSON. THIS is
+            // the undenied equivalent the hosted malformed-body assertion is measured against: the 400 boundary
+            // is real here, so the hosted refusal genuinely short-circuits before binding.
+            var malformed = await probe.Http.PostAsync(bodyBoundUrl,
+                new StringContent("{ not json", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.BadRequest, malformed.StatusCode);
+
+            // The observable-binder canary serves off hosted and its binder RUNS.
+            var bound = await probe.Http.PostAsync(binderUrl,
+                HostedLauncherMachineDenyTests.JsonBody(new { text = "hello" }));
+            Assert.Equal(HttpStatusCode.OK, bound.StatusCode);
+            Assert.Contains("served", await bound.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        }
+
+        // Off hosted the real handler IS mapped, so the observable binder ran - once per prefix. The hosted
+        // twin asserts this same instrument stayed at zero.
+        Assert.Equal(2, FutureRouteBinding.Count);
+    }
+
+    /// <summary>Maps both canaries with the self-host "served" payload into a group.</summary>
+    private static Action<HostedDenyGroup> MapBothServedCanaries() => group =>
+    {
+        group.MapPost(HostedLauncherMachineExclusiveGroupTests.ProbeRelativePath,
+            (FutureRouteBody body) => Results.Json(new { probe = "served", echoed = body.Text }));
+        group.MapPost(HostedLauncherMachineExclusiveGroupTests.BinderProbeRelativePath,
+            (FutureRouteBinding bound) => Results.Json(new { probe = "served", bound = bound.Value }));
+    };
+}
+
+/// <summary>
+/// The FRAMEWORK-body-bound canary type: a plain record bound from the request body by the framework's OWN
+/// model binding (the <c>[FromBody]</c> inference minimal APIs apply to a complex parameter), exactly like the
+/// production routes' <c>LauncherRegistrationRequest</c> / <c>NewSessionRequest</c> and the #1904 primitive's
+/// <c>EchoBody</c>. Using the framework's binder is the whole point: only a genuine body-bound record reaches
+/// the framework's own malformed-JSON 400 boundary, so a refusal that returns instead of that 400 proves the
+/// deny short-circuits BEFORE binding. A custom <c>BindAsync</c> would ignore the body and never reach that
+/// boundary, making the malformed-body assertion vacuous.
+/// </summary>
+internal sealed record FutureRouteBody(string Text);
+
+/// <summary>
+/// A minimal-API parameter whose BINDING IS OBSERVABLE, so a proof can assert that NO handler-bound code ran
+/// behind the hosted refusal - the property that separates a refusal placed BEFORE argument binding (the
+/// exclusive catch-all) from a guard placed AFTER it (a per-handler check). Argument binding leaves no trace
+/// of its own; this records the fact it was invoked. It ignores the request body deliberately: the claim is
+/// about WHETHER the binder ran, not what it read - which is ALSO why it cannot carry the malformed-body 400
+/// proof, and why <see cref="FutureRouteBody"/> exists as a separate framework-bound canary for that row.
+/// </summary>
+internal sealed class FutureRouteBinding
+{
+    private static int _count;
+
+    public string Value { get; init; } = "";
+
+    public static int Count => Volatile.Read(ref _count);
+
+    public static void Reset() => Interlocked.Exchange(ref _count, 0);
+
+    public static ValueTask<FutureRouteBinding?> BindAsync(HttpContext context)
+    {
+        Interlocked.Increment(ref _count);
+        return ValueTask.FromResult<FutureRouteBinding?>(new FutureRouteBinding { Value = "bound" });
     }
 }

--- a/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
@@ -118,13 +118,30 @@ namespace CcDirector.Gateway.Tests;
 ///   refusal is ALSO 404 with application/json, so status and media type still match; what separates them is
 ///   the body, which carries { error, machine } with a different error string instead of { error } alone.
 ///   THAT IS THE SHARPEST PREDICTION IN THIS FILE and it is the reason the refusal is asserted as an exact
-///   property set rather than as a status code: if those four rows came back GREEN under the mutation, it
-///   would mean the deny had been indistinguishable from "no launcher registered on that machine" all along.
+///   property set rather than as a status code.
 ///
-/// DECLARED UNKNOWN, stated as an unknown rather than left open: those four rows depend on the launcher
-/// STREAM arm returning null inside a full GatewayHost booted with streamMode true, so the REST relay arm is
-/// the one that answers. If the stream arm answers instead, they redden on the status assertion rather than
-/// the property set. What is NOT unknown is that they must redden; a green there is a finding, not a pass.
+/// THOSE FOUR ROWS ARE A TRAP DETECTOR, NOT MERELY AN EXPECTATION - AND THE TRAP IS
+/// ABSENCE-PROVED-TWICE-PRESENCE-NEVER. The hosted deny answers 404, and so does the relay's own "no launcher
+/// registered on that machine". Two different absences, identical on the wire except in the body. So:
+///
+///   - If those four come back GREEN under the mutation, the deny was INDISTINGUISHABLE from
+///     no-launcher-registered all along, and every hosted pass on them proved nothing.
+///   - IF THOSE FOUR REDDEN ON THE STATUS ASSERTION RATHER THAN ON THE PROPERTY-SET ASSERTION, THAT IS A
+///     FINDING ABOUT THE DENY'S DISTINGUISHABILITY - NOT A HARMLESS VARIATION IN THE ARM. It means something
+///     other than the body carried the difference, and the property-set assertion - the only thing separating
+///     a deny from a missing route on this family - was never the load-bearing check it is claimed to be.
+///
+/// Write that down, because the failure mode is a READER failure: four reds appear, a reviewer counts four
+/// against a prediction of four, and nobody notices they ARRIVED BY THE WRONG ROUTE. That is the
+/// arrival-classification rule turned on this file's own prediction. A red is classified by WHERE IT ARRIVES,
+/// and that applies to the predicted reds exactly as it applies to the unexpected ones.
+///
+/// DECLARED UNKNOWN, and note WHICH DIMENSION is uncertain - uncertain about the ROUTE, certain about the
+/// OUTCOME. Those four rows depend on the launcher STREAM arm returning null inside a full GatewayHost booted
+/// with streamMode true, so the REST relay arm is the one that answers; whether that holds is what cannot be
+/// predicted from reading alone. What is NOT unknown is that they MUST REDDEN. A blanket "not sure what
+/// happens here" would have been unfalsifiable; naming the one uncertain dimension leaves every other claim
+/// testable, and the status-versus-property-set arrival is then a FINDING rather than a shrug.
 ///
 /// MUST STAY GREEN - the controls, and a control that moves with the change under test is not a control:
 ///   HostedLauncherMachineDenyTests.An_unauthenticated_caller_is_still_rejected
@@ -137,8 +154,12 @@ namespace CcDirector.Gateway.Tests;
 /// finding about every other hosted test in this assembly, not a detail about this one.
 ///
 /// RECONCILE EVERY ARM, INCLUDING BASELINE AND RESTORE: passed plus failed plus skipped must EQUAL the
-/// baseline total. A pre-existing race can truncate a run while still printing a cheerful passed line, and a
-/// truncated arm reads exactly like a mutation that reddened fewer tests than predicted.
+/// baseline total, taken FRESH at this head and never quoted from another run. A pre-existing race can
+/// truncate a run while still printing a cheerful passed line - and a truncated arm reads EXACTLY like a
+/// mutation that reddened fewer tests than predicted. Without the reconciliation, a truncation that swallowed
+/// three of the fifteen would present as a twelve-red arm, which under this pre-registration would have to be
+/// treated as a finding about the deny. Reconcile FIRST, then classify; a total that does not add up
+/// disqualifies the arm before any red in it is worth interpreting.
 /// </summary>
 public sealed class HostedLauncherMachineDenyTests : IAsyncLifetime
 {

--- a/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
@@ -15,6 +15,7 @@ using CcDirector.Gateway.Api;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
 using CcDirector.Gateway.Running;
+using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -57,11 +58,14 @@ namespace CcDirector.Gateway.Tests;
 /// that does not exist, and an allow-list on the property set reddens automatically on any extra leaked
 /// field, unlike a substring check.
 ///
-/// ONE GROUP FILTER, NOT A GUARD PER ROUTE. The refusal is an endpoint filter on the route group, so it runs
-/// before every route in the group INCLUDING ROUTES THAT DO NOT EXIST YET. A guard repeated in each handler
-/// passes exactly the same tests as a group filter for the routes that exist today, which is precisely what
-/// makes it dangerous. <see cref="HostedLauncherMachineGroupFilterTests"/> proves the difference with a
-/// brand-new probe route, in BOTH directions (refused on hosted, served on self-host).
+/// ONE EXCLUSIVE-PREFIX DENY, NOT A GUARD PER ROUTE. The refusal is expressed through the shared primitive
+/// <see cref="HostedRouteDeny.ExclusiveGroup"/> (the same boundary #1904 adopted for /vault/keys), one
+/// exclusive group per prefix - <c>/launchers</c> and <c>/machines</c>. On hosted the family's handlers are
+/// never mapped; each prefix maps ONE verb-less catch-all refusal that covers every verb, every sub-path, and
+/// ROUTES THAT DO NOT EXIST YET. A guard repeated in each handler passes exactly the same tests as this for
+/// the routes that exist today, which is precisely what makes it dangerous.
+/// <see cref="HostedLauncherMachineExclusiveGroupTests"/> proves the difference with a brand-new probe route,
+/// in BOTH directions (refused on hosted, served on self-host).
 ///
 /// THE WRITE IS STOPPED ON THE HTTP SURFACE, BUT NOT EVERYWHERE - AND THAT DECIDES THE UN-DENY. This file
 /// proves the denied write routes leave no state behind: after a refused POST /launchers/register the
@@ -78,20 +82,22 @@ namespace CcDirector.Gateway.Tests;
 /// by a positive effect - a seeded registration read back, a relay reaching a STUB LAUNCHER and returning its
 /// sentinel payload, a spawned session id - never merely by the refusal being absent.
 ///
-/// REVERT-PROOF RECIPE. In <c>src/CcDirector.Gateway/Api/MachineEndpoints.cs</c> DELETE the
-/// <c>app.AddEndpointFilter(...)</c> block outright, leaving <c>var app = outer.MapGroup("");</c> in place so
-/// the group still exists and the file compiles - the hosted deny is then absent ENTIRELY with no per-route
-/// guard put back in its place. Deleting is the only correct revert: wrapping it in <c>if (false)</c> leaves
-/// unreachable code, which is a BUILD ERROR here, and a test run after a failed build silently executes the
-/// previous binary and reports a false pass. Rebuild, CONFIRM ZERO ERRORS, verify by diff that the mutation
-/// is actually present in the source, then run the FULL suite - never a filter over these classes, which
-/// could not see whether some existing test already covered the behaviour nor any collateral damage.
+/// REVERT-PROOF RECIPE - the recipe to RUN, not to describe. In
+/// <c>src/CcDirector.Gateway/Api/MachineEndpoints.cs</c> change the two
+/// <c>HostedRouteDeny.ExclusiveGroup(outer, prefix, ...)</c> constructions so the family maps its real
+/// handlers on hosted too - the simplest such mutation is to construct plain non-denied groups with the same
+/// prefixes (<c>outer.MapGroup(LauncherPrefix)</c> / <c>outer.MapGroup(MachinePrefix)</c>) and map the nine
+/// routes on them. The hosted deny is then absent ENTIRELY, with no per-route guard put in its place. This is
+/// the only correct revert: it must COMPILE (a build error means a test run silently executes the previous
+/// binary and reports a false pass), so confirm ZERO ERRORS and verify by diff that the mutation is present in
+/// the source, then run the FULL suite - never a filter over these classes, which could not see whether some
+/// existing test already covered the behaviour nor any collateral damage.
 ///
 /// THE REDS ARE PRE-REGISTERED BELOW, WRITTEN AND PUSHED BEFORE THE ARM WAS EVER RUN. That ordering is the
 /// whole point: A PREDICTED RED THAT DOES NOT APPEAR IS A FINDING. A list filled in afterwards from what was
 /// observed cannot produce that finding at all - whatever reddens is by definition what was expected, so a
 /// mutation that silently failed to apply, or that reddened the wrong tests, reads as a clean result. It
-/// guards the other direction too: MORE reds than predicted means the filter was carrying something that was
+/// guards the other direction too: MORE reds than predicted means the deny was carrying something that was
 /// not accounted for, and that is to be understood rather than accepted.
 ///
 /// PREDICTION: EXACTLY 15 TEST CASES REDDEN, ALL OF THEM IN THIS FILE, AND NOTHING ELSE IN THE SUITE MOVES.
@@ -100,15 +106,15 @@ namespace CcDirector.Gateway.Tests;
 ///       - ALL NINE theory rows.
 ///   HostedLauncherMachineDenyTests.The_launcher_listing_leaks_no_machine_on_hosted
 ///   HostedLauncherMachineDenyTests.The_refusal_is_not_an_empty_launcher_list
-///   HostedLauncherMachineGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own
-///   HostedLauncherMachineGroupFilterTests.A_refused_registration_writes_nothing_into_the_registry
-///   HostedLauncherMachineGroupFilterTests.A_refused_spawn_never_reaches_the_resolver
-///   HostedLauncherMachineGroupFilterTests.A_refused_launch_never_dials_the_launcher
+///   HostedLauncherMachineExclusiveGroupTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own
+///   HostedLauncherMachineExclusiveGroupTests.A_refused_registration_writes_nothing_into_the_registry
+///   HostedLauncherMachineExclusiveGroupTests.A_refused_spawn_never_reaches_the_resolver
+///   HostedLauncherMachineExclusiveGroupTests.A_refused_launch_never_dials_the_launcher
 ///
 /// WHERE EACH RED IS PREDICTED TO ARRIVE, because a red that arrives from the fixture is VOID and only a red
 /// that arrives from an assertion about what was served proves anything:
 ///
-///   Five of the nine theory rows redden on the STATUS assertion, because with the filter gone the handler's
+///   Five of the nine theory rows redden on the STATUS assertion, because with the deny gone the handler's
 ///   own answer is a different status: register -> 201 Created, heartbeat on an unregistered machine -> 410
 ///   Gone, unregister -> 200 OK, the listing -> 200 OK, and the spawn -> 502 Bad Gateway (no Director on that
 ///   machine; the spawner fails loud rather than falling back).
@@ -145,11 +151,11 @@ namespace CcDirector.Gateway.Tests;
 ///
 /// MUST STAY GREEN - the controls, and a control that moves with the change under test is not a control:
 ///   HostedLauncherMachineDenyTests.An_unauthenticated_caller_is_still_rejected
-///   HostedLauncherMachineGroupFilterTests.A_route_outside_the_group_still_serves_on_hosted
+///   HostedLauncherMachineExclusiveGroupTests.A_route_outside_the_group_still_serves_on_hosted
 ///   ALL TEN cases of HostedLauncherMachineSelfHostControlTests (five methods, two non-hosted forms each)
 ///
 /// AND ZERO REDS ANYWHERE ELSE IN THE SUITE. The twelve existing launcher and machine test files run under
-/// the runner's ambient non-hosted default, where this filter is a pass-through, so deleting it cannot reach
+/// the runner's ambient non-hosted default, where this deny is a pass-through (the primitive maps real handlers off hosted), so removing it cannot reach
 /// them. If one of them reddens, the ambient default is not what it is believed to be - which would be a
 /// finding about every other hosted test in this assembly, not a detail about this one.
 ///
@@ -227,9 +233,9 @@ namespace CcDirector.Gateway.Tests;
 /// OVER THE FILESYSTEM, and the reference graph is structurally blind to it.
 ///
 /// For THIS mutation it is settled, and settled for FREE by text rather than by spending a box slot: the
-/// deleted block is five lines of routing code containing ZERO loopback literals, and MachineEndpoints.cs
-/// still contains four afterwards - so the allowlist entry stays honest and that guard cannot flip. Verified
-/// by applying the mutation, grepping, and restoring.
+/// mutation only swaps the two exclusive-group constructions for plain groups (routing wiring), touching ZERO
+/// loopback literals, and MachineEndpoints.cs still contains four afterwards - so the allowlist entry stays
+/// honest and that guard cannot flip. Verified by applying the mutation, grepping, and restoring.
 ///
 /// THE DECIDING ARGUMENT IS THE RECONCILIATION GATE, NOT THE COUPLING. Scoping the ARM narrower than the
 /// BASELINE BREAKS the primary truncation detector, because passed plus failed plus skipped is then compared
@@ -363,7 +369,7 @@ public sealed class HostedLauncherMachineDenyTests : IAsyncLifetime
     public async Task An_unauthenticated_caller_is_still_rejected()
     {
         // Control: the deny must not have opened the family up as a side effect of running before the gate.
-        // Without a key the host-wide auth middleware still refuses FIRST, so the 404s above are the filter
+        // Without a key the host-wide auth middleware still refuses FIRST, so the 404s above are the deny
         // and not the absence of a gate.
         Assert.Equal(HttpStatusCode.Unauthorized, (await _http.GetAsync("launchers")).StatusCode);
         Assert.Equal(HttpStatusCode.Unauthorized,
@@ -455,7 +461,7 @@ internal sealed class MachineGroupProbeHost : IAsyncDisposable
     }
 
     public static async Task<MachineGroupProbeHost> StartAsync(
-        Action<RouteGroupBuilder>? mapIntoGroup = null,
+        Action<HostedDenyGroup>? mapIntoGroup = null,
         Action<IEndpointRouteBuilder>? mapOutsideGroup = null,
         bool withStubLauncher = false)
     {
@@ -500,8 +506,11 @@ internal sealed class MachineGroupProbeHost : IAsyncDisposable
             (directorId, req, ct) => Task.FromResult<(bool, SessionDto?, string?)>(
                 (true, new SessionDto { SessionId = SpawnedSessionId }, null)));
 
-        var group = MachineEndpoints.Map(app, launchers, spawner, sendLauncherCommand: null);
-        mapIntoGroup?.Invoke(group);
+        // The probe routes are /machines paths, so mapIntoGroup targets the MACHINE exclusive group. On hosted
+        // its handler is discarded and the group's catch-all refuses the path; off hosted the handler is mapped
+        // and served - which is exactly the future-route property both directions of the proof turn on.
+        var (_, machineGroup) = MachineEndpoints.Map(app, launchers, spawner, sendLauncherCommand: null);
+        mapIntoGroup?.Invoke(machineGroup);
         mapOutsideGroup?.Invoke(app);
 
         await app.StartAsync();
@@ -538,10 +547,10 @@ internal sealed class MachineGroupProbeHost : IAsyncDisposable
 }
 
 /// <summary>
-/// THE POINT OF THE WHOLE CHANGE: the hosted refusal is a filter on the ROUTE GROUP, so it covers routes that
+/// THE POINT OF THE WHOLE CHANGE: the hosted refusal is an exclusive-prefix deny on the ROUTE GROUP, so it covers routes that
 /// have not been written yet.
 ///
-/// A guard repeated in every handler passes exactly the same tests as a group filter for the routes that
+/// A guard repeated in every handler passes exactly the same tests as an exclusive-prefix deny for the routes that
 /// exist today, which is precisely why it is dangerous - the difference only shows up on the route somebody
 /// adds NEXT, when it is open by default and nothing fails. On THIS family, "open by default" means
 /// cross-machine code execution. That difference is not observable by driving the nine routes that exist, so
@@ -550,14 +559,21 @@ internal sealed class MachineGroupProbeHost : IAsyncDisposable
 /// <see cref="HostedLauncherMachineSelfHostControlTests"/>: one direction alone cannot tell a working gate
 /// apart from a brick.
 /// </summary>
-public sealed class HostedLauncherMachineGroupFilterTests : IDisposable
+public sealed class HostedLauncherMachineExclusiveGroupTests : IDisposable
 {
     internal const string ProbePayloadSentinel = "probe-payload-that-must-never-be-served-on-hosted";
-    internal const string ProbePath = "/machines/added-after-the-deny-was-written";
+
+    /// <summary>The probe route mapped RELATIVE to the machine group prefix, so the full path is
+    /// <see cref="ProbeUrl"/>. It is mapped through the returned <see cref="HostedDenyGroup"/> handle, never
+    /// through the outer builder, which is what lets the future-route property be stated from a test.</summary>
+    internal const string ProbeRelativePath = "/added-after-the-deny-was-written";
+
+    /// <summary>The full URL the probe route answers on - the machine prefix plus <see cref="ProbeRelativePath"/>.</summary>
+    internal const string ProbeUrl = "/machines/added-after-the-deny-was-written";
 
     private readonly string? _priorHosted;
 
-    public HostedLauncherMachineGroupFilterTests()
+    public HostedLauncherMachineExclusiveGroupTests()
     {
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
@@ -569,17 +585,17 @@ public sealed class HostedLauncherMachineGroupFilterTests : IDisposable
     /// <summary>
     /// A route that did not exist when the refusal was written is refused anyway. NOTHING in
     /// <see cref="MachineEndpoints"/> mentions this path and no guard is written for it here - the only thing
-    /// standing between the caller and the probe payload is the group filter. Replace the filter with
-    /// per-handler guards and this test serves the probe payload with a 200, which is the future-route hole
-    /// stated out loud.
+    /// standing between the caller and the probe payload is the exclusive-prefix catch-all refusal. Replace the
+    /// exclusive-group deny with per-handler guards and this test serves the probe payload with a 200, which is
+    /// the future-route hole stated out loud.
     /// </summary>
     [Fact]
     public async Task A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own()
     {
         await using var probe = await MachineGroupProbeHost.StartAsync(
-            mapIntoGroup: group => group.MapGet(ProbePath, () => Results.Json(new { probe = ProbePayloadSentinel })));
+            mapIntoGroup: group => group.MapGet(ProbeRelativePath, () => Results.Json(new { probe = ProbePayloadSentinel })));
 
-        var resp = await probe.Http.GetAsync(ProbePath);
+        var resp = await probe.Http.GetAsync(ProbeUrl);
 
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
         Assert.DoesNotContain(ProbePayloadSentinel, await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
@@ -587,8 +603,8 @@ public sealed class HostedLauncherMachineGroupFilterTests : IDisposable
     }
 
     /// <summary>
-    /// CONTROL: the filter is scoped to this group, not a blanket refusal on the whole application. A route
-    /// mapped OUTSIDE the group still serves on hosted, so the passing tests here are the filter doing its
+    /// CONTROL: the deny is scoped to this group, not a blanket refusal on the whole application. A route
+    /// mapped OUTSIDE the group still serves on hosted, so the passing tests here are the deny doing its
     /// job rather than the host refusing everything.
     /// </summary>
     [Fact]
@@ -829,9 +845,9 @@ public sealed class HostedLauncherMachineSelfHostControlTests : IDisposable
 
     /// <summary>
     /// THE SECOND HALF OF THE FUTURE-ROUTE PROOF: the same probe path that
-    /// <see cref="HostedLauncherMachineGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own"/>
+    /// <see cref="HostedLauncherMachineExclusiveGroupTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own"/>
     /// finds refused on hosted must be SERVED with hosted mode explicitly off, in both non-hosted forms.
-    /// Without this half, "the filter refuses everything, always" would pass every hosted assertion in this
+    /// Without this half, "the deny refuses everything, always" would pass every hosted assertion in this
     /// file while having silently killed the family for self-host too.
     /// </summary>
     [Theory]
@@ -840,10 +856,10 @@ public sealed class HostedLauncherMachineSelfHostControlTests : IDisposable
     {
         DeclareSelfHost(hostedValue);
         await using var probe = await MachineGroupProbeHost.StartAsync(
-            mapIntoGroup: group => group.MapGet(HostedLauncherMachineGroupFilterTests.ProbePath,
+            mapIntoGroup: group => group.MapGet(HostedLauncherMachineExclusiveGroupTests.ProbeRelativePath,
                 () => Results.Json(new { probe = "served" })));
 
-        var resp = await probe.Http.GetAsync(HostedLauncherMachineGroupFilterTests.ProbePath);
+        var resp = await probe.Http.GetAsync(HostedLauncherMachineExclusiveGroupTests.ProbeUrl);
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.Contains("served", await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);

--- a/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
@@ -627,11 +627,13 @@ public sealed class HostedLauncherMachineExclusiveGroupTests : IDisposable
     /// own #1904 canary (<c>HostedRouteDenyTests</c>) exactly.
     ///   * The FRAMEWORK-body-bound canary (<see cref="ProbeRelativePath"/>) takes a real record,
     ///     <see cref="FutureRouteBody"/>, bound by the FRAMEWORK'S OWN model binding - NOT a custom binder. That
-    ///     is the whole point of the malformed-body row: only a genuine <c>[FromBody]</c> record reaches the
-    ///     framework's own 400 boundary, so a refusal that returns instead of that 400 proves the deny
-    ///     short-circuits BEFORE binding. A custom <c>BindAsync</c> ignores the body and never reaches that
-    ///     boundary, so a malformed-body assertion against one would be VACUOUS - the exact defect this fix
-    ///     closes. The undenied equivalent (this SAME route off hosted) is shown to answer the framework 400 in
+    ///     is the whole point of the malformed-body AND wrong-media-type rows: only a genuine <c>[FromBody]</c>
+    ///     record reaches the framework's own 400 boundary (malformed JSON) and its own 415 boundary (a body
+    ///     media type endpoint SELECTION rejects), so a refusal that returns instead of that 400 or 415 proves
+    ///     the deny short-circuits BEFORE binding and BEFORE selection. A custom <c>BindAsync</c> ignores the
+    ///     body and reaches neither boundary, so those assertions against one would be VACUOUS - the exact
+    ///     defect this fix closes. The undenied equivalents (this SAME route off hosted) are shown to answer the
+    ///     framework 400 and 415 in
     ///     <see cref="HostedLauncherMachineSelfHostControlTests.A_body_bound_route_added_to_either_group_still_serves_and_binds_on_self_host"/>.
     ///   * The OBSERVABLE-binder canary (<see cref="BinderProbeRelativePath"/>) exists ONLY to make the
     ///     no-binder claim observable: framework body binding leaves no trace, so proving NO binder ran needs a
@@ -643,8 +645,8 @@ public sealed class HostedLauncherMachineExclusiveGroupTests : IDisposable
     /// about the other's future-route coverage.
     ///
     /// Replace the exclusive-group deny with per-handler guards (or delete it) and this test serves the probe
-    /// payload with a 200, answers the framework 400 on malformed JSON, AND records a bind - which is the
-    /// future-route + body-binding hole stated out loud.
+    /// payload with a 200, answers the framework 400 on malformed JSON, answers the framework 415 on a wrong
+    /// media type, AND records a bind - which is the future-route + body-binding hole stated out loud.
     /// </summary>
     [Fact]
     public async Task A_body_bound_route_added_to_either_group_later_is_refused_on_hosted_with_no_binder_run()
@@ -678,6 +680,19 @@ public sealed class HostedLauncherMachineExclusiveGroupTests : IDisposable
             Assert.Equal(HttpStatusCode.NotFound, malformed.StatusCode);
             Assert.DoesNotContain(ProbePayloadSentinel, await malformed.Content.ReadAsStringAsync(), StringComparison.Ordinal);
             await HostedLauncherMachineDenyTests.AssertBodyIsNothingButTheRefusal(malformed);
+
+            // A WRONG MEDIA TYPE against that SAME framework-bound route. Its body parameter makes the
+            // framework infer a media-type constraint that endpoint SELECTION enforces ahead of any handler,
+            // so off hosted this shape meets the framework's OWN 415 (the undenied equivalent, proved in the
+            // self-host control). On hosted the family's handlers are never mapped and each prefix's verb-less
+            // catch-all claims the path, so the refusal short-circuits before selection could reject the media
+            // type - this must meet the SAME refusal, not a framework 415. THIS is the row a wrong media type
+            // could otherwise slip through if the deny ran after endpoint selection.
+            var wrongMedia = await probe.Http.PostAsync(bodyBoundUrl,
+                new StringContent("hello", Encoding.UTF8, "text/plain"));
+            Assert.Equal(HttpStatusCode.NotFound, wrongMedia.StatusCode);
+            Assert.DoesNotContain(ProbePayloadSentinel, await wrongMedia.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+            await HostedLauncherMachineDenyTests.AssertBodyIsNothingButTheRefusal(wrongMedia);
 
             // THE OBSERVABLE-BINDER CANARY, across shapes: the refusal must short-circuit before ANY argument
             // binder runs. Its BindAsync records every invocation, so a bind behind the refusal reddens the
@@ -964,11 +979,12 @@ public sealed class HostedLauncherMachineSelfHostControlTests : IDisposable
     /// self-host too; and a primitive that broke binding on every deployment would satisfy the hosted
     /// no-binder assertion and nothing would notice.
     ///
-    /// IT ALSO PINS THE UNDENIED 400 BOUNDARY THE HOSTED MALFORMED-BODY ROW IS MEASURED AGAINST. The
-    /// framework-body-bound canary here answers the framework's OWN 400 on malformed JSON off hosted - so the
-    /// hosted refusal returning instead of that 400 genuinely proves a short-circuit BEFORE binding, rather
-    /// than dodging a boundary that never existed. The bind count is the positive twin of the hosted
-    /// no-binder assertion.
+    /// IT ALSO PINS THE UNDENIED 400 AND 415 BOUNDARIES THE HOSTED MALFORMED-BODY AND WRONG-MEDIA ROWS ARE
+    /// MEASURED AGAINST. The framework-body-bound canary here answers the framework's OWN 400 on malformed JSON
+    /// AND its OWN 415 on a wrong media type off hosted - so the hosted refusal returning instead of that 400
+    /// or 415 genuinely proves a short-circuit BEFORE binding and BEFORE endpoint selection, rather than
+    /// dodging a boundary that never existed. The bind count is the positive twin of the hosted no-binder
+    /// assertion.
     /// </summary>
     [Theory]
     [MemberData(nameof(NonHostedValues))]
@@ -1002,6 +1018,15 @@ public sealed class HostedLauncherMachineSelfHostControlTests : IDisposable
             var malformed = await probe.Http.PostAsync(bodyBoundUrl,
                 new StringContent("{ not json", Encoding.UTF8, "application/json"));
             Assert.Equal(HttpStatusCode.BadRequest, malformed.StatusCode);
+
+            // ...and a WRONG MEDIA TYPE makes the framework answer its OWN 415: the record parameter infers a
+            // media-type constraint that endpoint SELECTION enforces here, because off hosted the real handler
+            // IS mapped. This is the undenied equivalent the hosted wrong-media row is measured against - the
+            // 415 boundary is real here, so the hosted refusal returning instead of it genuinely proves a
+            // short-circuit before endpoint selection, not a boundary that never existed.
+            var wrongMedia = await probe.Http.PostAsync(bodyBoundUrl,
+                new StringContent("hello", Encoding.UTF8, "text/plain"));
+            Assert.Equal(HttpStatusCode.UnsupportedMediaType, wrongMedia.StatusCode);
 
             // The observable-binder canary serves off hosted and its binder RUNS.
             var bound = await probe.Http.PostAsync(binderUrl,

--- a/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
@@ -212,6 +212,34 @@ namespace CcDirector.Gateway.Tests;
 /// truncated arm, a crash-red arm, a stayed-green arm) and confirming it returns a distinct non-zero verdict,
 /// and against a clean arm to confirm it does not fire on the happy path. A detector that has only ever been
 /// read is another printout.
+///
+/// WHY ALL THREE ARMS ARE THE FULL SOLUTION, AND NOT THE GATEWAY ASSEMBLY PER ARM. The obvious answer is the
+/// reference graph: of the seven test projects, ONLY CcDirector.Gateway.Tests references
+/// CcDirector.Gateway, so nothing else can even load the mutated code. THAT ANSWER IS WRONG, and it is worth
+/// writing down because it is the answer anyone would give.
+///
+/// CcDirector.Core.Tests contains TEN ARCHITECTURE FITNESS FUNCTIONS THAT READ PRODUCTION SOURCE UNDER src/
+/// AS TEXT, with NO assembly reference to the Gateway at all. One of them,
+/// NoCrossMachineLoopbackGuardTests, carries a PATH-KEYED ALLOWLIST that names
+/// "src/CcDirector.Gateway/Api/MachineEndpoints.cs" EXPLICITLY - THIS FILE'S production twin - and by its own
+/// documentation it fails on a STALE entry, meaning a file that no longer contains the literal. So a source
+/// edit in the Gateway CAN redden a project that does not reference the Gateway. The coupling is TEXTUAL,
+/// OVER THE FILESYSTEM, and the reference graph is structurally blind to it.
+///
+/// For THIS mutation it is settled, and settled for FREE by text rather than by spending a box slot: the
+/// deleted block is five lines of routing code containing ZERO loopback literals, and MachineEndpoints.cs
+/// still contains four afterwards - so the allowlist entry stays honest and that guard cannot flip. Verified
+/// by applying the mutation, grepping, and restoring.
+///
+/// THE DECIDING ARGUMENT IS THE RECONCILIATION GATE, NOT THE COUPLING. Scoping the ARM narrower than the
+/// BASELINE BREAKS the primary truncation detector, because passed plus failed plus skipped is then compared
+/// against a total from a DIFFERENT population and can never match. Preserving the gate under a scoped arm
+/// requires a scoped baseline TOO - which is a FOURTH run, on a contended serial box, to save part of one.
+/// The per-arm saving scales with the NUMBER OF ARMS while the extra full run is FIXED, so the scoping that
+/// is correct for an eight-arm proof INVERTS at three arms: measured against roughly seventeen minutes a full
+/// solution and ten a Gateway suite, three full runs is about fifty minutes, and every scoped variant that
+/// keeps the gate intact lands at forty-seven to fifty-six. There is no saving here to buy, only a detector
+/// to lose.
 /// </summary>
 public sealed class HostedLauncherMachineDenyTests : IAsyncLifetime
 {

--- a/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
@@ -1,0 +1,697 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Running;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1917: the launcher and machine-control family is DENIED on the hosted Gateway.
+///
+/// THE DEFECT. The family is TENANT-BLIND BY CONSTRUCTION - there is no tenant dimension anywhere in the
+/// path. <see cref="LauncherRegistry"/> keys on machine NAME alone, <c>LauncherConnectionRegistry</c> keys on
+/// machine NAME alone, and <c>LauncherHub.Hello</c> binds a connection to a machine name with NO tenant
+/// resolution at all - in direct contrast to <c>DirectorHub.Hello</c>, which aborts when the device key
+/// resolves to no tenant. So on hosted, ANY authenticated device key could enumerate every tenant's machines
+/// through GET /launchers - which returns every machine name, network address, port and process id
+/// fleet-wide, so the identifier the write routes need is not even guesswork - and then drive the machine
+/// routes AGAINST ANOTHER TENANT'S MACHINE. That is cross-machine CODE EXECUTION
+/// (POST /machines/{machine}/launch forwards a caller-supplied path, arguments and working directory) plus
+/// OUTBOUND-REQUEST FORGERY (POST /launchers/register overwrites a machine's stored token, port and network
+/// address, re-pointing the relay at an arbitrary host).
+///
+/// WHY THE USUAL PROTECTION DOES NOT APPLY. Elsewhere on the hosted Gateway, bare-identifier Director routes
+/// are inert cross-tenant because the command rides <c>SendCommandAsync</c>, which refuses to resolve a
+/// tunnel connection with no tenant in scope. THAT PROTECTION LIVES IN THE TRANSPORT, NOT IN THE ROUTE. This
+/// family has three dispatch arms and only the Director-tunnel arm is gated; the launcher stream arm resolves
+/// purely on machine name, and the launcher REST relay - the FALLBACK taken when the stream arm returns null -
+/// dials the launcher's stored address with its stored bearer token. The FAILURE path is the ungated one.
+///
+/// A DENY, NOT A PARTITION. On shared hosted infrastructure A TENANT DOES NOT OWN A MACHINE. There is no
+/// correct per-tenant answer to serve here - only a leak to close. A partition would require inventing an
+/// ownership relation that was never recorded, which is a half-partition: worse than an honest refusal
+/// because it looks like isolation. And it is a REFUSAL, never an empty result: an empty GET /launchers would
+/// be a FALSE statement (a fleet with no machines) where a refusal is merely absent - the /healthz mistake.
+///
+/// THE REFUSAL IS IDENTIFIABLE AS ITSELF. Every denied route serves 404 with
+/// <c>application/json</c> and a body whose property set is EXACTLY <c>{ error }</c> carrying
+/// <see cref="MachineEndpoints.HostedRefusal"/> verbatim. A bare 404 would be indistinguishable from a route
+/// that does not exist, and an allow-list on the property set reddens automatically on any extra leaked
+/// field, unlike a substring check.
+///
+/// ONE GROUP FILTER, NOT A GUARD PER ROUTE. The refusal is an endpoint filter on the route group, so it runs
+/// before every route in the group INCLUDING ROUTES THAT DO NOT EXIST YET. A guard repeated in each handler
+/// passes exactly the same tests as a group filter for the routes that exist today, which is precisely what
+/// makes it dangerous. <see cref="HostedLauncherMachineGroupFilterTests"/> proves the difference with a
+/// brand-new probe route, in BOTH directions (refused on hosted, served on self-host).
+///
+/// THE WRITE IS STOPPED ON THE HTTP SURFACE, BUT NOT EVERYWHERE - AND THAT DECIDES THE UN-DENY. This file
+/// proves the denied write routes leave no state behind: after a refused POST /launchers/register the
+/// registry is re-read directly and is still empty, and after a refused POST /machines/{machine}/sessions the
+/// spawner was never invoked. But the /launcher-stream SignalR hub is NOT in this route group:
+/// <c>LauncherHub.Hello</c> still writes a machine-name-keyed connection row into
+/// <c>LauncherConnectionRegistry</c> behind this deny. So tenant-blind state can still ACCUMULATE, and the
+/// un-deny is the later tenant-key unit PLUS A PURGE of the launcher and launcher-connection registries.
+/// Deny-closed on the safe side: assume the purge is required until write-coverage is proven complete.
+///
+/// SELF-HOST IS PROVED, NOT INHERITED. <see cref="HostedLauncherMachineSelfHostControlTests"/> sets
+/// <c>CC_GATEWAY_HOSTED</c> ITSELF to BOTH non-hosted forms (absent, and present-but-"0"), asserts
+/// <see cref="GatewayHostedMode.IsHosted"/> is actually false, and then proves each route is genuinely SERVED
+/// by a positive effect - a seeded registration read back, a relay reaching a STUB LAUNCHER and returning its
+/// sentinel payload, a spawned session id - never merely by the refusal being absent.
+///
+/// REVERT-PROOF RECIPE. In <c>src/CcDirector.Gateway/Api/MachineEndpoints.cs</c> DELETE the
+/// <c>app.AddEndpointFilter(...)</c> block outright, leaving <c>var app = outer.MapGroup("");</c> in place so
+/// the group still exists and the file compiles - the hosted deny is then absent ENTIRELY with no per-route
+/// guard put back in its place. Deleting is the only correct revert: wrapping it in <c>if (false)</c> leaves
+/// unreachable code, which is a BUILD ERROR here, and a test run after a failed build silently executes the
+/// previous binary and reports a false pass. Rebuild, CONFIRM ZERO ERRORS, verify by diff that the mutation
+/// is actually present in the source, then run the FULL suite - never a filter over these classes, which
+/// could not see whether some existing test already covered the behaviour nor any collateral damage.
+/// </summary>
+public sealed class HostedLauncherMachineDenyTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string Machine = "MACHINE-VICTIM";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _key = "";
+    private string? _priorHosted;
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-launcher-deny-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        // EXPLICIT, not ambient: this class asserts hosted behaviour, so it states hosted mode itself rather
+        // than inheriting whatever the runner happened to leave set, and proves the statement took.
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // A fully enrolled, tenant-bound device key - the STRONGEST caller hosted has. The point is that even
+        // this one is refused: no credential makes "this tenant owns that machine" true on shared hardware.
+        _key = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var tenant = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", tenant.Value);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch (Exception) { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Every route in the family, driven end to end through a REAL hosted Gateway by a fully enrolled
+    /// tenant's device key. The theory data is the whole denied surface, one row per path AND verb - a deny
+    /// proved on GET while a sibling POST still writes is not a deny.
+    /// </summary>
+    public static TheoryData<string, string> DeniedRoutes => new()
+    {
+        { "POST",   "launchers/register" },
+        { "POST",   $"launchers/{Machine}/heartbeat" },
+        { "DELETE", $"launchers/{Machine}" },
+        { "GET",    "launchers" },
+        { "POST",   $"machines/{Machine}/director/restart" },
+        { "POST",   $"machines/{Machine}/director/start" },
+        { "POST",   $"machines/{Machine}/director/stop" },
+        { "POST",   $"machines/{Machine}/launch" },
+        { "POST",   $"machines/{Machine}/sessions" },
+    };
+
+    [Theory]
+    [MemberData(nameof(DeniedRoutes))]
+    public async Task Every_launcher_and_machine_route_is_refused_to_an_enrolled_tenant(string verb, string path)
+    {
+        var resp = await Send(verb, path, _key);
+
+        // STATUS AND MEDIA TYPE BEFORE ANY PARSE. Parsing is itself an assertion about format: with the guard
+        // deleted these routes serve other shapes entirely, and a JsonDocument.Parse crash would prove only
+        // that the mutation broke something upstream - it cannot say WHAT was served in place of the refusal.
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+        await AssertBodyIsNothingButTheRefusal(resp);
+    }
+
+    [Fact]
+    public async Task The_launcher_listing_leaks_no_machine_on_hosted()
+    {
+        // The listing is what makes the write routes aimable: it returns every machine name, network address,
+        // port and process id fleet-wide. Seeding a machine directly into the registry and then proving the
+        // hosted response cannot possibly carry it states the disclosure in its own terms - an empty list
+        // would satisfy "no leak" while being a false statement about the fleet, so the refusal is asserted too.
+        _gateway.Launchers.Upsert(new LauncherRegistrationRequest
+        {
+            MachineName = "SOMEONE-ELSES-PC",
+            Port = 7999,
+            NetworkAddress = "someone-elses-pc.example.ts.net",
+            Token = "victim-token",
+            Pid = 4242,
+            Version = "1.2.3",
+        });
+
+        var resp = await Send("GET", "launchers", _key);
+        var body = await resp.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+        Assert.DoesNotContain("SOMEONE-ELSES-PC", body, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("someone-elses-pc.example.ts.net", body, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("7999", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("4242", body, StringComparison.Ordinal);
+        await AssertBodyIsNothingButTheRefusal(resp);
+    }
+
+    [Fact]
+    public async Task The_refusal_is_not_an_empty_launcher_list()
+    {
+        // The /healthz lesson applied on purpose: an empty list is a FALSE statement (a fleet with no
+        // machines) where an absent one is merely absent. A caller must never be handed a shaped, empty
+        // answer that reads as isolation. The exact-property-set assertion above is what enforces this; this
+        // states the intent in the terms the mistake is usually made in.
+        var body = await (await Send("GET", "launchers", _key)).Content.ReadAsStringAsync();
+        Assert.NotEqual("[]", body.Trim());
+        Assert.Contains("not available", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_caller_is_still_rejected()
+    {
+        // Control: the deny must not have opened the family up as a side effect of running before the gate.
+        // Without a key the host-wide auth middleware still refuses FIRST, so the 404s above are the filter
+        // and not the absence of a gate.
+        Assert.Equal(HttpStatusCode.Unauthorized, (await _http.GetAsync("launchers")).StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized,
+            (await _http.PostAsync($"machines/{Machine}/launch", JsonBody(new { path = "cmd.exe" }))).StatusCode);
+    }
+
+    /// <summary>
+    /// Asserts the body is the hosted refusal and NOTHING ELSE, by parsing the JSON and comparing the WHOLE
+    /// property set to a one-name allow-list. A substring check cannot see an extra leaked field; enumerating
+    /// the property set reddens automatically on anything extra without this file being touched.
+    /// </summary>
+    internal static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp)
+    {
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+
+        var properties = doc.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Equal(new[] { "error" }, properties);
+        Assert.Equal(MachineEndpoints.HostedRefusal, doc.RootElement.GetProperty("error").GetString());
+    }
+
+    internal static HttpContent JsonBody(object value) =>
+        new StringContent(JsonSerializer.Serialize(value), Encoding.UTF8, "application/json");
+
+    private Task<HttpResponseMessage> Send(string verb, string path, string deviceKey)
+    {
+        var req = new HttpRequestMessage(new HttpMethod(verb), path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        if (verb == "POST")
+        {
+            // A REAL, WELL-FORMED body for each write, so a refusal can never be a validation accident. The
+            // sessions route needs repoPath or its own handler 400s; register needs machineName/port/token or
+            // its own handler 400s. Both would be a 400, not the 404 asserted - but sending a valid body means
+            // the assertion is about the deny and nothing else.
+            req.Content = path.EndsWith("/sessions", StringComparison.Ordinal)
+                ? JsonBody(new { repoPath = @"C:\repo", agent = "ClaudeCode" })
+                : path.EndsWith("launchers/register", StringComparison.Ordinal)
+                    ? JsonBody(new { machineName = Machine, port = 7788, token = "tok", pid = 11, version = "1.0.0" })
+                    : JsonBody(new { path = @"C:\Windows\System32\cmd.exe", args = "/c whoami", cwd = @"C:\" });
+        }
+        return _http.SendAsync(req);
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}
+
+/// <summary>
+/// Boots ONLY the launcher/machine group on an ephemeral port and hands the caller back the route group, the
+/// registry and the spawner's call counters. That is what makes the future-route proof possible at all: the
+/// group is created INSIDE <see cref="MachineEndpoints.Map"/>, so nothing outside that method could otherwise
+/// state a property about routes added to it. Owning the registry object also lets a test re-read the write
+/// side directly rather than through the very routes under test.
+///
+/// <c>sendLauncherCommand</c> is deliberately null so the launcher STREAM arm returns null and dispatch falls
+/// through to the REST RELAY - the ungated fallback arm the defect actually rides. The self-host control
+/// therefore exercises the same arm an attacker would.
+/// </summary>
+internal sealed class MachineGroupProbeHost : IAsyncDisposable
+{
+    public required WebApplication App { get; init; }
+    public required HttpClient Http { get; init; }
+    public required LauncherRegistry Launchers { get; init; }
+    public required StubResolver Resolver { get; init; }
+    public required WebApplication? StubLauncher { get; init; }
+    public required int StubLauncherPort { get; init; }
+    public required List<string> StubLauncherHits { get; init; }
+
+    public const string SpawnedSessionId = "sid-self-host-sentinel";
+    public const string StubLauncherSentinel = "stub-launcher-actually-reached";
+
+    /// <summary>A resolver that returns a fixed target and COUNTS its calls, so "the write never happened" is statable.</summary>
+    internal sealed class StubResolver : IDirectorTargetResolver
+    {
+        public int ResolveCount { get; private set; }
+
+        public Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct)
+        {
+            ResolveCount++;
+            return Task.FromResult(new DirectorTargetResult("d-probe", null));
+        }
+    }
+
+    public static async Task<MachineGroupProbeHost> StartAsync(
+        Action<RouteGroupBuilder>? mapIntoGroup = null,
+        Action<IEndpointRouteBuilder>? mapOutsideGroup = null,
+        bool withStubLauncher = false)
+    {
+        // A stub launcher standing in for the real cc-launcher REST API on the target machine. When the relay
+        // reaches it, it answers with a sentinel - so a served relay is proved by an effect that could only
+        // come from the handler dialing out, not by the refusal merely being absent.
+        WebApplication? stub = null;
+        var hits = new List<string>();
+        var stubPort = 0;
+        if (withStubLauncher)
+        {
+            var stubBuilder = WebApplication.CreateBuilder();
+            stubBuilder.Logging.ClearProviders();
+            stub = stubBuilder.Build();
+            stub.Urls.Add("http://127.0.0.1:0");
+            foreach (var verb in new[] { "restart", "start", "stop" })
+            {
+                var captured = verb;
+                stub.MapPost($"/director/{captured}", () =>
+                {
+                    lock (hits) hits.Add($"director/{captured}");
+                    return Results.Json(new { stub = StubLauncherSentinel, verb = captured });
+                });
+            }
+            stub.MapPost("/launch", () =>
+            {
+                lock (hits) hits.Add("launch");
+                return Results.Json(new { stub = StubLauncherSentinel, verb = "launch" });
+            });
+            await stub.StartAsync();
+            stubPort = new Uri(stub.Urls.First()).Port;
+        }
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        var launchers = new LauncherRegistry();
+        var resolver = new StubResolver();
+        var spawner = new MachineSessionSpawner(resolver,
+            (directorId, req, ct) => Task.FromResult<(bool, SessionDto?, string?)>(
+                (true, new SessionDto { SessionId = SpawnedSessionId }, null)));
+
+        var group = MachineEndpoints.Map(app, launchers, spawner, sendLauncherCommand: null);
+        mapIntoGroup?.Invoke(group);
+        mapOutsideGroup?.Invoke(app);
+
+        await app.StartAsync();
+        return new MachineGroupProbeHost
+        {
+            App = app,
+            Http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) },
+            Launchers = launchers,
+            Resolver = resolver,
+            StubLauncher = stub,
+            StubLauncherPort = stubPort,
+            StubLauncherHits = hits,
+        };
+    }
+
+    /// <summary>Register the stub launcher under <paramref name="machine"/> so the REST relay dials it on loopback.</summary>
+    public void SeedStubLauncher(string machine) =>
+        Launchers.Upsert(new LauncherRegistrationRequest
+        {
+            MachineName = machine,
+            Port = StubLauncherPort,
+            NetworkAddress = "",          // empty -> the relay dials 127.0.0.1:<port>
+            Token = "stub-token",
+            Pid = 1234,
+            Version = "9.9.9",
+        });
+
+    public async ValueTask DisposeAsync()
+    {
+        Http.Dispose();
+        await App.DisposeAsync();
+        if (StubLauncher is not null) await StubLauncher.DisposeAsync();
+    }
+}
+
+/// <summary>
+/// THE POINT OF THE WHOLE CHANGE: the hosted refusal is a filter on the ROUTE GROUP, so it covers routes that
+/// have not been written yet.
+///
+/// A guard repeated in every handler passes exactly the same tests as a group filter for the routes that
+/// exist today, which is precisely why it is dangerous - the difference only shows up on the route somebody
+/// adds NEXT, when it is open by default and nothing fails. On THIS family, "open by default" means
+/// cross-machine code execution. That difference is not observable by driving the nine routes that exist, so
+/// this class maps a BRAND-NEW probe route onto the group and asserts it is refused with no deny of its own
+/// written anywhere. Its mirror - the same probe path SERVED with hosted mode explicitly off - lives in
+/// <see cref="HostedLauncherMachineSelfHostControlTests"/>: one direction alone cannot tell a working gate
+/// apart from a brick.
+/// </summary>
+public sealed class HostedLauncherMachineGroupFilterTests : IDisposable
+{
+    internal const string ProbePayloadSentinel = "probe-payload-that-must-never-be-served-on-hosted";
+    internal const string ProbePath = "/machines/added-after-the-deny-was-written";
+
+    private readonly string? _priorHosted;
+
+    public HostedLauncherMachineGroupFilterTests()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+    }
+
+    public void Dispose() => Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+
+    /// <summary>
+    /// A route that did not exist when the refusal was written is refused anyway. NOTHING in
+    /// <see cref="MachineEndpoints"/> mentions this path and no guard is written for it here - the only thing
+    /// standing between the caller and the probe payload is the group filter. Replace the filter with
+    /// per-handler guards and this test serves the probe payload with a 200, which is the future-route hole
+    /// stated out loud.
+    /// </summary>
+    [Fact]
+    public async Task A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own()
+    {
+        await using var probe = await MachineGroupProbeHost.StartAsync(
+            mapIntoGroup: group => group.MapGet(ProbePath, () => Results.Json(new { probe = ProbePayloadSentinel })));
+
+        var resp = await probe.Http.GetAsync(ProbePath);
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.DoesNotContain(ProbePayloadSentinel, await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        await HostedLauncherMachineDenyTests.AssertBodyIsNothingButTheRefusal(resp);
+    }
+
+    /// <summary>
+    /// CONTROL: the filter is scoped to this group, not a blanket refusal on the whole application. A route
+    /// mapped OUTSIDE the group still serves on hosted, so the passing tests here are the filter doing its
+    /// job rather than the host refusing everything.
+    /// </summary>
+    [Fact]
+    public async Task A_route_outside_the_group_still_serves_on_hosted()
+    {
+        await using var probe = await MachineGroupProbeHost.StartAsync(
+            mapOutsideGroup: routes => routes.MapGet("/not-a-machine-route", () => Results.Json(new { ok = true })));
+
+        var resp = await probe.Http.GetAsync("/not-a-machine-route");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Contains("true", await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// THE WRITE IS STOPPED, NOT JUST THE READ - on the HTTP surface. A deny that only silences the response
+    /// while the handler still mutates state is a DEFERRED LEAK: it looks closed and un-denies onto a
+    /// poisoned registry. The registry is re-read DIRECTLY here, not through the routes under test, so this
+    /// cannot be satisfied by the read being denied too.
+    ///
+    /// This does NOT establish full write-coverage for the family: <c>LauncherHub.Hello</c> writes a
+    /// machine-name-keyed connection row over the /launcher-stream SignalR hub, which is not in this route
+    /// group and is therefore untouched by this deny. The un-deny is consequently the tenant-key unit PLUS A
+    /// PURGE.
+    /// </summary>
+    [Fact]
+    public async Task A_refused_registration_writes_nothing_into_the_registry()
+    {
+        await using var probe = await MachineGroupProbeHost.StartAsync();
+
+        var resp = await probe.Http.PostAsync("/launchers/register", HostedLauncherMachineDenyTests.JsonBody(
+            new { machineName = "ATTACKER-REDIRECT", port = 31337, networkAddress = "evil.example.com", token = "t", version = "1.0.0" }));
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        await HostedLauncherMachineDenyTests.AssertBodyIsNothingButTheRefusal(resp);
+
+        // Read the write side directly. Nothing landed - so the outbound-request-forgery primitive
+        // (re-pointing a machine's relay at an arbitrary host) never armed.
+        Assert.Null(probe.Launchers.Get("ATTACKER-REDIRECT"));
+        Assert.Empty(probe.Launchers.ListLaunchers());
+    }
+
+    /// <summary>
+    /// The same statement for the spawn route, whose FAILURE branch is the one that starts a Director on
+    /// another machine through the relay. The resolver counts its calls, so "the handler never ran" is an
+    /// observation rather than an inference from the status code.
+    /// </summary>
+    [Fact]
+    public async Task A_refused_spawn_never_reaches_the_resolver()
+    {
+        await using var probe = await MachineGroupProbeHost.StartAsync();
+
+        var resp = await probe.Http.PostAsync("/machines/SOMEONE-ELSES-PC/sessions",
+            HostedLauncherMachineDenyTests.JsonBody(new { repoPath = @"C:\repo", agent = "ClaudeCode" }));
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        await HostedLauncherMachineDenyTests.AssertBodyIsNothingButTheRefusal(resp);
+        Assert.Equal(0, probe.Resolver.ResolveCount);
+    }
+
+    /// <summary>
+    /// The relay is not merely refused - it never DIALS. The stub launcher records every hit it receives, so
+    /// a deny that answered 404 to the caller while still forwarding the launch would redden here.
+    /// </summary>
+    [Fact]
+    public async Task A_refused_launch_never_dials_the_launcher()
+    {
+        await using var probe = await MachineGroupProbeHost.StartAsync(withStubLauncher: true);
+        probe.SeedStubLauncher("SOMEONE-ELSES-PC");
+
+        var resp = await probe.Http.PostAsync("/machines/SOMEONE-ELSES-PC/launch",
+            HostedLauncherMachineDenyTests.JsonBody(new { path = @"C:\Windows\System32\cmd.exe", args = "/c whoami" }));
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        await HostedLauncherMachineDenyTests.AssertBodyIsNothingButTheRefusal(resp);
+        Assert.Empty(probe.StubLauncherHits);
+    }
+}
+
+/// <summary>
+/// THE SELF-HOST CONTROL, STATED EXPLICITLY.
+///
+/// Self-host is the control for this entire hosted-tenancy mission, so it has to be PROVEN rather than
+/// INHERITED. <see cref="LauncherRegistryEndpointTests"/> does not prove it: those tests never mention
+/// <c>CC_GATEWAY_HOSTED</c> and pass only because the runner happens to leave it unset. If that ambient
+/// default ever flipped - one leaked environment variable, one continuous-integration image change, one test
+/// that forgot to restore it - they would keep passing while self-host was completely broken, because they
+/// assert nothing about which mode they are in.
+///
+/// So this class sets the variable itself, to BOTH non-hosted values that occur in practice - absent, and
+/// present-but-not-"1" - and asserts <see cref="GatewayHostedMode.IsHosted"/> is actually false before
+/// driving anything. Each route is then proved SERVED by a POSITIVE EFFECT: a seeded registration read back
+/// out of the listing, a heartbeat and an unregister whose effects are re-read from the registry, a relay
+/// that actually reaches a STUB LAUNCHER and returns its sentinel payload, and a spawn that returns the
+/// stubbed session id. Absence of the refusal is never the assertion - an empty-but-successful response would
+/// satisfy that while being a dead surface.
+///
+/// These tests must stay GREEN through the revert described on <see cref="HostedLauncherMachineDenyTests"/>.
+/// A control that moves with the change under test is not a control.
+/// </summary>
+public sealed class HostedLauncherMachineSelfHostControlTests : IDisposable
+{
+    private const string Machine = "PROBE-MACHINE";
+    private readonly string? _priorHosted;
+
+    public HostedLauncherMachineSelfHostControlTests() =>
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+
+    public void Dispose() => Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+
+    /// <summary>
+    /// Puts the process into a STATED non-hosted mode and proves the statement took, so no test below can
+    /// silently be running in the mode it thinks it is not in.
+    /// </summary>
+    private static void DeclareSelfHost(string? value)
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", value);
+        Assert.False(GatewayHostedMode.IsHosted);
+    }
+
+    /// <summary>null = the variable is absent. "0" = present and explicitly not hosted. Both are real non-hosted deployments.</summary>
+    public static TheoryData<string?> NonHostedValues => new() { null, "0" };
+
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task Registration_listing_heartbeat_and_unregister_all_still_work_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+        await using var probe = await MachineGroupProbeHost.StartAsync();
+
+        // REGISTER - and read the effect back out of the LISTING, which is a different route, so neither
+        // route can pass by being a no-op.
+        var register = await probe.Http.PostAsJsonAsync("/launchers/register", new LauncherRegistrationRequest
+        {
+            MachineName = Machine,
+            Port = 7788,
+            NetworkAddress = "probe-machine.example.ts.net",
+            Token = "tok",
+            Pid = 4242,
+            Version = "1.2.3",
+        });
+        Assert.Equal(HttpStatusCode.Created, register.StatusCode);
+
+        var list = await probe.Http.GetFromJsonAsync<List<LauncherDto>>("/launchers");
+        var entry = Assert.Single(list!);
+        Assert.Equal(Machine, entry.MachineName);
+        Assert.Equal(7788, entry.Port);
+        Assert.Equal("probe-machine.example.ts.net", entry.NetworkAddress);
+        Assert.Equal(4242, entry.Pid);
+        Assert.Equal("1.2.3", entry.Version);
+
+        // HEARTBEAT - 200 for a known machine, and 410 for an unknown one. The 410 is the handler's OWN
+        // negative answer, which is only reachable if the route is genuinely served.
+        var beat = await probe.Http.PostAsync($"/launchers/{Machine}/heartbeat", content: null);
+        Assert.Equal(HttpStatusCode.OK, beat.StatusCode);
+        Assert.Contains("\"ok\":true", await beat.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        Assert.Equal(HttpStatusCode.Gone,
+            (await probe.Http.PostAsync("/launchers/NO-SUCH-MACHINE/heartbeat", content: null)).StatusCode);
+
+        // UNREGISTER - and re-read the registry OBJECT directly, so the effect is observed at the write side
+        // rather than only through the route that reports it.
+        Assert.Equal(HttpStatusCode.OK, (await probe.Http.DeleteAsync($"/launchers/{Machine}")).StatusCode);
+        Assert.Null(probe.Launchers.Get(Machine));
+        Assert.Empty((await probe.Http.GetFromJsonAsync<List<LauncherDto>>("/launchers"))!);
+    }
+
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task The_director_lifecycle_relay_still_reaches_the_launcher_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+        await using var probe = await MachineGroupProbeHost.StartAsync(withStubLauncher: true);
+        probe.SeedStubLauncher(Machine);
+
+        foreach (var verb in new[] { "restart", "start", "stop" })
+        {
+            var resp = await probe.Http.PostAsync($"/machines/{Machine}/director/{verb}",
+                HostedLauncherMachineDenyTests.JsonBody(new { exePath = @"C:\builds\cc-director7.exe" }));
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            Assert.Equal(Machine, doc.RootElement.GetProperty("machine").GetString());
+            Assert.Equal(verb, doc.RootElement.GetProperty("verb").GetString());
+            Assert.Equal(200, doc.RootElement.GetProperty("relayStatus").GetInt32());
+            // The sentinel came back OUT OF THE STUB LAUNCHER, so the relay genuinely dialled - the route is
+            // served, not merely un-refused.
+            Assert.Contains(MachineGroupProbeHost.StubLauncherSentinel,
+                doc.RootElement.GetProperty("payload").GetString()!, StringComparison.Ordinal);
+        }
+
+        Assert.Equal(new[] { "director/restart", "director/start", "director/stop" }, probe.StubLauncherHits);
+    }
+
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task The_generic_launch_relay_still_reaches_the_launcher_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+        await using var probe = await MachineGroupProbeHost.StartAsync(withStubLauncher: true);
+        probe.SeedStubLauncher(Machine);
+
+        var resp = await probe.Http.PostAsync($"/machines/{Machine}/launch",
+            HostedLauncherMachineDenyTests.JsonBody(new { path = @"C:\Windows\System32\cmd.exe", args = "/c echo hi" }));
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal("launch", doc.RootElement.GetProperty("verb").GetString());
+        Assert.Contains(MachineGroupProbeHost.StubLauncherSentinel,
+            doc.RootElement.GetProperty("payload").GetString()!, StringComparison.Ordinal);
+        Assert.Equal(new[] { "launch" }, probe.StubLauncherHits);
+    }
+
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task Starting_a_session_on_another_machine_still_works_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+        await using var probe = await MachineGroupProbeHost.StartAsync();
+
+        var resp = await probe.Http.PostAsync($"/machines/{Machine}/sessions",
+            HostedLauncherMachineDenyTests.JsonBody(new { repoPath = @"C:\repo", agent = "ClaudeCode" }));
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal(MachineGroupProbeHost.SpawnedSessionId, doc.RootElement.GetProperty("sessionId").GetString());
+        // The spawn actually ran the resolve-then-create path; the deny is not silently short-circuiting it.
+        Assert.Equal(1, probe.Resolver.ResolveCount);
+
+        // The handler's OWN validation is still reachable too - a 400 here is the route serving, and it is
+        // distinguishable from the hosted 404, which is the whole reason the deny is not a bare 404.
+        var bad = await probe.Http.PostAsync($"/machines/{Machine}/sessions",
+            HostedLauncherMachineDenyTests.JsonBody(new { agent = "ClaudeCode" }));
+        Assert.Equal(HttpStatusCode.BadRequest, bad.StatusCode);
+        Assert.Contains("repoPath is required", await bad.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// THE SECOND HALF OF THE FUTURE-ROUTE PROOF: the same probe path that
+    /// <see cref="HostedLauncherMachineGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own"/>
+    /// finds refused on hosted must be SERVED with hosted mode explicitly off, in both non-hosted forms.
+    /// Without this half, "the filter refuses everything, always" would pass every hosted assertion in this
+    /// file while having silently killed the family for self-host too.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task A_route_added_to_the_group_still_serves_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+        await using var probe = await MachineGroupProbeHost.StartAsync(
+            mapIntoGroup: group => group.MapGet(HostedLauncherMachineGroupFilterTests.ProbePath,
+                () => Results.Json(new { probe = "served" })));
+
+        var resp = await probe.Http.GetAsync(HostedLauncherMachineGroupFilterTests.ProbePath);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Contains("served", await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
@@ -86,6 +86,59 @@ namespace CcDirector.Gateway.Tests;
 /// previous binary and reports a false pass. Rebuild, CONFIRM ZERO ERRORS, verify by diff that the mutation
 /// is actually present in the source, then run the FULL suite - never a filter over these classes, which
 /// could not see whether some existing test already covered the behaviour nor any collateral damage.
+///
+/// THE REDS ARE PRE-REGISTERED BELOW, WRITTEN AND PUSHED BEFORE THE ARM WAS EVER RUN. That ordering is the
+/// whole point: A PREDICTED RED THAT DOES NOT APPEAR IS A FINDING. A list filled in afterwards from what was
+/// observed cannot produce that finding at all - whatever reddens is by definition what was expected, so a
+/// mutation that silently failed to apply, or that reddened the wrong tests, reads as a clean result. It
+/// guards the other direction too: MORE reds than predicted means the filter was carrying something that was
+/// not accounted for, and that is to be understood rather than accepted.
+///
+/// PREDICTION: EXACTLY 15 TEST CASES REDDEN, ALL OF THEM IN THIS FILE, AND NOTHING ELSE IN THE SUITE MOVES.
+///
+///   HostedLauncherMachineDenyTests.Every_launcher_and_machine_route_is_refused_to_an_enrolled_tenant
+///       - ALL NINE theory rows.
+///   HostedLauncherMachineDenyTests.The_launcher_listing_leaks_no_machine_on_hosted
+///   HostedLauncherMachineDenyTests.The_refusal_is_not_an_empty_launcher_list
+///   HostedLauncherMachineGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own
+///   HostedLauncherMachineGroupFilterTests.A_refused_registration_writes_nothing_into_the_registry
+///   HostedLauncherMachineGroupFilterTests.A_refused_spawn_never_reaches_the_resolver
+///   HostedLauncherMachineGroupFilterTests.A_refused_launch_never_dials_the_launcher
+///
+/// WHERE EACH RED IS PREDICTED TO ARRIVE, because a red that arrives from the fixture is VOID and only a red
+/// that arrives from an assertion about what was served proves anything:
+///
+///   Five of the nine theory rows redden on the STATUS assertion, because with the filter gone the handler's
+///   own answer is a different status: register -> 201 Created, heartbeat on an unregistered machine -> 410
+///   Gone, unregister -> 200 OK, the listing -> 200 OK, and the spawn -> 502 Bad Gateway (no Director on that
+///   machine; the spawner fails loud rather than falling back).
+///
+///   The other FOUR - the three director lifecycle verbs and the generic launch - are predicted to redden on
+///   the PROPERTY-SET assertion and NOT on the status assertion. With no launcher registered, the relay's own
+///   refusal is ALSO 404 with application/json, so status and media type still match; what separates them is
+///   the body, which carries { error, machine } with a different error string instead of { error } alone.
+///   THAT IS THE SHARPEST PREDICTION IN THIS FILE and it is the reason the refusal is asserted as an exact
+///   property set rather than as a status code: if those four rows came back GREEN under the mutation, it
+///   would mean the deny had been indistinguishable from "no launcher registered on that machine" all along.
+///
+/// DECLARED UNKNOWN, stated as an unknown rather than left open: those four rows depend on the launcher
+/// STREAM arm returning null inside a full GatewayHost booted with streamMode true, so the REST relay arm is
+/// the one that answers. If the stream arm answers instead, they redden on the status assertion rather than
+/// the property set. What is NOT unknown is that they must redden; a green there is a finding, not a pass.
+///
+/// MUST STAY GREEN - the controls, and a control that moves with the change under test is not a control:
+///   HostedLauncherMachineDenyTests.An_unauthenticated_caller_is_still_rejected
+///   HostedLauncherMachineGroupFilterTests.A_route_outside_the_group_still_serves_on_hosted
+///   ALL TEN cases of HostedLauncherMachineSelfHostControlTests (five methods, two non-hosted forms each)
+///
+/// AND ZERO REDS ANYWHERE ELSE IN THE SUITE. The twelve existing launcher and machine test files run under
+/// the runner's ambient non-hosted default, where this filter is a pass-through, so deleting it cannot reach
+/// them. If one of them reddens, the ambient default is not what it is believed to be - which would be a
+/// finding about every other hosted test in this assembly, not a detail about this one.
+///
+/// RECONCILE EVERY ARM, INCLUDING BASELINE AND RESTORE: passed plus failed plus skipped must EQUAL the
+/// baseline total. A pre-existing race can truncate a run while still printing a cheerful passed line, and a
+/// truncated arm reads exactly like a mutation that reddened fewer tests than predicted.
 /// </summary>
 public sealed class HostedLauncherMachineDenyTests : IAsyncLifetime
 {

--- a/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
@@ -153,13 +153,39 @@ namespace CcDirector.Gateway.Tests;
 /// them. If one of them reddens, the ambient default is not what it is believed to be - which would be a
 /// finding about every other hosted test in this assembly, not a detail about this one.
 ///
-/// RECONCILE EVERY ARM, INCLUDING BASELINE AND RESTORE: passed plus failed plus skipped must EQUAL the
-/// baseline total, taken FRESH at this head and never quoted from another run. A pre-existing race can
-/// truncate a run while still printing a cheerful passed line - and a truncated arm reads EXACTLY like a
-/// mutation that reddened fewer tests than predicted. Without the reconciliation, a truncation that swallowed
-/// three of the fifteen would present as a twelve-red arm, which under this pre-registration would have to be
-/// treated as a finding about the deny. Reconcile FIRST, then classify; a total that does not add up
-/// disqualifies the arm before any red in it is worth interpreting.
+/// THE RECONCILIATION PROTOCOL. Three rules, in this order, and the ORDER is load-bearing.
+///
+///   1. RECONCILE AGAINST THE BASELINE TOTAL, NOT AGAINST RESTORED PASSED. The tempting identity - passed
+///      plus failed under the mutation equals passed under the restore - holds ONLY IF SKIPPED NEVER MOVES.
+///      Skips in this suite are environment-gated and CAN move, so that identity balances by accident: when a
+///      skip count shifts it either breaks for a reason that will be chased for nothing, or it silently
+///      ABSORBS a real discrepancy. The check with nothing left out is
+///      PASSED + FAILED + SKIPPED == THE BASELINE TOTAL, on every arm including baseline and restore.
+///
+///   2. RECONCILE BEFORE SCORING, NOT AFTER. Reconciliation is a PRECONDITION for the arm counting at all,
+///      not a post-hoc validation of a score already formed. Score first and a truncated run has already been
+///      read as a result by the time the total is checked. A short total means the arm is
+///      UNPROVEN-TRUNCATED: it is not scored in EITHER direction, and it does NOT become "a mutation that
+///      reddened fewer tests than predicted".
+///
+///   3. THE TRUNCATION TRAP BEARS DIRECTLY ON THE FIFTEEN ABOVE. If a run truncates, FEWER THAN FIFTEEN reds
+///      appear. Under the rule this file already holds - a predicted red that does not appear is a FINDING -
+///      a truncated arm would present itself as a finding ABOUT THE DENY. IT IS NOT. It is a finding about
+///      the HARNESS. So the total is checked FIRST and the fifteen are compared only afterwards. A
+///      pre-registration makes truncation MORE dangerous, not less, because it hands truncation a ready-made
+///      story to be mistaken for.
+///
+/// BASELINE PRECONDITIONS, both checked before the first run:
+///   - THE WHOLE SOURCE TREE IS CLEAN, not merely the Gateway project. A lost TEST edit falsifies an arm as
+///     thoroughly as a lost production edit, and a tree-scoped-to-one-project check would not see it.
+///   - THE WORKING HEAD EQUALS THE PUSHED HEAD. Cleanliness alone is not sufficient: a stash leaves the tree
+///     CLEAN at the pinned head, so a tree that looks perfect can be missing the very repair under test, and
+///     a guard checking only cleanliness would ADMIT it.
+///
+/// THE RUN PLAN IS EXACTLY THREE FULL-SUITE RUNS, and the path actually taken is the path registered:
+/// baseline, arm, restore. There is no slice-then-full escalation and no separate canary gate here - all
+/// three arms are the FULL suite, so no ordering can slip a fourth run in behind the registered three. On a
+/// contended serial box a fourth run spends someone else's slot.
 /// </summary>
 public sealed class HostedLauncherMachineDenyTests : IAsyncLifetime
 {

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -41,6 +41,46 @@ namespace CcDirector.Gateway.Api;
 ///   - Remote launcher (networkAddress set):         dials http://<networkAddress>:<port>/
 /// This enables the Gateway on MACHINE_A to relay lifecycle verbs to the launcher on
 /// EXAMPLE-PC when EXAMPLE-PC's launcher registered with its tailnet hostname.
+///
+/// DENIED IN WHOLE ON HOSTED (issue #1917). EVERY route in this group is refused on the hosted Gateway,
+/// through ONE group filter rather than a guard repeated per route - so a route added here later is refused
+/// too, without anyone remembering to defend it.
+///
+/// THE DEFECT THIS CLOSES. This family is TENANT-BLIND BY CONSTRUCTION: there is no tenant dimension
+/// anywhere in the path. <see cref="LauncherRegistry"/> keys on machine NAME alone,
+/// <see cref="Streaming.LauncherConnectionRegistry"/> keys on machine NAME alone, and
+/// <see cref="Streaming.LauncherHub"/>.Hello binds a connection to a machine name with NO tenant resolution
+/// at all - in direct contrast to <see cref="Streaming.DirectorHub"/>.Hello, which aborts when the device key
+/// resolves to no tenant. So on hosted, ANY authenticated device key could enumerate every tenant's machines
+/// through GET /launchers and then drive the machine routes AGAINST ANOTHER TENANT'S MACHINE: cross-machine
+/// CODE EXECUTION via POST /machines/{machine}/launch, and OUTBOUND-REQUEST FORGERY via
+/// POST /launchers/register, which overwrites a machine's stored token, port and network address and so
+/// re-points the REST relay at an arbitrary host.
+///
+/// WHY THE USUAL PROTECTION DOES NOT APPLY. Elsewhere on the hosted Gateway, bare-identifier Director routes
+/// are inert cross-tenant because the command rides SendCommandAsync, which refuses to resolve a tunnel
+/// connection with no tenant in scope. THAT PROTECTION LIVES IN THE TRANSPORT, NOT IN THE ROUTE. This family
+/// has three dispatch arms and only the Director-tunnel arm is gated: the launcher STREAM arm resolves purely
+/// on machine name, and the launcher REST RELAY - the FALLBACK taken when the stream arm returns null - dials
+/// the launcher's stored address with its stored bearer token. The FAILURE path is the ungated one by design.
+///
+/// IT IS A DENY, NOT A PARTITION. On shared hosted infrastructure A TENANT DOES NOT OWN A MACHINE. There is
+/// no correct per-tenant answer to serve here - only a leak to close. A partition would require inventing an
+/// ownership relation that was never recorded, which is a half-partition: worse than an honest refusal
+/// because it looks like isolation. Nothing is substituted and no empty list is served: an empty
+/// GET /launchers would be a FALSE statement (a fleet with no machines) where a refusal is merely absent.
+///
+/// SELF-HOST IS COMPLETELY UNCHANGED AND IS THE CONTROL. Cross-machine launch is legitimate fleet function
+/// there: one operator, his own machines.
+///
+/// UN-DENY. The permanent fix is a tenant-scoped launcher design that binds machine identity to a tenant at
+/// REGISTRATION and authorizes every launch, lifecycle and relay call against the calling tenant - including
+/// on the REST fallback arm. That unit is NOT enough on its own: this HTTP deny does NOT stop every write.
+/// <see cref="Streaming.LauncherHub"/>.Hello still writes a machine-name-keyed connection row into
+/// <see cref="Streaming.LauncherConnectionRegistry"/> over the /launcher-stream hub, which is not in this
+/// route group, so tenant-blind state can still ACCUMULATE behind the deny. The un-deny is therefore the
+/// tenant-key unit PLUS A PURGE of the launcher and launcher-connection registries. Deny-closed on the safe
+/// side: assume the purge is required until write-coverage is proven complete.
 /// </summary>
 internal static class MachineEndpoints
 {
@@ -52,7 +92,42 @@ internal static class MachineEndpoints
     private static readonly Regex SlotFromPath =
         new(@"cc-director(\d*)\.exe$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    public static void Map(IEndpointRouteBuilder app, LauncherRegistry launchers,
+    /// <summary>
+    /// The exact refusal every route in this group serves on hosted. One string, asserted verbatim by the
+    /// tests, so the refusal is identifiable as ITSELF - a bare 404 would be indistinguishable from a route
+    /// that does not exist.
+    /// </summary>
+    internal const string HostedRefusal =
+        "machine and launcher control is not available on the hosted gateway";
+
+    /// <summary>
+    /// The hosted refusal for the whole machine/launcher family (issue #1917), or null on self-host where
+    /// nothing changes.
+    ///
+    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> - the INDEPENDENT signal - and not on a boundary or
+    /// tenant argument being passed in. A security branch that depends on an optional argument fails OPEN
+    /// when a caller forgets it, which is exactly how the hosted account-status fix nearly shipped a hole.
+    ///
+    /// 404 rather than 403: on hosted a tenant-owned machine does not exist as a concept, so "not here" is the
+    /// truthful answer. 403 would imply the right credential could reach it, and none can. The BODY is what
+    /// makes this a deny rather than a missing route, so it is always served and always the same.
+    /// </summary>
+    private static IResult? DenyOnHosted()
+    {
+        if (!GatewayHostedMode.IsHosted) return null;
+
+        FileLog.Write("[MachineEndpoints] DENIED on hosted: the launcher and machine-control family is tenant-blind - a tenant does not own a machine on shared infrastructure (issue #1917)");
+        return Results.Json(new { error = HostedRefusal }, statusCode: StatusCodes.Status404NotFound);
+    }
+
+    /// <summary>
+    /// Maps the machine/launcher group and RETURNS it, so the refusal can be proved to cover routes that do
+    /// not exist yet: a test maps a NEW probe route onto the returned group and finds it already refused on
+    /// hosted, without anyone having written a deny for it. Returning the group is the only way to state that
+    /// property from outside this file - and it is the ONLY property that distinguishes a group filter from a
+    /// guard repeated per route, because the two behave identically on every route that exists today.
+    /// </summary>
+    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, LauncherRegistry launchers,
         MachineSessionSpawner spawner,
         LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand = null,
         // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store. When non-null, a
@@ -70,6 +145,21 @@ internal static class MachineEndpoints
         Workflows.WorkflowRunStore? workflowRuns = null)
     {
         if (spawner is null) throw new ArgumentNullException(nameof(spawner));
+
+        FileLog.Write($"[MachineEndpoints] mapping /launchers + /machines; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1917)");
+
+        // The whole family behind ONE filter, rather than a guard line repeated in every handler.
+        // A repeated guard is a thing to forget: the route added to this file next year would be open by
+        // default and nothing would fail - and on this family "open by default" means cross-machine code
+        // execution. A group filter runs before EVERY route mapped below, including routes that do not exist
+        // yet. The empty prefix keeps the route paths written out in full, exactly as before, so the self-host
+        // surface is byte-identical.
+        var app = outer.MapGroup("");
+        app.AddEndpointFilter(async (ctx, next) =>
+        {
+            if (DenyOnHosted() is { } denied) return denied;
+            return await next(ctx);
+        });
 
         // ===== Launcher self-registration surface =====
 
@@ -314,6 +404,8 @@ internal static class MachineEndpoints
             }
             return result;
         });
+
+        return app;
     }
 
     // -------------------------------------------------------------------------

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -5,6 +5,7 @@ using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
 using CcDirector.Gateway.Running;
+using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -42,9 +43,8 @@ namespace CcDirector.Gateway.Api;
 /// This enables the Gateway on MACHINE_A to relay lifecycle verbs to the launcher on
 /// EXAMPLE-PC when EXAMPLE-PC's launcher registered with its tailnet hostname.
 ///
-/// DENIED IN WHOLE ON HOSTED (issue #1917). EVERY route in this group is refused on the hosted Gateway,
-/// through ONE group filter rather than a guard repeated per route - so a route added here later is refused
-/// too, without anyone remembering to defend it.
+/// DENIED IN WHOLE ON HOSTED (issue #1917). EVERY route in this file is refused on the hosted Gateway - both
+/// prefixes, every verb, every existing and future sub-path alike.
 ///
 /// THE DEFECT THIS CLOSES. This family is TENANT-BLIND BY CONSTRUCTION: there is no tenant dimension
 /// anywhere in the path. <see cref="LauncherRegistry"/> keys on machine NAME alone,
@@ -70,17 +70,50 @@ namespace CcDirector.Gateway.Api;
 /// because it looks like isolation. Nothing is substituted and no empty list is served: an empty
 /// GET /launchers would be a FALSE statement (a fleet with no machines) where a refusal is merely absent.
 ///
-/// SELF-HOST IS COMPLETELY UNCHANGED AND IS THE CONTROL. Cross-machine launch is legitimate fleet function
-/// there: one operator, his own machines.
+/// HOW THE DENY IS EXPRESSED - THE SHARED REFUSAL PRIMITIVE, NOT A BESPOKE FILTER. This family is denied
+/// through <see cref="HostedRouteDeny.ExclusiveGroup"/>, the ONE hosted-refusal boundary every deny family on
+/// this Gateway adopts (reference adoption: #1904 for /vault/keys; primitive at
+/// <c>src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs</c>). An earlier revision of this file rolled its own
+/// <c>AddEndpointFilter</c> deny before that primitive existed; it has been replaced so the release ships ONE
+/// refusal boundary, not one per family. What the primitive buys here over the old ad-hoc filter:
+///
+///   * On hosted the family's handlers are NEVER MAPPED. In their place each prefix maps ONE verb-less
+///     catch-all refusal over everything beneath it plus a root refusal at the prefix itself. There is no
+///     binding step to get ahead of, no body parameter, no media-type constraint and no method constraint, so
+///     EVERY request shape - a valid body, a malformed body, a wrong media type, a verb the group never
+///     mapped, and a route added LATER - meets the refusal. The old request-time filter answered only the
+///     shapes that reached it.
+///   * The exclusivity claim is CHECKED at startup, not trusted:
+///     <see cref="HostedRefusalRouteSpace.ValidateBeforeStart"/> refuses to start the Gateway if any live
+///     route serves beneath <c>/launchers</c> or <c>/machines</c>, or if two refusals tie.
+///   * The refusal payload is validated on CONSTRUCTION, so a blank message fails the Gateway at startup
+///     rather than serving an empty refusal that reads like a working route.
+///
+/// TWO EXCLUSIVE PREFIXES, BECAUSE THIS FAMILY OWNS TWO. The launcher self-registration surface owns
+/// <c>/launchers</c> outright and the machine relay surface owns <c>/machines</c> outright; nothing else on
+/// the Gateway serves beneath either (checked at startup). Each is its own exclusive group, so each gets the
+/// verb-less catch-all and the future-route coverage independently. A single empty-prefix group would NOT be
+/// an exclusive claim - it would claim the whole Gateway - which is why the bespoke filter used an empty
+/// prefix plus a request-time check and the primitive uses two real prefixes plus a startup-checked claim.
+///
+/// WHAT THIS DENY STOPS, NARROWLY: the HTTP ROUTE reads, writes and relays under both prefixes. It does NOT
+/// stop every write to launcher state. Every mutating call to <see cref="LauncherRegistry"/> in the
+/// codebase - Upsert (register), Heartbeat, Remove (unregister) - is an ON-ROUTE handler in THIS file, so all
+/// three close with the routes. But <see cref="Streaming.LauncherHub"/>.Hello still writes a
+/// machine-name-keyed connection row into <see cref="Streaming.LauncherConnectionRegistry"/> over the
+/// /launcher-stream SignalR hub, which is NOT in this route group (it is the HUB half, host-gated on a
+/// separate change). So tenant-blind state can still ACCUMULATE behind this deny.
+///
+/// SELF-HOST IS COMPLETELY UNCHANGED AND IS THE CONTROL. Off hosted the primitive maps the nine real handlers
+/// on the two groups exactly as an unguarded builder would and creates no refusal at all. Cross-machine
+/// launch is legitimate fleet function there: one operator, his own machines.
 ///
 /// UN-DENY. The permanent fix is a tenant-scoped launcher design that binds machine identity to a tenant at
 /// REGISTRATION and authorizes every launch, lifecycle and relay call against the calling tenant - including
-/// on the REST fallback arm. That unit is NOT enough on its own: this HTTP deny does NOT stop every write.
-/// <see cref="Streaming.LauncherHub"/>.Hello still writes a machine-name-keyed connection row into
-/// <see cref="Streaming.LauncherConnectionRegistry"/> over the /launcher-stream hub, which is not in this
-/// route group, so tenant-blind state can still ACCUMULATE behind the deny. The un-deny is therefore the
-/// tenant-key unit PLUS A PURGE of the launcher and launcher-connection registries. Deny-closed on the safe
-/// side: assume the purge is required until write-coverage is proven complete.
+/// on the REST fallback arm. That unit is NOT enough on its own: because the /launcher-stream hub keeps
+/// writing behind this deny, the un-deny is the tenant-key unit PLUS A PURGE of the launcher and
+/// launcher-connection registries. Deny-closed on the safe side: assume the purge is required until
+/// write-coverage is proven complete.
 /// </summary>
 internal static class MachineEndpoints
 {
@@ -93,41 +126,72 @@ internal static class MachineEndpoints
         new(@"cc-director(\d*)\.exe$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     /// <summary>
-    /// The exact refusal every route in this group serves on hosted. One string, asserted verbatim by the
-    /// tests, so the refusal is identifiable as ITSELF - a bare 404 would be indistinguishable from a route
-    /// that does not exist.
+    /// The exact refusal every route in this family serves on hosted. One string, shared by BOTH denied
+    /// groups and asserted verbatim by the tests, so the refusal is identifiable as ITSELF - a bare 404 would
+    /// be indistinguishable from a route that does not exist.
     /// </summary>
     internal const string HostedRefusal =
         "machine and launcher control is not available on the hosted gateway";
 
-    /// <summary>
-    /// The hosted refusal for the whole machine/launcher family (issue #1917), or null on self-host where
-    /// nothing changes.
-    ///
-    /// Gated on <see cref="GatewayHostedMode.IsHosted"/> - the INDEPENDENT signal - and not on a boundary or
-    /// tenant argument being passed in. A security branch that depends on an optional argument fails OPEN
-    /// when a caller forgets it, which is exactly how the hosted account-status fix nearly shipped a hole.
-    ///
-    /// 404 rather than 403: on hosted a tenant-owned machine does not exist as a concept, so "not here" is the
-    /// truthful answer. 403 would imply the right credential could reach it, and none can. The BODY is what
-    /// makes this a deny rather than a missing route, so it is always served and always the same.
-    /// </summary>
-    private static IResult? DenyOnHosted()
-    {
-        if (!GatewayHostedMode.IsHosted) return null;
+    /// <summary>The launcher self-registration prefix this family owns outright on hosted.</summary>
+    internal const string LauncherPrefix = "/launchers";
 
-        FileLog.Write("[MachineEndpoints] DENIED on hosted: the launcher and machine-control family is tenant-blind - a tenant does not own a machine on shared infrastructure (issue #1917)");
-        return Results.Json(new { error = HostedRefusal }, statusCode: StatusCodes.Status404NotFound);
-    }
+    /// <summary>The machine relay prefix this family owns outright on hosted.</summary>
+    internal const string MachinePrefix = "/machines";
 
     /// <summary>
-    /// Maps the machine/launcher group and RETURNS it, so the refusal can be proved to cover routes that do
-    /// not exist yet: a test maps a NEW probe route onto the returned group and finds it already refused on
-    /// hosted, without anyone having written a deny for it. Returning the group is the only way to state that
-    /// property from outside this file - and it is the ONLY property that distinguishes a group filter from a
-    /// guard repeated per route, because the two behave identically on every route that exists today.
+    /// The hosted refusal payload for the launcher self-registration surface (issue #1917). Validated on
+    /// construction, so a blank field fails the Gateway at startup rather than serving a refusal a caller
+    /// cannot act on. 404 rather than 403: on hosted a tenant-owned machine does not exist as a concept, so
+    /// "not here" is the truthful answer; 403 would imply some credential could reach it, and none can. The
+    /// hosted decision is read inside the primitive from <see cref="GatewayHostedMode.IsHosted"/> directly -
+    /// the INDEPENDENT signal - never from an argument a caller could forget and so fail OPEN.
     /// </summary>
-    public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, LauncherRegistry launchers,
+    private static HostedDenial LauncherDenial() => new(
+        family: "launcher-registration",
+        message: HostedRefusal,
+        reason: "the launcher registry keys on machine name alone with no tenant in the file, the store or the " +
+                "routes, and the host-wide auth gate admits any enrolled device key from any account - so one " +
+                "subscriber could enumerate, overwrite or delete every other subscriber's registered machines",
+        unDenyInstruction: "do NOT simply remove this deny: bind machine identity to a tenant at registration and " +
+                "authorize every call against the calling tenant, THEN purge the launcher and launcher-connection " +
+                "registries - the /launcher-stream hub keeps writing machine-name-keyed rows behind this deny",
+        statusCode: StatusCodes.Status404NotFound);
+
+    /// <summary>
+    /// The hosted refusal payload for the machine relay surface - the SAME message and status as the launcher
+    /// group, so a caller sees one consistent refusal across the family, with a family name and reason tuned to
+    /// the relay's cross-machine-code-execution risk.
+    /// </summary>
+    private static HostedDenial MachineDenial() => new(
+        family: "machine-control",
+        message: HostedRefusal,
+        reason: "the machine relay resolves purely on machine name with no tenant scope; its REST fallback arm " +
+                "dials a machine's stored address with its stored token, so one subscriber could run code on and " +
+                "relay lifecycle verbs to every other subscriber's machine",
+        unDenyInstruction: "do NOT simply remove this deny: bind machine identity to a tenant at registration and " +
+                "authorize every launch, lifecycle and relay call against the calling tenant - including the REST " +
+                "fallback arm - THEN purge the launcher and launcher-connection registries",
+        statusCode: StatusCodes.Status404NotFound);
+
+    /// <summary>
+    /// Maps the launcher and machine groups and RETURNS both denied handles, so the refusal can be proved to
+    /// cover routes that do not exist yet: a test maps a NEW probe route onto a returned group and finds it
+    /// already refused on hosted, without anyone having written a deny for it. Returning the groups is the only
+    /// way to state that future-route property from outside this file - and it is the ONLY property that
+    /// distinguishes an exclusive-prefix deny from a guard repeated per route, because the two behave
+    /// identically on every route that exists today.
+    ///
+    /// Each surface is its OWN exclusive group. <see cref="LauncherPrefix"/> and <see cref="MachinePrefix"/>
+    /// are owned outright - nothing else on the Gateway serves beneath either, which
+    /// <see cref="HostedRefusalRouteSpace.ValidateBeforeStart"/> checks at startup - so each maps ONE verb-less
+    /// catch-all refusal on hosted (covering every verb, every sub-path, and every route added later) and its
+    /// real handlers off hosted. The routes are mapped through the returned GROUP HANDLES, never through
+    /// <paramref name="outer"/>: a route mapped around the refusal is not expressible without changing the
+    /// signatures of <see cref="MapLauncherRoutes"/> / <see cref="MapMachineRoutes"/>, which take only the
+    /// handle - the bypass count is reduced by design, not by care.
+    /// </summary>
+    public static (HostedDenyGroup Launchers, HostedDenyGroup Machines) Map(IEndpointRouteBuilder outer, LauncherRegistry launchers,
         MachineSessionSpawner spawner,
         LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand = null,
         // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store. When non-null, a
@@ -146,25 +210,31 @@ internal static class MachineEndpoints
     {
         if (spawner is null) throw new ArgumentNullException(nameof(spawner));
 
-        FileLog.Write($"[MachineEndpoints] mapping /launchers + /machines; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused (issue #1917)");
+        FileLog.Write($"[MachineEndpoints] mapping {LauncherPrefix} + {MachinePrefix}; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in both groups is refused via the shared refusal primitive (issue #1917)");
 
-        // The whole family behind ONE filter, rather than a guard line repeated in every handler.
-        // A repeated guard is a thing to forget: the route added to this file next year would be open by
-        // default and nothing would fail - and on this family "open by default" means cross-machine code
-        // execution. A group filter runs before EVERY route mapped below, including routes that do not exist
-        // yet. The empty prefix keeps the route paths written out in full, exactly as before, so the self-host
-        // surface is byte-identical.
-        var app = outer.MapGroup("");
-        app.AddEndpointFilter(async (ctx, next) =>
-        {
-            if (DenyOnHosted() is { } denied) return denied;
-            return await next(ctx);
-        });
+        var launcherGroup = HostedRouteDeny.ExclusiveGroup(outer, LauncherPrefix, LauncherDenial());
+        MapLauncherRoutes(launcherGroup, launchers);
 
+        var machineGroup = HostedRouteDeny.ExclusiveGroup(outer, MachinePrefix, MachineDenial());
+        MapMachineRoutes(machineGroup, launchers, spawner, sendLauncherCommand, missions, workflowRuns);
+
+        return (launcherGroup, machineGroup);
+    }
+
+    /// <summary>
+    /// The four launcher self-registration routes, mapped relative to <see cref="LauncherPrefix"/> so the full
+    /// paths are <c>/launchers</c> and <c>/launchers/{machine}/...</c> exactly as before. Takes the denied
+    /// GROUP HANDLE and nothing else: the ungrouped route builder is deliberately out of scope so no route can
+    /// be mapped around the hosted refusal. All three <see cref="LauncherRegistry"/> writers - Upsert
+    /// (register), Heartbeat, Remove (unregister) - live here, ON-ROUTE, so every one of them closes with the
+    /// group; there is no off-route launcher-registry writer to host-gate separately.
+    /// </summary>
+    private static void MapLauncherRoutes(HostedDenyGroup app, LauncherRegistry launchers)
+    {
         // ===== Launcher self-registration surface =====
 
         // POST /launchers/register - the launcher POSTs this on startup and after reconnects.
-        app.MapPost("/launchers/register", (LauncherRegistrationRequest req) =>
+        app.MapPost("/register", (LauncherRegistrationRequest req) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.MachineName))
                 return Results.BadRequest(new { error = "machineName is required" });
@@ -179,7 +249,7 @@ internal static class MachineEndpoints
         });
 
         // POST /launchers/{machine}/heartbeat - keep-alive from the launcher every 30 s.
-        app.MapPost("/launchers/{machine}/heartbeat", (string machine) =>
+        app.MapPost("/{machine}/heartbeat", (string machine) =>
         {
             var ok = launchers.Heartbeat(machine);
             if (!ok)
@@ -192,7 +262,7 @@ internal static class MachineEndpoints
         });
 
         // DELETE /launchers/{machine} - graceful unregister on launcher shutdown.
-        app.MapDelete("/launchers/{machine}", (string machine) =>
+        app.MapDelete("/{machine}", (string machine) =>
         {
             launchers.Remove(machine);
             FileLog.Write($"[MachineEndpoints] DELETE /launchers/{machine}: removed");
@@ -200,24 +270,36 @@ internal static class MachineEndpoints
         });
 
         // GET /launchers - list all registered launchers (machine name, port, last-seen).
-        app.MapGet("/launchers", () =>
+        app.MapGet("", () =>
         {
             var list = launchers.ListLaunchers();
             FileLog.Write($"[MachineEndpoints] GET /launchers: count={list.Count}");
             return Results.Json(list);
         });
+    }
 
+    /// <summary>
+    /// The five machine relay routes, mapped relative to <see cref="MachinePrefix"/> so the full paths are
+    /// <c>/machines/{machine}/...</c> exactly as before. Takes the denied GROUP HANDLE and the relay
+    /// dependencies, and nothing else that could map a route around the hosted refusal.
+    /// </summary>
+    private static void MapMachineRoutes(HostedDenyGroup app, LauncherRegistry launchers,
+        MachineSessionSpawner spawner,
+        LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand,
+        Core.Sessions.MissionStore? missions,
+        Workflows.WorkflowRunStore? workflowRuns)
+    {
         // ===== Machine relay surface =====
 
         // POST /machines/{machine}/director/restart
-        app.MapPost("/machines/{machine}/director/restart", async (string machine, HttpContext ctx, CancellationToken ct) =>
+        app.MapPost("/{machine}/director/restart", async (string machine, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/director/restart: caller={ctx.Connection.RemoteIpAddress}");
             return await RelayDirectorLifecycleAsync(machine, "restart", ctx, launchers, sendLauncherCommand, ct);
         });
 
         // POST /machines/{machine}/director/start
-        app.MapPost("/machines/{machine}/director/start", async (string machine, HttpContext ctx, CancellationToken ct) =>
+        app.MapPost("/{machine}/director/start", async (string machine, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/director/start: caller={ctx.Connection.RemoteIpAddress}");
             return await RelayDirectorLifecycleAsync(machine, "start", ctx, launchers, sendLauncherCommand, ct);
@@ -227,7 +309,7 @@ internal static class MachineEndpoints
         // to a Director (auto-launching one via the launcher if none is running) and create the session
         // there through the SAME resolve-then-create path the cron firing engine uses. Fail loud: an
         // off/unreachable machine or a create failure returns 502 with the error - NEVER a local spawn.
-        app.MapPost("/machines/{machine}/sessions", async (string machine, NewSessionRequest req, CancellationToken ct) =>
+        app.MapPost("/{machine}/sessions", async (string machine, NewSessionRequest req, CancellationToken ct) =>
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: repo={req?.RepoPath}, agent={req?.Agent}");
             if (req is null || string.IsNullOrWhiteSpace(req.RepoPath))
@@ -344,14 +426,14 @@ internal static class MachineEndpoints
         });
 
         // POST /machines/{machine}/director/stop
-        app.MapPost("/machines/{machine}/director/stop", async (string machine, HttpContext ctx, CancellationToken ct) =>
+        app.MapPost("/{machine}/director/stop", async (string machine, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/director/stop: caller={ctx.Connection.RemoteIpAddress}");
             return await RelayDirectorLifecycleAsync(machine, "stop", ctx, launchers, sendLauncherCommand, ct);
         });
 
         // POST /machines/{machine}/launch - relay a generic launch request to the launcher.
-        app.MapPost("/machines/{machine}/launch", async (string machine, HttpContext ctx, CancellationToken ct) =>
+        app.MapPost("/{machine}/launch", async (string machine, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/launch: caller={ctx.Connection.RemoteIpAddress}");
 
@@ -404,8 +486,6 @@ internal static class MachineEndpoints
             }
             return result;
         });
-
-        return app;
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Closes thefrederiksen/devthrottle#1917 on the interim shape the Architect ruled: **deny the machine and launcher routes on hosted**. The permanent fix - a tenant-scoped launcher design - is a separate later unit, booked as thefrederiksen/devthrottle_internal#909.

Follows the merged stats deny (#1888, `1d456ddd`) exactly: one route group, one endpoint filter, gated directly on the hosted deployment signal.

## The defect, confirmed independently against origin/main

Read at `origin/main` (`f2028deb`), not from a summary:

- `LauncherRegistry` keys on **machine name alone** (`ConcurrentDictionary<string, Entry>` with `StringComparer.OrdinalIgnoreCase`). No tenant.
- `LauncherConnectionRegistry` keys on **machine name alone**. No tenant.
- `LauncherHub.Hello` binds a connection to `hello.MachineName` with **no tenant resolution at all** - in direct contrast to `DirectorHub.Hello`, which aborts when the device key resolves to no tenant.
- Not one of the nine routes in `MachineEndpoints` takes a tenant, resolves one, or filters by one.

So on hosted, **any authenticated device key** could enumerate every tenant's machines through `GET /launchers` - which returns every machine name, network address, port and process id fleet-wide, so the identifier the write routes need is not even guesswork - and then drive the machine routes **against another tenant's machine**:

- `POST /machines/{machine}/launch` forwards a caller-supplied path, arguments and working directory to another machine. **Cross-machine code execution.**
- `POST /launchers/register` overwrites a machine's stored token, port and network address, re-pointing the REST relay at an arbitrary host. **Outbound-request forgery.**
- `POST /machines/{machine}/sessions` starts a Director on that machine through the relay on its failure branch.

**Why the usual protection does not apply**, also verified: elsewhere, bare-identifier Director routes are inert cross-tenant because the command rides `SendCommandAsync`, which refuses to resolve a tunnel connection with no tenant in scope. **That protection lives in the transport, not in the route.** This family has three dispatch arms and only the Director-tunnel arm is gated. `LauncherCommandRouter.TrySendAsync` resolves purely on machine name, and when it returns null the **REST relay fallback** dials the launcher's stored address with its stored bearer token. The *failure* path is the ungated one by design.

## Denied, not partitioned

**On shared hosted infrastructure a tenant does not own a machine.** There is no ownership relation anywhere in the schema, so there is nothing to partition by - a per-tenant answer would have to be recomputed from an attribution that was never recorded, and inventing one is a half-partition, which looks like isolation while not being it.

And it is a **refusal, never an empty list**: an empty `GET /launchers` would be a *false* statement - a fleet with no machines - where an absent one is merely absent. That is the healthz mistake, stated as a test.

## Nine routes denied, one filter

| Verb | Route |
|---|---|
| POST | `/launchers/register` |
| POST | `/launchers/{machine}/heartbeat` |
| DELETE | `/launchers/{machine}` |
| GET | `/launchers` |
| POST | `/machines/{machine}/director/restart` |
| POST | `/machines/{machine}/director/start` |
| POST | `/machines/{machine}/director/stop` |
| POST | `/machines/{machine}/launch` |
| POST | `/machines/{machine}/sessions` |

All nine through **one** `AddEndpointFilter` on the group, not a guard per handler. `MachineEndpoints.Map` now returns its `RouteGroupBuilder`; that return value exists **solely** to make the future-route proof statable from outside the file.

## The deny bar, point by point

**Dual-sided.** Hosted serves `404` with `application/json` and a body whose property set is **exactly** `{ error }` carrying one exact string, asserted verbatim - never a bare 404, which would be indistinguishable from a route that does not exist. Self-host is proved by **handler-positive seeded fingerprints and independently re-read effects**, never by the refusal being absent:

- a seeded registration read back out of a *different* route (`GET /launchers`), field by field;
- heartbeat `200 {ok:true}` for a known machine and the handler's own `410` for an unknown one;
- unregister re-read **directly off the registry object**, not through the route that reports it;
- the three lifecycle verbs and the generic launch relayed to a **stub launcher** that records its hits and returns a sentinel - so a served relay is proved by an effect that could only come from the handler dialing out;
- a spawn returning the stubbed session id, plus the handler's own `400 repoPath is required`, which is reachable only if the route is genuinely served **and** is distinguishable from the hosted 404.

"Absence proved twice, presence never" does not apply: every denied path and verb has a served-side positive fact.

**The hosted signal is set explicitly, in both directions, and asserted.** The hosted classes set `CC_GATEWAY_HOSTED=1` themselves and `Assert.True(GatewayHostedMode.IsHosted)`. The self-host control sets it to **both** non-hosted forms - absent, and present-but-`"0"` - and `Assert.False(GatewayHostedMode.IsHosted)` before driving anything. Nothing here inherits the runner's ambient default.

**Future-route probe, both directions.** `A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own` maps a brand-new route onto the returned group and finds it refused with no deny written for it; `A_route_added_to_the_group_still_serves_on_self_host` drives the **same path** with hosted mode explicitly off, over both non-hosted forms, and finds it served. This is the only test of the property that justifies a group filter at all - a per-route guard and a group filter are identical on every route that already exists. A second control, `A_route_outside_the_group_still_serves_on_hosted`, shows the filter is scoped to the group and not the host refusing everything.

**Status and media type asserted BEFORE any parse**, everywhere a body is parsed. Parsing is itself an assertion about format: with the guard deleted these routes serve other shapes, and a `JsonDocument.Parse` crash would prove only that the mutation broke something upstream - it cannot say *what* was served in place of the refusal.

## The un-deny: the tenant-key unit **PLUS A PURGE**

A deny must stop the WRITE, not only the read, or its un-deny is a **deferred leak**.

The HTTP writes **are** stopped, and that is asserted rather than assumed:

- `A_refused_registration_writes_nothing_into_the_registry` - the registry is re-read **directly**, not through the routes under test, so it cannot pass merely because the read is denied too. The forgery primitive never arms.
- `A_refused_spawn_never_reaches_the_resolver` - the resolver counts its calls, so "the handler never ran" is an observation.
- `A_refused_launch_never_dials_the_launcher` - the stub launcher records every hit; a deny that answered 404 while still forwarding would redden here.

**Write-coverage is NOT complete.** `LauncherHub.Hello` still writes a machine-name-keyed connection row into `LauncherConnectionRegistry` over the `/launcher-stream` SignalR hub, which is **not in the denied route group**. Tenant-blind state can therefore still accumulate behind this deny.

**So the un-deny is the later tenant-key unit PLUS A PURGE of the launcher and launcher-connection registries, and this pull request defaults to assuming the purge is required until write-coverage is proven complete - deny-closed on the safe side.** That sentence is also written into the class documentation, the production file, and thefrederiksen/devthrottle_internal#909.

## Revert-proof

The recipe, the deletion (not `if (false)` - unreachable code is a build error here, and a test run after a failed build silently executes the previous binary), the mutation-present-by-diff check, and the requirement to run the **full** suite rather than a filter over these classes, are all recorded on `HostedLauncherMachineDenyTests`.

## The reds, PRE-REGISTERED - written and pushed before the arm is run

**A predicted red that does not appear is a finding.** A list filled in afterwards from what was observed cannot produce that finding at all: whatever reddens is by definition what was expected, so a mutation that silently failed to apply, or that reddened the wrong tests, would read as a clean result. It guards the other direction too - **more** reds than predicted would mean the filter was carrying something not accounted for, and that is to be understood rather than accepted.

The mutation is a single one: **delete the `app.AddEndpointFilter(...)` block** in `MachineEndpoints.Map` (currently lines 158-162), leaving `var app = outer.MapGroup("");` in place. Three full-suite runs: baseline, arm, restore.

### Predicted: exactly **15 test cases** redden, all of them in the new file

| Test | Rows |
|---|---|
| `HostedLauncherMachineDenyTests.Every_launcher_and_machine_route_is_refused_to_an_enrolled_tenant` | **all 9** theory rows |
| `HostedLauncherMachineDenyTests.The_launcher_listing_leaks_no_machine_on_hosted` | 1 |
| `HostedLauncherMachineDenyTests.The_refusal_is_not_an_empty_launcher_list` | 1 |
| `HostedLauncherMachineGroupFilterTests.A_route_added_to_the_group_later_is_refused_on_hosted_with_no_deny_of_its_own` | 1 |
| `HostedLauncherMachineGroupFilterTests.A_refused_registration_writes_nothing_into_the_registry` | 1 |
| `HostedLauncherMachineGroupFilterTests.A_refused_spawn_never_reaches_the_resolver` | 1 |
| `HostedLauncherMachineGroupFilterTests.A_refused_launch_never_dials_the_launcher` | 1 |

### Where each red is predicted to ARRIVE

A red that arrives from the fixture or from schema setup is **void** - the arm never ran. Only a red that arrives from an assertion about what was served proves anything. So the arrival point is predicted per row, not just the count:

- **Five** of the nine theory rows redden on the **status** assertion, because with the filter gone the handler's own answer carries a different status: register -> `201`, heartbeat on an unregistered machine -> `410`, unregister -> `200`, listing -> `200`, spawn -> `502` (the spawner fails loud rather than falling back).
- **Four** of them - the three director lifecycle verbs and the generic launch - are predicted to redden on the **property-set** assertion and **not** on the status assertion. With no launcher registered, the relay's own refusal is *also* `404` with `application/json`, so status and media type still match; what separates them is the body, `{ error, machine }` with a different error string versus `{ error }` alone. **This is the sharpest prediction here**, and it is exactly why the refusal is asserted as an exact property set rather than as a status code.

### Those four rows are a TRAP DETECTOR, and the trap is absence-proved-twice-presence-never

The hosted deny answers `404`. The relay's own "no launcher registered on that machine" *also* answers `404`, with the same media type. **Two different absences, identical on the wire except in the body.** So this arm is arranged to detect that in advance rather than have it surface in review:

- If those four come back **green** under the mutation, the deny was **indistinguishable from no-launcher-registered all along**, and every hosted pass on them proved nothing.
- **If those four redden on the STATUS assertion rather than on the PROPERTY-SET assertion, that is a FINDING about the deny's distinguishability - not a harmless variation in the arm.** It would mean something other than the body carried the difference, and that the property-set assertion - the only thing separating a deny from a missing route on this family - was never the load-bearing check it is claimed to be.

Stated explicitly because the failure mode here is a **reader** failure: four reds appear, a reviewer counts four against a prediction of four, and nobody notices they **arrived by the wrong route**. That is this mission's arrival-classification rule turned on this pull request's own prediction - a red is classified by *where it arrives*, and that applies to the predicted reds exactly as it applies to the unexpected ones.

### Declared unknown - uncertain about the ROUTE, certain about the OUTCOME

Those four rows depend on the launcher **stream** arm returning null inside a full `GatewayHost` booted with `streamMode: true`, so that the REST relay arm is the one that answers. Whether that holds is what cannot be predicted from reading alone. What is **not** unknown is that they **must redden**.

That decomposition is deliberate: a blanket "not sure what happens here" would have been unfalsifiable, whereas naming the one uncertain dimension leaves every other claim testable - and makes the status-versus-property-set arrival a **finding** rather than a shrug.

### Must stay GREEN (controls)

`An_unauthenticated_caller_is_still_rejected`, `A_route_outside_the_group_still_serves_on_hosted`, and **all ten** cases of `HostedLauncherMachineSelfHostControlTests` (five methods x two non-hosted forms). A control that moves with the change under test is not a control.

### And zero reds anywhere else in the suite

The twelve existing launcher and machine test files run under the runner's ambient non-hosted default, where this filter is a pass-through, so deleting it cannot reach them. If one of them reddens, the ambient default is not what it is believed to be - a finding about every other hosted test in this assembly, not a detail about this one.

### The reconciliation protocol - three rules, and the order is load-bearing

1. **Reconcile against the baseline TOTAL, not against restored passed.** The tempting identity - passed plus failed under the mutation equals passed under the restore - holds *only if skipped never moves*. Skips in this suite are environment-gated and **can** move, so that identity balances by accident: when a skip count shifts it either breaks for a reason that gets chased for nothing, or it **silently absorbs a real discrepancy**. The check with nothing left out is `passed + failed + skipped == baseline total`, on **every** arm including baseline and restore, against a baseline taken fresh at this head and never quoted from another run.

2. **Reconcile BEFORE scoring, not after.** Reconciliation is a **precondition for the arm counting at all**, not a post-hoc validation of a score already formed - score first and a truncated run has already been read as a result by the time the total is checked. A short total means the arm is **unproven-truncated**: not scored in either direction, and it does **not** become "a mutation that reddened fewer tests than predicted".

3. **The truncation trap bears directly on the fifteen above.** If a run truncates, **fewer than fifteen** reds appear - and under the rule this pull request already holds (a predicted red that does not appear is a finding), a truncated arm would present itself as a finding **about the deny**. It is not. It is a finding about the **harness**. So the total is checked first and the fifteen are compared only afterwards. **A pre-registration makes truncation more dangerous, not less**, because it hands truncation a ready-made story to be mistaken for.

### Baseline preconditions

- **The whole source tree is clean**, not merely the Gateway project. A lost *test* edit falsifies an arm as thoroughly as a lost production edit, and a check scoped to one project would not see it.
- **The working head equals the pushed head.** Cleanliness alone is not sufficient: a stash leaves the tree **clean at the pinned head**, so a tree that looks perfect can be missing the very repair under test, and a guard checking only cleanliness would admit it. (This branch is committed and pushed, so it satisfies this today; the check exists for the case where it would not.)

### The run plan is exactly three full-suite runs

Baseline, arm, restore - and the path actually taken is the path registered. There is **no slice-then-full escalation and no separate canary gate** here: all three arms are the full suite, so no ordering can slip a fourth run in behind the registered three. On a contended serial box a fourth run spends someone else's slot.

**That count was observed by EXECUTING the driver against a counting stub, not by reading it**: three test invocations, counted. The same execution mutated the real source, verified the mutation by diff, restored it with `git checkout --`, and left the tree clean.

### A finding that does not change the verdict is not a finding, it is a comment

The first version of this unit's driver had **eight things I would have called controls and zero that could stop it**: the clean-tree check printed, the mutation diff printed, build exit codes were masked by pipes, and reconciliation and red-classification existed only as prose. Every one reported into a void, because **the log is what nobody re-reads once the exit code is green**. Being confidently wrong about which of your checks can actually stop you is worse than having fewer checks. The three questions, answered:

1. **A predicted red that arrives as a CRASH does not count toward the fifteen, and the arm is not proven.** Crediting a crash to the prediction - so a parse exception satisfies the expectation and keeps its row out of the not-reddened set - is precisely the laundering the arrival rule exists to prevent, happening inside the mechanism written to enforce it.
2. **A predicted row that stays GREEN changes the verdict to unproven.** It does not become a line in a report filed beside a passing score. Already registered for the four relay rows; the same rule now covers all fifteen.
3. **A total that does not match stops the arm being scored at all.** Not mentioned alongside a score already formed. Reconcile first; a short total is unproven-truncated, scored in neither direction.

Those three, plus controls-must-not-move and nothing-else-may-redden, are **five preventing controls**. Each was validated by **executing** it against a synthetic arm built to trip it - a truncated arm, a crash-red arm, a stayed-green arm - confirming a distinct non-zero verdict, and against a clean arm to confirm it does not fire on the happy path. Observed exit codes: perfect `0`, truncated `2`, crash `3`, stayed-green `3`. A detector that has only ever been read is another printout.

### Why all three arms are the full solution, and not the Gateway assembly per arm

The obvious answer is the **reference graph**: of the seven test projects, only `CcDirector.Gateway.Tests` references `CcDirector.Gateway`, so nothing else can even load the mutated code. **That answer is wrong**, and it is worth recording because it is the answer anyone would give - including me, until I checked.

`CcDirector.Core.Tests` contains **ten architecture fitness functions that read production source under `src/` as text**, with no assembly reference to the Gateway at all. One of them, `NoCrossMachineLoopbackGuardTests`, carries a **path-keyed allowlist naming `src/CcDirector.Gateway/Api/MachineEndpoints.cs` explicitly** - the exact file this pull request mutates - and by its own documentation it fails on a **stale** entry, meaning a file that no longer contains the literal. **So a source edit in the Gateway can redden a project that does not reference the Gateway.** The coupling is textual, over the filesystem, and the reference graph is structurally blind to it.

For **this** mutation it is settled, and settled **for free by text** rather than by spending a box slot: the deleted block is five lines of routing code containing **zero** loopback literals, and `MachineEndpoints.cs` still contains **four** afterwards, so the allowlist entry stays honest and that guard cannot flip. Verified by applying the mutation, grepping, and restoring.

**The deciding argument is the reconciliation gate, not the coupling.** Scoping the arm narrower than the baseline **breaks the primary truncation detector**: `passed + failed + skipped` would be compared against a total from a *different population* and could never match. Preserving the gate under a scoped arm requires a **scoped baseline too - a fourth run**, on a contended serial box, to save part of one.

The per-arm saving **scales with the number of arms** while the extra full run is **fixed**, so the scoping that is correct for an eight-arm proof **inverts at three arms**. Measured against roughly 17 minutes for a full solution and 10 for the Gateway suite: three full runs is about 50 minutes, and every scoped variant that keeps the gate intact lands between 47 and 56. **There is no saving here to buy, only a detector to lose** - so the registration stands: three full-solution runs.

Self-host is completely unchanged and is the control.
