### PR TITLE
Change gateway from the UI: disconnect + reconnect, and enable the hosted choice

### DIFF
--- a/src/CcDirector.Avalonia.Tests/GatewayChoicePanelIntegrationTests.cs
+++ b/src/CcDirector.Avalonia.Tests/GatewayChoicePanelIntegrationTests.cs
@@ -171,7 +171,7 @@ public class GatewayChoicePanelIntegrationTests
     // ---- Hosted choice: the enabled card runs the SAME proven hosted enroll the CLI uses ----------
 
     [AvaloniaFact]
-    public async Task HostedChoice_EnabledCard_RunsHostedEnroll_WithThisDeviceId()
+    public async Task HostedChoice_ActivatingTheEnabledCard_RunsHostedEnroll_WithThisDeviceId()
     {
         await WithTempRootAsync(async () =>
         {
@@ -180,27 +180,29 @@ public class GatewayChoicePanelIntegrationTests
             panel.ShowChoiceForTests();
             panel.DirectorIdOverride = "test-director-id";
 
-            string? seenDeviceId = null;
-            var calls = 0;
+            var seen = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             // Injected hosted-enroll seam: no browser, no network. Fail so nothing re-applies or handshakes.
             panel.HostedEnrollSeam = (deviceId, _, _) =>
             {
-                calls++;
-                seenDeviceId = deviceId;
+                seen.TrySetResult(deviceId);
                 return Task.FromResult(OperationResult<MobileEnrollmentResponse>.Fail("not this time"));
             };
 
-            // The hosted card is enabled, so activating it EXACTLY as a click would must fire the enroll.
+            // Drive the ACTUAL card dispatch, exactly as a click would (through ActivateChoiceForTests, which
+            // respects the card's enabled state) - NOT HostedEnrollAndHandshakeAsync directly. So removing the
+            // UseHosted case from the dispatch (or its StartHostedEnroll wiring) reddens this test.
             Assert.True(CardFor(panel, GatewayChoiceAction.UseHosted).IsEnabled);
-            await panel.HostedEnrollAndHandshakeAsync();
+            panel.ActivateChoiceForTests(GatewayChoiceAction.UseHosted);
 
-            Assert.Equal(1, calls);
-            Assert.Equal("test-director-id", seenDeviceId);
+            var winner = await Task.WhenAny(seen.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.True(ReferenceEquals(winner, seen.Task),
+                "activating the enabled hosted card did not invoke the hosted enroll");
+            Assert.Equal("test-director-id", await seen.Task);
         });
     }
 
     [AvaloniaFact]
-    public async Task HostedChoice_FailedEnroll_DoesNotReapply_AndDoesNotMutateConfig()
+    public async Task HostedChoice_FailedEnroll_ShowsTheFailure_DoesNotReapply_AndDoesNotMutateConfig()
     {
         await WithTempRootAsync(async () =>
         {
@@ -215,7 +217,13 @@ public class GatewayChoicePanelIntegrationTests
 
             await panel.HostedEnrollAndHandshakeAsync();
 
-            // A failed hosted enroll persists nothing and never re-applies: the old connection is untouched.
+            // The failure is actually SHOWN, carrying the reason (removing ShowFailure reddens this) - never a
+            // silent no-op and never a stuck "Connecting" spinner.
+            Assert.True(panel.IsShowingFailureForTests, "a failed hosted enroll must show the failure panel");
+            Assert.False(panel.IsShowingConnectingForTests, "the panel must not be stuck on Connecting");
+            Assert.Contains("hosted enroll failed", panel.FailureSummaryForTests);
+
+            // It persists nothing and never re-applies: the old connection is untouched.
             var config = GatewayConfig.Load();
             Assert.Equal(OldUrl, config.Url);
             Assert.Equal(OldToken, config.Token);
@@ -251,10 +259,34 @@ public class GatewayChoicePanelIntegrationTests
         });
     }
 
+    [AvaloniaFact]
+    public async Task HostedChoice_ReapplyFaultsAfterEnroll_ShowsFailure_NotStuckOnConnecting()
+    {
+        await WithTempRootAsync(async () =>
+        {
+            var panel = GatewayConnectionPanel.CreateForCurrentState(GatewayChoiceConsumer.Settings);
+            panel.DirectorIdOverride = "test-director-id";
+            // The enroll SUCCEEDS (the credential is persisted), but the live re-apply faults afterwards.
+            panel.HostedEnrollSeam = (_, _, _) =>
+                Task.FromResult(OperationResult<MobileEnrollmentResponse>.Ok(
+                    new MobileEnrollmentResponse { DeviceKey = "hosted-verified-key" }));
+            panel.ReapplyGatewaySeam = () => throw new InvalidOperationException("reapply boom");
+
+            // The fault must be OBSERVED: this await must NOT throw out, and the panel must NOT be left
+            // spinning - it lands on a named failure. Reverting the fix (awaiting reapply outside the
+            // try/catch) makes this await rethrow the fault, reddening the test.
+            await panel.HostedEnrollAndHandshakeAsync();
+
+            Assert.True(panel.IsShowingFailureForTests, "a reapply fault after enroll must show the failure panel");
+            Assert.False(panel.IsShowingConnectingForTests, "the panel must not be stuck on Connecting after a reapply fault");
+            Assert.Contains("could not apply", panel.FailureSummaryForTests);
+        });
+    }
+
     // ---- Change gateway: disconnect clears the stored connection, then re-shows the choice --------
 
     [AvaloniaFact]
-    public async Task ChangeGateway_Disconnect_ClearsTheStoredConnection_ReAppliesAndShowsChoice()
+    public async Task ChangeGateway_Disconnect_ClearsTheStoredConnection_ReAppliesAndReturnsToChoice()
     {
         await WithTempRootAsync(async () =>
         {
@@ -272,11 +304,32 @@ public class GatewayChoicePanelIntegrationTests
             Assert.False(config.IsEnabled);
             Assert.Equal("", config.Url);
             Assert.Equal("", config.Token);
-            // The running client was re-applied so it drops the old connection, and the choice is shown so a
-            // different gateway can be connected.
+            // The running client was re-applied so it drops the old connection...
             Assert.True(reapplied);
+            // ...and the panel actually RETURNS TO THE STEP-0 CHOICE view (removing ShowChoice reddens this),
+            // not merely leaving hidden cards around.
+            Assert.True(panel.IsShowingChoiceForTests, "disconnect must return to the step-0 choice view");
             Assert.NotNull(CardFor(panel, GatewayChoiceAction.JoinExisting));
             Assert.NotNull(CardFor(panel, GatewayChoiceAction.UseHosted));
+        });
+    }
+
+    [AvaloniaFact]
+    public async Task ChangeGateway_Disconnect_ReapplyFault_StillClearsAndReturnsToChoice()
+    {
+        await WithTempRootAsync(async () =>
+        {
+            SaveOldGatewayConnection();
+
+            var panel = GatewayConnectionPanel.CreateForCurrentState(GatewayChoiceConsumer.Settings);
+            // The connection is cleared before re-apply; a reapply fault must NOT undo the disconnect nor
+            // leave the user stuck - it is observed and the choice is still shown.
+            panel.ReapplyGatewaySeam = () => throw new InvalidOperationException("reapply boom");
+
+            await panel.DisconnectAndShowChoiceAsync();
+
+            Assert.False(GatewayConfig.Load().IsEnabled);
+            Assert.True(panel.IsShowingChoiceForTests, "disconnect must return to the choice even if re-apply faults");
         });
     }
 

--- a/src/CcDirector.Avalonia.Tests/GatewayChoicePanelIntegrationTests.cs
+++ b/src/CcDirector.Avalonia.Tests/GatewayChoicePanelIntegrationTests.cs
@@ -154,17 +154,130 @@ public class GatewayChoicePanelIntegrationTests
     // ---- R2(b): rendered card actionability + Mac omission ---------------------------------------
 
     [AvaloniaFact]
-    public void Choice_OnWindows_RendersDisabledSelfHostAndHosted_NonActionable_JoinAndSkipActionable()
+    public void Choice_OnWindows_RendersDisabledSelfHost_HostedJoinAndSkipActionable()
     {
         var panel = GatewayConnectionPanel.CreateForCurrentState(GatewayChoiceConsumer.Onboarding);
         // Force a self-host-capable (Windows) context regardless of the test host.
         panel.SetChoiceContextForTests(new GatewayChoiceContext(GatewayChoiceConsumer.Onboarding, SelfHostSupported: true));
         panel.ShowChoiceForTests();
 
+        // Self-host is still a disabled "coming" card; hosted is now a live, actionable card.
         Assert.False(CardFor(panel, GatewayChoiceAction.SelfHost).IsEnabled);
-        Assert.False(CardFor(panel, GatewayChoiceAction.UseHosted).IsEnabled);
+        Assert.True(CardFor(panel, GatewayChoiceAction.UseHosted).IsEnabled);
         Assert.True(CardFor(panel, GatewayChoiceAction.JoinExisting).IsEnabled);
         Assert.True(CardFor(panel, GatewayChoiceAction.Skip).IsEnabled);
+    }
+
+    // ---- Hosted choice: the enabled card runs the SAME proven hosted enroll the CLI uses ----------
+
+    [AvaloniaFact]
+    public async Task HostedChoice_EnabledCard_RunsHostedEnroll_WithThisDeviceId()
+    {
+        await WithTempRootAsync(async () =>
+        {
+            var panel = GatewayConnectionPanel.CreateForCurrentState(GatewayChoiceConsumer.Settings);
+            panel.SetChoiceContextForTests(new GatewayChoiceContext(GatewayChoiceConsumer.Settings, SelfHostSupported: true));
+            panel.ShowChoiceForTests();
+            panel.DirectorIdOverride = "test-director-id";
+
+            string? seenDeviceId = null;
+            var calls = 0;
+            // Injected hosted-enroll seam: no browser, no network. Fail so nothing re-applies or handshakes.
+            panel.HostedEnrollSeam = (deviceId, _, _) =>
+            {
+                calls++;
+                seenDeviceId = deviceId;
+                return Task.FromResult(OperationResult<MobileEnrollmentResponse>.Fail("not this time"));
+            };
+
+            // The hosted card is enabled, so activating it EXACTLY as a click would must fire the enroll.
+            Assert.True(CardFor(panel, GatewayChoiceAction.UseHosted).IsEnabled);
+            await panel.HostedEnrollAndHandshakeAsync();
+
+            Assert.Equal(1, calls);
+            Assert.Equal("test-director-id", seenDeviceId);
+        });
+    }
+
+    [AvaloniaFact]
+    public async Task HostedChoice_FailedEnroll_DoesNotReapply_AndDoesNotMutateConfig()
+    {
+        await WithTempRootAsync(async () =>
+        {
+            SaveOldGatewayConnection();
+
+            var panel = GatewayConnectionPanel.CreateForCurrentState(GatewayChoiceConsumer.Settings);
+            var reapplied = false;
+            panel.DirectorIdOverride = "test-director-id";
+            panel.ReapplyGatewaySeam = () => { reapplied = true; return Task.CompletedTask; };
+            panel.HostedEnrollSeam = (_, _, _) =>
+                Task.FromResult(OperationResult<MobileEnrollmentResponse>.Fail("hosted enroll failed"));
+
+            await panel.HostedEnrollAndHandshakeAsync();
+
+            // A failed hosted enroll persists nothing and never re-applies: the old connection is untouched.
+            var config = GatewayConfig.Load();
+            Assert.Equal(OldUrl, config.Url);
+            Assert.Equal(OldToken, config.Token);
+            Assert.False(reapplied);
+        });
+    }
+
+    [AvaloniaFact]
+    public async Task HostedChoice_SuccessfulEnroll_ReAppliesTheVerifiedCredential()
+    {
+        await WithTempRootAsync(async () =>
+        {
+            const string hostedUrl = "https://devthrottle-gw.azurewebsites.net";
+            var panel = GatewayConnectionPanel.CreateForCurrentState(GatewayChoiceConsumer.Settings);
+            var reapplied = false;
+            panel.DirectorIdOverride = "test-director-id";
+            panel.ReapplyGatewaySeam = () => { reapplied = true; return Task.CompletedTask; };
+            // Mirror the runner's verified-success persistence (it owns the atomic hosted-url+key write).
+            panel.HostedEnrollSeam = (_, _, _) =>
+            {
+                CcDirectorConfigService.MergePatch(new JsonObject
+                {
+                    ["gateway"] = new JsonObject { ["url"] = hostedUrl, ["token"] = "hosted-verified-key" },
+                });
+                return Task.FromResult(OperationResult<MobileEnrollmentResponse>.Ok(
+                    new MobileEnrollmentResponse { DeviceKey = "hosted-verified-key" }));
+            };
+
+            await panel.HostedEnrollAndHandshakeAsync();
+
+            Assert.True(reapplied);
+            Assert.Equal(hostedUrl, GatewayConfig.Load().Url);
+        });
+    }
+
+    // ---- Change gateway: disconnect clears the stored connection, then re-shows the choice --------
+
+    [AvaloniaFact]
+    public async Task ChangeGateway_Disconnect_ClearsTheStoredConnection_ReAppliesAndShowsChoice()
+    {
+        await WithTempRootAsync(async () =>
+        {
+            SaveOldGatewayConnection();
+            Assert.True(GatewayConfig.Load().IsEnabled); // connected to a gateway
+
+            var panel = GatewayConnectionPanel.CreateForCurrentState(GatewayChoiceConsumer.Settings);
+            var reapplied = false;
+            panel.ReapplyGatewaySeam = () => { reapplied = true; return Task.CompletedTask; };
+
+            await panel.DisconnectAndShowChoiceAsync();
+
+            // The stored connection is cleared: url + token gone, so the Director is local-only again.
+            var config = GatewayConfig.Load();
+            Assert.False(config.IsEnabled);
+            Assert.Equal("", config.Url);
+            Assert.Equal("", config.Token);
+            // The running client was re-applied so it drops the old connection, and the choice is shown so a
+            // different gateway can be connected.
+            Assert.True(reapplied);
+            Assert.NotNull(CardFor(panel, GatewayChoiceAction.JoinExisting));
+            Assert.NotNull(CardFor(panel, GatewayChoiceAction.UseHosted));
+        });
     }
 
     [AvaloniaFact]

--- a/src/CcDirector.Avalonia.Tests/SelfHostChoiceRouteTests.cs
+++ b/src/CcDirector.Avalonia.Tests/SelfHostChoiceRouteTests.cs
@@ -80,11 +80,11 @@ public class SelfHostChoiceRouteTests
     {
         var panel = WindowsPanel();
 
-        // The regression guard that matters: Join and Skip are the only working paths today, and
-        // adding a self-host route must not disturb either.
+        // The regression guard that matters: adding a self-host route must not disturb the working paths.
+        // Join, Skip, and (now) hosted are the enabled choices; only self-host stays disabled.
         Assert.True(CardFor(panel, GatewayChoiceAction.JoinExisting).IsEnabled);
         Assert.True(CardFor(panel, GatewayChoiceAction.Skip).IsEnabled);
-        Assert.False(CardFor(panel, GatewayChoiceAction.UseHosted).IsEnabled);
+        Assert.True(CardFor(panel, GatewayChoiceAction.UseHosted).IsEnabled);
     }
 
     private static string TextOf(Control control)

--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml
@@ -292,6 +292,17 @@
                     </StackPanel>
                 </StackPanel>
             </Border>
+
+            <!-- Change gateway: disconnect this Director from the current Gateway and reconnect to a
+                 different one (local OR hosted). The click confirms, then clears the stored connection
+                 and returns to the step-0 choice. -->
+            <StackPanel Spacing="6" Margin="0,4,0,0">
+                <Button x:Name="ChangeGatewayButton" Classes="secondaryButton" Content="Change gateway"
+                        HorizontalAlignment="Left" Click="ChangeGateway_Click"
+                        ToolTip.Tip="Disconnect this Director and connect it to a different Gateway" />
+                <TextBlock Classes="body" FontSize="11.5" Foreground="#888888" TextWrapping="Wrap"
+                           Text="Disconnect from this Gateway and connect to a different one - local or hosted." />
+            </StackPanel>
         </StackPanel>
 
         <!-- STEP 1e: named failure -->

--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
@@ -501,6 +501,14 @@ public partial class GatewayConnectionPanel : UserControl
     internal void EmitTerminalForTests()
         => ShowDone(GatewayConfig.Load(), GatewayAccountStatus.NotConfigured());
 
+    // ---- Test hooks: which step sub-panel is currently shown, and the surfaced failure text. These let a
+    // test pin the VISIBLE outcome (a failure is actually shown, disconnect actually returns to the choice)
+    // rather than just inspecting hidden state - so removing ShowFailure / ShowChoice reddens.
+    internal bool IsShowingChoiceForTests => ChoicePanel.IsVisible;
+    internal bool IsShowingConnectingForTests => ConnectingPanel.IsVisible;
+    internal bool IsShowingFailureForTests => FailedPanel.IsVisible;
+    internal string FailureSummaryForTests => FailureSummaryText.Text ?? string.Empty;
+
     // ---- Step 1a: scan --------------------------------------------------------------------------
 
     private async void StartScan()
@@ -1181,7 +1189,22 @@ public partial class GatewayConnectionPanel : UserControl
             ShowFailure("The Control API is not running yet, so this Director cannot finish connecting.", null);
             return;
         }
-        await reapply();
+        // OBSERVE the re-apply. The verified credential is ALREADY persisted, so if reapply faults the awaited
+        // Task would fault unobserved in this fire-and-forget flow, leaving the panel spinning on "Connecting".
+        // Catch it and land on a named failure that says the enroll succeeded but could not be applied live,
+        // with a retry affordance - never a stuck spinner.
+        try
+        {
+            await reapply();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayConnectionPanel] remote enroll: re-apply after enroll FAILED: {ex.Message}");
+            ShowFailure(
+                "Signed in and enrolled with the Gateway, but this Director could not apply the new connection right now.",
+                "Try again, or restart the Director to finish connecting.");
+            return;
+        }
         _ = TimeoutAsync(attempt);
     }
 
@@ -1276,7 +1299,22 @@ public partial class GatewayConnectionPanel : UserControl
             ShowFailure("The Control API is not running yet, so this Director cannot finish connecting.", null);
             return;
         }
-        await reapply();
+        // OBSERVE the re-apply. The hosted credential is ALREADY persisted at this point, so if reapply faults
+        // the awaited Task would fault unobserved in this fire-and-forget flow, leaving the panel spinning on
+        // "Connecting" with partial live state. Catch it and land on a named failure that says the enroll
+        // succeeded but could not be applied live, with a retry affordance - never a stuck spinner.
+        try
+        {
+            await reapply();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayConnectionPanel] hosted enroll: re-apply after enroll FAILED: {ex.Message}");
+            ShowFailure(
+                "Signed in and enrolled with the hosted Gateway, but this Director could not apply the new connection right now.",
+                "Try again, or restart the Director to finish connecting.");
+            return;
+        }
         _ = TimeoutAsync(attempt);
     }
 
@@ -1679,11 +1717,24 @@ public partial class GatewayConnectionPanel : UserControl
         await Task.Run(GatewayCredentialStore.ClearConnection);
 
         // Re-apply so the running Gateway client picks up the now-empty config and stops presenting the old
-        // per-device key. Uses the same re-apply seam the connect paths use (injectable for tests).
+        // per-device key. Uses the same re-apply seam the connect paths use (injectable for tests). OBSERVE a
+        // reapply fault here: the connection is ALREADY cleared (config emptied, credential deleted), so a
+        // reapply failure does NOT undo the disconnect - log it and still return to the choice rather than
+        // reporting a false "could not disconnect" or leaving the user stuck. (A ClearConnection failure DOES
+        // propagate, so the caller surfaces it: nothing was cleared in that case.)
         var reapply = ReapplyGatewaySeam
             ?? ((global::Avalonia.Application.Current as App)?.ControlApiHost is { } host ? host.ReapplyGatewayAsync : null);
         if (reapply is not null)
-            await reapply();
+        {
+            try
+            {
+                await reapply();
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[GatewayConnectionPanel] disconnect: re-apply after clear FAILED (connection already cleared): {ex.Message}");
+            }
+        }
 
         FileLog.Write("[GatewayConnectionPanel] disconnected; showing the gateway choice");
         ShowChoice();

--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
@@ -103,6 +103,12 @@ public partial class GatewayConnectionPanel : UserControl
     internal Func<Task>? ReapplyGatewaySeam;
     internal string? DirectorIdOverride;
 
+    // ---- Hosted-enroll test seam: run the hosted account sign-in + enroll headless with no browser or
+    // network. Defaults to null -> the real GatewayAccountEnrollRunner.SignInAndEnrollHostedAsync (the exact
+    // path the CLI's `enroll --hosted` uses). Tests inject a fake so ActivateChoiceForTests(UseHosted) can
+    // prove the enabled card runs the hosted enroll with this device's id, without a real network enroll.
+    internal Func<string, string, CancellationToken, Task<OperationResult<MobileEnrollmentResponse>>>? HostedEnrollSeam;
+
     // Which step the panel opens on (spec section 6: the status-box click opens the panel on the resolver's
     // current step). Connect (the default) starts the auto-scan; SignIn/Done skip the scan and read the
     // signed-in state directly, because the handshake is already proven in those states.
@@ -403,6 +409,12 @@ public partial class GatewayConnectionPanel : UserControl
             case GatewayChoiceAction.Skip:
                 HandleSkip();
                 break;
+            case GatewayChoiceAction.UseHosted:
+                // Hosted is live: a browser account sign-in whose token is enrolled at the one shared
+                // hosted Gateway, which mints this machine's tenant-scoped device key. Same proven runner
+                // the CLI's `enroll --hosted` uses - there is no address to type and nothing to provision.
+                StartHostedEnroll();
+                break;
             case GatewayChoiceAction.SelfHost:
                 // Routed, but UNREACHABLE in production today: the card is still rendered disabled
                 // and wires no handler, so a user cannot fire this. The route exists so the
@@ -410,7 +422,6 @@ public partial class GatewayConnectionPanel : UserControl
                 // in the same change that first exposes it to a stranger's machine.
                 StartSelfHost();
                 break;
-            // Hosted is disabled in this slice and never wires a handler, so it cannot fire.
         }
     }
 
@@ -1179,6 +1190,102 @@ public partial class GatewayConnectionPanel : UserControl
         string url, string deviceId, string machineName, CancellationToken ct)
         => new GatewayAccountEnrollRunner().VerifyAndSaveAsync(url, deviceId, machineName, ct);
 
+    // ---- Step 0->Done: Use hosted (#1808c/#1811) ------------------------------------------------
+
+    // Fire the hosted-enroll transaction from the choice card. Kept separate (fire-and-forget) so the render
+    // test can activate the enabled card exactly as a click would, while the awaitable core runs the work.
+    private void StartHostedEnroll()
+    {
+        FileLog.Write("[GatewayConnectionPanel] choice: Use hosted -> hosted enroll");
+        _ = HostedEnrollAndHandshakeAsync();
+    }
+
+    // Join DevThrottle's HOSTED Gateway (#1808c): the SAME proven flow the CLI's `enroll --hosted` runs. A
+    // browser account sign-in whose account token goes straight to the hosted Gateway
+    // (GatewayAccountEnrollRunner.SignInAndEnrollHostedAsync), which mints this machine's tenant-scoped device
+    // key in one step and persists the hosted url + key on verified success ONLY. There is no address to type
+    // and nothing to provision - enrolling IS the join. On success we re-apply and run the normal handshake so
+    // the verdict path drives to the signed-in Done view (which then reads "Connected to Gateway on" the
+    // hosted host from HostedGateway.ResolveUrl). Nothing is written on cancel or failure, so a
+    // previously-saved connection is untouched. Internal so a headless test can drive and await it with the
+    // enroll seam injected.
+    internal async Task HostedEnrollAndHandshakeAsync()
+    {
+        var attempt = ++_attemptId;
+        _connecting = true;
+        // Hosted has no address; clear any stale Join attempt so a post-failure "Try again" does not retry a
+        // previous Join URL - it falls back to the scan instead.
+        _lastAttempt = null;
+        ConnectingTitle.Text = "Signing in to DevThrottle to join the hosted Gateway...";
+        LegReachMarker.Text = "[.]";
+        LegCallbackMarker.Text = "[.]";
+        ShowOnly(ConnectingPanel);
+
+        var host = (global::Avalonia.Application.Current as App)?.ControlApiHost;
+        var directorId = DirectorIdOverride ?? host?.DirectorId;
+        if (directorId is null)
+        {
+            ShowFailure("The Control API is not running yet, so this Director cannot connect.",
+                "Wait for the Director to finish starting, then try again.");
+            return;
+        }
+
+        _remoteEnrollCts?.Cancel();
+        _remoteEnrollCts = new CancellationTokenSource();
+        var ct = _remoteEnrollCts.Token;
+
+        OperationResult<MobileEnrollmentResponse> result;
+        try
+        {
+            // The runner signs in on the PUBLIC /signin surface and enrolls the account token at the hosted
+            // Gateway, which mints and returns this machine's tenant-scoped device key. It persists hosted
+            // url + key on verified success ONLY, so a cancel/failure never mutates the saved connection.
+            var enroll = HostedEnrollSeam ?? DefaultHostedEnroll;
+            result = await enroll(directorId, Environment.MachineName, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            // The panel was left, or a newer attempt superseded this one; leave the view (and config) alone.
+            return;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayConnectionPanel] hosted enroll error: {ex.Message}");
+            ShowFailure($"Could not sign in and join the hosted Gateway: {ex.Message}", null);
+            return;
+        }
+
+        if (attempt != _attemptId) return; // superseded by a newer connect
+
+        if (!result.Success)
+        {
+            // Enrollment failed: the runner persisted nothing, so any previously-saved connection is
+            // untouched. Surface the reason inline - never a silent no-op.
+            ShowFailure(result.ErrorMessage ?? "Could not join the hosted Gateway.", null);
+            return;
+        }
+
+        // The runner committed the verified hosted url + this device's local key atomically. Re-apply so the
+        // running client authenticates with the NEW credential, then the handshake settles to Sign-in/Done.
+        FileLog.Write("[GatewayConnectionPanel] hosted enroll succeeded; re-applying and handshaking");
+        if (host is not null)
+            EnsureSubscribed(host.GatewayMonitor);
+        var reapply = ReapplyGatewaySeam ?? (host is not null ? host.ReapplyGatewayAsync : null);
+        if (reapply is null)
+        {
+            ShowFailure("The Control API is not running yet, so this Director cannot finish connecting.", null);
+            return;
+        }
+        await reapply();
+        _ = TimeoutAsync(attempt);
+    }
+
+    // The real hosted-enroll seam: sign in with DevThrottle and enroll at the hosted Gateway for this
+    // machine's tenant-scoped device key, persisting the hosted url + key on success only.
+    private static Task<OperationResult<MobileEnrollmentResponse>> DefaultHostedEnroll(
+        string deviceId, string machineName, CancellationToken ct)
+        => new GatewayAccountEnrollRunner().SignInAndEnrollHostedAsync(deviceId, machineName, ct);
+
     private enum EnrollFirst { Enrolled, SignInNeeded, RemoteNotSupported, FellThrough }
 
     // Try to earn this device's first Gateway key via the co-located loopback enrollment (epic #1069 A3).
@@ -1524,6 +1631,62 @@ public partial class GatewayConnectionPanel : UserControl
         var open = DoneAdvancedToggle.IsChecked == true;
         if (DoneAdvancedPanel is not null) DoneAdvancedPanel.IsVisible = open;
         if (DoneAdvancedCaret is not null) DoneAdvancedCaret.Text = open ? "^" : "v";
+    }
+
+    // ---- Done: Change gateway (disconnect + reconnect) ------------------------------------------
+
+    // Change which Gateway this Director is connected to: confirm, DISCONNECT (clear the stored connection),
+    // then return to the step-0 CHOICE so the user can connect to a different Gateway - local OR hosted.
+    private async void ChangeGateway_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var host = SafeHost(GatewayConfig.Load().Url);
+            var target = string.IsNullOrWhiteSpace(host) ? "the Gateway" : host;
+
+            // Confirm before disconnecting (a connection is not cheap to re-establish).
+            var owner = TopLevel.GetTopLevel(this) as Window;
+            if (owner is not null)
+            {
+                var confirm = new ConfirmDialog(
+                    "Change gateway",
+                    $"This will disconnect this Director from {target}. Continue?",
+                    confirmLabel: "Disconnect",
+                    cancelLabel: "Cancel");
+                if (!await confirm.ShowDialog<bool>(owner))
+                {
+                    FileLog.Write("[GatewayConnectionPanel] change gateway: cancelled at the confirm prompt");
+                    return;
+                }
+            }
+
+            await DisconnectAndShowChoiceAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayConnectionPanel] ChangeGateway FAILED: {ex.Message}");
+            ShowFailure($"Could not disconnect from the Gateway: {ex.Message}", null);
+        }
+    }
+
+    // Clear the stored connection (config.json gateway url + urls + token, and the per-device credential
+    // file), re-apply so the running client drops the old connection immediately, then show the CHOICE so a
+    // different Gateway can be connected. Internal so a headless test can drive the disconnect transaction
+    // without the modal confirm.
+    internal async Task DisconnectAndShowChoiceAsync()
+    {
+        FileLog.Write("[GatewayConnectionPanel] disconnecting from the current gateway");
+        await Task.Run(GatewayCredentialStore.ClearConnection);
+
+        // Re-apply so the running Gateway client picks up the now-empty config and stops presenting the old
+        // per-device key. Uses the same re-apply seam the connect paths use (injectable for tests).
+        var reapply = ReapplyGatewaySeam
+            ?? ((global::Avalonia.Application.Current as App)?.ControlApiHost is { } host ? host.ReapplyGatewayAsync : null);
+        if (reapply is not null)
+            await reapply();
+
+        FileLog.Write("[GatewayConnectionPanel] disconnected; showing the gateway choice");
+        ShowChoice();
     }
 
     // The token is shown masked, never in the clear (decision 7) - same masking as the old pairing dialog.

--- a/src/CcDirector.Core.Tests/GatewayConnection/GatewayChoiceStateMachineTests.cs
+++ b/src/CcDirector.Core.Tests/GatewayConnection/GatewayChoiceStateMachineTests.cs
@@ -40,8 +40,8 @@ public class GatewayChoiceStateMachineTests
 
         // Self-host: disabled where the OS supports it, absent where it does not.
         Assert.Equal(expectedSelfHost, plan.AvailabilityOf(GatewayChoiceAction.SelfHost));
-        // Hosted is a disabled "coming" action everywhere in this slice.
-        Assert.Equal(GatewayChoiceAvailability.Disabled, plan.AvailabilityOf(GatewayChoiceAction.UseHosted));
+        // Hosted is now functional - a browser account sign-in enrolls this machine at the hosted Gateway.
+        Assert.Equal(GatewayChoiceAvailability.Enabled, plan.AvailabilityOf(GatewayChoiceAction.UseHosted));
         // Join and Skip are always enabled.
         Assert.Equal(GatewayChoiceAvailability.Enabled, plan.AvailabilityOf(GatewayChoiceAction.JoinExisting));
         Assert.Equal(GatewayChoiceAvailability.Enabled, plan.AvailabilityOf(GatewayChoiceAction.Skip));
@@ -50,10 +50,10 @@ public class GatewayChoiceStateMachineTests
     }
 
     [Fact]
-    public void SelfHostAndHosted_AreDisabledComingActions_WithAReason_NeverEnabled()
+    public void SelfHost_IsADisabledComingAction_WithAReason_NeverEnabled()
     {
-        // On a host that can self-host, both not-yet-built provisioning actions are shown DISABLED with a
-        // reason - never live buttons that would no-op (dumb-client rule). The reason pin is the value this
+        // On a host that can self-host, the not-yet-built provisioning action is shown DISABLED with a
+        // reason - never a live button that would no-op (dumb-client rule). The reason pin is the value this
         // adds beyond the matrix availability.
         var plan = GatewayChoiceStateMachine.Resolve(
             new GatewayChoiceContext(GatewayChoiceConsumer.Settings, SelfHostSupported: true));
@@ -61,12 +61,19 @@ public class GatewayChoiceStateMachineTests
         var selfHost = Assert.Single(plan.Options, o => o.Action == GatewayChoiceAction.SelfHost);
         Assert.Equal(GatewayChoiceAvailability.Disabled, selfHost.Availability);
         Assert.Equal(GatewayChoiceStateMachine.ComingSoonReason, selfHost.DisabledReason);
+        Assert.NotEqual(GatewayChoiceAvailability.Enabled, selfHost.Availability);
+    }
+
+    [Fact]
+    public void Hosted_IsEnabled_WithNoDisabledReason()
+    {
+        // Hosted is functional now: a browser account sign-in enrolls this machine at the one shared hosted
+        // Gateway, which mints its tenant-scoped device key. It is offered ENABLED (no "coming" reason).
+        var plan = GatewayChoiceStateMachine.Resolve(
+            new GatewayChoiceContext(GatewayChoiceConsumer.Settings, SelfHostSupported: true));
 
         var hosted = Assert.Single(plan.Options, o => o.Action == GatewayChoiceAction.UseHosted);
-        Assert.Equal(GatewayChoiceAvailability.Disabled, hosted.Availability);
-        Assert.Equal(GatewayChoiceStateMachine.ComingSoonReason, hosted.DisabledReason);
-
-        Assert.NotEqual(GatewayChoiceAvailability.Enabled, selfHost.Availability);
-        Assert.NotEqual(GatewayChoiceAvailability.Enabled, hosted.Availability);
+        Assert.Equal(GatewayChoiceAvailability.Enabled, hosted.Availability);
+        Assert.Null(hosted.DisabledReason);
     }
 }

--- a/src/CcDirector.Core.Tests/GatewayCredentialStoreTests.cs
+++ b/src/CcDirector.Core.Tests/GatewayCredentialStoreTests.cs
@@ -94,4 +94,81 @@ public sealed class GatewayCredentialStoreTests : IDisposable
         Assert.Throws<ArgumentException>(() =>
             GatewayCredentialStore.SaveEnrolledKey("https://gw.example.ts.net", ""));
     }
+
+    // Seed the credential file at the CURRENT CC_DIRECTOR_ROOT path (computed fresh). The production
+    // SaveEnrolledKey writes to the cached-static CredentialFile, whose root is locked at first access
+    // assembly-wide; ClearConnection computes the path fresh, so the test must seed the fresh path to match.
+    private static string SeedCredentialFileAtFreshPath(string key)
+    {
+        var path = Path.Combine(CcStorage.Config(), "director", "gateway-token.txt");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, key);
+        return path;
+    }
+
+    [Fact]
+    public void ClearConnection_DeletesCredentialFile_AndClearsConfig()
+    {
+        // Arrange: a connected Director - credential file present and config.json gateway block populated.
+        var credentialFile = SeedCredentialFileAtFreshPath("test-per-device-key-abcdef0123456789");
+        var configPath = CcStorage.ConfigJson();
+        Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+        File.WriteAllText(configPath,
+            """{ "gateway": { "url": "https://gw.example.ts.net", "token": "k", "streamMode": true } }""");
+        Assert.True(File.Exists(credentialFile));
+        Assert.True(GatewayConfig.Load().IsEnabled);
+
+        // Act: disconnect.
+        GatewayCredentialStore.ClearConnection();
+
+        // Assert: the per-device key file is gone and the Director is local-only again.
+        Assert.False(File.Exists(credentialFile), "the per-device credential file must be deleted on disconnect");
+        var config = GatewayConfig.Load();
+        Assert.False(config.IsEnabled);
+        Assert.Equal("", config.Url);
+        Assert.Equal("", config.Token);
+        Assert.Empty(config.Urls);
+        Assert.False(config.StreamMode);
+    }
+
+    [Fact]
+    public void ClearConnection_ClearsTheDiscoveredFallbackUrls()
+    {
+        // A connection discovered from the account also seeds gateway.urls (issue #1233); disconnect must
+        // clear that fallback list too, not just the active url.
+        var configPath = CcStorage.ConfigJson();
+        Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+        File.WriteAllText(configPath,
+            """{ "gateway": { "url": "https://gw.example.ts.net", "token": "k", "urls": ["https://a:7878", "https://b:7878"] } }""");
+        Assert.Equal(2, GatewayConfig.Load().Urls.Count);
+
+        GatewayCredentialStore.ClearConnection();
+
+        Assert.Empty(GatewayConfig.Load().Urls);
+    }
+
+    [Fact]
+    public void ClearConnection_PreservesUnrelatedConfigSections()
+    {
+        // Disconnect touches ONLY the gateway block; a sibling section (here screenshots) must survive.
+        var configPath = CcStorage.ConfigJson();
+        Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+        File.WriteAllText(configPath,
+            """{ "gateway": { "url": "https://gw.example.ts.net", "token": "k" }, "screenshots": { "dir": "D:\\shots" } }""");
+
+        GatewayCredentialStore.ClearConnection();
+
+        var root = JsonNode.Parse(File.ReadAllText(configPath)) as JsonObject;
+        var screenshots = root?["screenshots"] as JsonObject;
+        Assert.NotNull(screenshots);
+        Assert.Equal("D:\\shots", (string?)screenshots["dir"]);
+    }
+
+    [Fact]
+    public void ClearConnection_NoCredentialFile_DoesNotThrow()
+    {
+        // Disconnecting a never-connected Director (no credential file yet) is a no-op clear, not an error.
+        GatewayCredentialStore.ClearConnection();
+        Assert.False(GatewayConfig.Load().IsEnabled);
+    }
 }

--- a/src/CcDirector.Core.Tests/GatewayCredentialStoreTests.cs
+++ b/src/CcDirector.Core.Tests/GatewayCredentialStoreTests.cs
@@ -95,34 +95,26 @@ public sealed class GatewayCredentialStoreTests : IDisposable
             GatewayCredentialStore.SaveEnrolledKey("https://gw.example.ts.net", ""));
     }
 
-    // Seed the credential file at the CURRENT CC_DIRECTOR_ROOT path (computed fresh). The production
-    // SaveEnrolledKey writes to the cached-static CredentialFile, whose root is locked at first access
-    // assembly-wide; ClearConnection computes the path fresh, so the test must seed the fresh path to match.
-    private static string SeedCredentialFileAtFreshPath(string key)
-    {
-        var path = Path.Combine(CcStorage.Config(), "director", "gateway-token.txt");
-        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-        File.WriteAllText(path, key);
-        return path;
-    }
-
     [Fact]
-    public void ClearConnection_DeletesCredentialFile_AndClearsConfig()
+    public void ClearConnection_IsTheInverseOfSaveEnrolledKey_ClearsTheSavedFileAndConfig()
     {
-        // Arrange: a connected Director - credential file present and config.json gateway block populated.
-        var credentialFile = SeedCredentialFileAtFreshPath("test-per-device-key-abcdef0123456789");
-        var configPath = CcStorage.ConfigJson();
-        Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
-        File.WriteAllText(configPath,
-            """{ "gateway": { "url": "https://gw.example.ts.net", "token": "k", "streamMode": true } }""");
-        Assert.True(File.Exists(credentialFile));
+        // A GENUINE save -> clear inverse: SAVE writes the credential to the CredentialFile static path (whose
+        // root is locked at first assembly access) and records the gateway block; CLEAR must remove the SAME
+        // file the save wrote and blank the gateway block. Asserting on GatewayCredentialStore.CredentialFile
+        // (the static path) pins the static-path-cache gotcha: if ClearConnection recomputed a fresh-root path
+        // instead, it would delete a DIFFERENT file and the saved one would survive - reddening this test.
+        const string url = "https://gw.example.ts.net";
+        const string key = "test-per-device-key-abcdef0123456789";
+
+        GatewayCredentialStore.SaveEnrolledKey(url, key);
+        Assert.True(File.Exists(GatewayCredentialStore.CredentialFile),
+            "SaveEnrolledKey must write the per-device key file");
         Assert.True(GatewayConfig.Load().IsEnabled);
 
-        // Act: disconnect.
         GatewayCredentialStore.ClearConnection();
 
-        // Assert: the per-device key file is gone and the Director is local-only again.
-        Assert.False(File.Exists(credentialFile), "the per-device credential file must be deleted on disconnect");
+        Assert.False(File.Exists(GatewayCredentialStore.CredentialFile),
+            "ClearConnection must delete the SAME credential file SaveEnrolledKey wrote");
         var config = GatewayConfig.Load();
         Assert.False(config.IsEnabled);
         Assert.Equal("", config.Url);

--- a/src/CcDirector.Core/Configuration/GatewayCredentialStore.cs
+++ b/src/CcDirector.Core/Configuration/GatewayCredentialStore.cs
@@ -75,19 +75,20 @@ public static class GatewayCredentialStore
     /// so the Director stops presenting a per-device key and the connect flow can point it at a different
     /// Gateway (local or hosted).
     ///
-    /// The credential-file path is computed fresh (not the cached <see cref="CredentialFile"/> static) so a
-    /// test's <c>CC_DIRECTOR_ROOT</c> redirect is honored. MergePatch cannot remove keys, so the connection
+    /// It is the exact inverse of <see cref="SaveEnrolledKey"/>, so it deletes the SAME
+    /// <see cref="CredentialFile"/> that save wrote (not a freshly-recomputed path): the credential a save
+    /// persisted is precisely the one a clear removes. MergePatch cannot remove keys, so the connection
     /// fields are blanked rather than deleted; a blank <c>url</c> is exactly what local-only mode reads.
     /// </summary>
     public static void ClearConnection()
     {
         FileLog.Write("[GatewayCredentialStore] ClearConnection: disconnecting this Director from its Gateway");
 
-        var credentialFile = Path.Combine(CcStorage.Config(), "director", "gateway-token.txt");
-        if (File.Exists(credentialFile))
+        // The SAME file SaveEnrolledKey writes - so save and clear are a true inverse pair on one path.
+        if (File.Exists(CredentialFile))
         {
-            File.Delete(credentialFile);
-            FileLog.Write($"[GatewayCredentialStore] Deleted per-device key file {credentialFile}");
+            File.Delete(CredentialFile);
+            FileLog.Write($"[GatewayCredentialStore] Deleted per-device key file {CredentialFile}");
         }
 
         var patch = new JsonObject

--- a/src/CcDirector.Core/Configuration/GatewayCredentialStore.cs
+++ b/src/CcDirector.Core/Configuration/GatewayCredentialStore.cs
@@ -65,4 +65,43 @@ public static class GatewayCredentialStore
         CcDirectorConfigService.MergePatch(patch);
         FileLog.Write($"[GatewayCredentialStore] Recorded gateway url + per-device key + streamMode=true in config.json (url={gatewayUrl})");
     }
+
+    /// <summary>
+    /// Disconnect this Director from its Gateway: the inverse of <see cref="SaveEnrolledKey"/>. Deletes the
+    /// local per-device credential file (the key that binds this Director to the Gateway) and clears the
+    /// gateway block in config.json - the active <c>url</c>, the discovered <c>urls</c> fallback list, the
+    /// <c>token</c>, the <c>tailnetEndpoint</c> override, and turns the persistent stream off. After this,
+    /// <see cref="GatewayConfig.Load"/> reports local-only (<see cref="GatewayConfig.IsEnabled"/> is false),
+    /// so the Director stops presenting a per-device key and the connect flow can point it at a different
+    /// Gateway (local or hosted).
+    ///
+    /// The credential-file path is computed fresh (not the cached <see cref="CredentialFile"/> static) so a
+    /// test's <c>CC_DIRECTOR_ROOT</c> redirect is honored. MergePatch cannot remove keys, so the connection
+    /// fields are blanked rather than deleted; a blank <c>url</c> is exactly what local-only mode reads.
+    /// </summary>
+    public static void ClearConnection()
+    {
+        FileLog.Write("[GatewayCredentialStore] ClearConnection: disconnecting this Director from its Gateway");
+
+        var credentialFile = Path.Combine(CcStorage.Config(), "director", "gateway-token.txt");
+        if (File.Exists(credentialFile))
+        {
+            File.Delete(credentialFile);
+            FileLog.Write($"[GatewayCredentialStore] Deleted per-device key file {credentialFile}");
+        }
+
+        var patch = new JsonObject
+        {
+            ["gateway"] = new JsonObject
+            {
+                ["url"] = "",
+                ["urls"] = new JsonArray(),
+                ["token"] = "",
+                ["tailnetEndpoint"] = "",
+                ["streamMode"] = false,
+            },
+        };
+        CcDirectorConfigService.MergePatch(patch);
+        FileLog.Write("[GatewayCredentialStore] Cleared gateway url + urls + token + tailnetEndpoint + streamMode in config.json (disconnected)");
+    }
 }

--- a/src/CcDirector.Core/GatewayConnection/GatewayChoice.cs
+++ b/src/CcDirector.Core/GatewayConnection/GatewayChoice.cs
@@ -13,7 +13,8 @@ public enum GatewayChoiceAction
     /// <summary>Provision and run a Gateway on this computer. Windows-only; not built yet (slice #1808b/#1810).</summary>
     SelfHost,
 
-    /// <summary>Use the DevThrottle-hosted Gateway. Not built yet (slice #1808c/#1811).</summary>
+    /// <summary>Use the DevThrottle-hosted Gateway. Functional - a browser account sign-in whose token is
+    /// enrolled at the hosted Gateway, which mints this machine's tenant-scoped device key.</summary>
     UseHosted,
 
     /// <summary>Connect to a Gateway that is already running (on the network, over Tailscale, or on the
@@ -140,7 +141,8 @@ public sealed record GatewayChoicePlan(
 /// the UI. The load-bearing rules it enforces:
 ///   - Self-host is Windows-only. Where the host cannot self-host (a Mac), the action is ABSENT, not a
 ///     disabled tease. Where it can, it is DISABLED "coming" in this slice - the orchestrator is #1808b/#1810.
-///   - Hosted is DISABLED "coming" everywhere in this slice - the provisioning is #1808c/#1811.
+///   - Hosted is always ENABLED - a browser account sign-in enrolls this machine at the one shared hosted
+///     Gateway, which mints its tenant-scoped device key (there is no address to type and nothing to provision).
 ///   - Join is always ENABLED - it drives the existing scan / manual-URL / enroll flow.
 ///   - Skip is always ENABLED; what it DOES is per-consumer (onboarding completes local-only, others return).
 /// </summary>
@@ -155,8 +157,9 @@ public static class GatewayChoiceStateMachine
         var options = new List<GatewayChoiceOption>
         {
             ResolveSelfHost(context),
-            // Hosted has no provisioning yet (#1808c/#1811): offered, clearly disabled, never live.
-            new(GatewayChoiceAction.UseHosted, GatewayChoiceAvailability.Disabled, ComingSoonReason),
+            // Hosted is functional: a browser account sign-in enrolls this machine at the one shared hosted
+            // Gateway, which mints its tenant-scoped device key. No address to type, nothing to provision.
+            new(GatewayChoiceAction.UseHosted, GatewayChoiceAvailability.Enabled, null),
             // Join drives today's scan / manual-URL / enroll flow - always available.
             new(GatewayChoiceAction.JoinExisting, GatewayChoiceAvailability.Enabled, null),
             // Skip is always available; SkipBehavior below says what it does for this consumer.


### PR DESCRIPTION
## Why

The Director Settings -> Gateway tab could show "Connected to Gateway on <host> / Signed in as <email>" but offered **no way to switch gateways**, and the connect flow's "Use hosted" choice was disabled ("coming"). This gives the user a full change-gateway path from the UI - disconnect from the current gateway and reconnect to a different one, local **or** hosted - and turns the hosted choice on.

## What changed

### 1. Change gateway / disconnect (`GatewayConnectionPanel` Done view)
- New **"Change gateway"** button on the connected (Done) view. On click it confirms (`This will disconnect this Director from <gateway>. Continue?`), then disconnects and returns to the step-0 gateway **choice** so the user can connect to a different gateway.
- Disconnect is a new **`GatewayCredentialStore.ClearConnection()`** - the inverse of `SaveEnrolledKey`. It deletes the per-device credential file that binds this Director and clears the gateway block in `config.json` (`url`, the `urls` fallback array, `token`, `tailnetEndpoint`, and `streamMode` off), so `GatewayConfig.Load` reports local-only. The credential path is computed fresh so the redirect used in tests is honored; the config write deep-merges so sibling sections survive.

### 2. Enable the hosted choice
- `GatewayChoiceStateMachine` now marks `UseHosted` **Enabled** (was a disabled "coming" action).
- The panel wires the hosted card to the **same proven hosted enroll the CLI's `enroll --hosted` runs**: `GatewayAccountEnrollRunner.SignInAndEnrollHostedAsync` (browser account sign-in whose account token is enrolled at the hosted gateway, which mints this machine's tenant-scoped device key). The mint is **not** reimplemented. On success the panel re-applies and handshakes to the signed-in Done view; on failure it shows a clear inline error, never a silent no-op. A test seam runs the flow headless with no browser or network.

### 3. Self-host / local join path unchanged
The whole point: from the UI the user can disconnect and reconnect to **either** a local gateway or the hosted gateway - one stored `config.json`, one machine.

## Tests
- **Core:** `ClearConnection` deletes the credential file, clears `url`/`urls`/`token`/`streamMode`, clears the discovered fallback urls, preserves unrelated config sections, and is a safe no-op with no credential file. State machine: hosted is Enabled with no disabled reason; self-host stays disabled-coming.
- **Avalonia:** the hosted card is enabled and its enroll runs with this device id; a failed hosted enroll does not re-apply or mutate config; a successful one re-applies the verified credential; disconnect clears the stored connection, re-applies, and re-shows the choice. Updated the prior asserts that expected hosted disabled.

## Verification
- Full solution test suite green - all seven projects, 0 failures (Core 3364, Gateway 3070, Avalonia 226, HostedAgent 86, Engine 62, Launcher 27, Terminal.Avalonia 21; skips are the usual environment-gated ones).
- Cockpit + mobile web builds and all workspace typechecks green.
