### PR TITLE
Bound voice-turn upload staging with a production, activity-aware age sweep

### DIFF
--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -138,7 +138,9 @@ public static class CcStorage
     /// <summary>
     /// Resumable upload staging for the Gateway voice-turn front door: base/voice-turn-uploads/&lt;uploadId&gt;/.
     /// Each chunk lands here as it arrives (SHA-checked, idempotent) and the dir is deleted once the
-    /// chunks are assembled and the turn has been started. Owned by the Gateway.
+    /// chunks are assembled and the turn has been started. An upload that never reaches that point is
+    /// removed by the Gateway's voice-turn upload sweep once nothing has written to it for hours, so
+    /// abandoned recorded audio has a retention ceiling. Owned by the Gateway.
     /// </summary>
     public static string VoiceTurnUploads() => Ensure(Path.Combine(Base(), "voice-turn-uploads"));
 
@@ -146,8 +148,10 @@ public static class CcStorage
     /// Resumable upload staging for durable dictation (issue #1006): base/dictation-uploads/&lt;uploadId&gt;/.
     /// The mobile app persists the raw audio locally the instant Send is pressed and streams it here in
     /// SHA-checked chunks; once assembled the Gateway transcribes it and injects the turn into the owning
-    /// session itself, so a dead tab or a dropped connection cannot lose a recorded utterance. Abandoned
-    /// staging dirs are swept after ~1 hour. Owned by the Gateway.
+    /// session itself, so a dead tab or a dropped connection cannot lose a recorded utterance. There is
+    /// deliberately NO age sweep here (unlike the voice-turn staging above): each upload id carries a durable
+    /// delivery record, its chunks are retained while it is undelivered, and the record is retired only by
+    /// the client's acknowledgment. Owned by the Gateway.
     /// </summary>
     public static string DictationUploads() => Ensure(Path.Combine(Base(), "dictation-uploads"));
 

--- a/src/CcDirector.Gateway.Tests/VoiceTurnUploadSweepWiringTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceTurnUploadSweepWiringTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using CcDirector.Core.Storage;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The voice-turn upload staging is bounded IN PRODUCTION, not merely bounded in principle.
+///
+/// WHY THIS TEST EXISTS AND WHY IT BOOTS A REAL GATEWAY. <see cref="VoiceUploadStore.SweepAbandoned"/> has
+/// had a direct unit test since it was written, and for that whole time nothing in production called it: the
+/// staging directory for a voice turn is deleted on the SUCCESS path only, so every refused, dropped or
+/// never-completed upload kept its recorded audio forever. A test that calls the sweep itself cannot notice
+/// that - it passes with the timer present and passes with the timer gone. So this test never calls the
+/// sweep. It stages an abandoned upload on disk, starts a real <see cref="GatewayHost"/>, and waits for the
+/// Gateway to remove that upload on its own. The only thing that can make it pass is the sweep actually
+/// running in the host, which is the fact that was missing.
+///
+/// The schedule is compressed through <see cref="GatewayHost.VoiceTurnUploadSweepScheduleForTests"/>; the
+/// AGE cut-off is production's real one, and the staged upload is aged into the past on disk, so the test
+/// exercises the deployed retention rule rather than a shortened copy of it.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class VoiceTurnUploadSweepWiringTests : IAsyncLifetime
+{
+    private const string GatewayToken = "test-token";
+
+    private GatewayHost? _gateway;
+    private string? _originalRoot;
+
+    private readonly string _storageRoot =
+        Path.Combine(Path.GetTempPath(), "cc-sweep-storage-" + Guid.NewGuid().ToString("N"));
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-sweep-instances-" + Guid.NewGuid().ToString("N"));
+
+    public Task InitializeAsync()
+    {
+        _originalRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        GatewayHost.VoiceTurnUploadSweepScheduleForTests = null;
+        if (_gateway is not null) await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _originalRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* cleanup */ }
+        try { if (Directory.Exists(_storageRoot)) Directory.Delete(_storageRoot, true); } catch { /* cleanup */ }
+    }
+
+    [Fact]
+    public async Task RunningGateway_SweepsAbandonedVoiceTurnStaging_KeepsFreshAndTenantPartitions()
+    {
+        var stagingRoot = CcStorage.VoiceTurnUploads();
+
+        // An upload that was abandoned long ago: staged chunks, nothing written for well past the retention
+        // window. This is what a size refusal, a dropped connection or a caller that walked away leaves.
+        var abandoned = StageUpload(stagingRoot, Guid.NewGuid().ToString("N"));
+        Directory.SetLastWriteTimeUtc(abandoned, DateTime.UtcNow.AddDays(-2));
+
+        // An upload that is still in flight. It must survive - a retention sweep that eats live uploads is a
+        // worse defect than the leak it replaces.
+        var inFlight = StageUpload(stagingRoot, Guid.NewGuid().ToString("N"));
+
+        // The per-tenant partition container, aged the same as the abandoned upload. It is not an upload, and
+        // deleting it would take every tenant's staging with it.
+        var tenantsDir = Path.Combine(stagingRoot, VoiceUploadStore.TenantPartitionDirectoryName);
+        var tenantUpload = StageUpload(Path.Combine(tenantsDir, Guid.NewGuid().ToString("D")),
+            Guid.NewGuid().ToString("N"));
+        Directory.SetLastWriteTimeUtc(tenantsDir, DateTime.UtcNow.AddDays(-2));
+
+        // Compress only the SCHEDULE. The age cut-off stays production's.
+        GatewayHost.VoiceTurnUploadSweepScheduleForTests = TimeSpan.FromMilliseconds(150);
+        _gateway = new GatewayHost(
+            port: AllocateFreePort(), token: GatewayToken, authEnabled: false,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+        await _gateway.StartAsync();
+
+        var swept = await WaitUntilGone(abandoned, TimeSpan.FromSeconds(20));
+
+        Assert.True(swept, $"the running Gateway never swept the abandoned staging at {abandoned} - " +
+            "nothing in production is running the age sweep");
+        Assert.True(Directory.Exists(inFlight), "the sweep removed an upload that was still in flight");
+        Assert.True(Directory.Exists(tenantsDir), "the sweep deleted the per-tenant partition container");
+        Assert.True(File.Exists(Path.Combine(tenantUpload, "00000.part")),
+            "the sweep descended into the per-tenant partition container and removed another tenant's staging");
+    }
+
+    // ===== helpers =================================================================================
+
+    /// <summary>Write one staged chunk for an upload id under a staging root, as a real upload would.</summary>
+    private static string StageUpload(string root, string uploadId)
+    {
+        var dir = Path.Combine(root, uploadId);
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, "00000.part"), new byte[] { 1, 2, 3, 4 });
+        return dir;
+    }
+
+    private static async Task<bool> WaitUntilGone(string dir, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (!Directory.Exists(dir)) return true;
+            await Task.Delay(100);
+        }
+        return !Directory.Exists(dir);
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
@@ -164,6 +164,36 @@ public sealed class VoiceUploadStoreTests : IDisposable
         Assert.True(_store.Exists(fresh));
     }
 
+    [Fact]
+    public async Task SweepAbandoned_DoesNotDescendIntoThePartitionContainer()
+    {
+        // The per-tenant partition container holds OTHER tenants' staging roots, not uploads. It is a plain
+        // directory under the same root, so an age sweep that treated it as an upload would delete every
+        // tenant's staging in one call the first time the container itself went quiet. The container is aged
+        // well past the cut-off here precisely so that only the skip can keep it alive - and the upload
+        // inside it must survive too, which proves the sweep did not descend into it either.
+        var tenantsDir = Path.Combine(_root, VoiceUploadStore.TenantPartitionDirectoryName);
+        var tenantUpload = Path.Combine(tenantsDir, Guid.NewGuid().ToString("D"), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tenantUpload);
+        await File.WriteAllBytesAsync(Path.Combine(tenantUpload, "00000.part"), Bytes("other tenant audio"));
+
+        var stale = _store.Register(null);
+        await _store.StoreChunkAsync(stale, 0, Bytes("old"), null);
+        var staleDir = Path.Combine(_root, Guid.Parse(stale).ToString("N"));
+
+        var longAgo = DateTime.UtcNow.AddHours(-9);
+        Directory.SetLastWriteTimeUtc(staleDir, longAgo);
+        Directory.SetLastWriteTimeUtc(tenantsDir, longAgo);
+
+        var removed = _store.SweepAbandoned(TimeSpan.FromHours(1));
+
+        // Only the real abandoned upload went; the container and everything under it stayed.
+        Assert.Equal(1, removed);
+        Assert.False(_store.Exists(stale));
+        Assert.True(Directory.Exists(tenantsDir));
+        Assert.True(File.Exists(Path.Combine(tenantUpload, "00000.part")));
+    }
+
     // ===== durable delivery record (issue #1183) =====================================================
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
@@ -194,25 +194,64 @@ public sealed class VoiceUploadStoreTests : IDisposable
         Assert.True(File.Exists(Path.Combine(tenantUpload, "00000.part")));
     }
 
+    // The idle-age guarantee must hold for the RESUME path, which the first cut got wrong: an upload that a
+    // live client comes back to must never be swept. It holds because EVERY successful operation refreshes
+    // the activity signal - so each operation is pinned in ITS OWN test, exercising ONLY that operation on an
+    // aged upload. Split deliberately: a single test doing several operations would let their touches mask
+    // one another, and a touch that can be individually removed while the test stays green is not proven.
+    // Each of these reddens if and only if its own operation's EnsureFreshStaging touch is removed.
+
     [Fact]
-    public async Task SweepAbandoned_DoesNotDeleteAResumedUpload_EvenWhenItWasAgedFirst()
+    public async Task SweepAbandoned_ReRegisterAlone_KeepsAnAgedUpload()
     {
-        // The idle-age guarantee must hold for the RESUME path, which the first cut got wrong: re-registering
-        // an existing id did not touch the staging, and an idempotent chunk returned without writing a byte,
-        // so a genuinely-active client that resumed kept whatever stale timestamp it had and the sweep
-        // deleted it mid-use. Reproduce exactly that: stage a chunk, age the dir nine hours, then perform the
-        // two SUCCESSFUL resume operations - re-register the same id and re-send the identical chunk - and
-        // the upload must survive a four-hour sweep because both operations are activity.
+        // Stage an upload, age it past the limit, then do ONLY a re-register of the existing id (no chunk
+        // retry, no assemble). Re-registering is a resume and therefore activity, so the upload must survive.
         var id = _store.Register(null);
         await _store.StoreChunkAsync(id, 0, Bytes("hello"), null);
-
         var dir = Path.Combine(_root, Guid.Parse(id).ToString("N"));
         Directory.SetLastWriteTimeUtc(dir, DateTime.UtcNow.AddHours(-9));
 
-        // Successful resume: re-register the existing id, then re-send the identical (idempotent) chunk.
-        var reopened = _store.Register(id);
+        var reopened = _store.Register(id);   // the only operation under test
         Assert.Equal(Guid.Parse(id).ToString("N"), reopened);
+
+        var removed = _store.SweepAbandoned(TimeSpan.FromHours(4));
+
+        Assert.Equal(0, removed);
+        Assert.True(_store.Exists(id));
+    }
+
+    [Fact]
+    public async Task SweepAbandoned_IdenticalChunkRetryAlone_KeepsAnAgedUpload()
+    {
+        // Stage an upload, age it, then do ONLY an idempotent re-send of the identical chunk (no re-register,
+        // no assemble). The retry writes no byte - it is a no-op on disk - but it IS a live client working,
+        // so it refreshes activity and the upload must survive.
+        var id = _store.Register(null);
         await _store.StoreChunkAsync(id, 0, Bytes("hello"), null);
+        var dir = Path.Combine(_root, Guid.Parse(id).ToString("N"));
+        Directory.SetLastWriteTimeUtc(dir, DateTime.UtcNow.AddHours(-9));
+
+        await _store.StoreChunkAsync(id, 0, Bytes("hello"), null);   // the only operation under test
+
+        var removed = _store.SweepAbandoned(TimeSpan.FromHours(4));
+
+        Assert.Equal(0, removed);
+        Assert.True(_store.Exists(id));
+    }
+
+    [Fact]
+    public async Task SweepAbandoned_AssembleAlone_KeepsAnAgedUpload()
+    {
+        // Stage a complete single-chunk upload, age it, then do ONLY an assemble/complete (no re-register, no
+        // chunk retry). Completing is a live client finishing its upload, so it refreshes activity and the
+        // staging must survive the sweep that runs alongside the turn it kicks off.
+        var id = _store.Register(null);
+        await _store.StoreChunkAsync(id, 0, Bytes("hello"), null);
+        var dir = Path.Combine(_root, Guid.Parse(id).ToString("N"));
+        Directory.SetLastWriteTimeUtc(dir, DateTime.UtcNow.AddHours(-9));
+
+        var assembled = await _store.AssembleAsync(id, 1);   // the only operation under test
+        Assert.Equal("ok", assembled.Status);
 
         var removed = _store.SweepAbandoned(TimeSpan.FromHours(4));
 

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
@@ -194,6 +194,68 @@ public sealed class VoiceUploadStoreTests : IDisposable
         Assert.True(File.Exists(Path.Combine(tenantUpload, "00000.part")));
     }
 
+    [Fact]
+    public async Task SweepAbandoned_DoesNotDeleteAResumedUpload_EvenWhenItWasAgedFirst()
+    {
+        // The idle-age guarantee must hold for the RESUME path, which the first cut got wrong: re-registering
+        // an existing id did not touch the staging, and an idempotent chunk returned without writing a byte,
+        // so a genuinely-active client that resumed kept whatever stale timestamp it had and the sweep
+        // deleted it mid-use. Reproduce exactly that: stage a chunk, age the dir nine hours, then perform the
+        // two SUCCESSFUL resume operations - re-register the same id and re-send the identical chunk - and
+        // the upload must survive a four-hour sweep because both operations are activity.
+        var id = _store.Register(null);
+        await _store.StoreChunkAsync(id, 0, Bytes("hello"), null);
+
+        var dir = Path.Combine(_root, Guid.Parse(id).ToString("N"));
+        Directory.SetLastWriteTimeUtc(dir, DateTime.UtcNow.AddHours(-9));
+
+        // Successful resume: re-register the existing id, then re-send the identical (idempotent) chunk.
+        var reopened = _store.Register(id);
+        Assert.Equal(Guid.Parse(id).ToString("N"), reopened);
+        await _store.StoreChunkAsync(id, 0, Bytes("hello"), null);
+
+        var removed = _store.SweepAbandoned(TimeSpan.FromHours(4));
+
+        Assert.Equal(0, removed);
+        Assert.True(_store.Exists(id));
+    }
+
+    [Fact]
+    public void SweepAbandoned_KeepsAgedDirectoriesThatAreNotCanonicalUploadIds()
+    {
+        // The sweep deletes only what it can positively identify as a disposable upload - a directory whose
+        // name IS a canonical 32-hex upload id. Anything else survives, aged or not: an unknown name, an
+        // almost-canonical name, a partition container, a future sibling directory. A deny-list that skipped
+        // only one known name would recursively delete every unanticipated directory, including a
+        // future-partition directory with real data under it. Each of these is aged well past the cut-off so
+        // that only the positive admit-test can keep it alive.
+        void AgedDirWithSentinel(string name)
+        {
+            var d = Path.Combine(_root, name);
+            Directory.CreateDirectory(d);
+            File.WriteAllBytes(Path.Combine(d, "sentinel.txt"), Bytes("keep me"));
+            Directory.SetLastWriteTimeUtc(d, DateTime.UtcNow.AddHours(-9));
+        }
+
+        AgedDirWithSentinel("not-an-upload-id");                       // plainly not an id
+        AgedDirWithSentinel(Guid.NewGuid().ToString("D"));            // hyphenated GUID - a spelling this store never writes
+        AgedDirWithSentinel(Guid.NewGuid().ToString("N").ToUpperInvariant()); // upper-cased 32-hex - not the canonical form
+        AgedDirWithSentinel(VoiceUploadStore.TenantPartitionDirectoryName);   // the future-partition container
+
+        var removed = _store.SweepAbandoned(TimeSpan.FromHours(1));
+
+        Assert.Equal(0, removed);
+        foreach (var name in new[]
+                 {
+                     "not-an-upload-id",
+                     VoiceUploadStore.TenantPartitionDirectoryName,
+                 })
+        {
+            Assert.True(Directory.Exists(Path.Combine(_root, name)));
+            Assert.True(File.Exists(Path.Combine(_root, name, "sentinel.txt")));
+        }
+    }
+
     // ===== durable delivery record (issue #1183) =====================================================
 
     [Fact]

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -427,9 +427,11 @@ public sealed class GatewayHost : IAsyncDisposable
     // on a failing mobile link retrying chunks with backoff - is minutes, tens of minutes at the extreme.
     // Four hours is an order of magnitude beyond that extreme, so no upload that is still genuinely trying
     // can be cut off, while abandoned audio has a hard retention ceiling measured in hours rather than in
-    // the lifetime of the process. The sweep judges by LAST WRITE, not by creation, so an upload that is
-    // still receiving chunks keeps resetting its own clock and only ages out once nothing has touched it
-    // for the full window - which is precisely the definition of abandoned.
+    // the lifetime of the process. The sweep judges by an EXPLICIT last-activity signal that every
+    // successful operation refreshes - a register or resume, an idempotent chunk, a real chunk, an assemble
+    // (see VoiceUploadStore.EnsureFreshStaging) - not by whether a byte happened to be written, so a client
+    // that resumes an upload without writing new bytes still counts as alive and only truly-idle staging
+    // ages out. That is precisely the definition of abandoned.
     private static readonly TimeSpan VoiceTurnUploadMaxAge = TimeSpan.FromHours(4);
     /// <summary>
     /// Test seam: overrides the voice-turn upload sweep schedule (both the first tick and the period).

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -412,6 +412,36 @@ public sealed class GatewayHost : IAsyncDisposable
     // StopAsync.
     private System.Threading.Timer? _displayStateSweepTimer;
     private static readonly TimeSpan DisplayStateSweepInterval = TimeSpan.FromSeconds(5);
+
+    // Voice-turn upload staging retention. The staging directory for a voice turn is deleted on the SUCCESS
+    // path only, so every upload that ends any other way - a size refusal, a dropped connection, an assembly
+    // that never completed, a caller that simply walked away - stays on disk with its recorded audio until
+    // something removes it. This timer is that something; without it the staging grows without bound and
+    // holds recorded speech for as long as the Gateway lives.
+    private System.Threading.Timer? _voiceTurnUploadSweepTimer;
+    private static readonly TimeSpan VoiceTurnUploadSweepInterval = TimeSpan.FromMinutes(15);
+    // WHY FOUR HOURS, from what the staging is for rather than from a round number. A voice-turn staging
+    // directory exists only between a register and that same upload's own complete: the phone records one
+    // push-to-talk utterance, streams it in chunks, and the Gateway assembles it immediately. In normal
+    // operation that whole life is seconds to a couple of minutes, and the worst legitimate case - a phone
+    // on a failing mobile link retrying chunks with backoff - is minutes, tens of minutes at the extreme.
+    // Four hours is an order of magnitude beyond that extreme, so no upload that is still genuinely trying
+    // can be cut off, while abandoned audio has a hard retention ceiling measured in hours rather than in
+    // the lifetime of the process. The sweep judges by LAST WRITE, not by creation, so an upload that is
+    // still receiving chunks keeps resetting its own clock and only ages out once nothing has touched it
+    // for the full window - which is precisely the definition of abandoned.
+    private static readonly TimeSpan VoiceTurnUploadMaxAge = TimeSpan.FromHours(4);
+    /// <summary>
+    /// Test seam: overrides the voice-turn upload sweep schedule (both the first tick and the period).
+    /// Null in production and never assigned outside tests.
+    ///
+    /// It exists so the WIRING can be tested rather than assumed. The sweep method itself already had a
+    /// direct unit test while nothing in production called it at all - which is exactly how an unbounded
+    /// staging directory sat behind what read like coverage. A test that boots a real Gateway and watches
+    /// stale staging disappear on its own can only pass when the timer below is really started, so removing
+    /// the timer turns it red.
+    /// </summary>
+    internal static TimeSpan? VoiceTurnUploadSweepScheduleForTests;
     private readonly Running.WorkListRunnerManager _runnerManager = new();
     // Issue #218: Gateway-owned clock for when each session entered the red / NEEDS-YOU state.
     private readonly NeedsYouClock _needsYouClock = new();
@@ -1862,8 +1892,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // deliberately NO age sweep here: a fixed age cut would reopen exactly the hole this closes - a
         // phone out of signal for longer than the cut would lose its already-uploaded chunks, or re-inject
         // an already-delivered turn. The record is retired only by the client ack
-        // (POST /dictation/{uploadId}/ack). The unrelated voice-turn upload staging keeps its own
-        // transient SweepAbandoned; only the dictation record changed.
+        // (POST /dictation/{uploadId}/ack). The unrelated voice-turn upload staging is transient and IS age
+        // swept - by the timer started in StartAsync (see the voice-turn upload sweep there). That sweep was
+        // written long before it was ever started: for its whole life this comment said the voice-turn
+        // staging "keeps its own transient SweepAbandoned" while nothing in production called the method, so
+        // a reader checking whether the staging was bounded found a confident answer here and stopped
+        // looking. It is bounded now because a timer runs it, not because a method exists.
 
         // Central key vault (docs/architecture/gateway/GATEWAY_KEY_VAULT.md): set keys once
         // here (via the Cockpit Keys page); Directors pull them on demand. Inherits the
@@ -2167,6 +2201,22 @@ public sealed class GatewayHost : IAsyncDisposable
             null, DisplayStateSweepInterval, DisplayStateSweepInterval);
         FileLog.Write($"[GatewayHost] display-state sweep started: every {DisplayStateSweepInterval.TotalSeconds:0}s");
 
+        // Voice-turn upload staging retention. The success path deletes an upload's staging directory when
+        // the turn starts; everything else - a refused, dropped or never-completed upload - is bounded here
+        // and only here. It runs on every deployment, self-host and hosted alike, because the audio it
+        // removes is recorded speech and there is no deployment where keeping it forever is right.
+        var voiceTurnUploadSchedule = VoiceTurnUploadSweepScheduleForTests ?? VoiceTurnUploadSweepInterval;
+        _voiceTurnUploadSweepTimer = new System.Threading.Timer(
+            _ =>
+            {
+                try { _voiceTurnUploads.SweepAbandoned(VoiceTurnUploadMaxAge); }
+                catch (Exception ex) { FileLog.Write($"[GatewayHost] voice-turn upload sweep error: {ex.Message}"); }
+            },
+            null, voiceTurnUploadSchedule, voiceTurnUploadSchedule);
+        FileLog.Write($"[GatewayHost] voice-turn upload sweep started: every " +
+            $"{voiceTurnUploadSchedule.TotalMinutes:0.###}min, removing staging idle longer than " +
+            $"{VoiceTurnUploadMaxAge.TotalHours:0.###}h");
+
         // Issue #629: start the durable telemetry retry-queue flusher. It drains any events restored
         // from disk on construction (so a backend outage that spanned the previous run's lifetime now
         // delivers) and every event the relay enqueues going forward, in FIFO order, retrying with
@@ -2439,6 +2489,8 @@ public sealed class GatewayHost : IAsyncDisposable
         _autoDismissTimer = null;
         try { _displayStateSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] display-state sweep timer dispose error: {ex.Message}"); }
         _displayStateSweepTimer = null;
+        try { _voiceTurnUploadSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] voice-turn upload sweep timer dispose error: {ex.Message}"); }
+        _voiceTurnUploadSweepTimer = null;
 
 
         // Issue #640: stop the background token refresh timer.

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -57,11 +57,16 @@ public sealed class VoiceUploadStore
     /// Begin (or re-open) an upload. The caller supplies a GUID id (it is also the
     /// idempotency key for the resulting turn); a missing/blank id mints a fresh one.
     /// Idempotent: re-registering the same id just ensures the folder exists.
+    ///
+    /// Registering an EXISTING id is a resume, and a resume is activity: it refreshes the upload's
+    /// last-activity signal (see <see cref="EnsureFreshStaging"/>), so a client that comes back to finish an
+    /// upload is never treated as abandoned by <see cref="SweepAbandoned"/>. Without this a resumed upload
+    /// kept whatever stale timestamp it had and the age sweep would delete it out from under a live client.
     /// </summary>
     public string Register(string? uploadId)
     {
         var uid = NormalizeId(uploadId) ?? Guid.NewGuid().ToString("N");
-        Directory.CreateDirectory(DirFor(uid));
+        EnsureFreshStaging(uid);
         FileLog.Write($"[VoiceUploadStore] Register: uploadId={uid}");
         return uid;
     }
@@ -123,11 +128,19 @@ public sealed class VoiceUploadStore
                 $"chunk {index} SHA mismatch: header={expectedSha} actual={actualSha}");
         }
 
+        // Touch FIRST: storing a chunk is activity, so refresh the last-activity signal before doing the
+        // work (this also creates the staging dir if it is new). Doing it up front, not at the end, means the
+        // directory carries a fresh timestamp for the whole duration of the operation, so the age sweep
+        // cannot judge it abandoned while this chunk is being written. It is here on EVERY successful chunk -
+        // including the idempotent no-op below - because a client retrying the same chunk on a flaky link is
+        // as alive as one sending a new one; judging liveness by whether a byte happened to land would cut
+        // off exactly the resuming client this staging exists to serve.
+        EnsureFreshStaging(uid);
+
         var dir = DirFor(uid);
-        Directory.CreateDirectory(dir);
         var path = ChunkPath(dir, index);
 
-        // Idempotent: identical chunk already on disk -> no-op.
+        // Idempotent: identical chunk already on disk -> no-op (still counted as activity, touched above).
         if (File.Exists(path) &&
             string.Equals(Sha256Hex(await File.ReadAllBytesAsync(path, ct)), actualSha, StringComparison.OrdinalIgnoreCase))
         {
@@ -155,6 +168,11 @@ public sealed class VoiceUploadStore
             return AssembleResult.Unknown();
         if (totalChunks <= 0)
             throw new InvalidOperationException("totalChunks must be > 0");
+
+        // Assembling - whether it completes or comes back incomplete asking for more chunks - is a live
+        // client working through its upload, so it is activity: refresh the last-activity signal so a slow
+        // assemble/resend cycle is never judged abandoned mid-flight.
+        EnsureFreshStaging(uid);
 
         // Completeness gate (issue #586 contract, applied here for the phone push-to-talk upload,
         // issue #592): every index 0..totalChunks-1 must be present AND non-empty. A missing OR
@@ -184,9 +202,34 @@ public sealed class VoiceUploadStore
     }
 
     /// <summary>
-    /// Delete staging dirs whose last write is older than <paramref name="maxAge"/> — abandoned uploads
-    /// whose client dropped before completing (the staging is only deleted on success, so without this
-    /// an interrupted upload would leak forever). Best-effort per dir; returns how many were removed.
+    /// Remove ABANDONED voice-turn staging - an upload whose client dropped before completing (the staging is
+    /// deleted on success only, so without this an interrupted upload would leak its recorded audio forever).
+    /// Returns how many were removed.
+    ///
+    /// This is a DESTRUCTIVE sweep over the owner's own recorded audio, so it is deliberately lopsided: a
+    /// wrong DELETE is unrecoverable, a wrong KEEP costs only disk, and the two are not close, so it leans
+    /// entirely toward keeping. It therefore ENUMERATES THE ONE THING IT MAY DELETE and keeps everything
+    /// else - the inverse of a deny-list. A directory is removed only when BOTH of these positively hold:
+    ///
+    ///  1. Its name IS a canonical upload id - the exact 32-hex-lowercase form this store itself writes (see
+    ///     <see cref="IsCanonicalUploadDirName"/>). A malformed name, an almost-canonical one, an
+    ///     upper-cased alias, a partial, the per-tenant partition container, a future sibling directory, or
+    ///     anything else this sweep did not anticipate is NOT provably a disposable upload, so it SURVIVES.
+    ///     Blocking one known name ("tenants") would delete every unknown one; admitting one known shape
+    ///     deletes only what it can identify.
+    ///
+    ///  2. Its last-activity signal is genuinely older than <paramref name="maxAge"/>. Every successful
+    ///     operation on an upload - register (including a resume of an existing id), an idempotent chunk, a
+    ///     real chunk write, an assemble - refreshes that signal through <see cref="EnsureFreshStaging"/>, so
+    ///     "stale" means nothing has touched it for the whole window, which is the definition of abandoned.
+    ///
+    /// RACE WITH A LIVE RESUME. The activity refresh and this age-check-and-delete run under the SAME
+    /// per-upload gate (<see cref="WithRecordLock"/>, keyed by the canonicalized staging directory), and the
+    /// age is RE-READ inside that gate immediately before the delete. So a resume that arrives concurrently
+    /// is serialized against the delete for that one upload: either its refresh commits first and this sweep
+    /// then reads a fresh timestamp and does not delete, or the delete commits first and the resume's own
+    /// register re-creates the staging fresh. There is no window in which an upload is checked-old, then
+    /// touched-by-a-resume, then deleted-anyway - the gate closes it.
     /// </summary>
     public int SweepAbandoned(TimeSpan maxAge)
     {
@@ -196,24 +239,31 @@ public sealed class VoiceUploadStore
         {
             foreach (var dir in Directory.EnumerateDirectories(_root))
             {
-                // The per-tenant partition container is not an upload; sweeping it by age would delete every
-                // tenant's staging in one go (issue #1884 partitions this staging by tenant under this
-                // container). An upload directory name is a 32-hex identifier, so this name can only ever be
-                // the container. The skip is here BEFORE the partitioning lands as well as after: this sweep
-                // runs on a timer, and a sweep that is only safe once some other change ships is not safe.
-                if (IsPartitionContainer(dir)) continue;
-                try
+                var name = Path.GetFileName(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+
+                // POSITIVELY ADMIT: delete only a directory whose name is exactly a canonical upload id.
+                // Everything else - unknown, reserved, malformed, or a shape from a future change - survives,
+                // aged or not, because none of them can be proven a disposable upload and a false delete is
+                // unrecoverable.
+                if (!IsCanonicalUploadDirName(name)) continue;
+
+                // Under this upload's gate: re-read the age and delete atomically, so a concurrent resume
+                // that refreshes activity cannot be interleaved between the check and the delete (see remarks).
+                WithRecordLock(name, () =>
                 {
-                    if (Directory.GetLastWriteTimeUtc(dir) < cutoff)
+                    try
                     {
-                        Directory.Delete(dir, recursive: true);
-                        removed++;
+                        if (Directory.Exists(dir) && Directory.GetLastWriteTimeUtc(dir) < cutoff)
+                        {
+                            Directory.Delete(dir, recursive: true);
+                            removed++;
+                        }
                     }
-                }
-                catch (Exception ex)
-                {
-                    FileLog.Write($"[VoiceUploadStore] Sweep dir={dir} failed: {ex.Message}");
-                }
+                    catch (Exception ex)
+                    {
+                        FileLog.Write($"[VoiceUploadStore] Sweep dir={dir} failed: {ex.Message}");
+                    }
+                });
             }
             if (removed > 0) FileLog.Write($"[VoiceUploadStore] SweepAbandoned removed={removed} older than {maxAge}");
         }
@@ -223,6 +273,35 @@ public sealed class VoiceUploadStore
         }
         return removed;
     }
+
+    /// <summary>
+    /// Create the staging directory for an upload if it does not exist and stamp its last-activity signal to
+    /// now, ATOMICALLY under the upload's gate. This is the one place activity is recorded, so every caller
+    /// that represents a live client (register, a resume, a chunk, an assemble) refreshes the same signal the
+    /// sweep judges by - liveness is an explicit touch, never an incidental side effect of a byte landing on
+    /// disk. Running under the gate is what lets the sweep's age-check-and-delete not race a resume.
+    /// </summary>
+    private void EnsureFreshStaging(string uid)
+    {
+        WithRecordLock(uid, () =>
+        {
+            var dir = DirFor(uid);
+            Directory.CreateDirectory(dir);
+            Directory.SetLastWriteTimeUtc(dir, DateTime.UtcNow);
+        });
+    }
+
+    /// <summary>
+    /// True only for the EXACT canonical upload-id directory name this store writes: 32 lowercase hex digits,
+    /// no hyphens - the form <see cref="NormalizeId"/> produces. Deliberately strict, because this is the
+    /// admit-test for a destructive delete: an upper-cased or hyphenated GUID would name the SAME upload to a
+    /// human but is not a spelling this store ever creates, so it is not admitted and the directory survives.
+    /// Nothing is lost by that conservatism - the store only ever creates the canonical spelling - and a
+    /// surprising name surviving is exactly the safe outcome.
+    /// </summary>
+    private static bool IsCanonicalUploadDirName(string name)
+        => Guid.TryParseExact(name, "N", out var parsed)
+           && string.Equals(name, parsed.ToString("N"), StringComparison.Ordinal);
 
     /// <summary>Delete the staging dir for an upload. Best-effort; called once the turn is started.</summary>
     public void Delete(string uploadId)
@@ -638,12 +717,6 @@ public sealed class VoiceUploadStore
     private string GateKey(string uid) => Path.GetFullPath(DirFor(uid));
 
     private string DirFor(string uid) => Path.Combine(_root, uid);
-
-    // True for the directory that HOLDS the other tenants' partitions, which is never itself an upload.
-    private static bool IsPartitionContainer(string dir)
-        => string.Equals(Path.GetFileName(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)),
-            TenantPartitionDirectoryName, StringComparison.OrdinalIgnoreCase);
-
     private static string ChunkPath(string dir, int index) => Path.Combine(dir, $"{index:D5}.part");
     private static string RecordPath(string dir) => Path.Combine(dir, "record.json");
 

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -23,7 +23,11 @@ namespace CcDirector.Gateway.Voice;
 /// audio-reply turn become one pipeline behind a single Gateway URL.
 ///
 /// Transient by design for the voice-turn path: the per-upload dir is deleted once the turn has been
-/// started (<see cref="Delete"/> + the age-based <see cref="SweepAbandoned"/>).
+/// started (<see cref="Delete"/>), and anything that never got that far is bounded by the age-based
+/// <see cref="SweepAbandoned"/>, which the Gateway host runs on a timer for the voice-turn staging root
+/// (see the voice-turn upload sweep in <c>GatewayHost</c>). Both halves are needed: the success path alone
+/// leaves every refused, dropped or incomplete upload staged forever, which on a hosted Gateway is recorded
+/// speech accumulating with no retention bound at all.
 ///
 /// The durable dictation path (issue #1183) adds a per-upload-id DELIVERY RECORD on top of the same
 /// staging: while an upload is undelivered it stays PENDING (its chunks are retained for resume, never
@@ -35,6 +39,9 @@ namespace CcDirector.Gateway.Voice;
 /// </summary>
 public sealed class VoiceUploadStore
 {
+    /// <summary>The container directory hosting the non-local partitions, directly under the base root.</summary>
+    public const string TenantPartitionDirectoryName = "tenants";
+
     private readonly string _root;
 
     public VoiceUploadStore() : this(CcStorage.VoiceTurnUploads()) { }
@@ -189,6 +196,12 @@ public sealed class VoiceUploadStore
         {
             foreach (var dir in Directory.EnumerateDirectories(_root))
             {
+                // The per-tenant partition container is not an upload; sweeping it by age would delete every
+                // tenant's staging in one go (issue #1884 partitions this staging by tenant under this
+                // container). An upload directory name is a 32-hex identifier, so this name can only ever be
+                // the container. The skip is here BEFORE the partitioning lands as well as after: this sweep
+                // runs on a timer, and a sweep that is only safe once some other change ships is not safe.
+                if (IsPartitionContainer(dir)) continue;
                 try
                 {
                     if (Directory.GetLastWriteTimeUtc(dir) < cutoff)
@@ -625,6 +638,12 @@ public sealed class VoiceUploadStore
     private string GateKey(string uid) => Path.GetFullPath(DirFor(uid));
 
     private string DirFor(string uid) => Path.Combine(_root, uid);
+
+    // True for the directory that HOLDS the other tenants' partitions, which is never itself an upload.
+    private static bool IsPartitionContainer(string dir)
+        => string.Equals(Path.GetFileName(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)),
+            TenantPartitionDirectoryName, StringComparison.OrdinalIgnoreCase);
+
     private static string ChunkPath(string dir, int index) => Path.Combine(dir, $"{index:D5}.part");
     private static string RecordPath(string dir) => Path.Combine(dir, "record.json");
 


### PR DESCRIPTION
## What this changes

Voice-turn upload staging is deleted only on the success path, so every upload that ends any other way - a size refusal, a dropped connection, an assembly that never completed, a caller that walked away - kept its recorded audio on disk for the life of the Gateway. The age sweep that would remove it (`VoiceUploadStore.SweepAbandoned`) existed and had a direct unit test, but nothing in production ever called it. On the hosted multi-tenant Gateway that is recorded speech from every account accumulating in one shared directory with no retention bound and no deletion path. Two comments (in `VoiceUploadStore` and `GatewayHost`) asserted the sweep already ran, which is how it went unnoticed.

This wires the sweep into production and makes it safe:

**1. Runs on a timer, in production.** `GatewayHost.StartAsync` starts a voice-turn upload sweep next to the existing periodic sweeps - created in `StartAsync`, disposed in `StopAsync`, logged the same way. It runs on every deployment because the audio it removes is recorded speech and no deployment should keep it forever.

**2. Four-hour maximum age, justified from purpose.** A staging directory exists only between a register and that same upload's own complete: seconds to a couple of minutes normally, tens of minutes at the pathological extreme of a phone retrying chunks over a failing link. Four hours is an order of magnitude past that, so nothing still genuinely trying is cut off, while abandoned audio has a hard ceiling in hours.

**3. Liveness is judged by an explicit activity touch, not by an incidental byte write.** Every successful operation - a register (including a resume of an existing id), an idempotent chunk retry, a real chunk write, and an assemble - refreshes the upload's last-activity signal through one `EnsureFreshStaging` touch. Without this a client that resumed an upload (re-register, or re-send an identical chunk that writes no byte) kept its stale timestamp and the sweep would delete it mid-use. The sweep judges by that explicit signal.

**4. The activity touch and the sweep coordinate through the per-upload gate, closing the resume race.** The touch and the sweep's age-check-and-delete run under the same in-process per-upload lock (keyed by the canonicalized staging directory), and the age is re-read inside that lock immediately before the delete. So a concurrent resume is serialized against the delete for that one upload: either its refresh commits first and the sweep then reads a fresh timestamp and keeps the directory, or the delete commits first and the resume's own register re-creates the staging fresh. There is no check-old-then-touched-by-resume-then-deleted-anyway window, and closing it does not depend on the window being small.

**5. Deletes only what it can positively identify - a canonical upload id - not a deny-list.** The sweep removes only a directory whose name IS a canonical 32-hex lowercase upload id (the exact form the store writes) and keeps everything else, aged or not: an unknown name, an almost-canonical one, an upper-cased alias, the per-tenant partition container, or any future sibling directory. A single hard-coded exclusion would have recursively deleted every unanticipated directory; positive validation is the safe direction for an unrecoverable delete over recorded audio, and it is also what keeps the sweep safe before and after the sibling tenant-partition change (pull request #1900) lands.

## Proof

Build is confirmed at zero errors as its own step before every test run (a build failure here would run the previous binary and report a false green). Guards are proven by removing them and watching the exact tests go red, then restoring.

- **Wiring.** A test boots a real `GatewayHost`, stages an abandoned upload on disk, and waits for the running host to remove it on its own - it fails if the timer wiring is removed (`the running Gateway never swept the abandoned staging`), which the pre-existing direct-call unit test could not detect. It also asserts a still-in-flight upload and the partition container survive.
- **Activity touch, per operation, bypassability-clean.** Three independent tests each exercise ONLY one operation on an aged upload - re-register alone, identical-chunk-retry alone, assemble alone. Removing each operation's touch in isolation reddens exactly that one test and no other: the register touch reddens only the re-register test, the chunk touch only the retry test, the assemble touch only the assemble test.
- **Positive canonical-id validation.** A test ages an unknown name, a hyphenated GUID, an upper-cased 32-hex name, and the partition container, each with a sentinel file, and asserts the sweep keeps all of them. Removing the positive validation reddens it (aged non-canonical directories deleted).
- **Full Gateway suite:** green (see the latest run recorded in the review thread).

## Not proven

Only in-process test evidence - no live hosted Gateway was exercised. Behaviour once the real partitioned store (pull request #1900) lands is covered by the canonical-id and partition-container tests using the same container name and helper as that branch, but the two have not yet been merged together.
