### PR TITLE
fix(gateway): map entitlements.subject as Postgres uuid via a value converter

### DIFF
--- a/src/CcDirector.Gateway.Tests/Data/EntitlementSchemaQualificationTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/EntitlementSchemaQualificationTests.cs
@@ -29,6 +29,12 @@ public sealed class EntitlementSchemaQualificationTests
 {
     private const string PgTestConnectionEnvVar = "CC_GATEWAY_TEST_PG_CONNECTION";
 
+    /// <summary>A throwaway but VALID canonical account subject for the query-shape probes. The subject column
+    /// is Postgres uuid and the Gateway maps it through a string&lt;-&gt;Guid value converter, so the WHERE
+    /// constant must be a real uuid - EF evaluates the converter on it when it generates the SQL literal. The
+    /// value is irrelevant to what these facts assert (the FROM clause schema), it only has to parse as a uuid.</summary>
+    private const string ProbeSubject = "35543491-85cb-468d-a0c9-560193683105";
+
     /// <summary>A Fact that skips itself when the throwaway-Postgres connection is unset, so the normal
     /// SQLite test run and CI are unaffected. Anything reading a real PostgresException needs a real server.</summary>
     private sealed class RequiresPostgresFactAttribute : FactAttribute
@@ -81,7 +87,7 @@ public sealed class EntitlementSchemaQualificationTests
         Assert.Equal("gateway", entity!.GetSchema());
         Assert.Equal("entitlements", entity.GetTableName());
 
-        var sql = ctx.Entitlements.AsNoTracking().Where(e => e.Subject == "any").ToQueryString();
+        var sql = ctx.Entitlements.AsNoTracking().Where(e => e.Subject == ProbeSubject).ToQueryString();
 
         // The relation is schema-qualified. Postgres quotes an identifier only when it must, so EF emits the
         // bare-but-qualified form gateway.entitlements here; assert on that exact qualified reference.
@@ -107,7 +113,7 @@ public sealed class EntitlementSchemaQualificationTests
         Assert.NotNull(entity);
         Assert.Null(entity!.GetSchema());
 
-        var sql = ctx.Entitlements.AsNoTracking().Where(e => e.Subject == "any").ToQueryString();
+        var sql = ctx.Entitlements.AsNoTracking().Where(e => e.Subject == ProbeSubject).ToQueryString();
         Assert.DoesNotContain("gateway", sql);
         Assert.Contains("entitlements", sql);
     }
@@ -124,7 +130,12 @@ public sealed class EntitlementSchemaQualificationTests
     public void EntitlementRead_AgainstRealPostgres_ResolvesGatewaySchemaTable()
     {
         var conn = Environment.GetEnvironmentVariable(PgTestConnectionEnvVar)!;
-        var subject = "sub-live-" + Guid.NewGuid().ToString("N");
+        // A CANONICAL D-form uuid subject. The subject column is Postgres uuid and the Gateway reads it through
+        // the string<->Guid value converter, so a non-uuid value (the old "sub-live-..." marker) would throw
+        // Guid.ParseExact before the read ever reached Postgres. A fresh uuid keeps the fixture rerunnable and
+        // unique per run.
+        var subject = Guid.NewGuid().ToString("D");
+        var subjectGuid = Guid.Parse(subject);
         var previous = Environment.GetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar);
         Environment.SetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar, conn);
         try
@@ -132,17 +143,21 @@ public sealed class EntitlementSchemaQualificationTests
             using var db = new GatewayDatabase(new SingleTenantContext());
             using (var ctx = db.CreateUnscopedContext())
             {
-                // The payment side owns this table; create it in the gateway schema as that side would, and
-                // seed one live, active entitlement. IF NOT EXISTS / delete-then-insert keeps the test rerunnable.
+                // The payment side owns this table; create it in the gateway schema as that side would - with
+                // subject as `uuid`, MATCHING the live column the converter is typed against, so this proves the
+                // real scenario (uuid column + the converter's uuid parameter), not a text-column stand-in. Drop
+                // first so a stale text-column table from an earlier test build cannot linger and defeat the fix.
+                ctx.Database.ExecuteSqlRaw("DROP TABLE IF EXISTS gateway.entitlements;");
                 ctx.Database.ExecuteSqlRaw(
-                    "CREATE TABLE IF NOT EXISTS gateway.entitlements (" +
-                    "subject text NOT NULL PRIMARY KEY, status text NOT NULL, " +
+                    "CREATE TABLE gateway.entitlements (" +
+                    "subject uuid NOT NULL PRIMARY KEY, status text NOT NULL, " +
                     "current_period_end timestamptz NULL, stripe_subscription_id text NULL, " +
                     "updated_at timestamptz NULL, livemode boolean NULL);");
-                ctx.Database.ExecuteSqlRaw("DELETE FROM gateway.entitlements WHERE subject = {0};", subject);
+                // Seed one live, active entitlement. The subject is bound as a native uuid parameter so it lands
+                // in the uuid column exactly as the payment side would write it.
                 ctx.Database.ExecuteSqlRaw(
                     "INSERT INTO gateway.entitlements (subject, status, livemode) VALUES ({0}, 'active', true);",
-                    subject);
+                    subjectGuid);
             }
 
             var registry = new EntitlementRegistry(db, requireLivemode: true);
@@ -167,8 +182,12 @@ public sealed class EntitlementSchemaQualificationTests
     public void EntitlementReadFailure_OnPostgresException_LogsSqlStateAndMessageText_NeverSubject()
     {
         var conn = Environment.GetEnvironmentVariable(PgTestConnectionEnvVar)!;
-        // A subject with a distinctive, PII-shaped marker so a leak into the log is unmistakable.
-        var subject = "sub-PII-marker-" + Guid.NewGuid().ToString("N");
+        // A CANONICAL D-form uuid subject, unique per run. It MUST be a valid uuid: the converter parses it on
+        // the way to Postgres, so a non-uuid marker (the old "sub-PII-marker-...") would throw Guid.ParseExact
+        // before the read reached the server, and the intended undefined-table 42P01 would never be produced -
+        // the diagnostic path this fact exists to prove would go unexercised. A fresh uuid is still a unique,
+        // searchable token, so the never-log-the-subject assertion below is just as unmistakable.
+        var subject = Guid.NewGuid().ToString("D");
         var previous = Environment.GetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar);
         Environment.SetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar, conn);
 

--- a/src/CcDirector.Gateway.Tests/Data/EntitlementSubjectUuidMappingTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/EntitlementSubjectUuidMappingTests.cs
@@ -1,0 +1,107 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Data;
+
+/// <summary>
+/// The go-live proof for the hosted-enrollment 503: the <c>gateway.entitlements.subject</c> column is Postgres
+/// <c>uuid</c>, but the CLR property is a string, so unless EF is told to convert it Npgsql types the
+/// key-lookup parameter as text and Postgres rejects <c>subject = @p</c> with 42883
+/// 'operator does not exist: uuid = text'. That rejection is exactly why the entitlement read failed and
+/// enrollment answered 503.
+///
+/// These tests build the SAME provider-agnostic <see cref="GatewayDbContext"/> model under each provider and
+/// inspect the mapping EF actually resolved for the Subject key - no live database is opened (model building
+/// touches no connection), so they run in the ordinary suite:
+///
+///  - UNDER POSTGRES the Subject key maps through a string&lt;-&gt;Guid value converter and its store type is
+///    <c>uuid</c>, so the generated parameter is a UUID, not text. This is the necessary condition for the
+///    live enroll-200; the sufficient condition is the live box answering 200 after deploy.
+///  - UNDER SQLITE (self-host) nothing changes: no converter is in play and the column stays a plain string,
+///    proving the Postgres-only conditional correctly does nothing off Postgres.
+///
+/// A Postgres-branch claim MUST be evaluated under the Postgres provider - the same assertion checked on the
+/// default SQLite context proves the wrong branch - so each test pins its own provider explicitly.
+/// </summary>
+public sealed class EntitlementSubjectUuidMappingTests
+{
+    /// <summary>Build the model under Npgsql. A dummy connection string is enough: only the model is read, and
+    /// model building opens no connection. UseNpgsql is what makes Database.IsNpgsql() true at model-build time,
+    /// which is the branch this test exists to check.</summary>
+    private static GatewayDbContext NewPostgresContext()
+    {
+        var options = new DbContextOptionsBuilder<GatewayDbContext>()
+            .UseNpgsql("Host=localhost;Database=ccpg_model_only;Username=u;Password=p")
+            .Options;
+        return new GatewayDbContext(options) { ActiveTenant = TenantId.Local.Value };
+    }
+
+    /// <summary>Build the model under SQLite (the self-host provider), again model-only, no connection.</summary>
+    private static GatewayDbContext NewSqliteContext()
+    {
+        var options = new DbContextOptionsBuilder<GatewayDbContext>()
+            .UseSqlite("Data Source=:memory:")
+            .Options;
+        return new GatewayDbContext(options) { ActiveTenant = TenantId.Local.Value };
+    }
+
+    private static Microsoft.EntityFrameworkCore.Metadata.IProperty SubjectProperty(GatewayDbContext ctx)
+    {
+        var entity = ctx.Model.FindEntityType(typeof(EntitlementEntity));
+        Assert.NotNull(entity);
+        var property = entity!.FindProperty(nameof(EntitlementEntity.Subject));
+        Assert.NotNull(property);
+        return property!;
+    }
+
+    [Fact]
+    public void UnderPostgres_SubjectKey_MapsAsUuid_ThroughAStringToGuidConverter()
+    {
+        using var ctx = NewPostgresContext();
+        var subject = SubjectProperty(ctx);
+
+        // It is the primary key - so this is the parameter the entitlement read binds. If a value converter on
+        // a key property were dropped by EF the read would revert to text, so proving it here proves the key
+        // lookup itself types as uuid.
+        Assert.True(subject.IsPrimaryKey());
+
+        // A value converter is applied and its provider side is Guid, so EF sends a Guid to Npgsql.
+        var converter = subject.GetValueConverter();
+        Assert.NotNull(converter);
+        Assert.Equal(typeof(string), converter!.ModelClrType);
+        Assert.Equal(typeof(Guid), converter.ProviderClrType);
+
+        // The RESOLVED store type is uuid - this is the type that decides the parameter's NpgsqlDbType. Text
+        // here would be the defect; uuid is the fix.
+        var mapping = subject.FindRelationalTypeMapping();
+        Assert.NotNull(mapping);
+        Assert.Equal("uuid", mapping!.StoreType);
+
+        // A round-trip through the converter is the canonical "D" string both ways, so the property stays a
+        // plain string for the token validator and the entitlement registry.
+        var uid = "35543491-85cb-468d-a0c9-560193683105";
+        var toProvider = converter.ConvertToProvider(uid);
+        Assert.IsType<Guid>(toProvider);
+        Assert.Equal(Guid.Parse(uid), (Guid)toProvider!);
+        Assert.Equal(uid, converter.ConvertFromProvider(toProvider));
+    }
+
+    [Fact]
+    public void UnderSqlite_SubjectKey_StaysAPlainString_WithNoConverter()
+    {
+        using var ctx = NewSqliteContext();
+        var subject = SubjectProperty(ctx);
+
+        // Still the key, but with no Guid converter in play - the Postgres-only conditional does nothing here.
+        Assert.True(subject.IsPrimaryKey());
+        Assert.Null(subject.GetValueConverter());
+
+        var mapping = subject.FindRelationalTypeMapping();
+        Assert.NotNull(mapping);
+        Assert.Equal(typeof(string), mapping!.ClrType);
+        Assert.NotEqual("uuid", mapping.StoreType);
+    }
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -403,6 +403,21 @@ public sealed class GatewayDbContext : DbContext
             // so pin them to "C" too - the account subject in particular must match EXACTLY on both providers.
             modelBuilder.Entity<TenantEntity>().Property(e => e.Id).UseCollation("C");
             modelBuilder.Entity<TenantEntity>().Property(e => e.AccountSubject).UseCollation("C");
+
+            // 3. The entitlements.subject column is Postgres `uuid`, not text. The CLR property stays a string
+            //    (its callers pass and compare a string), so map it through a string<->Guid value converter and
+            //    pin the store type to `uuid`. This makes Npgsql emit a UUID parameter for the account-subject
+            //    key lookup instead of a text one - the single change that stops Postgres rejecting the read
+            //    with 42883 'operator does not exist: uuid = text' and 503'ing hosted enrollment. The `subject`
+            //    column stays uuid by contract (the website's read_gateway_entitlement(p_subject uuid) and the
+            //    Supabase auth identifier both depend on it); the Gateway is what was out of step. Postgres
+            //    ONLY: SQLite has no uuid type, so off this branch the column stays a plain string, unchanged.
+            //    Subject is the entity's primary key; a value converter on a key property is supported, and the
+            //    generated key-lookup parameter carries the uuid store type this pins.
+            modelBuilder.Entity<EntitlementEntity>()
+                .Property(e => e.Subject)
+                .HasConversion(EntitlementSubjectToGuidConverter)
+                .HasColumnType("uuid");
         }
     }
 
@@ -427,6 +442,23 @@ public sealed class GatewayDbContext : DbContext
     private static readonly ValueConverter<DateTime?, DateTime?> NullableUtcConverter = new(
         v => v.HasValue ? (v.Value.Kind == DateTimeKind.Utc ? v.Value : v.Value.ToUniversalTime()) : v,
         v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : v);
+
+    /// <summary>
+    /// The account-subject converter for the entitlements table, applied ONLY under Postgres. The
+    /// <c>gateway.entitlements.subject</c> column is Postgres <c>uuid</c> (the website's
+    /// <c>read_gateway_entitlement(p_subject uuid)</c> depends on it, and the subject IS the Supabase auth
+    /// identifier), but the CLR property is a <see cref="string"/> - the form the token validator and the
+    /// entitlement registry pass and compare. Without a converter Npgsql types the key-lookup parameter as
+    /// text, so Postgres rejects <c>subject = @p</c> with 42883 'operator does not exist: uuid = text' and
+    /// every entitlement read fails (which is what made hosted enrollment answer 503). Converting the string
+    /// to a <see cref="Guid"/> on the way to the database makes Npgsql emit a UUID parameter that matches the
+    /// column, and back to the canonical "D" string on the way out keeps the property a plain string for its
+    /// callers. The subject is the canonical Supabase auth identifier (the "D" form), so ParseExact("D") is
+    /// exact rather than lenient; a value that is not that form is a caller error, not something to normalise.
+    /// </summary>
+    private static readonly ValueConverter<string, Guid> EntitlementSubjectToGuidConverter = new(
+        v => Guid.ParseExact(v, "D"),
+        v => v.ToString("D"));
 
     /// <summary>
     /// Apply the model-wide correctness conventions across every mapped property: UTC DateTime storage, a


### PR DESCRIPTION
## What changed

`gateway.entitlements.subject` is a Postgres `uuid` column, but `EntitlementEntity.Subject` is a CLR `string` with no value converter and no column type. Under Npgsql that types the account-subject key-lookup parameter as `text`, so Postgres rejects the entitlement read with `42883 operator does not exist: uuid = text`. That failure made every entitlement read fail and hosted device enrollment answer 503.

The `subject` column stays `uuid` by contract - the website's `read_gateway_entitlement(p_subject uuid)` depends on it and the subject is the Supabase auth identifier. The Gateway was the side out of step, so this is a Gateway-side fix.

Inside the existing Postgres-only model block (the one that sets the `gateway` default schema), `EntitlementEntity.Subject` is now mapped through a `string`<->`Guid` value converter with its store type pinned to `uuid`, so Npgsql emits a UUID parameter for the key lookup instead of a text one. The CLR property stays a `string`, transparent to the token validator and the entitlement registry, which pass and compare it as a string. Applied only under Npgsql; self-host SQLite has no `uuid` type and keeps the plain-string column unchanged - a provider conditional, not a fallback.

## Proof

New model-only tests (`EntitlementSubjectUuidMappingTests`) that open no live database and run in the ordinary suite:

- **Under the Postgres provider** the `Subject` primary-key property maps through the value converter (model type `string`, provider type `Guid`) and its resolved relational store type is `uuid` - so the generated key-lookup parameter is a UUID, not text. Red-first: with the converter removed the property has no converter and its store type resolves to `text` (the defect); restoring the converter returns it to `uuid`.
- **Under the SQLite provider** the same `Subject` key has no converter and its store type stays a plain string, proving the Postgres-only conditional does nothing off Postgres (self-host unchanged).

The full Gateway test suite is green (one unrelated prompt-endpoint test flaked under concurrent-suite load and passes in isolation; it is structurally disjoint from this change).

The necessary condition proven here is that the key parameter now types as `uuid`. The definitive arbiter remains the live hosted Gateway's own `enroll` returning 200 after deploy.

## Note on ordering

This coexists with the sibling entitlements-schema pull request #1954, which changes the `ToTable(...)` call in the same `EntitlementEntity` block to schema-qualify it on Postgres. That change lands in the entity-config block; this one lands in the separate Postgres-only model-shape block, so they are adjacent but non-overlapping. This branch should be rebased onto `origin/main` to include #1954 once #1954 merges.
