### PR TITLE
release: v1.7.1 - change gateway from the app

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
   </PropertyGroup>
 </Project>

--- a/docs/public/release-notes/v1.7.1.md
+++ b/docs/public/release-notes/v1.7.1.md
@@ -1,0 +1,10 @@
+## v1.7.1 - July 21, 2026
+
+You can now change which gateway a Director connects to from the app - disconnect and reconnect to a local or the hosted gateway without editing any files.
+
+### Highlights
+- Change gateway from the app: Settings -> Gateway now has a "Change gateway" button. It disconnects this Director from its current gateway and takes you back to the connect screen, where you can connect to a different one - a gateway on your own machine or the DevThrottle hosted gateway. No config files, no command line.
+- Connect to the hosted gateway with one click: the "Use hosted" choice is now live. Sign in with your DevThrottle account in the browser and this machine joins the hosted gateway under your account - there is no address to type.
+
+### Also in this release
+- If applying a new connection does not take effect immediately, the app now tells you clearly ("signed in, but could not apply the new connection - try again or restart") instead of sitting on "Connecting".


### PR DESCRIPTION
Bumps to 1.7.1 + release notes. Ships the Change gateway button (disconnect/reconnect to local or hosted from the UI, Use hosted enabled).