### PR TITLE
fix(gateway): require the tenant to construct the voice upload store

### DIFF
--- a/src/CcDirector.Gateway.Tests/DictationDesktopLockTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationDesktopLockTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using CcDirector.ControlApi;
 using CcDirector.Core.Sessions;
 using CcDirector.Gateway.Contracts;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Voice;
 using Xunit;
 
@@ -30,7 +31,7 @@ public sealed class DictationDesktopLockTests
         var root = Path.Combine(Path.GetTempPath(), "cc-dictlock-xfmt-" + Guid.NewGuid().ToString("N"));
         try
         {
-            var store = new VoiceUploadStore(root);
+            var store = new VoiceUploadStore(root, TenantId.Local);
             var sid = Guid.NewGuid().ToString();
             var uploadId = Guid.NewGuid().ToString();
             store.Register(uploadId);
@@ -53,7 +54,7 @@ public sealed class DictationDesktopLockTests
         var root = Path.Combine(Path.GetTempPath(), "cc-dictlock-xfmt-" + Guid.NewGuid().ToString("N"));
         try
         {
-            var store = new VoiceUploadStore(root);
+            var store = new VoiceUploadStore(root, TenantId.Local);
             var sid = Guid.NewGuid().ToString();
             var uploadId = Guid.NewGuid().ToString();
             store.Register(uploadId);

--- a/src/CcDirector.Gateway.Tests/DictationOmittedTenantBoundaryTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationOmittedTenantBoundaryTests.cs
@@ -1,0 +1,524 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Transcription;
+using CcDirector.Gateway.Voice;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1884, the FAIL-OPEN case: a HOSTED Gateway whose dictation endpoint was wired with NO tenant
+/// boundary must REFUSE on all five legs, never quietly serve the shared self-host partition.
+///
+/// Why this is its own test class. The tenant boundary is a SECURITY argument, and it used to be declared
+/// optional and nullable (<c>HostedTenantBoundary? tenantBoundary = null</c>) with <c>ResolveTenant</c>
+/// answering <see cref="TenantId.Local"/> whenever it was absent - WITHOUT ever asking
+/// <see cref="GatewayHostedMode.IsHosted"/>. Correctness therefore rested on every present and future call
+/// site remembering a one-word argument. Any hosted call site, test, or rewire that omitted it sent
+/// register, chunk, complete, ack and abandon to the base shared root - reopening transcript disclosure,
+/// chunk overwrite, ack, abandon and completion-cache joining - and NOTHING failed loud to say so. An
+/// optional security argument is indistinguishable from a resolved one at the call site, which is exactly
+/// why that mistake survives review.
+///
+/// TWO DEFENCES, and this class proves the runtime one. The compile-time one is that
+/// <c>GatewayDictationEndpoint.Map</c> now takes the boundary as a REQUIRED parameter, so omitting it will
+/// not build; the tests below have to force a null through explicitly (<c>null!</c>) to reproduce the
+/// miswire at all, which is the point - the accident is now unrepresentable, and even the deliberate
+/// version is refused.
+///
+/// EVERY LEG, not one. A fix proven on one leg says nothing about the other four: each leg calls
+/// <c>ResolveTenant</c> itself, so each is its own opportunity to fall back to Local.
+///
+/// EVERY ABSENCE CLAIM HAS A POSITIVE COMPANION. Each leg asserts the concrete refusal STATUS (403), the
+/// exact refusal the deny path - and only the deny path - produces, and the response's property set as an
+/// ALLOW-LIST (a substring check cannot see an extra leaked field). On top of that, a secret is seeded in
+/// the LOCAL partition under the very same upload id, and each leg is checked to have left it alone: not
+/// disclosed, not overwritten, not retired, not abandoned. Before the fix, the register leg alone handed
+/// that secret transcript straight back in its terminal-register body.
+///
+/// AND THE ROUTES ARE PROVEN TO EXIST. A test that drives a verb or path production does not map gets a
+/// framework 405/404 BEFORE endpoint selection, so no handler runs and the test passes for the wrong
+/// reason. Every request here is replayed against an IDENTICAL harness differing ONLY in the boundary
+/// argument (<see cref="Wired"/>), which answers each of them successfully - so a 403 above is the guard
+/// refusing, never a route that does not exist.
+///
+/// REVERT-PROVE: restore <c>ResolveTenant</c> to <c>boundary is null ? TenantId.Local : ...</c> and all five
+/// tests below go RED - the unwired legs answer 200 and the register leg hands back the seeded secret.
+///
+/// WHAT IS PROVED SEPARATELY, AND WHY THERE ARE EIGHT THINGS RATHER THAN THIRTEEN.
+///
+/// The rule this change is held to: mutate every line whose INDIVIDUAL wrongness could break isolation
+/// while everything else stays correct. A line is exempt only when bypass is STRUCTURALLY IMPOSSIBLE -
+/// never merely because its test also reddens under some other primitive's global revert. A global collapse
+/// reddening a leg's test proves the test is sensitive to the collapse; it does not prove the test would
+/// catch THAT LEG ALONE being wrong, and the leg alone being wrong is the realistic defect.
+///
+/// The five per-leg scopings USED to be five independent chances to forget - two hand-written lines
+/// repeated per leg, with the raw un-partitioned store sitting in scope beside them. They are now ONE
+/// primitive, and not by argument: <see cref="GatewayDictationEndpoint.Map"/> does not take a
+/// <c>VoiceUploadStore</c> at all, so there is no unscoped store in that file to use, and
+/// <c>DictationTenantGate.TryOpen</c> is the only source of a store and cannot return an unscoped one. The
+/// same was done to the two static caches: the tenant is a required parameter of every cache operation and
+/// the key is composed inside <c>TenantKeyedCache</c>, so an un-tenanted key is not expressible at a call
+/// site. Fewer proof units because the design got safer, not because the proof was argued down.
+///
+/// Stated precisely, because "no unscoped store identifier exists" and "an unscoped store cannot be passed"
+/// are DIFFERENT claims and only the first was proved: two private helpers on the completion path still take
+/// a bare store in their signatures. They cannot be reached with an unscoped one today because the gate
+/// privately owns the sole raw store, so the guarantee rests on that encapsulation rather than on the type
+/// system at those two signatures. See the note on <c>DictationTenantGate</c> for the stronger form and why
+/// it is deliberately left to a follow-up.
+///
+///   P1 DictationTenantGate.TryOpen   - partition selection for all five legs (absorbs the five)
+///   P2 ResolveTenant hosted gate      - whether a request has an owning tenant at all
+///   P3 PartitionRootFor               - which directory a tenant's staging lives in
+///   P4 IsMintedAccountTenant          - whether a tenant id may name a directory
+///   P5 WriteRecordMarker tenant stamp - the owner recorded ON the record
+///   P6 BelongsHere                    - whether a record found here belongs here
+///   P7 TenantKeyedCache key           - the process-wide cache key (absorbs both cache call-site families)
+///   P8 SweepAbandoned container skip  - whether the partition container is an upload
+///
+/// P5 and P6 are two, not one, because each is independently bypassable: the stamp can be dropped while the
+/// check stays right, and the check can be neutered while the stamp stays right.
+///
+/// THEIR FAILURE MODES ARE NOT THE SAME, and blurring them across two rows costs exactly the precision this
+/// separation was for. P6 is the DISCLOSURE guard - neuter it and a record sitting in the wrong partition is
+/// handed to the wrong account. P5 is not: with the primary partition intact, dropping the stamp makes
+/// account records unattributed and therefore UNREADABLE - a correctness and availability failure. P5 still
+/// earns its own proof because the accepted design requires the persisted ownership stamp, but a mutation
+/// showing a line is load-bearing does not show it is load-bearing FOR THE SECURITY PROPERTY. Two different
+/// claims; only the one actually observed is ours to make.
+///
+/// Settled exempt, with reasons recorded at the guards themselves: the pending-projection container skip
+/// (redundant - BelongsHere on the same line is the real boundary and it has canaries) and the containment
+/// belt in PartitionRootFor (unreachable while IsMintedAccountTenant stays strict). Neither got a test
+/// invented for it, because the only test either could have is one that cannot fail.
+///
+/// A SURVIVAL CLAIM NEEDS ITS PRECONDITION ESTABLISHED, NOT ASSUMED - the trap these tests fell into first.
+///
+/// Every leg here asserts that something SURVIVED a refused operation: the tombstone is still there, the
+/// record is still Pending, the audio is unchanged. That is only evidence of a refusal if the operation
+/// would OTHERWISE HAVE DESTROYED IT. The starting state a survival claim depends on is not "a record
+/// exists" - it is "a record exists THAT THIS OPERATION WOULD DESTROY", and the second half is the half
+/// that gets assumed.
+///
+/// As first written, these tests never established it. A no-op ack leg, a no-op abandon leg, or a chunk leg
+/// that stored nothing at all would have left everything standing exactly as a refusal does, and every
+/// assertion would still have passed - a test that cannot fail, wearing the shape of a strong one. Note the
+/// direction of the trap: a refusal test is ASSERTING that nothing happened, so "nothing happened" can
+/// never by itself distinguish the refusal from the operation being inert.
+///
+/// So each leg now closes with a DESTRUCTIBILITY CONTROL: the same operation, permitted, really does retire
+/// the tombstone / resolve the record / overwrite the bytes. They run last because they consume the
+/// fixture. Together with the deny fingerprint - the exact 403 and the exact refusal message, which prove
+/// the request reached the guard rather than a missing route - the pair says: the thing was destructible,
+/// something tried to destroy it, it was refused, and it survived.
+///
+/// EVERY RED MUST ARRIVE AS AN ASSERTION, NOT A CRASH. A NullReferenceException or an input/output error
+/// means the mutation broke something upstream before the test could ask its question - that is laundering
+/// and it does not prove the line it was aimed at. Hence MustStillExist instead of bare `!` dereferences,
+/// and hence the cross-boundary question is asked BEFORE any setup step that could throw.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED and the storage root
+/// here is safe; both are restored in DisposeAsync.
+/// </summary>
+public sealed class DictationOmittedTenantBoundaryTests : IAsyncLifetime
+{
+    private const string GatewayToken = "test-token";
+
+    /// <summary>The thing an unwired hosted leg must never read, overwrite, retire, or abandon.</summary>
+    private const string LocalSecretTranscript = "self-host-partition-secret-transcript";
+    private const string LocalSecretAudio = "self-host-partition-secret-audio";
+
+    /// <summary>The one message the deny path produces. Asserted exactly, so a 403 from anywhere else fails.</summary>
+    private const string DenyMessage = "no tenant is bound to this request";
+
+    private readonly string _storageRoot =
+        Path.Combine(Path.GetTempPath(), "cc-dictation-nobound-" + Guid.NewGuid().ToString("N"));
+
+    private string? _priorHosted;
+    private string? _priorRoot;
+
+    /// <summary>The miswired host: hosted mode ON, no tenant boundary. The subject of every test here.</summary>
+    private Harness _unwired = null!;
+
+    /// <summary>The identical host WITH the boundary. The control that proves the routes and harness work.</summary>
+    private Harness _wired = null!;
+
+    private TenantId _tenant;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
+
+        // A canonical lowercase minted GUID - the ONE tenant spelling the registry produces and the upload
+        // store accepts as a partition name.
+        _tenant = new TenantId(Guid.NewGuid().ToString("D"));
+
+        _unwired = await Harness.StartAsync(_storageRoot, "unwired", _tenant, wireBoundary: false);
+        _wired = await Harness.StartAsync(_storageRoot, "wired", _tenant, wireBoundary: true);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _unwired.DisposeAsync();
+        await _wired.DisposeAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_storageRoot)) Directory.Delete(_storageRoot, true); } catch { /* cleanup */ }
+    }
+
+    // ===== leg 1: register =========================================================================
+
+    [Fact]
+    public async Task Register_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // THE CONCRETE DISCLOSURE this class exists for. Seed a delivered upload in the LOCAL partition -
+        // the base shared root, where self-host's dictations live - and register that same id against the
+        // unwired hosted host. Before the fix the missing boundary resolved to Local, the terminal-register
+        // short-circuit fired, and the response body carried the seeded transcript verbatim.
+        var id = Guid.NewGuid().ToString();
+        LocalStore().MarkDelivered(id, submitted: true, movedOn: false, transcript: LocalSecretTranscript);
+
+        // Establish the starting state: DELIVERED is precisely the state that arms the terminal-register
+        // short-circuit, and the disclosure claim below is meaningless if the record is not in it.
+        Assert.Equal(DictationDeliveryState.Delivered,
+            MustStillExist(LocalStore(), id, "the local record must be terminal before register is attempted").State);
+
+        var (status, body) = await Read(await _unwired.RegisterAsync(id));
+        AssertRefusal(status, body);
+
+        // The local record is untouched: still delivered, still its own words.
+        var record = LocalStore().ReadRecord(id);
+        Assert.NotNull(record);
+        Assert.Equal(DictationDeliveryState.Delivered, record!.State);
+        Assert.Equal(LocalSecretTranscript, record.Transcript);
+
+        // Positive companion: the SAME request on the SAME harness WITH a boundary is served, so the 403
+        // above is the guard refusing and not a route that does not exist or a host that answers nothing.
+        var wired = await Read(await _wired.RegisterAsync(id));
+        Assert.Equal(HttpStatusCode.OK, wired.status);
+        Assert.DoesNotContain(LocalSecretTranscript, wired.body, StringComparison.Ordinal);
+        var wiredRegister = JsonDocument.Parse(wired.body).RootElement;
+        // The fresh-register shape, which ONLY the genuine handler produces: an upload id, and no terminal
+        // short-circuit - the local partition's delivered record was not this host's to see.
+        Assert.False(string.IsNullOrWhiteSpace(wiredRegister.GetProperty("upload_id").GetString()));
+        Assert.False(wiredRegister.TryGetProperty("terminal", out _));
+    }
+
+    // ===== leg 2: chunk ============================================================================
+
+    [Fact]
+    public async Task Chunk_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // Staged audio in the local partition. An unwired hosted chunk must not be able to overwrite it,
+        // extend it, or even confirm that the upload id exists.
+        var id = Guid.NewGuid().ToString();
+        var local = LocalStore();
+        local.Register(id);
+        await local.StoreChunkAsync(id, 0, Encoding.UTF8.GetBytes(LocalSecretAudio), null, default);
+        Assert.Equal(LocalSecretAudio, await StagedTextAsync(local, id));
+
+        var (status, body) = await Read(await _unwired.PutChunkAsync(id, 0, "overwritten-by-the-unwired-host"));
+        AssertRefusal(status, body);
+        Assert.Equal(LocalSecretAudio, await StagedTextAsync(local, id));
+
+        // Positive companion: PUT on this exact path is a real production route and the wired host stores
+        // the chunk - into its OWN tenant partition, leaving the local bytes alone.
+        await _wired.RegisterAsync(id);
+        var wired = await Read(await _wired.PutChunkAsync(id, 0, "wired-host-audio"));
+        Assert.Equal(HttpStatusCode.OK, wired.status);
+        Assert.True(JsonDocument.Parse(wired.body).RootElement.GetProperty("ok").GetBoolean());
+        Assert.Equal(LocalSecretAudio, await StagedTextAsync(local, id));
+
+        // AND PROVE THE LOCAL STAGING WAS OVERWRITABLE ALL ALONG. "The bytes did not change" only means the
+        // write was refused if a write that IS permitted would have changed them - otherwise a chunk leg
+        // that stores nothing at all passes this test. Done last: it consumes the fixture.
+        await local.StoreChunkAsync(id, 0, Encoding.UTF8.GetBytes("rewritten-by-the-control"), null, default);
+        Assert.Equal("rewritten-by-the-control", await StagedTextAsync(local, id));
+    }
+
+    // ===== leg 3: complete =========================================================================
+
+    [Fact]
+    public async Task Complete_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // The other door onto the same disclosure: complete's cached-terminal-outcome short-circuit. It also
+        // reaches the STATIC single-flight cache, which an unwired host would key as "Local|<id>" - joining
+        // the self-host partition's in-flight run.
+        var id = Guid.NewGuid().ToString();
+        LocalStore().MarkDelivered(id, submitted: true, movedOn: false, transcript: LocalSecretTranscript);
+
+        // Same armed starting state as the register leg: the cached-terminal-outcome short-circuit only
+        // fires on a terminal record, so assert it rather than assume the seeding worked.
+        Assert.Equal(DictationDeliveryState.Delivered,
+            MustStillExist(LocalStore(), id, "the local record must be terminal before complete is attempted").State);
+
+        var (status, body) = await Read(await _unwired.CompleteAsync(id));
+        AssertRefusal(status, body);
+
+        // Nothing of the local record was disclosed and nothing of it moved.
+        var record = LocalStore().ReadRecord(id);
+        Assert.NotNull(record);
+        Assert.Equal(DictationDeliveryState.Delivered, record!.State);
+        Assert.Equal(LocalSecretTranscript, record.Transcript);
+
+        // Positive companion: the wired host reaches its own handler on this exact verb and path. It is NOT
+        // refused, and it does not see the local partition's terminal outcome either.
+        var wired = await Read(await _wired.CompleteAsync(id));
+        Assert.NotEqual(HttpStatusCode.Forbidden, wired.status);
+        Assert.NotEqual(HttpStatusCode.MethodNotAllowed, wired.status);
+        Assert.DoesNotContain(LocalSecretTranscript, wired.body, StringComparison.Ordinal);
+    }
+
+    // ===== leg 4: ack ==============================================================================
+
+    [Fact]
+    public async Task Ack_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // An ack DELETES state - it retires the durable tombstone that stops a delivered turn being injected
+        // twice. An unwired hosted host must not be able to retire the self-host partition's tombstone.
+        var id = Guid.NewGuid().ToString();
+        LocalStore().MarkDelivered(id, submitted: true, movedOn: false, transcript: LocalSecretTranscript);
+
+        // ESTABLISH THE STARTING STATE, never assume it. The claim below is that the tombstone SURVIVED a
+        // refused ack, and "it is still there" is only evidence of a refusal if it was there to begin with.
+        Assert.Equal(DictationDeliveryState.Delivered,
+            MustStillExist(LocalStore(), id, "the local tombstone must exist before the ack is attempted").State);
+
+        var (status, body) = await Read(await _unwired.AckAsync(id));
+        AssertRefusal(status, body);
+        Assert.NotNull(LocalStore().ReadRecord(id));
+        Assert.Equal(LocalSecretTranscript,
+            MustStillExist(LocalStore(), id, "the unwired ack must not have retired the local tombstone").Transcript);
+
+        // Positive companion: the wired host's ack really does run - it answers the handler's own shape and
+        // reports retired=false for an id that is not in ITS partition, which is a refusal by partition, not
+        // a broken route. The local tombstone is still standing.
+        var wired = await Read(await _wired.AckAsync(id));
+        Assert.Equal(HttpStatusCode.OK, wired.status);
+        var wiredRoot = JsonDocument.Parse(wired.body).RootElement;
+        Assert.True(wiredRoot.GetProperty("ok").GetBoolean());
+        Assert.False(wiredRoot.GetProperty("retired").GetBoolean());
+        Assert.NotNull(LocalStore().ReadRecord(id));
+
+        // AND PROVE THE TOMBSTONE WAS DESTRUCTIBLE ALL ALONG - the precondition the survival claim above
+        // silently rests on. Without this the test cannot tell "the ack was refused" from "an ack retires
+        // nothing anyway": a no-op ack leg would leave the record standing too, and every assertion above
+        // would still pass. The handler's ack IS this call (store.Acknowledge on the request's partition),
+        // so retiring it here proves the refusal prevented exactly the operation that would have destroyed
+        // it. Done last, because it deliberately consumes the fixture.
+        Assert.True(LocalStore().Acknowledge(id));
+        Assert.Null(LocalStore().ReadRecord(id));
+    }
+
+    // ===== leg 5: abandon ==========================================================================
+
+    [Fact]
+    public async Task Abandon_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // Abandon DISCARDS staged audio and clears the session lock. An unwired hosted host must not be able
+        // to resolve or discard the self-host partition's live dictation.
+        var sessionId = Guid.NewGuid().ToString();
+        var id = Guid.NewGuid().ToString();
+        var local = LocalStore();
+        local.Register(id);
+        local.MarkPending(id, sessionId);
+        await local.StoreChunkAsync(id, 0, Encoding.UTF8.GetBytes(LocalSecretAudio), null, default);
+        Assert.True(local.IsSessionLocked(sessionId));
+
+        var (status, body) = await Read(await _unwired.AbandonAsync(id));
+        AssertRefusal(status, body);
+        Assert.Equal(DictationDeliveryState.Pending,
+            MustStillExist(local, id, "the unwired abandon must not have resolved the local record").State);
+        Assert.Equal(LocalSecretAudio, await StagedTextAsync(local, id));
+        Assert.True(local.IsSessionLocked(sessionId));
+
+        // Positive companion: the wired host's abandon really does run on this exact verb and path - it
+        // answers the handler's own shape, inside its own partition, and the local dictation is still live.
+        var wired = await Read(await _wired.AbandonAsync(id));
+        Assert.Equal(HttpStatusCode.OK, wired.status);
+        Assert.True(JsonDocument.Parse(wired.body).RootElement.GetProperty("abandoned").GetBoolean());
+        Assert.Equal(DictationDeliveryState.Pending,
+            MustStillExist(local, id, "the wired abandon must have stayed inside its own partition").State);
+        Assert.True(local.IsSessionLocked(sessionId));
+
+        // AND PROVE THE LIVE DICTATION WAS RESOLVABLE ALL ALONG - same reasoning as the ack leg. "Still
+        // Pending, still locked" only means the abandon was refused if an abandon that IS permitted would
+        // have resolved it; otherwise a no-op abandon leg passes this test unchanged. The handler's abandon
+        // IS this call on the request's own partition. Done last: it consumes the fixture.
+        local.MarkAbandoned(id, "destructibility_control");
+        Assert.Equal(DictationDeliveryState.Abandoned,
+            MustStillExist(local, id, "the local record must be resolvable by an abandon that is allowed").State);
+        Assert.False(local.IsSessionLocked(sessionId));
+    }
+
+    // ===== the refusal itself ======================================================================
+
+    /// <summary>
+    /// The refusal, asserted positively: the concrete status, the exact message only the deny path emits,
+    /// and the response's property set as an ALLOW-LIST. The allow-list matters - a substring check for what
+    /// must be absent cannot see an EXTRA field that leaked, and the whole hazard here is a body that
+    /// carries another partition's state.
+    /// </summary>
+    private static void AssertRefusal(HttpStatusCode status, string body)
+    {
+        Assert.Equal(HttpStatusCode.Forbidden, status);
+        var root = JsonDocument.Parse(body).RootElement;
+        Assert.Equal(JsonValueKind.Object, root.ValueKind);
+        Assert.Equal(new[] { "error" }, root.EnumerateObject().Select(p => p.Name).ToArray());
+        Assert.Equal(DenyMessage, root.GetProperty("error").GetString());
+        Assert.DoesNotContain(LocalSecretTranscript, body, StringComparison.Ordinal);
+        Assert.DoesNotContain(LocalSecretAudio, body, StringComparison.Ordinal);
+    }
+
+    // ===== helpers =================================================================================
+
+    /// <summary>The LOCAL (base, shared, self-host) partition - the one an unwired hosted leg would take.</summary>
+    private VoiceUploadStore LocalStore() => new VoiceUploadStore(Harness.UploadRoot(_storageRoot), TenantId.Local);
+
+
+    /// <summary>
+    /// Read a record the claim under test says MUST still be there, asserting its presence before touching
+    /// it. Dereferencing with <c>!</c> turns an absent record into a NullReferenceException, and a crash is
+    /// not evidence about the line the test was aimed at - it only says something upstream broke before the
+    /// test could ask its question. Every red must be able to name what it caught.
+    /// </summary>
+    private static DictationDeliveryRecord MustStillExist(VoiceUploadStore store, string uploadId, string claim)
+    {
+        var record = store.ReadRecord(uploadId);
+        Assert.True(record is not null, claim + " (the record was absent)");
+        return record!;
+    }
+
+    private static async Task<string> StagedTextAsync(VoiceUploadStore store, string uploadId)
+    {
+        var assembled = await store.AssembleAsync(uploadId, 1);
+        return assembled.Audio is null ? "" : Encoding.UTF8.GetString(assembled.Audio);
+    }
+
+    private static async Task<(HttpStatusCode status, string body)> Read(HttpResponseMessage resp)
+    {
+        using (resp) return (resp.StatusCode, await resp.Content.ReadAsStringAsync());
+    }
+
+    /// <summary>
+    /// A minimal host that maps ONLY the dictation endpoint. The two instances are built by the same code
+    /// with the same dependencies and differ in EXACTLY ONE argument - whether the tenant boundary is
+    /// supplied - so a difference in behaviour between them can only be that argument.
+    /// </summary>
+    private sealed class Harness : IAsyncDisposable
+    {
+        private readonly WebApplication _app;
+        private readonly HttpClient _http;
+
+        private Harness(WebApplication app, HttpClient http)
+        {
+            _app = app;
+            _http = http;
+        }
+
+        internal static string UploadRoot(string storageRoot) => Path.Combine(storageRoot, "dictation-uploads");
+
+        internal static async Task<Harness> StartAsync(string storageRoot, string name, TenantId tenant, bool wireBoundary)
+        {
+            var devices = new DeviceRegistry(Path.Combine(storageRoot, name, "devices.json"));
+            var deviceKey = devices.Register("dev-" + name, "M-" + name).DeviceKey;
+            devices.SetAccountBinding("dev-" + name, "sub-" + name, tenant.Value);
+
+            // BOTH harnesses share ONE upload root, so "the unwired host did not touch the local partition"
+            // is a claim about the very bytes the wired host would have to reach through its own partition.
+            var uploads = new VoiceUploadStore(UploadRoot(storageRoot), TenantId.Local);
+
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0");
+
+            var transcription = new GatewayTranscriptionService(
+                new KeyVault(Path.Combine(storageRoot, name, "keyvault.json")));
+
+            // The ONE argument under test. The unwired case has to be forced through with null! because the
+            // parameter is REQUIRED - the compile-time half of the fix - so the accidental version of this
+            // miswire cannot be written at all.
+            HostedTenantBoundary? boundary = wireBoundary
+                ? new HostedTenantBoundary(new AsyncLocalTenantContext(), devices)
+                : null;
+
+            GatewayDictationEndpoint.Map(app,
+                new DirectorRegistry(Path.Combine(storageRoot, name, "instances")),
+                owners: null,
+                token: GatewayToken,
+                transcription,
+                new TranscribingSessions(),
+                new DictationTenantGate(uploads, boundary!),
+                devices);
+
+            await app.StartAsync();
+            var http = new HttpClient
+            {
+                BaseAddress = new Uri(app.Urls.First()),
+                Timeout = TimeSpan.FromSeconds(30),
+            };
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+            return new Harness(app, http);
+        }
+
+        // The verbs and paths below are the production ones, and the wired harness answering each of them
+        // is what proves it: a verb or path production does not map is answered 405/404 by the framework
+        // BEFORE endpoint selection, so no handler would run on either harness.
+        internal async Task<HttpResponseMessage> RegisterAsync(string uploadId, string? sessionId = null)
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Post, "/dictation/upload")
+            {
+                Content = JsonContent.Create(new { sessionId = sessionId ?? Guid.NewGuid().ToString(), baselineBufferBytes = 0 }),
+            };
+            req.Headers.Add("Idempotency-Key", uploadId);
+            return await _http.SendAsync(req);
+        }
+
+        internal async Task<HttpResponseMessage> PutChunkAsync(string uploadId, int index, string text)
+        {
+            using var content = new ByteArrayContent(Encoding.UTF8.GetBytes(text));
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            return await _http.PutAsync($"/dictation/{uploadId}/chunk/{index}", content);
+        }
+
+        internal Task<HttpResponseMessage> CompleteAsync(string uploadId)
+            => _http.PostAsJsonAsync($"/dictation/{uploadId}/complete",
+                new { sessionId = Guid.NewGuid().ToString(), totalChunks = 1 });
+
+        internal Task<HttpResponseMessage> AckAsync(string uploadId)
+            => _http.PostAsync($"/dictation/{uploadId}/ack", content: null);
+
+        internal Task<HttpResponseMessage> AbandonAsync(string uploadId)
+            => _http.PostAsync($"/dictation/{uploadId}/abandon", content: null);
+
+        public async ValueTask DisposeAsync()
+        {
+            _http.Dispose();
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DictationOrangeProducerTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationOrangeProducerTests.cs
@@ -58,8 +58,11 @@ public sealed class DictationOrangeProducerTests : IDisposable
         catch (IOException) { /* a temp directory that outlives the test is not a test failure */ }
     }
 
-    /// <summary>The production seam itself - the exact method the live roster's dictationStatusFor calls.</summary>
-    private string? PhaseFor(string sessionId) => GatewayHost.DictationStatusFor(sessionId, _marks, _uploads);
+    /// <summary>The production seam itself - the exact method the live roster's dictationStatusFor calls.
+    /// This is a self-host (Local) store, so the tenant is Local throughout - the same partition the live
+    /// self-host roster reads. Cross-tenant isolation of the mark is proven in
+    /// <see cref="TranscribingSessionsTenantIsolationTests"/>.</summary>
+    private string? PhaseFor(string sessionId) => GatewayHost.DictationStatusFor(TenantId.Local, sessionId, _marks, _uploads);
 
     /// <summary>
     /// A real durable PENDING record, written by the real store's real verb, and read back through the real
@@ -107,7 +110,7 @@ public sealed class DictationOrangeProducerTests : IDisposable
     public void AProgressMarkThatGoesIdle_StopsPainting_TheNinetySecondBound()
     {
         ARealUndeliveredDictation("quiet-phone");
-        _marks.Begin("quiet-phone");
+        _marks.Begin(TenantId.Local, "quiet-phone");
 
         Assert.Equal(DictationPhase.Uploading, PhaseFor("quiet-phone"));
 
@@ -133,12 +136,12 @@ public sealed class DictationOrangeProducerTests : IDisposable
     public void AnUploadThatKeepsMakingProgress_KeepsPainting_HoweverLongItTakes()
     {
         ARealUndeliveredDictation("slow-phone");
-        _marks.Begin("slow-phone");
+        _marks.Begin(TenantId.Local, "slow-phone");
 
         for (var chunk = 0; chunk < 10; chunk++)
         {
             _now = _now.AddSeconds(60);      // slow, but alive
-            _marks.Refresh("slow-phone");    // the real verb the chunk-store path calls
+            _marks.Refresh(TenantId.Local, "slow-phone");    // the real verb the chunk-store path calls
             Assert.Equal(DictationPhase.Uploading, PhaseFor("slow-phone"));
         }
     }
@@ -149,7 +152,7 @@ public sealed class DictationOrangeProducerTests : IDisposable
     public void WhileTheServerIsActuallyTranscribing_TheLabelSaysSo()
     {
         ARealUndeliveredDictation("transcribing");
-        _marks.MarkActivelyTranscribing("transcribing");
+        _marks.MarkActivelyTranscribing(TenantId.Local, "transcribing");
 
         Assert.Equal(DictationPhase.Transcribing, PhaseFor("transcribing"));
     }
@@ -172,7 +175,7 @@ public sealed class DictationOrangeProducerTests : IDisposable
     [Fact]
     public void AProgressMarkWithNoUndeliveredRecord_PaintsNothing()
     {
-        _marks.Begin("no-record");
+        _marks.Begin(TenantId.Local, "no-record");
 
         Assert.False(_uploads.IsSessionLocked("no-record"));
         Assert.Null(PhaseFor("no-record"));
@@ -188,7 +191,7 @@ public sealed class DictationOrangeProducerTests : IDisposable
     public void OnceTheWordsAreDelivered_NothingPaints()
     {
         var uploadId = ARealUndeliveredDictation("delivering");
-        _marks.Begin("delivering");
+        _marks.Begin(TenantId.Local, "delivering");
         Assert.Equal(DictationPhase.Uploading, PhaseFor("delivering"));
 
         _uploads.MarkDelivered(uploadId, submitted: true, movedOn: false, transcript: "the 362 characters");

--- a/src/CcDirector.Gateway.Tests/DictationOrangeProducerTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationOrangeProducerTests.cs
@@ -1,5 +1,6 @@
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Transcription;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Voice;
 using Xunit;
 
@@ -48,7 +49,7 @@ public sealed class DictationOrangeProducerTests : IDisposable
     public DictationOrangeProducerTests()
     {
         _marks = new TranscribingSessions(() => _now);
-        _uploads = new VoiceUploadStore(_root);
+        _uploads = new VoiceUploadStore(_root, TenantId.Local);
     }
 
     public void Dispose()

--- a/src/CcDirector.Gateway.Tests/DictationPermanentFailureTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationPermanentFailureTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using CcDirector.Gateway.Api;
 using CcDirector.Gateway.Transcription;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Voice;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,7 +25,7 @@ public sealed class DictationPermanentFailureTests : IDisposable
     private readonly string _root = Path.Combine(Path.GetTempPath(), "cc-perm-" + Guid.NewGuid().ToString("N"));
     private readonly VoiceUploadStore _store;
 
-    public DictationPermanentFailureTests() => _store = new VoiceUploadStore(_root);
+    public DictationPermanentFailureTests() => _store = new VoiceUploadStore(_root, TenantId.Local);
 
     public void Dispose()
     {

--- a/src/CcDirector.Gateway.Tests/DictationSessionLockTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationSessionLockTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Voice;
 using Xunit;
 
@@ -83,7 +84,7 @@ public sealed class DictationSessionLockTests : IAsyncLifetime
 
     // ===== helpers =================================================================================
 
-    private static VoiceUploadStore Store() => new(CcStorage.DictationUploads());
+    private static VoiceUploadStore Store() => new(CcStorage.DictationUploads(), TenantId.Local);
 
     private async Task<(HttpStatusCode status, JsonElement body)> PromptAsync(string sessionId, HttpClient? http = null)
     {

--- a/src/CcDirector.Gateway.Tests/DictationTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationTenantIsolationTests.cs
@@ -1,0 +1,443 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1884: the dictation front door is TENANT-KEYED on the hosted Gateway, proven over real HTTP with
+/// two accounts posting THE SAME UPLOAD ID.
+///
+/// This is an AUDIO and TRANSCRIPT disclosure surface. Before this, <c>VoiceUploadStore</c> had one global
+/// root and keyed every directory, chunk and record solely by the caller-supplied upload id; the delivery
+/// record carried no tenant; the upload / chunk / ack / abandon legs authenticated a DEVICE and never asked
+/// whose upload it was; and the static single-flight completion cache was keyed by upload id alone. So after
+/// account A completed upload id X, account B posting <c>Idempotency-Key: X</c> read A's terminal record and
+/// was handed A's TRANSCRIPT - and before A reached a terminal state, B could overwrite A's chunks, ack or
+/// abandon A's record, or race its completion. A GUID is not a tenant boundary: secrecy of an identifier is
+/// not authorization, and upload ids travel in client logs, retries and store-and-forward queues.
+///
+/// Every canary here is BIDIRECTIONAL and every absence claim has a POSITIVE CONTROL in front of it - the
+/// same account's own operation on the same id succeeding - so no assertion can pass merely because nothing
+/// happened at all.
+///
+/// Dictation now WORKS on hosted (issue #1884, un-deny): the family is no longer refused, the five legs are
+/// served through <c>DictationTenantGate</c>, and the completion's session locate is scoped to the request's
+/// tenant so a hosted session is found in its own account's partition. What these tests prove is that the
+/// STATE stays isolated across accounts while that happens - the same upload id in two tenants is two
+/// separate uploads, and no leg of one account can read, overwrite, resolve, or retire another's.
+///
+/// THE PRODUCTION LINES THESE TESTS PROTECT (each revert-provable - revert it, watch these go red):
+///   - The <c>gate.TryOpen</c> at the head of each of the five legs in <c>GatewayDictationEndpoint</c>, which
+///     hands back a store bound to the caller's tenant. Put any leg back on a shared/unscoped store and that
+///     leg's canary goes RED.
+///   - <c>GatewayDictationEndpoint.CacheKey</c> at the <c>_completes.GetOrAdd</c> call site. Key that call on
+///     the upload id alone and the single-flight canary goes RED.
+///   - <c>VoiceUploadStore.PartitionRootFor</c>, which is what makes all of the above structural rather than
+///     conventional.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED and the storage root
+/// here is safe; both are restored in DisposeAsync.
+/// </summary>
+public sealed class DictationTenantIsolationTests : IAsyncLifetime
+{
+    private const string GatewayToken = "test-token";
+
+    // The things one account must never be able to read, overwrite, or resolve out of the other.
+    private const string SecretTranscriptA = "alpha-account-secret-transcript";
+    private const string SecretTranscriptB = "bravo-account-secret-transcript";
+    private const string SecretAudioA = "alpha-account-secret-audio-bytes";
+    private const string SecretAudioB = "bravo-account-secret-audio-bytes";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _httpA = null!;
+    private HttpClient _httpB = null!;
+    private HttpClient _httpUnbound = null!;
+
+    private TenantId _tenantA;
+    private TenantId _tenantB;
+
+    private string? _priorHosted;
+    private string? _priorRoot;
+
+    private readonly string _storageRoot =
+        Path.Combine(Path.GetTempPath(), "cc-dictation-iso-storage-" + Guid.NewGuid().ToString("N"));
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-dictation-iso-instances-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        // Isolate the storage root BEFORE the Gateway starts so its dictation upload store binds the temp
+        // root, never the developer's real one.
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
+
+        _gateway = new GatewayHost(port: FreePort(), token: GatewayToken, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            promptLogPath: Path.Combine(_instancesDir, "prompt-log"));
+        await _gateway.StartAsync();
+
+        // Two accounts: two device keys, each bound to its OWN tenant, plus one registered-but-unbound key.
+        // The tenants are MINTED BY THE REAL REGISTRY, exactly as the hosted enrollment route does, because
+        // the upload store turns a tenant id into a DIRECTORY NAME and enforces the real minted shape - a
+        // test binding a made-up id would be testing a partition production can never create.
+        var keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        var keyUnbound = _gateway.Devices.Register("dev-x", "MX").DeviceKey;
+        _tenantA = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        _tenantB = _gateway.TenantRegistry.MintOrLookupBySubject("sub-bob", "bob@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", _tenantA.Value);
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", _tenantB.Value);
+
+        _httpA = NewClient(keyA);
+        _httpB = NewClient(keyB);
+        _httpUnbound = NewClient(keyUnbound);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _httpA.Dispose();
+        _httpB.Dispose();
+        _httpUnbound.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* cleanup */ }
+        try { if (Directory.Exists(_storageRoot)) Directory.Delete(_storageRoot, true); } catch { /* cleanup */ }
+    }
+
+    // ===== leg 1: chunks ===========================================================================
+
+    [Fact]
+    public async Task Chunks_cannot_cross_between_accounts_on_the_same_upload_id()
+    {
+        var id = Guid.NewGuid().ToString();
+
+        // Positive control: A registers the id and stages a chunk under it, successfully.
+        Assert.Equal(HttpStatusCode.OK, (await RegisterAsync(_httpA, id)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await PutChunkAsync(_httpA, id, 0, SecretAudioA)).StatusCode);
+        Assert.Equal(SecretAudioA, await StagedTextAsync(_tenantA, id));
+
+        // B cannot write into it. The upload id does not exist in B's partition, so B cannot overwrite A's
+        // audio, extend it, or even confirm that it exists.
+        Assert.Equal(HttpStatusCode.NotFound, (await PutChunkAsync(_httpB, id, 0, SecretAudioB)).StatusCode);
+        Assert.Equal(SecretAudioA, await StagedTextAsync(_tenantA, id));
+
+        // The other direction, on the same id - which is now legally B's id too, and that is the point: an
+        // upload id is only meaningful inside its own tenant.
+        Assert.Equal(HttpStatusCode.OK, (await RegisterAsync(_httpB, id)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await PutChunkAsync(_httpB, id, 0, SecretAudioB)).StatusCode);
+        Assert.Equal(SecretAudioB, await StagedTextAsync(_tenantB, id));
+        Assert.Equal(SecretAudioA, await StagedTextAsync(_tenantA, id));
+    }
+
+    // ===== leg 2: the terminal transcript, at register =============================================
+
+    [Fact]
+    public async Task A_terminal_transcript_is_never_handed_to_another_account_at_register()
+    {
+        // THE CONCRETE DISCLOSURE from the issue, driven over HTTP: after A completes upload id X, B posts
+        // /dictation/upload with Idempotency-Key: X and the terminal-register result hands B A's transcript.
+        var id = Guid.NewGuid().ToString();
+        Store(_tenantA).MarkDelivered(id, submitted: true, movedOn: false, transcript: SecretTranscriptA);
+
+        // Positive control: A re-registering its OWN delivered id really does get the cached terminal outcome
+        // back, so "B does not get it" cannot pass because the short-circuit never fires.
+        var (statusA, bodyA) = await ReadAsync(await RegisterAsync(_httpA, id));
+        Assert.Equal(HttpStatusCode.OK, statusA);
+        Assert.Contains(SecretTranscriptA, bodyA);
+
+        // The absence claim: B's register of the same id is an ordinary fresh register - no terminal flag, no
+        // transcript, nothing of A's in any form.
+        var (statusB, bodyB) = await ReadAsync(await RegisterAsync(_httpB, id));
+        Assert.Equal(HttpStatusCode.OK, statusB);
+        Assert.DoesNotContain(SecretTranscriptA, bodyB);
+        Assert.False(JsonDocument.Parse(bodyB).RootElement.TryGetProperty("terminal", out var terminal)
+                     && terminal.GetBoolean());
+        // A's record is untouched by B's register - still delivered, still A's words.
+        var afterB = MustStillExist(_tenantA, id, "A's delivered record must survive B registering the same upload id");
+        Assert.Equal(DictationDeliveryState.Delivered, afterB.State);
+        Assert.Equal(SecretTranscriptA, afterB.Transcript);
+
+        // The mirror direction on a second id owned by B.
+        var idB = Guid.NewGuid().ToString();
+        Store(_tenantB).MarkDelivered(idB, submitted: true, movedOn: false, transcript: SecretTranscriptB);
+        Assert.Contains(SecretTranscriptB, (await ReadAsync(await RegisterAsync(_httpB, idB))).body);
+        Assert.DoesNotContain(SecretTranscriptB, (await ReadAsync(await RegisterAsync(_httpA, idB))).body);
+    }
+
+    [Fact]
+    public async Task A_terminal_transcript_is_never_handed_to_another_account_at_complete()
+    {
+        // The same disclosure through the OTHER door: the cached-terminal-outcome short-circuit in complete.
+        var id = Guid.NewGuid().ToString();
+        Store(_tenantA).MarkDelivered(id, submitted: true, movedOn: false, transcript: SecretTranscriptA);
+
+        // Positive control: A's own re-complete returns its cached submitted outcome.
+        var (statusA, bodyA) = await ReadAsync(await CompleteAsync(_httpA, id));
+        Assert.Equal(HttpStatusCode.OK, statusA);
+        Assert.Contains(SecretTranscriptA, bodyA);
+
+        // B completing the same id gets nothing of A's: no 200, and no transcript in any form.
+        var (statusB, bodyB) = await ReadAsync(await CompleteAsync(_httpB, id));
+        Assert.NotEqual(HttpStatusCode.OK, statusB);
+        Assert.DoesNotContain(SecretTranscriptA, bodyB);
+
+        // Mirror.
+        var idB = Guid.NewGuid().ToString();
+        Store(_tenantB).MarkDelivered(idB, submitted: true, movedOn: false, transcript: SecretTranscriptB);
+        Assert.Contains(SecretTranscriptB, (await ReadAsync(await CompleteAsync(_httpB, idB))).body);
+        var crossing = await ReadAsync(await CompleteAsync(_httpA, idB));
+        Assert.NotEqual(HttpStatusCode.OK, crossing.status);
+        Assert.DoesNotContain(SecretTranscriptB, crossing.body);
+    }
+
+    // ===== leg 3: the in-flight completion cache ===================================================
+
+    [Fact]
+    public async Task The_static_single_flight_completion_cache_is_keyed_by_tenant()
+    {
+        // The cache is STATIC and used to be keyed by upload id alone, so whichever account's complete
+        // arrived first supplied the cached run to every other account posting that id - a purely in-memory
+        // cross-serve that no on-disk partition can guard.
+        //
+        // Bound to the REAL GetOrAdd call site through its seam, not to the key helper: a unit test of the
+        // helper alone would stay green if that call went back to keying on the upload id.
+        var id = Guid.NewGuid().ToString();
+        var observed = new List<string>();
+        GatewayDictationEndpoint.OnCompleteEntryCreatedForTests = key => { lock (observed) observed.Add(key); };
+        try
+        {
+            await RegisterAsync(_httpA, id);
+            await PutChunkAsync(_httpA, id, 0, SecretAudioA);
+            await CompleteAsync(_httpA, id);
+
+            await RegisterAsync(_httpB, id);
+            await PutChunkAsync(_httpB, id, 0, SecretAudioB);
+            await CompleteAsync(_httpB, id);
+        }
+        finally
+        {
+            GatewayDictationEndpoint.OnCompleteEntryCreatedForTests = null;
+        }
+
+        // Positive control: both completes really did create an entry, so "the two entries are different"
+        // cannot pass because the cache was never reached.
+        Assert.Contains(observed, k => k.Contains(_tenantA.Value, StringComparison.Ordinal));
+        Assert.Contains(observed, k => k.Contains(_tenantB.Value, StringComparison.Ordinal));
+
+        // Both directions: neither account's key can be read as the other's, so neither can join the other's
+        // in-flight run for the same upload id.
+        var keyA = GatewayDictationEndpoint.CacheKey(_tenantA, id);
+        var keyB = GatewayDictationEndpoint.CacheKey(_tenantB, id);
+        Assert.NotEqual(keyA, keyB);
+        Assert.DoesNotContain(_tenantB.Value, keyA, StringComparison.Ordinal);
+        Assert.DoesNotContain(_tenantA.Value, keyB, StringComparison.Ordinal);
+        Assert.Contains(keyA, observed);
+        Assert.Contains(keyB, observed);
+    }
+
+    // ===== leg 4: ack ==============================================================================
+
+    [Fact]
+    public async Task An_ack_never_retires_another_accounts_record()
+    {
+        // Positive control on a separate id first: an ack really does retire this account's own tombstone in
+        // this setup, so the "retired=false" claim below is a refusal and not a broken route.
+        var control = Guid.NewGuid().ToString();
+        Store(_tenantA).MarkDelivered(control, submitted: true, movedOn: false, transcript: SecretTranscriptA);
+        Assert.True(await AckRetiredAsync(_httpA, control));
+
+        var id = Guid.NewGuid().ToString();
+        Store(_tenantA).MarkDelivered(id, submitted: true, movedOn: false, transcript: SecretTranscriptA);
+
+        // B acking A's id retires nothing, and A's tombstone - the durable de-dupe that stops A's turn being
+        // injected a second time - is still standing afterwards.
+        Assert.False(await AckRetiredAsync(_httpB, id));
+        Assert.NotNull(Store(_tenantA).ReadRecord(id));
+        Assert.Equal(SecretTranscriptA,
+            MustStillExist(_tenantA, id, "B's ack must not have retired A's tombstone").Transcript);
+
+        // And A can still retire its own, on the very id B just tried to.
+        Assert.True(await AckRetiredAsync(_httpA, id));
+        Assert.Null(Store(_tenantA).ReadRecord(id));
+
+        // Mirror.
+        var idB = Guid.NewGuid().ToString();
+        Store(_tenantB).MarkDelivered(idB, submitted: true, movedOn: false, transcript: SecretTranscriptB);
+        Assert.False(await AckRetiredAsync(_httpA, idB));
+        Assert.NotNull(Store(_tenantB).ReadRecord(idB));
+        Assert.True(await AckRetiredAsync(_httpB, idB));
+    }
+
+    // ===== leg 5: abandon ==========================================================================
+
+    [Fact]
+    public async Task An_abandon_never_resolves_or_discards_another_accounts_dictation()
+    {
+        var sessionA = Guid.NewGuid().ToString();
+
+        // Positive control on a separate id first: abandon really does work for this account.
+        var control = Guid.NewGuid().ToString();
+        await RegisterAsync(_httpA, control, sessionA);
+        Assert.True(await AbandonedAsync(_httpA, control));
+        Assert.Equal(DictationDeliveryState.Abandoned,
+            MustStillExist(_tenantA, control, "A's own abandon must have written A's tombstone").State);
+
+        // A has a live pending dictation, with staged audio, holding its session lock.
+        var id = Guid.NewGuid().ToString();
+        await RegisterAsync(_httpA, id, sessionA);
+        await PutChunkAsync(_httpA, id, 0, SecretAudioA);
+        Assert.True(Store(_tenantA).IsSessionLocked(sessionA));
+
+        // B abandoning that id resolves nothing of A's: A's record is still PENDING, its audio is still
+        // staged, and its session is still locked. (B's own partition gets B's own tombstone, which is B's
+        // business and nobody else's.)
+        await AbandonedAsync(_httpB, id);
+        Assert.Equal(DictationDeliveryState.Pending,
+            MustStillExist(_tenantA, id, "B's abandon must not have resolved A's pending record").State);
+        Assert.Equal(SecretAudioA, await StagedTextAsync(_tenantA, id));
+        Assert.True(Store(_tenantA).IsSessionLocked(sessionA));
+
+        // Mirror: A cannot abandon B's live dictation either.
+        var sessionB = Guid.NewGuid().ToString();
+        var idB = Guid.NewGuid().ToString();
+        await RegisterAsync(_httpB, idB, sessionB);
+        await PutChunkAsync(_httpB, idB, 0, SecretAudioB);
+        await AbandonedAsync(_httpA, idB);
+        Assert.Equal(DictationDeliveryState.Pending,
+            MustStillExist(_tenantB, idB, "A's abandon must not have resolved B's pending record").State);
+        Assert.Equal(SecretAudioB, await StagedTextAsync(_tenantB, idB));
+        Assert.True(Store(_tenantB).IsSessionLocked(sessionB));
+    }
+
+    // ===== deny by default =========================================================================
+
+    [Fact]
+    public async Task Every_leg_denies_an_authenticated_key_with_no_bound_tenant()
+    {
+        // Deny-by-default: on hosted, an authenticated device whose key has no bound tenant is refused
+        // outright - it is never quietly served the LOCAL partition, which is where self-host's uploads live.
+        var id = Guid.NewGuid().ToString();
+        Store(_tenantA).MarkDelivered(id, submitted: true, movedOn: false, transcript: SecretTranscriptA);
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await RegisterAsync(_httpUnbound, id)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await PutChunkAsync(_httpUnbound, id, 0, SecretAudioB)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await CompleteAsync(_httpUnbound, id)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden,
+            (await _httpUnbound.PostAsync($"/dictation/{id}/ack", content: null)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden,
+            (await _httpUnbound.PostAsync($"/dictation/{id}/abandon", content: null)).StatusCode);
+
+        // Positive control: the same five calls from a BOUND key are not refused, so the 403s above are the
+        // tenant deny and not a route that is simply broken for everyone.
+        Assert.NotEqual(HttpStatusCode.Forbidden, (await RegisterAsync(_httpA, id)).StatusCode);
+        Assert.NotEqual(HttpStatusCode.Forbidden, (await PutChunkAsync(_httpA, id, 0, SecretAudioA)).StatusCode);
+        Assert.NotEqual(HttpStatusCode.Forbidden, (await CompleteAsync(_httpA, id)).StatusCode);
+        Assert.NotEqual(HttpStatusCode.Forbidden,
+            (await _httpA.PostAsync($"/dictation/{id}/abandon", content: null)).StatusCode);
+        Assert.NotEqual(HttpStatusCode.Forbidden,
+            (await _httpA.PostAsync($"/dictation/{id}/ack", content: null)).StatusCode);
+    }
+
+    // ===== helpers =================================================================================
+
+    // A store bound to ONE tenant's partition of the SAME on-disk dictation root the running Gateway reads
+    // (both resolve CcStorage.DictationUploads() under the isolated CC_DIRECTOR_ROOT), so a record written
+    // here is the one that tenant's handlers see - and one no other tenant's handlers can.
+
+    /// <summary>
+    /// Read a record the claim under test says MUST still be there, asserting its presence before touching
+    /// it. Dereferencing with <c>!</c> turns an absent record into a NullReferenceException, and a crash is
+    /// not evidence about the line the test was aimed at - it only says something upstream broke before the
+    /// test could ask its question. Every red must be able to name what it caught.
+    /// </summary>
+    private static DictationDeliveryRecord MustStillExist(TenantId tenant, string uploadId, string claim)
+    {
+        var record = Store(tenant).ReadRecord(uploadId);
+        Assert.True(record is not null, claim + " (the record was absent)");
+        return record!;
+    }
+
+    private static VoiceUploadStore Store(TenantId tenant)
+        => new VoiceUploadStore(CcStorage.DictationUploads(), TenantId.Local).ForTenant(tenant);
+
+    private static async Task<string> StagedTextAsync(TenantId tenant, string uploadId)
+    {
+        var assembled = await Store(tenant).AssembleAsync(uploadId, 1);
+        return assembled.Audio is null ? "" : Encoding.UTF8.GetString(assembled.Audio);
+    }
+
+    private static async Task<HttpResponseMessage> RegisterAsync(HttpClient http, string uploadId, string? sessionId = null)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/dictation/upload")
+        {
+            Content = JsonContent.Create(new { sessionId = sessionId ?? Guid.NewGuid().ToString(), baselineBufferBytes = 0 }),
+        };
+        req.Headers.Add("Idempotency-Key", uploadId);
+        return await http.SendAsync(req);
+    }
+
+    private static async Task<HttpResponseMessage> PutChunkAsync(HttpClient http, string uploadId, int index, string text)
+    {
+        using var content = new ByteArrayContent(Encoding.UTF8.GetBytes(text));
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        return await http.PutAsync($"/dictation/{uploadId}/chunk/{index}", content);
+    }
+
+    private static Task<HttpResponseMessage> CompleteAsync(HttpClient http, string uploadId)
+        => http.PostAsJsonAsync($"/dictation/{uploadId}/complete",
+            new { sessionId = Guid.NewGuid().ToString(), totalChunks = 1 });
+
+    private static async Task<bool> AckRetiredAsync(HttpClient http, string uploadId)
+    {
+        var resp = await http.PostAsync($"/dictation/{uploadId}/ack", content: null);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        return (await resp.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("retired").GetBoolean();
+    }
+
+    private static async Task<bool> AbandonedAsync(HttpClient http, string uploadId)
+    {
+        var resp = await http.PostAsync($"/dictation/{uploadId}/abandon", content: null);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        return (await resp.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("abandoned").GetBoolean();
+    }
+
+    private static async Task<(HttpStatusCode status, string body)> ReadAsync(HttpResponseMessage resp)
+        => (resp.StatusCode, await resp.Content.ReadAsStringAsync());
+
+    private HttpClient NewClient(string deviceKey)
+    {
+        var http = new HttpClient
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/"),
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return http;
+    }
+
+    private static int FreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DurableDictationDedupeTests.cs
+++ b/src/CcDirector.Gateway.Tests/DurableDictationDedupeTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Voice;
 using Xunit;
 
@@ -207,7 +208,7 @@ public sealed class DurableDictationDedupeTests : IAsyncLifetime
     // A store bound to the SAME on-disk dictation root the running Gateway reads (both resolve
     // CcStorage.DictationUploads() under the isolated CC_DIRECTOR_ROOT), so a tombstone written here is the
     // one the Gateway's complete/register handlers see.
-    private static VoiceUploadStore Store() => new(CcStorage.DictationUploads());
+    private static VoiceUploadStore Store() => new(CcStorage.DictationUploads(), TenantId.Local);
 
     private static async Task<(HttpStatusCode status, JsonElement body)> CompleteAsync(HttpClient http, string uploadId)
     {

--- a/src/CcDirector.Gateway.Tests/HostedContentDenyGroupFilterTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentDenyGroupFilterTests.cs
@@ -83,12 +83,13 @@ public sealed class HostedContentDenyGroupFilterTests
     /// also carries the live batch + cleanup routes, but its group prefix is <c>/transcription</c> all the
     /// same, so its probe sits one segment deeper than before.
     /// </summary>
+    // The /dictation and /wingman/utterance upload families are NO LONGER denied (issue #1884, un-deny): they
+    // are served tenant-partitioned on hosted, so they are not deny groups and are not probed here. The
+    // remaining denied content-read families keep their group-filter proof.
     private static string PrefixFor(string family) => family switch
     {
         "transcription" => "transcription/",
         "instructions" => "gateway/wingman/instructions/",
-        "utterance" => "wingman/utterance/",
-        "dictation" => "dictation/",
         _ => throw new ArgumentOutOfRangeException(nameof(family)),
     };
 
@@ -99,18 +100,14 @@ public sealed class HostedContentDenyGroupFilterTests
 
     private const string TranscriptionRefusal = "transcription analysis is not available on the hosted gateway";
     private const string InstructionsRefusal = "the wingman instructions surface is not available on the hosted gateway";
-    private const string UtteranceRefusal = "the wingman utterance upload is not available on the hosted gateway";
-    private const string DictationRefusal = "dictation upload is not available on the hosted gateway";
 
     /// <summary>Which family, its group-mapper, and the refusal its filter must produce.</summary>
-    public static TheoryData<string> Families() => new() { "transcription", "instructions", "utterance", "dictation" };
+    public static TheoryData<string> Families() => new() { "transcription", "instructions" };
 
     private static string RefusalFor(string family) => family switch
     {
         "transcription" => TranscriptionRefusal,
         "instructions" => InstructionsRefusal,
-        "utterance" => UtteranceRefusal,
-        "dictation" => DictationRefusal,
         _ => throw new ArgumentOutOfRangeException(nameof(family)),
     };
 
@@ -193,10 +190,6 @@ public sealed class HostedContentDenyGroupFilterTests
     [InlineData("transcription", "0")]
     [InlineData("instructions", null)]
     [InlineData("instructions", "0")]
-    [InlineData("utterance", null)]
-    [InlineData("utterance", "0")]
-    [InlineData("dictation", null)]
-    [InlineData("dictation", "0")]
     public async Task A_route_added_to_the_group_still_binds_and_serves_on_self_host(string family, string? hostedValue)
     {
         using var env = new HostedEnv(hostedValue);
@@ -328,31 +321,8 @@ public sealed class HostedContentDenyGroupFilterTests
                         new WingmanTrainingStore(() => false, Path.Combine(root, "training")),
                         brain);
 
-                case "utterance":
-                {
-                    var vault = new KeyVault(Path.Combine(root, "probe.vault"));
-                    var voice = new WingmanVoiceService(brain, vault, Path.Combine(root, "voice.json"));
-                    return GatewayWingmanVoiceEndpoint.Map(
-                        app,
-                        new DirectorRegistry(Path.Combine(root, "instances")),
-                        brain,
-                        vault,
-                        voice);
-                }
-
-                case "dictation":
-                {
-                    var vault = new KeyVault(Path.Combine(root, "probe.vault"));
-                    return GatewayDictationEndpoint.Map(
-                        app,
-                        new DirectorRegistry(Path.Combine(root, "instances")),
-                        owners: null,
-                        token: "probe-token",
-                        transcription: new GatewayTranscriptionService(vault),
-                        transcribingSessions: new TranscribingSessions(),
-                        uploads: new VoiceUploadStore(Path.Combine(root, "uploads")),
-                        devices: new Pairing.DeviceRegistry(Path.Combine(root, "devices.json")));
-                }
+                // NOTE: /wingman/utterance and /dictation are deliberately absent - they are un-denied and
+                // tenant-partitioned (issue #1884), not deny groups, so they have no group filter to probe.
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(family), family, "unknown family");

--- a/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
@@ -213,8 +213,8 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
 
     private const string TranscriptionRefusal = "transcription analysis is not available on the hosted gateway";
     private const string InstructionsRefusal = "the wingman instructions surface is not available on the hosted gateway";
-    private const string UtteranceRefusal = "the wingman utterance upload is not available on the hosted gateway";
-    private const string DictationRefusal = "dictation upload is not available on the hosted gateway";
+    // The utterance and dictation refusal constants were removed with their theories (issue #1884, un-deny):
+    // those two upload families are now served tenant-partitioned on hosted, not refused.
 
     private GatewayHost _gateway = null!;
     private HttpClient _http = null!;
@@ -329,68 +329,11 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
-    /// <summary>
-    /// Issue #1896. All three legs, not only the one that returns the transcript: the chunk leg lets a
-    /// caller overwrite another account's staged recording, which is the same missing boundary with a
-    /// different consequence.
-    /// </summary>
-    [Theory]
-    [InlineData("POST", "wingman/utterance/upload", "")]
-    [InlineData("PUT", "wingman/utterance/someone-elses-id/chunk/0", "audio-bytes")]
-    [InlineData("POST", "wingman/utterance/someone-elses-id/complete", "{\"totalChunks\":1}")]
-    public async Task Wingman_utterance_upload_family_is_refused_to_an_enrolled_tenant(
-        string method, string path, string body)
-    {
-        var resp = await Send(new HttpMethod(method), path, body);
-        await AssertBodyIsNothingButTheRefusal(resp, UtteranceRefusal, $"{method} {path}");
-        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
-    }
-
-    /// <summary>
-    /// Issue #1884, the sibling family on the same store shape. The register leg is the live read: it
-    /// short-circuits on the terminal tombstone and hands back the recorded transcript WITHOUT looking any
-    /// session up, so the fact that /complete's session lookup already fails on hosted does not contain it.
-    /// ack and abandon destroy another account's in-flight recording.
-    /// </summary>
-    [Theory]
-    [InlineData("POST", "dictation/upload", "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}")]
-    [InlineData("PUT", "dictation/someone-elses-id/chunk/0", "audio-bytes")]
-    [InlineData("POST", "dictation/someone-elses-id/complete", "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\",\"totalChunks\":1}")]
-    [InlineData("POST", "dictation/someone-elses-id/ack", "")]
-    [InlineData("POST", "dictation/someone-elses-id/abandon", "")]
-    public async Task Dictation_upload_family_is_refused_to_an_enrolled_tenant(
-        string method, string path, string body)
-    {
-        var resp = await Send(new HttpMethod(method), path, body);
-        await AssertBodyIsNothingButTheRefusal(resp, DictationRefusal, $"{method} {path}");
-        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
-    }
-
-    /// <summary>
-    /// The refusal must PREVENT the work, not merely relabel it. A handler that ran and then reported 404
-    /// would pass a status-code-only assertion, so this proves the two upload families staged nothing: the
-    /// idempotency key was never registered, so no directory for it exists under the isolated root.
-    /// </summary>
-    [Fact]
-    public async Task A_refused_upload_registration_staged_nothing_on_disk()
-    {
-        var key = "claimed-" + Guid.NewGuid().ToString("N");
-
-        var utterance = await Send(HttpMethod.Post, "wingman/utterance/upload", "", key);
-        Assert.Equal(HttpStatusCode.NotFound, utterance.StatusCode);
-
-        var dictation = await Send(HttpMethod.Post, "dictation/upload",
-            "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}", key);
-        Assert.Equal(HttpStatusCode.NotFound, dictation.StatusCode);
-
-        // Nothing named for that key anywhere under the isolated storage root. Searching the whole root
-        // rather than one expected directory is deliberate: it does not depend on knowing which staging
-        // path the store would have chosen, so it cannot pass by looking in the wrong place.
-        var staged = Directory.Exists(_root)
-            ? Directory.EnumerateFileSystemEntries(_root, "*" + key + "*", SearchOption.AllDirectories).ToArray()
-            : Array.Empty<string>();
-        Assert.Empty(staged);
-    }
+    // NOTE (issue #1884, un-deny): the /wingman/utterance and /dictation upload families are NO LONGER denied
+    // on hosted - they are served tenant-partitioned so the owner's mobile dictation works. Their hosted
+    // isolation (tenant A round-trips, tenant B cannot read/list/complete/ack A's upload, and a legacy
+    // pre-partition dir is never served) is proved in HostedDictationTenantRoundTripTests. What remains denied
+    // here is the transcription-analysis and wingman-instructions content-read surface, which has no partition.
 
     /// <summary>
     /// THE GATE MUST NOT DEPEND ON RESOLVING A TENANT, AND THIS IS THE CASE THAT PROVES IT.
@@ -410,8 +353,6 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
     [Theory]
     [InlineData("GET", "transcription/turns", null, TranscriptionRefusal)]
     [InlineData("GET", "gateway/wingman/instructions/records", null, InstructionsRefusal)]
-    [InlineData("POST", "wingman/utterance/upload", "", UtteranceRefusal)]
-    [InlineData("POST", "dictation/upload", "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\"}", DictationRefusal)]
     public async Task Every_family_is_refused_to_a_caller_carrying_no_tenant_at_all(
         string method, string path, string? body, string refusal)
     {

--- a/src/CcDirector.Gateway.Tests/HostedDictationLegacyQuarantineTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedDictationLegacyQuarantineTests.cs
@@ -135,6 +135,45 @@ public sealed class HostedDictationLegacyQuarantineTests : IDisposable
     }
 
     [Fact]
+    public void A_colliding_quarantine_target_still_moves_the_source_aside_without_overwriting()
+    {
+        // THE COLLISION HOLE (issue #1884, finding 3). A legacy id was quarantined by an earlier run (or a
+        // concurrent worker), and then a rolling/older worker recreated the SAME id at the base root. The old
+        // code saw quarantine/<id> already present and simply skipped - leaving the freshly-recreated legacy
+        // dir LIVE at the base root, where the base age sweep and the base PENDING projection still read it.
+        // The fix moves the source aside under a unique name, so NO legacy source is ever left live at base,
+        // and never overwrites the already-quarantined data.
+        var baseStore = BaseStore();
+        var legacyId = Guid.NewGuid().ToString();
+        var cid = Guid.Parse(legacyId).ToString("N");
+
+        // An occupant already sitting in the canonical quarantine slot, with its own distinct content.
+        var occupant = Path.Combine(_root, VoiceUploadStore.QuarantineDirectoryName, cid);
+        Directory.CreateDirectory(occupant);
+        File.WriteAllText(Path.Combine(occupant, "occupant.txt"), "already-quarantined-bytes");
+
+        // A NEW legacy dir with the same id, recreated live at the base root, with DIFFERENT content.
+        baseStore.MarkDelivered(legacyId, submitted: true, movedOn: false, transcript: "recreated-legacy-transcript");
+        var legacyDir = Path.Combine(_root, cid);
+        Assert.True(File.Exists(Path.Combine(legacyDir, "record.json")), "precondition: the recreated legacy dir is live at base");
+
+        var moved = baseStore.QuarantineLegacyUploads();
+
+        // The source is moved aside - NO legacy source is left live at the base root.
+        Assert.Equal(1, moved);
+        Assert.False(Directory.Exists(legacyDir), "the recreated legacy dir must NOT be left live at the base root");
+        Assert.True(baseStore.ReadRecord(legacyId) is null, "the base handle must no longer read the recreated legacy record as live");
+
+        // The already-quarantined occupant is untouched (never overwritten): move, not overwrite.
+        Assert.Equal("already-quarantined-bytes", File.ReadAllText(Path.Combine(occupant, "occupant.txt")));
+        Assert.False(File.Exists(Path.Combine(occupant, "record.json")), "the occupant slot must not have been overwritten with the source");
+
+        // The source's bytes are preserved under a unique, non-canonical dup name (never lost - move, not delete).
+        var dup = Path.Combine(_root, VoiceUploadStore.QuarantineDirectoryName, cid + "__dup-1");
+        Assert.True(File.Exists(Path.Combine(dup, "record.json")), "the recreated legacy bytes must be preserved under a unique dup slot");
+    }
+
+    [Fact]
     public void Quarantine_on_an_account_partition_is_a_no_op()
     {
         // Only the base (Local) handle scans the shared root; an account partition is clean by construction, so

--- a/src/CcDirector.Gateway.Tests/HostedDictationLegacyQuarantineTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedDictationLegacyQuarantineTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -171,6 +172,91 @@ public sealed class HostedDictationLegacyQuarantineTests : IDisposable
         // The source's bytes are preserved under a unique, non-canonical dup name (never lost - move, not delete).
         var dup = Path.Combine(_root, VoiceUploadStore.QuarantineDirectoryName, cid + "__dup-1");
         Assert.True(File.Exists(Path.Combine(dup, "record.json")), "the recreated legacy bytes must be preserved under a unique dup slot");
+    }
+
+    [Fact]
+    public async Task Concurrent_workers_quarantine_every_legacy_upload_without_loss_and_leave_none_live()
+    {
+        // THE CONCURRENCY CLAIM the method's summary is granted on ("safe under restart and concurrent
+        // workers"), driven directly. GatewayHost.StartAsync calls this at startup on hosted, and the fleet
+        // runs several Gateway workers, so two can enter QuarantineLegacyUploads over the SAME shared base root
+        // at once. This stages the HARD case for that - the collision hole of finding 3, now under contention:
+        // every legacy id ALREADY has its canonical quarantine slot occupied (an earlier run quarantined it and
+        // then it was recreated live at base). The old "skip if the canonical slot is taken" would leave every
+        // recreated source LIVE at base; the fix moves each aside under a unique name. This is the line the test
+        // is revert-proof against - restore the skip (FreeQuarantineTarget / the always-move at the call site)
+        // and "no legacy left live" reddens.
+        //
+        // The invariants asserted are PHYSICAL, not the workers' return values: two workers can each observe a
+        // successful rename to the same target before either sees the other, so the counts legitimately
+        // over-report. What must hold on disk is no recorded speech lost, no legacy source left live, no occupant
+        // overwritten, and convergence to a no-op.
+        var baseStore = BaseStore();
+        var quarantineDir = Path.Combine(_root, VoiceUploadStore.QuarantineDirectoryName);
+        Directory.CreateDirectory(quarantineDir);
+
+        const int legacyCount = 24;
+        var expected = new Dictionary<string, string>(StringComparer.Ordinal); // canonical id -> its transcript
+        foreach (var _ in Enumerable.Range(0, legacyCount))
+        {
+            var id = Guid.NewGuid().ToString();
+            var cid = Guid.Parse(id).ToString("N");
+            var transcript = "recreated-legacy-" + cid;
+
+            // The occupant already sitting in the canonical quarantine slot, with its OWN distinct content.
+            var occupant = Path.Combine(quarantineDir, cid);
+            Directory.CreateDirectory(occupant);
+            File.WriteAllText(Path.Combine(occupant, "occupant.txt"), "already-quarantined-" + cid);
+
+            // The recreated legacy dir, live at the base root, with different content and the same id.
+            baseStore.MarkDelivered(id, submitted: true, movedOn: false, transcript: transcript);
+            expected[cid] = transcript;
+        }
+
+        // Two workers over the SAME base root, at once - the shape of two Gateway processes sharing one Azure
+        // Files root.
+        var workerOne = BaseStore();
+        var workerTwo = BaseStore();
+        await Task.WhenAll(
+            Task.Run(() => workerOne.QuarantineLegacyUploads()),
+            Task.Run(() => workerTwo.QuarantineLegacyUploads()));
+
+        // NO LEGACY LEFT LIVE. Not one canonical upload-id directory remains at the base root for any base pass
+        // (the age sweep, the PENDING projection) to still read as live. THIS is the revert canary: the old
+        // skip-on-collision leaves every recreated source here.
+        var survivingAtBase = Directory.EnumerateDirectories(_root)
+            .Select(d => Path.GetFileName(d.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)))
+            .Where(name => Guid.TryParseExact(name, "N", out _))
+            .ToList();
+        Assert.Empty(survivingAtBase);
+
+        foreach (var (canonicalId, transcript) in expected)
+        {
+            // THE OCCUPANT IS NEVER OVERWRITTEN. Its canonical slot still holds its own bytes and never gained
+            // the source's record - a move aside, not an overwrite.
+            var occupant = Path.Combine(quarantineDir, canonicalId);
+            Assert.Equal("already-quarantined-" + canonicalId, File.ReadAllText(Path.Combine(occupant, "occupant.txt")));
+            Assert.False(File.Exists(Path.Combine(occupant, "record.json")),
+                $"occupant slot for {canonicalId} must not have been overwritten by the recreated source");
+
+            // NO DATA LOSS and NO DUPLICATION. The recreated source's transcript is preserved under EXACTLY ONE
+            // unique __dup-N sibling - moved, never deleted, and the race never made a second physical copy.
+            var dupRecords = Directory.EnumerateDirectories(quarantineDir)
+                .Where(d =>
+                {
+                    var name = Path.GetFileName(d.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                    return name.StartsWith(canonicalId + "__dup-", StringComparison.Ordinal);
+                })
+                .Select(d => Path.Combine(d, "record.json"))
+                .Where(File.Exists)
+                .ToList();
+            Assert.True(dupRecords.Count == 1,
+                $"recreated legacy {canonicalId} must be preserved under exactly one dup slot (found {dupRecords.Count})");
+            Assert.Contains(transcript, File.ReadAllText(dupRecords[0]), StringComparison.Ordinal);
+        }
+
+        // IDEMPOTENT UNDER CONCURRENCY. A further pass converges to a no-op - nothing is left to move.
+        Assert.Equal(0, baseStore.QuarantineLegacyUploads());
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/HostedDictationLegacyQuarantineTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedDictationLegacyQuarantineTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1884, the UN-DENY SAFETY GATE. When the /dictation and /wingman/utterance upload families were
+/// refused on hosted, the pre-partition shared upload root could hold cross-tenant staged audio, delivery
+/// records and transcripts with no owner. Serving those families again (so the owner's mobile dictation
+/// works) means that legacy, unattributable data must never be treated as live: not served to a caller, not
+/// aged-and-deleted by the sweep, and not surfaced by the base handle's PENDING lock projection.
+///
+/// The DIRECTORY PARTITION already stops a hosted ACCOUNT tenant from ever reading a legacy dir - an account
+/// reads only <c>base/tenants/&lt;id&gt;/</c> and a legacy dir lives directly at <c>base/&lt;uploadId&gt;</c>,
+/// a path it cannot address. What these tests pin is the remaining edge: the BASE (Local) handle's own passes
+/// over the shared root, which <see cref="VoiceUploadStore.QuarantineLegacyUploads"/> moves the legacy dirs
+/// out of - once, at startup on hosted (see <c>GatewayHost.StartAsync</c>).
+///
+/// MOVE, NEVER DELETE, and idempotent/re-entrant, are asserted directly here because they are the guardrails
+/// the change was granted on: a delete would lose recorded speech, and a non-re-entrant move would corrupt on
+/// a restart or a second worker.
+/// </summary>
+public sealed class HostedDictationLegacyQuarantineTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "cc-legacy-quarantine-" + Guid.NewGuid().ToString("N"));
+
+    private VoiceUploadStore BaseStore() => new VoiceUploadStore(_root, TenantId.Local);
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* cleanup */ }
+    }
+
+    [Fact]
+    public void A_legacy_upload_dir_is_moved_aside_and_never_deleted()
+    {
+        // A pre-partition upload sitting directly under the shared root, with a delivered record (its
+        // transcript) and a staged chunk on disk - exactly the shape the un-deny must not serve.
+        var baseStore = BaseStore();
+        var legacyId = Guid.NewGuid().ToString();
+        baseStore.MarkDelivered(legacyId, submitted: true, movedOn: false, transcript: "legacy-secret-transcript");
+        var legacyDir = Path.Combine(_root, Guid.Parse(legacyId).ToString("N"));
+        Assert.True(File.Exists(Path.Combine(legacyDir, "record.json")), "precondition: the legacy record is at the base root");
+
+        var moved = baseStore.QuarantineLegacyUploads();
+
+        Assert.Equal(1, moved);
+        // Moved OUT of the served/enumerated root...
+        Assert.False(Directory.Exists(legacyDir), "the legacy dir must no longer sit at the base root");
+        // ...and INTO quarantine with its bytes intact - a MOVE, not a delete. No recorded speech is lost.
+        var quarantined = Path.Combine(_root, VoiceUploadStore.QuarantineDirectoryName, Guid.Parse(legacyId).ToString("N"));
+        Assert.True(Directory.Exists(quarantined), "the legacy dir must be preserved under quarantine");
+        Assert.True(File.Exists(Path.Combine(quarantined, "record.json")), "the legacy record (its transcript) is preserved, not deleted");
+
+        // The base handle no longer reads it as a live record.
+        Assert.Null(baseStore.ReadRecord(legacyId));
+    }
+
+    [Fact]
+    public void A_hosted_account_partition_never_reads_a_legacy_base_root_upload()
+    {
+        // The account partition is base/tenants/<id>/, so a legacy dir at base/<id> is not even addressable
+        // from it - the isolation holds by construction, before quarantine has run at all. (Quarantine exists
+        // for the BASE handle's own passes, not for the account read path, which was never exposed.)
+        var baseStore = BaseStore();
+        var legacyId = Guid.NewGuid().ToString();
+        baseStore.MarkDelivered(legacyId, submitted: true, movedOn: false, transcript: "legacy-secret-transcript");
+
+        var account = new TenantId(Guid.NewGuid().ToString());
+        var accountStore = baseStore.ForTenant(account);
+
+        Assert.Null(accountStore.ReadRecord(legacyId));
+        // And after quarantine it is still absent from the account partition (nothing changed for it).
+        baseStore.QuarantineLegacyUploads();
+        Assert.Null(accountStore.ReadRecord(legacyId));
+    }
+
+    [Fact]
+    public async Task Quarantine_removes_a_legacy_pending_from_the_base_handle_lock_projection()
+    {
+        // The concrete state the quarantine cleans: a legacy PENDING record's session is seen as locked by the
+        // BASE (Local) handle's projection over the shared root. On a hosted Gateway that projection would
+        // otherwise surface a session that belongs to no live tenant.
+        var baseStore = BaseStore();
+        var legacyId = Guid.NewGuid().ToString();
+        var legacySession = Guid.NewGuid().ToString();
+        baseStore.MarkPending(legacyId, legacySession);
+        await baseStore.StoreChunkAsync(legacyId, 0, System.Text.Encoding.UTF8.GetBytes("legacy-audio"), null);
+
+        // REVERT-PROOF: this is true only because the legacy record is still at the base root. Remove the
+        // QuarantineLegacyUploads call from GatewayHost.StartAsync and this state is what the base handle keeps
+        // seeing on hosted.
+        Assert.True(baseStore.IsSessionLocked(legacySession), "precondition: the base handle sees the legacy pending");
+
+        var moved = baseStore.QuarantineLegacyUploads();
+
+        Assert.Equal(1, moved);
+        Assert.False(baseStore.IsSessionLocked(legacySession),
+            "after quarantine the base handle's pending projection must no longer see the legacy record");
+        // The bytes are preserved (moved, not deleted) - the audio and its marker are still on disk.
+        var quarantined = Path.Combine(_root, VoiceUploadStore.QuarantineDirectoryName, Guid.Parse(legacyId).ToString("N"));
+        Assert.True(File.Exists(Path.Combine(quarantined, "record.json")));
+        Assert.True(File.Exists(Path.Combine(quarantined, "00000.part")));
+    }
+
+    [Fact]
+    public void Quarantine_is_idempotent_and_re_entrant()
+    {
+        var baseStore = BaseStore();
+        var legacyId = Guid.NewGuid().ToString();
+        baseStore.MarkDelivered(legacyId, submitted: true, movedOn: false, transcript: "legacy");
+
+        // A real account partition alongside it, so the run has a tenants container to (correctly) leave alone.
+        var account = new TenantId(Guid.NewGuid().ToString());
+        baseStore.ForTenant(account).MarkDelivered(Guid.NewGuid().ToString(), submitted: true, movedOn: false, transcript: "account-owned");
+        var tenantsContainer = Path.Combine(_root, VoiceUploadStore.TenantPartitionDirectoryName);
+        Assert.True(Directory.Exists(tenantsContainer), "precondition: an account partition container exists");
+
+        var first = baseStore.QuarantineLegacyUploads();
+        Assert.Equal(1, first);
+
+        // Re-entrant: a second run moves nothing, does not throw, and does not disturb the quarantine dir, the
+        // tenants container, or the already-quarantined data.
+        var second = baseStore.QuarantineLegacyUploads();
+        Assert.Equal(0, second);
+        Assert.True(Directory.Exists(tenantsContainer), "the tenants partition container is never quarantined");
+        var quarantined = Path.Combine(_root, VoiceUploadStore.QuarantineDirectoryName, Guid.Parse(legacyId).ToString("N"));
+        Assert.True(File.Exists(Path.Combine(quarantined, "record.json")), "the already-quarantined data is untouched by a second run");
+    }
+
+    [Fact]
+    public void Quarantine_on_an_account_partition_is_a_no_op()
+    {
+        // Only the base (Local) handle scans the shared root; an account partition is clean by construction, so
+        // running it there moves nothing - it must never reach up into the shared root it is nested under.
+        var baseStore = BaseStore();
+        var legacyId = Guid.NewGuid().ToString();
+        baseStore.MarkDelivered(legacyId, submitted: true, movedOn: false, transcript: "legacy");
+
+        var account = new TenantId(Guid.NewGuid().ToString());
+        var moved = baseStore.ForTenant(account).QuarantineLegacyUploads();
+
+        Assert.Equal(0, moved);
+        // The legacy dir at the base root is untouched by the account-partition call.
+        Assert.True(Directory.Exists(Path.Combine(_root, Guid.Parse(legacyId).ToString("N"))));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedDictationWiringCanaryTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedDictationWiringCanaryTests.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Transcription;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1884, the WIRING canaries. The store, the mark and the phase rule are each pinned elsewhere
+/// (<see cref="VoiceUploadStoreTenantPartitionTests"/>, <see cref="TranscribingSessionsTenantIsolationTests"/>,
+/// <c>DictationPhase</c>'s own tests). What THOSE tests do not exercise is the PRODUCTION WIRING that selects
+/// the tenant at each of the three seams - they call the store, the dictionary and the phase function
+/// directly. So a bundle that reverts every dictation/transcribing call-site tenant argument back to
+/// <see cref="TenantId.Local"/> - the transcribing route's mark, the roster's dictationStatusFor callback and
+/// the voice-turn retention timer - left all of those direct tests green while re-opening the cross-account
+/// hole. A test that supplies the tenant itself cannot catch a production line that supplies the WRONG tenant.
+///
+/// These three canaries close that gap by driving the ACTUAL production wiring end to end - a real
+/// <see cref="GatewayHost"/> on hosted, two accounts over real HTTP, two tunnel Directors pushing the SAME
+/// session id on two tenants - and asserting on what the caller's OWN request produces:
+///
+///   1. <see cref="Transcribing_mark_and_roster_are_isolated_per_tenant_over_the_real_route"/> drives
+///      POST /sessions/{sid}/transcribing and reads the mark back through the roster's transcribingFor
+///      callback. Revert the route's <c>Begin/End(reqTenant, sid)</c> (GatewayEndpoints, the transcribing
+///      route) OR the roster's <c>transcribingFor(reqTenant.Value, ...)</c> to Local and the caller's own
+///      positive control reddens; revert BOTH and the cross-tenant isolation assertions redden.
+///
+///   2. <see cref="A_hosted_tenants_pending_dictation_paints_its_OWN_roster_row_through_the_production_callback"/>
+///      reads DictationStatus off the roster, which the GatewayHost dictationStatusFor callback
+///      (<c>DictationStatusFor(tenant, sid, _transcribingSessions, _dictationUploads.ForTenant(tenant))</c>)
+///      produces. Revert that callback to the Local/base handle (<c>_dictationUploads</c>) and the phase
+///      collapses to null, because the base projection never descends into <c>base/tenants/&lt;id&gt;</c>.
+///
+///   3. <see cref="The_voice_turn_retention_timer_sweeps_each_tenants_aged_upload_in_its_OWN_partition"/>
+///      stages an aged upload in each tenant's own voice-turn partition and lets the REAL retention timer
+///      (the <c>_tenantPass.ForEachTenant(() =&gt; _voiceTurnUploads.ForTenant(tenant).SweepAbandoned(...))</c>
+///      timer) run. Revert it to the base handle (<c>_voiceTurnUploads.SweepAbandoned(...)</c>) and neither
+///      aged upload is ever swept, because the base sweep does not descend into the partition container.
+///
+/// The assembly runs sequentially, so toggling CC_GATEWAY_HOSTED, CC_DIRECTOR_ROOT and the static sweep
+/// schedule here is safe; all three are restored in DisposeAsync.
+/// </summary>
+public sealed class HostedDictationWiringCanaryTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    // ONE session id, pushed by BOTH Directors on BOTH tenants. That is what puts the same id in both
+    // accounts' rosters - the exact shape a bare-session-id mark would cross - and what makes the per-tenant
+    // sweep iterate both tenants (they are both "known").
+    private const string Sid = "shared-session-id";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _httpA = null!;
+    private HttpClient _httpB = null!;
+    private FakeTunnelDirector _dirA = null!;
+    private FakeTunnelDirector _dirB = null!;
+
+    private TenantId _tenantA;
+    private TenantId _tenantB;
+
+    private string? _priorHosted;
+    private string? _priorRoot;
+    private TimeSpan? _priorSweepSchedule;
+
+    private readonly string _storageRoot =
+        Path.Combine(Path.GetTempPath(), "cc-wiring-canary-storage-" + Guid.NewGuid().ToString("N"));
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-wiring-canary-instances-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        // Isolate the storage root BEFORE the Gateway starts so its upload stores bind the temp root, never the
+        // developer's real one - and so a store constructed here reads the SAME on-disk root the Gateway does.
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
+
+        // Drive the REAL voice-turn retention timer fast, so canary 3 exercises the production timer wiring
+        // rather than a hand-called SweepAbandoned. Set before the host is constructed (the timer reads this
+        // static at StartAsync); restored in DisposeAsync.
+        _priorSweepSchedule = GatewayHost.VoiceTurnUploadSweepScheduleForTests;
+        GatewayHost.VoiceTurnUploadSweepScheduleForTests = TimeSpan.FromMilliseconds(200);
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+
+        // Two accounts: two device keys, each bound to its OWN minted tenant. The tenants are minted by the
+        // real registry (canonical GUIDs), the only shape the upload-store partition admits.
+        var keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        _tenantA = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        _tenantB = _gateway.TenantRegistry.MintOrLookupBySubject("sub-bob", "bob@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", _tenantA.Value);
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", _tenantB.Value);
+
+        _httpA = NewClient(keyA);
+        _httpB = NewClient(keyB);
+
+        // One tunnel Director per account, each authenticated as that account's device key and pushing a
+        // session under the SAME id. The push binds the session into that account's partition (and the account
+        // into KnownTenants), so A's roster and B's roster each carry their own row for id Sid.
+        _dirA = await FakeTunnelDirector.StartAsync(_gateway, keyA, "dir-a", "MA", dispatch: AnswerAnything);
+        _dirB = await FakeTunnelDirector.StartAsync(_gateway, keyB, "dir-b", "MB", dispatch: AnswerAnything);
+        await _dirA.PushSnapshotAsync(Sample(Sid));
+        await _dirB.PushSnapshotAsync(Sample(Sid));
+    }
+
+    private static DirectorCommandResult AnswerAnything(DirectorCommand cmd) =>
+        FakeTunnelDirector.Ok(new { ok = true, lines = Array.Empty<string>(), items = Array.Empty<object>() });
+
+    public async Task DisposeAsync()
+    {
+        _httpA.Dispose();
+        _httpB.Dispose();
+        await _dirA.DisposeAsync();
+        await _dirB.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        GatewayHost.VoiceTurnUploadSweepScheduleForTests = _priorSweepSchedule;
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* cleanup */ }
+        try { if (Directory.Exists(_storageRoot)) Directory.Delete(_storageRoot, true); } catch { /* cleanup */ }
+    }
+
+    // ===== canary 1: the transcribing mark, through the real route AND the real roster callback ==========
+
+    [Fact]
+    public async Task Transcribing_mark_and_roster_are_isolated_per_tenant_over_the_real_route()
+    {
+        // A marks its own session transcribing through the PRODUCTION route.
+        Assert.Equal(HttpStatusCode.OK, (await SetTranscribingAsync(_httpA, Sid, true)).StatusCode);
+
+        // Positive control, read through the production transcribingFor callback: A's OWN roster row is orange.
+        // Reddens if the route's Begin(reqTenant, sid) OR the roster's transcribingFor(reqTenant.Value, ...) is
+        // reverted onto Local - A's mark would then land under, or be read from, a tenant that is not A's.
+        Assert.True((await RosterRow(_httpA, Sid)).Transcribing,
+            "A must see its own transcribing mark on its own roster row");
+
+        // Isolation: B - whose Director pushed the SAME session id - must NOT see A's mark on its own row.
+        // Reddens if BOTH sites are reverted to Local, which re-merges the two accounts onto one shared mark.
+        Assert.False((await RosterRow(_httpB, Sid)).Transcribing,
+            "B must not see A's transcribing mark for the same session id");
+
+        // B ending the mark on the same id through the route clears only B's (nonexistent) mark - A's stands.
+        // Reddens under the both-reverted-to-Local bundle: B's End would then wipe the one shared mark A set.
+        Assert.Equal(HttpStatusCode.OK, (await SetTranscribingAsync(_httpB, Sid, false)).StatusCode);
+        Assert.True((await RosterRow(_httpA, Sid)).Transcribing,
+            "B's clear on the same session id must not wipe A's transcribing mark");
+
+        // A can still clear its own.
+        Assert.Equal(HttpStatusCode.OK, (await SetTranscribingAsync(_httpA, Sid, false)).StatusCode);
+        Assert.False((await RosterRow(_httpA, Sid)).Transcribing, "A can clear its own mark");
+    }
+
+    // ===== canary 2: the dictation phase, through the real roster dictationStatusFor callback ===========
+
+    [Fact]
+    public async Task A_hosted_tenants_pending_dictation_paints_its_OWN_roster_row_through_the_production_callback()
+    {
+        // A durable PENDING dictation in A's OWN dictation partition (base/tenants/<A>), plus a live progress
+        // mark set through the real transcribing route, so the honest phase is "Uploading from phone".
+        var uploadId = Guid.NewGuid().ToString("N");
+        DictationStore(_tenantA).MarkPending(uploadId, Sid);
+        Assert.Equal(HttpStatusCode.OK, (await SetTranscribingAsync(_httpA, Sid, true)).StatusCode);
+
+        // A's roster row, read through the GatewayHost dictationStatusFor callback - the one that passes
+        // _dictationUploads.ForTenant(caller) - reports the phase from A's own partition. Revert that callback
+        // to the Local/base handle and this reddens: the base projection never descends into base/tenants/<A>,
+        // so IsSessionLocked is false, undelivered is false, and DictationPhase.For collapses to null.
+        Assert.Equal(DictationPhase.Uploading, (await RosterRow(_httpA, Sid)).DictationStatus);
+
+        // Isolation half: B holds no pending for this id, so its own row carries no dictation status. A's
+        // pending is not B's to read, even on the same session id.
+        Assert.Null((await RosterRow(_httpB, Sid)).DictationStatus);
+    }
+
+    // ===== canary 3: the voice-turn retention sweep, through the real background timer =================
+
+    [Fact]
+    public async Task The_voice_turn_retention_timer_sweeps_each_tenants_aged_upload_in_its_OWN_partition()
+    {
+        // Both accounts are live (their Directors pushed sessions), so the per-tenant sweep iterates them. This
+        // is the positive control for the wait below: if this were empty the sweep would run zero passes and the
+        // aged uploads would linger for a reason that has nothing to do with the line under test.
+        var known = _gateway.PushedSessions.KnownTenants();
+        Assert.Contains(_tenantA, known);
+        Assert.Contains(_tenantB, known);
+
+        var storeA = VoiceTurnStore(_tenantA);
+        var storeB = VoiceTurnStore(_tenantB);
+
+        // An AGED voice-turn upload staged in each tenant's OWN partition (last-activity backdated well past the
+        // 4-hour retention bound), plus a FRESH one that must survive - the age-selective positive control that
+        // stops this passing on a blanket wipe.
+        var agedA = StageAged(storeA);
+        var agedB = StageAged(storeB);
+        var freshA = Guid.NewGuid().ToString(); storeA.Register(freshA);
+        var freshB = Guid.NewGuid().ToString(); storeB.Register(freshB);
+
+        // Let the REAL production timer run. Revert it to the base handle (_voiceTurnUploads.SweepAbandoned)
+        // and this never comes true: the base sweep does not descend into base/tenants/<id>, so neither aged
+        // upload is ever removed and this times out RED.
+        Assert.True(await PollAsync(() => !storeA.Exists(agedA) && !storeB.Exists(agedB), TimeSpan.FromSeconds(20)),
+            "the production per-tenant voice-turn timer must sweep each tenant's aged upload from its OWN partition");
+
+        Assert.True(storeA.Exists(freshA), "the sweep must not remove A's fresh upload (it is age-selective, not a wipe)");
+        Assert.True(storeB.Exists(freshB), "the sweep must not remove B's fresh upload (it is age-selective, not a wipe)");
+    }
+
+    // ===== helpers =====================================================================================
+
+    private static VoiceUploadStore DictationStore(TenantId tenant)
+        => new VoiceUploadStore(CcStorage.DictationUploads(), TenantId.Local).ForTenant(tenant);
+
+    private static VoiceUploadStore VoiceTurnStore(TenantId tenant)
+        => new VoiceUploadStore(CcStorage.VoiceTurnUploads(), TenantId.Local).ForTenant(tenant);
+
+    /// <summary>Stage an upload whose last-activity signal is backdated past the 4-hour retention bound, so
+    /// the production sweep (which compares directory write time to now minus the max age) treats it as aged
+    /// without any real waiting.</summary>
+    private static string StageAged(VoiceUploadStore store)
+    {
+        var id = Guid.NewGuid().ToString();
+        store.Register(id);
+        var dir = Path.Combine(store.Root, Guid.Parse(id).ToString("N"));
+        Directory.SetLastWriteTimeUtc(dir, DateTime.UtcNow - TimeSpan.FromHours(5));
+        return id;
+    }
+
+    private static Task<HttpResponseMessage> SetTranscribingAsync(HttpClient http, string sid, bool transcribing)
+        => http.PostAsJsonAsync($"/sessions/{sid}/transcribing", new { transcribing });
+
+    private static async Task<SessionDto> RosterRow(HttpClient http, string sid)
+    {
+        var resp = await http.GetAsync("/sessions");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var sessions = await resp.Content.ReadFromJsonAsync<List<SessionDto>>();
+        Assert.NotNull(sessions);
+        var row = sessions!.FirstOrDefault(s => string.Equals(s.SessionId, sid, StringComparison.Ordinal));
+        Assert.True(row is not null, $"this tenant's roster must list session {sid}");
+        return row!;
+    }
+
+    private static async Task<bool> PollAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(50);
+        }
+        return condition();
+    }
+
+    private static SessionDto Sample(string sid) => new()
+    {
+        SessionId = sid,
+        Agent = "claude",
+        RepoPath = "/repo",
+        ActivityState = "Idle",
+        Status = "Running",
+        StatusColor = "blue",
+        CreatedAt = DateTime.UtcNow,
+        LastActivityAt = DateTime.UtcNow,
+    };
+
+    private HttpClient NewClient(string deviceKey)
+    {
+        var http = new HttpClient
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/"),
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return http;
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedUtteranceTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedUtteranceTenantIsolationTests.cs
@@ -1,0 +1,210 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1884, finding 4: the hosted <c>/wingman/utterance</c> upload family is served and TENANT-SCOPED,
+/// proven over real HTTP with two bound accounts plus one unbound key across ALL THREE legs (register, chunk,
+/// complete).
+///
+/// WHY THIS FILE EXISTS. Before it, there was NO hosted request test for the utterance family at all - the
+/// only executable utterance-route tests were self-host controls. So reinstating the old hosted
+/// <c>ExclusiveGroup</c> refusal for the three utterance handlers would leave the whole suite green while the
+/// mobile Voice screen's guaranteed audio-turn front door went dead on hosted. An earlier claim that this
+/// proof lived in a <c>HostedDictationTenantRoundTripTests</c> class was false - no such class existed.
+///
+/// WHAT IS PROVED, each revert-provable:
+///   - A's own round-trip WORKS on hosted: register returns 200 and the leg bodies run (chunk 200, complete
+///     gets past the gate and the unknown-upload check to the transcription step). Put the hosted deny back on
+///     any of the three legs and A's positive control for that leg goes RED - this is what makes re-denying
+///     utterance redden, where before it stayed green.
+///   - B (a different bound tenant) cannot reach A's staged upload: the same upload id does not exist in B's
+///     partition, so B's chunk and complete on A's id are 404, while A's own are not. State stays isolated.
+///   - An authenticated key with NO bound tenant is refused (403) on every leg - never quietly served the
+///     shared/Local root - with a bound-key positive control in front so the 403s are the tenant deny and not
+///     a route broken for everyone.
+///
+/// The complete leg cannot finish a real transcription offline (no backend key is configured on the test
+/// Gateway), so A's complete is asserted to get PAST the gate and the unknown-upload check (not 403, not 404)
+/// rather than to return a transcript. That is the same offline bound the dictation isolation suite runs
+/// under, and it is exactly enough to prove the leg is served for A and denied for B.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED and the storage root
+/// here is safe; both are restored in DisposeAsync.
+/// </summary>
+public sealed class HostedUtteranceTenantIsolationTests : IAsyncLifetime
+{
+    private const string GatewayToken = "test-token";
+    private const string SecretAudioA = "alpha-account-secret-utterance-audio";
+    private const string SecretAudioB = "bravo-account-secret-utterance-audio";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _httpA = null!;
+    private HttpClient _httpB = null!;
+    private HttpClient _httpUnbound = null!;
+
+    private string? _priorHosted;
+    private string? _priorRoot;
+
+    private readonly string _storageRoot =
+        Path.Combine(Path.GetTempPath(), "cc-utterance-iso-storage-" + Guid.NewGuid().ToString("N"));
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-utterance-iso-instances-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
+
+        _gateway = new GatewayHost(port: FreePort(), token: GatewayToken, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            promptLogPath: Path.Combine(_instancesDir, "prompt-log"));
+        await _gateway.StartAsync();
+
+        var keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        var keyUnbound = _gateway.Devices.Register("dev-x", "MX").DeviceKey;
+        var tenantA = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        var tenantB = _gateway.TenantRegistry.MintOrLookupBySubject("sub-bob", "bob@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", tenantA.Value);
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", tenantB.Value);
+
+        _httpA = NewClient(keyA);
+        _httpB = NewClient(keyB);
+        _httpUnbound = NewClient(keyUnbound);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _httpA.Dispose();
+        _httpB.Dispose();
+        _httpUnbound.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* cleanup */ }
+        try { if (Directory.Exists(_storageRoot)) Directory.Delete(_storageRoot, true); } catch { /* cleanup */ }
+    }
+
+    // ===== A's own round-trip is served on hosted (re-deny reddens here) ============================
+
+    [Fact]
+    public async Task A_can_register_chunk_and_complete_its_own_utterance_on_hosted()
+    {
+        var id = Guid.NewGuid().ToString();
+
+        // Register: 200 with an upload_id. This is the anchor - re-adding the hosted deny to /wingman/utterance
+        // makes THIS 403, which reddens the test that today proves the family is served.
+        var register = await RegisterAsync(_httpA, id);
+        Assert.Equal(HttpStatusCode.OK, register.StatusCode);
+        // The store echoes the id in its canonical staging form (a normalized GUID), so compare by GUID value
+        // rather than by spelling.
+        var returnedId = (await register.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("upload_id").GetString();
+        Assert.Equal(Guid.Parse(id), Guid.Parse(returnedId!));
+
+        // Chunk: 200. The leg body ran inside A's partition.
+        Assert.Equal(HttpStatusCode.OK, (await PutChunkAsync(_httpA, id, 0, SecretAudioA)).StatusCode);
+
+        // Complete: gets PAST the gate and the unknown-upload check for A's own upload. A real transcription
+        // backend is not configured offline, so this is 503 (no key) rather than a transcript - the point is it
+        // is NEITHER 403 (denied) NOR 404 (upload not found), so the leg is genuinely served for A.
+        var complete = await CompleteAsync(_httpA, id, totalChunks: 1);
+        Assert.NotEqual(HttpStatusCode.Forbidden, complete.StatusCode);
+        Assert.NotEqual(HttpStatusCode.NotFound, complete.StatusCode);
+    }
+
+    // ===== B cannot reach A's staged upload ========================================================
+
+    [Fact]
+    public async Task B_cannot_chunk_or_complete_another_accounts_utterance_upload_id()
+    {
+        var id = Guid.NewGuid().ToString();
+
+        // A stages an upload under the id.
+        Assert.Equal(HttpStatusCode.OK, (await RegisterAsync(_httpA, id)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await PutChunkAsync(_httpA, id, 0, SecretAudioA)).StatusCode);
+
+        // B has never registered this id in ITS partition, so to B it does not exist: chunk and complete are
+        // both 404. B cannot overwrite, extend, or resolve A's staged audio.
+        Assert.Equal(HttpStatusCode.NotFound, (await PutChunkAsync(_httpB, id, 0, SecretAudioB)).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await CompleteAsync(_httpB, id, totalChunks: 1)).StatusCode);
+
+        // Positive control: B registering the SAME id in its own partition succeeds (an upload id is only
+        // meaningful inside its own tenant), and B's own chunk then lands - so the 404s above are the partition
+        // boundary, not a route that is simply broken for B.
+        Assert.Equal(HttpStatusCode.OK, (await RegisterAsync(_httpB, id)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await PutChunkAsync(_httpB, id, 0, SecretAudioB)).StatusCode);
+    }
+
+    // ===== deny-by-default on every leg ============================================================
+
+    [Fact]
+    public async Task Every_utterance_leg_denies_an_authenticated_key_with_no_bound_tenant()
+    {
+        var id = Guid.NewGuid().ToString();
+
+        // An authenticated device whose key has no bound tenant is refused outright on all three legs on
+        // hosted - never quietly served the shared/Local root.
+        Assert.Equal(HttpStatusCode.Forbidden, (await RegisterAsync(_httpUnbound, id)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await PutChunkAsync(_httpUnbound, id, 0, SecretAudioB)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await CompleteAsync(_httpUnbound, id, totalChunks: 1)).StatusCode);
+
+        // Positive control: the same three calls from a BOUND key are not refused, so the 403s are the tenant
+        // deny and not a route broken for everyone.
+        Assert.NotEqual(HttpStatusCode.Forbidden, (await RegisterAsync(_httpA, id)).StatusCode);
+        Assert.NotEqual(HttpStatusCode.Forbidden, (await PutChunkAsync(_httpA, id, 0, SecretAudioA)).StatusCode);
+        Assert.NotEqual(HttpStatusCode.Forbidden, (await CompleteAsync(_httpA, id, totalChunks: 1)).StatusCode);
+    }
+
+    // ===== helpers =================================================================================
+
+    private static async Task<HttpResponseMessage> RegisterAsync(HttpClient http, string uploadId)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/wingman/utterance/upload");
+        req.Headers.Add("Idempotency-Key", uploadId);
+        return await http.SendAsync(req);
+    }
+
+    private static async Task<HttpResponseMessage> PutChunkAsync(HttpClient http, string uploadId, int index, string text)
+    {
+        using var content = new ByteArrayContent(Encoding.UTF8.GetBytes(text));
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        return await http.PutAsync($"/wingman/utterance/{uploadId}/chunk/{index}", content);
+    }
+
+    private static Task<HttpResponseMessage> CompleteAsync(HttpClient http, string uploadId, int totalChunks)
+        => http.PostAsJsonAsync($"/wingman/utterance/{uploadId}/complete", new { totalChunks });
+
+    private HttpClient NewClient(string deviceKey)
+    {
+        var http = new HttpClient
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/"),
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return http;
+    }
+
+    private static int FreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Issue1593FailedAttemptRebaselineTests.cs
+++ b/src/CcDirector.Gateway.Tests/Issue1593FailedAttemptRebaselineTests.cs
@@ -246,7 +246,7 @@ public sealed class Issue1593FailedAttemptRebaselineTests : IAsyncLifetime
 
     // ===== helpers =================================================================================
 
-    private static VoiceUploadStore Store() => new(CcStorage.DictationUploads());
+    private static VoiceUploadStore Store() => new(CcStorage.DictationUploads(), TenantId.Local);
 
     private SessionDto SessionAt(long bufferBytes) => new()
     {

--- a/src/CcDirector.Gateway.Tests/TranscribingSessionsTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscribingSessionsTenantIsolationTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.IO;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Transcription;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1884, Gap B: the Gateway-owned transcribing state is TENANT-KEYED, so one account can never set,
+/// clear, or read ANOTHER account's transcribing state by supplying that account's session id.
+///
+/// THE DEFECT THIS CLOSES. <see cref="TranscribingSessions"/> is a single process-wide instance shared by
+/// every tenant on the hosted Gateway, and it used to key both of its maps (the idle "Transcribing..." mark
+/// and the "actively transcribing" mark) on the BARE session id. A session id is a client-supplied GUID that
+/// travels in logs and retries - not a tenant boundary - so once the <c>/dictation</c> family was un-denied on
+/// hosted, tenant B could register with tenant A's session id and paint A's session orange for the idle
+/// window, or complete/abandon an id carrying A's session id and CLEAR A's real mark on a live dictation.
+///
+/// THE FIX, proven here two ways:
+///   1. <see cref="Set_clear_and_read_are_isolated_per_tenant_for_the_same_session_id"/> and
+///      <see cref="The_actively_transcribing_mark_is_isolated_per_tenant"/> drive
+///      <see cref="TranscribingSessions"/> directly with two tenants over ONE session id. Revert the keying
+///      (make the map key ignore the tenant) and these go RED: B would read A's mark, and B's clear would wipe
+///      A's mark.
+///   2. <see cref="A_hosted_tenants_pending_dictation_is_read_from_its_OWN_partition"/> and
+///      <see cref="Another_tenants_mark_never_colours_this_tenants_roster_row"/> drive the SAME
+///      <c>GatewayHost.DictationStatusFor</c> the live roster calls, with the REAL tenant-partitioned
+///      <see cref="VoiceUploadStore"/>. They prove the two halves of finding 2 together: the status is read
+///      from the CALLER'S partition (a hosted tenant's PENDING dictation is invisible through the Local/base
+///      handle), and a mark that belongs to another tenant never colours this tenant's row.
+/// </summary>
+public sealed class TranscribingSessionsTenantIsolationTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "transcribing-iso-" + Guid.NewGuid().ToString("N"));
+
+    // Two distinct MINTED account tenants (canonical lowercase GUIDs - the only shape VoiceUploadStore admits
+    // as a partition) plus the base/Local handle they both partition from.
+    private readonly TenantId _tenantA = new(Guid.NewGuid().ToString("D"));
+    private readonly TenantId _tenantB = new(Guid.NewGuid().ToString("D"));
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); }
+        catch (IOException) { /* a temp directory that outlives the test is not a test failure */ }
+    }
+
+    // ===== the mark itself, driven directly with two tenants over one session id ====================
+
+    [Fact]
+    public void Set_clear_and_read_are_isolated_per_tenant_for_the_same_session_id()
+    {
+        var marks = new TranscribingSessions();
+        var sid = Guid.NewGuid().ToString();
+
+        // A marks its own session transcribing.
+        marks.Begin(_tenantA, sid);
+
+        // A reads it (positive control); B - supplying A's very session id - does NOT (B cannot READ A's mark).
+        Assert.True(marks.IsTranscribing(_tenantA, sid));
+        Assert.False(marks.IsTranscribing(_tenantB, sid));
+
+        // B beginning ITS OWN mark on the same id does not touch A's view, and vice versa - the two are
+        // independent (B cannot SET into A's mark).
+        marks.Begin(_tenantB, sid);
+        Assert.True(marks.IsTranscribing(_tenantA, sid));
+        Assert.True(marks.IsTranscribing(_tenantB, sid));
+
+        // B ending the id clears only B's mark; A's is untouched (B cannot CLEAR A's mark).
+        marks.End(_tenantB, sid);
+        Assert.False(marks.IsTranscribing(_tenantB, sid));
+        Assert.True(marks.IsTranscribing(_tenantA, sid));
+
+        // A can still clear its own.
+        marks.End(_tenantA, sid);
+        Assert.False(marks.IsTranscribing(_tenantA, sid));
+    }
+
+    [Fact]
+    public void The_actively_transcribing_mark_is_isolated_per_tenant()
+    {
+        var marks = new TranscribingSessions();
+        var sid = Guid.NewGuid().ToString();
+
+        marks.MarkActivelyTranscribing(_tenantA, sid);
+
+        Assert.True(marks.IsActivelyTranscribing(_tenantA, sid));
+        Assert.False(marks.IsActivelyTranscribing(_tenantB, sid)); // B cannot read A's active mark
+
+        // B clearing the id clears only B's (nonexistent) mark; A's active mark stands.
+        marks.ClearActivelyTranscribing(_tenantB, sid);
+        Assert.True(marks.IsActivelyTranscribing(_tenantA, sid)); // B cannot clear A's active mark
+
+        marks.ClearActivelyTranscribing(_tenantA, sid);
+        Assert.False(marks.IsActivelyTranscribing(_tenantA, sid));
+    }
+
+    // ===== the roster-read seam, with the real tenant-partitioned store =============================
+
+    [Fact]
+    public void A_hosted_tenants_pending_dictation_is_read_from_its_OWN_partition()
+    {
+        // Finding 2: DictationStatusFor must read the CALLER'S partition, not the Local/base handle. A hosted
+        // tenant's PENDING dictation lives under base/tenants/<id>, which the base-root projection deliberately
+        // does not descend into - so reading through the base handle MISSES it.
+        var marks = new TranscribingSessions();
+        var basement = new VoiceUploadStore(_root, TenantId.Local);
+        var storeA = basement.ForTenant(_tenantA);
+
+        var sid = Guid.NewGuid().ToString();
+        var uploadId = Guid.NewGuid().ToString("N");
+        storeA.MarkPending(uploadId, sid); // a durable PENDING dictation in A's OWN partition
+        marks.Begin(_tenantA, sid);        // and a live progress mark, so the phase is "Uploading"
+
+        // Read through A's own partition (what the fixed wiring passes): the status is visible.
+        Assert.Equal(DictationPhase.Uploading,
+            GatewayHost.DictationStatusFor(_tenantA, sid, marks, storeA));
+
+        // Read through the Local/base handle (what a revert of finding 2 would pass): A's PENDING is under the
+        // tenants container, which the base projection skips, so the status is silently NULL. This is the
+        // assertion that reddens if DictationStatusFor is ever put back on the base handle.
+        Assert.Null(GatewayHost.DictationStatusFor(_tenantA, sid, marks, basement));
+    }
+
+    [Fact]
+    public void Another_tenants_mark_never_colours_this_tenants_roster_row()
+    {
+        // Finding 1 through the production seam. Both tenants hold a PENDING dictation for the SAME session id,
+        // but only A has a live progress mark. If the mark keying reverted to the bare session id, B - reading
+        // its own partition, which does hold a PENDING record - would pick up A's mark and paint "Uploading".
+        var marks = new TranscribingSessions();
+        var basement = new VoiceUploadStore(_root, TenantId.Local);
+        var storeA = basement.ForTenant(_tenantA);
+        var storeB = basement.ForTenant(_tenantB);
+
+        var sid = Guid.NewGuid().ToString();
+        storeA.MarkPending(Guid.NewGuid().ToString("N"), sid);
+        storeB.MarkPending(Guid.NewGuid().ToString("N"), sid);
+        marks.Begin(_tenantA, sid); // ONLY A is progressing
+
+        // A: PENDING + its own live mark -> Uploading.
+        Assert.Equal(DictationPhase.Uploading,
+            GatewayHost.DictationStatusFor(_tenantA, sid, marks, storeA));
+
+        // B: PENDING but NO mark of its own -> nothing. A's mark is not B's to read.
+        Assert.Null(GatewayHost.DictationStatusFor(_tenantB, sid, marks, storeB));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TranscribingSessionsTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscribingSessionsTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Transcription;
 using Xunit;
 
@@ -7,16 +8,20 @@ namespace CcDirector.Gateway.Tests;
 /// The Gateway-owned set of sessions whose dictated utterance is being transcribed in the
 /// background. It feeds the orange "Transcribing..." roster color. These tests cover the
 /// begin/end/idempotency contract and the stale-mark backstop that stops a crashed/offline client
-/// from wedging a session orange forever.
+/// from wedging a session orange forever. Every call is scoped to a tenant (issue #1884, Gap B); these
+/// single-tenant tests use <see cref="TenantId.Local"/>, the self-host identity. Cross-tenant isolation
+/// is proven separately in <see cref="TranscribingSessionsTenantIsolationTests"/>.
 /// </summary>
 public sealed class TranscribingSessionsTests
 {
+    private static readonly TenantId T = TenantId.Local;
+
     [Fact]
     public void IsTranscribing_UnknownSession_IsFalse()
     {
         var store = new TranscribingSessions();
 
-        Assert.False(store.IsTranscribing("sid-1"));
+        Assert.False(store.IsTranscribing(T, "sid-1"));
     }
 
     [Fact]
@@ -24,20 +29,20 @@ public sealed class TranscribingSessionsTests
     {
         var store = new TranscribingSessions();
 
-        store.Begin("sid-1");
+        store.Begin(T, "sid-1");
 
-        Assert.True(store.IsTranscribing("sid-1"));
+        Assert.True(store.IsTranscribing(T, "sid-1"));
     }
 
     [Fact]
     public void End_ClearsTheMark()
     {
         var store = new TranscribingSessions();
-        store.Begin("sid-1");
+        store.Begin(T, "sid-1");
 
-        store.End("sid-1");
+        store.End(T, "sid-1");
 
-        Assert.False(store.IsTranscribing("sid-1"));
+        Assert.False(store.IsTranscribing(T, "sid-1"));
     }
 
     [Fact]
@@ -45,11 +50,11 @@ public sealed class TranscribingSessionsTests
     {
         var store = new TranscribingSessions();
 
-        store.Begin("sid-1");
-        store.Begin("sid-1"); // second Begin must not throw or double-count
+        store.Begin(T, "sid-1");
+        store.Begin(T, "sid-1"); // second Begin must not throw or double-count
 
-        Assert.True(store.IsTranscribing("sid-1"));
-        Assert.False(store.IsTranscribing("sid-2")); // another session is untouched
+        Assert.True(store.IsTranscribing(T, "sid-1"));
+        Assert.False(store.IsTranscribing(T, "sid-2")); // another session is untouched
     }
 
     [Fact]
@@ -57,9 +62,9 @@ public sealed class TranscribingSessionsTests
     {
         var store = new TranscribingSessions();
 
-        store.End("never-began"); // must not throw
+        store.End(T, "never-began"); // must not throw
 
-        Assert.False(store.IsTranscribing("never-began"));
+        Assert.False(store.IsTranscribing(T, "never-began"));
     }
 
     [Fact]
@@ -67,11 +72,11 @@ public sealed class TranscribingSessionsTests
     {
         var now = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
         var store = new TranscribingSessions(() => now);
-        store.Begin("sid-1");
+        store.Begin(T, "sid-1");
 
         now = now.Add(TranscribingSessions.IdleTimeout); // exactly at the cap is still live
 
-        Assert.True(store.IsTranscribing("sid-1"));
+        Assert.True(store.IsTranscribing(T, "sid-1"));
     }
 
     [Fact]
@@ -79,14 +84,14 @@ public sealed class TranscribingSessionsTests
     {
         var now = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
         var store = new TranscribingSessions(() => now);
-        store.Begin("sid-1");
+        store.Begin(T, "sid-1");
 
         now = now.Add(TranscribingSessions.IdleTimeout).AddSeconds(1); // just past the cap
 
-        Assert.False(store.IsTranscribing("sid-1"));
+        Assert.False(store.IsTranscribing(T, "sid-1"));
         // The stale mark is removed, so a later read is still false even if the clock rewinds.
         now = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
-        Assert.False(store.IsTranscribing("sid-1"));
+        Assert.False(store.IsTranscribing(T, "sid-1"));
     }
 
     [Fact]
@@ -94,13 +99,13 @@ public sealed class TranscribingSessionsTests
     {
         var now = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
         var store = new TranscribingSessions(() => now);
-        store.Begin("sid-1");
+        store.Begin(T, "sid-1");
         now = now.Add(TranscribingSessions.IdleTimeout).AddMinutes(5);
-        Assert.False(store.IsTranscribing("sid-1")); // expired
+        Assert.False(store.IsTranscribing(T, "sid-1")); // expired
 
-        store.Begin("sid-1"); // a fresh Send re-marks with the current time
+        store.Begin(T, "sid-1"); // a fresh Send re-marks with the current time
 
-        Assert.True(store.IsTranscribing("sid-1"));
+        Assert.True(store.IsTranscribing(T, "sid-1"));
     }
 
     [Fact]
@@ -111,27 +116,27 @@ public sealed class TranscribingSessionsTests
         // total as long as progress keeps arriving (issue #1126).
         var now = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
         var store = new TranscribingSessions(() => now);
-        store.Begin("sid-1");
+        store.Begin(T, "sid-1");
 
         for (var step = 0; step < 5; step++)
         {
             now = now.Add(TranscribingSessions.IdleTimeout).Subtract(TimeSpan.FromSeconds(1)); // just shy of idle
-            store.Refresh("sid-1");
+            store.Refresh(T, "sid-1");
         }
 
-        Assert.True(store.IsTranscribing("sid-1")); // still live after 5x the idle window of active upload
+        Assert.True(store.IsTranscribing(T, "sid-1")); // still live after 5x the idle window of active upload
     }
 
     [Fact]
     public void Refresh_DoesNotResurrectAClearedMark()
     {
         var store = new TranscribingSessions();
-        store.Begin("sid-1");
-        store.End("sid-1");
+        store.Begin(T, "sid-1");
+        store.End(T, "sid-1");
 
-        store.Refresh("sid-1"); // must not re-mark a session that was already cleared
+        store.Refresh(T, "sid-1"); // must not re-mark a session that was already cleared
 
-        Assert.False(store.IsTranscribing("sid-1"));
+        Assert.False(store.IsTranscribing(T, "sid-1"));
     }
 
     [Fact]
@@ -139,8 +144,8 @@ public sealed class TranscribingSessionsTests
     {
         var store = new TranscribingSessions();
 
-        store.Refresh("never-began"); // must not throw or create a mark
+        store.Refresh(T, "never-began"); // must not throw or create a mark
 
-        Assert.False(store.IsTranscribing("never-began"));
+        Assert.False(store.IsTranscribing(T, "never-began"));
     }
 }

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreRequiredTenantTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreRequiredTenantTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The upload staging store is bound to a tenant AT CONSTRUCTION, and there is no way to construct one
+/// that is not.
+///
+/// This is a structural guarantee rather than a runtime check, and the distinction is the point. The
+/// partition itself (issue #1884) is enforced by the directory a store resolves to; that work assumed every
+/// store in existence had been given a tenant. Two public constructors could produce one WITHOUT being
+/// given a tenant, so the widest scope was the shape reached by writing the LEAST code - which is the
+/// inverse of what a reviewer's attention rewards, because there is nothing on the line to question.
+///
+/// Making the tenant a required argument removes the shape entirely: the failure mode is a BUILD ERROR at
+/// the call site of anyone who does not name a partition, so there is no unscoped store to guard, to
+/// enumerate, or to forget to guard. The tests below stand watch over that property so it cannot be
+/// re-opened by a well-meaning convenience overload, and pin the two runtime edges of construction that a
+/// compiler cannot decide: a struct default that never went through validation, and the partition a named
+/// account tenant actually lands in.
+/// </summary>
+public sealed class VoiceUploadStoreRequiredTenantTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "cc-required-tenant-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); }
+        catch (IOException) { }
+    }
+
+    /// <summary>
+    /// EVERY public way to construct this store names the partition it belongs to. This is the guard that
+    /// keeps the guarantee from quietly regressing: a convenience overload added later - a no-argument one,
+    /// or a root-only one - reddens here, at the moment it is written, rather than the first time a new
+    /// endpoint uses it against real accounts' audio.
+    /// </summary>
+    [Fact]
+    public void EveryPublicConstructor_RequiresATenant()
+    {
+        var constructors = typeof(VoiceUploadStore).GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+
+        Assert.NotEmpty(constructors);
+        foreach (var constructor in constructors)
+        {
+            var signature = string.Join(
+                ", ", constructor.GetParameters().Select(p => p.ParameterType.Name + " " + p.Name));
+            Assert.True(
+                constructor.GetParameters().Any(p => p.ParameterType == typeof(TenantId)),
+                $"Public constructor VoiceUploadStore({signature}) does not take a TenantId. "
+                + "An upload store must name its partition at construction; a store that can be built "
+                + "without one makes the widest scope the default.");
+        }
+    }
+
+    /// <summary>
+    /// A tenant that never went through validation is REFUSED, not silently read as the local partition.
+    /// <c>default(TenantId)</c> is the one value that reaches this type without its owner having decided
+    /// anything, because a struct default bypasses the validating constructor.
+    ///
+    /// The MESSAGE is asserted, not merely the exception type, and that is not decoration. Measured, not
+    /// assumed: with the validity check removed, an unresolved tenant still threw - from the partition-naming
+    /// rule further down, which refuses a null value because it is not a canonical identifier. Asserting only
+    /// the type therefore passed whether or not the check that is supposed to own this decision existed at
+    /// all, and could not tell the two apart. Pinning the message makes this test a canary for THAT check.
+    /// </summary>
+    [Fact]
+    public void Construction_WithAnUnresolvedTenant_IsRefusedByTheValidityCheck()
+    {
+        var error = Assert.Throws<ArgumentException>(() => new VoiceUploadStore(_root, default));
+
+        Assert.Contains("unresolved tenant is denied", error.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Naming an account tenant at construction puts the store INSIDE that tenant's partition - the same
+    /// directory the re-scoping path resolves - so the direct constructor is not a second, unpartitioned
+    /// way in.
+    /// </summary>
+    [Fact]
+    public void Construction_WithAnAccountTenant_StagesInsideThatTenantsPartition()
+    {
+        var tenant = new TenantId(Guid.NewGuid().ToString("D"));
+
+        var constructed = new VoiceUploadStore(_root, tenant);
+        var rescoped = new VoiceUploadStore(_root, TenantId.Local).ForTenant(tenant);
+
+        Assert.Equal(rescoped.Root, constructed.Root);
+        Assert.Equal(tenant, constructed.Tenant);
+        Assert.NotEqual(
+            Path.GetFullPath(_root).TrimEnd(Path.DirectorySeparatorChar),
+            Path.GetFullPath(constructed.Root).TrimEnd(Path.DirectorySeparatorChar));
+    }
+
+    /// <summary>
+    /// Naming the local tenant keeps the exact root self-host has always used: requiring the argument
+    /// changes what an author must WRITE, never where an existing install's audio lives.
+    /// </summary>
+    [Fact]
+    public void Construction_WithTheLocalTenant_KeepsTheRootUnchanged()
+    {
+        var store = new VoiceUploadStore(_root, TenantId.Local);
+
+        Assert.Equal(
+            Path.GetFullPath(_root).TrimEnd(Path.DirectorySeparatorChar),
+            Path.GetFullPath(store.Root).TrimEnd(Path.DirectorySeparatorChar));
+        Assert.True(store.Tenant.IsLocal);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTenantPartitionTests.cs
@@ -295,6 +295,32 @@ public sealed class VoiceUploadStoreTenantPartitionTests : IDisposable
             MustStillExist(a, id, "the sweep must not have destroyed another tenant's pending record").State);
     }
 
+    [Fact]
+    public void A_tenant_partition_sweep_removes_that_tenants_abandoned_upload_and_no_others()
+    {
+        // Issue #1884, finding 2: the voice-turn retention sweep now runs PER TENANT (GatewayHost wraps it in
+        // _tenantPass.ForEachTenant and sweeps ForTenant(tenant)). This proves the mechanism that wiring drives:
+        // ForTenant(A).SweepAbandoned removes A's OWN aged staging - which the base/Local sweep deliberately
+        // never descends into - while leaving B's staging untouched. Without the per-tenant sweep, a hosted
+        // tenant's interrupted utterance audio would be retained forever (only the base root was ever swept).
+        var a = _base.ForTenant(_tenantA);
+        var b = _base.ForTenant(_tenantB);
+        var agedA = Guid.NewGuid().ToString();
+        var liveB = Guid.NewGuid().ToString();
+        a.Register(agedA);
+        b.Register(liveB);
+
+        // A cutoff in the FUTURE (a negative max age) so "aged out" is deterministic without sleeping. Sweep
+        // A's partition: A's staging is removed; B's partition is a different root and is untouched.
+        Assert.Equal(1, a.SweepAbandoned(TimeSpan.FromDays(-1)));
+        Assert.False(a.Exists(agedA), "A's own partition sweep must remove A's aged staging");
+        Assert.True(b.Exists(liveB), "sweeping A's partition must not touch B's staging");
+
+        // Positive control that the per-tenant sweep is what removes B's too - the base sweep would not.
+        Assert.Equal(1, b.SweepAbandoned(TimeSpan.FromDays(-1)));
+        Assert.False(b.Exists(liveB));
+    }
+
     /// <summary>
     /// Read a record that the claim under test says MUST still be there, asserting its presence before
     /// touching it.

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTenantPartitionTests.cs
@@ -1,0 +1,313 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1884: <see cref="VoiceUploadStore"/> is PARTITIONED BY TENANT - the on-disk root and the record -
+/// so a caller-supplied upload id is only meaningful inside its own tenant.
+///
+/// This is the store half. The end-to-end proof that no LEG of the dictation front door can cross an account
+/// boundary lives in <c>DictationTenantIsolationTests</c>; what is pinned here is the partition those legs
+/// stand on: the directory that makes a cross-tenant read physically impossible, the second (record-borne)
+/// check behind it, and the two path aliases that would quietly re-merge two accounts into one folder.
+///
+/// THE PRODUCTION LINES THESE TESTS PROTECT (each revert-provable - revert it, watch these go red):
+///   - <c>VoiceUploadStore.PartitionRootFor</c> - return <c>_partitionBase</c> for every tenant and the
+///     isolation assertions go RED (two accounts share one folder again).
+///   - <c>VoiceUploadStore.IsMintedAccountTenant</c> - loosen it to a character allow-list and the
+///     traversal / casing-alias refusals go RED.
+///   - <c>VoiceUploadStore.BelongsHere</c> - the independent DISCLOSURE guard. Neuter it (<c>=&gt; true</c>)
+///     and a record physically present in the wrong partition is handed over; the foreign-record refusal
+///     goes RED.
+///   - <c>VoiceUploadStore.WriteRecordMarker</c>'s tenant stamp - a separate line with a DIFFERENT failure
+///     mode, and the distinction is worth keeping crisp. Drop the stamp while <c>BelongsHere</c> stays
+///     strict and nothing is disclosed: with the primary partition intact, account records simply become
+///     unattributed and are therefore REFUSED - a correctness and availability failure, not a disclosure
+///     one. It still earns its own proof, because the accepted design requires the persisted ownership
+///     stamp; it just must not be described as demonstrating cross-tenant disclosure.
+///   - The partition-container skip in <c>SweepAbandoned</c> - remove it and the sweep deletes every other
+///     tenant's staging in one pass, which that test goes RED on.
+///
+/// IF YOU ARE ADDING A PARTITION TEST HERE, READ THIS FIRST: A RED MUST BE AN ASSERTION, NEVER A CRASH.
+///
+/// Every test in this file is a canary for a specific mutation, and a canary only pays for itself if its
+/// red can NAME what it caught. A NullReferenceException or an input/output error means the mutation broke
+/// something before the test could ask its question. It still shows up as a red, which is why it is so
+/// easy to accept - but it is evidence that SOMETHING is wrong, not evidence about the line the mutation
+/// was aimed at. Counting it launders the mutation into a proof it did not earn.
+///
+/// Two ways that happens in a PARTITION test specifically, both of which have already bitten this file:
+///
+///  1. DEREFERENCING A RECORD THAT THE MUTATION DELETED. <c>store.ReadRecord(id)!.State</c> reads fine
+///     until a mutation makes the read return null, and then the test dies on the <c>!</c> instead of
+///     failing on the claim. Use <see cref="MustStillExist"/>: it asserts presence, with the sentence the
+///     test is actually making, before anything touches the record.
+///
+///  2. THE SETUP ITSELF THROWING - the subtler one, and the one that looks like an environment fault.
+///     Several tests here copy one tenant's record file into another tenant's partition to stage the
+///     mis-computed-root scenario. When a mutation COLLAPSES the partitions, those two paths become THE
+///     SAME PATH, and copying a file onto itself throws a file-in-use error. The test crashes during
+///     ARRANGE, before a single assertion runs, and the crash tells you nothing about the record check the
+///     test exists for. So ASK THE CROSS-BOUNDARY QUESTION FIRST: assert the two partition paths differ
+///     BEFORE the copy. The same mutation then reddens as a plain assertion that says the partitions
+///     collapsed - which is exactly what happened. That is why those <c>Assert.NotEqual</c> calls are
+///     ordered ahead of the <c>File.Copy</c> calls, and they must stay ahead of them.
+///
+/// The general rule both cases are instances of: put the assertion that states the boundary claim BEFORE
+/// any control, setup, or dereference that a broken boundary could make throw.
+/// </summary>
+public sealed class VoiceUploadStoreTenantPartitionTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "cc-upload-partition-" + Guid.NewGuid().ToString("N"));
+
+    private readonly VoiceUploadStore _base;
+
+    // Two tenants in exactly the form the real registry mints (a canonical lowercase GUID), because the
+    // store now enforces that shape - a made-up id would be testing a partition production cannot create.
+    private readonly TenantId _tenantA = new(Guid.NewGuid().ToString());
+    private readonly TenantId _tenantB = new(Guid.NewGuid().ToString());
+
+    public VoiceUploadStoreTenantPartitionTests() => _base = new VoiceUploadStore(_root, TenantId.Local);
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public void Self_host_keeps_the_exact_root_it_has_always_used()
+    {
+        // Self-host is the CONTROL for this whole change: the local tenant must resolve to the same directory
+        // as before, so nothing migrates and no upload moves.
+        Assert.Equal(_root, _base.Root);
+        Assert.Equal(_root, _base.ForTenant(TenantId.Local).Root);
+        Assert.True(_base.ForTenant(TenantId.Local).Tenant.IsLocal);
+
+        var id = Guid.NewGuid().ToString();
+        _base.Register(id);
+        Assert.True(Directory.Exists(Path.Combine(_root, Guid.Parse(id).ToString("N"))));
+        // And the local partition does not sprout a container it never had.
+        Assert.False(Directory.Exists(Path.Combine(_root, VoiceUploadStore.TenantPartitionDirectoryName)));
+    }
+
+    [Fact]
+    public async Task The_same_upload_id_is_two_different_uploads_in_two_tenants()
+    {
+        // The heart of the fix: an upload id is only meaningful INSIDE its tenant, so the SAME id is legal in
+        // both accounts at once and neither can see the other's staging.
+        var id = Guid.NewGuid().ToString();
+        var a = _base.ForTenant(_tenantA);
+        var b = _base.ForTenant(_tenantB);
+
+        a.Register(id);
+        await a.StoreChunkAsync(id, 0, Encoding.UTF8.GetBytes("alpha-audio"), null);
+
+        // Positive control in front of the absence claim: A really did stage bytes under this id.
+        Assert.True(a.Exists(id));
+        Assert.True(a.StagedBytes(id) > 0);
+
+        // Both directions. B does not see A's upload at all - not its bytes, not even its existence.
+        Assert.False(b.Exists(id));
+        Assert.Equal(0, b.StagedBytes(id));
+
+        b.Register(id);
+        await b.StoreChunkAsync(id, 0, Encoding.UTF8.GetBytes("bravo-audio"), null);
+
+        var assembledA = await a.AssembleAsync(id, 1);
+        var assembledB = await b.AssembleAsync(id, 1);
+        Assert.Equal("alpha-audio", Encoding.UTF8.GetString(assembledA.Audio!));
+        Assert.Equal("bravo-audio", Encoding.UTF8.GetString(assembledB.Audio!));
+
+        // ...and neither is the LOCAL partition's, which stays empty of this id entirely.
+        Assert.False(_base.Exists(id));
+    }
+
+    [Fact]
+    public void A_terminal_record_is_invisible_and_unresolvable_from_another_tenant()
+    {
+        // The concrete disclosure from the issue: after A completes upload id X, B posting the same id was
+        // handed A's terminal record - and therefore A's TRANSCRIPT.
+        var id = Guid.NewGuid().ToString();
+        var a = _base.ForTenant(_tenantA);
+        var b = _base.ForTenant(_tenantB);
+
+        a.MarkDelivered(id, submitted: true, movedOn: false, transcript: "alpha-secret-transcript");
+
+        // Positive control: A reads its own terminal record back, so the absence claim below is not passing
+        // because nothing was ever written.
+        var mine = a.ReadRecord(id);
+        Assert.NotNull(mine);
+        Assert.Equal("alpha-secret-transcript", mine!.Transcript);
+        Assert.Equal(_tenantA.Value, mine.Tenant);
+
+        Assert.Null(b.ReadRecord(id));
+        Assert.Null(_base.ReadRecord(id));
+
+        // The mirror direction, on the same id: B's own terminal record is equally invisible to A.
+        //
+        // Read through MustStillExist rather than dereferencing with `!`. Under a mutation that collapses the
+        // partitions, B's write lands on A's record and A's read then returns null - and a bare `!` turns that
+        // into a NullReferenceException, which is a CRASH, not a proof. A crash says "something upstream
+        // broke"; it does not say "A's transcript survived B writing", which is the claim on this line. Asked
+        // by assertion, the same mutation reddens here with that sentence.
+        b.MarkDelivered(id, submitted: true, movedOn: false, transcript: "bravo-secret-transcript");
+        Assert.Equal("bravo-secret-transcript",
+            MustStillExist(b, id, "B's own terminal record must be readable in B's partition").Transcript);
+        Assert.Equal("alpha-secret-transcript",
+            MustStillExist(a, id, "A's transcript must survive B writing the same upload id").Transcript);
+    }
+
+    [Fact]
+    public void A_record_carrying_another_tenant_is_refused_even_inside_this_partition()
+    {
+        // The second, independent check. The directory already makes this unreachable, which is exactly why
+        // it must be tested directly: if a partition root were ever mis-computed, the record itself still
+        // refuses to be handed to the wrong account rather than silently disclosing a transcript.
+        var id = Guid.NewGuid().ToString();
+        var a = _base.ForTenant(_tenantA);
+        var b = _base.ForTenant(_tenantB);
+
+        a.MarkDelivered(id, submitted: true, movedOn: false, transcript: "alpha-secret-transcript");
+        b.Register(id);
+
+        // Physically place A's record file inside B's partition - the mis-computed-root scenario.
+        var aFile = Path.Combine(a.Root, Guid.Parse(id).ToString("N"), "record.json");
+        var bFile = Path.Combine(b.Root, Guid.Parse(id).ToString("N"), "record.json");
+
+        // ASK THE CROSS-BOUNDARY QUESTION FIRST - see the class comment. Under a mutation that collapses
+        // the partitions these are the SAME path, and File.Copy of a file onto itself throws during ARRANGE,
+        // before any assertion runs, which proves nothing about the record check this test exists for.
+        // Asserting the paths differ turns that mutation into a red that says the partitions collapsed.
+        // This line must stay AHEAD of the copy.
+        Assert.NotEqual(aFile, bFile);
+        File.Copy(aFile, bFile, overwrite: true);
+
+        // Positive control: the file really is there and really is A's, so the refusal below is a refusal and
+        // not a missing file.
+        Assert.Contains("alpha-secret-transcript", File.ReadAllText(bFile));
+
+        Assert.Null(b.ReadRecord(id));
+
+        // The same check on the PENDING projection, which reads records by enumeration rather than by id: a
+        // foreign pending record planted in this partition must not lock a session here either.
+        var pendingId = Guid.NewGuid().ToString();
+        var sessionA = Guid.NewGuid().ToString();
+        a.Register(pendingId);
+        a.MarkPending(pendingId, sessionA);
+        Assert.True(a.IsSessionLocked(sessionA));  // positive control
+        b.Register(pendingId);
+        var aPending = Path.Combine(a.Root, Guid.Parse(pendingId).ToString("N"), "record.json");
+        var bPending = Path.Combine(b.Root, Guid.Parse(pendingId).ToString("N"), "record.json");
+        // Ahead of the copy for the reason in the class comment: under a collapse these are the same path
+        // and File.Copy would throw during setup, laundering the mutation into a crash-red.
+        Assert.NotEqual(aPending, bPending);
+        File.Copy(aPending, bPending, overwrite: true);
+        Assert.False(b.IsSessionLocked(sessionA));
+    }
+
+    [Fact]
+    public void The_session_lock_projection_never_crosses_tenants()
+    {
+        var idA = Guid.NewGuid().ToString();
+        var idB = Guid.NewGuid().ToString();
+        var sessionA = Guid.NewGuid().ToString();
+        var sessionB = Guid.NewGuid().ToString();
+        var a = _base.ForTenant(_tenantA);
+        var b = _base.ForTenant(_tenantB);
+
+        a.Register(idA);
+        a.MarkPending(idA, sessionA);
+        b.Register(idB);
+        b.MarkPending(idB, sessionB);
+
+        // Positive controls first: each account's own pending upload does lock its own session.
+        Assert.True(a.IsSessionLocked(sessionA));
+        Assert.True(b.IsSessionLocked(sessionB));
+
+        // Both directions: neither account's pending upload can lock (or be seen by) the other.
+        Assert.False(a.IsSessionLocked(sessionB));
+        Assert.False(b.IsSessionLocked(sessionA));
+        Assert.DoesNotContain(sessionB, a.LockedSessionIds());
+        Assert.DoesNotContain(sessionA, b.LockedSessionIds());
+        // The local partition sees neither, which is the self-host control.
+        Assert.Empty(_base.LockedSessionIds());
+    }
+
+    [Theory]
+    // The traversal alias: combining the base root with "tenants" and ".." canonicalizes to exactly the base
+    // root - the LOCAL partition - so a character allow-list that accepts ".." merges an account into it.
+    [InlineData("..")]
+    [InlineData("../..")]
+    [InlineData("a/b")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-guid")]
+    // The reserved system identity: no recorded audio belongs to it, so the safe answer is no partition.
+    [InlineData("system")]
+    public void A_tenant_id_that_is_not_a_minted_account_is_refused_not_normalised(string value)
+    {
+        // A blank value cannot even construct a TenantId, which is the same refusal one layer earlier.
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            Assert.Throws<ArgumentException>(() => new TenantId(value));
+            return;
+        }
+        Assert.Throws<ArgumentException>(() => _base.ForTenant(new TenantId(value)));
+    }
+
+    [Fact]
+    public void An_uppercase_spelling_of_a_minted_tenant_is_refused_rather_than_folded()
+    {
+        // The casing alias, and the reason refusing beats normalising: Windows and Azure Files name the SAME
+        // directory for both spellings, while the tenants table treats them as DIFFERENT identities. Folding
+        // the case would hand two identities one folder full of audio; refusing keeps them apart.
+        var upper = new TenantId(_tenantA.Value.ToUpperInvariant());
+        Assert.Throws<ArgumentException>(() => _base.ForTenant(upper));
+    }
+
+    [Fact]
+    public void Sweeping_the_local_partition_never_touches_another_tenants_staging()
+    {
+        // The container holding the other partitions is not an upload. Age-sweeping it would delete every
+        // other account's staged audio in one pass - the loudest possible cross-tenant write.
+        var id = Guid.NewGuid().ToString();
+        var a = _base.ForTenant(_tenantA);
+        a.Register(id);
+        a.MarkPending(id, Guid.NewGuid().ToString());
+
+        // Positive control: the sweep really does run and really does remove an aged LOCAL upload, so the
+        // survival assertion below is not passing because the sweep did nothing at all.
+        // A cutoff in the FUTURE (a negative max age), so "aged out" is deterministic without sleeping.
+        var localId = Guid.NewGuid().ToString();
+        _base.Register(localId);
+        Assert.Equal(1, _base.SweepAbandoned(TimeSpan.FromDays(-1)));
+        Assert.False(_base.Exists(localId));
+
+        Assert.True(a.Exists(id));
+        Assert.Equal(DictationDeliveryState.Pending,
+            MustStillExist(a, id, "the sweep must not have destroyed another tenant's pending record").State);
+    }
+
+    /// <summary>
+    /// Read a record that the claim under test says MUST still be there, asserting its presence before
+    /// touching it.
+    ///
+    /// This exists so a mutation reddens by ASSERTION rather than by CRASH. Dereferencing with <c>!</c> turns
+    /// an absent record into a NullReferenceException, and a NullReferenceException is not evidence about the
+    /// line the test was aimed at - it only says something upstream broke before the test could ask its
+    /// question. Every red has to be able to name what it caught.
+    /// </summary>
+    private static DictationDeliveryRecord MustStillExist(VoiceUploadStore store, string uploadId, string claim)
+    {
+        var record = store.ReadRecord(uploadId);
+        Assert.True(record is not null, claim + " (the record was absent)");
+        return record!;
+    }
+}

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Voice;
 using Xunit;
 
@@ -14,7 +15,7 @@ public sealed class VoiceUploadStoreTests : IDisposable
     private readonly string _root = Path.Combine(Path.GetTempPath(), "cc-upload-" + Guid.NewGuid().ToString("N"));
     private readonly VoiceUploadStore _store;
 
-    public VoiceUploadStoreTests() => _store = new VoiceUploadStore(_root);
+    public VoiceUploadStoreTests() => _store = new VoiceUploadStore(_root, TenantId.Local);
 
     public void Dispose()
     {
@@ -329,7 +330,7 @@ public sealed class VoiceUploadStoreTests : IDisposable
         await _store.StoreChunkAsync(id, 1, Bytes("BBB"), null);
         await _store.StoreChunkAsync(id, 2, Bytes("CCC"), null);
 
-        var afterRestart = new VoiceUploadStore(_root);
+        var afterRestart = new VoiceUploadStore(_root, TenantId.Local);
         Assert.True(afterRestart.IsPending(id));
         var result = await afterRestart.AssembleAsync(id, 3);
         Assert.Equal("ok", result.Status);
@@ -352,7 +353,7 @@ public sealed class VoiceUploadStoreTests : IDisposable
         Assert.True(File.Exists(Path.Combine(dir, "record.json"))); // marker kept
         Assert.False(_store.IsPending(id), "a delivered upload is terminal, not pending");
 
-        var afterRestart = new VoiceUploadStore(_root);
+        var afterRestart = new VoiceUploadStore(_root, TenantId.Local);
         var record = afterRestart.ReadRecord(id);
         Assert.NotNull(record);
         Assert.Equal(DictationDeliveryState.Delivered, record!.State);
@@ -371,7 +372,7 @@ public sealed class VoiceUploadStoreTests : IDisposable
         _store.MarkAbandoned(id, "user cancelled");
 
         Assert.False(_store.IsPending(id), "an abandoned upload is terminal, not pending");
-        var record = new VoiceUploadStore(_root).ReadRecord(id);
+        var record = new VoiceUploadStore(_root, TenantId.Local).ReadRecord(id);
         Assert.NotNull(record);
         Assert.Equal(DictationDeliveryState.Abandoned, record!.State);
         Assert.False(record.Submitted);
@@ -487,7 +488,7 @@ public sealed class VoiceUploadStoreTests : IDisposable
         Assert.True(_store.IsSessionLocked(sid), "a PENDING record locks its session");
         Assert.False(_store.IsSessionLocked(Guid.NewGuid().ToString()), "an unrelated session is not locked");
         // Restart-safe: a fresh store over the same root recomputes the lock from disk.
-        Assert.True(new VoiceUploadStore(_root).IsSessionLocked(sid));
+        Assert.True(new VoiceUploadStore(_root, TenantId.Local).IsSessionLocked(sid));
     }
 
     [Fact]
@@ -560,7 +561,7 @@ public sealed class VoiceUploadStoreTests : IDisposable
 
         var values = Enumerable.Range(1, 64).Select(i => (long)i * 1_000).ToArray();
         var shuffled = values.OrderBy(v => (v * 7919) % 101).ToArray();
-        Parallel.ForEach(shuffled, v => new VoiceUploadStore(_root).RecordFailedDeliveryBaseline(uploadId, v));
+        Parallel.ForEach(shuffled, v => new VoiceUploadStore(_root, TenantId.Local).RecordFailedDeliveryBaseline(uploadId, v));
 
         Assert.Equal(values.Max(), _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
     }
@@ -591,7 +592,7 @@ public sealed class VoiceUploadStoreTests : IDisposable
             // this re-baseline writes. The gate is what must stop it; nothing else here does.
             competing = Task.Run(() =>
             {
-                new VoiceUploadStore(_root).MarkDelivered(uploadId, submitted: true, movedOn: false, transcript: "delivered words");
+                new VoiceUploadStore(_root, TenantId.Local).MarkDelivered(uploadId, submitted: true, movedOn: false, transcript: "delivered words");
                 tombstoneLanded.Set();
             });
             // A bounded wait, NOT a barrier: under the gate this must time out (the tombstone is blocked behind

--- a/src/CcDirector.Gateway/Api/DictationTenantGate.cs
+++ b/src/CcDirector.Gateway/Api/DictationTenantGate.cs
@@ -1,0 +1,110 @@
+using System.Diagnostics.CodeAnalysis;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Voice;
+using Microsoft.AspNetCore.Http;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The ONE door onto the dictation upload staging, and the reason a dictation leg can no longer be written
+/// unscoped (issue #1884).
+///
+/// THE DEFECT SHAPE THIS REMOVES. Every dictation leg used to be scoped by hand:
+///
+///   <code>
+///   if (ResolveTenant(ctx, tenantBoundary) is not { } tenant) return NoTenantResult();
+///   var store = uploads.ForTenant(tenant);
+///   </code>
+///
+/// Two lines, repeated five times, with the raw un-partitioned <see cref="VoiceUploadStore"/> sitting in
+/// scope beside them. That is not one safeguard used five times - it is FIVE INDEPENDENT CHANCES TO FORGET.
+/// Any one leg could drop its <c>ForTenant</c> while the tenant boundary and the partition computation both
+/// stayed perfectly correct, and that leg alone would then read, overwrite, retire or discard another
+/// account's recorded audio and its transcript. Nothing would fail to compile and nothing would fail loud.
+/// The realistic version of that defect is not someone editing an existing leg: it is the SIXTH leg somebody
+/// adds next month, who will never read any of the reasoning that surrounds these five.
+///
+/// So the fix is not to prove the five legs correct today. It is to make the mistake INEXPRESSIBLE:
+/// <see cref="GatewayDictationEndpoint.Map"/> does not take a <see cref="VoiceUploadStore"/> at all. It takes
+/// this gate. There is no unscoped store in scope anywhere in that file, so "forget to scope this leg" stops
+/// being something a person can type - a new leg has nothing to call except <see cref="TryOpen"/>, and
+/// <see cref="TryOpen"/> cannot hand back an unscoped store. A guarantee held by the type system does not
+/// depend on the next author knowing why it matters.
+///
+/// It also folds the DENY into the same call. Resolving a tenant and refusing when there is none are one
+/// decision, and splitting them across two statements is what let a leg keep the resolve and lose the scope.
+/// Here a caller that does not check the return value has no store to use.
+///
+/// EXACTLY WHAT CARRIES THE GUARANTEE, stated precisely because the exemption from per-leg proof was granted
+/// on structural impossibility and a reader who finds a looser signature will rightly doubt the rest.
+///
+/// What is shown: <see cref="GatewayDictationEndpoint.Map"/> does not accept or capture a
+/// <see cref="VoiceUploadStore"/>, no unscoped store IDENTIFIER exists anywhere in that file, and the five
+/// legs can obtain a store only from <see cref="TryOpen"/>, which cannot return an unscoped one.
+///
+/// What is NOT shown: that an unscoped store could not be PASSED. Two private helpers on the completion path
+/// (<c>RunCompleteCoreAsync</c> and <c>MapNonOkTranscription</c>) still take a bare
+/// <see cref="VoiceUploadStore"/> in their signatures and would accept an unscoped one if such a store were
+/// ever in reach. Today none can be: this gate PRIVATELY OWNS the only raw store and hands out nothing but
+/// partitioned views. So the property holds by THIS TYPE'S ENCAPSULATION, not by the type system at those two
+/// signatures. Both statements are true; only the first was proved by inspection, and they are different
+/// claims.
+///
+/// The stronger form - give <see cref="TryOpen"/> a distinct scoped-handle type, constructible only here, and
+/// take THAT in the two helpers - would move the guarantee into the type system, where it would survive
+/// someone later making a raw store reachable for an unrelated reason. It is deliberately NOT done in this
+/// change: the structure above has been independently inspected and is what the mutation proof runs against,
+/// and altering it now would mean proving something other than what was validated. Worth doing next, when it
+/// is not racing a proof.
+/// </summary>
+internal sealed class DictationTenantGate
+{
+    private readonly VoiceUploadStore _uploads;
+    private readonly Tenancy.HostedTenantBoundary? _boundary;
+
+    /// <param name="uploads">
+    /// The base staging store. Held PRIVATELY and never handed out un-partitioned - that is the whole point
+    /// of this type, and it is why the endpoint takes the gate rather than the store.
+    /// </param>
+    /// <param name="boundary">
+    /// The hosted tenant boundary. Required, so omitting it is a compile error rather than a silent runtime
+    /// downgrade to the shared self-host root. It is still checked for null at the moment of use, because a
+    /// test can force one through to reproduce the miswire and must be refused on hosted even so.
+    /// </param>
+    internal DictationTenantGate(VoiceUploadStore uploads, Tenancy.HostedTenantBoundary boundary)
+    {
+        _uploads = uploads ?? throw new ArgumentNullException(nameof(uploads));
+        _boundary = boundary;
+    }
+
+    /// <summary>
+    /// Open this request's own partition of the dictation staging, or refuse.
+    ///
+    /// Returns true with a store bound to the caller's tenant, or false with the 403 the caller must return.
+    /// On the hosted Gateway a missing boundary, a boundary that is not hosted-wired, and an authenticated key
+    /// with no bound tenant are ALL refusals - never the local partition, never the reserved system tenant.
+    /// Off hosted mode every authenticated caller is the single local tenant, exactly as before.
+    ///
+    /// The out-parameter shape is deliberate: there is no way to obtain the store except through the branch
+    /// that has already proven a tenant, so the check cannot be separated from the use.
+    /// </summary>
+    internal bool TryOpen(
+        HttpContext ctx,
+        [NotNullWhen(true)] out VoiceUploadStore? store,
+        out TenantId tenant,
+        [NotNullWhen(false)] out IResult? deny)
+    {
+        if (GatewayDictationEndpoint.ResolveTenant(ctx, _boundary) is not { } resolved)
+        {
+            store = null;
+            tenant = default;
+            deny = GatewayDictationEndpoint.NoTenantResult();
+            return false;
+        }
+
+        store = _uploads.ForTenant(resolved);
+        tenant = resolved;
+        deny = null;
+        return true;
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -6,7 +6,6 @@ using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
 using CcDirector.Gateway.HostedAi;
-using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.Transcription;
 using CcDirector.Gateway.Util;
 using CcDirector.Gateway.Voice;
@@ -41,31 +40,25 @@ namespace CcDirector.Gateway.Api;
 /// <see cref="AuthMiddleware.HasValidToken"/> so it holds even when the production tray Gateway runs with
 /// the global auth middleware off.
 ///
-/// DENIED IN WHOLE ON HOSTED (issue #1884). This is the SIBLING of the utterance upload family denied in
-/// <see cref="GatewayWingmanVoiceEndpoint"/> under issue #1896 - a different route family standing on the
-/// same <see cref="VoiceUploadStore"/> shape, with the same defect: one on-disk root shared across every
-/// account, every directory and record and chunk keyed SOLELY by the caller-supplied upload id, a
-/// <c>DictationDeliveryRecord</c> that carries no tenant, and a static <c>_completes</c> cache keyed solely
-/// by that same id.
+/// TENANT-KEYED (issue #1884). Authenticating a DEVICE is not the same as authorizing an UPLOAD. Every leg -
+/// upload, chunk, complete, ack, abandon - now resolves the request's tenant from the authenticated device
+/// key and works ONLY inside that tenant's partition of <see cref="VoiceUploadStore"/>, and the two static
+/// in-memory caches below are keyed by tenant as well as upload id. Before this, an upload id was the whole
+/// key: after account A completed upload id X, account B posting with <c>Idempotency-Key: X</c> was handed
+/// A's terminal record - and A's TRANSCRIPT - and before A reached a terminal state B could overwrite A's
+/// chunks, ack or abandon A's record, or race its completion. A GUID is not a tenant boundary; upload ids
+/// travel in client logs, retries and store-and-forward queues.
 ///
-/// The disclosure is live and needs no session: after account A completes upload id X, account B posts
-/// /dictation/upload with <c>Idempotency-Key: X</c>, the terminal-register short-circuit reads A's record,
-/// and B is handed A's TRANSCRIPT. That leg never looks a session up, so the fact that /complete's session
-/// lookup already fails on hosted does not contain it. Before A reaches a terminal state, B can also
-/// overwrite A's chunks, or ack or abandon A's record.
-///
-/// A caller-supplied identifier is not a tenant boundary. Secrecy of an identifier is not authorization,
-/// and upload ids travel through client logs, retries and store-and-forward queues.
-///
-/// The whole family, not only the leg that hands text back: ack and abandon destroy another account's
-/// in-flight recording, which is the same missing boundary with a different consequence. It is a deny
-/// rather than a partition because the records carry no tenant to partition BY - partitioning the store is
-/// issue #1884's job, and un-denying is gated on it. It refuses rather than reporting an empty or dropped
-/// upload, because "your dictation was dropped" is a FALSE statement where a refusal is merely absent.
-///
-/// Self-host is COMPLETELY unchanged, and that is the control. Self-host has one tenant, so the shared root
-/// is the owner's own root and the phone's durable store-and-forward dictation lane behaves exactly as it
-/// always has.
+/// WORKS ON HOSTED, TENANT-SCOPED (issue #1884, un-deny). The family is no longer refused on the hosted
+/// Gateway: the five legs are mapped through <see cref="DictationTenantGate"/>, which resolves the request's
+/// tenant from the authenticated device key and hands each leg a store bound to that tenant's partition -
+/// fail-closed with 403 when no tenant resolves, never the shared/Local root. The completion's session
+/// LOCATE is scoped to that same request tenant (see <see cref="RunCompleteCoreAsync"/>), which is what makes
+/// dictation actually deliver on hosted rather than merely stop refusing: a hosted session is found in its
+/// own account's partition and never another's. Self-host resolves Local throughout and is byte-identical to
+/// before. The pre-partition shared root cannot be served to a hosted account tenant - it lives at the base
+/// root, which only the Local partition names, and Local is refused on hosted - and the store additionally
+/// quarantines any unattributable legacy staging on load (see <see cref="VoiceUploadStore"/>).
 /// </summary>
 internal static class GatewayDictationEndpoint
 {
@@ -74,139 +67,131 @@ internal static class GatewayDictationEndpoint
     // (non-resumed) sends always inject; the 1-hour staging sweep is the hard backstop for staleness.
     private const long MovedOnBufferGrowthBytes = 512;
 
-    // In-memory single-flight for complete, keyed by uploadId: concurrent or retried completes await the
-    // SAME in-flight work so the turn is submitted at most once WHILE this instance holds the entry. The
-    // entry is dropped as soon as the work settles - the DURABLE de-dupe (a delivered/abandoned upload id
-    // never re-injecting, past any age and across a restart) is owned by the on-disk delivery record
-    // (issue #1183), not by this cache, so there is no age-swept idempotency window to reopen the hole.
+    // In-memory single-flight for complete, keyed by TENANT AND uploadId: concurrent or retried completes
+    // await the SAME in-flight work so the turn is submitted at most once WHILE this instance holds the
+    // entry. The entry is dropped as soon as the work settles - the DURABLE de-dupe (a delivered/abandoned
+    // upload id never re-injecting, past any age and across a restart) is owned by the on-disk delivery
+    // record (issue #1183), not by this cache, so there is no age-swept idempotency window to reopen the
+    // hole.
+    //
+    // The TENANT in the key is issue #1884. This dictionary is static (process-wide) and used to be keyed by
+    // upload id alone, so whichever account's complete arrived first supplied the cached run to every other
+    // account posting that id - handing one account's transcript to another through a purely in-memory path
+    // that no on-disk partition can guard. The store partition and this key are two separate defences and
+    // both are needed: the same upload id is now perfectly legal in two tenants at once.
     private sealed record CompleteEntry(Lazy<Task<DictationOutcome>> Task);
-    private static readonly ConcurrentDictionary<string, CompleteEntry> _completes = new();
+    private static readonly TenantKeyedCache<CompleteEntry> _completes = new();
 
-    // uploadId -> sessionId, captured at register so the chunk handler (which only has the uploadId)
-    // can refresh the session's orange "Transcribing..." heartbeat as chunks stream in (issue #1126).
-    // Pruned when the upload reaches a terminal completion; a leaked entry for a never-completed upload
-    // is a single guid-pair and is bounded by real abandoned-upload volume.
-    private static readonly ConcurrentDictionary<string, string> _uploadSids = new();
-
-    /// <summary>The exclusive prefix the dictation upload route group owns outright on hosted.</summary>
-    internal const string Prefix = "/dictation";
-
-    /// <summary>The single error string the hosted refusal serves. Held here so a test can assert against the
-    /// exact string that is served rather than a copy that could drift.</summary>
-    internal const string RefusalMessage = "dictation upload is not available on the hosted gateway";
+    // (tenant, uploadId) -> sessionId, captured at register so the chunk handler (which only has the
+    // uploadId) can refresh the session's orange "Transcribing..." heartbeat as chunks stream in (issue
+    // #1126). Pruned when the upload reaches a terminal completion; a leaked entry for a never-completed
+    // upload is a single guid-pair and is bounded by real abandoned-upload volume. Tenant-keyed for the same
+    // reason as _completes: it is static, and a session id is not one account's to hand to another.
+    private static readonly TenantKeyedCache<string> _uploadSids = new();
 
     /// <summary>
-    /// The hosted refusal payload for the whole /dictation upload family (issue #1884). Validated on
-    /// construction, so a blank field fails the Gateway at startup rather than serving a refusal a caller
-    /// cannot act on. 404 rather than 403: on hosted this upload family does not exist as a concept - an
-    /// upload id is meaningless without a tenant to scope it to, and the store has none - so "not here" is
-    /// the truthful answer; 403 would imply the right credential could reach it, and none can. Driven off
-    /// <see cref="GatewayHostedMode.IsHosted"/> inside the primitive - the INDEPENDENT deployment signal, not
-    /// an optional argument a caller can omit and thereby fail OPEN.
+    /// A process-wide cache whose key CANNOT be composed without a tenant.
     ///
-    /// UN-DENY CONDITION. Two SEPARATE questions, because answering only the first is how a deny gets
-    /// mistaken for a clean slate.
-    ///
-    /// (a) DOES ANYTHING STILL WRITE IT? No, and NO OFF-ROUTE WRITER NEEDS A HOST-GATE HERE. Checked by
-    /// sweeping the COMPLETE MUTATING SURFACE of the state rather than the routes that touch it: every
-    /// <c>VoiceUploadStore</c> construction in the repository, then every production caller of every mutating
-    /// method on the type, and finally any raw file writer into the root that bypasses the type. The only
-    /// production instance on the dictation-uploads root is the one <c>GatewayHost</c> holds as
-    /// <c>_dictationUploads</c>, which reaches this endpoint plus one READ-only status query
-    /// (<c>DictationStatusFor</c>); Core's <c>DictationLockReader</c> also only reads. Every mutation -
-    /// register, mark pending, store chunk, assemble, delete, mark delivered, mark failed, clear failed,
-    /// record baseline, acknowledge, mark abandoned - is inside this refused group or inside a private helper
-    /// (<c>RunCompleteCoreAsync</c>, <c>MapNonOkTranscription</c>) whose only caller is the completion leg,
-    /// which is itself refused. The static <c>_completes</c> cache is filled only by that same leg.
-    /// <c>SweepAbandoned</c> has no production caller. Nothing writes the root outside the store. The only
-    /// residual write is the constructor ensuring the directory exists: an empty directory, never content. So
-    /// with the routes refused, no writer to this store reaches it on hosted - there is no OFF-route writer
-    /// to gate (unlike the transcription-telemetry and wingman-training stores, whose writers fire from
-    /// undenied paths and are host-gated at the writer).
-    ///
-    /// (b) WHAT ALREADY EXISTS? A SEPARATE QUESTION, and it is not answered by (a). NO NEW WRITES IS A
-    /// STATEMENT ABOUT THE FUTURE, NOT EVIDENCE ABOUT THE PAST. The shared dictation-uploads root may hold
-    /// pre-deny cross-tenant staged audio, delivery records and transcripts. SO THE UN-DENY STILL REQUIRES
-    /// PURGING OR QUARANTINING THE LEGACY ROOT, on top of issue #1884's tenant-keying of the store, the
-    /// record and the <c>_completes</c> cache.
-    ///
-    /// NOTE THE BOUNDARY OF THE (a) CLAIM: it is about THIS store. A completed dictation also writes a turn
-    /// into the shared transcription telemetry log - but that writer is now host-gated in
-    /// <c>GatewayTranscriptionService.RecordTelemetry</c>, so it too stops on hosted (see the un-deny
-    /// condition on <c>TranscriptionAnalysisEndpoint</c>).
-    ///
-    /// HOW THE DENY IS EXPRESSED - THE SHARED REFUSAL PRIMITIVE, NOT A BESPOKE FILTER. This group is denied
-    /// through <see cref="HostedRouteDeny.ExclusiveGroup"/>, the ONE hosted-refusal boundary every deny
-    /// family on this Gateway adopts (reference implementation: the key-vault deny in pull request #1904). An
-    /// earlier revision rolled its own <c>AddEndpointFilter</c> deny before the primitive existed; it has
-    /// been replaced. The family owns the <c>/dictation</c> prefix OUTRIGHT - nothing else serves beneath it
-    /// - so on hosted the five handlers are NEVER MAPPED and ONE verb-less catch-all refuses everything under
-    /// the prefix plus a root refusal at the prefix itself, covering every verb, every request shape, and
-    /// every future sub-path for free. The exclusivity claim is CHECKED at startup by
-    /// <see cref="HostedRefusalRouteSpace.ValidateBeforeStart"/>. Off hosted the primitive maps the five real
-    /// handlers exactly as an unguarded builder would - self-host unchanged.
+    /// Same reasoning as <see cref="DictationTenantGate"/>, applied to the in-memory half. These two caches
+    /// are static, so a key that omits the tenant hands one account's in-flight completion - and its
+    /// transcript - to another through a path no on-disk partition can guard. When they were raw
+    /// dictionaries keyed by a string the caller built, every use site was another chance to build that
+    /// string without the tenant. Here the tenant is a required PARAMETER of every operation and the key is
+    /// composed inside, so an un-tenanted key is not something a call site can express - including the call
+    /// site somebody adds next month.
     /// </summary>
-    private static HostedDenial Denial() => new(
-        family: "dictation-upload",
-        message: RefusalMessage,
-        reason: "the dictation upload store keys every directory, record and chunk SOLELY by the caller-supplied " +
-                "upload id under one on-disk root shared across every account, and a re-register of another " +
-                "account's upload id short-circuits on its terminal tombstone and hands back that account's " +
-                "transcript with no session lookup in the way - so a caller-supplied id is not a tenant boundary",
-        unDenyInstruction: "do NOT simply remove this deny: tenant-key the store, the delivery record and the " +
-                "_completes cache, THEN purge or quarantine the pre-existing shared dictation-uploads root " +
-                "(pre-deny cross-tenant staged audio, records and transcripts are already in it and this change " +
-                "never touched them), and only then restore a tenant-scoped route",
-        statusCode: StatusCodes.Status404NotFound);
+    private sealed class TenantKeyedCache<T>
+    {
+        private readonly ConcurrentDictionary<string, T> _map = new();
+
+        internal T GetOrAdd(TenantId tenant, string uploadId, Func<string, T> create)
+            => _map.GetOrAdd(CacheKey(tenant, uploadId), create);
+
+        internal bool TryGet(TenantId tenant, string uploadId, out T value)
+            => _map.TryGetValue(CacheKey(tenant, uploadId), out value!);
+
+        internal void Set(TenantId tenant, string uploadId, T value)
+            => _map[CacheKey(tenant, uploadId)] = value;
+
+        internal void Remove(TenantId tenant, string uploadId)
+            => _map.TryRemove(CacheKey(tenant, uploadId), out _);
+    }
 
     /// <summary>
-    /// Maps the dictation routes and RETURNS the denied group they were mapped through. The routes are mapped
-    /// through the group HANDLE (<see cref="HostedDenyGroup"/>), never through the ungrouped builder: the
-    /// handle is obtainable only from <see cref="HostedRouteDeny"/>, so a route mapped around the refusal is
-    /// not expressible in <see cref="MapRoutes"/> without changing its signature - the bypass count is reduced
-    /// by design, not by care. On hosted the exclusive catch-all refuses the whole group and each handler is
-    /// DISCARDED; off hosted the handle maps each handler as an unguarded builder would. The return value
-    /// exists so a test can map a brand-new route through the returned handle and show the refusal already
-    /// covers routes nobody has written yet.
+    /// The key both static caches use: the owning tenant AND the canonical staging spelling of the upload id.
+    /// The id is canonicalized through the store's own normalizer so two spellings of one GUID cannot become
+    /// two cache entries for one staging directory, and the tenant is first so a key can never be read as
+    /// belonging to a different account by accident.
     /// </summary>
-    public static HostedDenyGroup Map(IEndpointRouteBuilder outer, DirectorRegistry registry,
+    internal static string CacheKey(TenantId tenant, string uploadId)
+        => tenant.Value + "|" + (VoiceUploadStore.NormalizeUploadId(uploadId) ?? "invalid");
+
+    /// <summary>
+    /// Test seam: invoked with the cache key at the moment a single-flight completion entry is CREATED, so a
+    /// test can bind the real call site rather than a helper. Null in production, never assigned outside
+    /// tests. It exists because "the cache is tenant-keyed" is a claim about the GetOrAdd call, and a unit
+    /// test of the key function alone would stay green if that call went back to keying on the upload id.
+    /// </summary>
+    internal static Action<string>? OnCompleteEntryCreatedForTests;
+
+    /// <summary>
+    /// Resolve the request's tenant from the AUTHENTICATED device key the auth layer stashed - the same seam
+    /// the prompt log and the cockpit read path use. Null means DENY.
+    ///
+    /// GATED ON <see cref="GatewayHostedMode.IsHosted"/> ITSELF, never on whether a boundary was passed in.
+    /// Deciding on the argument fails OPEN, and this is the fail-open that matters most on this endpoint: the
+    /// boundary is a SECURITY argument, so a hosted call site, test, or future rewire that does not supply one
+    /// would be answered <see cref="TenantId.Local"/>, and every leg below would then operate on the shared
+    /// self-host root - reopening transcript reads, chunk overwrite, ack, abandon, and completion-cache
+    /// joining, silently, with nothing failing loud to say so. An optional security argument is
+    /// indistinguishable from a resolved one at the call site, which is exactly why that mistake survives.
+    ///
+    /// So on hosted this NEVER substitutes a tenant. A missing boundary, a boundary that is not hosted-wired
+    /// (its ambient context is the single-tenant one, so it can only ever answer Local), and a key with no
+    /// bound tenant all resolve to null, and null is a REFUSAL - never Local, never SYSTEM. Off hosted mode
+    /// the answer is Local exactly as it has always been, so self-host behaviour is byte-identical.
+    ///
+    /// The second defence is that <see cref="Map"/> takes the boundary as a REQUIRED argument, so omitting it
+    /// is a compile error rather than a runtime downgrade. Belt and braces is deliberate: this makes the
+    /// runtime safe, the required argument makes the mistake unrepresentable.
+    /// </summary>
+    internal static TenantId? ResolveTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
+    {
+        if (!GatewayHostedMode.IsHosted)
+            return boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+        if (boundary is null || !boundary.IsHosted)
+            return null;
+        return boundary.ResolveRequestTenant(ctx);
+    }
+
+    internal static IResult NoTenantResult()
+        => Results.Json(new { error = "no tenant is bound to this request" },
+            statusCode: StatusCodes.Status403Forbidden);
+
+    /// <param name="gate">
+    /// The ONLY way any leg below can obtain an upload store, and the reason a leg can no longer be written
+    /// unscoped. See <see cref="DictationTenantGate"/>: this method deliberately does NOT take a
+    /// <see cref="VoiceUploadStore"/>, so there is no unscoped store in scope anywhere in this file to
+    /// accidentally use.
+    /// </param>
+    public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry,
         SessionOwnerCache? owners, string token, GatewayTranscriptionService transcription,
-        TranscribingSessions transcribingSessions, VoiceUploadStore uploads, Pairing.DeviceRegistry devices,
+        TranscribingSessions transcribingSessions, DictationTenantGate gate, Pairing.DeviceRegistry devices,
         Streaming.PushedSessionStore? pushedSessions = null,
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = null,
         TimeSpan? streamStale = null)
     {
-        FileLog.Write($"[GatewayDictation] mapping {Prefix}; hosted={GatewayHostedMode.IsHosted} - on hosted the whole group is refused via the shared refusal primitive (issue #1884)");
-
-        var app = HostedRouteDeny.ExclusiveGroup(outer, Prefix, Denial());
-
         // Gateway Cleanup mission, Phase 2 (PR E-B): resolve the owning Director push-store-first and inject
         // the dictation through the tunnel-first SessionVerbClient (the delivery marker rides the PromptRequest
         // DeliveryUploadId field, not an HTTP header), so this path no longer HTTP-dials the Director.
         var stale = streamStale ?? TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
-
-        MapRoutes(app, registry, owners, token, transcription, transcribingSessions, uploads, devices,
-            pushedSessions, sendCommand, stale);
-        return app;
-    }
-
-    /// <summary>
-    /// The five dictation upload routes, mapped relative to the <see cref="Prefix"/> so the full paths are
-    /// <c>/dictation/upload</c> and <c>/dictation/{uploadId}/...</c> exactly as before. Takes the denied GROUP
-    /// HANDLE and nothing else: the ungrouped route builder is deliberately out of scope here, so no route in
-    /// this family can be mapped around the hosted refusal.
-    /// </summary>
-    private static void MapRoutes(HostedDenyGroup app, DirectorRegistry registry,
-        SessionOwnerCache? owners, string token, GatewayTranscriptionService transcription,
-        TranscribingSessions transcribingSessions, VoiceUploadStore uploads, Pairing.DeviceRegistry devices,
-        Streaming.PushedSessionStore? pushedSessions,
-        DirectorCommandRouter.SendDirectorCommandAsync? sendCommand,
-        TimeSpan stale)
-    {
-        app.MapPost("/upload", (DictationUploadRequest? body, HttpContext ctx) =>
+        app.MapPost("/dictation/upload", (DictationUploadRequest? body, HttpContext ctx) =>
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
+            // Authorize the UPLOAD, not just the device (issue #1884): everything below runs inside this
+            // request's own tenant partition, so an upload id from another account is simply not present.
+            if (!gate.TryOpen(ctx, out var store, out var tenant, out var deny)) return deny;
             var sid = body?.SessionId ?? "";
             if (!Guid.TryParse(sid, out _))
                 return Results.Json(new { error = "sessionId (guid) is required" }, statusCode: StatusCodes.Status400BadRequest);
@@ -219,11 +204,11 @@ internal static class GatewayDictationEndpoint
             // (delivered or abandoned), do NOT re-open it as a fresh PENDING upload - return the cached
             // outcome so a re-registering client (whose earlier response was lost) drops its on-device copy
             // and acknowledges instead of re-uploading and re-injecting. Survives a restart (on disk).
-            var existing = string.IsNullOrWhiteSpace(key) ? null : uploads.ReadRecord(key);
+            var existing = string.IsNullOrWhiteSpace(key) ? null : store.ReadRecord(key);
             if (existing is { State: DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned })
             {
                 FileLog.Write($"[GatewayDictation] upload re-register of terminal uploadId={key} state={existing.State}");
-                return TerminalRegisterResult(uploads.Register(key), existing);
+                return TerminalRegisterResult(store.Register(key), existing);
             }
             // A PENDING or FAILED record (or none) is (re-)opened as a fresh PENDING upload. Register
             // (re-)opens the staging dir; MarkPending writes the explicit durable PENDING marker carrying the
@@ -232,19 +217,23 @@ internal static class GatewayDictationEndpoint
             // to PENDING - overwriting the FAILED marker while keeping the staged chunks (issue #1185).
             if (existing is { State: DictationDeliveryState.Failed })
                 FileLog.Write($"[GatewayDictation] upload re-register clears FAILED uploadId={key}, retrying");
-            var uploadId = uploads.Register(string.IsNullOrWhiteSpace(key) ? null : key);
-            uploads.MarkPending(uploadId, sid);
-            _uploadSids[uploadId] = sid;
+            var uploadId = store.Register(string.IsNullOrWhiteSpace(key) ? null : key);
+            store.MarkPending(uploadId, sid);
+            _uploadSids.Set(tenant, uploadId, sid);
             try { transcribingSessions.Begin(sid); } catch { /* the orange mark is a nicety */ }
             FileLog.Write($"[GatewayDictation] upload registered sid={sid} uploadId={uploadId}");
             return Results.Json(new { upload_id = uploadId });
         });
 
-        app.MapPut("/{uploadId}/chunk/{index:int}", async (string uploadId, int index, HttpContext ctx) =>
+        app.MapPut("/dictation/{uploadId}/chunk/{index:int}", async (string uploadId, int index, HttpContext ctx) =>
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
-            if (!uploads.Exists(uploadId))
+            // Issue #1884: an upload id that belongs to another account does not exist in this partition, so
+            // the existing unknown-id guard becomes the authorization - the caller cannot overwrite, extend,
+            // or even confirm the existence of another account's staged audio.
+            if (!gate.TryOpen(ctx, out var store, out var tenant, out var deny)) return deny;
+            if (!store.Exists(uploadId))
                 return Results.Json(new { error = "unknown upload id (register it first)" }, statusCode: StatusCodes.Status404NotFound);
 
             var sha = ctx.Request.Headers["X-Chunk-Sha256"].ToString();
@@ -252,10 +241,10 @@ internal static class GatewayDictationEndpoint
             await ctx.Request.Body.CopyToAsync(ms, ctx.RequestAborted);
             try
             {
-                await uploads.StoreChunkAsync(uploadId, index, ms.ToArray(), string.IsNullOrEmpty(sha) ? null : sha, ctx.RequestAborted);
+                await store.StoreChunkAsync(uploadId, index, ms.ToArray(), string.IsNullOrEmpty(sha) ? null : sha, ctx.RequestAborted);
                 // Heartbeat: a stored chunk is progress, so keep the orange mark alive past its idle
                 // backstop for a slow upload that streams over more than the idle window (issue #1126).
-                if (_uploadSids.TryGetValue(uploadId, out var chunkSid))
+                if (_uploadSids.TryGet(tenant, uploadId, out var chunkSid))
                     transcribingSessions.Refresh(chunkSid);
                 return Results.Json(new { ok = true, index });
             }
@@ -266,10 +255,14 @@ internal static class GatewayDictationEndpoint
             }
         });
 
-        app.MapPost("/{uploadId}/complete", async (string uploadId, DictationCompleteRequest? req, HttpContext ctx) =>
+        app.MapPost("/dictation/{uploadId}/complete", async (string uploadId, DictationCompleteRequest? req, HttpContext ctx) =>
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
+            // Issue #1884: resolve and authorize the tenant BEFORE anything touches the store or the static
+            // single-flight cache, so a caller who does not own this upload id can neither read its record
+            // nor join its in-flight completion run.
+            if (!gate.TryOpen(ctx, out var store, out var tenant, out var deny)) return deny;
             if (req is null || req.TotalChunks <= 0 || !Guid.TryParse(req.SessionId ?? "", out _))
                 return Results.Json(new { error = "sessionId (guid) and totalChunks (>0) are required" },
                     statusCode: StatusCodes.Status400BadRequest);
@@ -290,11 +283,11 @@ internal static class GatewayDictationEndpoint
             // window and even after a Gateway restart (the record and this check both live on disk). This
             // handles the SEQUENTIAL/after-restart retry; the in-memory single-flight below handles two
             // CONCURRENT completes racing before the first tombstone is written (they share one run).
-            var settled = uploads.ReadRecord(uploadId);
+            var settled = store.ReadRecord(uploadId);
             if (settled is { State: DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned })
             {
                 EndTranscribing(transcribingSessions, req.SessionId!);
-                _uploadSids.TryRemove(uploadId, out _);
+                _uploadSids.Remove(tenant, uploadId);
                 FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: cached terminal outcome " +
                     $"state={settled.State} (no re-injection)");
                 return TerminalOutcome(settled).ToResult();
@@ -304,7 +297,7 @@ internal static class GatewayDictationEndpoint
             // chunks) and re-drive the real work below.
             if (settled is { State: DictationDeliveryState.Failed })
             {
-                uploads.ClearFailed(uploadId);
+                store.ClearFailed(uploadId);
                 FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: cleared FAILED, retrying");
             }
 
@@ -312,10 +305,13 @@ internal static class GatewayDictationEndpoint
             // still-PENDING id is assembled + transcribed + injected at most once even under a concurrent
             // race. The entry is dropped once the run settles (below); the durable tombstone owns de-dupe
             // from then on, so there is no age-swept cache window.
-            var entry = _completes.GetOrAdd(uploadId, id => new CompleteEntry(
-                new Lazy<Task<DictationOutcome>>(() => RunCompleteCoreAsync(
-                    id, req, uploads, registry, owners, transcription, transcribingSessions, deliverySurface,
-                    pushedSessions, sendCommand, stale))));
+            var entry = _completes.GetOrAdd(tenant, uploadId, completeKey =>
+            {
+                OnCompleteEntryCreatedForTests?.Invoke(completeKey);
+                return new CompleteEntry(new Lazy<Task<DictationOutcome>>(() => RunCompleteCoreAsync(
+                    uploadId, tenant, req, store, registry, owners, transcription, transcribingSessions, deliverySurface,
+                    pushedSessions, sendCommand, stale)));
+            });
 
             DictationOutcome outcome;
             try
@@ -324,7 +320,7 @@ internal static class GatewayDictationEndpoint
             }
             catch (Exception ex)
             {
-                _completes.TryRemove(uploadId, out _); // transient: let a retry re-run
+                _completes.Remove(tenant, uploadId); // transient: let a retry re-run
                 return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status502BadGateway);
             }
 
@@ -338,13 +334,13 @@ internal static class GatewayDictationEndpoint
             if (!outcome.IsIncomplete)
             {
                 EndTranscribing(transcribingSessions, req.SessionId!);
-                _uploadSids.TryRemove(uploadId, out _);
+                _uploadSids.Remove(tenant, uploadId);
             }
             // Drop the in-memory single-flight entry once the run settles. A terminal run has already
             // written the durable tombstone (inside the core), so a later retry short-circuits on the
             // ReadRecord check above; a non-terminal run (transient error, incomplete upload, out-of-credits)
             // leaves no tombstone, so the next complete re-runs the real work (issue #1183).
-            _completes.TryRemove(uploadId, out _);
+            _completes.Remove(tenant, uploadId);
             return outcome.ToResult();
         });
 
@@ -354,11 +350,15 @@ internal static class GatewayDictationEndpoint
         // is a no-op returning retired=false. If the ack is lost the tombstone simply persists and a later
         // re-complete returns the same outcome and the client re-acks - so the tombstone is retired ONLY on
         // a real client ack, never by age.
-        app.MapPost("/{uploadId}/ack", (string uploadId, HttpContext ctx) =>
+        app.MapPost("/dictation/{uploadId}/ack", (string uploadId, HttpContext ctx) =>
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
-            var retired = uploads.Acknowledge(uploadId);
+            // Issue #1884: an ack RETIRES a record - it deletes state. Scoped to the caller's own partition,
+            // so acking an id another account owns finds nothing and reports retired=false, leaving that
+            // account's tombstone (and therefore its de-dupe guarantee) untouched.
+            if (!gate.TryOpen(ctx, out var store, out _, out var deny)) return deny;
+            var retired = store.Acknowledge(uploadId);
             FileLog.Write($"[GatewayDictation] ack uploadId={uploadId} retired={retired}");
             return Results.Json(new { ok = true, retired });
         });
@@ -369,21 +369,25 @@ internal static class GatewayDictationEndpoint
         // Idempotent and safe against a race with delivery: if the turn already DELIVERED we do NOT abandon
         // (it landed) and say so; otherwise the id becomes ABANDONED. The client that still holds the audio
         // reconciles on its next contact - a re-register / re-complete of an abandoned id returns dropped, so
-        // it drops its on-device copy with no resurrection and no duplicate. Abandon may target ANY surface's
-        // dictation because it addresses the durable upload id, not the caller.
-        app.MapPost("/{uploadId}/abandon", (string uploadId, HttpContext ctx) =>
+        // it drops its on-device copy with no resurrection and no duplicate. Abandon may target ANY SURFACE'S
+        // dictation - phone, cockpit, desktop - because it addresses the durable upload id rather than the
+        // device that recorded it. Issue #1884 draws the line that "any surface" always meant: any surface OF
+        // THE SAME ACCOUNT. It is scoped to the caller's own partition, so it can no longer discard another
+        // account's staged audio or resolve its pending record.
+        app.MapPost("/dictation/{uploadId}/abandon", (string uploadId, HttpContext ctx) =>
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
+            if (!gate.TryOpen(ctx, out var store, out _, out var deny)) return deny;
 
-            var existing = uploads.ReadRecord(uploadId);
+            var existing = store.ReadRecord(uploadId);
             if (existing is { State: DictationDeliveryState.Delivered })
             {
                 FileLog.Write($"[GatewayDictation] abandon uploadId={uploadId}: already DELIVERED, not abandoning");
                 return Results.Json(new { ok = true, upload_id = uploadId, abandoned = false, already_delivered = true });
             }
 
-            uploads.MarkAbandoned(uploadId, "user_abandoned");
+            store.MarkAbandoned(uploadId, "user_abandoned");
             // Clear the in-memory transcribing marks so the roster un-oranges at once (the durable PENDING
             // marker - the "Uploading from phone" source - is already gone via MarkAbandoned).
             var sid = existing?.SessionId;
@@ -423,7 +427,7 @@ internal static class GatewayDictationEndpoint
     // The retryable arm used to return silently, which is why the log could say WHEN it wedged but never
     // WHY. It logs now.
     internal static DictationOutcome? MapNonOkTranscription(
-        GatewayTranscriptionResult result, string uploadId, VoiceUploadStore uploads)
+        GatewayTranscriptionResult result, string uploadId, VoiceUploadStore store)
     {
         if (result.Outcome == TranscriptionOutcome.Ok) return null;
         if (result.Outcome == TranscriptionOutcome.OutOfCredits)
@@ -432,7 +436,7 @@ internal static class GatewayDictationEndpoint
             // to transcribe it with; the client still gets 402, and adding credit + retrying re-enters
             // PENDING and delivers. NOTE: never once observed to fire - zero OutOfCredits in any log on this
             // machine, ever, across 846 terminal outcomes. The mechanism is real; the cause is not this.
-            uploads.MarkFailed(uploadId, "out_of_credits");
+            store.MarkFailed(uploadId, "out_of_credits");
             FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: out of credits " +
                 $"code={result.Code}; parked FAILED (chunks retained, retryable)");
             return DictationOutcome.OutOfCredits(HostedAiErrorMapper.MapCode(result.Code));
@@ -443,14 +447,14 @@ internal static class GatewayDictationEndpoint
         // explicit user retry can re-complete) and return the client's stop contract.
         if (result.Outcome == TranscriptionOutcome.PermanentError)
         {
-            uploads.MarkFailed(uploadId, result.Code ?? "");
+            store.MarkFailed(uploadId, result.Code ?? "");
             FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: permanent failure " +
                 $"code={result.Code}; parked FAILED");
             return DictationOutcome.Permanent(TranslatePermanentReason(result.Code));
         }
         // The retryable arm - THE ONE THAT ACTUALLY WEDGED (see f13cb4b6d9d0 above). Still a 502 the client
         // re-drives; now it parks the record so the colour tells the truth between attempts.
-        uploads.MarkFailed(uploadId, result.Code ?? "transcription_error");
+        store.MarkFailed(uploadId, result.Code ?? "transcription_error");
         FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: retryable transcription failure " +
             $"code={result.Code} error={result.Error}; parked FAILED (chunks retained, retryable)");
         return DictationOutcome.Error(StatusCodes.Status502BadGateway, result.Error ?? "transcription failed");
@@ -483,7 +487,7 @@ internal static class GatewayDictationEndpoint
             : Results.Json(new { upload_id = uploadId, terminal = true, submitted = record.Submitted, movedOn = record.MovedOn, dropped = false, transcript = record.Transcript });
 
     private static async Task<DictationOutcome> RunCompleteCoreAsync(
-        string uploadId, DictationCompleteRequest req, VoiceUploadStore uploads, DirectorRegistry registry,
+        string uploadId, TenantId tenant, DictationCompleteRequest req, VoiceUploadStore store, DirectorRegistry registry,
         SessionOwnerCache? owners, GatewayTranscriptionService transcription,
         TranscribingSessions transcribingSessions, string? deliverySurface,
         Streaming.PushedSessionStore? pushedSessions, DirectorCommandRouter.SendDirectorCommandAsync? sendCommand,
@@ -502,7 +506,7 @@ internal static class GatewayDictationEndpoint
                 return DictationOutcome.Error(StatusCodes.Status503ServiceUnavailable,
                     $"no key configured for transcription mode {routing.Mode}");
 
-            var assembled = await uploads.AssembleAsync(uploadId, req.TotalChunks);
+            var assembled = await store.AssembleAsync(uploadId, req.TotalChunks);
             if (assembled.Status == "unknown_upload")
                 return DictationOutcome.Error(StatusCodes.Status404NotFound, "unknown upload id");
             if (assembled.Status == "incomplete")
@@ -510,13 +514,13 @@ internal static class GatewayDictationEndpoint
             var audio = assembled.Audio;
             if (audio is null || audio.Length == 0)
             {
-                uploads.Delete(uploadId);
+                store.Delete(uploadId);
                 return DictationOutcome.Error(StatusCodes.Status502BadGateway, "assembled recording was empty");
             }
 
             var result = await transcription.TranscribeAsync(
                 audio, "audio." + (req.Ext ?? "wav"), req.Mime ?? "audio/wav", applyCorrection: true, CancellationToken.None);
-            if (MapNonOkTranscription(result, uploadId, uploads) is { } nonOk)
+            if (MapNonOkTranscription(result, uploadId, store) is { } nonOk)
                 return nonOk;
 
             var transcript = (result.Text ?? "").Trim();
@@ -532,14 +536,21 @@ internal static class GatewayDictationEndpoint
                 // Silent/empty clip with no typed text: nothing to submit, but the turn is genuinely done -
                 // record it as a durable DELIVERED tombstone so a re-complete returns the same no-op outcome
                 // instead of re-running (issue #1183). Discards the retained chunks, keeps the marker.
-                uploads.MarkDelivered(uploadId, submitted: false, movedOn: false, transcript);
+                store.MarkDelivered(uploadId, submitted: false, movedOn: false, transcript);
                 return DictationOutcome.Submitted(false, false, transcript);
             }
 
             // Gateway Cleanup mission, Phase 2: resolve the owner push-store-first (no HTTP fan-out) and gate
             // on an exited session, exactly as the old LocateAsync did, then reach it through the tunnel.
+            //
+            // Located in the REQUEST'S OWN TENANT (issue #1884, un-deny). This is what makes dictation actually
+            // WORK on the hosted Gateway: the tenant was resolved from the authenticated device key at the gate
+            // and carried in here, so the session is found in the caller's partition and NEVER another
+            // account's. On self-host the tenant is Local and this is byte-identical to before. A caller whose
+            // tenant did not resolve never reached this leg - the gate refused it up front - so there is no
+            // path here that falls back to a shared/Local locate on hosted.
             var (director, session) = await GatewayEndpoints.LocateSessionAsync(
-                registry, sid, pushedSessions, streamStale, TenantId.Local, owners);
+                registry, sid, pushedSessions, streamStale, tenant, owners);
             if (director is null || session is null)
                 return DictationOutcome.Error(StatusCodes.Status404NotFound, "session not found");
             if (IsExited(session))
@@ -558,14 +569,14 @@ internal static class GatewayDictationEndpoint
             // larger of the two costs nothing when no attempt failed (the stored value is absent) and is what
             // stops the observed drop when one did.
             var effectiveBaseline = Math.Max(
-                req.BaselineBufferBytes, uploads.ReadRecord(uploadId)?.RebaselineBufferBytes ?? 0);
+                req.BaselineBufferBytes, store.ReadRecord(uploadId)?.RebaselineBufferBytes ?? 0);
             if (req.Resumed && session is not null && req.BaselineBufferBytes > 0 &&
                 session.TotalBufferBytes > effectiveBaseline + MovedOnBufferGrowthBytes)
             {
                 // The turn is resolved (deliberately dropped as stale): a durable DELIVERED tombstone with
                 // movedOn set, so a re-complete returns the same moved-on outcome and never injects the stale
                 // clip (issue #1183). Discards the retained chunks, keeps the marker.
-                uploads.MarkDelivered(uploadId, submitted: false, movedOn: true, transcript);
+                store.MarkDelivered(uploadId, submitted: false, movedOn: true, transcript);
                 FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: session moved on " +
                     $"(buffer {req.BaselineBufferBytes}/effective {effectiveBaseline}->{session.TotalBufferBytes}); dropped");
                 return DictationOutcome.Submitted(false, true, transcript);
@@ -605,9 +616,9 @@ internal static class GatewayDictationEndpoint
                 // today (today re-baselines by exactly zero) and it is monotonic, so a later failed attempt
                 // can only improve it - but the residual lag window is real and is not closed here.
                 var (_, freshSession) = await GatewayEndpoints.LocateSessionAsync(
-                    registry, sid, pushedSessions, streamStale, TenantId.Local, owners);
+                    registry, sid, pushedSessions, streamStale, tenant, owners);
                 if (freshSession is not null)
-                    uploads.RecordFailedDeliveryBaseline(uploadId, freshSession.TotalBufferBytes);
+                    store.RecordFailedDeliveryBaseline(uploadId, freshSession.TotalBufferBytes);
                 FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: submit FAILED ({err}); " +
                     $"re-baselined to {freshSession?.TotalBufferBytes.ToString() ?? "unavailable"} " +
                     $"(was {req.BaselineBufferBytes}) so the retry is not dropped as stale");
@@ -620,7 +631,7 @@ internal static class GatewayDictationEndpoint
             // milliseconds between PostPromptAsync returning and this marker landing on disk would let a
             // later re-complete inject the turn a second time. We minimize and document it rather than paper
             // over it with a fallback. MarkDelivered discards the retained chunks and keeps the marker.
-            uploads.MarkDelivered(uploadId, submitted: true, movedOn: false, transcript);
+            store.MarkDelivered(uploadId, submitted: true, movedOn: false, transcript);
             FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: submitted chars={message.Length}");
             return DictationOutcome.Submitted(true, false, transcript);
         }

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -220,7 +220,7 @@ internal static class GatewayDictationEndpoint
             var uploadId = store.Register(string.IsNullOrWhiteSpace(key) ? null : key);
             store.MarkPending(uploadId, sid);
             _uploadSids.Set(tenant, uploadId, sid);
-            try { transcribingSessions.Begin(sid); } catch { /* the orange mark is a nicety */ }
+            try { transcribingSessions.Begin(tenant, sid); } catch { /* the orange mark is a nicety */ }
             FileLog.Write($"[GatewayDictation] upload registered sid={sid} uploadId={uploadId}");
             return Results.Json(new { upload_id = uploadId });
         });
@@ -245,7 +245,7 @@ internal static class GatewayDictationEndpoint
                 // Heartbeat: a stored chunk is progress, so keep the orange mark alive past its idle
                 // backstop for a slow upload that streams over more than the idle window (issue #1126).
                 if (_uploadSids.TryGet(tenant, uploadId, out var chunkSid))
-                    transcribingSessions.Refresh(chunkSid);
+                    transcribingSessions.Refresh(tenant, chunkSid);
                 return Results.Json(new { ok = true, index });
             }
             catch (Exception ex)
@@ -269,7 +269,7 @@ internal static class GatewayDictationEndpoint
 
             // A completion attempt is progress - keep the orange mark alive across the server-side
             // transcribe so a slow transcribe cannot let it age out mid-flight (issue #1126).
-            transcribingSessions.Refresh(req.SessionId!);
+            transcribingSessions.Refresh(tenant, req.SessionId!);
 
             // DevThrottle Stats: this dictation is a VOICE turn; resolve WHICH surface recorded it from the
             // verified device key that authenticated this complete (the phone that recorded it, or the
@@ -286,7 +286,7 @@ internal static class GatewayDictationEndpoint
             var settled = store.ReadRecord(uploadId);
             if (settled is { State: DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned })
             {
-                EndTranscribing(transcribingSessions, req.SessionId!);
+                EndTranscribing(transcribingSessions, tenant, req.SessionId!);
                 _uploadSids.Remove(tenant, uploadId);
                 FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: cached terminal outcome " +
                     $"state={settled.State} (no re-injection)");
@@ -333,7 +333,7 @@ internal static class GatewayDictationEndpoint
             // on the same upload id, so the session is genuinely still transcribing.
             if (!outcome.IsIncomplete)
             {
-                EndTranscribing(transcribingSessions, req.SessionId!);
+                EndTranscribing(transcribingSessions, tenant, req.SessionId!);
                 _uploadSids.Remove(tenant, uploadId);
             }
             // Drop the in-memory single-flight entry once the run settles. A terminal run has already
@@ -378,7 +378,7 @@ internal static class GatewayDictationEndpoint
         {
             if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
-            if (!gate.TryOpen(ctx, out var store, out _, out var deny)) return deny;
+            if (!gate.TryOpen(ctx, out var store, out var tenant, out var deny)) return deny;
 
             var existing = store.ReadRecord(uploadId);
             if (existing is { State: DictationDeliveryState.Delivered })
@@ -389,12 +389,13 @@ internal static class GatewayDictationEndpoint
 
             store.MarkAbandoned(uploadId, "user_abandoned");
             // Clear the in-memory transcribing marks so the roster un-oranges at once (the durable PENDING
-            // marker - the "Uploading from phone" source - is already gone via MarkAbandoned).
+            // marker - the "Uploading from phone" source - is already gone via MarkAbandoned). Keyed to the
+            // caller's own tenant (issue #1884, Gap B), so an abandon can never clear another account's mark.
             var sid = existing?.SessionId;
             if (!string.IsNullOrEmpty(sid))
             {
-                EndTranscribing(transcribingSessions, sid);
-                transcribingSessions.ClearActivelyTranscribing(sid);
+                EndTranscribing(transcribingSessions, tenant, sid);
+                transcribingSessions.ClearActivelyTranscribing(tenant, sid);
             }
             FileLog.Write($"[GatewayDictation] abandon uploadId={uploadId} sid={sid}: marked ABANDONED, staging discarded");
             return Results.Json(new { ok = true, upload_id = uploadId, abandoned = true });
@@ -497,7 +498,7 @@ internal static class GatewayDictationEndpoint
         // Issue #1181, Task 4: this run assembles + transcribes + delivers, so mark the session ACTIVELY
         // transcribing for its duration. The aggregator reads this to show "Transcribing" (vs the durable
         // PENDING marker's "Uploading from phone"). Cleared in the finally so it never outlives the run.
-        transcribingSessions.MarkActivelyTranscribing(sid);
+        transcribingSessions.MarkActivelyTranscribing(tenant, sid);
         try
         {
             // The configured mode's key must be present before we pay the reassembly + transcribe cost.
@@ -644,13 +645,13 @@ internal static class GatewayDictationEndpoint
         {
             // Issue #1181, Task 4: the transcription run is over (delivered, failed, or threw), so drop the
             // "Transcribing" mark. The durable PENDING/DELIVERED marker now owns the session's state.
-            transcribingSessions.ClearActivelyTranscribing(sid);
+            transcribingSessions.ClearActivelyTranscribing(tenant, sid);
         }
     }
 
-    private static void EndTranscribing(TranscribingSessions t, string sid)
+    private static void EndTranscribing(TranscribingSessions t, TenantId tenant, string sid)
     {
-        try { t.End(sid); } catch { /* the Gateway's stale-mark backstop clears it if this throws */ }
+        try { t.End(tenant, sid); } catch { /* the Gateway's stale-mark backstop clears it if this throws */ }
     }
 
     private static bool IsExited(SessionDto session)

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -53,8 +53,8 @@ internal static class GatewayEndpoints
         Func<TenantId, string, bool>? nothingToNarrateFor = null,
         Func<TenantId, string, bool>? servedViaFallbackFor = null,
         Func<string, bool, DateTime?>? needsYouStampFor = null,
-        Func<string, bool>? transcribingFor = null,
-        Func<string, string?>? dictationStatusFor = null,
+        Func<TenantId, string, bool>? transcribingFor = null,
+        Func<TenantId, string, string?>? dictationStatusFor = null,
         Transcription.TranscribingSessions? transcribingSessions = null,
         Func<string, (string? RailLine, string? Headline)>? interruptedBriefFor = null,
         Func<string, List<TurnBriefDto>>? briefHistoryFor = null,
@@ -998,12 +998,12 @@ internal static class GatewayEndpoints
                     // BEFORE the NeedsYouSince clock below so the EffectiveColor fold already sees orange
                     // (a transcribing session is not "needs you") when the clock reads the final color.
                     if (transcribingFor is not null)
-                        s.Transcribing = transcribingFor(s.SessionId);
+                        s.Transcribing = transcribingFor(reqTenant.Value, s.SessionId);
                     // Issue #1181, Task 4: the honest phase label - "Uploading from phone" (durable PENDING
                     // marker) vs "Transcribing" (active run). Drives the same orange, but the clients render
                     // this string so the user knows whether it is their phone still uploading or the server.
                     if (dictationStatusFor is not null)
-                        s.DictationStatus = dictationStatusFor(s.SessionId);
+                        s.DictationStatus = dictationStatusFor(reqTenant.Value, s.SessionId);
                     // The authoritative presentation fold (EffectiveColor / StateLabel / TriageBucket /
                     // NeedsYouSince) is stamped in ONE post-pass AFTER this loop assembles the whole fleet -
                     // see StampFleetRolesAndFold below. It is deferred because SessionRole (which the fold
@@ -1560,14 +1560,20 @@ internal static class GatewayEndpoints
         {
             if (transcribingSessions is null)
                 return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
+            // The transcribing mark is keyed by (tenant, sid) (issue #1884, Gap B): resolve the caller's
+            // tenant from the authenticated device key and refuse (403) when none resolves on hosted, so a
+            // request can only ever set or clear ITS OWN account's mark - never paint or clear another
+            // account's session by supplying that account's session id. Self-host resolves Local, unchanged.
+            if (ResolveReadTenant(ctx, tenantBoundary) is not { } reqTenant)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var transcribing = req?.Transcribing ?? false;
             if (transcribing)
-                transcribingSessions.Begin(sid);
+                transcribingSessions.Begin(reqTenant, sid);
             else
-                transcribingSessions.End(sid);
+                transcribingSessions.End(reqTenant, sid);
             return Results.Json(new { transcribing });
         });
 

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -82,72 +82,12 @@ internal static class GatewayWingmanVoiceEndpoint
     private static IResult TooLarge(string error) =>
         Results.Json(new { error }, statusCode: StatusCodes.Status413PayloadTooLarge);
 
-    /// <summary>The exclusive prefix the /wingman/utterance upload route group owns outright on hosted.</summary>
-    internal const string UtterancePrefix = "/wingman/utterance";
-
-    /// <summary>The single error string the hosted utterance refusal serves. Held here so a test can assert
-    /// against the exact string that is served rather than a copy that could drift.</summary>
-    internal const string UtteranceRefusalMessage = "the wingman utterance upload is not available on the hosted gateway";
-
-    /// <summary>
-    /// The hosted refusal payload for the whole /wingman/utterance upload family (issue #1896). Validated on
-    /// construction, so a blank field fails the Gateway at startup rather than serving a refusal a caller
-    /// cannot act on. 404 rather than 403: on hosted this upload family does not exist as a concept - an
-    /// upload id is meaningless without a tenant to scope it to, and the store has none - so "not here" is
-    /// the truthful answer; 403 would imply the right credential could reach it, and none can. Driven off
-    /// <see cref="GatewayHostedMode.IsHosted"/> inside the primitive - the INDEPENDENT deployment signal, not
-    /// an optional argument a caller can omit and thereby fail OPEN.
-    ///
-    /// UN-DENY CONDITION. Two SEPARATE questions, because answering only the first is how a deny gets
-    /// mistaken for a clean slate. "Does anything still write this state" and "what is already sitting
-    /// there" have different answers, and the second one does not improve while the deny stands.
-    ///
-    /// (a) DOES ANYTHING STILL WRITE IT? No, and NO OFF-ROUTE WRITER NEEDS A HOST-GATE HERE. Checked by
-    /// sweeping the COMPLETE MUTATING SURFACE of the state rather than the routes that touch it: every
-    /// construction of a <c>VoiceUploadStore</c> in the repository, then every production caller of every
-    /// mutating method on the type (<c>Register</c>, <c>StoreChunkAsync</c>, <c>AssembleAsync</c>,
-    /// <c>Delete</c>, <c>MarkPending</c>, <c>MarkDelivered</c>, <c>MarkAbandoned</c>, <c>MarkFailed</c>,
-    /// <c>ClearFailed</c>, <c>RecordFailedDeliveryBaseline</c>, <c>Acknowledge</c>, <c>SweepAbandoned</c>),
-    /// and finally any raw file writer into the root that bypasses the type entirely. The only production
-    /// instance on this root is the one <c>GatewayHost</c> holds as <c>_voiceTurnUploads</c> and hands to
-    /// this endpoint alone; every mutating call reached from this file is inside this refused group;
-    /// <c>SweepAbandoned</c> has NO production caller at all, only a test; nothing writes the root outside the
-    /// store. The one residual write is the constructor calling <c>CcStorage.VoiceTurnUploads()</c>, which
-    /// ENSURES the directory exists: an empty directory, never content. So with the routes refused, no writer
-    /// to this store reaches it on hosted - there is no OFF-route writer to gate (unlike the
-    /// transcription-telemetry and wingman-training stores, whose writers fire from undenied paths and are
-    /// host-gated at the writer).
-    ///
-    /// (b) WHAT ALREADY EXISTS? A SEPARATE QUESTION, and it is not answered by (a). NO NEW WRITES IS A
-    /// STATEMENT ABOUT THE FUTURE, NOT EVIDENCE ABOUT THE PAST. The shared root may hold pre-deny
-    /// cross-tenant staged audio and assembled transcripts, written before this refusal was hung and
-    /// untouched by it. SO THE UN-DENY STILL REQUIRES PURGING OR QUARANTINING THE LEGACY ROOT, on top of
-    /// issue #1896's tenant-keying of the store - "the write is stopped" is not "the root is clean" and must
-    /// never be read as the whole condition.
-    ///
-    /// HOW THE DENY IS EXPRESSED - THE SHARED REFUSAL PRIMITIVE, NOT A BESPOKE FILTER. This group is denied
-    /// through <see cref="HostedRouteDeny.ExclusiveGroup"/>, the ONE hosted-refusal boundary every deny
-    /// family on this Gateway adopts (reference implementation: the key-vault deny in pull request #1904). An
-    /// earlier revision rolled its own <c>AddEndpointFilter</c> deny before the primitive existed; it has
-    /// been replaced. The family owns the <c>/wingman/utterance</c> prefix OUTRIGHT - the rest of the voice
-    /// surface (voice-turn, tts, transcribe, explain, ask, menu) lives on OTHER paths and keeps serving on
-    /// hosted - so on hosted the three utterance handlers are NEVER MAPPED and ONE verb-less catch-all refuses
-    /// everything under the prefix plus a root refusal at the prefix itself, covering every verb, every
-    /// request shape, and every future sub-path for free. The exclusivity claim is CHECKED at startup by
-    /// <see cref="HostedRefusalRouteSpace.ValidateBeforeStart"/>. Off hosted the primitive maps the three real
-    /// handlers exactly as an unguarded builder would - self-host unchanged.
-    /// </summary>
-    private static HostedDenial UtteranceDenial() => new(
-        family: "wingman-utterance",
-        message: UtteranceRefusalMessage,
-        reason: "the utterance upload store keys staged audio and the assembled transcript SOLELY by a " +
-                "caller-supplied Idempotency-Key under one on-disk root shared across every account, and complete " +
-                "returns the assembled transcript - so an account can claim another account's upload id and be " +
-                "handed the words it spoke, or overwrite its chunks before it completes",
-        unDenyInstruction: "do NOT simply remove this deny: tenant-key the utterance store, THEN purge or " +
-                "quarantine the pre-existing shared root (pre-deny cross-tenant staged audio and transcripts are " +
-                "already in it and this change never touched them), and only then restore a tenant-scoped route",
-        statusCode: StatusCodes.Status404NotFound);
+    // The /wingman/utterance upload family is UN-DENIED and tenant-partitioned (issue #1884): see
+    // MapUtteranceRoutes, where each leg is opened through a DictationTenantGate over the voice-turn store.
+    // The prior hosted refusal (issue #1896: UtterancePrefix / UtteranceRefusalMessage / UtteranceDenial) is
+    // removed because the store is now partitioned by tenant - a hosted account tenant reads only its own
+    // base/tenants/<id>/ partition and never the shared root, and a request whose tenant does not resolve is
+    // refused (403) at the gate rather than served the shared root.
 
     /// <summary>
     /// Read a request body into memory, giving up the moment it exceeds <paramref name="max"/>.
@@ -173,12 +113,11 @@ internal static class GatewayWingmanVoiceEndpoint
         }
     }
 
-    /// Returns the DENIED utterance group. That return value exists SOLELY so a test can map a brand-new
-    /// route onto the same group and prove it is refused on hosted with no deny written for it - the
-    /// future-route property, which is otherwise invisible to any test that only drives the routes existing
-    /// today. Only the utterance family is denied; the rest of the voice surface stays on the ungrouped
-    /// builder and keeps serving on hosted.
-    public static HostedDenyGroup Map(
+    /// Maps the wingman voice surface, including the un-denied, tenant-partitioned /wingman/utterance upload
+    /// family (issue #1884): each utterance leg opens the caller's own partition through a
+    /// <see cref="DictationTenantGate"/> over the voice-turn store and is refused (403) when no tenant resolves
+    /// on hosted. The rest of the voice surface (voice-turn, tts, transcribe, explain, ask, menu) is unchanged.
+    public static void Map(
         IEndpointRouteBuilder app,
         DirectorRegistry registry,
         Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider,
@@ -365,8 +304,11 @@ internal static class GatewayWingmanVoiceEndpoint
         // Resumable, idempotent piece-by-piece upload store (the same one the native app path uses):
         // chunks land on disk under a stable upload id and survive between retry attempts, so the
         // phone can keep re-sending pieces until the whole recording is through. In production the host
-        // owns this instance and passes it; when omitted it defaults to a fresh one over the same root.
-        var uploads = uploadStore ?? new VoiceUploadStore();
+        // owns this instance and passes it; when omitted it defaults to a fresh one over the same root and
+        // the same explicitly-named partition. The partition cannot be omitted - the store has no
+        // constructor that would choose one silently - so this line states the scope it runs in.
+        var uploads = uploadStore
+            ?? new VoiceUploadStore(CcDirector.Core.Storage.CcStorage.VoiceTurnUploads(), CcDirector.Core.Tenancy.TenantId.Local);
 
         // ===== Resumable transcription upload (issue #531: drive-safe, keeps trying) =====
         // The phone records locally (works offline), then ships the recording in pieces here and
@@ -378,52 +320,24 @@ internal static class GatewayWingmanVoiceEndpoint
         //   PUT    /wingman/utterance/{id}/chunk/{i}           -> { ok }   (idempotent)
         //   POST   /wingman/utterance/{id}/complete {total}    -> { transcript } | 409 { missing }
         //
-        // DENIED IN WHOLE ON HOSTED (issue #1896). None of these three resolves a tenant at all, the upload
-        // id is CALLER-CHOSEN (it arrives as an Idempotency-Key header), the store behind them has one
-        // on-disk root shared across every account with no tenant segment in the path, and `complete`
-        // returns the assembled transcript. So an account can claim another account's upload id and be
-        // handed the words that account spoke - and, before the owner completes, overwrite its chunks.
-        // A caller-supplied identifier is not a tenant boundary: secrecy of an identifier is not
-        // authorization, and upload ids travel through client logs, retries and store-and-forward queues.
+        // UN-DENIED, TENANT-SCOPED (issue #1884). The utterance upload family used to be refused in whole on
+        // hosted because the store keyed staged audio and the assembled transcript SOLELY by a caller-chosen
+        // upload id under one shared root. It is now PARTITIONED like the dictation family: each of the three
+        // legs resolves the request's tenant from the authenticated device key and works only inside that
+        // tenant's partition of the voice-turn store, so an upload id from another account simply does not
+        // exist here and `complete` can only ever return the caller's own words. Resolution is server-side and
+        // FAIL-CLOSED: on hosted a request whose key has no bound tenant is refused (403), never served the
+        // shared/Local root. Self-host resolves Local throughout and is byte-identical to before.
         //
-        // The whole family, not just `complete`: denying only the leg that returns text would leave the
-        // chunk leg able to corrupt another account's recording, which is the same boundary failure with a
-        // different consequence. It is a deny rather than a partition because the staged records carry no
-        // tenant to partition BY - partitioning the store is issue #1896's job and un-denying is gated on
-        // it. It refuses rather than returning an empty transcript, because an empty transcript is a FALSE
-        // statement ("you said nothing") where a refusal is merely an absent one.
-        //
-        // Self-host is COMPLETELY unchanged: one tenant, so a shared root is the owner's own root, and the
-        // phone's record-locally-and-keep-retrying path works exactly as it always has.
-        //
-        // The exclusive prefix reproduces the route paths character for character (the legs are written
-        // relative to it), so the self-host surface is byte-identical; on hosted the ONE catch-all under the
-        // prefix also covers legs added to this family later, which a per-route guard would not.
-        var utterance = HostedRouteDeny.ExclusiveGroup(app, UtterancePrefix, UtteranceDenial());
-
-        // THE ROUTES ARE MAPPED WHERE THE UNFILTERED `app` IS NOT IN SCOPE - deliberately, and that is the
-        // only reason MapUtteranceRoutes exists as a separate method. It takes only the denied group handle
-        // (<see cref="HostedDenyGroup"/>), obtainable only from the refusal primitive.
-        //
-        // This file is the sharpest case of the problem, because unlike the other three families the
-        // unfiltered builder is LEGITIMATELY here: the voice-turn, text-to-speech, transcribe, explain, ask
-        // and menu routes below are not part of the denied family and must stay on `app`. That is exactly
-        // what made the bypass cheap - both builders in scope at the same mapping site, so each of these
-        // THREE utterance legs could INDIVIDUALLY be mapped onto `app` instead of onto `utterance`, a
-        // one-word edit that compiles, passes every existing test, and opens that leg on hosted while the
-        // other two stay correctly denied. Three independently bypassable primitives, each owing its own
-        // full-suite security run under the bypassability rule. Handing the group handle to a method that
-        // never receives `app` makes the mistake INEXPRESSIBLE rather than merely unlikely: inside
-        // MapUtteranceRoutes there is nothing to map onto except the group handle. The count falls by
-        // DESIGN, not by an argument about how careful the next author will be.
-        //
-        // THE LIMIT OF THAT PROPERTY, STATED SO NOBODY OVER-CLAIMS IT: it holds WITHIN THIS MAPPING SITE.
-        // It does not reach across sites. This deny is one of FOUR families, each creating its own group and
-        // mapping from its own site, so any one site can be wrong while the other three stay correct and no
-        // compiler notices. That is exactly why the registered proof is four handler-restore arms rather than
-        // one: the group handle removes the per-ROUTE bypass inside a family, it does not merge the four
-        // families into one primitive.
-        MapUtteranceRoutes(utterance, uploads, transcription);
+        // The three legs are handed a <see cref="DictationTenantGate"/> over the voice-turn store - the same
+        // gate the dictation family uses - and NOTHING ELSE. The unscoped store is not in scope inside
+        // MapUtteranceRoutes, so a leg cannot be written that touches the shared root: the only way to obtain a
+        // store there is TryOpen, which cannot return an unscoped one. The boundary is passed through with the
+        // null-forgiving operator because it is optional on this endpoint's test seams; the gate's own
+        // resolution refuses on hosted when it is null or not hosted-wired, so a missing boundary is a refusal,
+        // never a downgrade to the shared root.
+        var utteranceGate = new DictationTenantGate(uploads, tenantBoundary!);
+        MapUtteranceRoutes(app, utteranceGate, transcription);
 
         // Text-to-speech for the mobile Voice screen + Cockpit: turn the wingman's spoken summary into
         // natural-sounding audio (the browser's own voice is robotic). Returns audio/mpeg bytes the
@@ -830,30 +744,30 @@ internal static class GatewayWingmanVoiceEndpoint
         // picker profiles and a screen-version lock on every keypress. The GET /wingman/menu detection above
         // stays (read-only, for the announce step); it never leads to a keypress.
 
-        // The GUARDED group only - not the whole voice surface. Everything else mapped above is deliberately
-        // outside it and must keep serving on hosted, which is itself asserted by a scoping control.
-        return utterance;
     }
 
     /// <summary>
-    /// The three /wingman/utterance upload legs, mapped relative to the <see cref="UtterancePrefix"/> so the
-    /// full paths are <c>/wingman/utterance/upload</c> and <c>/wingman/utterance/{uploadId}/...</c> exactly as
-    /// before. Takes the denied GROUP HANDLE and nothing else - see the note at the call site: the unfiltered
-    /// route builder that the rest of this file legitimately uses is deliberately out of scope here, so no leg
-    /// of this family can be mapped around the hosted refusal.
+    /// The three /wingman/utterance upload legs, full paths on the ungrouped builder now that the family is
+    /// un-denied (issue #1884). Each leg opens the CALLER'S OWN partition through
+    /// <see cref="DictationTenantGate"/> and works only inside it: the out-store is named <c>uploads</c> so the
+    /// existing per-leg body (size caps, staging, assemble) is byte-identical, but it is now a tenant-scoped
+    /// view rather than the shared root. A request whose tenant does not resolve is refused (403) by the gate
+    /// before any leg body runs - on hosted that means no bound tenant, never a downgrade to Local.
     /// </summary>
-    private static void MapUtteranceRoutes(HostedDenyGroup utterance, VoiceUploadStore uploads,
+    private static void MapUtteranceRoutes(IEndpointRouteBuilder app, DictationTenantGate gate,
         Transcription.GatewayTranscriptionService transcription)
     {
-        utterance.MapPost("/upload", (HttpContext ctx) =>
+        app.MapPost("/wingman/utterance/upload", (HttpContext ctx) =>
         {
+            if (!gate.TryOpen(ctx, out var uploads, out _, out var deny)) return deny;
             var key = ctx.Request.Headers["Idempotency-Key"].ToString();
             var id = uploads.Register(string.IsNullOrWhiteSpace(key) ? null : key);
             return Results.Json(new { upload_id = id });
         });
 
-        utterance.MapPut("/{uploadId}/chunk/{index:int}", async (string uploadId, int index, HttpContext ctx, CancellationToken ct) =>
+        app.MapPut("/wingman/utterance/{uploadId}/chunk/{index:int}", async (string uploadId, int index, HttpContext ctx, CancellationToken ct) =>
         {
+            if (!gate.TryOpen(ctx, out var uploads, out _, out var deny)) return deny;
             if (!uploads.Exists(uploadId))
                 return Results.Json(new { error = "unknown upload id (register it first)" }, statusCode: StatusCodes.Status404NotFound);
 
@@ -891,8 +805,9 @@ internal static class GatewayWingmanVoiceEndpoint
             catch (Exception ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status400BadRequest); }
         });
 
-        utterance.MapPost("/{uploadId}/complete", async (string uploadId, UtteranceCompleteRequest? req, CancellationToken ct) =>
+        app.MapPost("/wingman/utterance/{uploadId}/complete", async (string uploadId, UtteranceCompleteRequest? req, HttpContext ctx, CancellationToken ct) =>
         {
+            if (!gate.TryOpen(ctx, out var uploads, out _, out var deny)) return deny;
             if (req is null || req.TotalChunks <= 0)
                 return Results.Json(new { error = "totalChunks (>0) is required" }, statusCode: StatusCodes.Status400BadRequest);
             if (!uploads.Exists(uploadId))

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -543,11 +543,12 @@ public sealed class GatewayHost : IAsyncDisposable
     /// now?" - must always expire).
     /// </summary>
     internal static string? DictationStatusFor(
-        string sessionId, Transcription.TranscribingSessions marks, Voice.VoiceUploadStore uploads)
+        CcDirector.Core.Tenancy.TenantId tenant, string sessionId,
+        Transcription.TranscribingSessions marks, Voice.VoiceUploadStore uploads)
         => Transcription.DictationPhase.For(
-            activelyTranscribing: marks.IsActivelyTranscribing(sessionId),
+            activelyTranscribing: marks.IsActivelyTranscribing(tenant, sessionId),
             undelivered: uploads.IsSessionLocked(sessionId),
-            progressing: marks.IsTranscribing(sessionId));
+            progressing: marks.IsTranscribing(tenant, sessionId));
     // Issue #629: the durable, bounded, restart-surviving retry queue behind the login-telemetry
     // relay. Constructed here (loads any events a previous run left on disk), wired into the relay
     // endpoint, started flushing in StartAsync, and disposed in StopAsync.
@@ -1788,7 +1789,7 @@ public sealed class GatewayHost : IAsyncDisposable
             needsYouStampFor: (sid, isRed) => _needsYouClock.Stamp(sid, isRed),
             // Stamp the orange "Transcribing..." flag while a dictated utterance is being uploaded
             // and transcribed in the background for this session (mobile Speak -> Send).
-            transcribingFor: sid => _transcribingSessions.IsTranscribing(sid),
+            transcribingFor: (tenant, sid) => _transcribingSessions.IsTranscribing(tenant, sid),
             // Issue #1181, Task 4: the honest phase label. "Transcribing" while the server is actively
             // turning the uploaded audio into text (a bounded run); "Uploading from phone" while the durable
             // PENDING marker stands AND the phone is still making progress; null when no dictation is
@@ -1834,7 +1835,11 @@ public sealed class GatewayHost : IAsyncDisposable
             // The rule itself lives in DictationPhase.For so it is testable without a running Gateway, and
             // the WIRING that supplies its three facts lives in DictationStatusFor so it is testable too -
             // see that method for why an inline lambda here was a hole rather than a style choice.
-            dictationStatusFor: sid => DictationStatusFor(sid, _transcribingSessions, _dictationUploads),
+            // Read the CALLER'S tenant partition (issue #1884, Gap B/finding 2): IsSessionLocked enumerates
+            // the partition root, so a fresh hosted tenant's PENDING dictation is visible in its own durable
+            // "Uploading from phone" status instead of being masked by the Local/base handle. Self-host resolves
+            // Local, so ForTenant(Local) is the base root and this is byte-identical to before.
+            dictationStatusFor: (tenant, sid) => DictationStatusFor(tenant, sid, _transcribingSessions, _dictationUploads.ForTenant(tenant)),
             // The mobile Speak flow marks/clears this via POST /sessions/{sid}/transcribing.
             transcribingSessions: _transcribingSessions,
             // Issue #212 W3: enrich the Interrupted sessions list from the durable brief store. Always
@@ -2385,7 +2390,20 @@ public sealed class GatewayHost : IAsyncDisposable
         _voiceTurnUploadSweepTimer = new System.Threading.Timer(
             _ =>
             {
-                try { _voiceTurnUploads.SweepAbandoned(VoiceTurnUploadMaxAge); }
+                // PER-TENANT retention (issue #1884, finding 2). /wingman/utterance now stages account uploads
+                // in tenant partitions (base/tenants/<id>), and SweepAbandoned deliberately does NOT descend
+                // into the partition container - so sweeping only the Local/base handle would retain every
+                // hosted tenant's interrupted utterance audio forever, breaking the four-hour privacy bound
+                // (#1952). Run one pass per live tenant, each inside that tenant's own partition. Self-host runs
+                // exactly one Local pass (ForTenant(Local) is the base root), byte-identical to before.
+                try
+                {
+                    _tenantPass.ForEachTenant(() =>
+                    {
+                        if (_tenantPass.Current is not { } tenant) return; // deny: no scope -> sweep nothing
+                        _voiceTurnUploads.ForTenant(tenant).SweepAbandoned(VoiceTurnUploadMaxAge);
+                    });
+                }
                 catch (Exception ex) { FileLog.Write($"[GatewayHost] voice-turn upload sweep error: {ex.Message}"); }
             },
             null, voiceTurnUploadSchedule, voiceTurnUploadSchedule);

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -495,7 +495,12 @@ public sealed class GatewayHost : IAsyncDisposable
     // delivery record (issue #1183): PENDING chunks are retained until delivered/abandoned, and the
     // terminal tombstone de-dupes the upload id forever until the client acknowledges it - so there is no
     // age sweep for dictation staging (only the unrelated voice-turn staging is age-swept).
-    private readonly Voice.VoiceUploadStore _dictationUploads = new(CcDirector.Core.Storage.CcStorage.DictationUploads());
+    // The tenant is named here because the store REQUIRES one - there is no constructor that picks a
+    // partition on the author's behalf. This is the BASE handle only: the dictation endpoint re-scopes it
+    // with ForTenant to the tenant it resolved from the authenticated device key, and does its work solely
+    // inside that partition. Naming Local here reproduces exactly the path this store has always used.
+    private readonly Voice.VoiceUploadStore _dictationUploads =
+        new(CcDirector.Core.Storage.CcStorage.DictationUploads(), CcDirector.Core.Tenancy.TenantId.Local);
     // Store injection points (Hosted Gateway, Step 1b): the host owns ONE instance of each durable store
     // that was previously reached through a process-wide static, and hands it to the endpoint/service that
     // uses it, so a tenant id can reach the storage layer in a later pull request. Same default paths as
@@ -504,7 +509,12 @@ public sealed class GatewayHost : IAsyncDisposable
     private readonly Prompts.GatewayPromptLog _promptLog;
     private readonly Transcription.TranscriptionTelemetryLog _transcriptionTelemetry = new();
     private readonly Transcription.TranscriptionAudioArchive _transcriptionAudioArchive = new();
-    private readonly Voice.VoiceUploadStore _voiceTurnUploads = new();
+    // The voice-turn staging root, likewise bound to an explicitly-named partition. This path stages a clip
+    // for the duration of one turn and then deletes it; it writes no delivery record and performs no
+    // cross-request lookup by upload id, so it is unchanged by the dictation partition work. Per-tenant
+    // scoping of the voice-turn path itself is a separate piece of work and is NOT claimed here.
+    private readonly Voice.VoiceUploadStore _voiceTurnUploads =
+        new(CcDirector.Core.Storage.CcStorage.VoiceTurnUploads(), CcDirector.Core.Tenancy.TenantId.Local);
     // The Gateway's stable per-machine install identity (issue #857), owned by the host and handed to the
     // device-registration service instead of the retired static GatewayInstallId.LoadOrCreate.
     private readonly Account.GatewayInstallId _installIdStore = new();
@@ -2002,7 +2012,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // in resumable chunks and the Gateway assembles → transcribes → injects the turn into the
         // owning session itself, so a refresh / dropped connection cannot lose a recorded utterance.
         GatewayDictationEndpoint.Map(_app, Registry, SessionOwners, Token,
-            _dictationTranscription ?? new Transcription.GatewayTranscriptionService(_keyVault, telemetry: _transcriptionTelemetry, audioArchive: _transcriptionAudioArchive), _transcribingSessions, _dictationUploads, Devices,
+            _dictationTranscription ?? new Transcription.GatewayTranscriptionService(_keyVault, telemetry: _transcriptionTelemetry, audioArchive: _transcriptionAudioArchive), _transcribingSessions, new Api.DictationTenantGate(_dictationUploads, _tenantBoundary), Devices,
             pushedSessions: PushedSessions,
             sendCommand: SendCommandAsync);
         // Durable per-upload-id dictation record (issue #1183): a PENDING upload's chunks are retained
@@ -2351,6 +2361,21 @@ public sealed class GatewayHost : IAsyncDisposable
             _ => { try { _tenantPass.ForEachTenant(() => FleetDisplayState.Sweep()); } catch (Exception ex) { FileLog.Write($"[GatewayHost] display-state sweep error: {ex.Message}"); } },
             null, DisplayStateSweepInterval, DisplayStateSweepInterval);
         FileLog.Write($"[GatewayHost] display-state sweep started: every {DisplayStateSweepInterval.TotalSeconds:0}s");
+
+        // Un-deny safety gate (issue #1884). Now that the /dictation and /wingman/utterance upload families
+        // are served on hosted (tenant-partitioned), any pre-partition upload directory sitting directly under
+        // a shared base root is legacy and unattributable - it predates the partition and belongs to no
+        // resolvable tenant. On hosted, move those aside ONCE at startup so no pass (the age sweep below, the
+        // durable PENDING projection, or any base-handle read) ever treats them as live. It MOVES, never
+        // deletes, and is idempotent/re-entrant, so it is safe under restart and concurrent workers. Self-host
+        // legitimately keeps its uploads at the root, so this runs only on hosted.
+        if (GatewayHostedMode.IsHosted)
+        {
+            var quarantinedDictation = _dictationUploads.QuarantineLegacyUploads();
+            var quarantinedVoiceTurn = _voiceTurnUploads.QuarantineLegacyUploads();
+            FileLog.Write($"[GatewayHost] hosted un-deny safety: quarantined legacy upload dirs " +
+                $"dictation={quarantinedDictation} voiceTurn={quarantinedVoiceTurn}");
+        }
 
         // Voice-turn upload staging retention. The success path deletes an upload's staging directory when
         // the turn starts; everything else - a refused, dropped or never-completed upload - is bounded here

--- a/src/CcDirector.Gateway/Transcription/TranscribingSessions.cs
+++ b/src/CcDirector.Gateway/Transcription/TranscribingSessions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Gateway.Transcription;
@@ -27,6 +28,17 @@ namespace CcDirector.Gateway.Transcription;
 /// quiet and ages out within the idle window. Issue #1126 shortened this from a fixed 20-minute age -
 /// which wedged sessions orange for a full 20 minutes whenever the explicit clear was skipped - to
 /// this short idle window.
+///
+/// TENANT-KEYED (issue #1884, Gap B). Both maps below key on (tenant, sessionId), NEVER on the bare
+/// sessionId. This set is a single process-wide instance shared across every tenant on the hosted
+/// Gateway, and a session id is a client-supplied GUID that travels in logs and retries - so keying on
+/// it alone let one account set, clear, or read ANOTHER account's transcribing state by supplying that
+/// account's session id (paint a stranger's session orange for the idle window, or clear the real mark
+/// on their live dictation). A GUID is not a tenant boundary. The tenant is resolved server-side from
+/// the authenticated device key at every call site (the /sessions/{sid}/transcribing route, the
+/// dictation completion flow, and the roster read) and is a REQUIRED argument here - there is no
+/// bare-sessionId overload that would silently key on one shared partition. Self-host passes
+/// <see cref="TenantId.Local"/> throughout and is byte-identical to before.
 /// </summary>
 public sealed class TranscribingSessions
 {
@@ -37,7 +49,7 @@ public sealed class TranscribingSessions
     /// that has genuinely stopped making progress.</summary>
     public static readonly TimeSpan IdleTimeout = TimeSpan.FromSeconds(90);
 
-    private readonly ConcurrentDictionary<string, DateTime> _lastProgress = new(); // sid -> last progress time (UTC)
+    private readonly ConcurrentDictionary<string, DateTime> _lastProgress = new(); // (tenant|sid) -> last progress time (UTC)
     private readonly Func<DateTime> _utcNow;
 
     /// <summary>Production uses the wall clock; tests inject a controllable clock so the
@@ -47,46 +59,55 @@ public sealed class TranscribingSessions
         _utcNow = utcNow ?? (() => DateTime.UtcNow);
     }
 
+    /// <summary>
+    /// The map key: the owning tenant AND the session id. The tenant is first so a key can never be
+    /// read as belonging to a different account by accident, and a session id from one account can never
+    /// name another account's mark.
+    /// </summary>
+    private static string MarkKey(TenantId tenant, string sessionId) => tenant.Value + "|" + sessionId;
+
     /// <summary>Mark a session as transcribing (idempotent). Stamps the progress time so a fresh Send
     /// restarts the idle backstop clock rather than inheriting an older mark's age.</summary>
-    public void Begin(string sessionId)
+    public void Begin(TenantId tenant, string sessionId)
     {
         ArgumentException.ThrowIfNullOrEmpty(sessionId);
-        _lastProgress[sessionId] = _utcNow();
-        FileLog.Write($"[TranscribingSessions] sid={sessionId}: begin transcribing");
+        _lastProgress[MarkKey(tenant, sessionId)] = _utcNow();
+        FileLog.Write($"[TranscribingSessions] tenant={tenant.ToLogString()} sid={sessionId}: begin transcribing");
     }
 
     /// <summary>Record progress on an EXISTING mark (a chunk stored, a completion attempt) so an active
     /// but slow upload keeps its mark alive past the idle backstop. A no-op when the session is not
     /// currently marked: Refresh keeps a live mark alive, it never resurrects a cleared one.</summary>
-    public void Refresh(string sessionId)
+    public void Refresh(TenantId tenant, string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId)) return;
+        var key = MarkKey(tenant, sessionId);
         // Only bump an existing mark. Using TryGetValue-then-set (not an unconditional write) keeps a
         // Refresh that races an End from re-creating the mark End just removed.
-        if (_lastProgress.ContainsKey(sessionId))
-            _lastProgress[sessionId] = _utcNow();
+        if (_lastProgress.ContainsKey(key))
+            _lastProgress[key] = _utcNow();
     }
 
     /// <summary>Clear a session's transcribing mark (idempotent). The authoritative clear, called by
     /// the dictation-upload flow on every terminal outcome.</summary>
-    public void End(string sessionId)
+    public void End(TenantId tenant, string sessionId)
     {
         ArgumentException.ThrowIfNullOrEmpty(sessionId);
-        if (_lastProgress.TryRemove(sessionId, out _))
-            FileLog.Write($"[TranscribingSessions] sid={sessionId}: end transcribing");
+        if (_lastProgress.TryRemove(MarkKey(tenant, sessionId), out _))
+            FileLog.Write($"[TranscribingSessions] tenant={tenant.ToLogString()} sid={sessionId}: end transcribing");
     }
 
     /// <summary>Whether the session is currently transcribing. A mark that has seen no progress for
     /// <see cref="IdleTimeout"/> is treated as an abandoned mark and removed on read, so a
     /// crashed/offline client cannot wedge the session orange.</summary>
-    public bool IsTranscribing(string sessionId)
+    public bool IsTranscribing(TenantId tenant, string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId)) return false;
-        if (!_lastProgress.TryGetValue(sessionId, out var since)) return false;
+        var key = MarkKey(tenant, sessionId);
+        if (!_lastProgress.TryGetValue(key, out var since)) return false;
         if (_utcNow() - since <= IdleTimeout) return true;
-        if (_lastProgress.TryRemove(sessionId, out _))
-            FileLog.Write($"[TranscribingSessions] sid={sessionId}: mark idle for over {IdleTimeout.TotalSeconds:0}s, cleared");
+        if (_lastProgress.TryRemove(key, out _))
+            FileLog.Write($"[TranscribingSessions] tenant={tenant.ToLogString()} sid={sessionId}: mark idle for over {IdleTimeout.TotalSeconds:0}s, cleared");
         return false;
     }
 
@@ -97,23 +118,24 @@ public sealed class TranscribingSessions
     // "actively transcribing" signal: set for the duration of the assemble+transcribe+deliver run and
     // cleared in a finally. No idle timeout is needed - it is bounded by the run; if a crash leaks an
     // entry, the Gateway restart clears it (in-memory) and the durable marker still shows "Uploading".
+    // Keyed by (tenant, sid) for the same reason as _lastProgress above (issue #1884, Gap B).
     private readonly ConcurrentDictionary<string, byte> _activelyTranscribing = new();
 
     /// <summary>Mark a session as ACTIVELY transcribing (the complete-run is assembling/transcribing).</summary>
-    public void MarkActivelyTranscribing(string sessionId)
+    public void MarkActivelyTranscribing(TenantId tenant, string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId)) return;
-        _activelyTranscribing[sessionId] = 1;
+        _activelyTranscribing[MarkKey(tenant, sessionId)] = 1;
     }
 
     /// <summary>Clear the actively-transcribing mark (called in the complete-run's finally).</summary>
-    public void ClearActivelyTranscribing(string sessionId)
+    public void ClearActivelyTranscribing(TenantId tenant, string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId)) return;
-        _activelyTranscribing.TryRemove(sessionId, out _);
+        _activelyTranscribing.TryRemove(MarkKey(tenant, sessionId), out _);
     }
 
     /// <summary>True while the server is actively transcribing this session's uploaded audio.</summary>
-    public bool IsActivelyTranscribing(string sessionId)
-        => !string.IsNullOrEmpty(sessionId) && _activelyTranscribing.ContainsKey(sessionId);
+    public bool IsActivelyTranscribing(TenantId tenant, string sessionId)
+        => !string.IsNullOrEmpty(sessionId) && _activelyTranscribing.ContainsKey(MarkKey(tenant, sessionId));
 }

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -471,8 +471,15 @@ public sealed class VoiceUploadStore
     /// MOVE, NEVER DELETE: the bytes are preserved under <see cref="QuarantineDirectoryName"/> for a later
     /// operator-run purge - this method loses nothing. IDEMPOTENT AND RE-ENTRANT: it admits ONLY a canonical
     /// upload-id directory, so the tenants partition container and the quarantine directory itself are never
-    /// moved; and a move whose target already exists is left untouched, so running it twice - or two workers
-    /// running it at once - converges without error and never overwrites an already-quarantined directory.
+    /// moved. A legacy source is ALWAYS moved aside - NEVER left live at the base root. When the canonical
+    /// quarantine slot is already taken - an earlier run (or a concurrent worker) quarantined that id and then
+    /// a rolling/older worker recreated the same base id, or an interrupted recovery is re-entered - the source
+    /// is moved to a UNIQUE non-colliding name beside it (a <c>__dup-N</c> suffix) rather than left where the
+    /// base age sweep and the base PENDING projection would still read it as live. The suffix is deliberately
+    /// NOT a canonical upload-id shape, so a quarantined dup is never re-admitted as an upload or a tenant.
+    /// Running it twice - or two workers at once - converges without error and never overwrites an existing
+    /// quarantined directory; and because a moved source is gone from the base root, a second run that sees the
+    /// same id at base is looking at a genuinely NEW legacy directory that must also be moved aside.
     ///
     /// Call it on the BASE (Local) handle; on an account partition there is nothing pre-partition to move and
     /// it is a no-op. Returns how many directories were moved.
@@ -494,12 +501,19 @@ public sealed class VoiceUploadStore
                 // not canonical names, so they are skipped - which is exactly what makes this re-entrant.
                 if (!IsCanonicalUploadDirName(name)) continue;
 
-                var target = Path.Combine(quarantine, name);
                 try
                 {
                     Directory.CreateDirectory(quarantine);
-                    // Already quarantined by an earlier run or a concurrent worker: leave it, never overwrite.
-                    if (Directory.Exists(target)) continue;
+                    // Pick a target that does not already exist. The canonical slot (quarantine/<id>) first; if
+                    // it is taken, a unique __dup-N sibling - so the source ALWAYS moves and is never left live
+                    // at base. A null return means no free slot was found (unreasonable), in which case we log
+                    // and leave the source rather than delete or overwrite anything.
+                    var target = FreeQuarantineTarget(quarantine, name);
+                    if (target is null)
+                    {
+                        FileLog.Write($"[VoiceUploadStore] quarantine {name} skipped: no free target slot");
+                        continue;
+                    }
                     Directory.Move(dir, target);
                     moved++;
                 }
@@ -514,6 +528,27 @@ public sealed class VoiceUploadStore
             FileLog.Write($"[VoiceUploadStore] QuarantineLegacyUploads failed: {ex.Message}");
         }
         return moved;
+    }
+
+    /// <summary>
+    /// The first quarantine target path for <paramref name="name"/> that does not already exist: the canonical
+    /// <c>quarantine/&lt;name&gt;</c> slot when it is free, else <c>quarantine/&lt;name&gt;__dup-N</c> for the
+    /// lowest N that is free. Returns null only if every candidate up to the bound is taken (unreasonable), so
+    /// the caller can leave the source rather than overwrite. The suffix keeps the name NON-canonical, so a
+    /// quarantined dup is never re-admitted as an upload id or a tenant by any later pass.
+    /// </summary>
+    private static string? FreeQuarantineTarget(string quarantine, string name)
+    {
+        var canonical = Path.Combine(quarantine, name);
+        if (!Directory.Exists(canonical)) return canonical;
+        // A bound rather than an unbounded loop: a hostile or pathological pile-up of colliding ids must not
+        // spin forever. 10000 distinct dup slots per id is far beyond any real rolling-deploy collision.
+        for (var n = 1; n <= 10000; n++)
+        {
+            var candidate = Path.Combine(quarantine, $"{name}__dup-{n}");
+            if (!Directory.Exists(candidate)) return candidate;
+        }
+        return null;
     }
 
     /// <summary>Delete the staging dir for an upload. Best-effort; called once the turn is started.</summary>

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -1,7 +1,7 @@
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Gateway.Voice;
@@ -36,22 +36,170 @@ namespace CcDirector.Gateway.Voice;
 /// keeps the outcome marker, so a delivered upload id is de-duplicated forever - across time and a
 /// Gateway restart - until the client acknowledges it (<see cref="Acknowledge"/>). See
 /// <see cref="DictationDeliveryRecord"/> for the model.
+///
+/// PARTITIONED BY TENANT (issue #1884). Every directory, chunk and record used to be keyed SOLELY by the
+/// caller-supplied upload id, on one global root. A GUID is not a tenant boundary: secrecy of an identifier
+/// is not authorization, and upload ids travel in client logs, retries and store-and-forward queues - so on
+/// the hosted Gateway one account holding another's upload id could read its transcript, overwrite its
+/// chunks, or resolve its record. An upload id is now only meaningful INSIDE its own tenant: the partition is
+/// the DIRECTORY (<see cref="ForTenant"/>), so a read physically cannot open another tenant's staging, and
+/// the record itself carries its tenant as a second, independent check. <see cref="TenantId.Local"/> keeps
+/// today's path exactly - self-host is unchanged and nothing migrates - and a hosted account tenant lands
+/// under tenants/&lt;id&gt;/. The tenant is always supplied by the caller, which resolved it from the
+/// authenticated device key at the boundary; this type never guesses one.
+///
+/// THE TENANT IS REQUIRED AT CONSTRUCTION. There is deliberately no constructor that omits it, so an
+/// unscoped store is not something to be guarded against - it cannot be built, and the attempt is a build
+/// error at the call site rather than a live object with the widest possible reach. See the constructor
+/// below for why the previous defaults were the wrong shape.
 /// </summary>
 public sealed class VoiceUploadStore
 {
     /// <summary>The container directory hosting the non-local partitions, directly under the base root.</summary>
     public const string TenantPartitionDirectoryName = "tenants";
 
+    // This partition's staging root: the base root for the local tenant, base/tenants/<id> otherwise.
     private readonly string _root;
+    // The base root every partition is computed from, so ForTenant on an already-partitioned store still
+    // resolves against the base rather than nesting a partition inside a partition.
+    private readonly string _partitionBase;
+    // The tenant this instance is bound to. Stamped onto every record written and required to match on
+    // every record read.
+    private readonly TenantId _tenant;
 
-    public VoiceUploadStore() : this(CcStorage.VoiceTurnUploads()) { }
+    /// <summary>
+    /// Stage under an explicit root, bound to ONE tenant.
+    ///
+    /// THE TENANT IS A REQUIRED ARGUMENT OF CONSTRUCTION, AND THAT IS THE WHOLE POINT OF THIS SIGNATURE.
+    /// This type used to offer a no-argument constructor and a root-only constructor, both of which silently
+    /// bound <see cref="TenantId.Local"/>. That made the widest scope the DEFAULT - reached by writing LESS
+    /// code, not more - so a new call site could hold every account's staged audio while looking, to a
+    /// reviewer, like an ordinary object creation with nothing to question. There is now no spelling of
+    /// "make me an upload store" that does not name the partition it belongs to: an unscoped store is not
+    /// guarded against, it is UNCONSTRUCTABLE, so there is no bypass to enumerate and none to forget.
+    ///
+    /// Naming <see cref="TenantId.Local"/> is still correct on self-host and still resolves to exactly the
+    /// path it always did - but it is now WRITTEN DOWN at the call site, which is the difference between a
+    /// decision a reviewer can see and one the compiler made on the author's behalf.
+    /// </summary>
+    /// <param name="root">The base staging root; the local partition is this directory itself.</param>
+    /// <param name="tenant">The partition this store is bound to. Never guessed, never defaulted.</param>
+    public VoiceUploadStore(string root, TenantId tenant)
+        : this(PartitionRootFor(root, RequireTenant(tenant)), tenant, root) { }
 
-    /// <summary>Test seam: stage under an explicit root instead of the shared storage dir.</summary>
-    public VoiceUploadStore(string root)
+    private VoiceUploadStore(string root, TenantId tenant, string partitionBase)
     {
         _root = root;
+        _tenant = tenant;
+        _partitionBase = partitionBase;
         Directory.CreateDirectory(_root);
     }
+
+    /// <summary>The tenant this store instance is bound to.</summary>
+    public TenantId Tenant => _tenant;
+
+    /// <summary>This partition's staging root on disk.</summary>
+    public string Root => _root;
+
+    /// <summary>
+    /// A view of this staging bound to ONE tenant. Every path, gate, chunk and record of the returned store
+    /// lives inside that tenant's partition, so an upload id from another tenant simply does not exist here -
+    /// the isolation is the directory, not a predicate a later edit could forget to apply.
+    /// </summary>
+    public VoiceUploadStore ForTenant(TenantId tenant) => new VoiceUploadStore(_partitionBase, tenant);
+
+    /// <summary>
+    /// The single place a tenant is admitted into this type. An unresolved tenant is DENIED here rather than
+    /// quietly becoming <see cref="TenantId.Local"/>: a default struct bypasses <see cref="TenantId"/>'s own
+    /// validating constructor, so <c>default(TenantId)</c> is the one way a caller could still arrive without
+    /// having decided anything, and it must not be the way in.
+    /// </summary>
+    private static TenantId RequireTenant(TenantId tenant)
+        => tenant.IsValid
+            ? tenant
+            : throw new ArgumentException(
+                "An upload partition needs a valid tenant; an unresolved tenant is denied, never defaulted.",
+                nameof(tenant));
+
+    /// <summary>
+    /// True only for the EXACT form <see cref="Tenancy.TenantRegistry"/> mints: a canonical lowercase GUID.
+    ///
+    /// A tenant id becomes a DIRECTORY NAME here, so it must be a shape this system actually produces - not
+    /// merely "characters that look harmless". Both structural aliases already found on the prompt-log
+    /// partition (<c>GatewayPromptLog</c>) apply verbatim to this one:
+    ///
+    ///  - A character allow-list such as <c>^[A-Za-z0-9._-]{1,64}$</c> accepts <c>".."</c>, and combining the
+    ///    base root with <c>tenants</c> and <c>".."</c> canonicalizes to exactly the base root - the LOCAL
+    ///    partition.
+    ///  - An allow-list accepting <c>A-F</c> as well as <c>a-f</c> lets two ids that differ only in case name
+    ///    the SAME directory on Windows and Azure Files while being DIFFERENT identities to the
+    ///    case-sensitive tenants table. That is one tenant reading another's audio through a casing alias.
+    ///
+    /// So this accepts ONE spelling: parse strictly, then require the value to equal its own canonical
+    /// round-trip. Anything else is REFUSED rather than normalised - normalising is how two identities
+    /// quietly share a folder, and this folder holds recorded AUDIO and its TRANSCRIPT.
+    /// </summary>
+    private static bool IsMintedAccountTenant(string value)
+        => Guid.TryParseExact(value, "D", out var parsed)
+           && string.Equals(value, parsed.ToString("D"), StringComparison.Ordinal);
+
+    /// <summary>
+    /// The staging root one tenant's uploads live in. The local tenant keeps the root it has always used -
+    /// self-host unchanged, nothing migrates - and every other tenant gets its own folder beneath it.
+    /// </summary>
+    private static string PartitionRootFor(string partitionBase, TenantId tenant)
+    {
+        if (tenant.IsLocal) return partitionBase;
+
+        // Every other partition must be a minted account tenant - including the reserved SYSTEM tenant, which
+        // is deliberately REFUSED rather than given a folder: no recorded audio belongs to it, so the safe
+        // answer is that it has no partition at all.
+        if (!IsMintedAccountTenant(tenant.Value))
+            throw new ArgumentException(
+                $"Tenant '{tenant.ToLogString()}' is not a minted account tenant and cannot name an upload partition.",
+                nameof(tenant));
+
+        var combined = Path.Combine(partitionBase, TenantPartitionDirectoryName, tenant.Value);
+
+        // Belt and braces, because the cost of being wrong here is one account reading another's dictation:
+        // the result must actually LIE INSIDE the partition container. The rule above already excludes
+        // traversal, so this can only fire if that rule is ever loosened - which is exactly when it is wanted.
+        //
+        // THIS GUARD HAS NO CANARY, DELIBERATELY, AND THAT IS NOT A COVERAGE GAP TO FILL. Measured, not
+        // assumed: deleting these three lines and running the tenant-partition and dictation suites reddens
+        // NOTHING. It cannot redden, because IsMintedAccountTenant above already refuses every value that
+        // could escape the root - ".." and "../.." and "a/b" and any non-GUID - so no input this method can
+        // legally receive reaches here with a combined path outside the container. It is unreachable by
+        // construction, which is the whole reason it is belt and braces rather than the primary defence.
+        //
+        // So do NOT write a test for it: the only test that could exist here is one that cannot fail, and a
+        // test that cannot fail is worse than no test - it reads as coverage. The condition under which this
+        // guard becomes reachable, and therefore the condition under which it becomes testable and MUST be
+        // given a canary, is precisely the moment someone loosens IsMintedAccountTenant. If you are here
+        // because you just did that, this guard is now live and needs a test that fails when you remove it.
+        var expectedRoot =
+            Path.GetFullPath(Path.Combine(partitionBase, TenantPartitionDirectoryName)) + Path.DirectorySeparatorChar;
+        if (!Path.GetFullPath(combined).StartsWith(expectedRoot, StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException(
+                $"Tenant '{tenant.ToLogString()}' resolves outside the upload partition root.", nameof(tenant));
+
+        return combined;
+    }
+
+    /// <summary>
+    /// The SECOND, independent check on a record: does the record on disk claim this partition's tenant?
+    /// The directory already makes a cross-tenant read impossible, so this can only fire if a partition root
+    /// is ever mis-computed - which is precisely the failure that must not silently hand over a transcript.
+    ///
+    /// An ABSENT tenant on the record is accepted ONLY for the local partition. That is not a fallback: it is
+    /// the exact reading of records written before this field existed, all of which are self-host records in
+    /// the local partition. In an account partition an absent tenant is refused, so a missing value can never
+    /// become a way in.
+    /// </summary>
+    private bool BelongsHere(DictationDeliveryRecord record)
+        => string.IsNullOrEmpty(record.Tenant)
+            ? _tenant.IsLocal
+            : string.Equals(record.Tenant, _tenant.Value, StringComparison.Ordinal);
 
     /// <summary>
     /// Begin (or re-open) an upload. The caller supplies a GUID id (it is also the
@@ -303,6 +451,71 @@ public sealed class VoiceUploadStore
         => Guid.TryParseExact(name, "N", out var parsed)
            && string.Equals(name, parsed.ToString("N"), StringComparison.Ordinal);
 
+    /// <summary>The subdirectory pre-partition legacy uploads are moved into by <see cref="QuarantineLegacyUploads"/>.
+    /// Not a canonical upload id, so no sweep, projection, or partition treats it as an upload or a tenant.</summary>
+    public const string QuarantineDirectoryName = "_quarantine-legacy";
+
+    /// <summary>
+    /// Move aside every pre-partition upload directory sitting DIRECTLY under this store's base root, so a
+    /// hosted Gateway never serves, sweeps, or projects a legacy unattributable upload as if it were live
+    /// (issue #1884, the un-deny safety gate; the same move-aside shape #1933 used for pre-version rows).
+    ///
+    /// WHY IT IS NEEDED EVEN WITH THE DIRECTORY PARTITION. A hosted account tenant reads only
+    /// <c>base/tenants/&lt;id&gt;/</c> and can never address <c>base/&lt;uploadId&gt;</c>, so the audio is
+    /// already unreachable to another account. What this closes is the BASE (Local) handle's OWN passes - the
+    /// age sweep and the durable PENDING projection both enumerate the base root on a hosted Gateway - which
+    /// would otherwise read a legacy record as live state (a legacy PENDING record surfacing a session as
+    /// locked, a legacy dir aged out and deleted). Moving the legacy dirs out of the enumerated root removes
+    /// them from every such pass at once, and out of any future un-scoped read.
+    ///
+    /// MOVE, NEVER DELETE: the bytes are preserved under <see cref="QuarantineDirectoryName"/> for a later
+    /// operator-run purge - this method loses nothing. IDEMPOTENT AND RE-ENTRANT: it admits ONLY a canonical
+    /// upload-id directory, so the tenants partition container and the quarantine directory itself are never
+    /// moved; and a move whose target already exists is left untouched, so running it twice - or two workers
+    /// running it at once - converges without error and never overwrites an already-quarantined directory.
+    ///
+    /// Call it on the BASE (Local) handle; on an account partition there is nothing pre-partition to move and
+    /// it is a no-op. Returns how many directories were moved.
+    /// </summary>
+    public int QuarantineLegacyUploads()
+    {
+        // Account partitions (base/tenants/<id>) are clean by construction - only the shared base root can
+        // hold pre-partition uploads - so this runs only for the base handle.
+        if (!string.Equals(_root, _partitionBase, StringComparison.Ordinal)) return 0;
+
+        var quarantine = Path.Combine(_root, QuarantineDirectoryName);
+        var moved = 0;
+        try
+        {
+            foreach (var dir in Directory.EnumerateDirectories(_root))
+            {
+                var name = Path.GetFileName(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                // Admit ONLY a canonical upload-id directory. The tenants container and the quarantine dir are
+                // not canonical names, so they are skipped - which is exactly what makes this re-entrant.
+                if (!IsCanonicalUploadDirName(name)) continue;
+
+                var target = Path.Combine(quarantine, name);
+                try
+                {
+                    Directory.CreateDirectory(quarantine);
+                    // Already quarantined by an earlier run or a concurrent worker: leave it, never overwrite.
+                    if (Directory.Exists(target)) continue;
+                    Directory.Move(dir, target);
+                    moved++;
+                }
+                catch (IOException ex) { FileLog.Write($"[VoiceUploadStore] quarantine {name} skipped: {ex.Message}"); }
+                catch (UnauthorizedAccessException ex) { FileLog.Write($"[VoiceUploadStore] quarantine {name} skipped: {ex.Message}"); }
+            }
+            if (moved > 0)
+                FileLog.Write($"[VoiceUploadStore] QuarantineLegacyUploads moved={moved} legacy upload dirs into {QuarantineDirectoryName}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[VoiceUploadStore] QuarantineLegacyUploads failed: {ex.Message}");
+        }
+        return moved;
+    }
+
     /// <summary>Delete the staging dir for an upload. Best-effort; called once the turn is started.</summary>
     public void Delete(string uploadId)
     {
@@ -334,7 +547,19 @@ public sealed class VoiceUploadStore
     public DictationDeliveryRecord? ReadRecord(string uploadId)
     {
         var uid = NormalizeId(uploadId);
-        return uid is null ? null : ReadRecordFile(RecordPath(DirFor(uid)));
+        if (uid is null) return null;
+        var record = ReadRecordFile(RecordPath(DirFor(uid)));
+        if (record is null) return null;
+        // Tenant-checked as well as partitioned (issue #1884). See BelongsHere: the directory is the boundary,
+        // this is the independent second opinion, and a record that fails it is treated as absent rather than
+        // handed to a caller it does not belong to.
+        if (!BelongsHere(record))
+        {
+            FileLog.Write($"[VoiceUploadStore] ReadRecord: uploadId={uid} record belongs to another tenant " +
+                $"(partition={_tenant.ToLogString()}); refused");
+            return null;
+        }
+        return record;
     }
 
     private static DictationDeliveryRecord? ReadRecordFile(string path)
@@ -415,8 +640,23 @@ public sealed class VoiceUploadStore
             dirs = Array.Empty<string>();
         }
         foreach (var dir in dirs)
-            if (ReadRecordFile(RecordPath(dir)) is { State: DictationDeliveryState.Pending } rec)
+        {
+            // The partition container is not an upload, so skip it rather than probing it for a record.
+            //
+            // NO CANARY HERE EITHER, and for a different reason than the containment guard in
+            // PartitionRootFor - this one is REDUNDANT rather than unreachable. Measured: removing this line
+            // reddens nothing. It cannot, because the container directory holds other tenants' partitions and
+            // no record.json of its own, so ReadRecordFile returns null and the pattern match already declines
+            // it; and even if a record were somehow found there, BelongsHere on the same line refuses a record
+            // belonging to another tenant. Two independent things downstream already give the right answer.
+            //
+            // It stays because it says what is true - a partition container is not an upload - and because it
+            // stops a pointless file probe per partition on every projection. It is clarity and cost, not a
+            // security boundary; the security boundary on this line is BelongsHere, and THAT one has canaries.
+            if (IsPartitionContainer(dir)) continue;
+            if (ReadRecordFile(RecordPath(dir)) is { State: DictationDeliveryState.Pending } rec && BelongsHere(rec))
                 yield return rec;
+        }
     }
 
     /// <summary>
@@ -620,11 +860,15 @@ public sealed class VoiceUploadStore
     }
 
     // Persist the record.json marker atomically (temp + move), leaving any staged chunks untouched.
-    private static void WriteRecordMarker(string dir, DictationDeliveryRecord record)
+    //
+    // THE ONE PLACE a record is written, so it is the one place the owning tenant is stamped (issue #1884).
+    // Stamped here rather than by each composer on purpose: a composer that forgot would write an
+    // unattributed record, and the whole point of the field is that it cannot be forgotten.
+    private void WriteRecordMarker(string dir, DictationDeliveryRecord record)
     {
         var path = RecordPath(dir);
         var tmp = path + ".tmp";
-        File.WriteAllText(tmp, JsonSerializer.Serialize(record, RecordJson));
+        File.WriteAllText(tmp, JsonSerializer.Serialize(record with { Tenant = _tenant.Value }, RecordJson));
         File.Move(tmp, path, overwrite: true);
     }
 
@@ -717,6 +961,12 @@ public sealed class VoiceUploadStore
     private string GateKey(string uid) => Path.GetFullPath(DirFor(uid));
 
     private string DirFor(string uid) => Path.Combine(_root, uid);
+
+    // True for the directory that HOLDS the other tenants' partitions, which is never itself an upload.
+    private static bool IsPartitionContainer(string dir)
+        => string.Equals(Path.GetFileName(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)),
+            TenantPartitionDirectoryName, StringComparison.OrdinalIgnoreCase);
+
     private static string ChunkPath(string dir, int index) => Path.Combine(dir, $"{index:D5}.part");
     private static string RecordPath(string dir) => Path.Combine(dir, "record.json");
 
@@ -732,6 +982,13 @@ public sealed class VoiceUploadStore
         if (string.IsNullOrWhiteSpace(id)) return null;
         return Guid.TryParse(id, out var g) ? g.ToString("N") : null;
     }
+
+    /// <summary>
+    /// The canonical staging form of a caller-supplied upload id, or null when it is not a GUID. Exposed so
+    /// the endpoint's in-memory caches key on the SAME single spelling this store keys its directories by:
+    /// two spellings of one GUID must not become two cache entries for one staging directory.
+    /// </summary>
+    internal static string? NormalizeUploadId(string? id) => NormalizeId(id);
 
     private static string Sha256Hex(byte[] bytes)
         => Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
@@ -775,6 +1032,14 @@ public enum DictationDeliveryState { Pending, Delivered, Abandoned, Failed }
 /// that never saw the 502 still retries against the honest baseline. Null (absent) in every record written
 /// before this field existed, which reads back as "no attempt has failed" - the correct meaning.
 /// </param>
+/// <param name="Tenant">
+/// The tenant that owns this upload (issue #1884). Stamped by <see cref="VoiceUploadStore"/> on every write
+/// from the partition the record is written into - callers never supply it - and required to match on every
+/// read. The directory partition is the boundary; this field is the independent second check, so a
+/// mis-computed partition root cannot silently hand one account another's audio or transcript. Empty in
+/// records written before the field existed, which are self-host records and are accepted only in the local
+/// partition.
+/// </param>
 public sealed record DictationDeliveryRecord(
     DictationDeliveryState State,
     bool Submitted,
@@ -782,4 +1047,5 @@ public sealed record DictationDeliveryRecord(
     string Transcript,
     string? Reason,
     string SessionId = "",
-    long? RebaselineBufferBytes = null);
+    long? RebaselineBufferBytes = null,
+    string Tenant = "");


### PR DESCRIPTION
Detail: devthrottle_internal#454

## What changed

`VoiceUploadStore` had two public constructors that named no partition - a no-argument one and a root-only one - and both bound the local tenant on the author's behalf. They are replaced by a single constructor that takes the root and the tenant.

The guarantee this buys: **there is no way to construct an upload store without naming the partition it belongs to.** An unscoped store is not something to guard against, enumerate, or remember to check - it cannot be built, and the attempt is a compile error at the call site. That is why this change is small: a structurally impossible state has no bypass set to prove.

Naming the local tenant resolves to exactly the path it always did. Self-host is unchanged, nothing migrates, no behaviour moves. What changed is what an author has to write down, and therefore what a reviewer can see.

Construction and re-scoping now share one partition-computing path, so the canonical-identifier rules that make a tenant id safe as a directory name apply identically however a store is obtained. This builds on the dictation partition work and expects to land after it.

## Base

Cut from `fix/1884-tenant-key-upload-store` rather than around it, so its commits are shared and it merges first.

## What proves it

**The compiler is the primary proof, and it was watched firing.** Removing the tenant-less constructors broke the build at three call sites that used target-typed `new(...)` - sites a text search for the type name does not find. Those are exactly the invisible omissions the change is aimed at, and they became build errors rather than silent objects.

**Four standing tests** (`VoiceUploadStoreRequiredTenantTests`), three of them watched reddening under a deliberate mutation, with the other three of the four staying green as controls each time:

| Property asserted | Mutation | Result |
|---|---|---|
| Every public constructor takes a tenant | re-add a no-argument constructor | RED, assertion, names the offending signature |
| An unresolved tenant is refused by the validity check | make the validity check accept everything | RED, assertion (see below) |
| A named account tenant lands inside that tenant's partition | construct against the base root instead of the partition | RED, assertion |
| Naming the local tenant leaves the root unchanged | (control - pins the no-migration claim) | green throughout |

Every red arrived in the assertion of the test under mutation. None arrived in fixture or schema setup, so no arm was void.

**A correction found by that exercise, and it is the more useful half of it.** The unresolved-tenant test first asserted only the exception type, and it stayed GREEN when the validity check was removed - an unresolved tenant has a null value, which the partition-naming rule refuses anyway because it is not a canonical identifier, so the same exception type arrived from a different guard. The test could not distinguish "this check works" from "this check does not exist". It now asserts the message, and reddens on removal. Second commit in this pull request.

Continuous integration is the run of record for the full suite on this head.

## Covered / not covered

**Covered**
- Every public construction path of `VoiceUploadStore` requires a tenant; a tenant-less one is a compile error, and a re-added convenience overload reddens a standing test at the moment it is written.
- An unresolved tenant (`default(TenantId)`, which bypasses the validating constructor of the struct) is refused at construction rather than read as local.
- Direct construction with an account tenant lands in the same partition the re-scoping path resolves - the constructor is not a second, unpartitioned way in.
- Local construction keeps today's root exactly; nothing on an existing install moves.

**Not covered**
- The voice-turn staging root is still constructed against the local tenant on the hosted Gateway. Unchanged behaviour, and that path writes no delivery record and does no lookup by upload id - but per-tenant scoping of the voice-turn path is separate work and is NOT claimed here. Named as follow-up in devthrottle_internal#454.
- This changes only how a store is OBTAINED. The behaviour of the partition once obtained is the dictation partition work's, proved there.
- Other stores in the Gateway with the same constructor shape are out of scope for this unit; nothing here surveys them.
