### PR TITLE
hosted: refuse the shared-vault transcription key provisioner, and pin it

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedTranscriptionKeyProvisioningGateTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedTranscriptionKeyProvisioningGateTests.cs
@@ -1,0 +1,260 @@
+using CcDirector.Core;
+using CcDirector.Core.Account;
+using CcDirector.Core.Configuration;
+using CcDirector.Gateway.Account;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Pins that a HOSTED Gateway cannot run either of the two key-vault operations in
+/// <see cref="TranscriptionKeyAutoProvisioner"/>.
+///
+/// THE REPORTED DEFECT DOES NOT HOLD ON HOSTED TODAY, AND THAT IS THE POINT OF THIS FILE. A future reader
+/// who finds only the gate will assume there was a live cross-tenant hole in production. There was not. As
+/// deployed, the hosted Gateway is a Linux container, <c>GatewayHost</c> builds its DevThrottle credential
+/// service only on Windows and macOS, and the provisioner and the sign-in service are both built only when
+/// that credential service exists - so on hosted no provisioner is ever constructed, no sign-in flow is ever
+/// mapped, and <c>POST /account/logout</c> short-circuits at "no credential service" before it reaches the
+/// sign-out hook. Neither the write nor the delete can execute. This work was done because that safety was
+/// UNASSERTED, not because it was absent.
+///
+/// SAFE ONLY BY WIRING is exactly the problem. The property held because of which platform hosted happens
+/// to run on, and nothing anywhere said so. The day hosted gains a credential service - a product
+/// direction, not a hypothesis - both harms below arm themselves and NOTHING GOES RED:
+///
+///   - BILLING INTEGRITY. <c>EnsureAsync</c> writes the shared, tenant-less key vault with SET-IF-ABSENT, so
+///     the first tenant to sign in owns the key and every later tenant silently transcribes on it, spending
+///     the first tenant's credits. Nobody is refused; nothing errors.
+///   - AVAILABILITY. <c>RevokeMintedKeyAsync</c> revokes and deletes that same shared entry, so one tenant's
+///     entirely ordinary sign-out breaks transcription for every other tenant on the box.
+///
+/// <see cref="Two_tenants_on_one_shared_vault_is_a_real_harm_when_the_provisioner_exists"/> DEMONSTRATES
+/// both harms rather than describing them, on a provisioner explicitly told it is not hosted. It is also the
+/// DESTRUCTIBILITY CONTROL for the hosted arm: without it, "the other tenant's key survived on hosted" would
+/// be satisfied by a revoke that never destroys anything at all.
+///
+/// The gate under proof is a private constructor plus <see cref="TranscriptionKeyAutoProvisioner.CreateUnlessHosted"/>
+/// as the only construction route. That is one removable line rather than a guard at the top of each method:
+/// with two guards, either could be individually removed while the other stayed correct, so each would need
+/// its own proof. With one construction route there is no second way to obtain an instance to bypass.
+///
+/// Revert-prove: delete the hosted branch from <c>CreateUnlessHosted</c> and
+/// <see cref="Hosted_yields_no_provisioner_so_neither_shared_vault_operation_can_run"/>,
+/// <see cref="On_hosted_a_second_tenant_cannot_inherit_or_destroy_a_first_tenants_key"/> and
+/// <see cref="A_hosted_gateway_wires_no_transcription_key_provisioner"/> all go RED, while the two-tenant
+/// harm demonstration and the self-host control stay GREEN - they are what must not move.
+/// </summary>
+public sealed class HostedTranscriptionKeyProvisioningGateTests : IDisposable
+{
+    /// <summary>One vault file for the whole class - which is the production shape being reasoned about:
+    /// the key vault is ONE file per box, with no tenant dimension.</summary>
+    private readonly string _sharedVaultPath =
+        Path.Combine(Path.GetTempPath(), "ccd-hosted-gate-" + Guid.NewGuid().ToString("N") + ".json");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_sharedVaultPath)) File.Delete(_sharedVaultPath); } catch { /* best effort */ }
+    }
+
+    /// <summary>Mints a distinct key per tenant and records what it was asked to revoke.</summary>
+    private sealed class TenantMinter : IInferenceKeyMinter
+    {
+        private readonly string _key;
+        private readonly string _id;
+        public int MintCalls { get; private set; }
+        public int RevokeCalls { get; private set; }
+        public string? RevokedId { get; private set; }
+
+        public TenantMinter(string key, string id) { _key = key; _id = id; }
+
+        public Task<MintedInferenceKey?> MintAsync(string accessToken, string label, CancellationToken ct = default)
+        {
+            MintCalls++;
+            return Task.FromResult<MintedInferenceKey?>(new MintedInferenceKey(_key, _id));
+        }
+
+        public Task<bool> RevokeAsync(string accessToken, string keyId, CancellationToken ct = default)
+        {
+            RevokeCalls++;
+            RevokedId = keyId;
+            return Task.FromResult(true);
+        }
+    }
+
+    // ----- The gate itself -----
+
+    [Fact]
+    public void Hosted_yields_no_provisioner_so_neither_shared_vault_operation_can_run()
+    {
+        var provisioner = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(
+            new KeyVault(_sharedVaultPath), () => "an.account.jwt", new TenantMinter("dt_live_a", "id-a"),
+            isHosted: true);
+
+        // Null is the refusal, and it is the ONLY way to refuse: the constructor is private, so there is no
+        // instance in existence on which EnsureAsync or RevokeMintedKeyAsync could be called.
+        Assert.Null(provisioner);
+    }
+
+    [Fact]
+    public void Self_host_still_gets_a_provisioner()
+    {
+        // The control for the gate: the refusal is specific to hosted and has not simply disabled the
+        // feature everywhere. Without this, the hosted assertion above would also pass if CreateUnlessHosted
+        // returned null unconditionally.
+        var provisioner = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(
+            new KeyVault(_sharedVaultPath), () => "an.account.jwt", new TenantMinter("dt_live_a", "id-a"),
+            isHosted: false);
+
+        Assert.NotNull(provisioner);
+    }
+
+    // ----- The harm, demonstrated, and the destructibility control -----
+
+    [Fact]
+    public async Task Two_tenants_on_one_shared_vault_is_a_real_harm_when_the_provisioner_exists()
+    {
+        // Two tenants, both signing in, both reaching the SAME vault file - the hosted shape. Told
+        // isHosted:false so the provisioner exists and its real behaviour is observable. This test asserts
+        // the DEFECT, not the fix: it is what makes the hosted arms mean something.
+        var vault = new KeyVault(_sharedVaultPath);
+        var alice = new TenantMinter("dt_live_ALICE", "id-alice");
+        var bob = new TenantMinter("dt_live_BOB", "id-bob");
+
+        var aliceProvisioner = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(
+            vault, () => "alice.jwt", alice, isHosted: false)!;
+        var bobProvisioner = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(
+            vault, () => "bob.jwt", bob, isHosted: false)!;
+
+        // Alice signs in first and mints. She owns the shared entry.
+        Assert.True(await aliceProvisioner.EnsureAsync());
+        Assert.Equal("dt_live_ALICE", new KeyVault(_sharedVaultPath).Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+
+        // HARM 1 - BILLING. Bob signs in second. Set-if-absent means first writer wins: Bob never mints, and
+        // the key the vault now serves HIM is Alice's, so Bob's transcription spends Alice's credits.
+        Assert.False(await bobProvisioner.EnsureAsync());
+        Assert.Equal(0, bob.MintCalls);
+        Assert.Equal("dt_live_ALICE", new KeyVault(_sharedVaultPath).Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+
+        // HARM 2 - AVAILABILITY, and the DESTRUCTIBILITY CONTROL. Bob does something entirely ordinary: he
+        // signs out. The revoke reads the shared id entry - Alice's - revokes it in the cloud with BOB's
+        // token, and deletes the shared key. Alice is still signed in and now has no key at all.
+        Assert.True(await bobProvisioner.RevokeMintedKeyAsync());
+        Assert.Equal(1, bob.RevokeCalls);
+        Assert.Equal("id-alice", bob.RevokedId);
+
+        var afterBobSignedOut = new KeyVault(_sharedVaultPath);
+        Assert.Null(afterBobSignedOut.Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+        Assert.Null(afterBobSignedOut.Get(TranscriptionKeyAutoProvisioner.InferenceKeyIdVaultName));
+    }
+
+    [Fact]
+    public async Task On_hosted_a_second_tenant_cannot_inherit_or_destroy_a_first_tenants_key()
+    {
+        // The same two tenants, the same shared vault, hosted this time. Neither can obtain a provisioner,
+        // so the shared-vault path is closed at the only door: there is no key for a second tenant to
+        // inherit and no key for a sign-out to destroy. The vault is never written at all.
+        var vault = new KeyVault(_sharedVaultPath);
+        var alice = new TenantMinter("dt_live_ALICE", "id-alice");
+        var bob = new TenantMinter("dt_live_BOB", "id-bob");
+
+        var aliceProvisioner = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(
+            vault, () => "alice.jwt", alice, isHosted: true);
+        var bobProvisioner = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(
+            vault, () => "bob.jwt", bob, isHosted: true);
+
+        Assert.Null(aliceProvisioner);
+        Assert.Null(bobProvisioner);
+
+        // Nothing minted, and the shared vault holds no transcription credential for anyone to spend or
+        // revoke. Read from a fresh KeyVault so this observes the FILE, not an in-memory instance.
+        Assert.Equal(0, alice.MintCalls);
+        Assert.Equal(0, bob.MintCalls);
+        var reread = new KeyVault(_sharedVaultPath);
+        Assert.Null(reread.Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+        Assert.Null(reread.Get(TranscriptionKeyAutoProvisioner.InferenceKeyIdVaultName));
+    }
+
+    // ----- The wiring: the gate is fed by the REAL hosted signal -----
+
+    private sealed class InMemoryTokenStore : IProtectedTokenStore
+    {
+        private DevThrottleTokens? _tokens;
+        public bool HasTokens => _tokens is not null;
+        public void Save(DevThrottleTokens tokens) => _tokens = tokens;
+        public DevThrottleTokens? Load() => _tokens;
+        public void Clear() => _tokens = null;
+    }
+
+    /// <summary>
+    /// A Gateway credential service over an in-memory store. Injected deliberately rather than left to the
+    /// platform: it is the whole point of these two tests to model the day HOSTED HAS A CREDENTIAL SERVICE,
+    /// which is precisely when the accidental safety stops holding. Injecting it also makes the tests
+    /// platform-independent instead of quietly passing on Linux because no credential service exists there.
+    /// </summary>
+    private static DevThrottleAccountService MakeAccount()
+    {
+        var previous = Environment.GetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar);
+        Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, "a-test-signing-secret-for-the-hosted-gate");
+        try
+        {
+            var authEventsLog = Path.Combine(Path.GetTempPath(), "cc-gw-hosted-gate-" + Guid.NewGuid().ToString("N") + ".jsonl");
+            return GatewayAccountFactory.Build(new InMemoryTokenStore(), authEventsLog);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, previous);
+        }
+    }
+
+    /// <summary>
+    /// Constructs a real GatewayHost with a real credential service under a stated hosted setting, and hands
+    /// back what it wired. The wiring happens in the constructor, so nothing is started and no port is bound.
+    /// The storage root is isolated so this never writes the running user's real vault. The assembly runs
+    /// sequentially, so toggling CC_GATEWAY_HOSTED here is safe; it is restored in the finally.
+    /// </summary>
+    private static async Task<bool> WiresAProvisionerAsync(bool hosted)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "cc-hosted-gate-root-" + Guid.NewGuid().ToString("N"));
+        var priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        var priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", root);
+        try
+        {
+            await using var gateway = new GatewayHost(
+                port: 0, token: "test-token", authEnabled: true,
+                instancesDirectory: Path.Combine(root, "instances"),
+                keyVaultPath: Path.Combine(root, "keyvault.json"),
+                workListsPath: Path.Combine(root, "worklists", "worklists.json"),
+                snoozePath: Path.Combine(root, "snooze", "snooze.json"),
+                account: MakeAccount());
+
+            return gateway.TranscriptionKeyProvisioner is not null;
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", priorHosted);
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", priorRoot);
+            try { if (Directory.Exists(root)) Directory.Delete(root, true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task A_hosted_gateway_wires_no_transcription_key_provisioner()
+    {
+        // The credential service is PRESENT here, so this is not passing for the incidental reason hosted is
+        // safe today. It is the real CC_GATEWAY_HOSTED signal that must close it, which is what pins the gate
+        // to the production hosted flag rather than to a boolean a test hands it.
+        Assert.False(await WiresAProvisionerAsync(hosted: true));
+    }
+
+    [Fact]
+    public async Task A_self_hosted_gateway_still_wires_the_provisioner()
+    {
+        // The control for the wiring assertion: the same construction with the same credential service and
+        // ONLY CC_GATEWAY_HOSTED differing still wires a provisioner, so the hosted result above is caused by
+        // the hosted signal and not by the account, the paths, or the isolated root.
+        Assert.True(await WiresAProvisionerAsync(hosted: false));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TranscriptionKeyAutoProvisionerTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscriptionKeyAutoProvisionerTests.cs
@@ -131,7 +131,7 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
         var vault = new KeyVault(_vaultPath);
         vault.Set(TranscriptionEndpointResolver.DevThrottleKeyName, "dt_live_manual_or_reused");
         var minter = new FakeMinter("dt_live_should_not_be_used");
-        var sut = new TranscriptionKeyAutoProvisioner(vault, () => "jwt", minter);
+        var sut = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(vault, () => "jwt", minter, isHosted: false)!;
 
         var minted = await sut.EnsureAsync();
 
@@ -145,7 +145,7 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
     {
         var vault = new KeyVault(_vaultPath);
         var minter = new FakeMinter("dt_live_x");
-        var sut = new TranscriptionKeyAutoProvisioner(vault, () => null, minter);
+        var sut = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(vault, () => null, minter, isHosted: false)!;
 
         var minted = await sut.EnsureAsync();
 
@@ -158,7 +158,7 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
     {
         var vault = new KeyVault(_vaultPath);
         var minter = new FakeMinter("dt_live_freshly_minted", id: "minted-key-id");
-        var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+        var sut = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(vault, () => "the.jwt", minter, isHosted: false)!;
 
         var minted = await sut.EnsureAsync();
 
@@ -177,7 +177,7 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
     {
         var vault = new KeyVault(_vaultPath);
         var minter = new FakeMinter("dt_live_x", id: "the-id");
-        var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+        var sut = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(vault, () => "the.jwt", minter, isHosted: false)!;
         await sut.EnsureAsync(); // mints + records the id
 
         var revoked = await sut.RevokeMintedKeyAsync();
@@ -197,7 +197,7 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
         var vault = new KeyVault(_vaultPath);
         vault.Set(TranscriptionEndpointResolver.DevThrottleKeyName, "dt_live_manual");
         var minter = new FakeMinter("dt_live_unused");
-        var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+        var sut = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(vault, () => "the.jwt", minter, isHosted: false)!;
 
         var revoked = await sut.RevokeMintedKeyAsync();
 
@@ -211,7 +211,7 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
     {
         var vault = new KeyVault(_vaultPath);
         var minter = new FakeMinter(null);
-        var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+        var sut = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(vault, () => "the.jwt", minter, isHosted: false)!;
 
         var minted = await sut.EnsureAsync();
 
@@ -250,7 +250,7 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
     {
         var vault = new KeyVault(_vaultPath);
         var minter = new UniqueSlowMinter(TimeSpan.FromMilliseconds(50));
-        var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+        var sut = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(vault, () => "the.jwt", minter, isHosted: false)!;
 
         // Fire the ensure from several callers at once (the sign-in hook and the startup task racing).
         var results = await Task.WhenAll(Enumerable.Range(0, 8).Select(_ => sut.EnsureAsync()));
@@ -289,7 +289,7 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
     {
         var vault = new KeyVault(_vaultPath);
         var minter = new RaceLosingMinter(vault);
-        var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+        var sut = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(vault, () => "the.jwt", minter, isHosted: false)!;
 
         var stored = await sut.EnsureAsync();
 
@@ -325,7 +325,7 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
         // residual cloud key can be revoked from the website.
         var vault = new KeyVault(_vaultPath);
         var minter = new RevokeFailingMinter("dt_live_x", "the-id");
-        var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+        var sut = TranscriptionKeyAutoProvisioner.CreateUnlessHosted(vault, () => "the.jwt", minter, isHosted: false)!;
         await sut.EnsureAsync(); // mints + records the id
 
         var revoked = await sut.RevokeMintedKeyAsync();

--- a/src/CcDirector.Gateway/Account/TranscriptionKeyAutoProvisioner.cs
+++ b/src/CcDirector.Gateway/Account/TranscriptionKeyAutoProvisioner.cs
@@ -46,12 +46,66 @@ public sealed class TranscriptionKeyAutoProvisioner
     /// </summary>
     private readonly SemaphoreSlim _ensureGate = new(1, 1);
 
+    /// <summary>
+    /// The ONLY way to obtain a provisioner: builds one on a self-hosted Gateway, and returns NULL on a
+    /// HOSTED Gateway. Every caller already handles the null (it is the same "no provisioner" state a host
+    /// with no credential service has always produced), so returning null costs no new code path.
+    ///
+    /// WHY THIS GATE EXISTS - read this before deleting it as redundant. Both of this class's operations
+    /// write the SHARED key vault, which has NO TENANT DIMENSION - one <c>keyvault.json</c> for the whole
+    /// box:
+    ///
+    ///   - <see cref="EnsureAsync"/> writes with SET-IF-ABSENT, so on a multi-tenant Gateway the FIRST
+    ///     tenant to sign in owns the key and every tenant who signs in afterwards silently transcribes on
+    ///     it. Nobody is refused and nothing errors; the usage simply BILLS TO THE FIRST TENANT'S ACCOUNT.
+    ///   - <see cref="RevokeMintedKeyAsync"/> revokes the key in the cloud and DELETES it from that shared
+    ///     vault, so ONE tenant's entirely ordinary sign-out breaks transcription for every other tenant
+    ///     on the box.
+    ///
+    /// On a self-hosted Gateway there is exactly ONE account, so neither can happen and both behaviours are
+    /// the deliberate safeguards their own documentation describes (the manual-key override, and clearing on
+    /// sign-out precisely so the NEXT account on the machine cannot reuse the key).
+    ///
+    /// THIS GATE IS REDUNDANT TODAY, AND THAT IS NOT A REASON TO REMOVE IT. As deployed, the hosted Gateway
+    /// is a Linux container, and <c>GatewayHost</c> builds its credential service only on Windows and macOS -
+    /// so hosted currently has no account component, no sign-in flow, and therefore no caller that could ever
+    /// reach these two methods. The safety is an ACCIDENT OF WHICH PLATFORM HOSTED HAPPENS TO RUN ON. The day
+    /// hosted gains a credential service - a product direction, not a hypothetical - both harms above arm
+    /// themselves, silently, with nothing to notice. This gate makes the safety structural instead of
+    /// platform-conditional, and it is pinned by
+    /// <c>CcDirector.Gateway.Tests.HostedTranscriptionKeyProvisioningGateTests</c>.
+    ///
+    /// The correct hosted answer is not this gate forever - it is a per-tenant credential, the way the hosted
+    /// enrollment path already partitions a shared store by prefixing with the authenticated tenant. Until
+    /// that exists, refusing is the answer that cannot mis-bill anyone.
+    /// </summary>
     /// <param name="vault">The Gateway key vault - where the transcription owner reads the hosted key.</param>
     /// <param name="accessTokenProvider">Supplies the signed-in account JWT (or null when not signed in);
     /// invoked fresh each call so it always reflects the current credential.</param>
     /// <param name="minter">Mints an inference key for the account.</param>
     /// <param name="label">A recognisable name for the minted key (defaults to the machine name).</param>
-    public TranscriptionKeyAutoProvisioner(
+    /// <param name="isHosted">Whether this Gateway is a hosted deployment. Defaults to the real
+    /// <see cref="GatewayHostedMode.IsHosted"/> signal; passed explicitly by tests so they assert on a stated
+    /// value rather than on whatever the runner happens to leave in the environment.</param>
+    public static TranscriptionKeyAutoProvisioner? CreateUnlessHosted(
+        KeyVault vault, Func<string?> accessTokenProvider, IInferenceKeyMinter minter, string? label = null,
+        bool? isHosted = null)
+    {
+        if (isHosted ?? GatewayHostedMode.IsHosted)
+        {
+            FileLog.Write("[TranscriptionKeyAutoProvisioner] CreateUnlessHosted: HOSTED -> no provisioner built; the key vault is shared across tenants, so neither the set-if-absent write nor the sign-out revoke may run here");
+            return null;
+        }
+
+        return new TranscriptionKeyAutoProvisioner(vault, accessTokenProvider, minter, label);
+    }
+
+    /// <summary>
+    /// Private on purpose: <see cref="CreateUnlessHosted"/> is the only way to get an instance, so the
+    /// hosted refusal cannot be bypassed by constructing one directly. Adding a second construction route
+    /// re-opens the hole the factory closes.
+    /// </summary>
+    private TranscriptionKeyAutoProvisioner(
         KeyVault vault, Func<string?> accessTokenProvider, IInferenceKeyMinter minter, string? label = null)
     {
         _vault = vault ?? throw new ArgumentNullException(nameof(vault));

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -307,6 +307,14 @@ public sealed class GatewayHost : IAsyncDisposable
     // Issue #881: mints/ensures the DevThrottle inference key after sign-in and at startup. Null on a
     // host with no credential service (nothing to sign in to).
     private readonly Account.TranscriptionKeyAutoProvisioner? _transcriptionKeyProvisioner;
+
+    /// <summary>
+    /// The auto-provisioner as actually wired, exposed to the test assembly so a test can assert the WIRING
+    /// rather than re-deriving it: on a hosted Gateway this must be null, because the provisioner's two
+    /// operations write a key vault that is shared across every tenant on the box. Null is also the ordinary
+    /// state on any host with no credential service.
+    /// </summary>
+    internal Account.TranscriptionKeyAutoProvisioner? TranscriptionKeyProvisioner => _transcriptionKeyProvisioner;
     private readonly WorkListStore _workLists;
     // Snooze Length mission: the Gateway-owned, restart-surviving snooze registry (the one piece of
     // new state). An expired snooze comes back on its own with no background timer: HoldStateFor reports
@@ -991,7 +999,16 @@ public sealed class GatewayHost : IAsyncDisposable
             // the vault so hosted transcription/TTS "just work" with zero configuration. The account JWT
             // authenticates the mint; a manual or already-minted vault key short-circuits it (manual
             // override + reuse across restarts, no key sprawl).
-            _transcriptionKeyProvisioner = new Account.TranscriptionKeyAutoProvisioner(
+            // CreateUnlessHosted returns NULL on a hosted Gateway, and that is deliberate: this provisioner
+            // writes and deletes the SHARED, tenant-less key vault, so on hosted the first tenant to sign in
+            // would own the key every later tenant then spends credits on, and any one tenant's sign-out
+            // would revoke the key all the others are using. The refusal reads as "no provisioner", which is
+            // the state hosted is already in today for an unrelated reason (its Linux container has no
+            // credential service at all) - so this changes nothing that runs now and holds the line if that
+            // ever changes. The full reasoning lives at the factory.
+            // Fully qualified: inside this class the bare name "Account" binds to the credential-service
+            // PROPERTY, not to the namespace, so the namespace has to be named from the root here.
+            _transcriptionKeyProvisioner = CcDirector.Gateway.Account.TranscriptionKeyAutoProvisioner.CreateUnlessHosted(
                 _keyVault,
                 accessTokenProvider: Account.GetAccessTokenForForwarding,
                 minter: new Account.AccountInferenceKeyProvisioner());
@@ -1002,7 +1019,8 @@ public sealed class GatewayHost : IAsyncDisposable
                 {
                     if (_deviceRegistration is not null)
                         await _deviceRegistration.EnsureRegisteredAsync(ct);
-                    await _transcriptionKeyProvisioner.EnsureAsync(ct);
+                    if (_transcriptionKeyProvisioner is not null)
+                        await _transcriptionKeyProvisioner.EnsureAsync(ct);
                 });
         }
         else


### PR DESCRIPTION
## The reported defect does not hold on hosted today

State this first, because a future reader who finds only the gate will assume there was a live cross-tenant hole in production. There was not.

The transcription-key auto-provisioner writes the key vault with a set-if-absent on sign-in, and revokes-and-deletes that same entry on sign-out. The vault is one `keyvault.json` per box with no tenant dimension. On a multi-tenant Gateway those two operations would be exactly the two harms reported: the first tenant to sign in owns the key and every later tenant silently transcribes on it, spending the first tenant's credits; and any one tenant's entirely ordinary sign-out revokes and deletes the key every other tenant is using.

Neither can execute on hosted. Walked end to end at `f2028de`:

- The hosted Gateway is a **Linux container** (`Dockerfile`, `mcr.microsoft.com/dotnet/aspnet:10.0`).
- `GatewayHost` builds its DevThrottle credential service only on Windows and macOS; Linux logs an explicit null. `GatewayAccountFactory` has no Linux path, and the only non-test construction (`GatewayService`) injects no account.
- The provisioner **and** the sign-in service are both built only inside `if (Account is not null)`, so on hosted neither exists.
- Consequently the startup ensure is skipped by its own null guard, `/account/sign-in-start` and `/account/sign-in-callback` report not-available, and `POST /account/logout` returns at its `account is null` branch **before** the sign-out hook or any vault delete.

On a self-hosted Gateway, where this code does run, there is exactly one account — and there both behaviours are the deliberate safeguards their own documentation describes.

## Why change anything, then

Because the safety is an accident of which platform hosted happens to run on, and nothing anywhere asserts it. Nothing in the provisioner or the logout hook is tenant-aware or hosted-gated. A credential service on hosted is a product direction, not a hypothesis; the day it lands, both harms arm themselves and **nothing goes red**. Whoever wires it will have no way to know they were relying on the platform.

That shape — a property that holds because of how something happens to be constructed, with no assertion that it holds — is what this pull request converts into an asserted property.

## What it does

**The gate.** `TranscriptionKeyAutoProvisioner.CreateUnlessHosted` is now the only way to obtain a provisioner and returns null on hosted; the constructor is private, so there is no second construction route to bypass it. Null is the state hosted is already in for its own unrelated reason, so no new code path is introduced — every caller already handles it. That is deliberately **one** removable line rather than a guard at the top of each of the two methods: with two guards either could be individually removed while the other stayed correct, so each would need its own proof; with one construction route there is nothing to bypass.

The reasoning — including that the gate is redundant **today** and why that is not a reason to delete it — is written at the factory and at the wiring site in `GatewayHost`, not only here. A rule without its reason gets removed by whoever is next and is sure it is redundant, and they will be right about today.

The gate is not the right hosted answer forever. That is a per-tenant credential, the way hosted enrollment already partitions a shared store by prefixing with the authenticated tenant. Until that exists, refusing is the answer that cannot mis-bill anyone.

**The tests**, which are the point.

- Two tenants on one shared vault, on a provisioner explicitly told it is not hosted: the second inherits the first's key without minting at all, then the second's sign-out revokes the *first's* key id and deletes the shared entry. This asserts the defect rather than describing it, and it is the **destructibility control** for the hosted arms — without it, "the other tenant's key survived" would be satisfied by a revoke that never destroys anything.
- The same two tenants, hosted: neither can obtain a provisioner, nothing mints, and the shared vault is never written — so there is no key to inherit and none to destroy.
- The **wiring**, pinned separately against the real `CC_GATEWAY_HOSTED` signal on a real `GatewayHost`, with a credential service **present** and injected. That matters: it models the day hosted has one, and it means the test is not passing for the incidental reason hosted is safe now. The self-host arm is the control — same construction, same credential service, only the hosted flag differs.

The nine existing provisioner tests now state `isHosted` explicitly, so they assert on a stated value instead of on whatever the runner happens to leave in the environment.

## Proof

Continuous integration runs on `windows-latest`, which is the platform where the wiring test genuinely fires: with a credential service present and hosted set, the pre-change code constructs a provisioner, so that test is red without the gate.

Revert-prove: delete the hosted branch from `CreateUnlessHosted` and the three hosted assertions go red by name, while the two-tenant harm demonstration and both self-host controls stay green — those are what must not move.
