### PR TITLE
fix(gateway): tenant-scope every per-director route; delete the bare-id registry accessor

### DIFF
--- a/src/CcDirector.Gateway.Tests/CronNotifyTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronNotifyTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Data;
@@ -213,7 +214,7 @@ public sealed class CronNotifyTests : IDisposable
 
         // Leg 1: it landed on the EXISTING per-Director event ring under the resolved director, with
         // the cron-run-completed event name (the fleet channel, not a new mechanism). AC5.
-        var ring = events.For("director-1");
+        var ring = events.For(TenantId.Local, "director-1");
         Assert.Single(ring);
         Assert.Equal(DoorbellEvents.CronRunCompleted, ring[0].Event);
         Assert.Equal("sid-1", ring[0].SessionId);
@@ -258,7 +259,7 @@ public sealed class CronNotifyTests : IDisposable
         await notifier.NotifyRunCompletedAsync(job, "", payload, CancellationToken.None);
 
         // No director resolved -> the failed run is still observable, filed under the job id.
-        var ring = events.For("cj_fail");
+        var ring = events.For(TenantId.Local, "cj_fail");
         Assert.Single(ring);
         Assert.Equal(DoorbellEvents.CronRunCompleted, ring[0].Event);
         Assert.Equal("not-started", ring[0].State);
@@ -283,7 +284,7 @@ public sealed class CronNotifyTests : IDisposable
 
         await notifier.NotifyRunCompletedAsync(job, "director-1", payload, CancellationToken.None);
 
-        Assert.Single(events.For("director-1"));     // ring still gets it
+        Assert.Single(events.For(TenantId.Local, "director-1"));     // ring still gets it
         Assert.Null(capture.LastBody);               // no webhook posted
     }
 

--- a/src/CcDirector.Gateway.Tests/DirectorEventsAndFactsTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorEventsAndFactsTests.cs
@@ -124,8 +124,8 @@ public sealed class DirectorEventsAndFactsTests : IAsyncLifetime
 
         client.NotifySessionState(sid, "Starting", DoorbellEvents.SessionCreated);
 
-        await WaitFor(() => Task.FromResult(_gateway.DirectorEvents.For(id).Count > 0), TimeSpan.FromSeconds(5));
-        var ev = Assert.Single(_gateway.DirectorEvents.For(id));
+        await WaitFor(() => Task.FromResult(_gateway.DirectorEvents.For(TenantId.Local, id).Count > 0), TimeSpan.FromSeconds(5));
+        var ev = Assert.Single(_gateway.DirectorEvents.For(TenantId.Local, id));
         Assert.Equal(sid, ev.SessionId);
         Assert.Equal(DoorbellEvents.SessionCreated, ev.Event);
         Assert.Equal("Starting", ev.State);

--- a/src/CcDirector.Gateway.Tests/DirectorRouteTenantScopingTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorRouteTenantScopingTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Net.Sockets;
 using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway;
 using CcDirector.Gateway.Contracts;
 using Xunit;
@@ -169,6 +170,117 @@ public sealed class DirectorRouteTenantScopingTests : IAsyncLifetime
         Assert.DoesNotContain("interrupted-list", _bOnlyVerbs);    // nor B's other Director
     }
 
+    // ===== Codex round 1: the three MISSED surfaces =====
+
+    [Fact]
+    public async Task Backfill_on_a_shared_director_id_reaches_only_the_callers_own_director()
+    {
+        // The director-scoped command surface POST /directors/{id}/backfill-numbers used to dispatch the bare
+        // id straight over the tunnel. Gated on the owned Director, A's backfill lands on A's OWN dir-shared and
+        // never on B's same-id Director.
+        var resp = await PostEmpty("directors/dir-shared/backfill-numbers", _keyA);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Contains("backfill-numbers", _aSharedVerbs);
+        Assert.DoesNotContain("backfill-numbers", _bSharedVerbs);
+    }
+
+    [Fact]
+    public async Task Backfill_on_a_foreign_director_id_is_404_and_no_command_is_sent()
+    {
+        // An id that exists only in tenant B. A naming it is refused at the registry gate (404) BEFORE dispatch,
+        // so B's Director is never sent the backfill verb over the tunnel.
+        var resp = await PostEmpty("directors/dir-b-only/backfill-numbers", _keyA);
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.DoesNotContain("backfill-numbers", _bOnlyVerbs);
+
+        // Positive control: B's own key reaches its Director, proving the id is real and routable.
+        var sameTenant = await PostEmpty("directors/dir-b-only/backfill-numbers", _keyB);
+        Assert.Equal(HttpStatusCode.OK, sameTenant.StatusCode);
+        Assert.Contains("backfill-numbers", _bOnlyVerbs);
+    }
+
+    [Fact]
+    public async Task Backfill_with_no_bound_tenant_is_denied()
+    {
+        // Deny-by-default: an authenticated but tenant-unbound key never falls back to the Local partition on
+        // the backfill command surface, and no verb is dispatched.
+        var resp = await PostEmpty("directors/dir-shared/backfill-numbers", _keyUnbound);
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        Assert.DoesNotContain("backfill-numbers", _aSharedVerbs);
+        Assert.DoesNotContain("backfill-numbers", _bSharedVerbs);
+    }
+
+    [Fact]
+    public async Task Event_ring_is_isolated_by_tenant_for_the_same_director_id()
+    {
+        // The Local-shadow read: the event ring was one global queue per bare id, so tenant A could read tenant
+        // B's ring for the same id. Keyed by (tenant, id), A's ring and B's ring for the IDENTICAL id
+        // "dir-shared" are distinct queues. Seed both, then prove each account reads only its own.
+        _gateway.DirectorEvents.Record(new TenantId("tenant-alice"), "dir-shared", "sess-alice", DoorbellEvents.CronRunCompleted, "started");
+        _gateway.DirectorEvents.Record(new TenantId("tenant-bob"), "dir-shared", "sess-bob", DoorbellEvents.CronRunCompleted, "started");
+
+        var aBody = await (await Get("directors/dir-shared/events", _keyA)).Content.ReadAsStringAsync();
+        Assert.Contains("sess-alice", aBody);
+        Assert.DoesNotContain("sess-bob", aBody);
+
+        var bBody = await (await Get("directors/dir-shared/events", _keyB)).Content.ReadAsStringAsync();
+        Assert.Contains("sess-bob", bBody);
+        Assert.DoesNotContain("sess-alice", bBody);
+    }
+
+    [Fact]
+    public async Task Event_ring_read_on_a_foreign_director_id_is_404()
+    {
+        // Even with a seeded ring for the foreign id under B, A naming dir-b-only is refused at the registry
+        // gate (404) - A does not own that Director, so it can never reach that ring.
+        _gateway.DirectorEvents.Record(new TenantId("tenant-bob"), "dir-b-only", "sess-bob", DoorbellEvents.CronRunCompleted, "started");
+
+        Assert.Equal(HttpStatusCode.NotFound, (await Get("directors/dir-b-only/events", _keyA)).StatusCode);
+
+        // Positive control: B's own key reads its own ring for that id.
+        var bBody = await (await Get("directors/dir-b-only/events", _keyB)).Content.ReadAsStringAsync();
+        Assert.Contains("sess-bob", bBody);
+    }
+
+    [Fact]
+    public async Task Event_ring_read_with_no_bound_tenant_is_denied()
+    {
+        Assert.Equal(HttpStatusCode.Forbidden, (await Get("directors/dir-shared/events", _keyUnbound)).StatusCode);
+    }
+
+    [Fact]
+    public async Task Legacy_discovery_plane_is_unavailable_on_hosted_and_leaves_no_shadow()
+    {
+        // The discovery legs (register / heartbeat / doorbell / unregister) are the same-machine HTTP plane and
+        // the Local-shadow registration path. On hosted they are explicitly unavailable (403), which closes the
+        // shadow: a hosted caller cannot fabricate a Local registration of another tenant's id, nor inject into
+        // or delete a Local registration.
+        var register = await Post("directors/register", _keyA, new DirectorRegistrationRequest
+        {
+            DirectorId = "shadow-x",
+            TailnetEndpoint = "http://127.0.0.1:9/",
+            MachineName = "attacker",
+            Pid = 1,
+            Version = "x",
+            StartedAt = DateTime.UtcNow,
+        });
+        Assert.Equal(HttpStatusCode.Forbidden, register.StatusCode);
+
+        // No-side-effect: the shadow id was never registered, in the attacker's tenant OR in Local.
+        Assert.Null(_gateway.Registry.Get(new TenantId("tenant-alice"), "shadow-x"));
+        Assert.Null(_gateway.Registry.Get(TenantId.Local, "shadow-x"));
+
+        Assert.Equal(HttpStatusCode.Forbidden,
+            (await Post("directors/dir-shared/heartbeat", _keyA, new { })).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden,
+            (await Post("directors/dir-shared/doorbell", _keyA,
+                new DoorbellRequest { SessionId = "s", NewState = "Working", Event = DoorbellEvents.SessionCreated })).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden,
+            (await Delete("directors/dir-shared/registration", _keyA)).StatusCode);
+    }
+
     // A dispatch that RECORDS every verb the Gateway sends this Director, then answers the read/create verbs
     // this test drives with an OK body so a route that DID reach it returns success (the positive controls).
     // The point is the verb log, not the body.
@@ -204,6 +316,20 @@ public sealed class DirectorRouteTenantScopingTests : IAsyncLifetime
     private Task<HttpResponseMessage> Post(string path, string deviceKey, object body)
     {
         var req = new HttpRequestMessage(HttpMethod.Post, path) { Content = JsonContent.Create(body) };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private Task<HttpResponseMessage> PostEmpty(string path, string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private Task<HttpResponseMessage> Delete(string path, string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Delete, path);
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
         return _http.SendAsync(req);
     }

--- a/src/CcDirector.Gateway.Tests/DirectorRouteTenantScopingTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorRouteTenantScopingTests.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// MTR-01: cross-tenant RCE / read / control via BARE director ids, proven over the REAL mapped endpoints and
+/// the REAL tunnel.
+///
+/// Before this fix ~20 <c>/directors/{id}/*</c> routes and the <c>/interrupted</c> plane resolved a Director by
+/// a bare id that scanned EVERY tenant's entries and returned the freshest match. So tenant A, holding its own
+/// valid device key, could enumerate tenant B's director id and then <c>POST /directors/{id}/sessions</c> to
+/// spawn a coding agent on B's machine, read B's repos/handovers/filesystem, overwrite B's settings, or stop
+/// B's Director. The fix deletes the bare-id registry accessor and forces every per-director route through the
+/// tenant-scoped <c>DirectorRegistry.Get(tenant, id)</c>, resolved from the request's authenticated device key.
+///
+/// The sharp proof is the SAME director id under TWO tenants: <c>dir-shared</c> exists in both tenant-alice and
+/// tenant-bob. A caller naming it can only ever reach ITS OWN "dir-shared", never the other tenant's - the id is
+/// identical, only the authenticated tenant differs. A "no command reached the other tenant" assertion is made
+/// directly: each fake Director records every verb the Gateway sends it, and B's Director records NOTHING for
+/// A's requests.
+///
+/// Revert-prove: restore the bare <c>DirectorRegistry.Get(string)</c> overload and point the routes back at it,
+/// and A's spawn lands on (or at minimum reaches) B's Director / the foreign-id read returns 200 - so the
+/// "DoesNotContain create/repos-list on B" and the 404 assertions go RED.
+///
+/// This drives the REAL auth middleware (which stashes the authenticated device key) and the REAL tunnel Hello
+/// (which binds each Director's tenant), like <c>SessionServingReadIsolationTests</c>. The assembly runs
+/// sequentially, so toggling CC_GATEWAY_HOSTED here is safe; it is reset in DisposeAsync.
+/// </summary>
+public sealed class DirectorRouteTenantScopingTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    // Two tenants, one shared director id: dir-shared exists in BOTH alice and bob.
+    private FakeTunnelDirector _dirAShared = null!; // tenant-alice, id "dir-shared"
+    private FakeTunnelDirector _dirBShared = null!; // tenant-bob,   id "dir-shared" (SAME id)
+    private FakeTunnelDirector _dirBOnly = null!;   // tenant-bob,   id "dir-b-only" (only bob has it)
+
+    // Every verb the Gateway sends each Director over the tunnel, so "no command reached the other tenant" is a
+    // direct assertion, not an inference from a status code.
+    private readonly ConcurrentQueue<string> _aSharedVerbs = new();
+    private readonly ConcurrentQueue<string> _bSharedVerbs = new();
+    private readonly ConcurrentQueue<string> _bOnlyVerbs = new();
+
+    private string _keyA = "";
+    private string _keyB = "";
+    private string _keyUnbound = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-mtr01-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // Two accounts: two device keys, each bound to its OWN tenant, plus one registered-but-unbound key.
+        _keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        _keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        _keyUnbound = _gateway.Devices.Register("dev-x", "MX").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", "tenant-alice");
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", "tenant-bob");
+
+        // Each Director authenticates with its OWN device key -> the tunnel Hello binds its tenant -> its entry
+        // lands in that tenant's partition. dir-shared is registered under BOTH tenants (the sharp case).
+        _dirAShared = await FakeTunnelDirector.StartAsync(_gateway, _keyA, "dir-shared", "MA", dispatch: Recorder(_aSharedVerbs));
+        _dirBShared = await FakeTunnelDirector.StartAsync(_gateway, _keyB, "dir-shared", "MB", dispatch: Recorder(_bSharedVerbs));
+        _dirBOnly = await FakeTunnelDirector.StartAsync(_gateway, _keyB, "dir-b-only", "MB", dispatch: Recorder(_bOnlyVerbs));
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _dirAShared.DisposeAsync();
+        await _dirBShared.DisposeAsync();
+        await _dirBOnly.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task Spawn_on_a_shared_director_id_reaches_only_the_callers_own_director()
+    {
+        // The RCE vector: POST /directors/{id}/sessions spawns a coding agent on that Director's machine. A and
+        // B both hold a Director with the IDENTICAL id "dir-shared"; A's spawn must land on A's OWN Director and
+        // never on B's. This is the whole exploit closed: same id, different tenant, no crossing.
+        var resp = await Post("directors/dir-shared/sessions", _keyA,
+            new NewSessionRequest { RepoPath = "/repo", Agent = "claude" });
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        Assert.Contains("create", _aSharedVerbs);       // A's own Director ran the spawn
+        Assert.DoesNotContain("create", _bSharedVerbs);  // B's same-id Director NEVER saw the command
+    }
+
+    [Fact]
+    public async Task A_foreign_director_id_is_404_and_no_command_is_sent()
+    {
+        // An id that exists ONLY in tenant B. Tenant A naming it is refused AT the registry gate (404), and B's
+        // Director is never reached over the tunnel.
+        var crossTenant = await Get("directors/dir-b-only/repos", _keyA);
+        Assert.Equal(HttpStatusCode.NotFound, crossTenant.StatusCode);
+        Assert.DoesNotContain("repos-list", _bOnlyVerbs);
+
+        // Positive control: B's OWN key reaches its Director, proving the id is real and routable - so the 404
+        // above is the tenant gate, not a missing Director.
+        var sameTenant = await Get("directors/dir-b-only/repos", _keyB);
+        Assert.Equal(HttpStatusCode.OK, sameTenant.StatusCode);
+        Assert.Contains("repos-list", _bOnlyVerbs);
+    }
+
+    [Fact]
+    public async Task A_write_route_on_a_foreign_director_id_is_404_and_spawns_nothing()
+    {
+        // The same guarantee on the WRITE/RCE path: A cannot spawn on an id it does not own, and B's Director
+        // gets no create command.
+        var resp = await Post("directors/dir-b-only/sessions", _keyA,
+            new NewSessionRequest { RepoPath = "/repo", Agent = "claude" });
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.DoesNotContain("create", _bOnlyVerbs);
+    }
+
+    [Fact]
+    public async Task A_device_key_with_no_bound_tenant_is_denied()
+    {
+        // Deny-by-default: an authenticated but tenant-unbound key never falls back to the Local partition on a
+        // per-director route - read OR write.
+        Assert.Equal(HttpStatusCode.Forbidden, (await Get("directors/dir-shared/repos", _keyUnbound)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden,
+            (await Post("directors/dir-shared/sessions", _keyUnbound, new NewSessionRequest { RepoPath = "/repo" })).StatusCode);
+    }
+
+    [Fact]
+    public async Task Interrupted_plane_fans_out_only_to_the_callers_own_directors()
+    {
+        // GET /interrupted used the fleet-global director list, so it enumerated and queried every tenant's
+        // Directors. Scoped to the caller's tenant, A's request reaches only A's Directors' crash journals; B's
+        // Directors are never queried over the tunnel.
+        var resp = await Get("interrupted", _keyA);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        Assert.Contains("interrupted-list", _aSharedVerbs);        // A's own Director was queried
+        Assert.DoesNotContain("interrupted-list", _bSharedVerbs);  // B's same-id Director never was
+        Assert.DoesNotContain("interrupted-list", _bOnlyVerbs);    // nor B's other Director
+    }
+
+    // A dispatch that RECORDS every verb the Gateway sends this Director, then answers the read/create verbs
+    // this test drives with an OK body so a route that DID reach it returns success (the positive controls).
+    // The point is the verb log, not the body.
+    private static Func<DirectorCommand, DirectorCommandResult> Recorder(ConcurrentQueue<string> log) =>
+        cmd =>
+        {
+            log.Enqueue(cmd.Verb);
+            return cmd.Verb switch
+            {
+                "create" => FakeTunnelDirector.Ok(new SessionDto
+                {
+                    SessionId = "new-sess",
+                    Agent = "claude",
+                    RepoPath = "/repo",
+                    Status = "Running",
+                    StatusColor = "blue",
+                    CreatedAt = DateTime.UtcNow,
+                    LastActivityAt = DateTime.UtcNow,
+                }),
+                "repos-list" => FakeTunnelDirector.Ok(Array.Empty<RepositoryDto>()),
+                "interrupted-list" => FakeTunnelDirector.Ok(Array.Empty<CrashJournalDto>()),
+                _ => FakeTunnelDirector.Ok(new { ok = true }),
+            };
+        };
+
+    private Task<HttpResponseMessage> Get(string path, string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private Task<HttpResponseMessage> Post(string path, string deviceKey, object body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, path) { Content = JsonContent.Create(body) };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayDirectoryRegistrationTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayDirectoryRegistrationTests.cs
@@ -142,7 +142,9 @@ public sealed class GatewayDirectoryRegistrationTests : IAsyncLifetime
         var resp = await _http.PostAsJsonAsync("directors/register", req);
         Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
 
-        var dto = _gateway.Registry.Get(id);
+        // The HTTP registration path keys its entry to the Local tenant (see DirectorRegistry.Upsert); MTR-01
+        // deleted the bare-id accessor, so read it back through the tenant-scoped overload.
+        var dto = _gateway.Registry.Get(CcDirector.Core.Tenancy.TenantId.Local, id);
         Assert.NotNull(dto);
         Assert.True(string.IsNullOrEmpty(dto.TailnetEndpoint));
         Assert.Equal(req.EndpointUnreachableReason, dto.EndpointUnreachableReason);
@@ -165,13 +167,14 @@ public sealed class GatewayDirectoryRegistrationTests : IAsyncLifetime
             MachineName = "machine-d",
         });
 
-        var before = _gateway.Registry.Get(id)!.LastSeen;
+        // MTR-01: the HTTP registration path is Local-keyed; read it back through the tenant-scoped overload.
+        var before = _gateway.Registry.Get(CcDirector.Core.Tenancy.TenantId.Local, id)!.LastSeen;
         await Task.Delay(50); // ensure a measurable delta
 
         var resp = await _http.PostAsync($"directors/{id}/heartbeat", content: null);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
 
-        var after = _gateway.Registry.Get(id)!.LastSeen;
+        var after = _gateway.Registry.Get(CcDirector.Core.Tenancy.TenantId.Local, id)!.LastSeen;
         Assert.True(after > before, $"expected LastSeen to move forward; before={before}, after={after}");
     }
 

--- a/src/CcDirector.Gateway.Tests/SessionWsProxyEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionWsProxyEndpointsTests.cs
@@ -141,10 +141,14 @@ public sealed class SessionWsProxyEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Backfill_numbers_for_an_unconnected_director_returns_503()
+    public async Task Backfill_numbers_for_an_unknown_director_id_returns_404()
     {
+        // MTR-01 (Codex round 1): the backfill leg now resolves the owned Director in the request's tenant
+        // BEFORE dispatch, so an id that is in no Director registry entry is a 404 at the gate - it never
+        // reaches the tunnel dispatch (which is what used to answer an unknown id with a 503). On self-host
+        // the request tenant is Local, so this is an ordinary present/absent lookup.
         var resp = await _http.PostAsync("directors/no-such-director/backfill-numbers", null);
-        Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
     private static SessionDto Session(string sid) => new()

--- a/src/CcDirector.Gateway.Tests/StreamCommandTests.cs
+++ b/src/CcDirector.Gateway.Tests/StreamCommandTests.cs
@@ -517,7 +517,8 @@ public sealed class StreamCommandTests : IAsyncLifetime
             Version = "test",
             StartedAt = DateTime.UtcNow,
         });
-        Assert.Equal("", _gateway.Registry.Get(DirectorId)?.ControlEndpoint);
+        // MTR-01: the HTTP-register path (Upsert) is Local-keyed; read it back through the tenant-scoped overload.
+        Assert.Equal("", _gateway.Registry.Get(CcDirector.Core.Tenancy.TenantId.Local, DirectorId)?.ControlEndpoint);
 
         var spy = new CountingDispatcher(_directorSessions);
         await using var client = NewClient(spy);

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -547,6 +547,15 @@ internal static class GatewayEndpoints
 
         app.MapPost("/directors/register", (DirectorRegistrationRequest req) =>
         {
+            // MTR-01 (Codex round 1): the HTTP register/heartbeat/doorbell/unregister legs are the legacy
+            // SAME-MACHINE discovery plane - a self-host-only concept. A hosted Director reaches the Gateway
+            // over the tunnel, never these HTTP legs, and every entry this plane writes is keyed to the Local
+            // tenant. Left open on hosted, POST /directors/register is exactly the Local-shadow path: a hosted
+            // caller could fabricate a Local registration for an arbitrary director id and then read that id's
+            // Local event ring. Make the whole plane explicitly UNAVAILABLE on hosted (403) so the shadow can
+            // never be created; self-host is unchanged.
+            if (tenantBoundary?.IsHosted == true)
+                return LegacyDiscoveryPlaneUnavailable();
             if (req is null || string.IsNullOrEmpty(req.DirectorId))
                 return Results.BadRequest(new { error = "directorId is required" });
             // Issue #324: a Director with no resolvable tailnet identity may register FLAGGED -
@@ -562,6 +571,11 @@ internal static class GatewayEndpoints
 
         app.MapPost("/directors/{id}/heartbeat", async (string id, HttpContext ctx) =>
         {
+            // MTR-01 (Codex round 1): part of the legacy same-machine discovery plane - unavailable on hosted
+            // (see /directors/register). This also replaces the pre-fix 410 that an unbound hosted request got
+            // here with the correct 403 for a plane that does not serve hosted accounts.
+            if (tenantBoundary?.IsHosted == true)
+                return LegacyDiscoveryPlaneUnavailable();
             var ok = registry.Heartbeat(id);
             if (!ok)
             {
@@ -602,9 +616,12 @@ internal static class GatewayEndpoints
         // the pre-#330 shape and records nothing.
         app.MapPost("/directors/{id}/doorbell", (string id, DoorbellRequest req) =>
         {
-            // MTR-01: the doorbell is part of the same-machine HTTP discovery plane, whose entries are always
-            // keyed to the Local tenant (see DirectorRegistry.Upsert). Resolve within Local - never a bare,
-            // cross-tenant scan - so this stays behavior-identical on self-host and serves no hosted account.
+            // MTR-01 (Codex round 1): the doorbell is a leg of the legacy same-machine HTTP discovery plane -
+            // unavailable on hosted (see /directors/register), where leaving it open would let a hosted caller
+            // inject into a bare-id event ring. On self-host its entries are always keyed to the Local tenant
+            // (see DirectorRegistry.Upsert), so it resolves within Local and records under Local.
+            if (tenantBoundary?.IsHosted == true)
+                return LegacyDiscoveryPlaneUnavailable();
             if (registry.Get(TenantId.Local, id) is null)
                 return Results.StatusCode(StatusCodes.Status410Gone);
             if (req is null || string.IsNullOrEmpty(req.SessionId) || string.IsNullOrEmpty(req.NewState))
@@ -612,7 +629,7 @@ internal static class GatewayEndpoints
 
             registry.MarkStateReporting(id);
             if (directorEvents is not null && !string.IsNullOrEmpty(req.Event))
-                directorEvents.Record(id, req.SessionId, req.Event, req.NewState);
+                directorEvents.Record(TenantId.Local, id, req.SessionId, req.Event, req.NewState);
             onSessionState?.Invoke(id, req.SessionId, req.NewState);
             return Results.Json(new { ok = true });
         });
@@ -621,15 +638,20 @@ internal static class GatewayEndpoints
         // (session-created/session-exited/prompt-detected) the Gateway has recorded for a
         // KNOWN director, oldest first. This is the minimal Phase-1 observable sink; the
         // real consumer (the SSE/WS event hub) is Phase 3.
-        app.MapGet("/directors/{id}/events", (string id) =>
+        app.MapGet("/directors/{id}/events", (string id, HttpContext ctx) =>
         {
-            // MTR-01: the per-director doorbell-event ring is keyed by bare director id and fed by the Local
-            // discovery plane; resolve the director within Local rather than by a cross-tenant bare scan. This
-            // debug surface is unchanged on self-host and empty for a hosted account (its Local partition is
-            // served to no account) - deny-by-default.
-            if (registry.Get(TenantId.Local, id) is null)
+            // MTR-01 (Codex round 1): this is a CLIENT-serving read, so it resolves the request's OWN tenant
+            // and reads only that tenant's ring for this id. 403 when no tenant is bound (deny-by-default,
+            // never the Local partition), 404 when the id is not the caller's Director. Because the ring is now
+            // keyed by (tenant, id), a hosted account can never read another account's ring - even for the same
+            // id, and even if a Local shadow of the id existed, the caller's tenant reads a different queue.
+            var reqTenant = ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+            if (registry.Get(reqTenant.Value, id) is null)
                 return Results.NotFound(new { error = "director not found" });
-            var events = directorEvents?.For(id) ?? (IReadOnlyList<DirectorEventDto>)Array.Empty<DirectorEventDto>();
+            var events = directorEvents?.For(reqTenant.Value, id) ?? (IReadOnlyList<DirectorEventDto>)Array.Empty<DirectorEventDto>();
             return Results.Json(new { directorId = id, events });
         });
 
@@ -640,6 +662,11 @@ internal static class GatewayEndpoints
 
         app.MapDelete("/directors/{id}/registration", (string id) =>
         {
+            // MTR-01 (Codex round 1): part of the legacy same-machine discovery plane - unavailable on hosted
+            // (see /directors/register). Left open, an unbound hosted caller holding the shared machine token
+            // could remove a Local registration; on hosted there is no such plane to unregister from.
+            if (tenantBoundary?.IsHosted == true)
+                return LegacyDiscoveryPlaneUnavailable();
             FileLog.Write($"[GatewayEndpoints] DELETE /directors/{id}/registration");
             var removed = registry.Remove(id);
             return removed
@@ -2754,6 +2781,16 @@ internal static class GatewayEndpoints
     /// </summary>
     private static TenantId? ResolveReadTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
         => boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+
+    /// <summary>
+    /// MTR-01 (Codex round 1): the answer for the legacy same-machine HTTP discovery plane (register /
+    /// heartbeat / doorbell / unregister) when this is the hosted Gateway. That plane is a self-host-only
+    /// concept - hosted Directors ride the tunnel - and every entry it writes is Local-keyed, so leaving it
+    /// reachable on hosted is the Local-shadow registration / event-ring injection path. 403, explicit.
+    /// </summary>
+    private static IResult LegacyDiscoveryPlaneUnavailable()
+        => Results.Json(new { error = "the same-machine HTTP discovery plane is not available on the hosted Gateway" },
+            statusCode: StatusCodes.Status403Forbidden);
 
     /// <summary>
     /// MTR-01: resolve a per-director route's target Director IN THE REQUEST'S OWN TENANT. Every client-serving

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -602,7 +602,10 @@ internal static class GatewayEndpoints
         // the pre-#330 shape and records nothing.
         app.MapPost("/directors/{id}/doorbell", (string id, DoorbellRequest req) =>
         {
-            if (registry.Get(id) is null)
+            // MTR-01: the doorbell is part of the same-machine HTTP discovery plane, whose entries are always
+            // keyed to the Local tenant (see DirectorRegistry.Upsert). Resolve within Local - never a bare,
+            // cross-tenant scan - so this stays behavior-identical on self-host and serves no hosted account.
+            if (registry.Get(TenantId.Local, id) is null)
                 return Results.StatusCode(StatusCodes.Status410Gone);
             if (req is null || string.IsNullOrEmpty(req.SessionId) || string.IsNullOrEmpty(req.NewState))
                 return Results.BadRequest(new { error = "sessionId and newState are required" });
@@ -620,7 +623,11 @@ internal static class GatewayEndpoints
         // real consumer (the SSE/WS event hub) is Phase 3.
         app.MapGet("/directors/{id}/events", (string id) =>
         {
-            if (registry.Get(id) is null)
+            // MTR-01: the per-director doorbell-event ring is keyed by bare director id and fed by the Local
+            // discovery plane; resolve the director within Local rather than by a cross-tenant bare scan. This
+            // debug surface is unchanged on self-host and empty for a hosted account (its Local partition is
+            // served to no account) - deny-by-default.
+            if (registry.Get(TenantId.Local, id) is null)
                 return Results.NotFound(new { error = "director not found" });
             var events = directorEvents?.For(id) ?? (IReadOnlyList<DirectorEventDto>)Array.Empty<DirectorEventDto>();
             return Results.Json(new { directorId = id, events });
@@ -1035,9 +1042,18 @@ internal static class GatewayEndpoints
         // per recoverable session, and enrich each with the Gateway's last-known brief so the
         // Cockpit Interrupted sessions list is triageable. Directors on one machine share the journal dir, so the
         // same dead journal can be reported by several live Directors - dedupe by directorId+pid.
-        app.MapGet("/interrupted", async (CancellationToken ct) =>
+        app.MapGet("/interrupted", async (HttpContext ctx, CancellationToken ct) =>
         {
-            var directors = registry.ListDirectors();
+            // MTR-01: the interrupted plane used the fleet-global director list, so it fanned out to - and
+            // enumerated - every tenant's Directors. Scope it to THIS request's tenant so a caller only ever
+            // sees, and only ever reaches over the tunnel, its own Directors' crash journals. A request with no
+            // bound tenant is DENIED (403), never served the fleet-global list.
+            var reqTenant = ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+
+            var directors = registry.ListDirectors(reqTenant.Value);
             var fanout = directors.Select(async d =>
             {
                 // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (interrupted-list verb, director-level).
@@ -1085,14 +1101,15 @@ internal static class GatewayEndpoints
 
         // Dismiss one interrupted journal once recovered or unwanted. Routed to the live
         // Director that surfaced it (via=reportedByDirectorId), which owns its machine's dir.
-        app.MapDelete("/interrupted/{deadDirectorId}/{deadPid:int}", async (string deadDirectorId, int deadPid, string? via, CancellationToken ct) =>
+        app.MapDelete("/interrupted/{deadDirectorId}/{deadPid:int}", async (HttpContext ctx, string deadDirectorId, int deadPid, string? via, CancellationToken ct) =>
         {
             FileLog.Write($"[GatewayEndpoints] DELETE /interrupted/{deadDirectorId}/{deadPid} via={via}");
             if (string.IsNullOrWhiteSpace(via))
                 return Results.BadRequest(new { error = "via (reporting director id) is required" });
-            var d = registry.Get(via);
-            if (d is null)
-                return Results.NotFound(new { error = "reporting director not found" });
+            // MTR-01: resolve the reporting Director in the request's OWN tenant, so a caller cannot dismiss a
+            // journal via another tenant's Director (403 with no tenant, 404 for a foreign id).
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, via, out _, out var err))
+                return err;
 
             // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (interrupted-dismiss verb on the reporting
             // Director). The HTTP path collapsed any non-success (incl a 404) to false -> 502, so a non-Ok
@@ -1106,14 +1123,14 @@ internal static class GatewayEndpoints
         // Dismiss ONE session from an interrupted journal (issue #212 W4): the rest of the
         // journal stays in the Interrupted sessions list. Routed like the journal-level dismiss above.
         app.MapDelete("/interrupted/{deadDirectorId}/{deadPid:int}/sessions/{sessionId}",
-            async (string deadDirectorId, int deadPid, string sessionId, string? via, CancellationToken ct) =>
+            async (HttpContext ctx, string deadDirectorId, int deadPid, string sessionId, string? via, CancellationToken ct) =>
         {
             FileLog.Write($"[GatewayEndpoints] DELETE /interrupted/{deadDirectorId}/{deadPid}/sessions/{sessionId} via={via}");
             if (string.IsNullOrWhiteSpace(via))
                 return Results.BadRequest(new { error = "via (reporting director id) is required" });
-            var d = registry.Get(via);
-            if (d is null)
-                return Results.NotFound(new { error = "reporting director not found" });
+            // MTR-01: resolve the reporting Director in the request's OWN tenant (403 with no tenant, 404 foreign).
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, via, out _, out var err))
+                return err;
 
             // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (interrupted-remove verb on the reporting
             // Director). Non-Ok -> 502, matching the HTTP path's false -> 502 collapse.
@@ -1131,7 +1148,7 @@ internal static class GatewayEndpoints
         // path is valid there. After a successful create the restored session is removed
         // from the dirty journal so the Interrupted sessions list reflects what is still unrecovered.
         app.MapPost("/interrupted/{deadDirectorId}/{deadPid:int}/restore",
-            async (string deadDirectorId, int deadPid, RestoreInterruptedRequest req, CancellationToken ct) =>
+            async (HttpContext ctx, string deadDirectorId, int deadPid, RestoreInterruptedRequest req, CancellationToken ct) =>
         {
             FileLog.Write($"[GatewayEndpoints] POST /interrupted/{deadDirectorId}/{deadPid}/restore: sid={req?.SessionId} via={req?.Via} toDir={req?.ToDirectorId}");
             if (req is null || string.IsNullOrWhiteSpace(req.SessionId))
@@ -1139,12 +1156,16 @@ internal static class GatewayEndpoints
             if (string.IsNullOrWhiteSpace(req.Via))
                 return Results.BadRequest(new { error = "via (reporting director id) is required" });
 
-            var reporter = registry.Get(req.Via);
-            if (reporter is null)
-                return Results.NotFound(new { error = "reporting director not found" });
-            var target = string.IsNullOrWhiteSpace(req.ToDirectorId) ? reporter : registry.Get(req.ToDirectorId);
-            if (target is null)
-                return Results.NotFound(new { error = "target director not found" });
+            // MTR-01: both the reporting Director and any explicit target Director are resolved in the request's
+            // OWN tenant, so a restore can neither read a foreign crash journal nor spawn a continuation session
+            // on another tenant's Director (403 with no tenant, 404 for a foreign id).
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, req.Via, out var reporter, out var reporterErr))
+                return reporterErr;
+            DirectorDto target;
+            if (string.IsNullOrWhiteSpace(req.ToDirectorId))
+                target = reporter;
+            else if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, req.ToDirectorId, out target, out var targetErr))
+                return targetErr;
 
             // The journal is the source of truth for what is restorable - never trust the
             // caller for repo/name. Re-read it from the reporting Director. Gateway Cleanup Phase 2 (PR D):
@@ -1743,10 +1764,9 @@ internal static class GatewayEndpoints
             return Results.Json(new { error = "director not connected to the tunnel" }, statusCode: StatusCodes.Status502BadGateway);
         });
 
-        app.MapGet("/directors/{id}/repos", async (string id, CancellationToken ct) =>
+        app.MapGet("/directors/{id}/repos", async (HttpContext ctx, string id, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
 
             // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (repos-list verb, director-level so SessionId
             // is ""). Tunnel-only: a null return means the Director is not connected, and a non-Ok stream
@@ -1767,10 +1787,9 @@ internal static class GatewayEndpoints
         // demand rather than pushed in registration/heartbeat: the inventory is large and
         // changes rarely, so riding the 15s heartbeat would bloat the hot path for a fact
         // a consumer reads occasionally.
-        app.MapGet("/directors/{id}/facts", async (string id, CancellationToken ct) =>
+        app.MapGet("/directors/{id}/facts", async (HttpContext ctx, string id, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
 
             // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (facts verb, director-level).
             var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "facts", "", null, ct, machineName: d.MachineName);
@@ -1789,10 +1808,9 @@ internal static class GatewayEndpoints
         // Issue #1497: the target Director's configured, enabled agents (one per kind) for the Cockpit New
         // Session dialog's agent picker. Rides the tunnel (agents-list verb, director-level), mirroring the
         // facts/repos-list read legs above; a null result (Director not connected) collapses to 502.
-        app.MapGet("/directors/{id}/agents", async (string id, CancellationToken ct) =>
+        app.MapGet("/directors/{id}/agents", async (HttpContext ctx, string id, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
 
             var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "agents-list", "", null, ct, machineName: d.MachineName);
             if (sr is not null)
@@ -1813,10 +1831,9 @@ internal static class GatewayEndpoints
         // called it settings. These legs ride the tunnel like every director-level verb above; the settings body
         // is an OPAQUE object the Director owns, so it is forwarded VERBATIM in both directions rather than
         // being modelled here (the Gateway must not become a second definition of the Director's config).
-        app.MapGet("/directors/{id}/settings", async (string id, CancellationToken ct) =>
+        app.MapGet("/directors/{id}/settings", async (HttpContext ctx, string id, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
 
             var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "settings-get", "", null, ct, machineName: d.MachineName);
             if (sr is null || !sr.Ok) return DirectorAnswerFailure(sr, d.MachineName);
@@ -1827,8 +1844,7 @@ internal static class GatewayEndpoints
 
         app.MapPut("/directors/{id}/settings", async (string id, HttpContext ctx, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
 
             string raw;
             using (var reader = new StreamReader(ctx.Request.Body))
@@ -1861,10 +1877,9 @@ internal static class GatewayEndpoints
             return Results.Content(sr.BodyJson ?? "{}", "application/json");
         });
 
-        app.MapPost("/directors/{id}/sessions", async (string id, NewSessionRequest req) =>
+        app.MapPost("/directors/{id}/sessions", async (HttpContext ctx, string id, NewSessionRequest req) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var ownerErr)) return ownerErr;
             if (req is null || string.IsNullOrWhiteSpace(req.RepoPath))
                 return Results.BadRequest(new { error = "repoPath is required" });
 
@@ -1891,10 +1906,9 @@ internal static class GatewayEndpoints
             return Results.Json(body, statusCode: 201);
         });
 
-        app.MapDelete("/directors/{id}/repos", async (string id, string? path, CancellationToken ct) =>
+        app.MapDelete("/directors/{id}/repos", async (HttpContext ctx, string id, string? path, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
             if (string.IsNullOrWhiteSpace(path)) return Results.BadRequest(new { error = "path is required" });
 
             // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (repo-delete verb, director-level). The
@@ -1914,10 +1928,9 @@ internal static class GatewayEndpoints
         // the repo-add verb (director-level). The Director core validates directory-existence and returns
         // { added, repo }; added selects the old route's 201 (newly added) vs 200 (already present). A typed
         // failure preserves 400; a null result (Director not tunnel-connected) is 502.
-        app.MapPost("/directors/{id}/repos", async (string id, RepoAddRequest req, CancellationToken ct) =>
+        app.MapPost("/directors/{id}/repos", async (HttpContext ctx, string id, RepoAddRequest req, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
             if (req is null || string.IsNullOrWhiteSpace(req.Path)) return Results.BadRequest(new { error = "path is required" });
 
             var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "repo-add", "", req, ct, machineName: d.MachineName);
@@ -1930,10 +1943,9 @@ internal static class GatewayEndpoints
         // Gateway Cleanup CUT RESTORATION (SB-4a): rename a registered repository (path is the identity). Rides
         // the repo-rename verb (director-level). A path not in the registry is the executor's NotFound -> 404;
         // a null result (Director not tunnel-connected) is 502.
-        app.MapPatch("/directors/{id}/repos", async (string id, RepoRenameRequest req, CancellationToken ct) =>
+        app.MapPatch("/directors/{id}/repos", async (HttpContext ctx, string id, RepoRenameRequest req, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
             if (req is null || string.IsNullOrWhiteSpace(req.Path)) return Results.BadRequest(new { error = "path is required" });
             if (string.IsNullOrWhiteSpace(req.Name)) return Results.BadRequest(new { error = "name is required" });
 
@@ -1946,20 +1958,18 @@ internal static class GatewayEndpoints
 
         // Gateway Cleanup CUT RESTORATION (SB-4a): the enriched per-repo overview the Repositories page reads.
         // Rides the repos-overview verb (director-level). A null result (Director not tunnel-connected) is 502.
-        app.MapGet("/directors/{id}/repos/overview", async (string id, CancellationToken ct) =>
+        app.MapGet("/directors/{id}/repos/overview", async (HttpContext ctx, string id, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
 
             var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "repos-overview", "", null, ct, machineName: d.MachineName);
             if (sr is null || !sr.Ok) return MapDirectorFailure(sr);
             return Results.Json(DirectorCommandRouter.ReadBody<List<RepoOverviewDto>>(sr) ?? new List<RepoOverviewDto>());
         });
 
-        app.MapGet("/directors/{id}/coaching/categories", async (string id, CancellationToken ct) =>
+        app.MapGet("/directors/{id}/coaching/categories", async (HttpContext ctx, string id, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
 
             // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (coaching-categories verb, director-level).
             var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "coaching-categories", "", null, ct, machineName: d.MachineName);
@@ -1973,10 +1983,9 @@ internal static class GatewayEndpoints
             return TunnelFailure(null);
         });
 
-        app.MapGet("/directors/{id}/claude-sessions", async (string id, CancellationToken ct) =>
+        app.MapGet("/directors/{id}/claude-sessions", async (HttpContext ctx, string id, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
 
             // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (claude-sessions verb, director-level; no
             // repo filter on this route, so the payload is empty).
@@ -1991,10 +2000,9 @@ internal static class GatewayEndpoints
             return TunnelFailure(null);
         });
 
-        app.MapGet("/directors/{id}/handovers", async (string id, CancellationToken ct) =>
+        app.MapGet("/directors/{id}/handovers", async (HttpContext ctx, string id, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
 
             // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (handovers-list verb, director-level; this
             // route has no repo filter, so the payload is empty).
@@ -2009,10 +2017,9 @@ internal static class GatewayEndpoints
             return TunnelFailure(null);
         });
 
-        app.MapGet("/directors/{id}/handovers/content", async (string id, string? path, CancellationToken ct) =>
+        app.MapGet("/directors/{id}/handovers/content", async (HttpContext ctx, string id, string? path, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
             if (string.IsNullOrWhiteSpace(path)) return Results.BadRequest(new { error = "path is required" });
 
             // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (handovers-content verb, director-level; the
@@ -2033,10 +2040,9 @@ internal static class GatewayEndpoints
         // Gateway Cleanup CUT RESTORATION (SB-4a): create a standalone saved-handover document. Rides the
         // handover-create verb (director-level). Success is the old route's 201; a typed failure preserves 400;
         // a null result (Director not tunnel-connected) is 502.
-        app.MapPost("/directors/{id}/handovers", async (string id, HandoverCreateRequest req, CancellationToken ct) =>
+        app.MapPost("/directors/{id}/handovers", async (HttpContext ctx, string id, HandoverCreateRequest req, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
             if (req is null || string.IsNullOrWhiteSpace(req.Title)) return Results.BadRequest(new { error = "title is required" });
             if (string.IsNullOrWhiteSpace(req.Content)) return Results.BadRequest(new { error = "content is required" });
 
@@ -2051,10 +2057,9 @@ internal static class GatewayEndpoints
         // verb (director-level; the ?path query rides in the payload). A path outside the handover folder is the
         // executor's BadRequest -> 400; a missing file its NotFound -> 404; a null result (Director not
         // tunnel-connected) is 502.
-        app.MapDelete("/directors/{id}/handovers", async (string id, string? path, CancellationToken ct) =>
+        app.MapDelete("/directors/{id}/handovers", async (HttpContext ctx, string id, string? path, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
             if (string.IsNullOrWhiteSpace(path)) return Results.BadRequest(new { error = "path is required" });
 
             var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "handover-delete", "", new RepoDeleteRequest { Path = path }, ct, machineName: d.MachineName);
@@ -2062,10 +2067,9 @@ internal static class GatewayEndpoints
             return Results.Content(sr.BodyJson ?? "{\"removed\":true}", "application/json");
         });
 
-        app.MapGet("/directors/{id}/fs/list", async (string id, string? path, CancellationToken ct) =>
+        app.MapGet("/directors/{id}/fs/list", async (HttpContext ctx, string id, string? path, CancellationToken ct) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var err)) return err;
 
             // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (fs-list verb, director-level; the ?path
             // query rides in the payload). A non-Ok stream result (e.g. the Director core's bad-path BadRequest)
@@ -2083,10 +2087,9 @@ internal static class GatewayEndpoints
             return TunnelFailure(null);
         });
 
-        app.MapPost("/directors/{id}/sessions/github", async (string id, GitHubSessionRequest req) =>
+        app.MapPost("/directors/{id}/sessions/github", async (HttpContext ctx, string id, GitHubSessionRequest req) =>
         {
-            var d = registry.Get(id);
-            if (d is null) return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var d, out var ownerErr)) return ownerErr;
             if (req is null || string.IsNullOrWhiteSpace(req.Owner) || string.IsNullOrWhiteSpace(req.Repo))
                 return Results.BadRequest(new { error = "owner and repo are required" });
 
@@ -2146,9 +2149,8 @@ internal static class GatewayEndpoints
             FileLog.Write($"[GatewayEndpoints] DELETE director: id={id} force={body.Force} " +
                 $"confirmSessions={(body.ConfirmSessions?.ToString() ?? "-")} reason=\"{Truncate(body.Reason)}\" client={caller}");
 
-            var director = registry.Get(id);
-            if (director is null)
-                return Results.NotFound(new { error = "director not found" });
+            if (!TryResolveOwnedDirector(ctx, tenantBoundary, registry, id, out var director, out var ownerErr))
+                return ownerErr;
 
             if (string.IsNullOrWhiteSpace(body.Reason))
             {
@@ -2158,8 +2160,11 @@ internal static class GatewayEndpoints
 
             // Post-cut: read the live session list from the push store (it carries the same SessionDto incl.
             // Status). A Director with no fresh push is not connected to the tunnel, so the live count is
-            // unknowable and the session gate is skipped below.
-            var cachedSessions = pushedSessions?.TryGetFresh(TenantId.Local, director.DirectorId, streamStaleResolved);
+            // unknowable and the session gate is skipped below. MTR-01: read the push store under the REQUEST's
+            // own tenant (the same tenant the Director was just resolved in), never a hard-coded Local - on
+            // hosted the Director lives in its account's partition, and Local would read the wrong one.
+            var gateTenant = ResolveReadTenant(ctx, tenantBoundary)!.Value;
+            var cachedSessions = pushedSessions?.TryGetFresh(gateTenant, director.DirectorId, streamStaleResolved);
             var sessions = cachedSessions?.ToList();
             if (sessions is not null)
             {
@@ -2685,7 +2690,10 @@ internal static class GatewayEndpoints
                 var newId = registry.ListDirectors().Select(d => d.DirectorId).FirstOrDefault(id => !beforeIds.Contains(id));
                 if (newId is not null)
                 {
-                    var d = registry.Get(newId)!;
+                    // MTR-01: this route ShellExecutes a cc-director.exe on the GATEWAY's own machine, so the
+                    // newly-registered instance is always a Local-tenant entry - resolve it within Local, not by
+                    // a bare cross-tenant scan.
+                    var d = registry.Get(TenantId.Local, newId)!;
                     return Results.Json(new { directorId = d.DirectorId, pid = d.Pid });
                 }
             }
@@ -2746,6 +2754,44 @@ internal static class GatewayEndpoints
     /// </summary>
     private static TenantId? ResolveReadTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
         => boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+
+    /// <summary>
+    /// MTR-01: resolve a per-director route's target Director IN THE REQUEST'S OWN TENANT. Every client-serving
+    /// <c>/directors/{id}/...</c> route (and the <c>/interrupted</c> plane's by-id legs) resolves its Director
+    /// through this, so a client-supplied id can only ever name a Director the caller's authenticated device key
+    /// owns. The registry has no bare-id accessor anymore, so there is no way to reach another tenant's entry.
+    ///
+    /// On success returns true and hands back the caller's own Director; on failure returns false and the
+    /// <see cref="IResult"/> the route must return unchanged:
+    ///   - 403 when the request has no bound tenant (deny-by-default, NEVER the Local partition);
+    ///   - 404 when the id is not in the caller's tenant (NEVER another tenant's freshest match).
+    /// Self-host is unchanged: there the request tenant is always Local and the registry holds the one tenant's
+    /// Directors, so this is an ordinary present/absent lookup.
+    /// </summary>
+    private static bool TryResolveOwnedDirector(
+        HttpContext ctx, Tenancy.HostedTenantBoundary? boundary, DirectorRegistry registry, string id,
+        out DirectorDto director, out IResult error)
+    {
+        director = null!;
+        var reqTenant = ResolveReadTenant(ctx, boundary);
+        if (reqTenant is null)
+        {
+            error = Results.Json(new { error = "no tenant is bound to this request" },
+                statusCode: StatusCodes.Status403Forbidden);
+            return false;
+        }
+
+        var found = registry.Get(reqTenant.Value, id);
+        if (found is null)
+        {
+            error = Results.NotFound(new { error = "director not found" });
+            return false;
+        }
+
+        director = found;
+        error = null!;
+        return true;
+    }
 
     /// <summary>
     /// THE route-facing session locator (issue #1869). Every per-session HTTP route resolves its session

--- a/src/CcDirector.Gateway/Api/NetDiagAlertService.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagAlertService.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Events;
@@ -25,6 +26,13 @@ public sealed class NetDiagAlertService
     // A fixed ring key for these gateway-originated network events (they are not tied to a Director/session).
     private const string RingKey = "network";
 
+    // MTR-01 (Codex round 1): these are same-machine, gateway-originated network signals with no per-account
+    // credential, so - like the doorbell/discovery plane - they file under the Local tenant. The event ring is
+    // now keyed by (tenant, id); recording under Local keeps self-host behavior identical and, on hosted, files
+    // into a ring no account's tenant reads (the reader keys by the request tenant, never Local), so this can
+    // never surface to another account.
+    private static readonly TenantId RingTenant = TenantId.Local;
+
     private readonly DirectorEventLog _events;
     private readonly Func<string, string, string, Task<bool>> _sendEmail; // (token, subject, bodyText) -> sent?
     private readonly Func<string?> _getToken;
@@ -51,7 +59,7 @@ public sealed class NetDiagAlertService
     /// <summary>Persistent home drift for <paramref name="deviceName"/>: doorbell always; owner email if signed in + under the daily cap.</summary>
     public void OnDrift(string deviceName)
     {
-        try { _events.Record(RingKey, "", DoorbellEvents.NetworkDrift, deviceName); }
+        try { _events.Record(RingTenant, RingKey, "", DoorbellEvents.NetworkDrift, deviceName); }
         catch (Exception ex) { FileLog.Write($"[NetDiagAlert] doorbell drift failed: {ex.Message}"); }
 
         // 401 FIRST, before touching the cap or the episode set. If not signed in we send only the doorbell
@@ -85,7 +93,7 @@ public sealed class NetDiagAlertService
     /// <summary>Observed recovery for <paramref name="deviceName"/>: doorbell always; a "recovered" email ONLY if we emailed a drift for it.</summary>
     public void OnResolve(string deviceName)
     {
-        try { _events.Record(RingKey, "", DoorbellEvents.NetworkRecovered, deviceName); }
+        try { _events.Record(RingTenant, RingKey, "", DoorbellEvents.NetworkRecovered, deviceName); }
         catch (Exception ex) { FileLog.Write($"[NetDiagAlert] doorbell recovered failed: {ex.Message}"); }
 
         bool weWarned;

--- a/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
@@ -50,6 +50,7 @@ internal static class SessionWsProxyEndpoints
         Streaming.PushedSessionStore pushedSessions,
         Streaming.GatewayStreamRegistry streamRegistry,
         DirectorCommandRouter.SendDirectorCommandAsync sendCommand,
+        Discovery.DirectorRegistry registry,
         TimeSpan? streamStaleAfter = null,
         Tenancy.HostedTenantBoundary? tenantBoundary = null)
     {
@@ -133,6 +134,20 @@ internal static class SessionWsProxyEndpoints
         // straight over the tunnel - unreachable/unknown Director -> 503.
         app.MapPost("/directors/{id}/backfill-numbers", async (string id, HttpContext ctx) =>
         {
+            // MTR-01 (Codex round 1): this is a client-facing per-director COMMAND surface, so it must resolve
+            // the owned Director in the REQUEST's own tenant before dispatching - the same boundary contract
+            // every other /directors/{id}/... route holds. 403 when no tenant is bound (deny-by-default), 404
+            // when the id is not the caller's Director. Gating BEFORE the dispatch is what guarantees no verb
+            // ever reaches another tenant's Director over the tunnel, and it routes the id through the only
+            // registry accessor there is (Get(tenant, id)) - there is no bare-id path to evade.
+            var reqTenant = ResolveTenantOrDeny(ctx, tenantBoundary);
+            if (reqTenant is null) return;
+            if (registry.Get(reqTenant.Value, id) is null)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+                await ctx.Response.WriteAsJsonAsync(new { error = "director not found" });
+                return;
+            }
             FileLog.Write($"[SessionWsProxy] backfill-numbers director={id} client={ctx.Connection.RemoteIpAddress}");
             var result = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "backfill-numbers", "", payload: null, ctx.RequestAborted);
             await WriteVerbJsonAsync(ctx, result, "backfill-numbers");

--- a/src/CcDirector.Gateway/Api/WorkListRunnerEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/WorkListRunnerEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Discovery;
 using CcDirector.Gateway.Running;
@@ -33,7 +34,11 @@ internal static class WorkListRunnerEndpoints
         WorkListStore store,
         DirectorRegistry registry,
         WorkListRunnerManager manager,
-        DirectorCommandRouter.SendDirectorCommandAsync? sendCommand)
+        DirectorCommandRouter.SendDirectorCommandAsync? sendCommand,
+        // MTR-01: the auth-boundary tenant binder. This route spawns a drain (sessions) on a target Director,
+        // so it must resolve that Director in the REQUEST's own tenant - a client-supplied directorId can only
+        // ever name a Director the caller owns. Null (self-host, tests) is the single Local tenant, unchanged.
+        Tenancy.HostedTenantBoundary? tenantBoundary = null)
     {
         app.MapPost("/lists/{name}/run", async (string name, HttpContext ctx) =>
         {
@@ -58,7 +63,13 @@ internal static class WorkListRunnerEndpoints
             // Gateway Cleanup mission (tunnel-only): a Director is reached over the tunnel, not by dialing a
             // control endpoint, so a registered Director with an empty ControlEndpoint is perfectly routable.
             // Gate on existence only; the run itself dispatches the create verb down the stream.
-            var director = registry.Get(body.DirectorId);
+            // MTR-01: resolve the target Director in the REQUEST's own tenant (403 with no bound tenant, 404 for
+            // an id the caller does not own) so a drain cannot be started on another tenant's Director.
+            var reqTenant = tenantBoundary is null ? TenantId.Local : tenantBoundary.ResolveRequestTenant(ctx);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+            var director = registry.Get(reqTenant.Value, body.DirectorId);
             if (director is null)
                 return Results.NotFound(new { error = "no such director", directorId = body.DirectorId });
 

--- a/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
@@ -26,8 +26,10 @@ namespace CcDirector.Gateway.Discovery;
 /// which the FSW path cannot provide.
 ///
 /// A client request is served <see cref="ListDirectors(TenantId)"/> or <see cref="Get(TenantId, string)"/>,
-/// which answer from one tenant's partition only. The no-tenant <see cref="ListDirectors()"/> and
-/// <see cref="Get(string)"/> overloads are fleet-global internal views and are NOT an answer to a client.
+/// which answer from one tenant's partition only. The no-tenant <see cref="ListDirectors()"/> overload is a
+/// fleet-global internal view (the roster fan-out / reconcile poll) and is NOT an answer to a client. There
+/// is deliberately NO bare-id <c>Get</c> overload (MTR-01): a Director is only ever resolved WITH the tenant
+/// that owns it, so a client-supplied id can never resolve, read, or reach another tenant's Director.
 /// </summary>
 public sealed class DirectorRegistry : IDisposable
 {
@@ -74,40 +76,16 @@ public sealed class DirectorRegistry : IDisposable
     private readonly ConcurrentDictionary<DirectorKey, DirectorDto> _directors = new();
 
     /// <summary>
-    /// LEGACY bare-director-id resolution, for the accessors that still take an id with NO tenant beside it.
-    /// It answers with the freshest matching entry - the one seen most recently - which reproduces what the
-    /// single-keyed registry used to hold, because there the last writer for an id simply replaced every
-    /// earlier one. On a single tenant (every self-host install, and any hosted id held by one account) there
-    /// is only ever one match and this is an ordinary lookup.
-    ///
-    /// It deliberately does NOT fail closed on a collision. Failing closed looked safer and is not: the
-    /// credential-less POST /directors/register path can create a Local-tenant entry for ANY id, so a
-    /// refusal-on-collision would let an unauthenticated caller disable every by-id route for a chosen
-    /// Director - trading the cross-tenant write this issue closes for a cross-tenant denial of service.
-    ///
-    /// The remaining callers are the /directors/{id}/... routes, which resolve a Director from a
-    /// client-supplied id with no tenant at all. Those are ALREADY addressable by any caller today and are the
-    /// same defect as this issue in a different hat; they are booked as their own work, and each is converted
-    /// to <see cref="Get(TenantId, string)"/> as its route learns whose Director it means. Nothing on the
-    /// tenant-aware session-serving path uses this.
+    /// Look up THE Local-tenant entry for a bare director id. The HTTP discovery plane (register / heartbeat /
+    /// unregister) is the same-machine path and always keys its entries to <see cref="TenantId.Local"/> (see
+    /// <see cref="Upsert"/>), so a bare id from that plane resolves to exactly one partition - Local - and
+    /// never scans across tenants. On the hosted Gateway a Local entry is served to no account, so this stays
+    /// deny-by-default there. Returns false when no Local entry exists for the id.
     /// </summary>
-    private bool TryResolveLegacyKey(string directorId, out DirectorKey key)
+    private bool TryResolveLocalKey(string directorId, out DirectorKey key)
     {
-        key = default;
-        if (string.IsNullOrEmpty(directorId)) return false;
-
-        var best = DateTime.MinValue;
-        var found = false;
-        foreach (var kv in _directors)
-        {
-            if (!string.Equals(kv.Key.DirectorId, directorId, StringComparison.Ordinal)) continue;
-            var seen = kv.Value.LastSeen ?? DateTime.MinValue;
-            if (found && seen <= best) continue;
-            best = seen;
-            key = kv.Key;
-            found = true;
-        }
-        return found;
+        key = new DirectorKey(TenantId.Local, directorId);
+        return !string.IsNullOrEmpty(directorId) && _directors.ContainsKey(key);
     }
 
     /// <summary>
@@ -296,7 +274,7 @@ public sealed class DirectorRegistry : IDisposable
     /// </summary>
     public bool Heartbeat(string directorId)
     {
-        if (!TryResolveLegacyKey(directorId, out var key)) return false;
+        if (!TryResolveLocalKey(directorId, out var key)) return false;
         if (!_directors.TryGetValue(key, out var existing)) return false;
         existing.LastSeen = DateTime.UtcNow;
         return true;
@@ -331,7 +309,7 @@ public sealed class DirectorRegistry : IDisposable
     /// </summary>
     public bool Remove(string directorId)
     {
-        if (!TryResolveLegacyKey(directorId, out var key)) return false;
+        if (!TryResolveLocalKey(directorId, out var key)) return false;
         if (TryRemoveEntry(key, out _))
         {
             _everReachable.TryRemove(directorId, out _); // graceful goodbye: next process starts blank
@@ -400,19 +378,6 @@ public sealed class DirectorRegistry : IDisposable
         => !string.IsNullOrEmpty(directorId) && _directors.TryGetValue(new DirectorKey(tenant, directorId), out var d)
             ? d
             : null;
-
-    /// <summary>
-    /// LEGACY look-up by bare Director ID, with no tenant. Null if unknown; on the (hosted-only) chance that
-    /// two tenants hold the same id it answers with the freshest entry - see <see cref="TryResolveLegacyKey"/>
-    /// for why that, and not a refusal, is the safe choice.
-    ///
-    /// Every remaining caller of this overload is a route that resolves a Director from a client-supplied id
-    /// WITHOUT a tenant beside it. Those are the same defect as #1847 in a different hat and are recorded as
-    /// their own work; this overload exists so they keep behaving exactly as they do today while they are
-    /// converted to <see cref="Get(TenantId, string)"/> one at a time.
-    /// </summary>
-    public DirectorDto? Get(string directorId)
-        => TryResolveLegacyKey(directorId, out var key) && _directors.TryGetValue(key, out var d) ? d : null;
 
     private void LoadExisting()
     {

--- a/src/CcDirector.Gateway/Events/DirectorEventLog.cs
+++ b/src/CcDirector.Gateway/Events/DirectorEventLog.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -11,17 +12,39 @@ namespace CcDirector.Gateway.Events;
 /// subscriptions, no push, no persistence; just enough that "the Gateway received
 /// session-created/session-exited/prompt-detected" is provable from the outside
 /// (GET /directors/{id}/events) and from the Gateway log.
+///
+/// MTR-01 (Codex round 1): the ring is keyed by the COMPOSITE (owning tenant, director id), not by the bare
+/// director id. Before this, the ring was one global queue per bare id, so tenant A's cron completions and
+/// tenant B's doorbell events for the SAME director id shared one queue - and a hosted account that registered
+/// a Local shadow of another account's id could read (or inject into) that shared queue through
+/// GET /directors/{id}/events. Keying by (tenant, id) makes A's ring and B's ring for the same id physically
+/// distinct queues, so a cross-tenant read or inject is STRUCTURALLY impossible, not merely refused. Self-host
+/// is unchanged: there is exactly one tenant (Local), so the composite key degenerates to the bare id it was.
 /// </summary>
 public sealed class DirectorEventLog
 {
     /// <summary>Ring capacity per director - enough to debug a busy Director without growing unbounded.</summary>
     public const int MaxEventsPerDirector = 200;
 
-    private readonly ConcurrentDictionary<string, Queue<DirectorEventDto>> _rings = new();
+    /// <summary>
+    /// The ring key. Composite - the owning tenant AND the director id - so a producer or reader naming a
+    /// director id can only ever reach the queue belonging to the tenant it carries. Matches the composite
+    /// keying <see cref="Discovery.DirectorRegistry"/> adopted for the registry entries themselves (#1847).
+    /// </summary>
+    private readonly record struct RingKey(TenantId Tenant, string DirectorId);
 
-    /// <summary>Record one received event and write the structured log line.</summary>
-    public void Record(string directorId, string sessionId, string eventName, string state)
+    private readonly ConcurrentDictionary<RingKey, Queue<DirectorEventDto>> _rings = new();
+
+    /// <summary>
+    /// Record one received event under its owning tenant and write the structured log line. The
+    /// <paramref name="tenant"/> is the tenant of the unit of work that produced the event (the doorbell
+    /// leg's Local tenant, the cron pass's tenant, ...) and is REQUIRED - it is half of the ring key, so a
+    /// producer can never file into another tenant's ring.
+    /// </summary>
+    public void Record(TenantId tenant, string directorId, string sessionId, string eventName, string state)
     {
+        if (!tenant.IsValid)
+            throw new ArgumentException("a valid tenant is required", nameof(tenant));
         if (string.IsNullOrEmpty(directorId))
             throw new ArgumentException("directorId is required", nameof(directorId));
         if (string.IsNullOrEmpty(eventName))
@@ -35,7 +58,7 @@ public sealed class DirectorEventLog
             State = state,
         };
 
-        var ring = _rings.GetOrAdd(directorId, _ => new Queue<DirectorEventDto>());
+        var ring = _rings.GetOrAdd(new RingKey(tenant, directorId), _ => new Queue<DirectorEventDto>());
         lock (ring)
         {
             ring.Enqueue(dto);
@@ -44,13 +67,17 @@ public sealed class DirectorEventLog
         }
 
         // The structured line the issue's acceptance criteria can be proven against.
-        FileLog.Write($"[DirectorEvents] director={directorId} session={sessionId} event={eventName} state={state}");
+        FileLog.Write($"[DirectorEvents] tenant={tenant.Value} director={directorId} session={sessionId} event={eventName} state={state}");
     }
 
-    /// <summary>Snapshot of a director's recorded events, oldest first. Empty when none.</summary>
-    public IReadOnlyList<DirectorEventDto> For(string directorId)
+    /// <summary>
+    /// Snapshot of a director's recorded events for ONE tenant, oldest first. Empty when none. A reader only
+    /// ever sees its own tenant's ring for the id - another tenant's ring for the same id is a different queue.
+    /// </summary>
+    public IReadOnlyList<DirectorEventDto> For(TenantId tenant, string directorId)
     {
-        if (string.IsNullOrEmpty(directorId) || !_rings.TryGetValue(directorId, out var ring))
+        if (!tenant.IsValid || string.IsNullOrEmpty(directorId)
+            || !_rings.TryGetValue(new RingKey(tenant, directorId), out var ring))
             return Array.Empty<DirectorEventDto>();
         lock (ring)
         {

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -937,7 +937,10 @@ public sealed class GatewayHost : IAsyncDisposable
                 return d is null ? null : (d.TailnetEndpoint ?? d.ControlEndpoint);
             },
             $"http://127.0.0.1:{Port}",
-            new HttpClient { Timeout = TimeSpan.FromSeconds(10) });
+            new HttpClient { Timeout = TimeSpan.FromSeconds(10) },
+            // MTR-01 (Codex round 1): file the run-complete event into the current cron pass's OWN tenant ring,
+            // the same per-tenant seam the deep-link resolver above reads. On self-host this is always Local.
+            resolveTenant: () => _tenantPass.Current);
         _cronEngine = new Running.CronEngine(
             _cronJobs, _cronRuns, new Running.DirectorCronSessionStarter(_machineSessionSpawner),
             cronWorkListRunner, cronNotifier, new Running.SystemClock());
@@ -1810,6 +1813,9 @@ public sealed class GatewayHost : IAsyncDisposable
             pushedSessions: PushedSessions,
             streamRegistry: StreamRegistry,
             sendCommand: SendCommandAsync,
+            // MTR-01 (Codex round 1): the director-scoped backfill leg resolves the owned Director in the
+            // request's tenant before dispatch, so it needs the registry.
+            registry: Registry,
             streamStaleAfter: _streamStaleAfter,
             // Hosted Multi-Tenancy (session-serving PR1): the per-session tunnel legs resolve the request's
             // tenant at the session locate, so a wrong-tenant session is never located and a request with no

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -928,7 +928,12 @@ public sealed class GatewayHost : IAsyncDisposable
             DirectorEvents,
             directorId =>
             {
-                var d = Registry.Get(directorId);
+                // MTR-01: the registry has no bare-id accessor. A cron notification's deep link resolves the
+                // Director in the tenant of the CURRENT unit of work (the per-tenant cron pass), the same way
+                // SendCommandAsync resolves the down-channel connection - never a hard-coded Local. No tenant in
+                // scope yields no deep link, which is deny-by-default for a best-effort convenience link.
+                if (_tenantPass.Current is not { } t) return null;
+                var d = Registry.Get(t, directorId);
                 return d is null ? null : (d.TailnetEndpoint ?? d.ControlEndpoint);
             },
             $"http://127.0.0.1:{Port}",
@@ -1375,7 +1380,10 @@ public sealed class GatewayHost : IAsyncDisposable
                     // Gateway Cleanup mission, Phase 2: reach the owning Director (carried on the signal as
                     // its DirectorId) through the tunnel-first SessionVerbClient - no HTTP dial. The Director
                     // may be push-only (empty control URL); the tunnel path still reaches it by id.
-                    var director = Registry.Get(signal.DirectorId);
+                    // MTR-01: this voice/turn-end sweep is Local-pinned (like every TenantId.Local read around
+                    // it - the voice state it mutates is not yet partitioned; see the note on
+                    // LocateSessionForRequestAsync), so resolve the Director in Local, not by a bare scan.
+                    var director = Registry.Get(TenantId.Local, signal.DirectorId);
                     if (director is null) return;
                     Api.DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = SendCommandAsync;
                     var route = new Api.SessionVerbClient(director, sendCommand);
@@ -2098,7 +2106,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // logic lives HERE at the Gateway; the Director host gains nothing (criterion 7). The
         // same-machine single-drain guard (criterion 8) lives on the shared runner manager.
         WorkListRunnerEndpoints.Map(_app, _workLists, Registry, _runnerManager,
-            SendCommandAsync);
+            SendCommandAsync, tenantBoundary: _tenantBoundary);
 
         // Issue #331: launcher registration + cross-machine Director lifecycle relay.
         // Launchers POST /launchers/register on startup; relay callers POST

--- a/src/CcDirector.Gateway/Running/GatewayCronNotifier.cs
+++ b/src/CcDirector.Gateway/Running/GatewayCronNotifier.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Events;
@@ -32,6 +33,7 @@ public sealed class GatewayCronNotifier : ICronNotifier
 
     private readonly DirectorEventLog _events;
     private readonly Func<string, string?> _resolveDirectorEndpoint;
+    private readonly Func<TenantId?> _resolveTenant;
     private readonly string _gatewayBaseUrl;
     private readonly HttpClient _webhookHttp;
 
@@ -45,14 +47,25 @@ public sealed class GatewayCronNotifier : ICronNotifier
     /// HttpClient for the optional outbound webhook POST. A dedicated short-timeout client is
     /// supplied by the host; tests inject a fake handler to capture the POST.
     /// </param>
+    /// <param name="resolveTenant">
+    /// MTR-01 (Codex round 1): the tenant of the current cron pass, so the run-complete event files into THAT
+    /// tenant's event ring (the ring is now keyed by (tenant, id)). Production passes
+    /// <c>() =&gt; _tenantPass.Current</c> - the same seam <paramref name="resolveDirectorEndpoint"/> uses -
+    /// which is the request/tunnel/per-tenant-pass scope in effect at fire time. A null return is DENY: no
+    /// tenant in scope means the best-effort ring event is skipped rather than filed under a guessed owner.
+    /// Optional, defaulting to the single Local tenant - the self-host shape and the unit-test default, so
+    /// omitting the seam can never accidentally produce hosted (cross-tenant) behavior.
+    /// </param>
     public GatewayCronNotifier(
         DirectorEventLog events,
         Func<string, string?> resolveDirectorEndpoint,
         string gatewayBaseUrl,
-        HttpClient webhookHttp)
+        HttpClient webhookHttp,
+        Func<TenantId?>? resolveTenant = null)
     {
         _events = events ?? throw new ArgumentNullException(nameof(events));
         _resolveDirectorEndpoint = resolveDirectorEndpoint ?? throw new ArgumentNullException(nameof(resolveDirectorEndpoint));
+        _resolveTenant = resolveTenant ?? (() => TenantId.Local);
         _gatewayBaseUrl = (gatewayBaseUrl ?? "").TrimEnd('/');
         _webhookHttp = webhookHttp ?? throw new ArgumentNullException(nameof(webhookHttp));
     }
@@ -84,7 +97,13 @@ public sealed class GatewayCronNotifier : ICronNotifier
         // exists to surface, AC2) it files under the job id so the failure is still observable. The
         // event's state carries the infra-status so a reader sees the outcome at a glance.
         var ringKey = string.IsNullOrEmpty(directorId) ? job.Id : directorId;
-        _events.Record(ringKey, payload.SessionId ?? "", DoorbellEvents.CronRunCompleted, payload.InfraStatus);
+        // MTR-01 (Codex round 1): file the event under the CURRENT pass's tenant so the owning account reads it
+        // at GET /directors/{id}/events. No tenant in scope (hosted, no pass) is a DENY - skip the best-effort
+        // ring event rather than file it under a guessed owner; self-host always resolves to Local.
+        if (_resolveTenant() is { } tenant)
+            _events.Record(tenant, ringKey, payload.SessionId ?? "", DoorbellEvents.CronRunCompleted, payload.InfraStatus);
+        else
+            FileLog.Write($"[GatewayCronNotifier] no tenant in scope; run-complete ring event skipped for job={job.Id}");
 
         // Leg 2: optional outbound webhook with the SAME payload (AC5).
         var webhookUrl = job.NotifyWebhookUrl;

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -108,8 +108,8 @@ public sealed class DirectorHub : Hub
         Context.Items[TenantIdItemKey] = tenant;
         _store.RegisterConnection(tenant, directorId, Context.ConnectionId);
         // Gateway Cleanup mission (tunnel-only): the stream IS the registration now (HTTP register is gone).
-        // Register this Director from the Hello identity so registry.Get(id) - the gate on create-session and
-        // the other director-level routes - resolves it. Source="stream", no dialable endpoint.
+        // Register this Director from the Hello identity so registry.Get(tenant, id) - the gate on create-session
+        // and the other director-level routes - resolves it. Source="stream", no dialable endpoint.
         // Issue #1847: register it UNDER THE RESOLVED TENANT. The tenant is half of the registry key, so this
         // Hello can only create or refresh THIS account's own entry - naming another account's Director is
         // structurally impossible, however the client chose hello.DirectorId. It also makes the entry visible


### PR DESCRIPTION
## The defect (MTR-01, verified on origin/main @ d26a093d)

The Director registry is keyed by `(tenantId, directorId)`, but ~20 `/directors/{id}/*` routes and the `/interrupted` plane resolved a Director by a **bare id** via `DirectorRegistry.Get(string)` -> `TryResolveLegacyKey`, which scanned **every tenant's** entries and returned the freshest match. An authenticated tenant A could enumerate tenant B's Director id and then:

- `POST /directors/{id}/sessions` - spawn a coding agent on B's machine (**remote code execution**),
- read B's repos / handovers / filesystem / settings,
- stop or delete B's Director.

Registry-keying (#1865) and director-removal scoping (#1942) had merged, but this read/control plane was still open on the deployed image.

## The fix

- **Delete** the bare `Get(string)` overload and `TryResolveLegacyKey` so unsafe code will not compile.
- Route every client-serving per-director route through the tenant-scoped `Get(TenantId, string)`, with the request tenant resolved from the authenticated device key: **403** when no tenant is bound (deny-by-default, never Local), **404** for an id the caller does not own.
- Scope `/interrupted` (GET fan-out + dismiss/restore legs), the `DELETE /directors/{id}` session gate, and `POST /lists/{name}/run` (a drain spawn) the same way.
- The same-machine HTTP discovery plane (heartbeat / remove / doorbell / events) resolves within the `Local` tenant it already keys to. **Self-host behavior is unchanged.**

The command-send path (`SendCommandAsync`) already resolved the tunnel connection under the ambient request tenant; this closes the read/enumeration plane and makes the crossing structurally impossible (no bare accessor exists).

## Test

`DirectorRouteTenantScopingTests` drives the real mapped endpoints through the real auth middleware and real tunnel (hosted mode). Two tenants hold a Director with the **same** id `dir-shared`; each fake Director records every verb it receives:

- A's spawn on `dir-shared` runs `create` on **A's own** Director; B's same-id Director records **no** `create`.
- A foreign id is **404** and B's Director sees no command; B's own key reaches it (positive control).
- The write/RCE path on a foreign id is 404 and spawns nothing.
- An unbound key is **403** on read and write.
- `/interrupted` fans out only to the caller's own Directors.

Revert-prove: restore the bare `Get(string)` overload and point the routes back at it -> the foreign-id reads return 200 / the shared-id spawn reaches B, so the `DoesNotContain` and 404 assertions go RED.

## Build / test status

- `dotnet build` gateway + tests: **0 warnings, 0 errors**.
- New test class: **5/5 passed**.
- Full `CcDirector.Gateway.Tests`: **3075 passed, 12 skipped (live-Postgres, env-gated), 0 failed**.

## Out of scope (per the mission brief)

`/machines/*` launcher/machine-control deny (#1939 / MTR-07); the voice/dictation Local-pinned paths whose upload/voice state is not yet partitioned (the turn-end voice resolve here is kept `Local` to match, not scoped, so nothing new is armed).
