### PR TITLE
feat(client): hosted callback forwards access_token as Bearer to /m/enroll

### DIFF
--- a/packages/client-core/src/api/enroll.test.ts
+++ b/packages/client-core/src/api/enroll.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { GATEWAY_NOT_SIGNED_IN, isGatewayNotSignedIn } from "./enroll";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GATEWAY_NOT_SIGNED_IN, enrollDevice, enrollDeviceHosted, isGatewayNotSignedIn } from "./enroll";
 import { GatewayError } from "./client";
 
 // There are TWO different sign-ins in this product and they are easy to conflate:
@@ -38,5 +38,100 @@ describe("isGatewayNotSignedIn", () => {
     expect(isGatewayNotSignedIn({ status: 409 })).toBe(false);
     expect(isGatewayNotSignedIn(null)).toBe(false);
     expect(isGatewayNotSignedIn(undefined)).toBe(false);
+  });
+});
+
+// The two enrollment requests (multi-tenant hosted sign-in, Phase C). The client forwards whichever
+// credential the website returned in the callback fragment, and the two gateway kinds authenticate the
+// mint differently:
+//   - SELF-HOST (enrollDevice): the device_key travels in the request BODY, no Authorization header.
+//     This is the pre-hosted behavior and must stay byte-for-byte identical, or every self-hosted
+//     install's sign-in breaks.
+//   - HOSTED (enrollDeviceHosted): the account access token travels as `Authorization: Bearer` and NO
+//     device_key is put in the body (tenant isolation is bound at the mint from the verified token).
+// Both read the local device key back from the response identically; only the request differs.
+describe("enrollment requests", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  // A minimal fetch Response stand-in with a JSON body, enough for the enroll response reader.
+  function jsonResponse(status: number, body: unknown): Response {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as unknown as Response;
+  }
+
+  function lastInit(fetchMock: ReturnType<typeof vi.fn>): { url: string; init: RequestInit } {
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    return { url, init };
+  }
+
+  describe("enrollDevice (self-host, unchanged)", () => {
+    it("posts the device_key in the body with NO Authorization header", async () => {
+      const fetchMock = vi.fn(async () => jsonResponse(200, { deviceKey: "local-key" }));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const local = await enrollDevice("cloud-key", "install-1", "Android phone", "android");
+
+      expect(local).toBe("local-key");
+      const { url, init } = lastInit(fetchMock);
+      expect(url).toBe("/m/enroll");
+      expect(init.method).toBe("POST");
+      const headers = init.headers as Record<string, string>;
+      expect(headers.Authorization).toBeUndefined();
+      expect(JSON.parse(init.body as string)).toEqual({
+        deviceKey: "cloud-key",
+        deviceId: "install-1",
+        name: "Android phone",
+        platform: "android",
+      });
+    });
+
+    it("surfaces the Gateway's reason on a non-2xx as a GatewayError", async () => {
+      globalThis.fetch = (async () =>
+        jsonResponse(409, { error: "gateway not signed in" })) as unknown as typeof fetch;
+
+      await expect(enrollDevice("cloud-key", "install-1", "Android phone", "android")).rejects.toMatchObject({
+        status: 409,
+      });
+    });
+  });
+
+  describe("enrollDeviceHosted (hosted)", () => {
+    it("sends Authorization: Bearer <token> and OMITS device_key from the body", async () => {
+      const fetchMock = vi.fn(async () => jsonResponse(200, { deviceKey: "tenant-scoped-key" }));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const local = await enrollDeviceHosted("access-token-abc", "install-9", "Edge on Windows", "browser");
+
+      expect(local).toBe("tenant-scoped-key");
+      const { url, init } = lastInit(fetchMock);
+      expect(url).toBe("/m/enroll");
+      expect(init.method).toBe("POST");
+      const headers = init.headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer access-token-abc");
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body).toEqual({ deviceId: "install-9", name: "Edge on Windows", platform: "browser" });
+      // The account token must never leak into the request body, only the header.
+      expect("deviceKey" in body).toBe(false);
+      expect(JSON.stringify(body)).not.toContain("access-token-abc");
+    });
+
+    it("surfaces a 402 (no paid entitlement) as a GatewayError carrying the status", async () => {
+      globalThis.fetch = (async () =>
+        jsonResponse(402, { error: "payment required" })) as unknown as typeof fetch;
+
+      await expect(
+        enrollDeviceHosted("access-token-abc", "install-9", "Edge on Windows", "browser"),
+      ).rejects.toBeInstanceOf(GatewayError);
+      await expect(
+        enrollDeviceHosted("access-token-abc", "install-9", "Edge on Windows", "browser"),
+      ).rejects.toMatchObject({ status: 402 });
+    });
   });
 });

--- a/packages/client-core/src/api/enroll.ts
+++ b/packages/client-core/src/api/enroll.ts
@@ -1,11 +1,19 @@
 // The enrollment call (issue #908, shared by the desktop Cockpit since issue #1088): hand the Gateway
-// the per-device key this device received from devthrottle.com, and receive back the LOCAL device key
-// the Gateway issues and validates offline. This is the only place the cloud-issued key is used; from
-// then on the app authenticates with the local key returned here. POST /m/enroll is under /m/, so it
-// is reachable before the device holds any credential (it carries its own authorization: the
-// account-scoped device key in the body). Both shells enroll through this ONE generalized endpoint -
-// the platform field tells the Gateway what kind of device this is (android/ios -> phone, anything
-// else, for example "browser" -> browser).
+// the credential this device received from devthrottle.com, and receive back the LOCAL device key the
+// Gateway issues and validates offline. This is the only place the cloud-issued credential is used;
+// from then on the app authenticates with the local key returned here. POST /m/enroll is under /m/, so
+// it is reachable before the device holds any credential. Both shells enroll through this ONE
+// generalized endpoint - the platform field tells the Gateway what kind of device this is
+// (android/ios -> phone, anything else, for example "browser" -> browser).
+//
+// There are TWO enrollment credentials, one per gateway kind, and the client forwards whichever the
+// website returned in the callback fragment (multi-tenant hosted sign-in, Phase C):
+//   - SELF-HOST gateway: an account-scoped device_key carried in the request BODY (enrollDevice), the
+//     pre-hosted behavior that must not regress.
+//   - HOSTED gateway: the person's short-lived Supabase access token, carried as an
+//     `Authorization: Bearer` header (enrollDeviceHosted). The hosted mint reads the account subject
+//     from that verified token, checks the paid entitlement, resolves the tenant, and mints a
+//     tenant-scoped device key. No device_key is sent in the hosted body.
 import { GatewayError } from "./client";
 
 /**
@@ -46,6 +54,46 @@ export async function enrollDevice(
     body: JSON.stringify({ deviceKey: cloudDeviceKey, deviceId, name, platform }),
     signal,
   });
+  return readLocalDeviceKey(res);
+}
+
+/**
+ * Exchange the account's short-lived Supabase access token for a tenant-scoped local device key on a
+ * HOSTED gateway (multi-tenant hosted sign-in, Phase C). The token is forwarded as the standard
+ * `Authorization: Bearer` header - exactly the mint boundary the hosted /m/enroll endpoint expects -
+ * and NO device_key is sent in the body (tenant isolation is bound at the mint from the verified
+ * token, never from anything the client puts in the body).
+ * @returns the tenant-scoped per-device key the app must store and send as its Bearer.
+ * @throws GatewayError on any non-2xx, carrying the server's reason (401 = token missing/invalid;
+ *   402 = the account has no paid entitlement; 409 = the Gateway is not signed in; 502 = the cloud
+ *   could not be reached).
+ */
+export async function enrollDeviceHosted(
+  accessToken: string,
+  deviceId: string,
+  name: string,
+  platform: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const res = await fetch("/m/enroll", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ deviceId, name, platform }),
+    signal,
+  });
+  return readLocalDeviceKey(res);
+}
+
+/**
+ * Read the local device key from an /m/enroll response, or throw a GatewayError carrying the server's
+ * reason. Shared verbatim by the self-host and hosted paths so both handle success and every failure
+ * identically - only the request differs between them, never the response handling.
+ */
+async function readLocalDeviceKey(res: Response): Promise<string> {
   if (!res.ok) {
     let detail = `${res.status}`;
     try {

--- a/packages/client-core/src/auth/DeviceCallback.tsx
+++ b/packages/client-core/src/auth/DeviceCallback.tsx
@@ -1,16 +1,22 @@
 // The shared device-enrollment callback (issue #908, generalized for the desktop Cockpit in issue
 // #1088), served at the installed profile's callback path (/m/device-callback for the phone,
 // /device-callback for the Cockpit). devthrottle.com redirects the browser here after sign-in with the
-// per-device key in the URL FRAGMENT (never the query, so it is not sent to any server - issue #1082).
-// This screen reads that key, exchanges it at the Gateway (POST /m/enroll) for a LOCAL device key,
-// stores the local key through the shared device-key store, mirrors it into the cc-gateway-token
-// cookie (so the terminal WebSocket and hard navigations authenticate immediately), and enters the app
-// on the originally-requested route. The account session never reaches here.
+// enrollment credential in the URL FRAGMENT (never the query, so it is not sent to any server - issue
+// #1082). This screen reads that credential, exchanges it at the Gateway (POST /m/enroll) for a LOCAL
+// device key, stores the local key through the shared device-key store, mirrors it into the
+// cc-gateway-token cookie (so the terminal WebSocket and hard navigations authenticate immediately),
+// and enters the app on the originally-requested route. The account session never reaches here.
+//
+// Which credential the fragment carries decides the path (multi-tenant hosted sign-in, Phase C): a
+// HOSTED gateway round trip returns the account's Supabase access_token (forwarded to the mint as
+// Authorization: Bearer), while a SELF-HOST round trip returns a device_key (posted in the body, the
+// pre-hosted behavior). readEnrollCredential picks one; only the enroll call differs - the state
+// check, cookie mirror, landing, and error handling below are shared byte-for-byte.
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getInstallId, setDeviceKey } from "./deviceKey";
-import { enrollmentProfile, takeEnrollState, takeEnrollNext } from "./enrollRequest";
-import { enrollDevice, isGatewayNotSignedIn } from "../api/enroll";
+import { enrollmentProfile, takeEnrollState, takeEnrollNext, readEnrollCredential } from "./enrollRequest";
+import { enrollDevice, enrollDeviceHosted, isGatewayNotSignedIn } from "../api/enroll";
 import { ensureGatewayCookie } from "../api/client";
 import { beginSignIn } from "../account/accountClient";
 
@@ -42,7 +48,7 @@ export function DeviceCallback() {
       const rawHash = window.location.hash.startsWith("#") ? window.location.hash.slice(1) : window.location.hash;
       const params = new URLSearchParams(rawHash);
       const error = params.get("error");
-      const deviceKey = params.get("device_key");
+      const credential = readEnrollCredential(params);
       const state = params.get("state");
       const expected = takeEnrollState();
 
@@ -58,14 +64,20 @@ export function DeviceCallback() {
         setMessage("This sign-in could not be verified. Please try again.");
         return;
       }
-      if (!deviceKey) {
+      if (!credential) {
         setPhase("error");
         setMessage("Sign-in did not return a device key. Please try again.");
         return;
       }
 
       try {
-        const localKey = await enrollDevice(deviceKey, getInstallId(), profile.deviceName(), profile.platform());
+        // Only the enroll call differs between the two gateway kinds; everything below is shared. The
+        // hosted path forwards the account access_token as Authorization: Bearer with no device_key in
+        // the body; the self-host path posts the device_key in the body exactly as before.
+        const localKey =
+          credential.mode === "hosted"
+            ? await enrollDeviceHosted(credential.accessToken, getInstallId(), profile.deviceName(), profile.platform())
+            : await enrollDevice(credential.deviceKey, getInstallId(), profile.deviceName(), profile.platform());
         if (cancelled) return;
         setDeviceKey(localKey);
         // Mirror the fresh key into the cc-gateway-token cookie right away, so the terminal WebSocket

--- a/packages/client-core/src/auth/DeviceCallback.tsx
+++ b/packages/client-core/src/auth/DeviceCallback.tsx
@@ -10,13 +10,16 @@
 // Which credential the fragment carries decides the path (multi-tenant hosted sign-in, Phase C): a
 // HOSTED gateway round trip returns the account's Supabase access_token (forwarded to the mint as
 // Authorization: Bearer), while a SELF-HOST round trip returns a device_key (posted in the body, the
-// pre-hosted behavior). readEnrollCredential picks one; only the enroll call differs - the state
-// check, cookie mirror, landing, and error handling below are shared byte-for-byte.
+// pre-hosted behavior). The dispatch - anti-forgery verification (which FAILS CLOSED), credential
+// classification, and which enroll request is sent - lives in runEnrollmentCallback (enrollCallback.ts)
+// so it is unit-tested without a DOM; this screen only maps the outcome to a phase and the shared side
+// effects (store the key, mirror the cookie, land on the route, surface errors).
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getInstallId, setDeviceKey } from "./deviceKey";
-import { enrollmentProfile, takeEnrollState, takeEnrollNext, readEnrollCredential } from "./enrollRequest";
-import { enrollDevice, enrollDeviceHosted, isGatewayNotSignedIn } from "../api/enroll";
+import { enrollmentProfile, takeEnrollNext } from "./enrollRequest";
+import { runEnrollmentCallback } from "./enrollCallback";
+import { isGatewayNotSignedIn } from "../api/enroll";
 import { ensureGatewayCookie } from "../api/client";
 import { beginSignIn } from "../account/accountClient";
 
@@ -47,47 +50,39 @@ export function DeviceCallback() {
     (async () => {
       const rawHash = window.location.hash.startsWith("#") ? window.location.hash.slice(1) : window.location.hash;
       const params = new URLSearchParams(rawHash);
-      const error = params.get("error");
-      const credential = readEnrollCredential(params);
-      const state = params.get("state");
-      const expected = takeEnrollState();
-
-      if (error) {
-        setPhase("denied");
-        setMessage("Sign-in was declined. Nothing was connected.");
-        return;
-      }
-      // Verify the round trip when we have a saved state; a null expected-state (storage cleared) is not
-      // treated as a failure, so a legitimate sign-in is never blocked by missing session storage.
-      if (expected && state !== expected) {
-        setPhase("error");
-        setMessage("This sign-in could not be verified. Please try again.");
-        return;
-      }
-      if (!credential) {
-        setPhase("error");
-        setMessage("Sign-in did not return a device key. Please try again.");
-        return;
-      }
 
       try {
-        // Only the enroll call differs between the two gateway kinds; everything below is shared. The
-        // hosted path forwards the account access_token as Authorization: Bearer with no device_key in
-        // the body; the self-host path posts the device_key in the body exactly as before.
-        const localKey =
-          credential.mode === "hosted"
-            ? await enrollDeviceHosted(credential.accessToken, getInstallId(), profile.deviceName(), profile.platform())
-            : await enrollDevice(credential.deviceKey, getInstallId(), profile.deviceName(), profile.platform());
+        // The whole dispatch - anti-forgery verification (fail closed), credential classification, and
+        // which enroll request is sent - lives in runEnrollmentCallback so it is exercised by tests.
+        // This screen only maps the outcome to a phase and the shared side effects.
+        const outcome = await runEnrollmentCallback(params, profile, getInstallId());
         if (cancelled) return;
-        setDeviceKey(localKey);
-        // Mirror the fresh key into the cc-gateway-token cookie right away, so the terminal WebSocket
-        // and any hard navigation authenticate without waiting for the next full page load.
-        ensureGatewayCookie();
-        // Land on the originally-requested route when one was remembered (issue #1088), otherwise the
-        // shell's default. Strip the key from the URL/history first, then hand the route to the router.
-        const landing = takeEnrollNext() ?? profile.defaultLanding;
-        window.history.replaceState(null, "", profile.basename + landing);
-        navigate(landing, { replace: true });
+        switch (outcome.kind) {
+          case "denied":
+            setPhase("denied");
+            setMessage("Sign-in was declined. Nothing was connected.");
+            return;
+          case "unverified":
+            setPhase("error");
+            setMessage("This sign-in could not be verified. Please try again.");
+            return;
+          case "noCredential":
+            setPhase("error");
+            setMessage("Sign-in did not return a device key. Please try again.");
+            return;
+          case "enrolled": {
+            setDeviceKey(outcome.localKey);
+            // Mirror the fresh key into the cc-gateway-token cookie right away, so the terminal
+            // WebSocket and any hard navigation authenticate without waiting for the next full page load.
+            ensureGatewayCookie();
+            // Land on the originally-requested route when one was remembered (issue #1088), otherwise
+            // the shell's default. Strip the key from the URL/history first, then hand it to the router.
+            const landing = takeEnrollNext() ?? profile.defaultLanding;
+            window.history.replaceState(null, "", profile.basename + landing);
+            navigate(landing, { replace: true });
+            return;
+          }
+        }
       } catch (err) {
         if (cancelled) return;
         if (isGatewayNotSignedIn(err)) {

--- a/packages/client-core/src/auth/enrollCallback.test.ts
+++ b/packages/client-core/src/auth/enrollCallback.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runEnrollmentCallback } from "./enrollCallback";
+import {
+  COCKPIT_ENROLLMENT_PROFILE,
+  MOBILE_ENROLLMENT_PROFILE,
+  newEnrollState,
+} from "./enrollRequest";
+
+// This drives the ACTUAL enrollment dispatch the DeviceCallback screen runs (runEnrollmentCallback),
+// not the request helpers in isolation. It pins the wiring the inspection flagged as untested: that a
+// HOSTED fragment reaches the hosted request (Authorization: Bearer, body {deviceId,name,platform},
+// NO device_key) and a SELF-HOST fragment reaches the device-key body request. Reverting the hosted
+// arm to the old enrollDevice body shape MUST redden the hosted assertion below.
+//
+// It also pins the fail-closed anti-forgery gate (finding 1 / login-CSRF): a callback whose saved
+// anti-forgery state is missing, absent from the fragment, or mismatched must NOT enroll - fetch is
+// never called and the outcome is "unverified".
+
+// A minimal in-memory sessionStorage so takeEnrollState/newEnrollState run under the node test
+// environment (client-core has no jsdom; the helpers only need getItem/setItem/removeItem).
+function stubSessionStorage(): void {
+  const store = new Map<string, string>();
+  vi.stubGlobal("sessionStorage", {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => { store.set(key, value); },
+    removeItem: (key: string) => { store.delete(key); },
+  });
+}
+
+// A minimal fetch Response stand-in with a JSON body, enough for the enroll response reader.
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("runEnrollmentCallback dispatch", () => {
+  const realFetch = globalThis.fetch;
+  beforeEach(() => stubSessionStorage());
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("routes a HOSTED fragment to the hosted request: Bearer + body {deviceId,name,platform}, no device_key", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { deviceKey: "tenant-scoped-key" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const state = newEnrollState();
+    const params = new URLSearchParams(`access_token=access-token-abc&state=${state}`);
+
+    const outcome = await runEnrollmentCallback(params, COCKPIT_ENROLLMENT_PROFILE, "install-9");
+
+    expect(outcome).toEqual({ kind: "enrolled", localKey: "tenant-scoped-key" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("/m/enroll");
+    const headers = init.headers as Record<string, string>;
+    // The hosted arm MUST use enrollDeviceHosted. Reverting it to enrollDevice (the old shape) drops
+    // the Authorization header and puts the token in the body, failing every assertion below.
+    expect(headers.Authorization).toBe("Bearer access-token-abc");
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toEqual({ deviceId: "install-9", name: COCKPIT_ENROLLMENT_PROFILE.deviceName(), platform: "browser" });
+    expect("deviceKey" in body).toBe(false);
+    expect(JSON.stringify(body)).not.toContain("access-token-abc");
+  });
+
+  it("routes a SELF-HOST fragment to the device-key body request with NO Authorization header", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { deviceKey: "local-key" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const state = newEnrollState();
+    const params = new URLSearchParams(`device_key=dk-123&state=${state}`);
+
+    const outcome = await runEnrollmentCallback(params, MOBILE_ENROLLMENT_PROFILE, "install-1");
+
+    expect(outcome).toEqual({ kind: "enrolled", localKey: "local-key" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("/m/enroll");
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toEqual({
+      deviceKey: "dk-123",
+      deviceId: "install-1",
+      name: MOBILE_ENROLLMENT_PROFILE.deviceName(),
+      platform: MOBILE_ENROLLMENT_PROFILE.platform(),
+    });
+  });
+
+  it("does NOT enroll a HOSTED callback when there is no saved anti-forgery state (login-CSRF, finding 1)", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { deviceKey: "attacker-tenant-key" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    // No newEnrollState() - nothing was minted before this callback, so no saved state exists. The
+    // fragment carries the attacker's access token and any state value; it must be rejected.
+    const params = new URLSearchParams("access_token=attacker-token&state=whatever");
+
+    const outcome = await runEnrollmentCallback(params, COCKPIT_ENROLLMENT_PROFILE, "install-9");
+
+    expect(outcome).toEqual({ kind: "unverified" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT enroll when the returned state does not match the saved state", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { deviceKey: "k" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    newEnrollState(); // saves a random nonce; the fragment returns a different one
+    const params = new URLSearchParams("access_token=tok&state=not-the-saved-one");
+
+    const outcome = await runEnrollmentCallback(params, COCKPIT_ENROLLMENT_PROFILE, "install-9");
+
+    expect(outcome).toEqual({ kind: "unverified" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT enroll when the fragment returns no state at all", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { deviceKey: "k" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    newEnrollState();
+    const params = new URLSearchParams("access_token=tok"); // saved state exists, none echoed back
+
+    const outcome = await runEnrollmentCallback(params, COCKPIT_ENROLLMENT_PROFILE, "install-9");
+
+    expect(outcome).toEqual({ kind: "unverified" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports 'denied' without enrolling when the fragment carries an error", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { deviceKey: "k" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const params = new URLSearchParams("error=access_denied");
+
+    const outcome = await runEnrollmentCallback(params, MOBILE_ENROLLMENT_PROFILE, "install-1");
+
+    expect(outcome).toEqual({ kind: "denied" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports 'noCredential' without enrolling when a verified fragment carries no credential", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { deviceKey: "k" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const state = newEnrollState();
+    const params = new URLSearchParams(`state=${state}`);
+
+    const outcome = await runEnrollmentCallback(params, MOBILE_ENROLLMENT_PROFILE, "install-1");
+
+    expect(outcome).toEqual({ kind: "noCredential" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports 'noCredential' for an ambiguous verified fragment carrying BOTH credentials (finding 3)", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { deviceKey: "k" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const state = newEnrollState();
+    const params = new URLSearchParams(`access_token=tok&device_key=dk-123&state=${state}`);
+
+    const outcome = await runEnrollmentCallback(params, COCKPIT_ENROLLMENT_PROFILE, "install-9");
+
+    expect(outcome).toEqual({ kind: "noCredential" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client-core/src/auth/enrollCallback.test.ts
+++ b/packages/client-core/src/auth/enrollCallback.test.ts
@@ -157,6 +157,36 @@ describe("runEnrollmentCallback dispatch", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("does NOT let a state survive a denied callback to verify a later replay (state consumed on every path)", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { deviceKey: "attacker-tenant-key" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    // This browser minted exactly one nonce before leaving. An attacker who knows that value first
+    // delivers a declined callback carrying it, then replays the SAME value with their own token.
+    const state = newEnrollState();
+
+    // First callback: declined at the site, echoing the live nonce. Must consume the nonce even
+    // though it returns "denied" without enrolling.
+    const denied = await runEnrollmentCallback(
+      new URLSearchParams(`error=access_denied&state=${state}`),
+      COCKPIT_ENROLLMENT_PROFILE,
+      "install-9",
+    );
+    expect(denied).toEqual({ kind: "denied" });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Second callback: the attacker replays the SAME state with their access token. Because the nonce
+    // was spent by the first (denied) callback, the saved state is now gone and the replay cannot
+    // verify - it must be rejected without any fetch/enroll.
+    const replay = await runEnrollmentCallback(
+      new URLSearchParams(`access_token=attacker-token&state=${state}`),
+      COCKPIT_ENROLLMENT_PROFILE,
+      "install-9",
+    );
+    expect(replay).toEqual({ kind: "unverified" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("reports 'noCredential' for an ambiguous verified fragment carrying BOTH credentials (finding 3)", async () => {
     const fetchMock = vi.fn(async () => jsonResponse(200, { deviceKey: "k" }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;

--- a/packages/client-core/src/auth/enrollCallback.ts
+++ b/packages/client-core/src/auth/enrollCallback.ts
@@ -28,16 +28,23 @@ export type EnrollCallbackOutcome =
  * Process the callback fragment and, when everything checks out, enroll this device.
  *
  * Order is deliberate and every gate runs BEFORE either enroll call:
+ *   0. CONSUME THE NONCE FIRST, ON EVERY PATH: the saved anti-forgery state is taken-and-removed
+ *      (takeEnrollState) before ANY branch below - denied, unverified, noCredential, or enroll. A
+ *      one-time nonce must be spent by whichever callback outcome reaches it first, or it is not
+ *      one-time. If the "denied"/error branch returned before consuming it, an attacker who knows a
+ *      stale state could send `error=access_denied&state=S` (leaves S live) then
+ *      `access_token=theirs&state=S` and REPLAY the still-live nonce to enroll. Taking it up front
+ *      makes S dead the instant the first callback (of any outcome) sees it.
  *   1. An explicit `error` in the fragment (the person declined at devthrottle.com) -> "denied".
- *   2. ANTI-FORGERY, FAIL CLOSED: proceed ONLY when we still hold the exact nonce we minted before
- *      leaving (takeEnrollState) AND the site echoed that same nonce back in `state`. A missing saved
- *      state (storage unavailable), a missing returned state, or a mismatch all mean we cannot prove
- *      this callback answers a sign-in THIS browser started, so we reject ("unverified") rather than
- *      enroll. Both the self-host and hosted branches are held to this same bar: the website echoes
- *      `state` for both callback shapes and SignIn always mints it, so a legitimate callback of either
- *      kind always carries a matching state. This closes the hosted login-CSRF path where an attacker
- *      delivers a callback carrying THEIR OWN account access token and enrolls a victim into the
- *      attacker's tenant.
+ *   2. ANTI-FORGERY, FAIL CLOSED: proceed ONLY when we still held the exact nonce we minted before
+ *      leaving (consumed in step 0) AND the site echoed that same nonce back in `state`. A missing
+ *      saved state (storage unavailable), a missing returned state, or a mismatch all mean we cannot
+ *      prove this callback answers a sign-in THIS browser started, so we reject ("unverified") rather
+ *      than enroll. Both the self-host and hosted branches are held to this same bar: the website
+ *      echoes `state` for both callback shapes and SignIn always mints it, so a legitimate callback of
+ *      either kind always carries a matching state. This closes the hosted login-CSRF path where an
+ *      attacker delivers a callback carrying THEIR OWN account access token and enrolls a victim into
+ *      the attacker's tenant.
  *   3. A credential must be present and unambiguous (readEnrollCredential) -> otherwise "noCredential".
  *   4. Enroll with the request bound to the credential kind.
  *
@@ -50,12 +57,15 @@ export async function runEnrollmentCallback(
   deviceId: string,
   signal?: AbortSignal,
 ): Promise<EnrollCallbackOutcome> {
+  // Spend the one-time nonce FIRST, before any branch - so a declined/error callback (or any other
+  // outcome) cannot leave it live in storage for a later callback to replay. See step 0 above.
+  const expectedState = takeEnrollState();
+
   if (params.get("error")) {
     return { kind: "denied" };
   }
 
   const returnedState = params.get("state");
-  const expectedState = takeEnrollState();
   if (!expectedState || !returnedState || returnedState !== expectedState) {
     return { kind: "unverified" };
   }

--- a/packages/client-core/src/auth/enrollCallback.ts
+++ b/packages/client-core/src/auth/enrollCallback.ts
@@ -1,0 +1,77 @@
+// The core of the device-enrollment callback, extracted from the DeviceCallback screen so the runtime
+// DISPATCH - anti-forgery verification, credential classification, and which enroll request is sent -
+// is testable without a DOM (client-core carries no jsdom/testing-library). DeviceCallback is now a
+// thin consumer: it parses the fragment, calls this, and maps the outcome to a phase / side effect.
+//
+// Everything here runs BEFORE anything is stored or entered. State verification fails CLOSED, and the
+// enroll request that is selected is bound solely to the credential the fragment carried - a hosted
+// access_token forwards as Authorization: Bearer with no device_key in the body, a self-host
+// device_key posts in the body (the pre-hosted behavior).
+import type { EnrollmentShellProfile } from "./enrollRequest";
+import { readEnrollCredential, takeEnrollState } from "./enrollRequest";
+import { enrollDevice, enrollDeviceHosted } from "../api/enroll";
+
+/**
+ * The result of processing a device-enrollment callback fragment. Everything except "enrolled" is a
+ * terminal display state the screen renders; "enrolled" carries the local device key the screen then
+ * stores, mirrors into the cookie, and lands on the app with. An enroll failure is NOT modelled here:
+ * it throws a GatewayError out of runEnrollmentCallback, which the screen catches (so it can tell the
+ * Gateway-not-signed-in conflict apart from a genuine error).
+ */
+export type EnrollCallbackOutcome =
+  | { kind: "denied" }
+  | { kind: "unverified" }
+  | { kind: "noCredential" }
+  | { kind: "enrolled"; localKey: string };
+
+/**
+ * Process the callback fragment and, when everything checks out, enroll this device.
+ *
+ * Order is deliberate and every gate runs BEFORE either enroll call:
+ *   1. An explicit `error` in the fragment (the person declined at devthrottle.com) -> "denied".
+ *   2. ANTI-FORGERY, FAIL CLOSED: proceed ONLY when we still hold the exact nonce we minted before
+ *      leaving (takeEnrollState) AND the site echoed that same nonce back in `state`. A missing saved
+ *      state (storage unavailable), a missing returned state, or a mismatch all mean we cannot prove
+ *      this callback answers a sign-in THIS browser started, so we reject ("unverified") rather than
+ *      enroll. Both the self-host and hosted branches are held to this same bar: the website echoes
+ *      `state` for both callback shapes and SignIn always mints it, so a legitimate callback of either
+ *      kind always carries a matching state. This closes the hosted login-CSRF path where an attacker
+ *      delivers a callback carrying THEIR OWN account access token and enrolls a victim into the
+ *      attacker's tenant.
+ *   3. A credential must be present and unambiguous (readEnrollCredential) -> otherwise "noCredential".
+ *   4. Enroll with the request bound to the credential kind.
+ *
+ * @throws GatewayError when the enroll request itself fails (non-2xx); the caller distinguishes the
+ *   409 Gateway-not-signed-in conflict from a genuine error.
+ */
+export async function runEnrollmentCallback(
+  params: URLSearchParams,
+  profile: EnrollmentShellProfile,
+  deviceId: string,
+  signal?: AbortSignal,
+): Promise<EnrollCallbackOutcome> {
+  if (params.get("error")) {
+    return { kind: "denied" };
+  }
+
+  const returnedState = params.get("state");
+  const expectedState = takeEnrollState();
+  if (!expectedState || !returnedState || returnedState !== expectedState) {
+    return { kind: "unverified" };
+  }
+
+  const credential = readEnrollCredential(params);
+  if (!credential) {
+    return { kind: "noCredential" };
+  }
+
+  // The ONLY difference between the two gateway kinds is this request. Hosted forwards the account
+  // access token as Authorization: Bearer with no device_key in the body (tenant isolation is bound
+  // at the mint from the verified token); self-host posts the device_key in the body, unchanged.
+  const localKey =
+    credential.mode === "hosted"
+      ? await enrollDeviceHosted(credential.accessToken, deviceId, profile.deviceName(), profile.platform(), signal)
+      : await enrollDevice(credential.deviceKey, deviceId, profile.deviceName(), profile.platform(), signal);
+
+  return { kind: "enrolled", localKey };
+}

--- a/packages/client-core/src/auth/enrollRequest.test.ts
+++ b/packages/client-core/src/auth/enrollRequest.test.ts
@@ -89,9 +89,12 @@ describe("readEnrollCredential", () => {
     expect(readEnrollCredential(params)).toEqual({ mode: "selfHost", deviceKey: "dk-123" });
   });
 
-  it("prefers the access_token when both are somehow present (only a hosted gateway mints from it)", () => {
+  it("rejects an ambiguous fragment carrying BOTH credentials (fail closed, do not guess)", () => {
+    // A legitimate callback carries exactly one credential. Both present means we cannot know which
+    // gateway kind the callback is for; guessing would send the wrong request shape, so it fails
+    // closed to null exactly like the neither-present case.
     const params = new URLSearchParams("device_key=dk-123&access_token=abc.def.ghi");
-    expect(readEnrollCredential(params)).toEqual({ mode: "hosted", accessToken: "abc.def.ghi" });
+    expect(readEnrollCredential(params)).toBeNull();
   });
 
   it("returns null when the fragment carries neither credential", () => {

--- a/packages/client-core/src/auth/enrollRequest.test.ts
+++ b/packages/client-core/src/auth/enrollRequest.test.ts
@@ -9,6 +9,7 @@ import {
   safeInternalPath,
   rememberEnrollNext,
   takeEnrollNext,
+  readEnrollCredential,
 } from "./enrollRequest";
 
 // The shell-agnostic enrollment profile (issue #1088). The mobile profile must stay the DEFAULT and
@@ -70,6 +71,32 @@ describe("desktop device identity", () => {
   it("falls back to a generic label when the user agent is unknown", () => {
     vi.stubGlobal("navigator", { userAgent: "SomethingUnrecognizable/1.0" });
     expect(desktopDeviceName()).toBe("Browser on desktop");
+  });
+});
+
+// The credential the website returns in the callback fragment decides the enrollment path (multi-tenant
+// hosted sign-in, Phase C): an access_token is a HOSTED round trip (forwarded as Authorization: Bearer),
+// a device_key is the pre-hosted SELF-HOST round trip (posted in the body). The self-host case must keep
+// selecting device_key exactly as before, or every self-hosted install's sign-in breaks.
+describe("readEnrollCredential", () => {
+  it("selects the hosted path when the fragment carries an access_token", () => {
+    const params = new URLSearchParams("access_token=abc.def.ghi&state=s1");
+    expect(readEnrollCredential(params)).toEqual({ mode: "hosted", accessToken: "abc.def.ghi" });
+  });
+
+  it("selects the self-host path when the fragment carries a device_key (unchanged behavior)", () => {
+    const params = new URLSearchParams("device_key=dk-123&state=s1");
+    expect(readEnrollCredential(params)).toEqual({ mode: "selfHost", deviceKey: "dk-123" });
+  });
+
+  it("prefers the access_token when both are somehow present (only a hosted gateway mints from it)", () => {
+    const params = new URLSearchParams("device_key=dk-123&access_token=abc.def.ghi");
+    expect(readEnrollCredential(params)).toEqual({ mode: "hosted", accessToken: "abc.def.ghi" });
+  });
+
+  it("returns null when the fragment carries neither credential", () => {
+    expect(readEnrollCredential(new URLSearchParams("state=s1"))).toBeNull();
+    expect(readEnrollCredential(new URLSearchParams(""))).toBeNull();
   });
 });
 

--- a/packages/client-core/src/auth/enrollRequest.ts
+++ b/packages/client-core/src/auth/enrollRequest.ts
@@ -134,6 +134,33 @@ export function enrollmentProfile(): EnrollmentShellProfile {
   return profile;
 }
 
+/**
+ * Which enrollment credential the website returned in the callback fragment, and therefore which
+ * gateway kind this sign-in is for (multi-tenant hosted sign-in, Phase C):
+ *   - "hosted": the account's short-lived Supabase access_token, forwarded to the mint as
+ *     `Authorization: Bearer` (enrollDeviceHosted).
+ *   - "selfHost": a device_key, posted in the request body (enrollDevice), the pre-hosted behavior.
+ * null when the fragment carried neither (a malformed or interrupted round trip).
+ */
+export type EnrollCredential =
+  | { mode: "hosted"; accessToken: string }
+  | { mode: "selfHost"; deviceKey: string };
+
+/**
+ * Decide the enrollment path from the callback fragment. The presence of an access_token means a
+ * HOSTED gateway round trip (it is the credential a hosted gateway issues); a device_key means the
+ * pre-hosted SELF-HOST round trip. access_token wins if both are somehow present, because only a
+ * hosted gateway mints from the account token. Returns null when neither is present, so the callback
+ * reports "no device key" exactly as it did before this branch existed.
+ */
+export function readEnrollCredential(params: URLSearchParams): EnrollCredential | null {
+  const accessToken = params.get("access_token");
+  if (accessToken) return { mode: "hosted", accessToken };
+  const deviceKey = params.get("device_key");
+  if (deviceKey) return { mode: "selfHost", deviceKey };
+  return null;
+}
+
 /** Mint a fresh anti-forgery state, persist it for the return leg, and return it. */
 export function newEnrollState(): string {
   const state = crypto.randomUUID();

--- a/packages/client-core/src/auth/enrollRequest.ts
+++ b/packages/client-core/src/auth/enrollRequest.ts
@@ -149,14 +149,18 @@ export type EnrollCredential =
 /**
  * Decide the enrollment path from the callback fragment. The presence of an access_token means a
  * HOSTED gateway round trip (it is the credential a hosted gateway issues); a device_key means the
- * pre-hosted SELF-HOST round trip. access_token wins if both are somehow present, because only a
- * hosted gateway mints from the account token. Returns null when neither is present, so the callback
- * reports "no device key" exactly as it did before this branch existed.
+ * pre-hosted SELF-HOST round trip. A legitimate callback carries EXACTLY ONE of the two. Both
+ * present is AMBIGUOUS - we cannot know which gateway kind the callback is for, and guessing would
+ * send the wrong request shape (a hosted Bearer where the Gateway expects a body device_key, or the
+ * reverse) - so both-present fails closed to null, exactly like neither-present. Returns null when
+ * neither is present, so the callback reports "no device key" exactly as it did before this branch
+ * existed.
  */
 export function readEnrollCredential(params: URLSearchParams): EnrollCredential | null {
   const accessToken = params.get("access_token");
-  if (accessToken) return { mode: "hosted", accessToken };
   const deviceKey = params.get("device_key");
+  if (accessToken && deviceKey) return null;
+  if (accessToken) return { mode: "hosted", accessToken };
   if (deviceKey) return { mode: "selfHost", deviceKey };
   return null;
 }
@@ -174,8 +178,9 @@ export function newEnrollState(): string {
 
 /**
  * Read and clear the state saved before the round trip. Returns null when none was saved (private
- * mode, or storage cleared); the callback treats a null expected-state as "cannot verify, proceed"
- * rather than blocking a legitimate sign-in.
+ * mode, or storage cleared). The callback (runEnrollmentCallback) FAILS CLOSED on a null
+ * expected-state: a callback whose round trip cannot be verified against a nonce THIS browser minted
+ * is rejected rather than enrolled, which closes the hosted login-CSRF path.
  */
 export function takeEnrollState(): string | null {
   try {


### PR DESCRIPTION
## What

Phase C of the hosted multi-tenant sign-in mission: make the client complete the HOSTED sign-in round trip.

The shared device-enrollment callback (`DeviceCallback`) now branches on which credential the website returned in the URL fragment:

- **Hosted gateway**: the fragment carries the account's Supabase `access_token`. The client POSTs `/m/enroll` with `Authorization: Bearer <access_token>` and body `{deviceId, name, platform}` (no `device_key`). This is the mint boundary the hosted endpoint expects (it reads the account subject from the verified token, checks the paid entitlement, resolves the tenant, and mints a tenant-scoped device key). Previously the client sent a `device_key` body with no auth header, which 401s on a hosted gateway.
- **Self-host gateway**: the fragment carries a `device_key`. Unchanged, byte-for-byte: `device_key` in the body, no auth header.

## How

- `readEnrollCredential(params)` — a pure helper keyed only on the fragment (`access_token` -> hosted, `device_key` -> self-host, access_token wins if both present). Makes the branch decision testable without a DOM and keeps the self-host path additive-only.
- `enrollDeviceHosted(accessToken, ...)` — new request that sends the Bearer header and omits `device_key`. `enrollDevice` (self-host) is unchanged. Both read the local device key back through one shared reader.
- `DeviceCallback` selects the enroll call from the credential mode; the state verification, cookie mirror, `next=` landing, and error handling are shared unchanged.

## Contract

Matches the pinned mission contract: website returns `#access_token=<token>&state=<state>` for hosted (self-host still returns `#device_key=...`); hosted `/m/enroll` expects `Authorization: Bearer <access_token>` + body `{deviceId, name, platform}`.

## Tests

Both branches, proven to fail on purpose:
- Hosted: sends `Authorization: Bearer <token>`, body omits `device_key`, token never leaks into the body.
- Self-host: sends `device_key` in the body with no `Authorization` header (unchanged).
- `readEnrollCredential`: hosted for access_token, self-host for device_key, access_token wins when both present, null for neither.

Full `client-core` vitest suite green (552 passed). All three web workspaces typecheck. Mobile + cockpit builds green. No .NET touched. Lint clean on all changed files (two pre-existing `rule definition not found` errors remain on untouched files identical to origin/main).
