### PR TITLE
ARM ONLY - DO NOT MERGE: revert-proof arm one for #1942

### DIFF
--- a/src/CcDirector.Gateway.Tests/DirectorRemovalTenantScopeTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorRemovalTenantScopeTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.IO;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Removing one tenant's Director must not destroy another tenant's cached roster.
+///
+/// THE DEFECT THESE PIN. The tunnel Hello takes the director id straight from the authenticated client's
+/// payload - trimmed, checked non-blank, and otherwise unconstrained - and the registry keys entries by
+/// (tenant, id), so TWO TENANTS MAY HOLD THE SAME ID AT ONCE. The registry's removal was already
+/// tenant-correct, but <c>OnDirectorRemoved</c> was typed <c>Action&lt;string&gt;</c>, which DISCARDED the
+/// tenant the sweep had in hand; the roster cache's forget was correspondingly ownerless and removed every
+/// partition whose id matched case-insensitively. So tenant A could register an id it had observed tenant B
+/// using, disconnect, and - after the heartbeat timeout plus one sweep - have B's cached roster destroyed.
+/// If B was healthy its next read repopulated the cache; if B was inside its GRACE WINDOW, its
+/// last-known-good sessions were destroyed and the next read dropped them instead of serving them.
+///
+/// WHAT EACH TEST HOLDS DOWN, and why both halves are needed. Survival alone proves nothing - a forget that
+/// removed nothing at all would also leave the victim intact - so every test here asserts the
+/// DESTRUCTIBILITY CONTROL beside it: the owner's own entry really is destroyed by the same call.
+///
+/// REVERT-PROOF. Make <see cref="FleetRosterCache.Forget"/> ignore its tenant argument and enumerate every
+/// partition again (the pre-fix body) and both survival assertions go RED while both destructibility
+/// controls stay GREEN. Separately, make <c>DirectorRegistry.RaiseDirectorRemoved</c> stamp a fixed tenant
+/// onto the event instead of the removed key's own, and
+/// <see cref="Stale_sweep_forgets_only_the_swept_tenants_cached_roster"/> goes RED on its destructibility
+/// control - the owner's entry survives a removal that should have cleared it.
+/// </summary>
+public sealed class DirectorRemovalTenantScopeTests
+{
+    private static readonly TenantId TenantA = new("tenant-alice");
+    private static readonly TenantId TenantB = new("tenant-bob");
+
+    /// <summary>The id both tenants choose. The client picks it, so this collision is reachable on purpose.</summary>
+    private const string SharedId = "dir-shared";
+
+    private static SessionDto Session(string id) => new()
+    {
+        SessionId = id,
+        ActivityState = "Working",
+        LastActivityAt = DateTime.UtcNow,
+    };
+
+    [Fact]
+    public void Forget_clears_only_the_named_tenants_entry()
+    {
+        // Arrange - both tenants have a last-known-good roster cached under the SAME director id.
+        var cache = new FleetRosterCache();
+        cache.RecordReachable(TenantA, SharedId, new[] { Session("a-only") });
+        cache.RecordReachable(TenantB, SharedId, new[] { Session("b-only") });
+
+        // Act - tenant A's Director is removed.
+        cache.Forget(TenantA, SharedId);
+
+        // Assert (DESTRUCTIBILITY CONTROL) - A's own entry really is gone: with no snapshot left, A's next
+        // failed read is Offline rather than a grace-window serve. Without this, "B survived" would be
+        // satisfied by a Forget that removed nothing whatsoever.
+        var forA = cache.RecordUnreachable(TenantA, SharedId, "gone");
+        Assert.Equal(FleetReachabilityState.Offline, forA.State);
+        Assert.Null(forA.StaleSessions);
+
+        // Assert (THE PROPERTY) - B's cached roster is untouched: still inside its grace window, still
+        // serving B's OWN session, never A's.
+        var forB = cache.RecordUnreachable(TenantB, SharedId, "transient");
+        Assert.Equal(FleetReachabilityState.Wobbly, forB.State);
+        Assert.NotNull(forB.StaleSessions);
+        Assert.Equal("b-only", Assert.Single(forB.StaleSessions!).SessionId);
+    }
+
+    [Fact]
+    public void Stale_sweep_forgets_only_the_swept_tenants_cached_roster()
+    {
+        // The end-to-end attack, through the real registry, the real event, and the real subscriber wiring.
+        var dir = Path.Combine(Path.GetTempPath(), "cc-drt-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var registry = new DirectorRegistry(dir);
+        try
+        {
+            var cache = new FleetRosterCache();
+            // Wired exactly as GatewayHost wires it.
+            registry.OnDirectorRemoved += removal => cache.Forget(removal.Tenant, removal.DirectorId);
+
+            // Arrange - both tenants register a Director under the SAME client-chosen id, and both have a
+            // last-known-good roster cached. Tenant B is the victim; it is healthy and cached.
+            var a = registry.RegisterFromStream(SharedId, "machine-a", "alice", "1.0", 111, DateTime.UtcNow, TenantA);
+            registry.RegisterFromStream(SharedId, "machine-b", "bob", "1.0", 222, DateTime.UtcNow, TenantB);
+            cache.RecordReachable(TenantA, SharedId, new[] { Session("a-only") });
+            cache.RecordReachable(TenantB, SharedId, new[] { Session("b-only") });
+
+            // Act - tenant A's tunnel dies: its entry stops being refreshed and ages past the heartbeat
+            // timeout, then the stale sweep runs. This is the attacker's move - A disconnects on purpose.
+            a.LastSeen = DateTime.UtcNow - DirectorRegistry.HttpHeartbeatTimeout - TimeSpan.FromSeconds(30);
+            registry.SweepStale();
+
+            // Assert (DESTRUCTIBILITY CONTROL) - the sweep really did remove A's entry AND really did reach
+            // the subscriber for A: A's registry entry is gone and A's cached roster was forgotten.
+            Assert.Null(registry.Get(TenantA, SharedId));
+            var forA = cache.RecordUnreachable(TenantA, SharedId, "swept");
+            Assert.Equal(FleetReachabilityState.Offline, forA.State);
+
+            // Assert (THE PROPERTY) - tenant B is untouched. Its registry entry survives, and its cached
+            // roster survives: a failed read still serves B's last-known-good session from the grace window
+            // rather than dropping it. This is the assertion the bare-string event could not satisfy.
+            Assert.NotNull(registry.Get(TenantB, SharedId));
+            var forB = cache.RecordUnreachable(TenantB, SharedId, "transient");
+            Assert.Equal(FleetReachabilityState.Wobbly, forB.State);
+            Assert.NotNull(forB.StaleSessions);
+            Assert.Equal("b-only", Assert.Single(forB.StaleSessions!).SessionId);
+        }
+        finally
+        {
+            registry.Dispose();
+            try { Directory.Delete(dir, true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void Removal_event_carries_the_tenant_that_owned_the_entry()
+    {
+        // The seam itself: the tenant must survive the event boundary. A subscriber that receives the wrong
+        // owner - or a defaulted one - cannot scope anything correctly no matter how careful it is.
+        var dir = Path.Combine(Path.GetTempPath(), "cc-drt-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var registry = new DirectorRegistry(dir);
+        try
+        {
+            var seen = new List<DirectorRemoval>();
+            registry.OnDirectorRemoved += removal => seen.Add(removal);
+
+            var a = registry.RegisterFromStream(SharedId, "machine-a", "alice", "1.0", 111, DateTime.UtcNow, TenantA);
+            registry.RegisterFromStream(SharedId, "machine-b", "bob", "1.0", 222, DateTime.UtcNow, TenantB);
+
+            a.LastSeen = DateTime.UtcNow - DirectorRegistry.HttpHeartbeatTimeout - TimeSpan.FromSeconds(30);
+            registry.SweepStale();
+
+            var removal = Assert.Single(seen);
+            Assert.Equal(TenantA, removal.Tenant);
+            Assert.Equal(SharedId, removal.DirectorId);
+            // And it is A's tenant specifically - not Local, not B's, not a default.
+            Assert.NotEqual(TenantB, removal.Tenant);
+            Assert.NotEqual(TenantId.Local, removal.Tenant);
+        }
+        finally
+        {
+            registry.Dispose();
+            try { Directory.Delete(dir, true); } catch { /* best-effort */ }
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/FleetRosterCacheTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetRosterCacheTests.cs
@@ -171,7 +171,7 @@ public sealed class FleetRosterCacheTests
         cache.RecordReachable(TenantId.Local, "dir-A", new[] { Session("s1") });
 
         // Act - the Director is unregistered/evicted, then a later stray failure is recorded
-        cache.Forget("dir-A");
+        cache.Forget(TenantId.Local, "dir-A");
         var projection = cache.RecordUnreachable(TenantId.Local, "dir-A", "unreachable");
 
         // Assert - no cached snapshot survives, so it reads Offline rather than serving stale sessions

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -2610,7 +2610,11 @@ internal static class GatewayEndpoints
             var queue = System.Threading.Channels.Channel.CreateUnbounded<GatewayEvent>();
 
             void OnAdded(DirectorDto d) => queue.Writer.TryWrite(new GatewayEvent("director.added", d.DirectorId));
-            void OnRemoved(string id) => queue.Writer.TryWrite(new GatewayEvent("director.removed", id));
+            // The removal carries its tenant now, but this stream has no tenant of its own to filter against
+            // (it is the fleet-global event feed), so it still announces every removal to every listener. That
+            // is a pre-existing disclosure of other accounts' director ids, booked with the rest of the
+            // not-yet-tenant-aware routes rather than changed here.
+            void OnRemoved(DirectorRemoval removal) => queue.Writer.TryWrite(new GatewayEvent("director.removed", removal.DirectorId));
 
             registry.OnDirectorAdded += OnAdded;
             registry.OnDirectorRemoved += OnRemoved;

--- a/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
@@ -130,8 +130,22 @@ public sealed class DirectorRegistry : IDisposable
     /// <summary>Raised when a Director appears (file created or HTTP register).</summary>
     public event Action<DirectorDto>? OnDirectorAdded;
 
-    /// <summary>Raised when a Director disappears (file removed, HTTP unregister, or stale).</summary>
-    public event Action<string>? OnDirectorRemoved;
+    /// <summary>
+    /// Raised when a Director disappears (file removed, HTTP unregister, or stale).
+    ///
+    /// It carries a <see cref="DirectorRemoval"/> - the TENANT as well as the id - and not a bare id, and
+    /// that is the whole point of the type. Issue #1847 made the registry's own key composite, so the
+    /// removal itself is already tenant-correct; but the event used to be typed <c>Action&lt;string&gt;</c>,
+    /// so it DISCARDED the tenant the removal path had in its hand and every subscriber inherited the loss.
+    /// The roster cache's forget then had nothing to scope by and swept every tenant's entry whose id
+    /// matched - and because the tunnel Hello's director id is chosen by the CLIENT, tenant A could register
+    /// an id it had seen tenant B use, disconnect, and have the stale sweep destroy B's cached roster. If B
+    /// was inside its grace window that silently destroyed its last-known-good sessions.
+    ///
+    /// A signature that cannot represent the owner is not a smaller problem than a missing check; it is the
+    /// same problem with no place to put the check. Keep the tenant on this event.
+    /// </summary>
+    public event Action<DirectorRemoval>? OnDirectorRemoved;
 
     /// <summary>
     /// Raise <see cref="OnDirectorRemoved"/> without letting a subscriber kill the process.
@@ -152,17 +166,22 @@ public sealed class DirectorRegistry : IDisposable
     /// (the session-number release and the roster-cache forget are on this list) - trading a process crash
     /// for a quiet partial removal, which is harder to notice and just as wrong.
     /// </summary>
-    private void RaiseDirectorRemoved(string directorId)
+    /// <remarks>
+    /// Takes the <see cref="DirectorKey"/> the removal already resolved, so the tenant reaches the
+    /// subscribers rather than being dropped at this signature. Every raise site below holds a key.
+    /// </remarks>
+    private void RaiseDirectorRemoved(DirectorKey key)
     {
+        var removal = new DirectorRemoval(key.Tenant, key.DirectorId);
         foreach (var handler in OnDirectorRemoved?.GetInvocationList() ?? Array.Empty<Delegate>())
         {
             try
             {
-                ((Action<string>)handler)(directorId);
+                ((Action<DirectorRemoval>)handler)(removal);
             }
             catch (Exception ex)
             {
-                FileLog.Write($"[DirectorRegistry] OnDirectorRemoved subscriber FAILED for director={directorId}: {ex}");
+                FileLog.Write($"[DirectorRegistry] OnDirectorRemoved subscriber FAILED for tenant={key.Tenant.Value}, director={key.DirectorId}: {ex}");
             }
         }
     }
@@ -320,7 +339,7 @@ public sealed class DirectorRegistry : IDisposable
         {
             _everReachable.TryRemove(directorId, out _); // graceful goodbye: next process starts blank
             FileLog.Write($"[DirectorRegistry] Remove (http): id={directorId}");
-            RaiseDirectorRemoved(directorId);
+            RaiseDirectorRemoved(key);
             return true;
         }
         return false;
@@ -439,7 +458,7 @@ public sealed class DirectorRegistry : IDisposable
         if (_directors.TryGetValue(key, out var existing) && existing.Source == "file")
         {
             if (TryRemoveEntry(key, out _))
-                RaiseDirectorRemoved(id);
+                RaiseDirectorRemoved(key);
         }
     }
 
@@ -452,7 +471,7 @@ public sealed class DirectorRegistry : IDisposable
             && existing.Source == "file"
             && TryRemoveEntry(oldKey, out _))
         {
-            RaiseDirectorRemoved(oldId);
+            RaiseDirectorRemoved(oldKey);
         }
         TryParseAndAdd(e.FullPath);
     }
@@ -500,7 +519,13 @@ public sealed class DirectorRegistry : IDisposable
         }
     }
 
-    private void SweepStale()
+    /// <remarks>
+    /// Internal rather than private so a test can drive the STALE SWEEP itself - the path that fires
+    /// <see cref="OnDirectorRemoved"/> for a Director whose tunnel died. That is the path a cross-tenant
+    /// removal actually travels, and a test that instead calls the graceful <see cref="Remove"/> would be
+    /// exercising a different, tenant-ambiguous seam. Production still reaches it only via the 30s timer.
+    /// </remarks>
+    internal void SweepStale()
     {
         if (_disposed) return;
         try
@@ -524,7 +549,7 @@ public sealed class DirectorRegistry : IDisposable
                         {
                             _everReachable.TryRemove(kv.Key.DirectorId, out _);
                             FileLog.Write($"[DirectorRegistry] Sweeper removed stale {kv.Value.Source} entry: {kv.Key.DirectorId} (last seen {(now - lastSeen).TotalSeconds:F0}s ago)");
-                            RaiseDirectorRemoved(kv.Key.DirectorId);
+                            RaiseDirectorRemoved(kv.Key);
                         }
                     }
                     continue;
@@ -537,7 +562,7 @@ public sealed class DirectorRegistry : IDisposable
                     if (TryRemoveEntry(kv.Key, out _))
                     {
                         FileLog.Write($"[DirectorRegistry] Sweeper removed orphan (file gone): {kv.Key.DirectorId}");
-                        RaiseDirectorRemoved(kv.Key.DirectorId);
+                        RaiseDirectorRemoved(kv.Key);
                     }
                     continue;
                 }
@@ -560,7 +585,7 @@ public sealed class DirectorRegistry : IDisposable
                         if (TryRemoveEntry(kv.Key, out _))
                         {
                             FileLog.Write($"[DirectorRegistry] Sweeper removed orphan (pid {pid} dead): {kv.Key.DirectorId}");
-                            RaiseDirectorRemoved(kv.Key.DirectorId);
+                            RaiseDirectorRemoved(kv.Key);
                         }
                     }
                     catch { /* permission errors etc - leave it for next pass */ }

--- a/src/CcDirector.Gateway/Discovery/DirectorRemoval.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorRemoval.cs
@@ -1,0 +1,23 @@
+using CcDirector.Core.Tenancy;
+
+namespace CcDirector.Gateway.Discovery;
+
+/// <summary>
+/// One Director leaving the registry, WITH the tenant that owned it. This is the payload of
+/// <see cref="DirectorRegistry.OnDirectorRemoved"/>.
+///
+/// It exists because the event used to be typed <c>Action&lt;string&gt;</c>. The registry's key has been
+/// composite - (tenant, director id) - since issue #1847, so every removal path already knows whose
+/// Director left; the bare-string signature then THREW THAT AWAY at the event boundary, and no subscriber
+/// could recover it. The roster cache's forget consequently swept every tenant's entry whose id matched,
+/// which - because the tunnel Hello lets the client choose its own director id - let one account destroy
+/// another account's cached roster on demand.
+///
+/// The lesson generalises past this one bug: a type that cannot represent what the caller knows destroys
+/// that knowledge silently, and every consumer downstream inherits the loss. Carrying the owner in the
+/// payload means an ownerless removal cannot be expressed, so a subscriber cannot forget to scope by it.
+/// </summary>
+/// <param name="Tenant">The tenant whose partition the entry was removed from.</param>
+/// <param name="DirectorId">The director id, as keyed in that tenant's partition. Client-chosen, so it is
+/// unique only WITHIN a tenant - never treat it as a fleet-wide identity.</param>
+public readonly record struct DirectorRemoval(TenantId Tenant, string DirectorId);

--- a/src/CcDirector.Gateway/Discovery/FleetRosterCache.cs
+++ b/src/CcDirector.Gateway/Discovery/FleetRosterCache.cs
@@ -130,25 +130,30 @@ public sealed class FleetRosterCache
     }
 
     /// <summary>
-    /// Forget a Director entirely (it was unregistered or evicted from the registry). Keeps the cache
-    /// from growing without bound as Directors come and go; a Director that re-registers starts with a
-    /// clean slate, exactly as the registry's own reachability state does.
+    /// Forget ONE tenant's Director (it was unregistered or evicted from that tenant's registry partition).
+    /// Keeps the cache from growing without bound as Directors come and go; a Director that re-registers
+    /// starts with a clean slate, exactly as the registry's own reachability state does.
+    ///
+    /// It removes exactly the one <c>(tenant, director)</c> entry and CANNOT touch another tenant's. That is
+    /// deliberate and it is a security property, not tidiness. This used to take a bare director id and sweep
+    /// every partition that matched it case-insensitively, on the premise - written down in the code - that a
+    /// director id is globally unique across the fleet. It is not: the tunnel Hello takes the id from the
+    /// authenticated client's own payload with no server minting and no namespacing, so two tenants may hold
+    /// the same id at once. Tenant A could therefore register an id it had seen tenant B use, disconnect, and
+    /// let the stale sweep destroy B's cached roster - and if B was inside its grace window, its
+    /// last-known-good sessions were silently destroyed and the next read dropped them instead of serving the
+    /// grace snapshot.
+    ///
+    /// The tenant is REQUIRED rather than optional, and there is no bare-id overload, so the ownerless call
+    /// that caused this cannot be written at all. Do not add one back "for convenience": the caller
+    /// (<see cref="DirectorRegistry.OnDirectorRemoved"/>, carrying a <see cref="DirectorRemoval"/>) always
+    /// knows the tenant.
     /// </summary>
-    public void Forget(string directorId)
+    public void Forget(TenantId tenant, string directorId)
     {
         if (string.IsNullOrEmpty(directorId)) return;
-        // The removal event (DirectorRegistry.OnDirectorRemoved) carries no tenant, and a Director id is
-        // globally unique across the fleet, so drop every partition's entry for it. On self-host there is only
-        // the Local partition; on hosted a Director lives in exactly one tenant, so this removes that one entry.
-        var removedAny = false;
-        foreach (var key in _byDirector.Keys)
-        {
-            if (string.Equals(key.DirectorId, directorId, StringComparison.OrdinalIgnoreCase)
-                && _byDirector.TryRemove(key, out _))
-                removedAny = true;
-        }
-        if (removedAny)
-            FileLog.Write($"[FleetRosterCache] {directorId} forgotten (unregistered/evicted); roster cache cleared");
+        if (_byDirector.TryRemove((tenant, directorId), out _))
+            FileLog.Write($"[FleetRosterCache] {directorId} forgotten for tenant {tenant.Value} (unregistered/evicted); roster cache cleared");
     }
 
     private static SessionDto RecomputeClocks(SessionDto s, DateTime nowUtc)

--- a/src/CcDirector.Gateway/Discovery/FleetRosterCache.cs
+++ b/src/CcDirector.Gateway/Discovery/FleetRosterCache.cs
@@ -151,9 +151,17 @@ public sealed class FleetRosterCache
     /// </summary>
     public void Forget(TenantId tenant, string directorId)
     {
+        // MUTATION ARM - DO NOT MERGE. The pre-fix body: ignore the tenant and sweep every partition.
         if (string.IsNullOrEmpty(directorId)) return;
-        if (_byDirector.TryRemove((tenant, directorId), out _))
-            FileLog.Write($"[FleetRosterCache] {directorId} forgotten for tenant {tenant.Value} (unregistered/evicted); roster cache cleared");
+        var removedAny = false;
+        foreach (var key in _byDirector.Keys)
+        {
+            if (string.Equals(key.DirectorId, directorId, StringComparison.OrdinalIgnoreCase)
+                && _byDirector.TryRemove(key, out _))
+                removedAny = true;
+        }
+        if (removedAny)
+            FileLog.Write($"[FleetRosterCache] {directorId} forgotten (unregistered/evicted); roster cache cleared");
     }
 
     private static SessionDto RecomputeClocks(SessionDto s, DateTime nowUtc)

--- a/src/CcDirector.Gateway/Discovery/FleetSessionNumberAllocator.cs
+++ b/src/CcDirector.Gateway/Discovery/FleetSessionNumberAllocator.cs
@@ -163,6 +163,14 @@ public sealed class FleetSessionNumberAllocator
     /// unreachable past the evict window) - a Director that died without releasing its sessions' numbers.
     /// This is tied to the registry's own liveness decision, so it never fires for a Director that is
     /// merely momentarily unreachable.
+    ///
+    /// NOT TENANT-SCOPED, and knowingly so. <see cref="DirectorRegistry.OnDirectorRemoved"/> now carries the
+    /// owning tenant, but this allocator's <c>_bySession</c> records only a bare director id beside each
+    /// assignment, so there is nothing here to filter by yet. Because the tunnel Hello lets a client choose
+    /// its own director id, two tenants can hold the same id, and one tenant's removal frees the other's
+    /// numbers - a collision that shows up as a duplicated rail number, not as data loss or disclosure.
+    /// Closing it means partitioning the whole allocator (the pool, the assignment record, and every
+    /// Allocate/Adopt/Release caller) by tenant, which is its own unit of work and is booked as such.
     /// </summary>
     public void ReleaseForDirector(string directorId)
     {

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -589,7 +589,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // Issue #1292: free a removed Director's session numbers so a Director that died without releasing
         // them does not leak the pool. OnDirectorRemoved fires on graceful unregister and on the registry's
         // own stale/unreachable sweep, so this never fires for a merely momentarily-unreachable Director.
-        Registry.OnDirectorRemoved += directorId => SessionNumbers.ReleaseForDirector(directorId);
+        // The allocator's own store keys assignments by BARE director id with no tenant beside them, so it
+        // cannot yet scope this release even though the event now carries the tenant. That is a real hole of
+        // the same family - one account's disconnect frees another account's session numbers - but closing it
+        // means partitioning the allocator, which is its own unit of work; see the note on
+        // FleetSessionNumberAllocator.ReleaseForDirector.
+        Registry.OnDirectorRemoved += removal => SessionNumbers.ReleaseForDirector(removal.DirectorId);
         PushedSessions = new Streaming.PushedSessionStore();
         // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store, at a Gateway-side file path
         // (CcStorage.Root(), the same location the cron and snooze stores use), NOT the Director's tool-config
@@ -602,7 +607,10 @@ public sealed class GatewayHost : IAsyncDisposable
         RosterCache = new Discovery.FleetRosterCache();
         // Issue #1215: when a Director is unregistered or evicted from the registry, forget its cached
         // roster too so the cache does not grow without bound; a re-registering Director starts clean.
-        Registry.OnDirectorRemoved += id => RosterCache.Forget(id);
+        // Scoped to the tenant the removal names. The cache is partitioned by (tenant, director) and the
+        // removal now carries its owner, so forgetting one account's Director cannot reach another's - which
+        // it could when this event was a bare string and the forget swept every matching partition.
+        Registry.OnDirectorRemoved += removal => RosterCache.Forget(removal.Tenant, removal.DirectorId);
         LauncherConnections = new Streaming.LauncherConnectionRegistry();
         var gatewayConfig = Core.Configuration.GatewayConfig.Load();
         // Gateway Cleanup: the tunnel is mandatory; the streamMode parameter is ignored and retained only for existing test call sites (removed with the test rewrite).
@@ -736,7 +744,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // session-serving increment makes per-tenant. The other OnDirectorRemoved subscribers (session-number
         // release, roster-cache forget) are in-memory and stay wired. Skipping it only leaves a removed
         // Director's snoozes as durable tombstones, bounded by the live-session prune paths.
-        Registry.OnDirectorRemoved += id => { if (!GatewayHostedMode.IsHosted) _snoozeRegistry.ClearForDirector(id); };
+        Registry.OnDirectorRemoved += removal => { if (!GatewayHostedMode.IsHosted) _snoozeRegistry.ClearForDirector(removal.DirectorId); };
         // THE PUSH SEAM where this Gateway drives the hold machine off the facts Directors report. The
         // DirectorHub (constructed per-invocation by SignalR) folds every pushed session through this one
         // instance, exactly as it does the input-stats aggregator.


### PR DESCRIPTION
Mutation arm for pull request #1942, so the full suite can show which tests detect the regression. Restores the pre-change body of `FleetRosterCache.Forget`. Predicted reds were registered with the mission before this was pushed. Close without merging once read.