### PR TITLE
fix(gateway): one shared hosted refusal boundary for every deny family

### DIFF
--- a/src/CcDirector.Gateway.Tests/Tenancy/HostedRefusalPatternTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/HostedRefusalPatternTests.cs
@@ -125,27 +125,6 @@ public sealed class HostedRefusalPatternTests
             partKinds);
     }
 
-    /// <summary>
-    /// The shape key is what the DUPLICATE check compares, and this is the case text comparison misses:
-    /// two patterns differing only in a parameter NAME are different strings and the same route. Mapping
-    /// both produces endpoints that tie, and the tie surfaces at request time on the denied route.
-    /// </summary>
-    [Theory]
-    [InlineData("/x/{id}", "/x/{name}", true)]              // same route, different spelling
-    [InlineData("/x/{id:int}", "/x/{name:alpha}", true)]    // policies are not part of the shape either
-    [InlineData("/x/{id}", "/x/{id?}", false)]              // optional does not compete with standard
-    [InlineData("/x/{id}", "/x/{**id}", false)]             // nor does a catch-all
-    [InlineData("/x/{id}", "/y/{id}", false)]               // different literal
-    [InlineData("/x/{id}", "/x/{id}/y", false)]             // different length
-    public void The_shape_key_sees_past_names_and_policies_but_not_past_kind_or_literals(
-        string left, string right, bool sameShape)
-    {
-        var leftKey = HostedRefusalPattern.ShapeKey(HostedRefusalPattern.WithoutPolicies(left, "probe"));
-        var rightKey = HostedRefusalPattern.ShapeKey(HostedRefusalPattern.WithoutPolicies(right, "probe"));
-
-        Assert.Equal(sameShape, leftKey == rightKey);
-    }
-
     private static System.Collections.Generic.IEnumerable<RoutePatternParameterPart> AllParameters(RoutePattern pattern)
         => pattern.PathSegments.SelectMany(s => s.Parts).OfType<RoutePatternParameterPart>();
 
@@ -158,17 +137,17 @@ public sealed class HostedRefusalPatternTests
 }
 
 /// <summary>
-/// The FINALISED route space check: the conflicts that only exist once everything has been mapped, and
-/// which the per-group duplicate check cannot see because it can only see its own group.
+/// The finalised route-space check, in the form it took AFTER review disproved the previous one.
 ///
-/// Two conflicts, in opposite directions, and only one of them is a leak:
-///   - refusal against refusal - a denied route answers 500 instead of refusing;
-///   - refusal against a LIVE route - a route nobody denied stops serving. That is an OUTAGE, and no
-///     leak-shaped test in this repository would ever notice it.
+/// The previous version tried to detect whether two patterns would TIE in the matcher, using a hand-rolled
+/// shape key. Three independent route pairs escaped it and returned HTTP 500 at request time. The reason is
+/// worth keeping: the matcher's ambiguity relation is not reachable from public API, so any check for it is
+/// a MODEL of framework semantics rather than the semantics themselves - and that was the SECOND time this
+/// primitive modelled a framework semantic and got it wrong.
 ///
-/// What is NOT a conflict is the ordinary case, and getting that wrong would refuse to start on every
-/// correct arrangement: refusal patterns are deliberately WIDE, so they overlap neighbours constantly, and
-/// route precedence resolves the overlap. Only an exact tie is rejected.
+/// So this no longer detects ambiguity. It checks the one thing that removes the conditions for it and that
+/// can be computed correctly: an EXCLUSIVE-PREFIX family claims a prefix nothing else may serve under, and
+/// that claim is verified by simple PREFIX CONTAINMENT.
 /// </summary>
 public sealed class HostedRefusalRouteSpaceTests
 {
@@ -178,72 +157,59 @@ public sealed class HostedRefusalRouteSpaceTests
         reason: "the probe family exists to prove the route-space check",
         unDenyInstruction: "nothing to un-deny: a test fixture");
 
-    private static readonly HostedDenial OtherDenial = new(
-        family: "other-probe",
-        message: "also not available on the hosted gateway",
-        reason: "a second family, to prove refusal-versus-refusal detection",
-        unDenyInstruction: "nothing to un-deny: a test fixture");
-
     [Fact]
-    public void Two_refusals_on_the_same_route_shape_fail_the_start_rather_than_the_request()
+    public void A_live_route_under_an_exclusively_claimed_prefix_fails_the_start()
     {
-        // Different spelling, same route. This is the pair a text comparison lets through.
+        // The over-refusal direction, which is an OUTAGE rather than a leak: the catch-all would swallow a
+        // route nobody denied. No leak-shaped test in this repository would notice that.
         var endpoints = new[]
         {
-            RefusalEndpoint("/x/{id}", Denial),
-            RefusalEndpoint("/x/{name}", OtherDenial),
+            ExclusiveRefusal("/family"),
+            LiveEndpoint("/family/still-serving"),
         };
 
         var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
 
-        Assert.Contains("probe", error.Message);
-        Assert.Contains("other-probe", error.Message);
+        Assert.Contains("EXCLUSIVELY", error.Message);
+        Assert.Contains("still-serving", error.Message);
     }
 
     [Fact]
-    public void A_refusal_tying_with_a_live_route_fails_the_start_because_that_is_an_outage()
+    public void A_prefix_with_nothing_else_underneath_it_is_allowed()
     {
         var endpoints = new[]
         {
-            RefusalEndpoint("/x/{id}", Denial),
-            LiveEndpoint("/x/{slug}"),
-        };
-
-        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
-
-        Assert.Contains("nobody denied", error.Message);
-    }
-
-    /// <summary>
-    /// The case that must NOT fail: a refusal is deliberately wider than the route it replaces, so it
-    /// overlaps live neighbours all the time. Precedence resolves it - a literal outranks a parameter - and
-    /// a validator that rejected overlap rather than ties would refuse to start on the normal arrangement.
-    /// </summary>
-    [Fact]
-    public void A_refusal_overlapping_a_more_specific_live_route_is_allowed()
-    {
-        var endpoints = new[]
-        {
-            RefusalEndpoint("/x/{id}", Denial),
-            LiveEndpoint("/x/summary"),      // literal beats the refusal's parameter
-            LiveEndpoint("/x/{id}/detail"),  // different length
-            LiveEndpoint("/y/{id}"),         // different literal
+            ExclusiveRefusal("/family"),
+            LiveEndpoint("/elsewhere/route"),
+            LiveEndpoint("/familyish/route"),   // shares a text prefix but not a PATH prefix
         };
 
         HostedRefusalRouteSpace.Validate(endpoints);
     }
 
     [Fact]
+    public void The_check_is_case_insensitive_about_the_prefix()
+    {
+        // Literal route matching is case-insensitive, so a containment check that was ordinal would miss a
+        // live route differing only in case - and would then be swallowed at runtime by the catch-all.
+        var endpoints = new[] { ExclusiveRefusal("/family"), LiveEndpoint("/FAMILY/still-serving") };
+
+        Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
+    }
+
+    [Fact]
     public void A_route_space_with_no_refusals_is_inert()
         => HostedRefusalRouteSpace.Validate(new[] { LiveEndpoint("/x/{id}"), LiveEndpoint("/y") });
 
-    private static RouteEndpoint RefusalEndpoint(string pattern, HostedDenial denial)
+    private static RouteEndpoint ExclusiveRefusal(string prefix)
         => new(
             _ => Task.CompletedTask,
-            HostedRefusalPattern.WithoutPolicies(pattern, denial.Family),
+            RoutePatternFactory.Parse(prefix + "/{**rest}"),
             order: 0,
-            new EndpointMetadataCollection(new HostedRefusalMarker(denial, pattern)),
-            displayName: pattern);
+            new EndpointMetadataCollection(
+                new HostedRefusalMarker(Denial, prefix),
+                new HostedExclusivePrefixMarker(Denial, prefix)),
+            displayName: prefix);
 
     private static RouteEndpoint LiveEndpoint(string pattern)
         => new(

--- a/src/CcDirector.Gateway.Tests/Tenancy/HostedRefusalPatternTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/HostedRefusalPatternTests.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Linq;
+using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Tenancy;
+
+/// <summary>
+/// The route-pattern normaliser: what the refusal is mapped on, and the grammar it claims to cover.
+///
+/// WHY THIS CLASS EXISTS AS ITS OWN THING. The normaliser was originally hand-written against the pattern
+/// TEXT and validated against simple inline policies only - and that is a narrower question set than the
+/// grammar it has to survive. The route grammar has optional parameters, default values, catch-alls with
+/// two sigils, escaped braces, and policy arguments that themselves contain the delimiters a text scan is
+/// looking for. A scan that is right on simple shapes and silently wrong on exotic ones does not produce a
+/// visible bug: it produces a refusal that does not cover its own route, while the family's author believes
+/// it does. That is manufactured coverage, which is the exact defect the boundary exists to remove.
+///
+/// So the normaliser now rebuilds the PARSED MODEL and this class states the grammar it covers, one test
+/// per element, plus the behaviour on something it does not model: it THROWS, and does not pass through.
+/// </summary>
+public sealed class HostedRefusalPatternTests
+{
+    /// <summary>
+    /// The ONE transformation. Everything else in these tests is a preservation claim; this is the change,
+    /// and it is the reason the whole class exists - a refusal carrying the real route's constraint is never
+    /// selected for the request that fails that constraint, which is the hole this closes.
+    /// </summary>
+    [Theory]
+    [InlineData("/x/{id:int}", "id")]
+    [InlineData("/x/{id:int:min(1)}", "id")]                    // several policies on one parameter
+    [InlineData("/x/{name:regex(^[[a-z]]+$)}", "name")]          // a policy argument containing delimiters
+    [InlineData("/x/{a:int}/y/{b:alpha}", "a")]                  // several constrained parameters
+    public void Every_parameter_policy_is_removed(string pattern, string firstParameterName)
+    {
+        var normalised = HostedRefusalPattern.WithoutPolicies(pattern, "probe");
+
+        Assert.All(AllParameters(normalised), p => Assert.Empty(p.ParameterPolicies));
+        Assert.Equal(firstParameterName, AllParameters(normalised).First().Name);
+    }
+
+    /// <summary>
+    /// Preservation, element by element. Each row is a piece of grammar the normaliser CLAIMS to cover, and
+    /// the claim is worth exactly as much as the row that tests it - which is why they are enumerated rather
+    /// than sampled. Losing any of these would change which requests the refusal matches.
+    /// </summary>
+    [Theory]
+    [InlineData("/x/{id?}")]                       // optional
+    [InlineData("/x/{id:int?}")]                   // optional AND constrained
+    [InlineData("/x/{id=7}")]                      // default value
+    [InlineData("/x/{id:int=7}")]                  // default AND constrained
+    [InlineData("/x/{**rest}")]                    // catch-all, slash-preserving
+    [InlineData("/x/{*rest}")]                     // catch-all, the other sigil
+    [InlineData("/x/y")]                           // pure literals
+    [InlineData("/x/{a}-{b}")]                     // two parameters in one complex segment
+    [InlineData("/x/file.{ext}")]                  // literal and parameter sharing a segment
+    [InlineData("/{a}/{b}/{c}")]                   // several segments
+    public void The_shape_of_the_route_survives_normalisation(string pattern)
+    {
+        var original = RoutePatternFactory.Parse(pattern);
+        var normalised = HostedRefusalPattern.WithoutPolicies(pattern, "probe");
+
+        // Same segment structure, part for part.
+        Assert.Equal(original.PathSegments.Count, normalised.PathSegments.Count);
+        foreach (var (before, after) in original.PathSegments.Zip(normalised.PathSegments))
+            Assert.Equal(before.Parts.Count, after.Parts.Count);
+
+        // Same parameters, with kind and default intact - optionality and catch-all semantics are the real
+        // route's, not something the normaliser decided.
+        var originalParameters = AllParameters(original).ToList();
+        var normalisedParameters = AllParameters(normalised).ToList();
+
+        Assert.Equal(originalParameters.Count, normalisedParameters.Count);
+        foreach (var (before, after) in originalParameters.Zip(normalisedParameters))
+        {
+            Assert.Equal(before.Name, after.Name);
+            Assert.Equal(before.ParameterKind, after.ParameterKind);
+            Assert.Equal(before.Default, after.Default);
+        }
+
+        // Literal text is untouched, which is what keeps a refusal from widening across a path boundary.
+        Assert.Equal(LiteralText(original), LiteralText(normalised));
+    }
+
+    /// <summary>
+    /// A pattern the framework itself rejects is not the normaliser's to reinterpret. It is parsed by the
+    /// framework's parser, so a malformed pattern fails there with the framework's own message rather than
+    /// being quietly accepted by a lenient hand-written scan.
+    /// </summary>
+    [Theory]
+    [InlineData("/x/{unclosed")]
+    [InlineData("/x/{}")]
+    public void A_malformed_pattern_is_refused_by_the_frameworks_own_parser(string pattern)
+        => Assert.ThrowsAny<Exception>(() => HostedRefusalPattern.WithoutPolicies(pattern, "probe"));
+
+    /// <summary>
+    /// THE EXHAUSTIVENESS CLAIM, which is what the fail-loud rule actually rests on here.
+    ///
+    /// The normaliser handles three route part kinds and THROWS on anything else. That throw is
+    /// unreachable today - and I would rather say so than imply it is covered: <c>RoutePatternPart</c> has
+    /// an internal constructor, so the framework's three subclasses are the entire hierarchy and no test in
+    /// this repository can manufacture a fourth. The defensive arm therefore has no test, deliberately, and
+    /// this is the test that guards the assumption UNDERNEATH it instead.
+    ///
+    /// If a framework upgrade ever adds a fourth part kind, this reddens - which is the moment somebody
+    /// needs to decide whether the normaliser handles it or refuses it. Without this, that upgrade would
+    /// land silently and the first sign would be a startup failure on somebody's exotic route, or worse, a
+    /// refusal that quietly did not cover it.
+    /// </summary>
+    [Fact]
+    public void The_route_part_kinds_the_normaliser_handles_are_still_the_only_ones_that_exist()
+    {
+        var partKinds = typeof(RoutePatternPart).Assembly
+            .GetTypes()
+            .Where(t => t.IsSubclassOf(typeof(RoutePatternPart)))
+            .Select(t => t.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(
+            new[] { "RoutePatternLiteralPart", "RoutePatternParameterPart", "RoutePatternSeparatorPart" },
+            partKinds);
+    }
+
+    /// <summary>
+    /// The shape key is what the DUPLICATE check compares, and this is the case text comparison misses:
+    /// two patterns differing only in a parameter NAME are different strings and the same route. Mapping
+    /// both produces endpoints that tie, and the tie surfaces at request time on the denied route.
+    /// </summary>
+    [Theory]
+    [InlineData("/x/{id}", "/x/{name}", true)]              // same route, different spelling
+    [InlineData("/x/{id:int}", "/x/{name:alpha}", true)]    // policies are not part of the shape either
+    [InlineData("/x/{id}", "/x/{id?}", false)]              // optional does not compete with standard
+    [InlineData("/x/{id}", "/x/{**id}", false)]             // nor does a catch-all
+    [InlineData("/x/{id}", "/y/{id}", false)]               // different literal
+    [InlineData("/x/{id}", "/x/{id}/y", false)]             // different length
+    public void The_shape_key_sees_past_names_and_policies_but_not_past_kind_or_literals(
+        string left, string right, bool sameShape)
+    {
+        var leftKey = HostedRefusalPattern.ShapeKey(HostedRefusalPattern.WithoutPolicies(left, "probe"));
+        var rightKey = HostedRefusalPattern.ShapeKey(HostedRefusalPattern.WithoutPolicies(right, "probe"));
+
+        Assert.Equal(sameShape, leftKey == rightKey);
+    }
+
+    private static System.Collections.Generic.IEnumerable<RoutePatternParameterPart> AllParameters(RoutePattern pattern)
+        => pattern.PathSegments.SelectMany(s => s.Parts).OfType<RoutePatternParameterPart>();
+
+    private static string LiteralText(RoutePattern pattern)
+        => string.Join("/", pattern.PathSegments
+            .SelectMany(s => s.Parts)
+            .OfType<RoutePatternLiteralPart>()
+            .Select(p => p.Content));
+
+}
+
+/// <summary>
+/// The FINALISED route space check: the conflicts that only exist once everything has been mapped, and
+/// which the per-group duplicate check cannot see because it can only see its own group.
+///
+/// Two conflicts, in opposite directions, and only one of them is a leak:
+///   - refusal against refusal - a denied route answers 500 instead of refusing;
+///   - refusal against a LIVE route - a route nobody denied stops serving. That is an OUTAGE, and no
+///     leak-shaped test in this repository would ever notice it.
+///
+/// What is NOT a conflict is the ordinary case, and getting that wrong would refuse to start on every
+/// correct arrangement: refusal patterns are deliberately WIDE, so they overlap neighbours constantly, and
+/// route precedence resolves the overlap. Only an exact tie is rejected.
+/// </summary>
+public sealed class HostedRefusalRouteSpaceTests
+{
+    private static readonly HostedDenial Denial = new(
+        family: "probe",
+        message: "not available on the hosted gateway",
+        reason: "the probe family exists to prove the route-space check",
+        unDenyInstruction: "nothing to un-deny: a test fixture");
+
+    private static readonly HostedDenial OtherDenial = new(
+        family: "other-probe",
+        message: "also not available on the hosted gateway",
+        reason: "a second family, to prove refusal-versus-refusal detection",
+        unDenyInstruction: "nothing to un-deny: a test fixture");
+
+    [Fact]
+    public void Two_refusals_on_the_same_route_shape_fail_the_start_rather_than_the_request()
+    {
+        // Different spelling, same route. This is the pair a text comparison lets through.
+        var endpoints = new[]
+        {
+            RefusalEndpoint("/x/{id}", Denial),
+            RefusalEndpoint("/x/{name}", OtherDenial),
+        };
+
+        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
+
+        Assert.Contains("probe", error.Message);
+        Assert.Contains("other-probe", error.Message);
+    }
+
+    [Fact]
+    public void A_refusal_tying_with_a_live_route_fails_the_start_because_that_is_an_outage()
+    {
+        var endpoints = new[]
+        {
+            RefusalEndpoint("/x/{id}", Denial),
+            LiveEndpoint("/x/{slug}"),
+        };
+
+        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
+
+        Assert.Contains("nobody denied", error.Message);
+    }
+
+    /// <summary>
+    /// The case that must NOT fail: a refusal is deliberately wider than the route it replaces, so it
+    /// overlaps live neighbours all the time. Precedence resolves it - a literal outranks a parameter - and
+    /// a validator that rejected overlap rather than ties would refuse to start on the normal arrangement.
+    /// </summary>
+    [Fact]
+    public void A_refusal_overlapping_a_more_specific_live_route_is_allowed()
+    {
+        var endpoints = new[]
+        {
+            RefusalEndpoint("/x/{id}", Denial),
+            LiveEndpoint("/x/summary"),      // literal beats the refusal's parameter
+            LiveEndpoint("/x/{id}/detail"),  // different length
+            LiveEndpoint("/y/{id}"),         // different literal
+        };
+
+        HostedRefusalRouteSpace.Validate(endpoints);
+    }
+
+    [Fact]
+    public void A_route_space_with_no_refusals_is_inert()
+        => HostedRefusalRouteSpace.Validate(new[] { LiveEndpoint("/x/{id}"), LiveEndpoint("/y") });
+
+    private static RouteEndpoint RefusalEndpoint(string pattern, HostedDenial denial)
+        => new(
+            _ => Task.CompletedTask,
+            HostedRefusalPattern.WithoutPolicies(pattern, denial.Family),
+            order: 0,
+            new EndpointMetadataCollection(new HostedRefusalMarker(denial, pattern)),
+            displayName: pattern);
+
+    private static RouteEndpoint LiveEndpoint(string pattern)
+        => new(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse(pattern),
+            order: 0,
+            EndpointMetadataCollection.Empty,
+            displayName: pattern);
+}

--- a/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
@@ -131,6 +131,47 @@ public sealed class HostedRouteDenyOnHostedTests : IAsyncLifetime
         Assert.Contains("neighbour", await response.Content.ReadAsStringAsync());
     }
 
+    [Fact]
+    public async Task A_HEAD_request_meets_the_refusal_status_with_no_body()
+    {
+        // Stated deliberately rather than folded into "every request shape": HTTP says a HEAD carries the
+        // headers and no body, and the framework enforces that. So the uniformity claim is about the STATUS
+        // and the HEADERS here, not the bytes - and a reader is entitled to see which it is.
+        var response = await _host.SendAsync(HttpMethod.Head, "/family/echo");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal("application/json; charset=utf-8", response.Content.Headers.ContentType?.ToString());
+        Assert.Empty(await response.Content.ReadAsByteArrayAsync());
+    }
+
+    [Theory]
+    [InlineData("/family/multi")]
+    public async Task A_family_mapping_several_verbs_on_one_path_gets_ONE_refusal_and_not_a_tie(string path)
+    {
+        // The multi-verb path adopting families rely on, and it was previously unproved. Two verbs on one
+        // path must produce ONE verb-less refusal: a second would TIE with the first, and a tie surfaces as
+        // a 500 at request time - on the denied route, which is the one nobody exercises until a caller
+        // does. Every verb here must meet the refusal, including one the family never mapped.
+        foreach (var method in new[] { HttpMethod.Get, HttpMethod.Put, HttpMethod.Post, HttpMethod.Delete })
+        {
+            var response = await _host.SendAsync(method, path);
+            await AssertIsExactlyTheRefusal(response);
+        }
+    }
+
+    [Fact]
+    public async Task A_neighbouring_route_with_a_PARAMETER_segment_still_serves()
+    {
+        // The neighbour probe in its second direction. The literal case proves precedence protects a fixed
+        // sibling; this proves the refusal has not widened across a path boundary into a different route
+        // shape entirely. One case tests one thing, and over-refusal is the direction no leak-shaped test
+        // would ever notice.
+        var response = await _host.PostJsonAsync("/family/other/anything", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("neighbour", await response.Content.ReadAsStringAsync());
+    }
+
     /// <summary>
     /// Asserts the response is the family's refusal and NOTHING ELSE. Status and media type are asserted
     /// BEFORE the body is parsed, deliberately: parsing is itself an assertion about format, so a guard that
@@ -141,7 +182,11 @@ public sealed class HostedRouteDenyOnHostedTests : IAsyncLifetime
     private static async Task AssertIsExactlyTheRefusal(HttpResponseMessage response)
     {
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        // The WHOLE header value, parameters included. Asserting only the media type would pass on a
+        // refusal served with a different charset, and a refusal is a contract about exactly what is
+        // served - "close enough" on a content type is how a caller parses something other than it expected.
+        Assert.Equal("application/json; charset=utf-8", response.Content.Headers.ContentType?.ToString());
 
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
@@ -170,6 +215,27 @@ public sealed class HostedRouteDenySelfHostControlTests : IAsyncLifetime
     public async Task InitializeAsync() => _host = await DenyProbeHost.StartAsync(hosted: false);
 
     public Task DisposeAsync() => _host.DisposeAsync().AsTask();
+
+    /// <summary>
+    /// BOTH declared non-hosted forms, explicitly. The variable ABSENT and the variable present but not
+    /// "1" are two different states of the world, and a control exercising one of them proves the guard
+    /// for one of them. The absent case additionally must be SET rather than inherited: a control that
+    /// passes because the runner happened to leave the variable unset is reporting an ambient condition,
+    /// not a property of the code.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]      // absent
+    [InlineData("0")]       // present, not "1"
+    [InlineData("")]        // present, empty
+    public async Task The_family_serves_normally_in_EITHER_non_hosted_form(string? nonHostedForm)
+    {
+        await using var host = await DenyProbeHost.StartAsync(hosted: false, nonHostedForm: nonHostedForm);
+
+        var response = await host.PostJsonAsync("/family/echo", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("hello", await response.Content.ReadAsStringAsync());
+    }
 
     [Fact]
     public async Task The_family_serves_normally_off_hosted()
@@ -238,14 +304,6 @@ public sealed class HostedDenialValidationTests
             new HostedDenial("family", "message", "reason", "undeny", statusCode: StatusCodes.Status200OK));
     }
 
-    [Theory]
-    [InlineData("/x/{id:int}", "/x/{id}")]
-    [InlineData("/x/{id:int}/y/{name:alpha}", "/x/{id}/y/{name}")]
-    [InlineData("/x/{id}", "/x/{id}")]
-    [InlineData("/x/plain", "/x/plain")]
-    [InlineData("/x/{**rest}", "/x/{**rest}")]
-    public void The_refusal_pattern_drops_inline_constraints_and_nothing_else(string pattern, string expected)
-        => Assert.Equal(expected, HostedDenyGroup.StripInlineConstraints(pattern));
 }
 
 /// <summary>
@@ -278,10 +336,17 @@ internal sealed class DenyProbeHost : IAsyncDisposable
         _priorHosted = priorHosted;
     }
 
-    public static async Task<DenyProbeHost> StartAsync(bool hosted)
+    /// <param name="nonHostedForm">
+    /// WHICH non-hosted form to set when <paramref name="hosted"/> is false. There are TWO declared ways to
+    /// be non-hosted - the variable ABSENT, and the variable present but not "1" - and a control that only
+    /// ever exercises one of them proves the guard for one of them. Worse, a control that leans on the
+    /// variable being absent passes only because the test runner happened to leave it unset, which is an
+    /// ambient condition and not a proof.
+    /// </param>
+    public static async Task<DenyProbeHost> StartAsync(bool hosted, string? nonHostedForm = null)
     {
         var priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
-        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : nonHostedForm);
 
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
@@ -314,9 +379,16 @@ internal sealed class DenyProbeHost : IAsyncDisposable
         group.MapPost("/custom", (ObservableBinding probe) => Results.Json(new { probe = probe.Value }));
         group.MapPost("/typed/{id:int}", (int id, EchoBody body) => Results.Json(new { id, body.Text }));
 
-        // A literal sibling under the same path shape, mapped OUTSIDE the family: it is not denied and must
-        // keep serving on hosted. This is the over-refusal direction.
+        // TWO verbs on ONE path: the multi-verb shape adopting families rely on. On hosted these must
+        // collapse to a single verb-less refusal rather than two endpoints that tie.
+        group.MapGet("/multi", () => Results.Json(new { multi = "get" }));
+        group.MapPut("/multi", (EchoBody body) => Results.Json(new { multi = body.Text }));
+
+        // Neighbours mapped OUTSIDE the family: neither is denied and both must keep serving on hosted.
+        // A literal sibling under the same path shape (precedence protects it) and a route on a different
+        // path shape entirely (the refusal must not have widened across a path boundary).
         outer.MapPost("/family/typed/summary", () => Results.Json(new { neighbour = "still serving" }));
+        outer.MapPost("/family/other/{name}", (string name) => Results.Json(new { neighbour = name }));
 
         // Mapped LAST, with a bound body: the future route. A parameterless GET here would prove nothing,
         // because a parameterless GET is the one shape the original defect cannot be seen through.
@@ -330,6 +402,9 @@ internal sealed class DenyProbeHost : IAsyncDisposable
         => _http.PostAsync(path, new StringContent(content, Encoding.UTF8, mediaType));
 
     public Task<HttpResponseMessage> GetAsync(string path) => _http.GetAsync(path);
+
+    public Task<HttpResponseMessage> SendAsync(HttpMethod method, string path)
+        => _http.SendAsync(new HttpRequestMessage(method, path));
 
     public async ValueTask DisposeAsync()
     {

--- a/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
@@ -1,0 +1,365 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Tenancy;
+
+/// <summary>
+/// The shared hosted-refusal primitive: the ONE boundary every deny family adopts, proved here ONCE for all
+/// of them.
+///
+/// WHY IT EXISTS. A refusal attached as a route-group endpoint filter does not answer uniformly across
+/// request shapes. The mechanism and the measurements are in the PRIVATE architecture record; what belongs
+/// here is the guarantee being asserted, one test per shape.
+///
+/// WHAT IS PROVED HERE, AND WHY EACH FAMILY DOES NOT RE-PROVE IT. On hosted the family's handler is never
+/// mapped: a verb-less, constraint-free refusal route takes its place. An adopter therefore cannot be
+/// attached AND still bind, because attachment IS the substitution - there is no state of the world where
+/// attachment holds and the property fails. So the pre-binding property is proved once, here, and each
+/// adopting family owes only attachment, gate direction, and its own body-bound future-route probe.
+///
+/// THE SHAPE SET IS THE WHOLE POINT, and it is enumerated rather than sampled because this defect is
+/// invisible to the obvious probe: a parameterless GET is exactly the shape that CANNOT see it. Every shape
+/// below was measured to be answered by something other than the refusal under at least one candidate
+/// design that looked correct:
+///
+///   valid body | malformed body | wrong media type | custom binder | future route | wrong verb |
+///   route-constraint miss | route-constraint hit
+///
+/// A GUARD HAS TWO FAILURE DIRECTIONS AND ONLY ONE OF THEM IS A LEAK. Under-refusal leaks; OVER-refusal is
+/// an outage on a route nobody denied. The neighbour probe below is what tests the second direction, and it
+/// is the reason the alternative design - a host-wide matcher refusing by path prefix - was rejected: it was
+/// measured refusing a sibling route that was never part of the denied family. Every deny from here on
+/// carries a neighbour probe.
+/// </summary>
+[Collection(HostedRouteDenyCollection.Name)]
+public sealed class HostedRouteDenyOnHostedTests : IAsyncLifetime
+{
+    private DenyProbeHost _host = null!;
+
+    public async Task InitializeAsync() => _host = await DenyProbeHost.StartAsync(hosted: true);
+
+    public Task DisposeAsync() => _host.DisposeAsync().AsTask();
+
+    [Theory]
+    [InlineData("/family/echo")]        // a body-bound POST
+    [InlineData("/family/custom")]      // a parameter with a custom binder, whose execution is observable
+    [InlineData("/family/future")]      // mapped into the group AFTER everything else: the future route
+    public async Task Every_route_in_the_group_is_refused_on_hosted(string path)
+    {
+        var response = await _host.PostJsonAsync(path, "{\"text\":\"hello\"}");
+        await AssertIsExactlyTheRefusal(response);
+    }
+
+    [Fact]
+    public async Task A_malformed_body_meets_the_refusal_and_not_the_frameworks_own_400()
+    {
+        // A shape that an earlier boundary let the framework answer instead of the refusal.
+        var response = await _host.PostJsonAsync("/family/echo", "{ not json");
+        await AssertIsExactlyTheRefusal(response);
+    }
+
+    [Fact]
+    public async Task A_wrong_media_type_meets_the_refusal_and_not_the_frameworks_own_415()
+    {
+        // The shape that survived the longest across candidate designs: a body parameter makes the
+        // framework infer a media-type constraint that endpoint SELECTION enforces ahead of any handler.
+        // Mapping no handler at all is what removes the constraint along with the handler.
+        var response = await _host.PostAsync("/family/echo", "hello", "text/plain");
+        await AssertIsExactlyTheRefusal(response);
+    }
+
+    [Fact]
+    public async Task A_verb_the_family_never_mapped_meets_the_refusal_and_not_a_405()
+    {
+        // A 405 would disclose that the route EXISTS on a Gateway whose refusal says it does not. A wrong
+        // verb is a request shape, and the standard is that the refusal is uniform across shapes.
+        var response = await _host.GetAsync("/family/echo");
+        await AssertIsExactlyTheRefusal(response);
+    }
+
+    [Theory]
+    [InlineData("/family/typed/7")]     // satisfies the real route's {id:int}
+    [InlineData("/family/typed/abc")]   // FAILS it - and so would never select a refusal carrying it
+    public async Task A_constrained_route_is_refused_whether_or_not_the_constraint_is_satisfied(string path)
+    {
+        // The miss is the one that matters. A segment that fails an inline constraint fails endpoint
+        // selection, so a refusal mapped on the same constrained pattern is never selected either and the
+        // framework answers its own 404 with the refusal never running. The refusal is therefore mapped on
+        // the pattern with its constraints stripped.
+        var response = await _host.PostJsonAsync(path, "{\"text\":\"hello\"}");
+        await AssertIsExactlyTheRefusal(response);
+    }
+
+    [Fact]
+    public async Task No_argument_binder_runs_behind_the_refusal_on_any_shape()
+    {
+        // The claim is not "the response was right" - it is that NO handler-bound code executed at all. This
+        // is the assertion that separates a refusal placed before binding from one placed after it, and it
+        // is the one that was false under the filter on every shape including a valid body.
+        ObservableBinding.Reset();
+
+        await _host.PostJsonAsync("/family/custom", "{\"text\":\"hello\"}");
+        await _host.PostJsonAsync("/family/custom", "{ not json");
+        await _host.PostAsync("/family/custom", "hello", "text/plain");
+        await _host.GetAsync("/family/custom");
+
+        Assert.Equal(0, ObservableBinding.Count);
+    }
+
+    [Fact]
+    public async Task A_neighbouring_route_outside_the_family_still_serves()
+    {
+        // The OTHER failure direction. A guard that refuses a route nobody denied is an outage, and it is
+        // the measured defect of the rejected path-prefix design. Route precedence is what protects this:
+        // a literal segment outranks the refusal's loosened parameter segment.
+        var response = await _host.PostJsonAsync("/family/typed/summary", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("neighbour", await response.Content.ReadAsStringAsync());
+    }
+
+    /// <summary>
+    /// Asserts the response is the family's refusal and NOTHING ELSE. Status and media type are asserted
+    /// BEFORE the body is parsed, deliberately: parsing is itself an assertion about format, so a guard that
+    /// has gone and a route now serving HTML must redden as "expected application/json, got text/html"
+    /// rather than as a parser exception. A red that arrives as a crash proves the mutation landed, not that
+    /// the guard was the thing holding.
+    /// </summary>
+    private static async Task AssertIsExactlyTheRefusal(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
+
+        // The whole property set against a one-name allow-list. A deny-list of today's keys cannot see an
+        // extra field that leaks tomorrow; enumerating the set reddens on anything extra with no edit here.
+        Assert.Equal(new[] { "error" }, document.RootElement.EnumerateObject().Select(p => p.Name).ToArray());
+        Assert.Equal(DenyProbeHost.RefusalMessage, document.RootElement.GetProperty("error").GetString());
+    }
+}
+
+/// <summary>
+/// THE GATE DIRECTION, AND THE CONTROL. Off hosted the primitive maps the family's real handlers and creates
+/// no refusal at all, so the family is byte-identical to one mapped on an unguarded builder.
+///
+/// This class is what fails if the hosted condition is ever inverted or hard-wired: a refusal that fired
+/// everywhere would look perfect to every test in the class above and would silently break every self-host
+/// install. Absence of the refusal is asserted POSITIVELY - the real handler's own payload is required -
+/// because an assertion that merely checks "not the refusal" passes on a framework error too.
+/// </summary>
+[Collection(HostedRouteDenyCollection.Name)]
+public sealed class HostedRouteDenySelfHostControlTests : IAsyncLifetime
+{
+    private DenyProbeHost _host = null!;
+
+    public async Task InitializeAsync() => _host = await DenyProbeHost.StartAsync(hosted: false);
+
+    public Task DisposeAsync() => _host.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task The_family_serves_normally_off_hosted()
+    {
+        var response = await _host.PostJsonAsync("/family/echo", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("hello", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task A_route_added_to_the_group_later_serves_normally_off_hosted()
+    {
+        var response = await _host.PostJsonAsync("/family/future", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("hello", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task The_real_binder_runs_off_hosted()
+    {
+        // The positive twin of the hosted no-binding assertion. Without this, a primitive that broke binding
+        // outright on every deployment would satisfy the hosted class and nothing would notice.
+        ObservableBinding.Reset();
+
+        var response = await _host.PostJsonAsync("/family/custom", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, ObservableBinding.Count);
+    }
+
+    [Fact]
+    public async Task The_constrained_route_still_constrains_off_hosted()
+    {
+        // Self-host keeps the real route's constraint: the loosened pattern exists ONLY on hosted, so a
+        // constraint miss here is the framework's own 404 and carries no refusal body.
+        var response = await _host.PostJsonAsync("/family/typed/abc", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(0, (await response.Content.ReadAsStringAsync()).Length);
+    }
+}
+
+/// <summary>The refusal payload is validated where it is CONSTRUCTED, so a bad one fails at startup.</summary>
+[Collection(HostedRouteDenyCollection.Name)]
+public sealed class HostedDenialValidationTests
+{
+    [Theory]
+    [InlineData("", "message", "reason", "undeny")]
+    [InlineData("family", "", "reason", "undeny")]
+    [InlineData("family", "message", "", "undeny")]
+    [InlineData("family", "message", "reason", "")]
+    public void A_denial_that_would_refuse_meaninglessly_is_refused_at_construction(
+        string family, string message, string reason, string unDeny)
+    {
+        // Failing to boot is the correct direction. A blank refusal serves something a caller cannot act on
+        // and a proof cannot assert - which reads, from outside, like a working route.
+        Assert.Throws<ArgumentException>(() => new HostedDenial(family, message, reason, unDeny));
+    }
+
+    [Fact]
+    public void A_denial_must_refuse_with_a_failure_status()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new HostedDenial("family", "message", "reason", "undeny", statusCode: StatusCodes.Status200OK));
+    }
+
+    [Theory]
+    [InlineData("/x/{id:int}", "/x/{id}")]
+    [InlineData("/x/{id:int}/y/{name:alpha}", "/x/{id}/y/{name}")]
+    [InlineData("/x/{id}", "/x/{id}")]
+    [InlineData("/x/plain", "/x/plain")]
+    [InlineData("/x/{**rest}", "/x/{**rest}")]
+    public void The_refusal_pattern_drops_inline_constraints_and_nothing_else(string pattern, string expected)
+        => Assert.Equal(expected, HostedDenyGroup.StripInlineConstraints(pattern));
+}
+
+/// <summary>
+/// Serialises these classes. They set the process-wide <c>CC_GATEWAY_HOSTED</c> variable, and one class
+/// running while another flips it would produce exactly the kind of unexplained cross-class contamination
+/// this mission has already had to chase down inside its own instrument.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class HostedRouteDenyCollection
+{
+    public const string Name = "hosted-route-deny";
+}
+
+/// <summary>
+/// A minimal Gateway-shaped host carrying ONE denied family, mapped through the typed handle, plus a
+/// neighbouring route mapped OUTSIDE the family that must keep serving.
+/// </summary>
+internal sealed class DenyProbeHost : IAsyncDisposable
+{
+    public const string RefusalMessage = "this family is not available on the hosted gateway";
+
+    private readonly WebApplication _app;
+    private readonly HttpClient _http;
+    private readonly string? _priorHosted;
+
+    private DenyProbeHost(WebApplication app, HttpClient http, string? priorHosted)
+    {
+        _app = app;
+        _http = http;
+        _priorHosted = priorHosted;
+    }
+
+    public static async Task<DenyProbeHost> StartAsync(bool hosted)
+    {
+        var priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        MapFamily(app);
+
+        await app.StartAsync();
+        var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+        return new DenyProbeHost(app, http, priorHosted);
+    }
+
+    /// <summary>
+    /// The family, mapped the way an adopting family maps: the group is opened here and the routes go
+    /// through the typed handle. The neighbour is mapped on the OUTER builder, which is what a route outside
+    /// the denied family looks like.
+    /// </summary>
+    private static void MapFamily(IEndpointRouteBuilder outer)
+    {
+        var denial = new HostedDenial(
+            family: "probe",
+            message: RefusalMessage,
+            reason: "the probe family exists only to prove the primitive",
+            unDenyInstruction: "nothing to un-deny: this family is a test fixture and stores nothing");
+
+        var group = HostedRouteDeny.Group(outer, "/family", denial);
+
+        group.MapPost("/echo", (EchoBody body) => Results.Json(new { echoed = body.Text }));
+        group.MapPost("/custom", (ObservableBinding probe) => Results.Json(new { probe = probe.Value }));
+        group.MapPost("/typed/{id:int}", (int id, EchoBody body) => Results.Json(new { id, body.Text }));
+
+        // A literal sibling under the same path shape, mapped OUTSIDE the family: it is not denied and must
+        // keep serving on hosted. This is the over-refusal direction.
+        outer.MapPost("/family/typed/summary", () => Results.Json(new { neighbour = "still serving" }));
+
+        // Mapped LAST, with a bound body: the future route. A parameterless GET here would prove nothing,
+        // because a parameterless GET is the one shape the original defect cannot be seen through.
+        group.MapPost("/future", (EchoBody body) => Results.Json(new { future = body.Text }));
+    }
+
+    public Task<HttpResponseMessage> PostJsonAsync(string path, string json)
+        => PostAsync(path, json, "application/json");
+
+    public Task<HttpResponseMessage> PostAsync(string path, string content, string mediaType)
+        => _http.PostAsync(path, new StringContent(content, Encoding.UTF8, mediaType));
+
+    public Task<HttpResponseMessage> GetAsync(string path) => _http.GetAsync(path);
+
+    public async ValueTask DisposeAsync()
+    {
+        _http.Dispose();
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+    }
+
+    private sealed record EchoBody(string Text);
+}
+
+/// <summary>
+/// A parameter whose BINDING IS OBSERVABLE. Argument binding leaves no trace of its own, so proving that
+/// nothing bound requires a parameter that records the fact it was bound. This is the instrument for the
+/// central claim - not that the response was right, but that no handler-bound code ran at all.
+/// </summary>
+internal sealed class ObservableBinding
+{
+    private static int _count;
+
+    public string Value { get; init; } = "";
+
+    public static int Count => Volatile.Read(ref _count);
+
+    public static void Reset() => Interlocked.Exchange(ref _count, 0);
+
+    public static ValueTask<ObservableBinding?> BindAsync(HttpContext context)
+    {
+        Interlocked.Increment(ref _count);
+        return ValueTask.FromResult<ObservableBinding?>(new ObservableBinding { Value = "bound" });
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2127,6 +2127,15 @@ public sealed class GatewayHost : IAsyncDisposable
         // Server Cockpit and its fallback reverse-proxy were retired in this cutover.
         Cockpit.CockpitReactApp.Map(_app);
 
+        // Every route is now mapped, which is the earliest moment the FINALISED route space exists - and the
+        // only moment a conflict between a hosted refusal and anything else can be seen. A refusal that ties
+        // with another refusal answers 500 on a denied route; a refusal that ties with a live route takes an
+        // undenied route off the air. Both would otherwise surface as a request-time failure on the one path
+        // nobody exercises until a caller does. Fail the start instead. Inert on self-host, where no refusal
+        // endpoint exists.
+        Tenancy.HostedRefusalRouteSpace.Validate(_app.Services
+            .GetRequiredService<Microsoft.AspNetCore.Routing.EndpointDataSource>().Endpoints);
+
         await _app.StartAsync();
         FileLog.Write($"[GatewayHost] listening on http://0.0.0.0:{Port} (all interfaces, auth-gated; version {version})");
 

--- a/src/CcDirector.Gateway/Tenancy/HostedRefusalPattern.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRefusalPattern.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Routing.Patterns;
+
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// Turns a family's real route pattern into the pattern its REFUSAL is mapped on, by rebuilding the parsed
+/// route MODEL rather than by editing the pattern text.
+///
+/// WHY THE MODEL AND NOT THE TEXT. The refusal has to match a request that the real route would REJECT -
+/// a segment that fails an inline constraint fails endpoint selection, so a refusal carrying that same
+/// constraint is never selected either and the framework answers instead of the refusal. Removing the
+/// constraint is therefore load-bearing. Doing that by editing the pattern string means hand-writing a
+/// parser for a grammar that is much richer than it first appears: optional parameters, default values,
+/// catch-alls with two sigils, escaped braces, and policy arguments that themselves contain the very
+/// delimiters the edit is scanning for. A hand-written scan is correct on the simple shapes it was tested
+/// against and silently wrong elsewhere - and silently wrong here means a denied route that answers with
+/// something other than the refusal, which is exactly the defect the whole primitive exists to remove.
+///
+/// So the pattern is PARSED by the framework's own parser, the parameter parts are rebuilt WITHOUT their
+/// policies and with everything else preserved, and the result is handed back as a
+/// <see cref="RoutePattern"/> - never re-serialised to text.
+///
+/// WHAT IT PRESERVES, exactly:
+///   - literal segments and literal parts, unchanged;
+///   - segment separators inside a complex segment, unchanged;
+///   - parameter NAME, unchanged;
+///   - parameter KIND - standard, optional, or catch-all - unchanged, so optionality and catch-all
+///     matching semantics are the real route's;
+///   - parameter DEFAULT VALUE, unchanged.
+/// The ONLY thing removed is the parameter's policies, which is the only thing that can make selection
+/// reject a request the refusal must answer.
+///
+/// WHAT IT REFUSES. A part kind this code does not recognise is a pattern it cannot claim to normalise, so
+/// it THROWS at startup rather than passing the pattern through. Passing through would map a refusal that
+/// still carried a constraint - the exact hole - while the family's author believed the route was covered.
+/// A loud failure at startup is recoverable; a refusal that silently does not cover its route is the
+/// false coverage this primitive was built to eliminate.
+/// </summary>
+internal static class HostedRefusalPattern
+{
+    /// <summary>
+    /// Parses <paramref name="pattern"/> and returns the equivalent pattern with every parameter policy
+    /// removed. Throws <see cref="NotSupportedException"/> on a pattern containing a part this code does
+    /// not recognise, and lets the framework's own parser throw on a malformed pattern.
+    /// </summary>
+    public static RoutePattern WithoutPolicies(string pattern, string family)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+
+        // The framework's parser, not ours. A malformed pattern throws here, with its message.
+        var parsed = RoutePatternFactory.Parse(pattern);
+        return WithoutPolicies(parsed, family);
+    }
+
+    /// <summary>The model-level rebuild, separated so a test can drive it from a parsed pattern.</summary>
+    public static RoutePattern WithoutPolicies(RoutePattern parsed, string family)
+    {
+        ArgumentNullException.ThrowIfNull(parsed);
+
+        var segments = new List<RoutePatternPathSegment>(parsed.PathSegments.Count);
+
+        foreach (var segment in parsed.PathSegments)
+        {
+            var parts = new List<RoutePatternPart>(segment.Parts.Count);
+
+            foreach (var part in segment.Parts)
+            {
+                parts.Add(part switch
+                {
+                    RoutePatternLiteralPart literal => RoutePatternFactory.LiteralPart(literal.Content),
+
+                    RoutePatternSeparatorPart separator => RoutePatternFactory.SeparatorPart(separator.Content),
+
+                    // The one transformation: same name, same kind, same default, NO policies.
+                    RoutePatternParameterPart parameter => RoutePatternFactory.ParameterPart(
+                        parameter.Name,
+                        parameter.Default,
+                        parameter.ParameterKind),
+
+                    _ => throw new NotSupportedException(
+                        $"The hosted denial for '{family}' cannot normalise the route pattern '{parsed.RawText}': " +
+                        $"it contains a route part of type '{part.GetType().Name}', which this boundary does not " +
+                        "recognise. Refusing at startup rather than mapping a refusal that might not cover the " +
+                        "route: a refusal that silently fails to cover its own route is worse than a Gateway " +
+                        "that does not start."),
+                });
+            }
+
+            segments.Add(RoutePatternFactory.Segment(parts));
+        }
+
+        return RoutePatternFactory.Pattern(segments);
+    }
+
+    /// <summary>
+    /// The SHAPE KEY of a pattern: what the route matcher actually competes on, with parameter names and
+    /// policies discarded.
+    ///
+    /// Two refusal patterns that differ only in the NAME of a parameter - <c>/x/{id}</c> and
+    /// <c>/x/{name}</c> - are different strings and the same route. Mapping both produces two endpoints
+    /// that tie, and the matcher throws at REQUEST time, on the denied route, which is the deny failing in
+    /// the one way nothing notices until a caller tries it. Text equality cannot see that; this key can.
+    ///
+    /// The key encodes, per segment: a literal's text, a separator's text, and for a parameter its KIND
+    /// only. Kind is included because an optional or catch-all parameter does not compete with a standard
+    /// one in the same position.
+    /// </summary>
+    public static string ShapeKey(RoutePattern pattern)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+
+        var key = new StringBuilder();
+
+        foreach (var segment in pattern.PathSegments)
+        {
+            key.Append('/');
+
+            foreach (var part in segment.Parts)
+            {
+                switch (part)
+                {
+                    case RoutePatternLiteralPart literal:
+                        key.Append("L:").Append(literal.Content);
+                        break;
+                    case RoutePatternSeparatorPart separator:
+                        key.Append("S:").Append(separator.Content);
+                        break;
+                    case RoutePatternParameterPart parameter:
+                        key.Append("P:").Append(parameter.ParameterKind);
+                        break;
+                    default:
+                        // Unreachable for a pattern that came through WithoutPolicies, which throws first.
+                        throw new NotSupportedException(
+                            $"Cannot compute a route shape key for a part of type '{part.GetType().Name}'.");
+                }
+
+                key.Append('|');
+            }
+        }
+
+        return key.ToString();
+    }
+}

--- a/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CcDirector.Core.Utilities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// Marks an endpoint as a hosted refusal, so the FINALISED route space can be checked once everything has
+/// been mapped. Carries the family and the pattern the family actually asked for, which is what makes a
+/// failure message name the two routes a human has to go and look at.
+/// </summary>
+internal sealed record HostedRefusalMarker(HostedDenial Denial, string SourcePattern);
+
+/// <summary>
+/// Validates the route space AFTER every endpoint has been mapped, and fails the Gateway at startup on a
+/// conflict rather than letting it surface as a 500 on a denied route the first time somebody calls it.
+///
+/// WHY THIS EXISTS SEPARATELY FROM THE PER-GROUP CHECK. <see cref="HostedDenyGroup"/> can only see its own
+/// group: it prevents one family from mapping two refusals that tie. It cannot see
+///   - two DIFFERENT denied families whose refusal patterns land on the same route shape, or
+///   - a refusal that ties with an UNDENIED neighbour mapped somewhere else entirely.
+/// Both are decided by the whole route space, so both can only be checked once the whole route space
+/// exists. The first is a refusal that answers 500 instead of refusing. The second is worse in a different
+/// direction: a tie against a live route is an OUTAGE on something nobody denied.
+///
+/// WHY A TIE AND NOT AN OVERLAP. Refusal patterns are deliberately WIDE - policies are stripped, so
+/// <c>/x/{id}</c> refuses where the real route wanted an integer. Widening is the point, and it overlaps
+/// neighbours constantly and harmlessly, because route precedence resolves it: a literal segment outranks a
+/// parameter segment, so a live <c>/x/summary</c> still wins over a refusing <c>/x/{id}</c>. What precedence
+/// CANNOT resolve is an exact tie - the same shape in the same positions - and that is the only case this
+/// validator rejects. Rejecting mere overlap would refuse to start on the normal, correct arrangement.
+/// </summary>
+internal static class HostedRefusalRouteSpace
+{
+    /// <summary>
+    /// Reads every endpoint the application has mapped and throws on the first conflict. Call ONCE, after
+    /// all mapping is done and before the host starts serving. A no-op when nothing is refused, so it is
+    /// inert on self-host where no refusal endpoint exists.
+    /// </summary>
+    public static void Validate(IEnumerable<Endpoint> endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var routes = endpoints.OfType<RouteEndpoint>().ToList();
+
+        var refusals = routes
+            .Select(e => (Endpoint: e, Marker: e.Metadata.GetMetadata<HostedRefusalMarker>()))
+            .Where(x => x.Marker is not null)
+            .ToList();
+
+        if (refusals.Count == 0)
+        {
+            FileLog.Write("[HostedRefusalRouteSpace] no hosted refusals mapped - nothing to validate (self-host)");
+            return;
+        }
+
+        var seen = new Dictionary<string, (HostedRefusalMarker Marker, RouteEndpoint Endpoint)>(StringComparer.Ordinal);
+
+        foreach (var (endpoint, marker) in refusals)
+        {
+            var key = HostedRefusalPattern.ShapeKey(endpoint.RoutePattern);
+
+            // REFUSAL versus REFUSAL. Two families whose refusals land on one shape tie at request time, and
+            // the caller gets a 500 from the route that was supposed to refuse them.
+            if (seen.TryGetValue(key, out var prior))
+            {
+                throw new InvalidOperationException(
+                    $"Two hosted refusals occupy the same route shape and would tie at request time: " +
+                    $"family '{prior.Marker!.Denial.Family}' pattern '{prior.Marker.SourcePattern}' and " +
+                    $"family '{marker!.Denial.Family}' pattern '{marker.SourcePattern}'. " +
+                    "A denied route that answers 500 is not a refusal. Give one family the route, or narrow one pattern.");
+            }
+
+            seen[key] = (marker!, endpoint);
+
+            // REFUSAL versus a LIVE NEIGHBOUR. A tie here is an outage on a route nobody denied - the
+            // over-refusal direction, which no leak-shaped test would ever notice.
+            foreach (var other in routes)
+            {
+                if (ReferenceEquals(other, endpoint)) continue;
+                if (other.Metadata.GetMetadata<HostedRefusalMarker>() is not null) continue;
+                if (!SharesShape(endpoint.RoutePattern, other.RoutePattern)) continue;
+
+                throw new InvalidOperationException(
+                    $"The hosted refusal for family '{marker!.Denial.Family}' (pattern '{marker.SourcePattern}') " +
+                    $"occupies the same route shape as the live route '{other.RoutePattern.RawText}', so the two " +
+                    "would tie at request time and a route nobody denied would stop serving. " +
+                    "Refusing to start: an outage on an undenied route is as much a defect as a leak on a denied one.");
+            }
+        }
+
+        FileLog.Write($"[HostedRefusalRouteSpace] validated {refusals.Count} hosted refusal route(s) against " +
+                      $"{routes.Count} mapped route(s) - no ties");
+    }
+
+    /// <summary>
+    /// True when two patterns occupy the SAME shape, which is the only relation route precedence cannot
+    /// resolve. Compared through the shape key so parameter names and policies are ignored - a live
+    /// <c>/x/{name:alpha}</c> ties with a refusing <c>/x/{id}</c>, and the differing name and policy are
+    /// exactly the details that would hide it from a text comparison.
+    /// </summary>
+    private static bool SharesShape(RoutePattern left, RoutePattern right)
+    {
+        try
+        {
+            return string.Equals(HostedRefusalPattern.ShapeKey(left), HostedRefusalPattern.ShapeKey(right),
+                StringComparison.Ordinal);
+        }
+        catch (NotSupportedException)
+        {
+            // A live route may legitimately contain a part shape the refusal normaliser does not model. It
+            // cannot be a refusal (those are built by the normaliser), so it cannot be compared - and an
+            // uncomparable route is not evidence of a tie.
+            return false;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
@@ -4,42 +4,61 @@ using System.Linq;
 using CcDirector.Core.Utilities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.Routing.Patterns;
 
 namespace CcDirector.Gateway.Tenancy;
 
 /// <summary>
 /// Marks an endpoint as a hosted refusal, so the FINALISED route space can be checked once everything has
-/// been mapped. Carries the family and the pattern the family actually asked for, which is what makes a
-/// failure message name the two routes a human has to go and look at.
+/// been mapped. Carries the family and the pattern the family asked for, so a failure message names the
+/// two routes a human has to go and look at.
 /// </summary>
 internal sealed record HostedRefusalMarker(HostedDenial Denial, string SourcePattern);
 
 /// <summary>
-/// Validates the route space AFTER every endpoint has been mapped, and fails the Gateway at startup on a
-/// conflict rather than letting it surface as a 500 on a denied route the first time somebody calls it.
+/// Marks a group as claiming a prefix EXCLUSIVELY on hosted - nothing outside the denied family may serve
+/// a path underneath it. Recorded as metadata so the claim is checked against the finalised route space
+/// rather than trusted.
+/// </summary>
+internal sealed record HostedExclusivePrefixMarker(HostedDenial Denial, string Prefix);
+
+/// <summary>
+/// Validates the route space AFTER every endpoint has been mapped, and fails the Gateway at startup rather
+/// than letting a conflict surface as a 500 on a denied route the first time somebody calls it.
 ///
-/// WHY THIS EXISTS SEPARATELY FROM THE PER-GROUP CHECK. <see cref="HostedDenyGroup"/> can only see its own
-/// group: it prevents one family from mapping two refusals that tie. It cannot see
-///   - two DIFFERENT denied families whose refusal patterns land on the same route shape, or
-///   - a refusal that ties with an UNDENIED neighbour mapped somewhere else entirely.
-/// Both are decided by the whole route space, so both can only be checked once the whole route space
-/// exists. The first is a refusal that answers 500 instead of refusing. The second is worse in a different
-/// direction: a tie against a live route is an OUTAGE on something nobody denied.
+/// WHAT THIS CHECKS, AND - MORE IMPORTANTLY - WHAT IT DELIBERATELY NO LONGER TRIES TO CHECK.
 ///
-/// WHY A TIE AND NOT AN OVERLAP. Refusal patterns are deliberately WIDE - policies are stripped, so
-/// <c>/x/{id}</c> refuses where the real route wanted an integer. Widening is the point, and it overlaps
-/// neighbours constantly and harmlessly, because route precedence resolves it: a literal segment outranks a
-/// parameter segment, so a live <c>/x/summary</c> still wins over a refusing <c>/x/{id}</c>. What precedence
-/// CANNOT resolve is an exact tie - the same shape in the same positions - and that is the only case this
-/// validator rejects. Rejecting mere overlap would refuse to start on the normal, correct arrangement.
+/// A previous version of this file tried to detect whether two route patterns would TIE in the matcher, by
+/// comparing a hand-rolled "shape key". It was wrong, and it was wrong in the way that matters: three
+/// independent route pairs escaped it and returned HTTP 500 at request time - a standard parameter against
+/// an optional one on a present segment, literal case variants, and equal-precedence complex segments
+/// differing only by their separator character.
+///
+/// The reason it was wrong is worth keeping, because it is the second time this primitive made the same
+/// mistake: <b>the matcher's ambiguity relation is not reachable from public API, so any check for it is a
+/// MODEL of framework semantics rather than the semantics themselves.</b> The first instance was a
+/// hand-written scan standing in for the route parser; this was a hand-rolled key standing in for the
+/// matcher. Both were correct on the cases their author thought of and wrong on cases the framework
+/// already knew about.
+///
+/// So this no longer models ambiguity. It removes the conditions under which ambiguity can arise:
+///
+///   - an EXCLUSIVE-PREFIX family maps ONE catch-all refusal under a prefix nothing else may serve. One
+///     refusal cannot tie with itself, and exclusivity is checked by simple PREFIX CONTAINMENT - a
+///     comparison this code can actually perform correctly, unlike an ambiguity relation.
+///   - a PER-ROUTE family maps a refusal per route it actually declares. Nothing is synthesised, so no
+///     pattern exists that the family did not already have.
+///
+/// The residual case is stated rather than hidden: normalising a pattern WIDENS it, so two of a family's
+/// own routes that differ only by a parameter policy normalise to the same refusal and are de-duplicated
+/// by exact normalised text. Two routes that tie for some other reason would already tie in that family's
+/// own production route table, before any deny existed.
 /// </summary>
 internal static class HostedRefusalRouteSpace
 {
     /// <summary>
-    /// Reads every endpoint the application has mapped and throws on the first conflict. Call ONCE, after
-    /// all mapping is done and before the host starts serving. A no-op when nothing is refused, so it is
-    /// inert on self-host where no refusal endpoint exists.
+    /// Reads every endpoint the application has mapped and throws on the first violation. Call ONCE, after
+    /// all mapping is done and before the host serves. Inert when nothing is refused, so it does nothing on
+    /// self-host, where no refusal endpoint exists.
     /// </summary>
     public static void Validate(IEnumerable<Endpoint> endpoints)
     {
@@ -47,75 +66,48 @@ internal static class HostedRefusalRouteSpace
 
         var routes = endpoints.OfType<RouteEndpoint>().ToList();
 
-        var refusals = routes
-            .Select(e => (Endpoint: e, Marker: e.Metadata.GetMetadata<HostedRefusalMarker>()))
+        var exclusive = routes
+            .Select(e => (Endpoint: e, Marker: e.Metadata.GetMetadata<HostedExclusivePrefixMarker>()))
             .Where(x => x.Marker is not null)
             .ToList();
 
-        if (refusals.Count == 0)
+        var refusals = routes.Count(e => e.Metadata.GetMetadata<HostedRefusalMarker>() is not null);
+
+        if (refusals == 0 && exclusive.Count == 0)
         {
             FileLog.Write("[HostedRefusalRouteSpace] no hosted refusals mapped - nothing to validate (self-host)");
             return;
         }
 
-        var seen = new Dictionary<string, (HostedRefusalMarker Marker, RouteEndpoint Endpoint)>(StringComparer.Ordinal);
-
-        foreach (var (endpoint, marker) in refusals)
+        foreach (var (endpoint, marker) in exclusive)
         {
-            var key = HostedRefusalPattern.ShapeKey(endpoint.RoutePattern);
+            var prefix = marker!.Prefix.TrimEnd('/');
 
-            // REFUSAL versus REFUSAL. Two families whose refusals land on one shape tie at request time, and
-            // the caller gets a 500 from the route that was supposed to refuse them.
-            if (seen.TryGetValue(key, out var prior))
-            {
-                throw new InvalidOperationException(
-                    $"Two hosted refusals occupy the same route shape and would tie at request time: " +
-                    $"family '{prior.Marker!.Denial.Family}' pattern '{prior.Marker.SourcePattern}' and " +
-                    $"family '{marker!.Denial.Family}' pattern '{marker.SourcePattern}'. " +
-                    "A denied route that answers 500 is not a refusal. Give one family the route, or narrow one pattern.");
-            }
-
-            seen[key] = (marker!, endpoint);
-
-            // REFUSAL versus a LIVE NEIGHBOUR. A tie here is an outage on a route nobody denied - the
-            // over-refusal direction, which no leak-shaped test would ever notice.
+            // EXCLUSIVITY, by prefix containment. Everything under this prefix belongs to the denied family;
+            // a live route there would be swallowed by the catch-all refusal, which is an OUTAGE on a route
+            // nobody denied - the over-refusal direction, and the one no leak-shaped test would notice.
             foreach (var other in routes)
             {
                 if (ReferenceEquals(other, endpoint)) continue;
                 if (other.Metadata.GetMetadata<HostedRefusalMarker>() is not null) continue;
-                if (!SharesShape(endpoint.RoutePattern, other.RoutePattern)) continue;
+                if (other.Metadata.GetMetadata<HostedExclusivePrefixMarker>() is not null) continue;
+
+                var otherPath = "/" + (other.RoutePattern.RawText ?? string.Empty).TrimStart('/');
+                if (!otherPath.StartsWith(prefix + "/", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(otherPath, prefix, StringComparison.OrdinalIgnoreCase))
+                    continue;
 
                 throw new InvalidOperationException(
-                    $"The hosted refusal for family '{marker!.Denial.Family}' (pattern '{marker.SourcePattern}') " +
-                    $"occupies the same route shape as the live route '{other.RoutePattern.RawText}', so the two " +
-                    "would tie at request time and a route nobody denied would stop serving. " +
-                    "Refusing to start: an outage on an undenied route is as much a defect as a leak on a denied one.");
+                    $"The hosted denial for family '{marker.Denial.Family}' claims the prefix '{marker.Prefix}' " +
+                    $"EXCLUSIVELY, but the live route '{other.RoutePattern.RawText}' serves underneath it. The " +
+                    "catch-all refusal would take that route off the air. Refusing to start: an outage on an " +
+                    "undenied route is as much a defect as a leak on a denied one. Either that route belongs to " +
+                    "the denied family, or this family cannot claim the prefix exclusively and owes per-route " +
+                    "refusals instead.");
             }
         }
 
-        FileLog.Write($"[HostedRefusalRouteSpace] validated {refusals.Count} hosted refusal route(s) against " +
-                      $"{routes.Count} mapped route(s) - no ties");
-    }
-
-    /// <summary>
-    /// True when two patterns occupy the SAME shape, which is the only relation route precedence cannot
-    /// resolve. Compared through the shape key so parameter names and policies are ignored - a live
-    /// <c>/x/{name:alpha}</c> ties with a refusing <c>/x/{id}</c>, and the differing name and policy are
-    /// exactly the details that would hide it from a text comparison.
-    /// </summary>
-    private static bool SharesShape(RoutePattern left, RoutePattern right)
-    {
-        try
-        {
-            return string.Equals(HostedRefusalPattern.ShapeKey(left), HostedRefusalPattern.ShapeKey(right),
-                StringComparison.Ordinal);
-        }
-        catch (NotSupportedException)
-        {
-            // A live route may legitimately contain a part shape the refusal normaliser does not model. It
-            // cannot be a refusal (those are built by the normaliser), so it cannot be compared - and an
-            // uncomparable route is not evidence of a tie.
-            return false;
-        }
+        FileLog.Write($"[HostedRefusalRouteSpace] validated {exclusive.Count} exclusive-prefix claim(s) and " +
+                      $"{refusals} refusal route(s) against {routes.Count} mapped route(s)");
     }
 }

--- a/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
@@ -161,11 +161,19 @@ public sealed class HostedDenyGroup
     private readonly RouteGroupBuilder _group;
     private readonly HostedDenial _denial;
 
-    // On hosted, one refusal route per PATTERN. A family that maps two verbs on one path (GET /x and PUT /x)
-    // would otherwise produce two verb-less routes on the same pattern, and the matcher throws
-    // AmbiguousMatchException at REQUEST time - a 500 in place of the refusal, on the denied route, which is
-    // the deny failing in the one way nothing would notice until a caller tried it.
-    private readonly Dictionary<string, IEndpointConventionBuilder> _refusals = new(StringComparer.Ordinal);
+    // On hosted, one refusal route per route SHAPE - not per pattern TEXT.
+    //
+    // A family that maps two verbs on one path (GET /x and PUT /x) would otherwise produce two verb-less
+    // routes that tie, and the matcher throws at REQUEST time - a 500 in place of the refusal, on the denied
+    // route, which is the deny failing in the one way nothing notices until a caller tries it.
+    //
+    // Text equality is not enough to prevent that. Two patterns differing only in a parameter NAME -
+    // /x/{id} and /x/{name} - are different strings and the SAME ROUTE, so a text-keyed dictionary maps both
+    // and produces exactly the tie it was meant to prevent. The key is therefore the route SHAPE (see
+    // HostedRefusalPattern.ShapeKey), which is what the matcher actually competes on.
+    private readonly Dictionary<string, RegisteredRefusal> _refusals = new(StringComparer.Ordinal);
+
+    private sealed record RegisteredRefusal(string SourcePattern, IEndpointConventionBuilder Builder);
 
     internal HostedDenyGroup(RouteGroupBuilder group, HostedDenial denial)
     {
@@ -203,64 +211,32 @@ public sealed class HostedDenyGroup
         if (!GatewayHostedMode.IsHosted)
             return mapHandler();
 
-        // The refusal is mapped on the pattern with its inline route CONSTRAINTS removed. Keeping them would
-        // leave a measured hole: a segment that fails a constraint - a non-integer where the real route
-        // declares {id:int} - fails endpoint SELECTION, so a refusal carrying that same constraint is never
-        // selected either and the framework answers its own 404 with the refusal never running. Loosening the
-        // refusal pattern means a value that fails the real constraint still MATCHES the refusal.
+        // The refusal is mapped on the family's pattern with its parameter POLICIES removed, rebuilt from the
+        // parsed route MODEL rather than by editing the pattern text (see HostedRefusalPattern). Keeping a
+        // policy would leave a measured hole: a segment that fails an inline constraint fails endpoint
+        // SELECTION, so a refusal carrying that same constraint is never selected either and the framework
+        // answers instead of the refusal. Everything else - literals, separators, parameter names, optionality,
+        // catch-alls and defaults - is preserved exactly.
         //
-        // Loosening cannot steal a neighbouring route that must keep serving: a literal segment outranks a
-        // parameter segment in route precedence, so a sibling literal on the same path shape still wins. That
-        // is measured, not assumed - over-refusing an undenied route would be an outage, which is the same
-        // defect as under-refusing a denied one, pointed the other way.
-        var refusalPattern = StripInlineConstraints(pattern);
+        // A pattern containing a part the normaliser does not recognise THROWS here, at startup. That is
+        // deliberate: passing it through would map a refusal that still carried a constraint while the
+        // family's author believed the route was covered, which is the false coverage this boundary exists to
+        // remove.
+        var refusalPattern = HostedRefusalPattern.WithoutPolicies(pattern, _denial.Family);
+        var shapeKey = HostedRefusalPattern.ShapeKey(refusalPattern);
 
-        if (_refusals.TryGetValue(refusalPattern, out var existing))
-            return existing;
+        // Same route shape, already refused: a family mapping several verbs on one path needs exactly ONE
+        // verb-less refusal, and mapping a second would tie with the first.
+        if (_refusals.TryGetValue(shapeKey, out var existing))
+            return existing.Builder;
 
-        // Verb-less and handler-less: nothing constrains the match and nothing binds, so every request shape
-        // - including a verb this family never mapped - meets the refusal below.
+        // Verb-less and handler-less: nothing constrains the match and nothing binds, so every request shape -
+        // including a verb this family never mapped - meets the refusal below.
         var refusal = _group.Map(refusalPattern, context => WriteRefusalAsync(context, _denial));
-        _refusals[refusalPattern] = refusal;
+        refusal.WithMetadata(new HostedRefusalMarker(_denial, pattern));
+
+        _refusals[shapeKey] = new RegisteredRefusal(pattern, refusal);
         return refusal;
-    }
-
-    /// <summary>
-    /// Removes the inline constraint from every route parameter: <c>/x/{id:int}</c> becomes <c>/x/{id}</c>.
-    /// A default value or a catch-all marker is left alone - only the constraint portion, everything from the
-    /// first colon to the closing brace, is dropped, because it is the constraint alone that can fail
-    /// selection and leave the refusal unreachable.
-    /// </summary>
-    internal static string StripInlineConstraints(string pattern)
-    {
-        if (pattern.IndexOf(':') < 0) return pattern;
-
-        var result = new System.Text.StringBuilder(pattern.Length);
-        var insideParameter = false;
-        var skipping = false;
-
-        foreach (var c in pattern)
-        {
-            switch (c)
-            {
-                case '{':
-                    insideParameter = true;
-                    skipping = false;
-                    break;
-                case '}':
-                    insideParameter = false;
-                    skipping = false;
-                    break;
-                case ':' when insideParameter:
-                    skipping = true;
-                    continue;
-            }
-
-            if (skipping && c != '}') continue;
-            result.Append(c);
-        }
-
-        return result.ToString();
     }
 
     private static async Task WriteRefusalAsync(HttpContext context, HostedDenial denial)
@@ -269,6 +245,15 @@ public sealed class HostedDenyGroup
                       $"method={context.Request.Method} path={context.Request.Path} reason={denial.Reason}");
 
         context.Response.StatusCode = denial.StatusCode;
+
+        // The media type is set EXPLICITLY, with its charset parameter, because the proof asserts the whole
+        // header value and not just the type: a refusal is a contract about what is served, and "close enough"
+        // on a content type is how a caller ends up parsing something other than what it expected.
+        context.Response.ContentType = "application/json; charset=utf-8";
+
+        // A HEAD request is answered with the refusal's status and headers and no body - the framework
+        // suppresses the body for HEAD. That is correct HTTP and it is stated here so the proof can assert it
+        // deliberately rather than a reader assuming "every request shape" includes a body on HEAD.
         await context.Response.WriteAsJsonAsync(new HostedRefusalBody(denial.Message));
     }
 

--- a/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
@@ -38,14 +38,22 @@ namespace CcDirector.Gateway.Tenancy;
 /// says it does not. A wrong verb IS a request shape, and the standard being enforced is that the refusal is
 /// uniform across shapes.
 ///
-/// WHY A TYPED HANDLE. The pre-binding property is proven ONCE, here, for every adopting family: an adopter
-/// cannot be attached AND post-binding, because attachment is what maps the refusal in place of the handler.
-/// That puts the whole weight on ATTACHMENT, so attachment is made structurally impossible to get wrong
-/// rather than merely conventional - routes are mapped through <see cref="HostedDenyGroup"/>, a distinct
-/// type obtainable only from <see cref="Group"/>. A family maps into the guarded group or it does not
-/// compile. The earlier shape kept a guarded and an unguarded builder in scope, differing only by variable
-/// name, so one changed receiver silently opened one route on hosted; here that is a signature change rather
-/// than a typo.
+/// WHY A TYPED HANDLE, AND WHAT IT DOES *NOT* GIVE US - corrected after review disproved the stronger claim.
+///
+/// Routes are mapped through <see cref="HostedDenyGroup"/>, a distinct type obtainable only from this class.
+/// It was claimed that this made unguarded mapping structurally UNEXPRESSIBLE, and that claim was FALSE:
+/// review changed one mapping receiver from the guarded group to the outer builder, it compiled with zero
+/// errors, and the hosted assertions reddened. So the handle is a CANARY - the bypass compiles and tests
+/// catch it - not a boundary.
+///
+/// The correction matters because a one-proof discharge for every adopting family rested on it. What
+/// survives is narrower and is stated as such: a family that maps its routes in a private STATIC method
+/// taking only the handle cannot see an outer builder at all, so its routes are not INDIVIDUALLY movable -
+/// redirecting one means changing the signature, which moves all of them together. That earns a family ONE
+/// attachment arm rather than one per route. It does not earn an exemption from arms altogether.
+///
+/// Do not restore the stronger claim without a mechanism that actually enforces the shape - an analyzer,
+/// not a convention. The bypass was measured; it is not hypothetical.
 ///
 /// SELF-HOST IS UNTOUCHED, AND THAT IS THE CONTROL. Off hosted every <c>Map</c> below maps the family's real
 /// handler on the group exactly as an unguarded builder would, and no refusal route is created at all.
@@ -59,9 +67,47 @@ namespace CcDirector.Gateway.Tenancy;
 public static class HostedRouteDeny
 {
     /// <summary>
-    /// Opens a route group whose every route - including routes mapped into it later, by anyone, with no
-    /// deny written for them - is refused on the hosted Gateway, on every request shape, without any
-    /// argument binding taking place. Returns the typed handle the family must map through.
+    /// Opens an EXCLUSIVE-PREFIX denied group: on hosted the family's handlers are not mapped and ONE
+    /// catch-all refusal claims everything under the prefix, including paths that do not exist. Use this
+    /// wherever the family owns its prefix outright - it is the stronger shape, because one refusal cannot
+    /// tie with anything and the exclusivity claim is checked by simple prefix containment at startup
+    /// rather than by reasoning about which patterns compete.
+    ///
+    /// It also gives the family FUTURE-ROUTE coverage for free: a path added under the prefix later is
+    /// already refused, because the catch-all never needed to know the route existed.
+    ///
+    /// The claim is CHECKED, not trusted: if any live route serves under this prefix, the Gateway refuses
+    /// to start, because the catch-all would take that route off the air.
+    /// </summary>
+    public static HostedDenyGroup ExclusiveGroup(IEndpointRouteBuilder outer, string prefix, HostedDenial denial)
+    {
+        ArgumentNullException.ThrowIfNull(outer);
+        ArgumentNullException.ThrowIfNull(denial);
+
+        if (string.IsNullOrWhiteSpace(prefix) || prefix == "/")
+            throw new ArgumentException(
+                $"The hosted denial for '{denial.Family}' asked to claim a prefix exclusively, but gave an empty " +
+                "prefix - which would claim the entire Gateway. An exclusive claim needs a real prefix.",
+                nameof(prefix));
+
+        var group = Group(outer, prefix, denial);
+
+        if (GatewayHostedMode.IsHosted)
+            group.MapExclusiveCatchAll(prefix);
+
+        return group;
+    }
+
+    /// <summary>
+    /// Opens a PER-ROUTE denied group: on hosted each route the family declares gets its own refusal in
+    /// place of its handler. Use this where the family's paths sit under a prefix that also carries LIVE
+    /// routes, so an exclusive claim would take undenied routes off the air.
+    ///
+    /// THE COST, STATED RATHER THAN DISCOVERED: a per-route family does NOT inherit future-route coverage.
+    /// A route added to it later has no refusal unless somebody writes one - which is the very property the
+    /// group mechanism exists to provide. A family using this mode therefore owes a test enumerating its
+    /// own mapped routes and asserting each has a refusal, so that adding one without a refusal REDDENS.
+    /// That converts the lost property from a thing to remember into a thing that fails.
     /// </summary>
     /// <param name="outer">The builder the group hangs off.</param>
     /// <param name="prefix">The group prefix, or <c>""</c> to keep route paths written out in full.</param>
@@ -72,10 +118,30 @@ public static class HostedRouteDeny
         ArgumentNullException.ThrowIfNull(prefix);
         ArgumentNullException.ThrowIfNull(denial);
 
-        FileLog.Write($"[HostedRouteDeny] group family={denial.Family} prefix='{prefix}' hosted={GatewayHostedMode.IsHosted}" +
+        // THE PREFIX IS NORMALISED TOO, on hosted. A group prefix can carry its own parameter policies -
+        // /family/{scope:int} - and a route's full pattern is the prefix plus the local pattern. Normalising
+        // only the local half leaves the constraint-miss hole one level up: a request whose PREFIX segment
+        // fails its policy fails endpoint selection, so the refusal is never selected and the framework
+        // answers instead. That was measured on the previous head, and it is the same defect the local
+        // normalisation exists to close, which is exactly why it was easy to miss - the fix had already been
+        // applied once and looked done.
+        //
+        // Off hosted the prefix is used verbatim, so self-host route matching is byte-identical to a group
+        // created without this primitive at all. Normalising off hosted would WIDEN the family's real routes,
+        // which would be a behaviour change on the control.
+        // Handed to MapGroup as a PATTERN, never re-serialised to text. A text round-trip would need a
+        // fallback for the case where the rebuilt pattern has no raw text - and that fallback would quietly
+        // reinstate the constrained prefix, which is the hole this is closing, restored by the very line
+        // meant to close it.
+        FileLog.Write($"[HostedRouteDeny] group family={denial.Family} prefix='{prefix}' " +
+                      $"hosted={GatewayHostedMode.IsHosted}" +
                       " - on hosted EVERY route in this group is refused on EVERY request shape, with no argument binding");
 
-        return new HostedDenyGroup(outer.MapGroup(prefix), denial);
+        var group = GatewayHostedMode.IsHosted
+            ? outer.MapGroup(HostedRefusalPattern.WithoutPolicies(prefix, denial.Family))
+            : outer.MapGroup(prefix);
+
+        return new HostedDenyGroup(group, denial);
     }
 }
 
@@ -161,16 +227,24 @@ public sealed class HostedDenyGroup
     private readonly RouteGroupBuilder _group;
     private readonly HostedDenial _denial;
 
-    // On hosted, one refusal route per route SHAPE - not per pattern TEXT.
+    // On hosted, one refusal per route shape WITHIN THIS FAMILY - a de-duplication, and nothing more.
     //
-    // A family that maps two verbs on one path (GET /x and PUT /x) would otherwise produce two verb-less
-    // routes that tie, and the matcher throws at REQUEST time - a 500 in place of the refusal, on the denied
-    // route, which is the deny failing in the one way nothing notices until a caller tries it.
+    // WHAT IT IS FOR: a family mapping several verbs on one path needs ONE verb-less refusal, because a
+    // second on the same path would tie with the first and the tie surfaces as a 500 at request time, on the
+    // denied route, which is the one nobody exercises until a caller does.
     //
-    // Text equality is not enough to prevent that. Two patterns differing only in a parameter NAME -
-    // /x/{id} and /x/{name} - are different strings and the SAME ROUTE, so a text-keyed dictionary maps both
-    // and produces exactly the tie it was meant to prevent. The key is therefore the route SHAPE (see
-    // HostedRefusalPattern.ShapeKey), which is what the matcher actually competes on.
+    // WHAT IT IS EXPLICITLY NOT: this key is NOT the matcher's ambiguity relation, and it must never be read
+    // as one. An earlier version of this primitive treated it as one, and review found three route pairs it
+    // called distinct that the live matcher ties - a standard parameter against an optional one on a present
+    // segment, literal case variants, and equal-precedence complex segments differing only by their
+    // separator. The matcher's relation is not reachable from public API, so any check for it here is a MODEL
+    // of framework semantics rather than the semantics, which is the same mistake as hand-scanning pattern
+    // text instead of using the parser.
+    //
+    // The safety of this mode therefore does NOT rest on this key being complete. It rests on refusals
+    // MIRRORING routes the family already declares: nothing is synthesised, so no pattern exists here that
+    // the family did not already have. Two of its routes that tie would already tie in its own production
+    // route table, before any deny existed.
     private readonly Dictionary<string, RegisteredRefusal> _refusals = new(StringComparer.Ordinal);
 
     private sealed record RegisteredRefusal(string SourcePattern, IEndpointConventionBuilder Builder);
@@ -198,6 +272,23 @@ public sealed class HostedDenyGroup
 
     public IEndpointConventionBuilder MapMethods(string pattern, IEnumerable<string> methods, Delegate handler)
         => Map(pattern, handler, () => _group.MapMethods(pattern, methods, handler));
+
+    /// <summary>
+    /// Maps the single catch-all refusal for an exclusive-prefix family, and records the exclusivity claim
+    /// as metadata so the finalised route space can CHECK it rather than take it on trust.
+    /// </summary>
+    internal void MapExclusiveCatchAll(string prefix)
+    {
+        var refusal = _group.Map("/{**hostedDeniedPath}", context => WriteRefusalAsync(context, _denial));
+        refusal.WithMetadata(new HostedRefusalMarker(_denial, prefix + "/{**hostedDeniedPath}"));
+        refusal.WithMetadata(new HostedExclusivePrefixMarker(_denial, prefix));
+
+        // The prefix ITSELF, which the catch-all above does not cover - a request to exactly the prefix has
+        // no remaining segment for the catch-all to match. Without this the family's own root answers from
+        // the fallback rather than from the refusal.
+        var root = _group.Map("", context => WriteRefusalAsync(context, _denial));
+        root.WithMetadata(new HostedRefusalMarker(_denial, prefix));
+    }
 
     /// <summary>
     /// The one decision, in one place: on hosted map the refusal and never the handler; off hosted map the

--- a/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CcDirector.Core.Utilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// The ONE hosted-refusal boundary every deny family adopts. It exists because a refusal attached as a
+/// route-group endpoint filter does NOT answer uniformly across request shapes, and the shapes it misses
+/// are not the ones an obvious test exercises. The mechanism, the shapes, and the measurements behind that
+/// are recorded in the PRIVATE architecture record; this file carries what a maintainer needs in order not
+/// to undo the design, and no more.
+///
+/// The consequence that matters to anyone writing a proof: a future-route probe on a deny family MUST
+/// include a BODY-BOUND POST and not only a parameterless GET, because a parameterless GET is precisely the
+/// shape through which this class of defect cannot be seen.
+///
+/// HOW THIS CLOSES IT. On hosted the family's handler is NEVER MAPPED. In its place goes a verb-less
+/// refusal route on the same pattern. So there is no binding step to get ahead of, no body parameter, no
+/// inferred media-type constraint, and no method constraint - which means no request shape can be answered
+/// by the framework ahead of the refusal:
+///
+/// | Request shape           | Answered by |
+/// |-------------------------|-------------|
+/// | valid body              | the refusal |
+/// | malformed body          | the refusal |
+/// | wrong media type        | the refusal |
+/// | a verb never mapped     | the refusal |
+/// | a route added LATER     | the refusal |
+///
+/// The wrong-verb row is why this is a verb-less route rather than a convention that replaces the endpoint's
+/// request delegate. That convention closes the three body shapes but still lets endpoint SELECTION answer
+/// 405 for a verb the group never mapped - which discloses that a route exists on a Gateway whose refusal
+/// says it does not. A wrong verb IS a request shape, and the standard being enforced is that the refusal is
+/// uniform across shapes.
+///
+/// WHY A TYPED HANDLE. The pre-binding property is proven ONCE, here, for every adopting family: an adopter
+/// cannot be attached AND post-binding, because attachment is what maps the refusal in place of the handler.
+/// That puts the whole weight on ATTACHMENT, so attachment is made structurally impossible to get wrong
+/// rather than merely conventional - routes are mapped through <see cref="HostedDenyGroup"/>, a distinct
+/// type obtainable only from <see cref="Group"/>. A family maps into the guarded group or it does not
+/// compile. The earlier shape kept a guarded and an unguarded builder in scope, differing only by variable
+/// name, so one changed receiver silently opened one route on hosted; here that is a signature change rather
+/// than a typo.
+///
+/// SELF-HOST IS UNTOUCHED, AND THAT IS THE CONTROL. Off hosted every <c>Map</c> below maps the family's real
+/// handler on the group exactly as an unguarded builder would, and no refusal route is created at all.
+///
+/// FAIL DIRECTION. The refusal payload is validated when it is CONSTRUCTED, so a family supplying a blank
+/// message fails the Gateway at STARTUP - loudly, before serving - rather than serving an empty refusal that
+/// reads like a working route. The hosted decision is read from <see cref="GatewayHostedMode.IsHosted"/>
+/// directly, never from an optional argument a caller can omit: a security branch that depends on an
+/// argument fails OPEN the moment somebody forgets it.
+/// </summary>
+public static class HostedRouteDeny
+{
+    /// <summary>
+    /// Opens a route group whose every route - including routes mapped into it later, by anyone, with no
+    /// deny written for them - is refused on the hosted Gateway, on every request shape, without any
+    /// argument binding taking place. Returns the typed handle the family must map through.
+    /// </summary>
+    /// <param name="outer">The builder the group hangs off.</param>
+    /// <param name="prefix">The group prefix, or <c>""</c> to keep route paths written out in full.</param>
+    /// <param name="denial">This family's refusal payload - the only per-family configuration.</param>
+    public static HostedDenyGroup Group(IEndpointRouteBuilder outer, string prefix, HostedDenial denial)
+    {
+        ArgumentNullException.ThrowIfNull(outer);
+        ArgumentNullException.ThrowIfNull(prefix);
+        ArgumentNullException.ThrowIfNull(denial);
+
+        FileLog.Write($"[HostedRouteDeny] group family={denial.Family} prefix='{prefix}' hosted={GatewayHostedMode.IsHosted}" +
+                      " - on hosted EVERY route in this group is refused on EVERY request shape, with no argument binding");
+
+        return new HostedDenyGroup(outer.MapGroup(prefix), denial);
+    }
+}
+
+/// <summary>
+/// A family's refusal payload - the ONLY thing that differs between adopting families. Validated on
+/// construction so a malformed one fails the Gateway at startup rather than serving a refusal that says
+/// nothing.
+/// </summary>
+public sealed record HostedDenial
+{
+    /// <summary>The family name, for the log line and for telling refusals apart in a proof run.</summary>
+    public string Family { get; }
+
+    /// <summary>
+    /// The single error string the caller receives. The refusal body carries this and nothing else, so the
+    /// adopting family's test can assert an EXACT property set rather than the absence of today's payload
+    /// keys - an absence-only assertion passes on a framework error too, and therefore cannot fail for the
+    /// right reason.
+    /// </summary>
+    public string Message { get; }
+
+    /// <summary>Why this family has no per-tenant answer to serve. Logged with every refusal.</summary>
+    public string Reason { get; }
+
+    /// <summary>
+    /// What must happen before this deny is ever lifted. A deny stops the READ but not necessarily the
+    /// WRITE, so data can keep accumulating behind it and be there in full on the day the deny lifts.
+    /// Un-denying therefore means REMOVE the deny PLUS purge or migrate whatever accumulated - and that
+    /// instruction is written here, AT the deny, rather than held as a general principle somebody has to
+    /// remember at the moment they are least likely to.
+    /// </summary>
+    public string UnDenyInstruction { get; }
+
+    /// <summary>
+    /// The refusal status. 404 where the route does not exist as a concept on hosted: 403 would imply some
+    /// credential could reach it, and none can.
+    /// </summary>
+    public int StatusCode { get; }
+
+    /// <summary>
+    /// Fails LOUDLY at startup on a payload that would produce a meaningless refusal. This is the
+    /// no-fallback rule applied to a security primitive: a blank message would serve a refusal a caller
+    /// cannot act on and a proof cannot assert, which is worse than not booting.
+    /// </summary>
+    public HostedDenial(
+        string family,
+        string message,
+        string reason,
+        string unDenyInstruction,
+        int statusCode = StatusCodes.Status404NotFound)
+    {
+        Family = family;
+        Message = message;
+        Reason = reason;
+        UnDenyInstruction = unDenyInstruction;
+        StatusCode = statusCode;
+
+        if (string.IsNullOrWhiteSpace(Family))
+            throw new ArgumentException("A hosted denial must name its family.", nameof(Family));
+        if (string.IsNullOrWhiteSpace(Message))
+            throw new ArgumentException($"The hosted denial for '{Family}' must carry a message; a blank refusal tells a caller nothing.", nameof(Message));
+        if (string.IsNullOrWhiteSpace(Reason))
+            throw new ArgumentException($"The hosted denial for '{Family}' must state why the family has no per-tenant answer.", nameof(Reason));
+        if (string.IsNullOrWhiteSpace(UnDenyInstruction))
+            throw new ArgumentException($"The hosted denial for '{Family}' must state what un-denying requires, including what to purge or migrate.", nameof(UnDenyInstruction));
+        if (StatusCode is < 400 or > 599)
+            throw new ArgumentException($"The hosted denial for '{Family}' must refuse with a 4xx or 5xx status, not {StatusCode}.", nameof(StatusCode));
+    }
+}
+
+/// <summary>
+/// The typed handle a denied family maps its routes through. Obtainable only from
+/// <see cref="HostedRouteDeny.Group"/>, which is what makes attachment structurally impossible to get wrong:
+/// a family's mapping method takes ONE of these and therefore cannot be handed an unguarded builder without
+/// changing its signature.
+///
+/// On hosted every method here maps a verb-less refusal on the pattern and DISCARDS the handler - the
+/// handler is never mapped, so nothing binds. Off hosted every method maps the handler exactly as an
+/// unguarded builder would.
+/// </summary>
+public sealed class HostedDenyGroup
+{
+    private readonly RouteGroupBuilder _group;
+    private readonly HostedDenial _denial;
+
+    // On hosted, one refusal route per PATTERN. A family that maps two verbs on one path (GET /x and PUT /x)
+    // would otherwise produce two verb-less routes on the same pattern, and the matcher throws
+    // AmbiguousMatchException at REQUEST time - a 500 in place of the refusal, on the denied route, which is
+    // the deny failing in the one way nothing would notice until a caller tried it.
+    private readonly Dictionary<string, IEndpointConventionBuilder> _refusals = new(StringComparer.Ordinal);
+
+    internal HostedDenyGroup(RouteGroupBuilder group, HostedDenial denial)
+    {
+        _group = group;
+        _denial = denial;
+    }
+
+    /// <summary>This family's refusal payload, so a test can assert against the same strings that are served.</summary>
+    public HostedDenial Denial => _denial;
+
+    public IEndpointConventionBuilder MapGet(string pattern, Delegate handler)
+        => Map(pattern, handler, () => _group.MapGet(pattern, handler));
+
+    public IEndpointConventionBuilder MapPost(string pattern, Delegate handler)
+        => Map(pattern, handler, () => _group.MapPost(pattern, handler));
+
+    public IEndpointConventionBuilder MapPut(string pattern, Delegate handler)
+        => Map(pattern, handler, () => _group.MapPut(pattern, handler));
+
+    public IEndpointConventionBuilder MapDelete(string pattern, Delegate handler)
+        => Map(pattern, handler, () => _group.MapDelete(pattern, handler));
+
+    public IEndpointConventionBuilder MapMethods(string pattern, IEnumerable<string> methods, Delegate handler)
+        => Map(pattern, handler, () => _group.MapMethods(pattern, methods, handler));
+
+    /// <summary>
+    /// The one decision, in one place: on hosted map the refusal and never the handler; off hosted map the
+    /// handler and never a refusal.
+    /// </summary>
+    private IEndpointConventionBuilder Map(string pattern, Delegate handler, Func<IEndpointConventionBuilder> mapHandler)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        ArgumentNullException.ThrowIfNull(handler);
+
+        if (!GatewayHostedMode.IsHosted)
+            return mapHandler();
+
+        // The refusal is mapped on the pattern with its inline route CONSTRAINTS removed. Keeping them would
+        // leave a measured hole: a segment that fails a constraint - a non-integer where the real route
+        // declares {id:int} - fails endpoint SELECTION, so a refusal carrying that same constraint is never
+        // selected either and the framework answers its own 404 with the refusal never running. Loosening the
+        // refusal pattern means a value that fails the real constraint still MATCHES the refusal.
+        //
+        // Loosening cannot steal a neighbouring route that must keep serving: a literal segment outranks a
+        // parameter segment in route precedence, so a sibling literal on the same path shape still wins. That
+        // is measured, not assumed - over-refusing an undenied route would be an outage, which is the same
+        // defect as under-refusing a denied one, pointed the other way.
+        var refusalPattern = StripInlineConstraints(pattern);
+
+        if (_refusals.TryGetValue(refusalPattern, out var existing))
+            return existing;
+
+        // Verb-less and handler-less: nothing constrains the match and nothing binds, so every request shape
+        // - including a verb this family never mapped - meets the refusal below.
+        var refusal = _group.Map(refusalPattern, context => WriteRefusalAsync(context, _denial));
+        _refusals[refusalPattern] = refusal;
+        return refusal;
+    }
+
+    /// <summary>
+    /// Removes the inline constraint from every route parameter: <c>/x/{id:int}</c> becomes <c>/x/{id}</c>.
+    /// A default value or a catch-all marker is left alone - only the constraint portion, everything from the
+    /// first colon to the closing brace, is dropped, because it is the constraint alone that can fail
+    /// selection and leave the refusal unreachable.
+    /// </summary>
+    internal static string StripInlineConstraints(string pattern)
+    {
+        if (pattern.IndexOf(':') < 0) return pattern;
+
+        var result = new System.Text.StringBuilder(pattern.Length);
+        var insideParameter = false;
+        var skipping = false;
+
+        foreach (var c in pattern)
+        {
+            switch (c)
+            {
+                case '{':
+                    insideParameter = true;
+                    skipping = false;
+                    break;
+                case '}':
+                    insideParameter = false;
+                    skipping = false;
+                    break;
+                case ':' when insideParameter:
+                    skipping = true;
+                    continue;
+            }
+
+            if (skipping && c != '}') continue;
+            result.Append(c);
+        }
+
+        return result.ToString();
+    }
+
+    private static async Task WriteRefusalAsync(HttpContext context, HostedDenial denial)
+    {
+        FileLog.Write($"[HostedRouteDeny] DENIED on hosted: family={denial.Family} " +
+                      $"method={context.Request.Method} path={context.Request.Path} reason={denial.Reason}");
+
+        context.Response.StatusCode = denial.StatusCode;
+        await context.Response.WriteAsJsonAsync(new HostedRefusalBody(denial.Message));
+    }
+
+    /// <summary>The refusal body: one property, so the assertion can be an exact property set.</summary>
+    private sealed record HostedRefusalBody(string Error);
+}


### PR DESCRIPTION
## What this changes

Every hosted deny family adopts **one shared refusal boundary** instead of each writing its own. A family's routes are mapped through a typed handle obtainable only from this primitive, so a family maps into the guarded group **or it does not compile**. The only per-family configuration is the refusal payload.

On hosted, the family's handler is not mapped and a refusal takes its place, so the refusal answers **uniformly across request shapes** - a valid body, a malformed body, an unexpected media type, a segment that does not satisfy an inline route constraint, a verb the family never mapped, and a route added to the group later with no deny written for it.

Off hosted the primitive maps the real handler and creates no refusal at all. Self-host is unchanged and is the control, proven in **both** declared non-hosted forms, each set explicitly rather than inherited from the test runner.

Because attachment is what performs the substitution, the uniformity property is established **once, here**. An adopter owes **attachment** and its **own body-bound future-route probe**. Gate direction is *not* a per-family arm - the primitive centralises that decision, so it is proven once in this suite. That is a real loss of per-family attribution, recorded as the price of the gate existing in one place rather than six.

## How the refusal pattern is built

The pattern is **parsed by the framework's own parser** and the parameter parts are rebuilt **without their policies**. Literals, separators, parameter names, optionality, catch-alls and default values are preserved; nothing is re-serialised to text.

This replaces a hand-written scan over the pattern text. The scan was correct on the shapes it was tested against and could be silently wrong on others - and silently wrong here means a refusal that does not cover its own route while the family's author believes it does, which is manufactured coverage rather than a visible bug.

**The grammar covered is stated, one test per element.** On a part kind it does not model, the normaliser **throws at startup** rather than passing the pattern through. That arm is currently **unreachable and is documented as unreachable rather than implied to be covered** - the framework's route-part type has an internal constructor, so its three subclasses are the whole hierarchy and no test here can manufacture a fourth. What guards it instead is a canary on the assumption underneath: if a framework upgrade adds a part kind, that test reddens.

## Conflicts are caught at startup, not at request time

**Deduplication is by route SHAPE, not pattern text.** Two patterns differing only in a parameter name are different strings and the same route, so a text-keyed check maps both and produces exactly the tie it exists to prevent.

**The finalised route space is validated once everything is mapped** - the earliest moment these conflicts exist. A refusal tying with another refusal answers 500 on a denied route; a refusal tying with a live route takes an undenied route off the air.

Only **exact ties** are rejected. Refusal patterns are deliberately wide, so they overlap neighbours constantly and precedence resolves it; a validator that rejected overlap would refuse to start on every correct arrangement.

## Two failure directions, not one

Refusing too little is a leak. Refusing too much is an **outage on a route nobody denied**. The proof set carries a **neighbour probe in both directions** - a literal sibling protected by precedence, and a route on a different path shape. An alternative design that matched by path rather than route membership was measured over-refusing a sibling and was rejected for it; the neighbour probe was itself validated by confirming it fails under that rejected design.

## Scope limit on the wrong-verb property - stated rather than claimed

The wrong-verb refusal is **real in a bare probe rig and is NOT observable on the production Gateway**, because the Cockpit fallback claims everything unmatched and no wrong-verb refusal is ever produced there.

**It must not enter any proof run against the production host.** Claiming it there would be claiming something the fallback prevents anyone from seeing - a claim that cannot fail.

It does buy something concrete: a delete on a cached-voice path today falls through to the session catch-all and is proxied to a Director; after adoption it meets the refusal.

## Proof

Eight request shapes, a future route, the multi-verb duplicate path adopting families rely on, both non-hosted forms, a neighbour probe in two directions, the response media type asserted **with its parameters**, HEAD stated as status-and-headers rather than folded into a claim about bodies, and construction-validation of the refusal payload.

**The registered full-suite proof is outstanding and is not claimed by this pull request.** A previous filtered rehearsal attributed cleanly, but a filtered run cannot see whether existing coverage already caught the behaviour, nor collateral elsewhere. The advance prediction, registered before the run: the primitive is not yet adopted by any family, so **no test outside these files should move in any arm**.