### PR TITLE
Show gateway host with connection state in desktop status box

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -246,15 +246,20 @@
                         Cursor="Hand"
                         PointerPressed="GatewayStatusBox_PointerPressed">
                     <StackPanel Spacing="6">
-                        <!-- Line 1: Gateway reachable (the two-way handshake). -->
-                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                        <!-- Line 1: WHICH gateway this Director is pointed at. The marker (green check /
+                             amber ring / red cross) carries connected / connecting / failed, so the line text
+                             names the gateway host instead of repeating "Connected"; the four-color box border
+                             carries the visual state. With no gateway selected yet (brand new) the host is empty
+                             and this whole row is hidden from code-behind so the box does not pretend a verdict
+                             it cannot have. -->
+                        <StackPanel x:Name="GatewayConnectedRow" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                             <Viewbox Width="15" Height="15" VerticalAlignment="Center">
                                 <Path x:Name="GatewayConnectedMarker"
                                       Fill="#F0B848"
                                       Data="M8,1 A7,7 0 1 0 8,15 A7,7 0 1 0 8,1 Z M8,3 A5,5 0 1 1 8,13 A5,5 0 1 1 8,3 Z" />
                             </Viewbox>
                             <TextBlock x:Name="GatewayConnectedLine"
-                                       Text="Connect to Gateway"
+                                       Text=""
                                        FontSize="11" FontWeight="SemiBold"
                                        Foreground="#F0B848"
                                        TextWrapping="Wrap" MaxWidth="176"

--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -232,9 +232,9 @@
                      section 6). The two former boxes (GatewayIndicator + AccountIndicator) are merged
                      into ONE box with two check lines and four visual states:
                        AMBER  = needs attention (NotConfigured, or Connected but not signed in);
-                       YELLOW = a handshake is verifying ("Connecting...");
+                       YELLOW = a handshake is verifying (gateway host + "Connecting...");
                        GREEN  = handshake proven AND the Gateway reports signed in (both lines filled);
-                       RED    = a leg failed, or was working and is now unreachable (the leg is named).
+                       RED    = connection failed, or was working and is now unreachable (gateway host + verdict).
                      GREEN is EARNED - the two-way nonce handshake for line 1, the Gateway's own account
                      report for line 2; a heartbeat or a cached value never paints either green. One click
                      opens the Gateway Connection panel on the resolver's current step. All colors, glyphs,
@@ -244,14 +244,15 @@
                         Margin="8,0,8,4" Padding="10,8" CornerRadius="4"
                         Background="#3A331B" BorderBrush="#F0B848" BorderThickness="1"
                         Cursor="Hand"
+                        Focusable="True"
+                        KeyDown="GatewayStatusBox_KeyDown"
                         PointerPressed="GatewayStatusBox_PointerPressed">
                     <StackPanel Spacing="6">
                         <!-- Line 1: WHICH gateway this Director is pointed at. The marker (green check /
-                             amber ring / red cross) carries connected / connecting / failed, so the line text
-                             names the gateway host instead of repeating "Connected"; the four-color box border
-                             carries the visual state. With no gateway selected yet (brand new) the host is empty
-                             and this whole row is hidden from code-behind so the box does not pretend a verdict
-                             it cannot have. -->
+                             amber ring / red cross) reinforces connected / connecting / failed. The line names
+                             the gateway host first and appends the resolved verdict in parentheses, so neither
+                             color nor glyph is the only way to learn the state. With no gateway selected yet
+                             (brand new) the host is empty and this whole row is hidden from code-behind. -->
                         <StackPanel x:Name="GatewayConnectedRow" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                             <Viewbox Width="15" Height="15" VerticalAlignment="Center">
                                 <Path x:Name="GatewayConnectedMarker"

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -484,6 +484,12 @@ public partial class MainWindow : Window
     /// </summary>
     private void WireGatewayStatusBox()
     {
+        // Seed the gateway host the box shows on line 1 from config NOW, rather than waiting for the first
+        // account-status poll to populate _boxGatewayHost. Without this a configured-Director startup
+        // would briefly paint line 1 empty (looking brand-new) until the poll returns; the poll later
+        // refreshes these same fields authoritatively.
+        SeedGatewayConfigFields();
+
         // Line 2 of the box (account signed-in) is fed by a heartbeat poll of the Gateway's
         // GET /account/status; line 1 (Gateway reachable) is fed by the GatewayConnectionMonitor
         // attached below. Both repaint the one box through GatewayStatusBoxPresenter.
@@ -496,6 +502,23 @@ public partial class MainWindow : Window
         _gatewayAttachTimer.Tick += (_, _) => TryAttachGatewayMonitor();
         _gatewayAttachTimer.Start();
         TryAttachGatewayMonitor();
+    }
+
+    // Read the configured gateway right now so line 1 of the box knows WHICH gateway to name before any
+    // network read returns. Cheap config-file read (same one RefreshAccountStatusAsync does on the UI
+    // thread); account fields are left untouched - the poll owns those.
+    private void SeedGatewayConfigFields()
+    {
+        try
+        {
+            var config = GatewayConfig.Load();
+            _boxGatewayConfigured = !string.IsNullOrWhiteSpace(config.Url);
+            _boxGatewayHost = SafeHost(config.Url);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[MainWindow] SeedGatewayConfigFields FAILED: {ex.Message}");
+        }
     }
 
     private void TryAttachGatewayMonitor()
@@ -613,6 +636,10 @@ public partial class MainWindow : Window
         GatewayStatusBox.BorderBrush = Brush.Parse(border);
         PaintCheckLine(GatewayConnectedMarker, GatewayConnectedLine, content.Connected);
         PaintCheckLine(GatewaySignedInMarker, GatewaySignedInLine, content.SignedIn);
+        // Line 1 names WHICH gateway; when none is selected yet the line is empty and the whole row is
+        // hidden so a brand-new box does not show a marker with no verdict. (Line 2 never goes empty, so
+        // the same rule never collapses the Sign in nudge.)
+        GatewayConnectedRow.IsVisible = !string.IsNullOrEmpty(content.Connected.Text);
         ToolTip.SetTip(GatewayStatusBox, content.Tooltip);
 
         // A missing gateway is NOT an error (a legitimate local-only Director); only the red failure

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Http;
 using System.Net.Http.Json;
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
@@ -484,11 +485,9 @@ public partial class MainWindow : Window
     /// </summary>
     private void WireGatewayStatusBox()
     {
-        // Seed the gateway host the box shows on line 1 from config NOW, rather than waiting for the first
-        // account-status poll to populate _boxGatewayHost. Without this a configured-Director startup
-        // would briefly paint line 1 empty (looking brand-new) until the poll returns; the poll later
-        // refreshes these same fields authoritatively.
-        SeedGatewayConfigFields();
+        // Seed the gateway host the box shows on line 1 from config NOW. Without this a configured-Director
+        // startup would briefly paint line 1 empty (looking brand-new) before the monitor attaches.
+        RefreshGatewayConfigFields();
 
         // Line 2 of the box (account signed-in) is fed by a heartbeat poll of the Gateway's
         // GET /account/status; line 1 (Gateway reachable) is fed by the GatewayConnectionMonitor
@@ -507,18 +506,11 @@ public partial class MainWindow : Window
     // Read the configured gateway right now so line 1 of the box knows WHICH gateway to name before any
     // network read returns. Cheap config-file read (same one RefreshAccountStatusAsync does on the UI
     // thread); account fields are left untouched - the poll owns those.
-    private void SeedGatewayConfigFields()
+    private void RefreshGatewayConfigFields()
     {
-        try
-        {
-            var config = GatewayConfig.Load();
-            _boxGatewayConfigured = !string.IsNullOrWhiteSpace(config.Url);
-            _boxGatewayHost = SafeHost(config.Url);
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[MainWindow] SeedGatewayConfigFields FAILED: {ex.Message}");
-        }
+        var config = GatewayConfig.Load();
+        _boxGatewayConfigured = config.IsEnabled;
+        _boxGatewayHost = SafeHost(config.Url);
     }
 
     private void TryAttachGatewayMonitor()
@@ -530,13 +522,25 @@ public partial class MainWindow : Window
         _gatewayMonitor = host.GatewayMonitor;
         _gatewayMonitor.Changed += () => Dispatcher.UIThread.Post(() =>
         {
-            UpdateGatewayStatusBox();
-            // The rail's offline floor (SessionViewModel.EffectiveColor) renders blue/red from local activity
-            // whenever the tunnel is not Connected, and Connected's stamp otherwise. A connect/disconnect
-            // carries none of the per-session events a row hears, so repaint every row from here - the one
-            // place that owns the GatewayConnectionMonitor subscription - or a settled row keeps its old dot
-            // until an unrelated event happens to repaint it.
-            foreach (var vm in _sessions) vm.RefreshGatewayFloor();
+            try
+            {
+                // ReapplyGatewayAsync resets this same monitor after loading the new config. Refresh the
+                // display identity before repainting so a change or disconnect can never pair the new verdict
+                // with the previous gateway host. The account poll deliberately does not own these fields.
+                RefreshGatewayConfigFields();
+                UpdateGatewayStatusBox();
+                // The rail's offline floor (SessionViewModel.EffectiveColor) renders blue/red from local activity
+                // whenever the tunnel is not Connected, and Connected's stamp otherwise. A connect/disconnect
+                // carries none of the per-session events a row hears, so repaint every row from here - the one
+                // place that owns the GatewayConnectionMonitor subscription - or a settled row keeps its old dot
+                // until an unrelated event happens to repaint it.
+                foreach (var vm in _sessions) vm.RefreshGatewayFloor();
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[MainWindow] Gateway monitor change handling FAILED: {ex}");
+                ShowNotification("Gateway status could not be refreshed. Open Gateway settings for details.");
+            }
         });
 
         // Same host: wire the Control-API status indicator. The bind may have already failed
@@ -546,6 +550,7 @@ public partial class MainWindow : Window
 
         _gatewayAttachTimer?.Stop();
         _gatewayAttachTimer = null;
+        RefreshGatewayConfigFields();
         UpdateGatewayStatusBox();
         UpdateControlApiIndicator();
         FileLog.Write("[MainWindow] Gateway status box attached to GatewayConnectionMonitor");
@@ -641,6 +646,11 @@ public partial class MainWindow : Window
         // the same rule never collapses the Sign in nudge.)
         GatewayConnectedRow.IsVisible = !string.IsNullOrEmpty(content.Connected.Text);
         ToolTip.SetTip(GatewayStatusBox, content.Tooltip);
+        var accessibleName = string.IsNullOrEmpty(content.Connected.Text)
+            ? content.SignedIn.Text
+            : $"{content.Connected.Text}. {content.SignedIn.Text}";
+        AutomationProperties.SetName(GatewayStatusBox, accessibleName);
+        AutomationProperties.SetHelpText(GatewayStatusBox, content.Tooltip);
 
         // A missing gateway is NOT an error (a legitimate local-only Director); only the red failure
         // states count against readiness and surface a problem row on the status screen.
@@ -699,7 +709,7 @@ public partial class MainWindow : Window
     {
         GatewayCheckState.Passed => (GatewayIconCheck, "#22C55E"),   // green filled check
         GatewayCheckState.Working => (GatewayIconRing, "#F0B848"),   // amber ring, in progress
-        GatewayCheckState.Failed => (GatewayIconCross, "#EF4444"),   // red cross, named leg
+        GatewayCheckState.Failed => (GatewayIconCross, "#EF4444"),   // red cross, connection failed
         GatewayCheckState.Pending => (GatewayIconRing, "#F0B848"),   // amber ring, the actionable nudge
         _ => (GatewayIconRing, "#777777"),                           // muted ring, cannot tell yet
     };
@@ -709,7 +719,7 @@ public partial class MainWindow : Window
         GatewayStatusBoxVisual.Green => ("#1B3A2A", "#22C55E"),
         GatewayStatusBoxVisual.Red => ("#3A1B1B", "#DC2626"),
         // Amber (needs attention) and Yellow (verifying) share the warm scheme; the line content and
-        // markers carry the distinction (line 1 "Connecting..." with a working ring for yellow).
+        // markers carry the distinction (line 1 appends "(Connecting...)" for yellow).
         _ => ("#3A331B", "#F0B848"),
     };
 
@@ -728,7 +738,23 @@ public partial class MainWindow : Window
         }
         catch (Exception ex)
         {
-            FileLog.Write($"[MainWindow] GatewayStatusBox_PointerPressed FAILED: {ex.Message}");
+            FileLog.Write($"[MainWindow] GatewayStatusBox_PointerPressed FAILED: {ex}");
+        }
+    }
+
+    private void GatewayStatusBox_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key is not (Key.Enter or Key.Space)) return;
+
+        e.Handled = true;
+        try
+        {
+            FileLog.Write("[MainWindow] GatewayStatusBox keyboard activation; opening the connection panel on its current step");
+            OpenGatewayConnectionPanel();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[MainWindow] GatewayStatusBox_KeyDown FAILED: {ex}");
         }
     }
 
@@ -833,18 +859,17 @@ public partial class MainWindow : Window
 
     /// <summary>
     /// Fold the Gateway's account status into the status box's line-2 inputs and repaint (spec sections 4,
-    /// 6): the signed-in state, the email (shown on the green line only), whether this device holds its own
-    /// token, whether a Gateway is configured, and the Gateway host for the tooltip. An unreachable or
-    /// not-configured Gateway maps to a MUTED "cannot tell yet" - never a false sign-out (decision 3). The
-    /// email is used only to render the identity; no token ever reaches the box (security DT-05).
+    /// 6): the signed-in state, the email (shown on the green line only), and whether this device holds its
+    /// own token. Gateway configuration and host are refreshed with the connection monitor so an older
+    /// account read can never overwrite line one after a gateway change. An unreachable or not-configured
+    /// Gateway maps to a MUTED "cannot tell yet" - never a false sign-out (decision 3). The email is used
+    /// only to render the identity; no token ever reaches the box (security DT-05).
     /// </summary>
     private void ApplyAccountStatus(GatewayConfig config, GatewayAccountStatus status)
     {
         _boxAccount = MapAccount(status);
         _boxAccountEmail = status.SignedIn ? status.Email : null;
         _boxDeviceKeyPresent = !string.IsNullOrWhiteSpace(config.Token);
-        _boxGatewayConfigured = status.GatewayConfigured;
-        _boxGatewayHost = SafeHost(config.Url);
 
         // Log the state and booleans, never the email (PII; CodingStyle Section 4 / 12).
         FileLog.Write($"[MainWindow] ApplyAccountStatus: account={_boxAccount}, deviceKey={_boxDeviceKeyPresent}, configured={status.GatewayConfigured}, reachable={status.Reachable}");

--- a/src/CcDirector.Core.Tests/GatewayConnection/GatewayStatusBoxPresenterTests.cs
+++ b/src/CcDirector.Core.Tests/GatewayConnection/GatewayStatusBoxPresenterTests.cs
@@ -6,11 +6,12 @@ namespace CcDirector.Core.Tests.GatewayConnection;
 /// <summary>
 /// Proves the single status box's presenter (design spec section 6): the pure mapping that turns a live
 /// verification snapshot into the box's four visual states and its two check lines. These tests pin the
-/// four looks and the load-bearing line-text rules the Architect confirmed for Phase 3: amber covers BOTH
-/// not-configured (line 1 "Connect to Gateway") and connected-not-signed-in (line 1 "Connected", line 2
-/// "Sign in"); yellow is "Connecting..."; green shows the account email on line 2; and red names the
-/// failing leg on line 1 for both the first-time failure and the was-working-now-unreachable case. The
-/// presenter has no UI and no I/O, so it is fully unit-tested here.
+/// four looks and the Connected-line rule: the marker carries the verdict (green check / amber ring / red
+/// cross) and the line names WHICH gateway - the host in every state where a gateway is configured
+/// (connected, connecting, AND failed, so the person can see which gateway is unreachable), and empty when
+/// no gateway is selected yet. Line 2 still shows the account identity or the "Sign in" nudge. The named
+/// failing leg moved off the box into the tooltip and the panel's repair banner. The presenter has no UI
+/// and no I/O, so it is fully unit-tested here.
 /// </summary>
 public sealed class GatewayStatusBoxPresenterTests
 {
@@ -26,8 +27,10 @@ public sealed class GatewayStatusBoxPresenterTests
     // ---- The four visual states -----------------------------------------------------------------
 
     [Fact]
-    public void Describe_NotConfigured_IsAmber_BothLinesShowNextAction()
+    public void Describe_NotConfigured_IsAmber_ConnectedLineEmptySignInNudge()
     {
+        // Brand new: no gateway selected yet. Line 1 carries no verdict it cannot have - it is left empty
+        // (the surface hides the row), so the box does not pretend a connection state. Line 2 still nudges.
         var inputs = new GatewayConnectionInputs(
             GatewayConfigured: false,
             Connection: GatewayConnectionVerification.Unknown,
@@ -40,7 +43,7 @@ public sealed class GatewayStatusBoxPresenterTests
 
         Assert.Equal(GatewayStatusBoxVisual.Amber, content.Visual);
         Assert.Equal(GatewayCheckState.Pending, content.Connected.Marker);
-        Assert.Equal("Connect to Gateway", content.Connected.Text);
+        Assert.Equal(string.Empty, content.Connected.Text);
         Assert.Equal("Sign in", content.SignedIn.Text);
     }
 
@@ -58,7 +61,8 @@ public sealed class GatewayStatusBoxPresenterTests
 
         Assert.Equal(GatewayStatusBoxVisual.Amber, content.Visual);
         Assert.Equal(GatewayCheckState.Passed, content.Connected.Marker);
-        Assert.Equal("Connected", content.Connected.Text);
+        // Line 1 names WHICH gateway; the green checkmarker carries "connected".
+        Assert.Equal("SOREN_NORTH", content.Connected.Text);
         Assert.Equal(GatewayCheckState.Pending, content.SignedIn.Marker);
         Assert.Equal("Sign in", content.SignedIn.Text);
     }
@@ -77,7 +81,8 @@ public sealed class GatewayStatusBoxPresenterTests
 
         Assert.Equal(GatewayStatusBoxVisual.Yellow, content.Visual);
         Assert.Equal(GatewayCheckState.Working, content.Connected.Marker);
-        Assert.Equal("Connecting...", content.Connected.Text);
+        // The amber working-ring carries "connecting"; the line names the gateway.
+        Assert.Equal("SOREN_NORTH", content.Connected.Text);
     }
 
     [Fact]
@@ -88,7 +93,7 @@ public sealed class GatewayStatusBoxPresenterTests
 
         Assert.Equal(GatewayStatusBoxVisual.Green, content.Visual);
         Assert.Equal(GatewayCheckState.Passed, content.Connected.Marker);
-        Assert.Equal("Connected", content.Connected.Text);
+        Assert.Equal("SOREN_NORTH", content.Connected.Text);
         Assert.Equal(GatewayCheckState.Passed, content.SignedIn.Marker);
         Assert.Equal("Signed in: soren@centerconsulting.com", content.SignedIn.Text);
     }
@@ -103,10 +108,13 @@ public sealed class GatewayStatusBoxPresenterTests
         Assert.Equal("Signed in", content.SignedIn.Text);
     }
 
+    // Both red states show WHICH gateway is unreachable on line 1 - the named failing leg moved off the
+    // line into the tooltip and the panel's repair banner; the red cross marker carries "failed".
+
     [Fact]
-    public void Describe_ConnectFailedCallback_IsRed_NamesTheCallbackLeg()
+    public void Describe_ConnectFailed_IsRed_ConnectedLineShowsGatewayHost()
     {
-        // A first-time connect failure on the callback leg: red, and the failing leg named (decision 11).
+        // A first-time connect failure: red, line 1 names the (unreachable) gateway, not the leg.
         var inputs = AllGreenInputs() with
         {
             Connection = GatewayConnectionVerification.Failed,
@@ -120,13 +128,13 @@ public sealed class GatewayStatusBoxPresenterTests
 
         Assert.Equal(GatewayStatusBoxVisual.Red, content.Visual);
         Assert.Equal(GatewayCheckState.Failed, content.Connected.Marker);
-        Assert.Equal("Gateway cannot reach this Director back", content.Connected.Text);
+        Assert.Equal("SOREN_NORTH", content.Connected.Text);
     }
 
     [Fact]
-    public void Describe_WasConnectedNowUnreachable_IsRed_NamesOutboundLeg()
+    public void Describe_WasConnectedNowUnreachable_IsRed_ConnectedLineShowsGatewayHost()
     {
-        // Mid-session Gateway drop: was working this run, now the handshake fails on the outbound leg.
+        // Mid-session Gateway drop: was working this run, now unreachable. Same line-1 rule: name the gateway.
         var inputs = AllGreenInputs() with
         {
             Connection = GatewayConnectionVerification.Failed,
@@ -139,7 +147,7 @@ public sealed class GatewayStatusBoxPresenterTests
 
         Assert.Equal(GatewayStatusBoxVisual.Red, content.Visual);
         Assert.Equal(GatewayCheckState.Failed, content.Connected.Marker);
-        Assert.Equal("Cannot reach the Gateway", content.Connected.Text);
+        Assert.Equal("SOREN_NORTH", content.Connected.Text);
     }
 
     // ---- Load-bearing rules ---------------------------------------------------------------------

--- a/src/CcDirector.Core.Tests/GatewayConnection/GatewayStatusBoxPresenterTests.cs
+++ b/src/CcDirector.Core.Tests/GatewayConnection/GatewayStatusBoxPresenterTests.cs
@@ -6,8 +6,8 @@ namespace CcDirector.Core.Tests.GatewayConnection;
 /// <summary>
 /// Proves the single status box's presenter (design spec section 6): the pure mapping that turns a live
 /// verification snapshot into the box's four visual states and its two check lines. These tests pin the
-/// four looks and the Connected-line rule: the marker carries the verdict (green check / amber ring / red
-/// cross) and the line names WHICH gateway - the host in every state where a gateway is configured
+/// four looks and the Connected-line rule: the marker reinforces the verdict (green check / amber ring / red
+/// cross) and the line names WHICH gateway plus the resolved state - the host in every configured state
 /// (connected, connecting, AND failed, so the person can see which gateway is unreachable), and empty when
 /// no gateway is selected yet. Line 2 still shows the account identity or the "Sign in" nudge. The named
 /// failing leg moved off the box into the tooltip and the panel's repair banner. The presenter has no UI
@@ -61,8 +61,7 @@ public sealed class GatewayStatusBoxPresenterTests
 
         Assert.Equal(GatewayStatusBoxVisual.Amber, content.Visual);
         Assert.Equal(GatewayCheckState.Passed, content.Connected.Marker);
-        // Line 1 names WHICH gateway; the green checkmarker carries "connected".
-        Assert.Equal("SOREN_NORTH", content.Connected.Text);
+        Assert.Equal("SOREN_NORTH (Connected)", content.Connected.Text);
         Assert.Equal(GatewayCheckState.Pending, content.SignedIn.Marker);
         Assert.Equal("Sign in", content.SignedIn.Text);
     }
@@ -81,8 +80,7 @@ public sealed class GatewayStatusBoxPresenterTests
 
         Assert.Equal(GatewayStatusBoxVisual.Yellow, content.Visual);
         Assert.Equal(GatewayCheckState.Working, content.Connected.Marker);
-        // The amber working-ring carries "connecting"; the line names the gateway.
-        Assert.Equal("SOREN_NORTH", content.Connected.Text);
+        Assert.Equal("SOREN_NORTH (Connecting...)", content.Connected.Text);
     }
 
     [Fact]
@@ -93,7 +91,7 @@ public sealed class GatewayStatusBoxPresenterTests
 
         Assert.Equal(GatewayStatusBoxVisual.Green, content.Visual);
         Assert.Equal(GatewayCheckState.Passed, content.Connected.Marker);
-        Assert.Equal("SOREN_NORTH", content.Connected.Text);
+        Assert.Equal("SOREN_NORTH (Connected)", content.Connected.Text);
         Assert.Equal(GatewayCheckState.Passed, content.SignedIn.Marker);
         Assert.Equal("Signed in: soren@centerconsulting.com", content.SignedIn.Text);
     }
@@ -108,13 +106,13 @@ public sealed class GatewayStatusBoxPresenterTests
         Assert.Equal("Signed in", content.SignedIn.Text);
     }
 
-    // Both red states show WHICH gateway is unreachable on line 1 - the named failing leg moved off the
-    // line into the tooltip and the panel's repair banner; the red cross marker carries "failed".
+    // Both red states show WHICH gateway is unreachable plus a compact verdict on line 1. The named failing
+    // leg stays in the tooltip and panel repair banner; the red cross reinforces the failure.
 
     [Fact]
     public void Describe_ConnectFailed_IsRed_ConnectedLineShowsGatewayHost()
     {
-        // A first-time connect failure: red, line 1 names the (unreachable) gateway, not the leg.
+        // A first-time connect failure: red, line 1 names the gateway and compact verdict, not the leg.
         var inputs = AllGreenInputs() with
         {
             Connection = GatewayConnectionVerification.Failed,
@@ -128,13 +126,14 @@ public sealed class GatewayStatusBoxPresenterTests
 
         Assert.Equal(GatewayStatusBoxVisual.Red, content.Visual);
         Assert.Equal(GatewayCheckState.Failed, content.Connected.Marker);
-        Assert.Equal("SOREN_NORTH", content.Connected.Text);
+        Assert.Equal("SOREN_NORTH (Connection failed)", content.Connected.Text);
+        Assert.Contains("The Gateway cannot reach this Director back.", content.Tooltip);
     }
 
     [Fact]
     public void Describe_WasConnectedNowUnreachable_IsRed_ConnectedLineShowsGatewayHost()
     {
-        // Mid-session Gateway drop: was working this run, now unreachable. Same line-1 rule: name the gateway.
+        // Mid-session Gateway drop: was working this run, now unreachable. Same line-1 rule: host first.
         var inputs = AllGreenInputs() with
         {
             Connection = GatewayConnectionVerification.Failed,
@@ -147,7 +146,64 @@ public sealed class GatewayStatusBoxPresenterTests
 
         Assert.Equal(GatewayStatusBoxVisual.Red, content.Visual);
         Assert.Equal(GatewayCheckState.Failed, content.Connected.Marker);
-        Assert.Equal("SOREN_NORTH", content.Connected.Text);
+        Assert.Equal("SOREN_NORTH (Unreachable)", content.Connected.Text);
+        Assert.Contains("This Director cannot reach the Gateway.", content.Tooltip);
+    }
+
+    [Fact]
+    public void Describe_ConfiguredPending_ShowsGatewayHostAndConnectingVerdict()
+    {
+        var inputs = new GatewayConnectionInputs(
+            GatewayConfigured: true,
+            Connection: GatewayConnectionVerification.Unknown,
+            FailedLeg: GatewayConnectionFailedLeg.None,
+            WasEverConnected: false,
+            DeviceKeyPresent: false,
+            Account: GatewayAccountSignInState.Unknown);
+
+        var content = GatewayStatusBoxPresenter.Describe(inputs, gatewayHost: "SOREN_NORTH", accountEmail: null);
+
+        Assert.Equal(GatewayStatusBoxVisual.Yellow, content.Visual);
+        Assert.Equal(GatewayCheckState.Pending, content.Connected.Marker);
+        Assert.Equal("SOREN_NORTH (Connecting...)", content.Connected.Text);
+    }
+
+    [Fact]
+    public void Describe_NotConfiguredWithStaleHost_ConnectedLineStillEmpty()
+    {
+        var inputs = new GatewayConnectionInputs(
+            GatewayConfigured: false,
+            Connection: GatewayConnectionVerification.Unknown,
+            FailedLeg: GatewayConnectionFailedLeg.None,
+            WasEverConnected: false,
+            DeviceKeyPresent: false,
+            Account: GatewayAccountSignInState.Unknown);
+
+        var content = GatewayStatusBoxPresenter.Describe(inputs, gatewayHost: "OLD_GATEWAY", accountEmail: null);
+
+        Assert.Equal(string.Empty, content.Connected.Text);
+    }
+
+    [Theory]
+    [InlineData(GatewayConnectionVerification.Unknown)]
+    [InlineData(GatewayConnectionVerification.Verifying)]
+    [InlineData(GatewayConnectionVerification.Connected)]
+    [InlineData(GatewayConnectionVerification.Failed)]
+    public void Describe_ConfiguredWithoutHost_ThrowsInvalidOperationException(
+        GatewayConnectionVerification connection)
+    {
+        var inputs = new GatewayConnectionInputs(
+            GatewayConfigured: true,
+            Connection: connection,
+            FailedLeg: connection == GatewayConnectionVerification.Failed
+                ? GatewayConnectionFailedLeg.OutboundReach
+                : GatewayConnectionFailedLeg.None,
+            WasEverConnected: false,
+            DeviceKeyPresent: false,
+            Account: GatewayAccountSignInState.Unknown);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            GatewayStatusBoxPresenter.Describe(inputs, gatewayHost: null, accountEmail: null));
     }
 
     // ---- Load-bearing rules ---------------------------------------------------------------------

--- a/src/CcDirector.Core/GatewayConnection/GatewayConnectionStateResolver.cs
+++ b/src/CcDirector.Core/GatewayConnection/GatewayConnectionStateResolver.cs
@@ -131,7 +131,7 @@ public enum GatewayCheckState
     /// <summary>Proven - a filled marker. Green.</summary>
     Passed,
 
-    /// <summary>The leg failed - named on the line. Red.</summary>
+    /// <summary>The connection failed. Red; the named detail appears in the tooltip and repair panel.</summary>
     Failed,
 
     /// <summary>Cannot tell yet - muted, explicitly NOT an alarm (an Unavailable Gateway, decision 3).</summary>

--- a/src/CcDirector.Core/GatewayConnection/GatewayStatusBoxPresenter.cs
+++ b/src/CcDirector.Core/GatewayConnection/GatewayStatusBoxPresenter.cs
@@ -11,23 +11,23 @@ public enum GatewayStatusBoxVisual
     /// <summary>Needs attention: NotConfigured or ConnectedNotSignedIn. One or both lines show the next action.</summary>
     Amber,
 
-    /// <summary>Working: a handshake is verifying. "Connecting...".</summary>
+    /// <summary>Working: the gateway host is shown with a "Connecting..." suffix.</summary>
     Yellow,
 
     /// <summary>All good: handshake proven AND the Gateway reports signed in. Both lines filled.</summary>
     Green,
 
-    /// <summary>Was working and is now broken (or a first-time connect failed): the failing leg is named.</summary>
+    /// <summary>Was working and is now broken (or a first-time connect failed).</summary>
     Red,
 }
 
 /// <summary>
 /// One of the two check lines the status box shows (spec section 6). The <see cref="Marker"/> is the paint
 /// state of the line (filled / hollow / working / failed / muted) which the surface maps to a glyph and
-/// color; the <see cref="Text"/> is the plain-English label - either the proven fact or the next action.
+/// color; the <see cref="Text"/> is the finished plain-English label the surface renders verbatim.
 /// </summary>
 /// <param name="Marker">The paint state of this line's marker.</param>
-/// <param name="Text">The plain-English label for this line.</param>
+/// <param name="Text">The finished plain-English label for this line.</param>
 public sealed record GatewayStatusLine(GatewayCheckState Marker, string Text);
 
 /// <summary>
@@ -57,12 +57,12 @@ public sealed record GatewayStatusBoxContent(
 ///   - The four visual states collapse the six resolver states: NotConfigured and ConnectedNotSignedIn are
 ///     both amber (needs attention); Connecting is yellow; AllGreen is green; ConnectFailed and
 ///     WasConnectedNowUnreachable are both red.
-///   - The Connected line shows WHICH gateway, not the verdict: the marker (green check / amber ring /
-///     red cross) carries connected / connecting / failed, so the word "Connected" beside a checkmark was
-///     redundant. The gateway host is shown in every state where a gateway is configured - failed included
-///     - so the person can see WHICH gateway is unreachable; the named failing leg stays in the tooltip and
-///     the panel's repair banner. With no gateway selected (brand new, NotConfigured) the line is left
-///     empty and the surface hides the row.
+///   - The Connected line shows WHICH gateway plus the verdict: the marker (green check / amber ring /
+///     red cross) reinforces connected / connecting / failed. The gateway host is shown first in every state
+///     where a gateway is configured - failed included - and the resolved state follows in parentheses so
+///     the verdict remains readable without relying on the glyph or color. The named failing leg stays in
+///     the tooltip and the panel's repair banner. With no gateway selected (brand new, NotConfigured) the
+///     line is left empty and the surface hides the row.
 ///   - A muted/unknown account line is "cannot tell yet", never a false sign-out (decision 3).
 /// </summary>
 public static class GatewayStatusBoxPresenter
@@ -79,9 +79,9 @@ public static class GatewayStatusBoxPresenter
     {
         var resolved = GatewayConnectionStateResolver.Resolve(inputs);
         var visual = VisualFor(resolved.State);
-        var connected = ConnectedLine(resolved.ConnectedCheck, gatewayHost);
+        var connected = ConnectedLine(resolved, inputs.GatewayConfigured, gatewayHost);
         var signedIn = SignedInLine(resolved.SignedInCheck, accountEmail);
-        var tooltip = Tooltip(resolved.State, gatewayHost, accountEmail);
+        var tooltip = Tooltip(resolved.State, inputs.FailedLeg, gatewayHost, accountEmail);
         return new GatewayStatusBoxContent(visual, connected, signedIn, tooltip);
     }
 
@@ -96,15 +96,32 @@ public static class GatewayStatusBoxPresenter
         _ => GatewayStatusBoxVisual.Amber,
     };
 
-    // The Connected line shows the gateway host when one is configured, whatever the marker state (the
-    // marker carries connected / connecting / failed). With no gateway selected the host is null and the
-    // line is left empty - the surface hides the row - so a brand-new box does not pretend a verdict it
-    // cannot have. The named failing leg has moved off this line into the tooltip and the panel repair
-    // banner; the box itself names WHICH gateway, not WHY it failed.
-    private static GatewayStatusLine ConnectedLine(GatewayCheckState check, string? gatewayHost)
+    // The Connected line names the configured gateway first, then states the resolver's finished verdict in
+    // parentheses. The marker remains resolver-owned reinforcement, not the only way to learn the verdict.
+    // No configured gateway means no line. A configured gateway without a displayable host is an invalid
+    // presenter input and fails explicitly instead of silently painting the box as if it were brand new.
+    private static GatewayStatusLine ConnectedLine(
+        GatewayConnectionResolved resolved, bool gatewayConfigured, string? gatewayHost)
     {
-        var text = string.IsNullOrWhiteSpace(gatewayHost) ? string.Empty : gatewayHost;
-        return new GatewayStatusLine(check, text);
+        if (!gatewayConfigured)
+            return new GatewayStatusLine(resolved.ConnectedCheck, string.Empty);
+
+        if (string.IsNullOrWhiteSpace(gatewayHost))
+            throw new InvalidOperationException(
+                $"Gateway host is required when the resolved state is {resolved.State} and a gateway is configured");
+
+        var stateText = resolved.State switch
+        {
+            GatewayConnectionState.Connecting => "Connecting...",
+            GatewayConnectionState.ConnectFailed => "Connection failed",
+            GatewayConnectionState.WasConnectedNowUnreachable => "Unreachable",
+            GatewayConnectionState.ConnectedNotSignedIn => "Connected",
+            GatewayConnectionState.AllGreen => "Connected",
+            GatewayConnectionState.NotConfigured => throw new InvalidOperationException(
+                "A configured gateway cannot resolve to NotConfigured"),
+            _ => throw new ArgumentOutOfRangeException(nameof(resolved), resolved.State, "Unknown gateway connection state"),
+        };
+        return new GatewayStatusLine(resolved.ConnectedCheck, $"{gatewayHost.Trim()} ({stateText})");
     }
 
     // The Signed-in line shows the identity when green, the next action when pending, and a muted
@@ -122,9 +139,14 @@ public static class GatewayStatusBoxPresenter
     private static string SignedInText(string? accountEmail) =>
         string.IsNullOrWhiteSpace(accountEmail) ? "Signed in" : $"Signed in: {accountEmail}";
 
-    private static string Tooltip(GatewayConnectionState state, string? gatewayHost, string? accountEmail)
+    private static string Tooltip(
+        GatewayConnectionState state,
+        GatewayConnectionFailedLeg failedLeg,
+        string? gatewayHost,
+        string? accountEmail)
     {
         var host = string.IsNullOrWhiteSpace(gatewayHost) ? "the Gateway" : $"Gateway on {gatewayHost}";
+        var failure = FailedLegText(failedLeg);
         return state switch
         {
             GatewayConnectionState.NotConfigured =>
@@ -132,7 +154,7 @@ public static class GatewayStatusBoxPresenter
             GatewayConnectionState.Connecting =>
                 $"Connecting to {host}. Click to see progress.",
             GatewayConnectionState.ConnectFailed =>
-                $"Could not connect to {host}. Click to see the failing leg and the fix.",
+                $"Could not connect to {host}. {failure} Click to see the fix.",
             GatewayConnectionState.ConnectedNotSignedIn =>
                 $"Connected to {host}, but this device is not signed in. Click to sign in with DevThrottle.",
             GatewayConnectionState.AllGreen =>
@@ -140,8 +162,15 @@ public static class GatewayStatusBoxPresenter
                     ? $"Connected to {host} and signed in. Click for details."
                     : $"Connected to {host} and signed in as {accountEmail}. Click for details.",
             GatewayConnectionState.WasConnectedNowUnreachable =>
-                $"Was connected to {host}, now unreachable. Click to reconnect.",
+                $"Was connected to {host}, now unreachable. {failure} Click to reconnect.",
             _ => "Click to open the Gateway connection panel.",
         };
     }
+
+    private static string FailedLegText(GatewayConnectionFailedLeg leg) => leg switch
+    {
+        GatewayConnectionFailedLeg.Callback => "The Gateway cannot reach this Director back.",
+        GatewayConnectionFailedLeg.OutboundReach => "This Director cannot reach the Gateway.",
+        _ => "The connection failed.",
+    };
 }

--- a/src/CcDirector.Core/GatewayConnection/GatewayStatusBoxPresenter.cs
+++ b/src/CcDirector.Core/GatewayConnection/GatewayStatusBoxPresenter.cs
@@ -57,9 +57,12 @@ public sealed record GatewayStatusBoxContent(
 ///   - The four visual states collapse the six resolver states: NotConfigured and ConnectedNotSignedIn are
 ///     both amber (needs attention); Connecting is yellow; AllGreen is green; ConnectFailed and
 ///     WasConnectedNowUnreachable are both red.
-///   - Each line shows the proven fact when passed, and the next action when pending - so a brand-new box
-///     reads "Connect to Gateway" / "Sign in", and a finished box reads "Connected" / "Signed in: email".
-///   - A failed handshake names the failing leg on the Connected line (decision 11, no fallback).
+///   - The Connected line shows WHICH gateway, not the verdict: the marker (green check / amber ring /
+///     red cross) carries connected / connecting / failed, so the word "Connected" beside a checkmark was
+///     redundant. The gateway host is shown in every state where a gateway is configured - failed included
+///     - so the person can see WHICH gateway is unreachable; the named failing leg stays in the tooltip and
+///     the panel's repair banner. With no gateway selected (brand new, NotConfigured) the line is left
+///     empty and the surface hides the row.
 ///   - A muted/unknown account line is "cannot tell yet", never a false sign-out (decision 3).
 /// </summary>
 public static class GatewayStatusBoxPresenter
@@ -68,14 +71,15 @@ public static class GatewayStatusBoxPresenter
     /// Describe how the single status box should paint for the given live snapshot.
     /// </summary>
     /// <param name="inputs">The full verification snapshot (the same inputs the panel resolves).</param>
-    /// <param name="gatewayHost">The Gateway host name, shown in the tooltip when connected (may be null).</param>
+    /// <param name="gatewayHost">The Gateway host name, shown on the Connected line and in the tooltip when
+    /// a gateway is configured (may be null when no gateway is selected yet).</param>
     /// <param name="accountEmail">The signed-in account email, shown on the signed-in line when green (may be null).</param>
     public static GatewayStatusBoxContent Describe(
         GatewayConnectionInputs inputs, string? gatewayHost, string? accountEmail)
     {
         var resolved = GatewayConnectionStateResolver.Resolve(inputs);
         var visual = VisualFor(resolved.State);
-        var connected = ConnectedLine(resolved.ConnectedCheck, inputs.FailedLeg);
+        var connected = ConnectedLine(resolved.ConnectedCheck, gatewayHost);
         var signedIn = SignedInLine(resolved.SignedInCheck, accountEmail);
         var tooltip = Tooltip(resolved.State, gatewayHost, accountEmail);
         return new GatewayStatusBoxContent(visual, connected, signedIn, tooltip);
@@ -92,23 +96,16 @@ public static class GatewayStatusBoxPresenter
         _ => GatewayStatusBoxVisual.Amber,
     };
 
-    // The Connected line reads the proven fact when passed, the next action when pending, "Connecting..."
-    // while verifying, and the named leg when it failed (decision 11).
-    private static GatewayStatusLine ConnectedLine(GatewayCheckState check, GatewayConnectionFailedLeg leg) => check switch
+    // The Connected line shows the gateway host when one is configured, whatever the marker state (the
+    // marker carries connected / connecting / failed). With no gateway selected the host is null and the
+    // line is left empty - the surface hides the row - so a brand-new box does not pretend a verdict it
+    // cannot have. The named failing leg has moved off this line into the tooltip and the panel repair
+    // banner; the box itself names WHICH gateway, not WHY it failed.
+    private static GatewayStatusLine ConnectedLine(GatewayCheckState check, string? gatewayHost)
     {
-        GatewayCheckState.Passed => new GatewayStatusLine(check, "Connected"),
-        GatewayCheckState.Working => new GatewayStatusLine(check, "Connecting..."),
-        GatewayCheckState.Failed => new GatewayStatusLine(check, FailedLegText(leg)),
-        // Pending and Unknown both show the next action; there is nothing to report yet.
-        _ => new GatewayStatusLine(check, "Connect to Gateway"),
-    };
-
-    private static string FailedLegText(GatewayConnectionFailedLeg leg) => leg switch
-    {
-        GatewayConnectionFailedLeg.Callback => "Gateway cannot reach this Director back",
-        GatewayConnectionFailedLeg.OutboundReach => "Cannot reach the Gateway",
-        _ => "Connection failed",
-    };
+        var text = string.IsNullOrWhiteSpace(gatewayHost) ? string.Empty : gatewayHost;
+        return new GatewayStatusLine(check, text);
+    }
 
     // The Signed-in line shows the identity when green, the next action when pending, and a muted
     // "Checking account..." while the read is in flight or cannot be told yet (never a false sign-out).


### PR DESCRIPTION
## Summary

- Show the configured gateway host together with its resolved connection state, such as `SOREN_NORTH (Connecting...)`.
- Hide the gateway row only when no gateway is configured, and keep the displayed host synchronized with live configuration changes.
- Preserve named failure detail in the tooltip, add accessibility metadata and keyboard activation, and expand regression coverage.

## Verification

- Focused gateway status presenter tests: 15 passed.
- Complete Avalonia test project: 228 passed.
- Complete core test project: 3,368 passed and 8 skipped.