### PR TITLE
fix(gateway): fail-closed hosted identity - refuse to start on an incomplete hosted contract

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,17 @@ ENV HOME=/home/gateway
 # CC_DIRECTOR_ROOT as its base directory; without it the base resolves relative to the read-only
 # /app working directory and the non-root user cannot create it.
 ENV CC_DIRECTOR_ROOT=/home/gateway/cc-director
+
+# Bake the hosted-mode toggle into the IMAGE (production-readiness item MH-3). It used to be set only as an
+# Azure App Service application setting, which a slot swap or a config restore can drop - and a dropped
+# toggle used to boot this same public image as a Local single-tenant, no-auth Gateway, silently. Setting it
+# in the image makes it part of the artifact, so it survives a settings reset. The IMMUTABLE identity is the
+# compiled-in HostedGatewayImage marker in CcDirector.Gateway.Host; this ENV is the runtime toggle that
+# marker requires to be present. The hosted Gateway also REQUIRES CC_GATEWAY_PUBLIC_URL (the https public
+# base URL) and CC_GATEWAY_DB_CONNECTION (the PostgreSQL connection string) at run time - those carry
+# environment-specific values / credentials, so they stay App Service settings and are NOT baked here. The
+# Gateway refuses to start (HostedStartupContract) if any of the three is missing.
+ENV CC_GATEWAY_HOSTED=1
 USER gateway
 
 # The Gateway binds to loopback (127.0.0.1:7878) by design - it is reached over the tunnel, not a public

--- a/src/CcDirector.Gateway.Host/CcDirector.Gateway.Host.csproj
+++ b/src/CcDirector.Gateway.Host/CcDirector.Gateway.Host.csproj
@@ -40,6 +40,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The IMAGE-WIDE hosted identity marker (GatewayHostedMode.HostedImageMarkerFileName). Publishing this
+         host ALSO ships a runnable, unmarked CcDirector.Gateway.dll; a compiled-in attribute only marks the
+         launcher it is stamped on, so this file - baked into the published output next to every shipped
+         executable - is what makes HostedStartupContract fire whichever entry executable the container runs.
+         CopyToOutputDirectory copies it to both build output and publish output, so the published-artifact
+         regression test (HostedImagePublishedArtifactTests) sees it exactly as the container does. -->
+    <Content Include="hosted-gateway.image" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- The cross-platform Gateway host code + the shared GatewayEntryPoint this executable calls. -->
     <ProjectReference Include="..\CcDirector.Gateway\CcDirector.Gateway.csproj" />
     <!-- The Postgres migration set. Referenced HERE, not from CcDirector.Gateway (which would be the circular

--- a/src/CcDirector.Gateway.Host/Program.cs
+++ b/src/CcDirector.Gateway.Host/Program.cs
@@ -1,5 +1,13 @@
 using CcDirector.Gateway;
 
+// The IMMUTABLE hosted identity. This executable is the ONLY one that ships in the hosted container image,
+// so stamping the marker here - at compile time, onto the artifact itself - makes "am I the hosted build"
+// impossible to drop with a slot swap, a config restore, or a lost environment variable. The shared
+// GatewayEntryPoint reads it (GatewayHostedMode.IsHostedImage) and refuses to start unless the full hosted
+// contract holds. The dev console host (CcDirector.Gateway) and the Windows tray skin do NOT apply it, so
+// they stay self-host.
+[assembly: HostedGatewayImage]
+
 // The hosted container entry point (see CcDirector.Gateway.Host.csproj for why this executable exists at
 // all). It runs the IDENTICAL Gateway startup as the local dev console host via the shared GatewayEntryPoint,
 // forwarding its process args verbatim - including the --port the Dockerfile passes - so the CC_GATEWAY_HOSTED

--- a/src/CcDirector.Gateway.Host/hosted-gateway.image
+++ b/src/CcDirector.Gateway.Host/hosted-gateway.image
@@ -1,0 +1,15 @@
+This file is the IMAGE-WIDE hosted Gateway identity marker.
+
+The hosted host project (CcDirector.Gateway.Host) bakes this file into its published output, so it lands
+in the application base directory of the hosted container image, alongside every executable that image
+ships. GatewayHostedMode.IsHostedImage treats the deployment as the hosted image when this marker is
+present, INDEPENDENTLY of which entry executable runs.
+
+Why it exists: publishing the host also ships a runnable, UNMARKED CcDirector.Gateway.dll (with its own
+deps.json / runtimeconfig.json). A compiled-in assembly attribute only identifies the launcher it is
+stamped on, so overriding the container entrypoint to run that unmarked executable would let the same
+hosted artifact boot as a self-host, single-tenant, no-auth Gateway with none of the hosted startup
+contract enforced. This marker is read from the deployment directory the two executables SHARE, so the
+fail-closed hosted startup contract (HostedStartupContract) fires whichever one runs.
+
+Do not remove this file or its build wiring in CcDirector.Gateway.Host.csproj.

--- a/src/CcDirector.Gateway.Tests/HostedImagePublishedArtifactTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedImagePublishedArtifactTests.cs
@@ -1,0 +1,203 @@
+using System.Diagnostics;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Published-artifact regression test for the fail-CLOSED hosted identity (production-readiness item MH-3).
+///
+/// Publishing the hosted host (<c>CcDirector.Gateway.Host</c>) does NOT ship a single runnable executable:
+/// it also emits the referenced, UNMARKED <c>CcDirector.Gateway.dll</c> with its own
+/// deps.json/runtimeconfig.json. Codex's review of PR #1968 reproduced the hole - running
+/// <c>dotnet CcDirector.Gateway.dll</c> from the published output with every hosted variable unset served
+/// <c>/healthz</c> 200, because the compiled-in <see cref="HostedGatewayImageAttribute"/> only identifies the
+/// launcher it is stamped on, so the contract gate was a no-op for the other entry executable.
+///
+/// The fix makes hosted identity IMAGE-WIDE: the host bakes a marker file
+/// (<see cref="GatewayHostedMode.HostedImageMarkerFileName"/>) into its published output, and
+/// <see cref="GatewayHostedMode.IsHostedImage"/> reads it from the deployment directory every shipped entry
+/// executable shares. This test proves the whole thing against the ACTUAL published artifact rather than a
+/// unit seam: it publishes the host, then asserts that EVERY runnable entry executable in the output -
+/// including the unmarked <c>CcDirector.Gateway.dll</c> Codex ran - fails closed (a non-zero exit with no
+/// listener) when the hosted contract is missing.
+/// </summary>
+public sealed class HostedImagePublishedArtifactTests
+{
+    // The contract-refusal exit code GatewayEntryPoint returns (distinct from a generic fault). Asserting on
+    // it proves the process refused because of the contract, not because it happened to crash for some other
+    // reason - a bare "non-zero" would pass on an unrelated failure and hide a real regression.
+    private const int ContractRefusalExitCode = 2;
+
+    // The five hosted-contract variables. They are stripped from every child process so the published entry
+    // executable boots into exactly the "hosted image, contract missing" state that must fail closed.
+    private static readonly string[] HostedContractEnvVars =
+    {
+        "CC_GATEWAY_HOSTED", "CC_GATEWAY_NO_AUTH", "CC_GATEWAY_AUTH",
+        "CC_GATEWAY_PUBLIC_URL", "CC_GATEWAY_DB_CONNECTION",
+    };
+
+    [Fact]
+    public void Every_published_entry_executable_fails_closed_without_the_hosted_contract()
+    {
+        var publishDir = Path.Combine(
+            Path.GetTempPath(), "cc-hosted-publish-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Publish(HostProjectPath(), publishDir);
+
+            // The marker that makes identity image-wide must actually be in the shipped output - it is what
+            // makes the unmarked entry (and any apphost that routes through the same managed entry point)
+            // fail closed. If it is missing, the whole mechanism is absent and the assertions below would be
+            // proving nothing.
+            var markerPath = Path.Combine(publishDir, GatewayHostedMode.HostedImageMarkerFileName);
+            Assert.True(File.Exists(markerPath),
+                $"the image-wide hosted marker '{GatewayHostedMode.HostedImageMarkerFileName}' was not baked "
+                + $"into the published output at {publishDir}.");
+
+            // Every runnable "dotnet <dll>" entry the artifact ships - identified by the presence of a
+            // sibling runtimeconfig.json, which is exactly what makes a dll launchable. This is the Codex
+            // reproduction vector and is deterministic across platforms.
+            var entryDlls = RunnableEntryDlls(publishDir);
+
+            // The set must contain BOTH the marked host AND the unmarked Gateway dll - the whole point is
+            // that the OTHER, unmarked entry ships and used to bypass the gate. An empty or single-entry set
+            // would let this test pass while proving nothing (a dead test that looks like coverage).
+            Assert.Contains("CcDirector.Gateway.Host.dll", entryDlls.Select(Path.GetFileName));
+            Assert.Contains("CcDirector.Gateway.dll", entryDlls.Select(Path.GetFileName));
+            Assert.True(entryDlls.Count >= 2,
+                $"expected at least two runnable entry executables in {publishDir}, found "
+                + $"{entryDlls.Count}: {string.Join(", ", entryDlls.Select(Path.GetFileName))}.");
+
+            foreach (var dll in entryDlls)
+                AssertEntryFailsClosed(publishDir, dll);
+        }
+        finally
+        {
+            TryDeleteDirectory(publishDir);
+        }
+    }
+
+    /// <summary>
+    /// Run one published entry executable as <c>dotnet &lt;dll&gt;</c> with the hosted contract stripped from
+    /// its environment, and assert it fails closed: it must EXIT with the contract-refusal code, not stay up
+    /// serving. A process that is still alive after the wait is the fail-OPEN regression (it started a
+    /// listener) - that is the exact failure this test exists to catch, so it is killed and the test fails.
+    /// </summary>
+    private static void AssertEntryFailsClosed(string publishDir, string entryDll)
+    {
+        var port = FreeTcpPort();
+        var psi = new ProcessStartInfo("dotnet", $"\"{entryDll}\" --port {port}")
+        {
+            WorkingDirectory = publishDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var name in HostedContractEnvVars)
+            psi.Environment.Remove(name);
+
+        using var proc = Process.Start(psi)!;
+        var stdout = proc.StandardOutput.ReadToEndAsync();
+        var stderr = proc.StandardError.ReadToEndAsync();
+
+        // The contract gate runs BEFORE the host is built, so a fail-closed entry exits in well under this
+        // budget; the generous window only absorbs cold dotnet startup. A process still running at the end
+        // has passed the gate and started serving - the regression.
+        var exited = proc.WaitForExit(TimeSpan.FromSeconds(60));
+
+        if (!exited)
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            Assert.Fail(
+                $"{Path.GetFileName(entryDll)} did NOT fail closed: it was still running (serving on port "
+                + $"{port}) after 60s with the hosted contract missing. The hosted image must refuse to start, "
+                + "not boot as a self-host Gateway.");
+        }
+
+        var outText = stdout.GetAwaiter().GetResult();
+        var errText = stderr.GetAwaiter().GetResult();
+        Assert.True(proc.ExitCode == ContractRefusalExitCode,
+            $"{Path.GetFileName(entryDll)} exited {proc.ExitCode}, expected {ContractRefusalExitCode} "
+            + $"(hosted contract refusal). stdout: {outText} | stderr: {errText}");
+
+        // The refusal must name the contract, so an operator learns why - and so this asserts the RIGHT exit
+        // 2, not some coincidental one.
+        Assert.Contains("REFUSING TO START", outText + errText);
+    }
+
+    /// <summary>Publish the host project to <paramref name="outputDir"/>, skipping the release-only web
+    /// (npm) build targets so the publish needs no Node.js and stays fast. Fails the test loudly with the
+    /// publish output if it does not succeed.</summary>
+    private static void Publish(string projectPath, string outputDir)
+    {
+        var psi = new ProcessStartInfo("dotnet",
+            $"publish \"{projectPath}\" -c Debug -o \"{outputDir}\" --nologo "
+            + "-p:RunMobileBuild=false -p:RunCockpitBuild=false -p:RunWorkspaceTypecheck=false")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var proc = Process.Start(psi)!;
+        var stdout = proc.StandardOutput.ReadToEndAsync();
+        var stderr = proc.StandardError.ReadToEndAsync();
+        var exited = proc.WaitForExit(TimeSpan.FromMinutes(5));
+        if (!exited)
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            Assert.Fail($"publishing {projectPath} did not finish within 5 minutes.");
+        }
+
+        var outText = stdout.GetAwaiter().GetResult();
+        var errText = stderr.GetAwaiter().GetResult();
+        Assert.True(proc.ExitCode == 0,
+            $"publishing {projectPath} failed with exit {proc.ExitCode}. stdout: {outText} | stderr: {errText}");
+    }
+
+    /// <summary>Every runnable "dotnet &lt;dll&gt;" entry in a published output: a dll with a sibling
+    /// runtimeconfig.json (which is what a framework-dependent app needs to launch).</summary>
+    private static List<string> RunnableEntryDlls(string publishDir)
+    {
+        var entries = new List<string>();
+        foreach (var config in Directory.GetFiles(publishDir, "*.runtimeconfig.json"))
+        {
+            // "X.runtimeconfig.json" -> "X.dll"
+            var name = Path.GetFileName(config);
+            var stem = name[..^".runtimeconfig.json".Length];
+            var dll = Path.Combine(publishDir, stem + ".dll");
+            if (File.Exists(dll))
+                entries.Add(dll);
+        }
+        return entries;
+    }
+
+    /// <summary>An OS-assigned free TCP port. The listener is closed immediately; a launched entry is
+    /// expected to refuse before it ever binds, so the tiny reuse window does not matter.</summary>
+    private static int FreeTcpPort()
+    {
+        var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    /// <summary>The hosted host csproj, located from this source file's own path - the tests always run from
+    /// a checkout, and bin-relative paths would break under different runners.</summary>
+    private static string HostProjectPath([CallerFilePath] string thisFile = "")
+    {
+        // this file: <repo>/src/CcDirector.Gateway.Tests/HostedImagePublishedArtifactTests.cs
+        var repoRoot = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", ".."));
+        return Path.Combine(repoRoot, "src", "CcDirector.Gateway.Host", "CcDirector.Gateway.Host.csproj");
+    }
+
+    private static void TryDeleteDirectory(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { /* best effort test cleanup */ }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedStartupContractTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedStartupContractTests.cs
@@ -92,6 +92,39 @@ public sealed class HostedStartupContractTests
         Assert.Contains(Check(env), v => v.Contains(GatewayPublicUrl.PublicBaseUrlEnvVar));
     }
 
+    [Theory]
+    // A bare "https://" prefix is NOT a valid absolute URL: these all cleared the old StartsWith("https://")
+    // check yet have no usable host, so GatewayPublicUrl would have served a broken base with no later guard.
+    [InlineData("https://")]        // scheme only, no host
+    [InlineData("https:///path")]   // empty host, path only
+    [InlineData("https://:443")]    // empty host, port only
+    [InlineData("https:// ")]       // scheme with a blank host
+    [InlineData("https://gateway.devthrottle.com?x=1")] // base URL must carry no query
+    [InlineData("https://gateway.devthrottle.com#frag")] // base URL must carry no fragment
+    [InlineData("not-a-url")]       // not absolute at all
+    [InlineData("ftp://gateway.devthrottle.com")] // wrong scheme
+    public void Malformed_https_public_url_is_a_violation(string value)
+    {
+        var env = ValidEnv();
+        env[GatewayPublicUrl.PublicBaseUrlEnvVar] = value;
+        Assert.Contains(Check(env), v => v.Contains(GatewayPublicUrl.PublicBaseUrlEnvVar));
+    }
+
+    [Theory]
+    // Well-formed public base URLs must pass: a plain host, a host with a port, and a host with a path
+    // prefix are all valid base URLs the contract must NOT reject (over-refusal would be a hosted outage).
+    [InlineData("https://gateway.devthrottle.com")]
+    [InlineData("https://gateway.devthrottle.com/")]
+    [InlineData("https://host:8443")]
+    [InlineData("https://gateway.devthrottle.com/base")]
+    [InlineData("  https://gateway.devthrottle.com  ")] // surrounding whitespace is trimmed, still valid
+    public void Well_formed_https_public_url_is_not_a_violation(string value)
+    {
+        var env = ValidEnv();
+        env[GatewayPublicUrl.PublicBaseUrlEnvVar] = value;
+        Assert.DoesNotContain(Check(env), v => v.Contains(GatewayPublicUrl.PublicBaseUrlEnvVar));
+    }
+
     [Fact]
     public void Missing_postgres_connection_is_a_violation()
     {
@@ -175,5 +208,55 @@ public sealed class HostedStartupContractTests
         var ctor = typeof(HostedGatewayImageAttribute).GetConstructor(Type.EmptyTypes)!;
         builder.SetCustomAttribute(new CustomAttributeBuilder(ctor, Array.Empty<object>()));
         Assert.True(GatewayHostedMode.IsHostedImageAssembly(builder));
+    }
+
+    [Fact]
+    public void Image_wide_marker_file_makes_an_unmarked_deployment_the_hosted_image()
+    {
+        // This is the fix for the entrypoint-swap bypass: publishing the hosted host also ships a runnable,
+        // UNMARKED CcDirector.Gateway.dll. When the image-wide marker file sits in the deployment directory,
+        // even that unmarked entry is the hosted image, so the fail-closed contract fires whichever executable
+        // the container runs.
+        var dir = Path.Combine(Path.GetTempPath(), "cc-hosted-marker-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // No marker yet: an unmarked entry assembly is self-host.
+            Assert.False(GatewayHostedMode.HostedImageMarkerPresent(dir));
+            Assert.False(GatewayHostedMode.IsHostedImageDeployment(entryAssembly: null, dir));
+
+            // Drop the marker the hosted host bakes into its published output.
+            File.WriteAllText(Path.Combine(dir, GatewayHostedMode.HostedImageMarkerFileName), "marker");
+
+            // Now the SAME unmarked deployment is the hosted image.
+            Assert.True(GatewayHostedMode.HostedImageMarkerPresent(dir));
+            Assert.True(GatewayHostedMode.IsHostedImageDeployment(entryAssembly: null, dir));
+            Assert.True(GatewayHostedMode.IsHostedImageDeployment(typeof(GatewayHostedMode).Assembly, dir));
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void No_marker_and_no_attribute_is_self_host()
+    {
+        // A directory with no marker, and no marked entry assembly, is self-host - the byte-identical dev /
+        // desktop path. A null or blank base directory never fabricates a hosted verdict.
+        var dir = Path.Combine(Path.GetTempPath(), "cc-hosted-nomarker-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            Assert.False(GatewayHostedMode.HostedImageMarkerPresent(dir));
+            Assert.False(GatewayHostedMode.HostedImageMarkerPresent(null));
+            Assert.False(GatewayHostedMode.HostedImageMarkerPresent(""));
+            Assert.False(GatewayHostedMode.IsHostedImageDeployment(typeof(GatewayHostedMode).Assembly, dir));
+            Assert.False(GatewayHostedMode.IsHostedImageDeployment(GetType().Assembly, null));
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
     }
 }

--- a/src/CcDirector.Gateway.Tests/HostedStartupContractTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedStartupContractTests.cs
@@ -1,0 +1,179 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Pins the fail-CLOSED hosted identity (production-readiness item MH-3 / TOP-ISSUES #8): the hosted Gateway
+/// image must prove its full contract at startup or refuse to run, and self-host must be entirely unaffected.
+///
+/// The pieces proven here:
+///  - The immutable hosted identity is read from the compiled-in <see cref="HostedGatewayImageAttribute"/>,
+///    not from the droppable CC_GATEWAY_HOSTED toggle.
+///  - The hosted contract holds only when hosted mode is on, auth is enabled (the disable flags are
+///    rejected), a public https URL is set, and PostgreSQL is configured. Any missing piece is a violation.
+///  - A hosted-image boot with an incomplete contract THROWS (the entry point turns that into a non-zero
+///    exit); a self-host boot never runs the contract at all.
+/// </summary>
+public sealed class HostedStartupContractTests
+{
+    // A complete, valid hosted environment - the baseline each test perturbs one field of.
+    private static Dictionary<string, string?> ValidEnv() => new()
+    {
+        [GatewayHostedMode.HostedEnvVar] = "1",
+        [GatewayHost.AuthDisabledEnvVar] = null,
+        [GatewayHost.AuthEnabledEnvVar] = null,
+        [GatewayPublicUrl.PublicBaseUrlEnvVar] = "https://gateway.devthrottle.com",
+        [CcDirector.Gateway.Data.GatewayDatabase.PostgresConnectionEnvVar] = "Host=db;Database=gateway;Username=u;Password=p",
+    };
+
+    private static IReadOnlyList<string> Check(Dictionary<string, string?> env)
+        => HostedStartupContract.CheckHostedContract(
+            env[GatewayHostedMode.HostedEnvVar],
+            env[GatewayHost.AuthDisabledEnvVar],
+            env[GatewayHost.AuthEnabledEnvVar],
+            env[GatewayPublicUrl.PublicBaseUrlEnvVar],
+            env[CcDirector.Gateway.Data.GatewayDatabase.PostgresConnectionEnvVar]);
+
+    [Fact]
+    public void Full_contract_has_no_violations()
+    {
+        Assert.Empty(Check(ValidEnv()));
+    }
+
+    [Fact]
+    public void Missing_hosted_toggle_is_a_violation()
+    {
+        var env = ValidEnv();
+        env[GatewayHostedMode.HostedEnvVar] = null;
+        var violations = Check(env);
+        Assert.Contains(violations, v => v.Contains(GatewayHostedMode.HostedEnvVar));
+    }
+
+    [Fact]
+    public void Hosted_toggle_other_than_one_is_a_violation()
+    {
+        var env = ValidEnv();
+        env[GatewayHostedMode.HostedEnvVar] = "0";
+        Assert.Contains(Check(env), v => v.Contains(GatewayHostedMode.HostedEnvVar));
+    }
+
+    [Fact]
+    public void No_auth_disable_flag_is_rejected()
+    {
+        var env = ValidEnv();
+        env[GatewayHost.AuthDisabledEnvVar] = "1";
+        Assert.Contains(Check(env), v => v.Contains(GatewayHost.AuthDisabledEnvVar));
+    }
+
+    [Fact]
+    public void Auth_zero_disable_flag_is_rejected()
+    {
+        var env = ValidEnv();
+        env[GatewayHost.AuthEnabledEnvVar] = "0";
+        Assert.Contains(Check(env), v => v.Contains(GatewayHost.AuthEnabledEnvVar));
+    }
+
+    [Fact]
+    public void Missing_public_url_is_a_violation()
+    {
+        var env = ValidEnv();
+        env[GatewayPublicUrl.PublicBaseUrlEnvVar] = null;
+        Assert.Contains(Check(env), v => v.Contains(GatewayPublicUrl.PublicBaseUrlEnvVar));
+    }
+
+    [Fact]
+    public void Non_https_public_url_is_a_violation()
+    {
+        var env = ValidEnv();
+        env[GatewayPublicUrl.PublicBaseUrlEnvVar] = "http://gateway.devthrottle.com";
+        Assert.Contains(Check(env), v => v.Contains(GatewayPublicUrl.PublicBaseUrlEnvVar));
+    }
+
+    [Fact]
+    public void Missing_postgres_connection_is_a_violation()
+    {
+        var env = ValidEnv();
+        env[CcDirector.Gateway.Data.GatewayDatabase.PostgresConnectionEnvVar] = null;
+        Assert.Contains(Check(env), v => v.Contains(CcDirector.Gateway.Data.GatewayDatabase.PostgresConnectionEnvVar));
+    }
+
+    [Fact]
+    public void Blank_postgres_connection_is_a_violation()
+    {
+        var env = ValidEnv();
+        env[CcDirector.Gateway.Data.GatewayDatabase.PostgresConnectionEnvVar] = "   ";
+        Assert.Contains(Check(env), v => v.Contains(CcDirector.Gateway.Data.GatewayDatabase.PostgresConnectionEnvVar));
+    }
+
+    [Fact]
+    public void Every_missing_piece_is_reported_at_once()
+    {
+        // A bare hosted image with nothing configured names every failing piece, so an operator fixes them
+        // in one pass rather than discovering them one restart at a time.
+        var violations = HostedStartupContract.CheckHostedContract(
+            hosted: null, noAuth: "1", authToggle: "0", publicUrl: null, dbConnection: null);
+
+        Assert.Contains(violations, v => v.Contains(GatewayHostedMode.HostedEnvVar));
+        Assert.Contains(violations, v => v.Contains(GatewayHost.AuthDisabledEnvVar));
+        Assert.Contains(violations, v => v.Contains(GatewayHost.AuthEnabledEnvVar));
+        Assert.Contains(violations, v => v.Contains(GatewayPublicUrl.PublicBaseUrlEnvVar));
+        Assert.Contains(violations, v => v.Contains(CcDirector.Gateway.Data.GatewayDatabase.PostgresConnectionEnvVar));
+    }
+
+    [Fact]
+    public void A_violation_message_never_echoes_the_connection_string()
+    {
+        // The connection string carries credentials; a violation about it must describe the value, never
+        // print it. (Here it is blank, but the redaction path is the one that matters.)
+        var violations = HostedStartupContract.CheckHostedContract(
+            hosted: "1", noAuth: null, authToggle: null,
+            publicUrl: "https://gateway.devthrottle.com", dbConnection: "   ");
+        Assert.All(violations, v => Assert.DoesNotContain("Password", v, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Self_host_never_runs_the_contract()
+    {
+        // Not the hosted image: Assert is a no-op even with a completely broken environment. This is what
+        // keeps self-host behavior byte-identical.
+        HostedStartupContract.Assert(isHostedImage: false, readEnv: _ => null);
+    }
+
+    [Fact]
+    public void Hosted_image_with_full_contract_starts()
+    {
+        var env = ValidEnv();
+        // Does not throw.
+        HostedStartupContract.Assert(isHostedImage: true, readEnv: name => env[name]);
+    }
+
+    [Fact]
+    public void Hosted_image_with_incomplete_contract_refuses()
+    {
+        var env = ValidEnv();
+        env[CcDirector.Gateway.Data.GatewayDatabase.PostgresConnectionEnvVar] = null;
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => HostedStartupContract.Assert(isHostedImage: true, readEnv: name => env[name]));
+        Assert.Contains("REFUSING TO START", ex.Message);
+        Assert.Contains(CcDirector.Gateway.Data.GatewayDatabase.PostgresConnectionEnvVar, ex.Message);
+    }
+
+    [Fact]
+    public void Hosted_image_marker_is_read_from_the_assembly_not_the_environment()
+    {
+        // Null entry assembly and unmarked assemblies are NOT the hosted image.
+        Assert.False(GatewayHostedMode.IsHostedImageAssembly(null));
+        Assert.False(GatewayHostedMode.IsHostedImageAssembly(typeof(GatewayHostedMode).Assembly));
+        Assert.False(GatewayHostedMode.IsHostedImageAssembly(GetType().Assembly));
+
+        // An assembly that carries the marker attribute IS the hosted image.
+        var marked = new AssemblyName("HostedImageMarkerProbe");
+        var builder = AssemblyBuilder.DefineDynamicAssembly(marked, AssemblyBuilderAccess.RunAndCollect);
+        var ctor = typeof(HostedGatewayImageAttribute).GetConstructor(Type.EmptyTypes)!;
+        builder.SetCustomAttribute(new CustomAttributeBuilder(ctor, Array.Empty<object>()));
+        Assert.True(GatewayHostedMode.IsHostedImageAssembly(builder));
+    }
+}

--- a/src/CcDirector.Gateway/GatewayEntryPoint.cs
+++ b/src/CcDirector.Gateway/GatewayEntryPoint.cs
@@ -64,6 +64,25 @@ public static class GatewayEntryPoint
             }
         }
 
+        // Fail-CLOSED hosted identity (production-readiness item MH-3). BEFORE anything else boots, if this
+        // executable is the HOSTED image (the immutable compiled-in marker, not the droppable
+        // CC_GATEWAY_HOSTED toggle), it must prove the full hosted contract - hosted mode on, auth enabled,
+        // HTTPS public URL, PostgreSQL provider - or REFUSE to run. A hosted deployment that lost a variable
+        // must crash the boot, never silently downgrade to Local single-tenant / no-auth semantics. This is a
+        // no-op on every non-hosted-image build (desktop tray, dev console host, tests), so self-host is
+        // unaffected. A distinct non-zero exit code (2) marks a contract refusal apart from a generic fault.
+        try
+        {
+            HostedStartupContract.AssertFromEnvironment();
+        }
+        catch (InvalidOperationException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            FileLog.Write($"[Program] HOSTED CONTRACT REFUSED: {ex.Message.Replace(Environment.NewLine, " | ")}");
+            FileLog.Stop();
+            return 2;
+        }
+
         // Hosted (Azure App Service): honor the platform's assigned port (WEBSITES_PORT, else PORT), so the
         // front-end can route to the container. Falls through to the --port value when unset. Applied HERE,
         // before the port flows into the Gateway, so the ONE port value is consistent everywhere - the

--- a/src/CcDirector.Gateway/GatewayHostedMode.cs
+++ b/src/CcDirector.Gateway/GatewayHostedMode.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace CcDirector.Gateway;
 
 /// <summary>
@@ -19,9 +21,32 @@ namespace CcDirector.Gateway;
 /// </summary>
 public static class GatewayHostedMode
 {
+    /// <summary>The runtime toggle that turns hosted mode on: <c>CC_GATEWAY_HOSTED=1</c>. This is the value
+    /// a slot swap or config restore can drop; the IMMUTABLE identity is <see cref="IsHostedImage"/>.</summary>
+    public const string HostedEnvVar = "CC_GATEWAY_HOSTED";
+
     /// <summary>True when <c>CC_GATEWAY_HOSTED=1</c> - this Gateway is a hosted/container deployment.</summary>
     public static bool IsHosted =>
-        string.Equals(Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED"), "1", StringComparison.Ordinal);
+        string.Equals(Environment.GetEnvironmentVariable(HostedEnvVar), "1", StringComparison.Ordinal);
+
+    /// <summary>
+    /// True when the RUNNING executable is the hosted container build - the IMMUTABLE hosted identity, read
+    /// from the <see cref="HostedGatewayImageAttribute"/> the hosted host (<c>CcDirector.Gateway.Host</c>)
+    /// stamps onto itself at compile time. Unlike <see cref="IsHosted"/> (a runtime environment toggle), this
+    /// cannot be dropped by a slot swap, a config restore, or a lost variable: it is part of the compiled
+    /// artifact. <see cref="HostedStartupContract"/> uses it to decide that the FULL hosted contract must be
+    /// proven at startup or the process must refuse to run - so a hosted image can never silently downgrade
+    /// to Local single-tenant / no-auth semantics.
+    /// </summary>
+    public static bool IsHostedImage => IsHostedImageAssembly(System.Reflection.Assembly.GetEntryAssembly());
+
+    /// <summary>
+    /// Pure form of <see cref="IsHostedImage"/> for testing: true when <paramref name="entryAssembly"/> is
+    /// non-null and carries <see cref="HostedGatewayImageAttribute"/>. A null entry assembly (some test
+    /// hosts) is treated as NOT the hosted image, so a test run is self-host by default.
+    /// </summary>
+    internal static bool IsHostedImageAssembly(System.Reflection.Assembly? entryAssembly)
+        => entryAssembly?.GetCustomAttribute<HostedGatewayImageAttribute>() is not null;
 
     /// <summary>
     /// The port a hosted Gateway should listen on: the App Service <c>WEBSITES_PORT</c>, else <c>PORT</c>, else

--- a/src/CcDirector.Gateway/GatewayHostedMode.cs
+++ b/src/CcDirector.Gateway/GatewayHostedMode.cs
@@ -30,23 +30,66 @@ public static class GatewayHostedMode
         string.Equals(Environment.GetEnvironmentVariable(HostedEnvVar), "1", StringComparison.Ordinal);
 
     /// <summary>
-    /// True when the RUNNING executable is the hosted container build - the IMMUTABLE hosted identity, read
-    /// from the <see cref="HostedGatewayImageAttribute"/> the hosted host (<c>CcDirector.Gateway.Host</c>)
-    /// stamps onto itself at compile time. Unlike <see cref="IsHosted"/> (a runtime environment toggle), this
-    /// cannot be dropped by a slot swap, a config restore, or a lost variable: it is part of the compiled
-    /// artifact. <see cref="HostedStartupContract"/> uses it to decide that the FULL hosted contract must be
-    /// proven at startup or the process must refuse to run - so a hosted image can never silently downgrade
-    /// to Local single-tenant / no-auth semantics.
+    /// The file name of the IMAGE-WIDE hosted identity marker. The hosted host project
+    /// (<c>CcDirector.Gateway.Host</c>) bakes this file into its published output, so it sits in the
+    /// application base directory of the hosted artifact ALONGSIDE every executable that image ships. It is
+    /// what makes hosted identity image-wide rather than tied to one entry assembly: publishing the host also
+    /// ships a runnable, UNMARKED <c>CcDirector.Gateway.dll</c> (with its own deps.json/runtimeconfig.json),
+    /// and a compiled-in attribute only identifies the launcher it is stamped on - so overriding the
+    /// container entrypoint to that unmarked executable would let the same hosted artifact boot as self-host
+    /// with no contract. This marker closes that hole: it is read from the deployment directory the two
+    /// executables SHARE, so <see cref="IsHostedImage"/> is true whichever one runs. Like the deps.json it
+    /// ships next to, it is part of the deployed artifact, so a slot swap or config restore - which drop
+    /// environment variables, not files in the image - cannot remove it.
     /// </summary>
-    public static bool IsHostedImage => IsHostedImageAssembly(System.Reflection.Assembly.GetEntryAssembly());
+    public const string HostedImageMarkerFileName = "hosted-gateway.image";
 
     /// <summary>
-    /// Pure form of <see cref="IsHostedImage"/> for testing: true when <paramref name="entryAssembly"/> is
-    /// non-null and carries <see cref="HostedGatewayImageAttribute"/>. A null entry assembly (some test
+    /// True when the RUNNING deployment is the hosted container build - the IMMUTABLE hosted identity. Unlike
+    /// <see cref="IsHosted"/> (a runtime environment toggle a slot swap or config restore can drop), this is
+    /// part of the compiled/published artifact. <see cref="HostedStartupContract"/> uses it to decide that
+    /// the FULL hosted contract must be proven at startup or the process must refuse to run - so a hosted
+    /// image can never silently downgrade to Local single-tenant / no-auth semantics.
+    ///
+    /// It is true when EITHER signal holds (see <see cref="IsHostedImageDeployment"/>): the entry assembly
+    /// carries the compiled-in <see cref="HostedGatewayImageAttribute"/> (the marked host launcher), OR the
+    /// image-wide <see cref="HostedImageMarkerFileName"/> marker is present in the application base directory.
+    /// The second signal is what the hosted image's OTHER, unmarked runnable executable
+    /// (<c>CcDirector.Gateway.dll</c>) reads, so the contract cannot be bypassed by which entry executable
+    /// the container runs.
+    /// </summary>
+    public static bool IsHostedImage =>
+        IsHostedImageDeployment(System.Reflection.Assembly.GetEntryAssembly(), AppContext.BaseDirectory);
+
+    /// <summary>
+    /// Pure form of <see cref="IsHostedImage"/> for testing: the running deployment IS the hosted image when
+    /// EITHER the entry assembly carries the compiled-in marker (<see cref="IsHostedImageAssembly"/>) OR the
+    /// image-wide marker file is present in <paramref name="baseDirectory"/>
+    /// (<see cref="HostedImageMarkerPresent"/>). Every executable the hosted image ships runs from the same
+    /// base directory, so the second signal makes the identity image-wide: the unmarked
+    /// <c>CcDirector.Gateway.dll</c> sees the marker exactly as the marked host does, and neither can boot the
+    /// hosted artifact as self-host.
+    /// </summary>
+    internal static bool IsHostedImageDeployment(System.Reflection.Assembly? entryAssembly, string? baseDirectory)
+        => IsHostedImageAssembly(entryAssembly) || HostedImageMarkerPresent(baseDirectory);
+
+    /// <summary>
+    /// Pure form of the entry-assembly half of the hosted identity: true when <paramref name="entryAssembly"/>
+    /// is non-null and carries <see cref="HostedGatewayImageAttribute"/>. A null entry assembly (some test
     /// hosts) is treated as NOT the hosted image, so a test run is self-host by default.
     /// </summary>
     internal static bool IsHostedImageAssembly(System.Reflection.Assembly? entryAssembly)
         => entryAssembly?.GetCustomAttribute<HostedGatewayImageAttribute>() is not null;
+
+    /// <summary>
+    /// Pure form of the image-wide half of the hosted identity: true when the
+    /// <see cref="HostedImageMarkerFileName"/> marker file exists in <paramref name="baseDirectory"/>. A null
+    /// or blank base directory is treated as NOT the hosted image (self-host), so this never fabricates a
+    /// hosted verdict from a missing path.
+    /// </summary>
+    internal static bool HostedImageMarkerPresent(string? baseDirectory)
+        => !string.IsNullOrEmpty(baseDirectory)
+           && File.Exists(Path.Combine(baseDirectory, HostedImageMarkerFileName));
 
     /// <summary>
     /// The port a hosted Gateway should listen on: the App Service <c>WEBSITES_PORT</c>, else <c>PORT</c>, else

--- a/src/CcDirector.Gateway/HostedGatewayImageAttribute.cs
+++ b/src/CcDirector.Gateway/HostedGatewayImageAttribute.cs
@@ -17,6 +17,12 @@ namespace CcDirector.Gateway;
 ///
 /// It lives in <c>CcDirector.Gateway</c> (the shared library both hosts reference) so the shared
 /// <see cref="GatewayEntryPoint"/> can read it off the entry assembly. Only the hosted host applies it.
+///
+/// This attribute identifies the MARKED launcher only. Publishing the hosted host ALSO ships a runnable,
+/// unmarked <c>CcDirector.Gateway.dll</c>, which this attribute cannot identify - so hosted identity is made
+/// IMAGE-WIDE by a companion signal, the <see cref="GatewayHostedMode.HostedImageMarkerFileName"/> marker
+/// file the hosted host bakes into its published output. <see cref="GatewayHostedMode.IsHostedImage"/> is
+/// true when EITHER holds, so the fail-closed contract fires whichever entry executable the container runs.
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
 public sealed class HostedGatewayImageAttribute : Attribute

--- a/src/CcDirector.Gateway/HostedGatewayImageAttribute.cs
+++ b/src/CcDirector.Gateway/HostedGatewayImageAttribute.cs
@@ -1,0 +1,24 @@
+namespace CcDirector.Gateway;
+
+/// <summary>
+/// The IMMUTABLE hosted-image identity marker. It is an assembly-level attribute that the hosted container
+/// executable (<c>CcDirector.Gateway.Host</c>) stamps onto ITSELF at compile time, and that the local dev
+/// console host (<c>CcDirector.Gateway</c>) and the Windows tray skin do NOT. So "am I the hosted build" is
+/// answered by the compiled ARTIFACT, not by a single runtime toggle that a slot swap, a config restore, or
+/// a lost environment variable can drop.
+///
+/// This is the fix for the fail-OPEN hole (production-readiness item MH-3 / TOP-ISSUES #8): before it,
+/// hosted identity was ONLY <c>CC_GATEWAY_HOSTED=1</c>, so a hosted deployment that lost that one variable
+/// booted the SAME public image as a Local single-tenant Gateway - the async tenant boundary disappeared,
+/// live-money entitlement enforcement relaxed, and every hosted refusal deactivated, silently. With this
+/// marker baked into the hosted binary, <see cref="HostedStartupContract"/> can tell "this IS the hosted
+/// image" independently of the toggle, and REFUSE to start (rather than silently downgrade) whenever the
+/// full hosted contract is not present.
+///
+/// It lives in <c>CcDirector.Gateway</c> (the shared library both hosts reference) so the shared
+/// <see cref="GatewayEntryPoint"/> can read it off the entry assembly. Only the hosted host applies it.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+public sealed class HostedGatewayImageAttribute : Attribute
+{
+}

--- a/src/CcDirector.Gateway/HostedStartupContract.cs
+++ b/src/CcDirector.Gateway/HostedStartupContract.cs
@@ -1,0 +1,139 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway;
+
+/// <summary>
+/// The fail-CLOSED startup gate for the hosted Gateway (production-readiness item MH-3 / TOP-ISSUES #8).
+///
+/// A hosted deployment must PROVE its full contract at boot or REFUSE to run. Before this gate, the hosted
+/// public image could silently fall back to Local single-tenant / no-auth semantics: <see cref="GatewayHostedMode.IsHosted"/>
+/// treated a missing <c>CC_GATEWAY_HOSTED</c> as "not hosted", so a slot swap, config restore, or lost
+/// environment variable booted the SAME image with the async tenant boundary gone, live-money entitlement
+/// enforcement relaxed, and every hosted refusal deactivated - a catastrophic SILENT downgrade rather than a
+/// loud failure.
+///
+/// The gate keys off the IMMUTABLE identity (<see cref="GatewayHostedMode.IsHostedImage"/>, the compiled-in
+/// <see cref="HostedGatewayImageAttribute"/>), NOT off the droppable <c>CC_GATEWAY_HOSTED</c> toggle. So when
+/// the running executable IS the hosted build, the full contract is REQUIRED even if the toggle was dropped -
+/// a dropped toggle now crashes the boot instead of downgrading it.
+///
+/// THE HOSTED CONTRACT (all must hold, checked here at startup):
+///  1. Hosted mode ON       - <c>CC_GATEWAY_HOSTED=1</c>. This is what drives the async tenant boundary AND
+///     live-entitlement enforcement (<see cref="Tenancy.EntitlementRegistry"/> requires live-mode when
+///     <see cref="GatewayHostedMode.IsHosted"/> is true), so requiring it here transitively guarantees both.
+///  2. Auth ENABLED         - the auth-disable debug flags (<c>CC_GATEWAY_NO_AUTH=1</c>, <c>CC_GATEWAY_AUTH=0</c>)
+///     are REJECTED: they must not be honorable in production, so their presence is a contract violation.
+///  3. Public HTTPS URL     - <c>CC_GATEWAY_PUBLIC_URL</c> is set to an <c>https://</c> URL.
+///  4. PostgreSQL provider  - <c>CC_GATEWAY_DB_CONNECTION</c> is set (the hosted Gateway does NOT run on the
+///     local SQLite file). The migrations themselves are applied fail-loud by
+///     <see cref="Data.GatewayDatabase"/> (it throws if Migrate() fails), so "migrations applied" is enforced
+///     by construction once this precondition holds.
+///
+/// SELF-HOST IS UNAFFECTED. When the running executable is not the hosted image (the desktop tray, the dev
+/// console host, the test runner), this gate does nothing at all - self-host stays a distinct artifact with
+/// its byte-identical, unchanged behavior.
+/// </summary>
+public static class HostedStartupContract
+{
+    /// <summary>
+    /// Assert the hosted contract against the live environment when this executable is the hosted image, and
+    /// throw <see cref="InvalidOperationException"/> listing every violation if it does not hold. A no-op on
+    /// any non-hosted-image build. Called ONCE, early in <see cref="GatewayEntryPoint.Run"/>, before the host
+    /// is built - so a violation fails the boot loud instead of downgrading it.
+    /// </summary>
+    public static void AssertFromEnvironment()
+        => Assert(GatewayHostedMode.IsHostedImage, Environment.GetEnvironmentVariable);
+
+    /// <summary>
+    /// Testable core of <see cref="AssertFromEnvironment"/>: a no-op unless <paramref name="isHostedImage"/>
+    /// is true, otherwise reads the five contract values through <paramref name="readEnv"/>, and throws
+    /// <see cref="InvalidOperationException"/> listing every violation if the contract does not hold. The
+    /// seam lets a test drive both the self-host no-op and the hosted-image refusal deterministically,
+    /// without depending on the process's real entry assembly or environment.
+    /// </summary>
+    internal static void Assert(bool isHostedImage, Func<string, string?> readEnv)
+    {
+        if (!isHostedImage)
+            return;
+
+        var violations = CheckHostedContract(
+            hosted: readEnv(GatewayHostedMode.HostedEnvVar),
+            noAuth: readEnv(GatewayHost.AuthDisabledEnvVar),
+            authToggle: readEnv(GatewayHost.AuthEnabledEnvVar),
+            publicUrl: readEnv(GatewayPublicUrl.PublicBaseUrlEnvVar),
+            dbConnection: readEnv(Data.GatewayDatabase.PostgresConnectionEnvVar));
+
+        if (violations.Count == 0)
+        {
+            FileLog.Write("[HostedStartupContract] hosted image: full hosted contract satisfied (hosted mode + auth + HTTPS public URL + PostgreSQL). Starting.");
+            return;
+        }
+
+        var message =
+            "REFUSING TO START. This is the hosted Gateway image, but the hosted contract is not satisfied. " +
+            "A hosted deployment must not fall back to Local single-tenant / no-auth semantics, so it fails " +
+            "closed rather than downgrade. Fix the following and restart:" +
+            Environment.NewLine + " - " + string.Join(Environment.NewLine + " - ", violations);
+
+        FileLog.Write("[HostedStartupContract] " + message.Replace(Environment.NewLine, " | "));
+        throw new InvalidOperationException(message);
+    }
+
+    /// <summary>
+    /// Pure hosted-contract check: given the raw environment values, return the list of violations (empty
+    /// when the contract holds). Fully unit-testable without touching the process environment. The caller is
+    /// responsible for only invoking this when the executable IS the hosted image.
+    /// </summary>
+    /// <param name="hosted">The <c>CC_GATEWAY_HOSTED</c> value.</param>
+    /// <param name="noAuth">The <c>CC_GATEWAY_NO_AUTH</c> value.</param>
+    /// <param name="authToggle">The <c>CC_GATEWAY_AUTH</c> value.</param>
+    /// <param name="publicUrl">The <c>CC_GATEWAY_PUBLIC_URL</c> value.</param>
+    /// <param name="dbConnection">The <c>CC_GATEWAY_DB_CONNECTION</c> value.</param>
+    public static IReadOnlyList<string> CheckHostedContract(
+        string? hosted, string? noAuth, string? authToggle, string? publicUrl, string? dbConnection)
+    {
+        var violations = new List<string>();
+
+        // 1. Hosted mode ON. This single check also guarantees live-entitlement enforcement, because the
+        //    EntitlementRegistry requires live-mode exactly when GatewayHostedMode.IsHosted is true.
+        if (!string.Equals(hosted, "1", StringComparison.Ordinal))
+            violations.Add(
+                $"{GatewayHostedMode.HostedEnvVar} must be \"1\" (hosted mode drives the tenant boundary and " +
+                $"live-entitlement enforcement); it is {Describe(hosted)}.");
+
+        // 2. Auth must be ENABLED - the debug disable flags are rejected outright in production.
+        if (string.Equals(noAuth, "1", StringComparison.Ordinal))
+            violations.Add(
+                $"{GatewayHost.AuthDisabledEnvVar}=1 disables the auth gate and is not honorable on the hosted " +
+                "image; remove it.");
+        if (string.Equals(authToggle, "0", StringComparison.Ordinal))
+            violations.Add(
+                $"{GatewayHost.AuthEnabledEnvVar}=0 disables the auth gate and is not honorable on the hosted " +
+                "image; remove it.");
+
+        // 3. Public HTTPS URL.
+        if (string.IsNullOrWhiteSpace(publicUrl))
+            violations.Add(
+                $"{GatewayPublicUrl.PublicBaseUrlEnvVar} must be set to the public base URL (for example " +
+                $"https://gateway.devthrottle.com); it is {Describe(publicUrl)}.");
+        else if (!publicUrl.Trim().StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            violations.Add(
+                $"{GatewayPublicUrl.PublicBaseUrlEnvVar} must be an https:// URL on the hosted image; it is " +
+                $"{Describe(publicUrl)}.");
+
+        // 4. PostgreSQL provider. GatewayDatabase applies the migrations fail-loud once this is set, so the
+        //    "migrations applied" part of the contract is enforced by construction from here.
+        if (string.IsNullOrWhiteSpace(dbConnection))
+            violations.Add(
+                $"{Data.GatewayDatabase.PostgresConnectionEnvVar} must be set to the PostgreSQL connection " +
+                "string (the hosted Gateway does not run on the local SQLite file); it is " +
+                $"{Describe(dbConnection)}.");
+
+        return violations;
+    }
+
+    /// <summary>Describe an environment value for a violation message without ever echoing a secret: unset,
+    /// blank, or "set" - never the value itself (a connection string carries credentials).</summary>
+    private static string Describe(string? value)
+        => value is null ? "unset" : string.IsNullOrWhiteSpace(value) ? "blank" : "set to an unexpected value";
+}

--- a/src/CcDirector.Gateway/HostedStartupContract.cs
+++ b/src/CcDirector.Gateway/HostedStartupContract.cs
@@ -12,10 +12,13 @@ namespace CcDirector.Gateway;
 /// enforcement relaxed, and every hosted refusal deactivated - a catastrophic SILENT downgrade rather than a
 /// loud failure.
 ///
-/// The gate keys off the IMMUTABLE identity (<see cref="GatewayHostedMode.IsHostedImage"/>, the compiled-in
-/// <see cref="HostedGatewayImageAttribute"/>), NOT off the droppable <c>CC_GATEWAY_HOSTED</c> toggle. So when
-/// the running executable IS the hosted build, the full contract is REQUIRED even if the toggle was dropped -
-/// a dropped toggle now crashes the boot instead of downgrading it.
+/// The gate keys off the IMMUTABLE identity (<see cref="GatewayHostedMode.IsHostedImage"/> - the compiled-in
+/// <see cref="HostedGatewayImageAttribute"/> on the marked launcher OR the image-wide
+/// <see cref="GatewayHostedMode.HostedImageMarkerFileName"/> marker baked into the published artifact), NOT
+/// off the droppable <c>CC_GATEWAY_HOSTED</c> toggle. So when the running DEPLOYMENT is the hosted build, the
+/// full contract is REQUIRED even if the toggle was dropped, and even if the container entrypoint is
+/// overridden to the unmarked <c>CcDirector.Gateway.dll</c> that also ships in the image - a dropped toggle,
+/// or a swapped entry executable, now crashes the boot instead of downgrading it.
 ///
 /// THE HOSTED CONTRACT (all must hold, checked here at startup):
 ///  1. Hosted mode ON       - <c>CC_GATEWAY_HOSTED=1</c>. This is what drives the async tenant boundary AND
@@ -111,15 +114,18 @@ public static class HostedStartupContract
                 $"{GatewayHost.AuthEnabledEnvVar}=0 disables the auth gate and is not honorable on the hosted " +
                 "image; remove it.");
 
-        // 3. Public HTTPS URL.
+        // 3. Public HTTPS URL. A bare "https://" prefix is NOT enough: GatewayPublicUrl only trims and
+        //    appends a surface path, so a value like "https://" (no host) would pass a prefix check and then
+        //    be served as a broken base URL with no later fail-loud guard. The value must PARSE as an
+        //    absolute https URL with a real host, in the base-URL shape (no query or fragment).
         if (string.IsNullOrWhiteSpace(publicUrl))
             violations.Add(
                 $"{GatewayPublicUrl.PublicBaseUrlEnvVar} must be set to the public base URL (for example " +
                 $"https://gateway.devthrottle.com); it is {Describe(publicUrl)}.");
-        else if (!publicUrl.Trim().StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        else if (!IsValidHttpsBaseUrl(publicUrl))
             violations.Add(
-                $"{GatewayPublicUrl.PublicBaseUrlEnvVar} must be an https:// URL on the hosted image; it is " +
-                $"{Describe(publicUrl)}.");
+                $"{GatewayPublicUrl.PublicBaseUrlEnvVar} must be an absolute https:// URL with a host (for " +
+                $"example https://gateway.devthrottle.com) on the hosted image; it is {Describe(publicUrl)}.");
 
         // 4. PostgreSQL provider. GatewayDatabase applies the migrations fail-loud once this is set, so the
         //    "migrations applied" part of the contract is enforced by construction from here.
@@ -130,6 +136,36 @@ public static class HostedStartupContract
                 $"{Describe(dbConnection)}.");
 
         return violations;
+    }
+
+    /// <summary>
+    /// True when <paramref name="value"/> is a well-formed public BASE URL for the hosted Gateway: it parses
+    /// as an ABSOLUTE URI, its scheme is exactly <c>https</c>, it has a non-empty host, and it carries no
+    /// query or fragment (a base URL onto which a surface path is appended). This rejects the
+    /// prefix-only values a <c>StartsWith("https://")</c> check let through - <c>https://</c> (no host),
+    /// <c>https:///path</c> (empty host), <c>https://:443</c> (empty host) - and non-https schemes, while
+    /// accepting a host with an optional port and path (for example <c>https://gateway.devthrottle.com</c> or
+    /// <c>https://host:8443</c>).
+    /// </summary>
+    private static bool IsValidHttpsBaseUrl(string value)
+    {
+        if (!Uri.TryCreate(value.Trim(), UriKind.Absolute, out var uri))
+            return false;
+
+        // Uri normalizes the scheme to lower case, so an ordinal compare to the https scheme constant is
+        // exact and case-correct.
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal))
+            return false;
+
+        if (string.IsNullOrEmpty(uri.Host))
+            return false;
+
+        // A base URL carries no query or fragment; a surface path is appended to it, so those would only ever
+        // corrupt the derived URL.
+        if (!string.IsNullOrEmpty(uri.Query) || !string.IsNullOrEmpty(uri.Fragment))
+            return false;
+
+        return true;
     }
 
     /// <summary>Describe an environment value for a violation message without ever echoing a secret: unset,


### PR DESCRIPTION
## What this fixes

Production-readiness item MH-3 / TOP-ISSUES #8: the hosted gateway could **silently** fall back to Local single-tenant / no-auth semantics.

- `GatewayHostedMode.IsHosted` treated a missing/unexpected `CC_GATEWAY_HOSTED` as **not hosted**, so a slot swap, config restore, or lost App Service setting booted the SAME public image as a Local single-tenant gateway: the async tenant boundary disappeared, live-money entitlement enforcement relaxed, and every hosted refusal deactivated.
- Production also honored `CC_GATEWAY_NO_AUTH=1` / `CC_GATEWAY_AUTH=0`, disabling the auth gate entirely.

Both were a catastrophic **silent downgrade**, not a startup failure.

## The fix

A hosted deployment now proves its contract at startup or refuses to run.

1. **Immutable hosted identity** - new `HostedGatewayImageAttribute`, applied by the hosted host executable (`CcDirector.Gateway.Host`), the only exe that ships in the hosted image. "Am I the hosted build" is answered by the compiled **artifact** (`GatewayHostedMode.IsHostedImage`), not a runtime toggle config can drop.
2. **Fail-closed startup gate** - new `HostedStartupContract`, called once early in the shared `GatewayEntryPoint.Run` before the host is built. When the running exe is the hosted image, the full contract must hold or the process exits non-zero (**2**, distinct from a generic fault's 1):
   - hosted mode on (`CC_GATEWAY_HOSTED=1`) - also guarantees live-entitlement enforcement (`EntitlementRegistry` requires live-mode when hosted);
   - auth enabled - the disable flags `CC_GATEWAY_NO_AUTH=1` / `CC_GATEWAY_AUTH=0` are **rejected**;
   - `CC_GATEWAY_PUBLIC_URL` set to an `https://` URL;
   - `CC_GATEWAY_DB_CONNECTION` set (PostgreSQL) - "migrations applied" is then enforced by construction, since `GatewayDatabase` applies the Postgres migrations fail-loud.
3. **Dockerfile** bakes `ENV CC_GATEWAY_HOSTED=1` into the image (was only an App Service setting). `CC_GATEWAY_PUBLIC_URL` and `CC_GATEWAY_DB_CONNECTION` are deliberately not baked - they are environment-specific / carry credentials and stay App Service settings.

Because the marker is the immutable source of truth, a dropped `CC_GATEWAY_HOSTED` no longer downgrades - it fails the contract and **crashes the boot**.

**Self-host is unaffected**: the desktop tray, the dev console host, and the test runner do not carry the marker, so the contract never runs and behavior is byte-identical.

## Files

- `src/CcDirector.Gateway/HostedGatewayImageAttribute.cs` (new)
- `src/CcDirector.Gateway/HostedStartupContract.cs` (new)
- `src/CcDirector.Gateway/GatewayHostedMode.cs` - `HostedEnvVar`, `IsHostedImage`, `IsHostedImageAssembly`
- `src/CcDirector.Gateway/GatewayEntryPoint.cs` - assert the contract before boot; exit 2 on refusal
- `src/CcDirector.Gateway.Host/Program.cs` - apply the marker
- `Dockerfile` - bake `CC_GATEWAY_HOSTED=1`
- `src/CcDirector.Gateway.Tests/HostedStartupContractTests.cs` (new, 15 tests)

## Proof

- `dotnet build src/CcDirector.Gateway.Host` -> **0 warnings, 0 errors** (TreatWarningsAsErrors on).
- `dotnet test --filter HostedStartupContractTests` -> **15/15 pass**.
- Full Gateway suite -> **3085 passed, 12 skipped, 0 failed** (clean re-run; 2 pre-existing flakes from a first run passed on re-run and do not touch hosted mode or the entry point).

## Note for the reviewer

The hosted image now **refuses a bare `docker run`** by design - it demands `CC_GATEWAY_PUBLIC_URL` + `CC_GATEWAY_DB_CONNECTION` at run time (plus the baked `CC_GATEWAY_HOSTED=1`). Any local smoke run of the hosted image and the deploy must supply those two settings or the container exits 2.
