### PR TITLE
fix(cockpit): terminal scrolling - fit the PTY grid to the pane (#1962)

### DIFF
--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -227,20 +227,19 @@ body {
   white-space: nowrap;
 }
 
-/* The xterm host. flex:1 so it takes all height under the bar; the exact-size PTY grid is anchored
-   to the BOTTOM (justify-content: flex-end) so a PTY shorter than the pane keeps its live input box
-   at the bottom edge - and a PTY taller than the pane scrolls within xterm's own viewport.
-
-   The engine mirrors the PTY grid EXACTLY (both cols and rows) to avoid TUI ghosting, so when the
-   PTY is wider than this host the grid overflows horizontally. overflow-x:auto makes that overflow
-   SCROLLABLE rather than silently clipped (issue #1022) - the full row is always reachable, never
-   cut off. overflow-y stays hidden because xterm owns vertical scrolling within its own viewport. */
+/* The xterm host. flex:1 so it takes all height under the bar. The engine mirrors the PTY grid
+   EXACTLY (both cols and rows) to avoid TUI ghosting, and then scales the FONT so the whole grid
+   fits this host in both axes (InteractiveTerminal.fitFont, issue #1962). Because the grid fits,
+   xterm's OWN viewport is the single scroll surface: its scrollbar sits at this host's right edge
+   (never overlapped by content that would otherwise overflow past it), it is grabbable, and its
+   native stick-to-bottom-on-new-output works. So this host does not scroll - overflow stays hidden
+   on both axes; the only scrolling is xterm's viewport inside it. justify-content:flex-end keeps the
+   live input box on the bottom edge when the fitted grid is a touch shorter than the host. */
 .term-host {
   flex: 1 1 auto;
   min-height: 0;
   background: #1e1e1e;
-  overflow-x: auto;
-  overflow-y: hidden;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;

--- a/packages/client-core/src/terminal/interactive.test.ts
+++ b/packages/client-core/src/terminal/interactive.test.ts
@@ -165,9 +165,24 @@ import { InteractiveTerminal } from "./interactive";
 const SID = "sess-123";
 
 // A host element that reports a real (non-zero) layout, so the engine's deferred bring-up opens the
-// terminal on the first animation frame (issue #1029).
+// terminal on the first animation frame (issue #1029). querySelector returns null so the font auto-fit
+// (fitFont) finds no rendered .xterm-screen to measure and no-ops - the fit is a pixel-measurement
+// concern proven in the browser, not here; this keeps the engine's OTHER contracts assertable headless.
 function host(): HTMLElement {
-  return { clientWidth: 800, clientHeight: 600 } as unknown as HTMLElement;
+  return {
+    clientWidth: 800,
+    clientHeight: 600,
+    querySelector: () => null,
+  } as unknown as HTMLElement;
+}
+
+// The engine observes the host with a ResizeObserver to re-fit the font on pane/window resize
+// (issue #1962). Model it as a no-op class in the headless test - construction must not throw, and
+// the fit itself is proven in the browser (fitFont no-ops here via the null querySelector above).
+class FakeResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
 }
 
 // Construct, start, and run the bring-up frame so the terminal + first WebSocket exist. Returns the
@@ -212,8 +227,17 @@ beforeEach(() => {
     cancelAnimationFrame: (id: number) => {
       rafCallbacks.delete(id);
     },
+    // The font auto-fit (fitFont, issue #1962) reads the host's padding to compute the usable box.
+    // The default host has no padding, so report zero on every side.
+    getComputedStyle: () => ({
+      paddingLeft: "0",
+      paddingRight: "0",
+      paddingTop: "0",
+      paddingBottom: "0",
+    }),
   };
   (globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket;
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = FakeResizeObserver;
 });
 
 afterEach(() => {
@@ -344,6 +368,84 @@ describe("InteractiveTerminal rendering", () => {
     const term = hoisted.terminals[0];
     FakeWebSocket.instances[0].emitString(JSON.stringify({ type: "size", cols: 137, rows: 51 }));
     expect(term.resizes[term.resizes.length - 1]).toEqual({ cols: 137, rows: 51 });
+  });
+
+  // Issue #1962: the grid mirrors the PTY exactly, so when the owning terminal is bigger than the
+  // cockpit pane the grid would overflow it - the top rows got clipped and unreachable and the
+  // scrollbar was painted over. The fix scales the FONT down so the whole grid fits the pane in both
+  // axes; xterm's own viewport then becomes the single, correctly-sized, grabbable scroll surface.
+  it("shrinks the font so an oversized PTY grid fits the pane in both axes (issue #1962)", () => {
+    // A pane, and a .xterm-screen whose rendered size tracks the current font: monospace cells are
+    // ~0.6*fontSize wide and lineHeight(1.2)*fontSize tall. The engine measures these to pick the fit.
+    const CELL_W_RATIO = 0.6;
+    const CELL_H_RATIO = 1.2;
+    const paneW = 1060;
+    const paneH = 710;
+    const currentTerm = () => hoisted.terminals[0];
+    const fontSize = () => (currentTerm().options as { fontSize: number }).fontSize;
+    const screenStub = {
+      get scrollWidth() {
+        return currentTerm().cols * (fontSize() * CELL_W_RATIO);
+      },
+      get scrollHeight() {
+        return currentTerm().rows * (fontSize() * CELL_H_RATIO);
+      },
+    };
+    const fitHost = {
+      clientWidth: paneW,
+      clientHeight: paneH,
+      querySelector: (sel: string) => (sel === ".xterm-screen" ? screenStub : null),
+    } as unknown as HTMLElement;
+
+    const t = new InteractiveTerminal(fitHost, SID);
+    t.start();
+    runFrames();
+    // The engine opens xterm at the 14px preferred size; at 14px this 137x50 grid is far bigger than
+    // the pane (137*8.4=1150 wide, 50*16.8=840 tall), so the fit must shrink the font.
+    expect(fontSize()).toBe(14);
+    FakeWebSocket.instances[FakeWebSocket.instances.length - 1].emitString(
+      JSON.stringify({ type: "size", cols: 137, rows: 50 }),
+    );
+
+    const fitted = fontSize();
+    expect(fitted).toBeLessThan(14);
+    // The whole grid now fits the usable box (pane minus the 2px rounding margin) on BOTH axes.
+    expect(137 * fitted * CELL_W_RATIO).toBeLessThanOrEqual(paneW - 2);
+    expect(50 * fitted * CELL_H_RATIO).toBeLessThanOrEqual(paneH - 2);
+
+    t.dispose();
+    runFrames();
+  });
+
+  // The font never grows past the 14px readability ceiling: a small grid that already fits a big pane
+  // is left at the preferred size rather than being blown up to fill the pane.
+  it("never enlarges the font past the preferred size for a grid that already fits", () => {
+    const currentTerm = () => hoisted.terminals[0];
+    const fontSize = () => (currentTerm().options as { fontSize: number }).fontSize;
+    const screenStub = {
+      get scrollWidth() {
+        return currentTerm().cols * (fontSize() * 0.6);
+      },
+      get scrollHeight() {
+        return currentTerm().rows * (fontSize() * 1.2);
+      },
+    };
+    const bigHost = {
+      clientWidth: 4000,
+      clientHeight: 3000,
+      querySelector: (sel: string) => (sel === ".xterm-screen" ? screenStub : null),
+    } as unknown as HTMLElement;
+
+    const t = new InteractiveTerminal(bigHost, SID);
+    t.start();
+    runFrames();
+    FakeWebSocket.instances[FakeWebSocket.instances.length - 1].emitString(
+      JSON.stringify({ type: "size", cols: 80, rows: 24 }),
+    );
+    expect(fontSize()).toBe(14);
+
+    t.dispose();
+    runFrames();
   });
 });
 

--- a/packages/client-core/src/terminal/interactive.ts
+++ b/packages/client-core/src/terminal/interactive.ts
@@ -49,7 +49,15 @@ import { findLineLinks, type LineLink } from "./lineLinks";
 // Code - no ligatures, crisper glyphs), then the same macOS/Linux fallbacks; 14px with lineHeight 1.2.
 const FONT_FAMILY =
   '"Cascadia Mono", Consolas, Menlo, "DejaVu Sans Mono", "Courier New", monospace';
+// The PREFERRED font size. It is the ceiling: the grid renders at this size whenever the whole PTY
+// grid fits the pane. When the PTY grid (which mirrors the owning terminal EXACTLY - see fitFont) is
+// bigger than the cockpit pane, the font shrinks toward MIN_FONT_SIZE so the grid still fits, rather
+// than overflowing the pane. It never grows past this size (readability ceiling).
 const FONT_SIZE = 14;
+// The floor for the auto-fit. Below this the text is too small to read, so a grid that still would
+// not fit at this size is allowed to overflow (xterm's own viewport then scrolls it) rather than
+// shrinking into illegibility. In practice a normal desktop terminal fits well above this.
+const MIN_FONT_SIZE = 8;
 const LINE_HEIGHT = 1.2;
 const SCROLLBACK = 5000;
 
@@ -102,6 +110,9 @@ export class InteractiveTerminal {
   private term: Xterm | null = null;
   private ws: WebSocket | null = null;
   private reconnectTimer: number | null = null;
+  // Watches the host for size changes (pane resize, window resize, layout shifts) so the auto-fit
+  // font size is recomputed and the grid keeps fitting the pane. Disposed with the terminal.
+  private resizeObserver: ResizeObserver | null = null;
   // The registered xterm link provider (Local Files, Phase 2), disposed with the terminal.
   private linkProvider: IDisposable | null = null;
   // The pending animation frame that waits for the host to be laid out before opening the terminal.
@@ -177,6 +188,15 @@ export class InteractiveTerminal {
     });
     term.open(this.hostEl);
     this.term = term;
+
+    // Recompute the auto-fit font whenever the host changes size (pane resize, window resize, a
+    // sibling panel opening/closing). Without this the grid only fits the size the pane had at open
+    // and overflows again after any resize. ResizeObserver fires once on observe with the current
+    // size, so the initial fit is covered too. Guarded by wantOpen so a torn-down instance is inert.
+    this.resizeObserver = new ResizeObserver(() => {
+      if (this.wantOpen) this.fitFont();
+    });
+    this.resizeObserver.observe(this.hostEl);
 
     // Forward every keystroke (raw bytes incl. Esc/Ctrl+C/arrows/the slash-command UI) to the owning
     // Director's PTY via a REST call to the Gateway - appendEnter:false writes the bytes verbatim (no
@@ -288,6 +308,14 @@ export class InteractiveTerminal {
   dispose(): void {
     this.wantOpen = false;
     this.pendingInput = ""; // drop any keystrokes not yet sent; the pump exits on its next check
+    if (this.resizeObserver !== null) {
+      try {
+        this.resizeObserver.disconnect();
+      } catch {
+        /* already gone */
+      }
+      this.resizeObserver = null;
+    }
     if (this.bringUpFrame !== null) {
       // Disposed before the host was ever laid out (the StrictMode throwaway mount): cancel the
       // pending open so no terminal is ever created for this instance.
@@ -350,9 +378,10 @@ export class InteractiveTerminal {
     }
   }
 
-  // Mirror the PTY grid EXACTLY - both cols and rows from the size message. Vertical placement within
-  // a too-tall pane is CSS's job (.term-host anchors the grid to the bottom); scrolling history is
-  // xterm's. Preserve the viewport's at-bottom position across the resize.
+  // Mirror the PTY grid EXACTLY - both cols and rows from the size message. The grid dimensions must
+  // match the owning terminal's or Claude Code's TUI ghosts (see the header note), so they are NEVER
+  // derived from the pane; the pane is made to fit the grid instead, by scaling the FONT (fitFont).
+  // Preserve the viewport's at-bottom position across the resize.
   private fit(): void {
     const t = this.term;
     if (!t || this.lastCols <= 0 || this.lastRows <= 0) return;
@@ -364,6 +393,70 @@ export class InteractiveTerminal {
     } catch {
       /* transient */
     }
+    // The grid changed dimensions, so re-fit the font so the (possibly larger) grid still fits the
+    // pane (pane-size changes are handled separately by the ResizeObserver). fitFont re-anchors to the
+    // bottom itself when it changes the font; when it leaves the font unchanged we restore the
+    // at-bottom position after the resize.
+    if (!this.fitFont() && atBottom) {
+      try {
+        t.scrollToBottom();
+      } catch {
+        /* transient */
+      }
+    }
+  }
+
+  // Scale the font so the WHOLE PTY grid fits the pane in both axes. The grid's cols and rows mirror
+  // the owning terminal exactly (fit) and must not change, so the only free variable is the font
+  // size: shrink it until cols*cellWidth <= pane width AND rows*cellHeight <= pane height. This makes
+  // xterm's own viewport the single, correctly-sized scroll surface - its scrollbar sits at the pane
+  // edge (never overlapped by content that overflows past it) and its native "stick to the bottom on
+  // new output unless the user scrolled up" behaviour works, because the viewport is no longer taller
+  // than the visible pane. Without this the grid overflowed the pane: the top rows were clipped and
+  // unreachable, and the scrollbar was painted over by the overflowing screen and could not be
+  // grabbed (issue #1962).
+  //
+  // The font never grows past FONT_SIZE (readability ceiling) and never shrinks below MIN_FONT_SIZE
+  // (a grid too big even then is left to overflow rather than become illegible). Cell metrics are
+  // read from the rendered DOM (screen width / cols, screen height / rows) rather than xterm private
+  // internals, so this stays correct across xterm versions. Returns true when it changed the font.
+  private fitFont(): boolean {
+    const t = this.term;
+    if (!t || this.lastCols <= 0 || this.lastRows <= 0) return false;
+    const screen = this.hostEl.querySelector<HTMLElement>(".xterm-screen");
+    if (!screen) return false;
+
+    // The available box is the host's content area (its padding is not usable for glyphs). A 2px
+    // safety margin per axis absorbs sub-pixel rounding so the fitted grid never overflows by a
+    // hair and reintroduces the scrollbar overlap.
+    const style = window.getComputedStyle(this.hostEl);
+    const padX = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+    const padY = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+    const availW = this.hostEl.clientWidth - padX - 2;
+    const availH = this.hostEl.clientHeight - padY - 2;
+    if (availW <= 0 || availH <= 0) return false;
+
+    const currentFont = t.options.fontSize ?? FONT_SIZE;
+    // Cell size AT THE CURRENT FONT, measured from what xterm actually rendered.
+    const cellW = screen.scrollWidth / this.lastCols;
+    const cellH = screen.scrollHeight / this.lastRows;
+    if (cellW <= 0 || cellH <= 0) return false;
+
+    // Largest font (per axis) whose grid still fits, derived by scaling the current cell metrics.
+    const fontByWidth = (currentFont * (availW / this.lastCols)) / cellW;
+    const fontByHeight = (currentFont * (availH / this.lastRows)) / cellH;
+    let target = Math.floor(Math.min(fontByWidth, fontByHeight, FONT_SIZE));
+    if (target < MIN_FONT_SIZE) target = MIN_FONT_SIZE;
+    if (target === currentFont) return false;
+
+    const buf = t.buffer.active;
+    const atBottom = buf.viewportY >= buf.baseY;
+    try {
+      t.options.fontSize = target;
+    } catch {
+      return false;
+    }
+    // Changing the font re-lays out the grid; keep the live input box in view if we were at the bottom.
     if (atBottom) {
       try {
         t.scrollToBottom();
@@ -371,6 +464,7 @@ export class InteractiveTerminal {
         /* transient */
       }
     }
+    return true;
   }
 
   // The first frame of a LIVE stream (a size header or PTY bytes) proves the whole


### PR DESCRIPTION
Fixes #1962.

## The bug
The live terminal mirrors the PTY grid exactly (cols and rows) so Claude Code's TUI does not ghost. When the owning terminal is larger than the cockpit pane, that grid is bigger than the pane. The old layout papered over the mismatch with `overflow-y:hidden` + `justify-content:flex-end`, and that single mismatch produced all four reported faults:

- top rows clipped and unreachable (could not scroll up)
- the wide screen painted over the vertical scrollbar (text overlapped it)
- the scrollbar track sat partly off-screen under the screen layer (could not be grabbed)
- xterm's native stick-to-bottom broke (did not stay at the bottom on new output)

## The fix
Keep cols and rows equal to the PTY, but scale the **font** so the whole grid fits the pane in both axes (`InteractiveTerminal.fitFont`). xterm's own viewport then becomes the single, correctly-sized scroll surface: its scrollbar sits at the pane edge, is grabbable, is never overlapped, and its native bottom-follow works. A `ResizeObserver` re-fits on pane and window resize. Font is capped at the 14px preferred size and floored at 8px.

Three files: `interactive.ts` (fit engine + observer), `styles.css` (host no longer clips), `interactive.test.ts` (test stubs + 2 regression tests).

## Verification
Ran the cockpit dev server proxied to a live gateway and drove it in a real browser against real sessions:

- buffer grew while the view stayed pinned to the bottom (`dist=0`)
- a scrolled-up view was left in place when new output arrived (did not yank to bottom)
- screen width stays within the viewport (no scrollbar overlap)
- the topmost element at the scrollbar column is the viewport itself (grabbable)

Also: 20/20 terminal unit tests pass, full client-core (563) and cockpit (150) suites green, typecheck clean, production cockpit build succeeds, changed files lint clean.
