### PR TITLE
release: v1.7.0 - hosted multi-tenant account sign-in

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
   </PropertyGroup>
 </Project>

--- a/docs/public/release-notes/v1.7.0.md
+++ b/docs/public/release-notes/v1.7.0.md
@@ -1,0 +1,16 @@
+## v1.7.0 - July 21, 2026
+
+You can now sign in with your DevThrottle account and control a hosted cc-director from the Cockpit and your phone, on the shared hosted gateway, with each account seeing only its own work.
+
+### Highlights
+- Sign in with your account on the hosted gateway: open the Cockpit or the phone app, sign in with your DevThrottle account, approve the device once, and you land in your own hosted Cockpit - no tokens to paste. Everything you see is scoped to your account.
+- The Cockpit opens from the gateway address: clicking Cockpit on a hosted director now opens the real hosted Cockpit in your browser instead of failing with a Tailscale error. The Cockpit and the phone app are both reached from the one gateway address - `{gateway}/cockpit` and `{gateway}/mobile` - the same way whether the gateway is hosted or running on your own machine.
+- Strict separation between accounts: the gateway works out which account a request belongs to from the signed-in identity alone, never from anything the browser or app claims, and refuses by default anything it cannot place. One account's directors, sessions, voice, and usage stay entirely separate from another's.
+- A hosted gateway is a paid gateway: signing a device in to the hosted gateway now requires an active subscription. A gateway you run yourself is unchanged and needs no subscription.
+
+### Also in this release
+- The phone app now lives at `{gateway}/mobile`, and the old `/m` address redirects to it so nothing you have bookmarked or installed breaks.
+- The in-window Fleet Map was removed from the desktop app.
+- Voice recordings that are still uploading are now cleaned up on a sensible, activity-aware schedule instead of lingering.
+- Groundwork for one-click self-host provisioning is in place but turned off in this release.
+- A plain-English guide to trying the hosted gateway is included in the documentation.


### PR DESCRIPTION
Bumps the version to 1.7.0 and adds the release notes. Highlights: hosted multi-tenant account sign-in (Cockpit + phone), the Cockpit opening from the gateway URL, strict per-account isolation, and the paid-entitlement gate on the hosted gateway. See docs/public/release-notes/v1.7.0.md.