### PR TITLE
fix(gateway): reject the shared machine token on hosted; disable break-glass /login; Secure cookies

### DIFF
--- a/src/CcDirector.Gateway.Tests/AuthMiddlewareTests.cs
+++ b/src/CcDirector.Gateway.Tests/AuthMiddlewareTests.cs
@@ -99,6 +99,64 @@ public sealed class AuthMiddlewareTests
         Assert.True(AuthMiddleware.HasValidToken(WithBearer(key), SharedToken, devices));
     }
 
+    // ===== Production-readiness MH-2: the shared machine token is REJECTED on hosted =====
+    // On a hosted, multi-tenant Gateway the shared token authenticates with no device - so no tenant - and
+    // would reach every tenant-blind route with zero scoping. These pin that with the hosted policy on
+    // (rejectSharedToken: true) the shared token is refused on BOTH Bearer and cookie, while a valid
+    // per-device key still authenticates AND resolves its tenant (stashes DeviceKeyItemKey). The self-host
+    // half (rejectSharedToken: false) proves the shared token still works off hosted, so self-host is green.
+
+    [Fact]
+    public void Hosted_rejects_the_shared_token_on_the_Bearer_header()
+    {
+        var devices = TempRegistry();
+        Assert.False(AuthMiddleware.HasValidToken(WithBearer(SharedToken), SharedToken, devices, rejectSharedToken: true));
+    }
+
+    [Fact]
+    public void Hosted_rejects_the_shared_token_in_the_cookie()
+    {
+        var devices = TempRegistry();
+        Assert.False(AuthMiddleware.HasValidToken(WithCookie(SharedToken), SharedToken, devices, rejectSharedToken: true));
+    }
+
+    [Fact]
+    public void Hosted_still_accepts_a_valid_per_device_key_on_the_Bearer_header_and_resolves_its_tenant()
+    {
+        var devices = TempRegistry();
+        var key = devices.Register("phone-hosted-bearer", "PHONE").DeviceKey;
+        var ctx = WithBearer(key);
+
+        Assert.True(AuthMiddleware.HasValidToken(ctx, SharedToken, devices, rejectSharedToken: true));
+        // The tenant boundary resolves the request's tenant from this same verified key, so it must be stashed.
+        Assert.Equal(key, ctx.Items[AuthMiddleware.DeviceKeyItemKey]);
+    }
+
+    [Fact]
+    public void Hosted_still_accepts_a_valid_per_device_key_in_the_cookie_and_resolves_its_tenant()
+    {
+        var devices = TempRegistry();
+        var key = devices.Register("phone-hosted-cookie", "PHONE").DeviceKey;
+        var ctx = WithCookie(key);
+
+        Assert.True(AuthMiddleware.HasValidToken(ctx, SharedToken, devices, rejectSharedToken: true));
+        Assert.Equal(key, ctx.Items[AuthMiddleware.DeviceKeyItemKey]);
+    }
+
+    [Fact]
+    public void SelfHost_still_accepts_the_shared_token_on_the_Bearer_header()
+    {
+        var devices = TempRegistry();
+        Assert.True(AuthMiddleware.HasValidToken(WithBearer(SharedToken), SharedToken, devices, rejectSharedToken: false));
+    }
+
+    [Fact]
+    public void SelfHost_still_accepts_the_shared_token_in_the_cookie()
+    {
+        var devices = TempRegistry();
+        Assert.True(AuthMiddleware.HasValidToken(WithCookie(SharedToken), SharedToken, devices, rejectSharedToken: false));
+    }
+
     // Epic #1069 (fresh-device unblock): the sign-in enrollment endpoint must be reachable by a
     // token-less device, or a brand-new co-located Director can never earn its first key (the deadlock).
     // It carries its own loopback + signed-in guards, so opening the route is safe. This pins that the

--- a/src/CcDirector.Gateway.Tests/CockpitUrlEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/CockpitUrlEndpointTests.cs
@@ -53,10 +53,13 @@ public sealed class CockpitUrlEndpointTests
     [Fact]
     public async Task Hosted_about_CockpitUrl_returns_configured_public_cockpit_url()
     {
-        await WithHostedGateway(PublicBase, async (http, _) =>
+        await WithHostedGateway(PublicBase, async (http, gateway) =>
         {
-            // /gateway/about is credential-gated; the shared machine token is a valid Bearer.
-            var about = await GetJson<AboutDto>(http, "gateway/about", auth: true);
+            // /gateway/about is credential-gated. On hosted the shared machine token is NO LONGER a valid
+            // Bearer (production-readiness MH-2 - it authenticates with no tenant), so the credential is a
+            // per-device key issued at enrollment, exactly as a real hosted caller uses.
+            var deviceKey = gateway.Devices.Register("cockpiturl-about", "PHONE").DeviceKey;
+            var about = await GetJson<AboutDto>(http, "gateway/about", bearer: deviceKey);
 
             Assert.Equal(ExpectedCockpit, about.CockpitUrl);
         });
@@ -65,13 +68,16 @@ public sealed class CockpitUrlEndpointTests
     [Fact]
     public async Task Hosted_settings_cockpit_url_returns_configured_public_cockpit_url()
     {
-        await WithHostedGateway(PublicBase, async (http, _) =>
+        await WithHostedGateway(PublicBase, async (http, gateway) =>
         {
             // The third call site (first cut missed it): /gateway/settings.cockpit.url must hand back the
             // SAME {base}/cockpit, not the raw front-door root it emitted before. Reverting this call site
             // to TryGetFrontDoorBaseUrl() turns this red (null in the test host).
+            //
+            // MH-2: authenticate with a per-device key, not the shared token (rejected on hosted).
+            var deviceKey = gateway.Devices.Register("cockpiturl-settings", "PHONE").DeviceKey;
             using var req = new HttpRequestMessage(HttpMethod.Get, "gateway/settings");
-            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
             using var resp = await http.SendAsync(req);
             resp.EnsureSuccessStatusCode();
 
@@ -126,10 +132,12 @@ public sealed class CockpitUrlEndpointTests
         }
     }
 
-    private static async Task<T> GetJson<T>(HttpClient http, string path, bool auth)
+    private static async Task<T> GetJson<T>(HttpClient http, string path, bool auth = false, string? bearer = null)
     {
         using var req = new HttpRequestMessage(HttpMethod.Get, path);
-        if (auth)
+        if (bearer is not null)
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+        else if (auth)
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
         using var resp = await http.SendAsync(req);
         resp.EnsureSuccessStatusCode();

--- a/src/CcDirector.Gateway.Tests/GatewayLoginEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayLoginEndpointTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Api;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// HTTP wire tests for the break-glass raw-token login pair (<see cref="GatewayLoginEndpoint"/>), boots ONLY
+/// that endpoint on an ephemeral port. Proves production-readiness MH-2:
+/// <list type="bullet">
+/// <item>On HOSTED the whole surface is bind-broken - GET /login and POST /login (even with the correct
+///   token) return 404 and NO cc-gateway-token cookie is ever written. The shared machine token
+///   authenticates with no device (no tenant) and must not be mintable into a browser cookie on a
+///   multi-tenant Gateway.</item>
+/// <item>On SELF-HOST /login is the reachable break-glass: GET serves the form, a correct token 302-redirects
+///   AND writes the cookie THROUGH the single GatewayTokenCookie helper (HttpOnly + SameSite=Lax, and - being
+///   plain-HTTP loopback - not Secure so it survives), and a wrong token is 401 with no cookie.</item>
+/// </list>
+/// The assembly runs sequentially (parallelization disabled), so toggling CC_GATEWAY_HOSTED here is safe;
+/// each test restores the prior value.
+/// </summary>
+public sealed class GatewayLoginEndpointTests
+{
+    private const string SharedToken = "shared-machine-token-mh2";
+
+    private sealed class EnvScope : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _prior;
+        public EnvScope(string name, string? value)
+        {
+            _name = name;
+            _prior = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+        public void Dispose() => Environment.SetEnvironmentVariable(_name, _prior);
+    }
+
+    private static async Task<(WebApplication app, HttpClient http)> StartAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        GatewayLoginEndpoint.Map(app, SharedToken);
+        await app.StartAsync();
+
+        // Do NOT auto-follow redirects: the self-host success path is a 302 whose Set-Cookie we must observe.
+        var handler = new HttpClientHandler { AllowAutoRedirect = false, UseCookies = false };
+        var http = new HttpClient(handler) { BaseAddress = new Uri(app.Urls.First()) };
+        return (app, http);
+    }
+
+    private static IEnumerable<string> SetCookies(HttpResponseMessage resp) =>
+        resp.Headers.TryGetValues("Set-Cookie", out var values) ? values : Enumerable.Empty<string>();
+
+    private static string? GatewayCookie(HttpResponseMessage resp) =>
+        SetCookies(resp).FirstOrDefault(c => c.StartsWith(Util.AuthMiddleware.CookieName + "=", StringComparison.Ordinal));
+
+    private static bool HasAttribute(string setCookie, string attribute) =>
+        setCookie.Split(';').Any(a => a.Trim().Equals(attribute, StringComparison.OrdinalIgnoreCase));
+
+    // ===== HOSTED: the whole /login surface is bind-broken (MH-2) =====
+
+    [Fact]
+    public async Task Hosted_GET_login_is_404()
+    {
+        using var _ = new EnvScope(GatewayHostedMode.HostedEnvVar, "1");
+        var (app, http) = await StartAsync();
+        try
+        {
+            var resp = await http.GetAsync("/login");
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        }
+        finally { await app.StopAsync(); }
+    }
+
+    [Fact]
+    public async Task Hosted_POST_login_with_the_correct_token_is_404_and_writes_no_cookie()
+    {
+        using var _ = new EnvScope(GatewayHostedMode.HostedEnvVar, "1");
+        var (app, http) = await StartAsync();
+        try
+        {
+            var body = new FormUrlEncodedContent(new Dictionary<string, string> { ["token"] = SharedToken });
+            var resp = await http.PostAsync("/login", body);
+
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+            // The break-glass mint is dead on hosted - not even the correct token writes the cookie.
+            Assert.Null(GatewayCookie(resp));
+        }
+        finally { await app.StopAsync(); }
+    }
+
+    // ===== SELF-HOST: /login stays the reachable break-glass, cookie via the single helper =====
+
+    [Fact]
+    public async Task SelfHost_GET_login_serves_the_form()
+    {
+        using var _ = new EnvScope(GatewayHostedMode.HostedEnvVar, null);
+        var (app, http) = await StartAsync();
+        try
+        {
+            var resp = await http.GetAsync("/login");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+        finally { await app.StopAsync(); }
+    }
+
+    [Fact]
+    public async Task SelfHost_POST_login_with_the_correct_token_redirects_and_writes_the_cookie_through_the_helper()
+    {
+        using var _ = new EnvScope(GatewayHostedMode.HostedEnvVar, null);
+        var (app, http) = await StartAsync();
+        try
+        {
+            var body = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["token"] = SharedToken,
+                ["next"] = "/fleet",
+            });
+            var resp = await http.PostAsync("/login", body);
+
+            Assert.Equal(HttpStatusCode.Found, resp.StatusCode);   // 302
+            Assert.Equal("/fleet", resp.Headers.Location?.ToString());
+
+            var cookie = GatewayCookie(resp);
+            Assert.NotNull(cookie);
+            // Routed through GatewayTokenCookie.Set: HttpOnly + SameSite=Lax on every write...
+            Assert.True(HasAttribute(cookie!, "httponly"));
+            Assert.Contains("samesite=lax", cookie!, StringComparison.OrdinalIgnoreCase);
+            // ...and NOT Secure on self-host, so the cookie survives plain-HTTP loopback/tailnet.
+            Assert.False(HasAttribute(cookie!, "secure"));
+        }
+        finally { await app.StopAsync(); }
+    }
+
+    [Fact]
+    public async Task SelfHost_POST_login_with_a_wrong_token_is_401_and_writes_no_cookie()
+    {
+        using var _ = new EnvScope(GatewayHostedMode.HostedEnvVar, null);
+        var (app, http) = await StartAsync();
+        try
+        {
+            var body = new FormUrlEncodedContent(new Dictionary<string, string> { ["token"] = "not-the-token" });
+            var resp = await http.PostAsync("/login", body);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+            Assert.Null(GatewayCookie(resp));
+        }
+        finally { await app.StopAsync(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayLoginEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayLoginEndpointTests.cs
@@ -159,4 +159,52 @@ public sealed class GatewayLoginEndpointTests
         }
         finally { await app.StopAsync(); }
     }
+
+    // ===== /logout clears the cookie THROUGH the single helper, so the expiring header carries Secure=IsHosted =====
+
+    [Fact]
+    public async Task Hosted_GET_logout_clears_the_cookie_with_a_Secure_header()
+    {
+        using var _ = new EnvScope(GatewayHostedMode.HostedEnvVar, "1");
+        var (app, http) = await StartAsync();
+        try
+        {
+            var resp = await http.GetAsync("/logout");
+
+            Assert.Equal(HttpStatusCode.Found, resp.StatusCode);   // 302 back to /login
+            Assert.Equal(GatewayLoginEndpoint.Path, resp.Headers.Location?.ToString());
+
+            var cookie = GatewayCookie(resp);
+            Assert.NotNull(cookie);
+            // Routed through GatewayTokenCookie.Delete: the expiring Set-Cookie is Secure on hosted, so a browser
+            // over HTTPS accepts the deletion and never emits the cleared cookie over plain HTTP.
+            Assert.True(HasAttribute(cookie!, "secure"));
+            Assert.True(HasAttribute(cookie!, "httponly"));
+            Assert.Contains("samesite=lax", cookie!, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { await app.StopAsync(); }
+    }
+
+    [Fact]
+    public async Task SelfHost_GET_logout_clears_the_cookie_with_an_HTTP_usable_header()
+    {
+        using var _ = new EnvScope(GatewayHostedMode.HostedEnvVar, null);
+        var (app, http) = await StartAsync();
+        try
+        {
+            var resp = await http.GetAsync("/logout");
+
+            Assert.Equal(HttpStatusCode.Found, resp.StatusCode);   // 302 back to /login
+            Assert.Equal(GatewayLoginEndpoint.Path, resp.Headers.Location?.ToString());
+
+            var cookie = GatewayCookie(resp);
+            Assert.NotNull(cookie);
+            // NOT Secure on self-host, so the expiring cookie is delivered - and the deletion takes - over the
+            // plain-HTTP loopback/tailnet the self-host owner logs out on. Same HttpOnly/SameSite as the write.
+            Assert.False(HasAttribute(cookie!, "secure"));
+            Assert.True(HasAttribute(cookie!, "httponly"));
+            Assert.Contains("samesite=lax", cookie!, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { await app.StopAsync(); }
+    }
 }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -308,50 +308,10 @@ internal static class GatewayEndpoints
         // ===== HTML pages =====
         // The Gateway serves NO UI pages anymore (docs/plans/one-url-cockpit.md): "/" and every
         // other UI path fall through to the Cockpit via the fallback proxy. Only the token
-        // login/logout pair remains (it guards the Gateway itself when auth is enabled).
-        app.MapGet("/login", (HttpContext ctx) =>
-        {
-            var next = ctx.Request.Query["next"].ToString();
-            if (string.IsNullOrEmpty(next)) next = "/";
-            var html = EmbeddedResources.Load("login.html")
-                .Replace("__NEXT__", System.Web.HttpUtility.HtmlAttributeEncode(next))
-                .Replace("__ERROR__", "");
-            return Results.Content(html, "text/html; charset=utf-8");
-        });
-
-        app.MapPost("/login", async (HttpContext ctx) =>
-        {
-            var form = await ctx.Request.ReadFormAsync();
-            var submitted = (form["token"].ToString() ?? "").Trim();
-            var next = form["next"].ToString();
-            if (string.IsNullOrEmpty(next)) next = "/";
-
-            if (!string.Equals(submitted, token, StringComparison.Ordinal))
-            {
-                var html = EmbeddedResources.Load("login.html")
-                    .Replace("__NEXT__", System.Web.HttpUtility.HtmlAttributeEncode(next))
-                    .Replace("__ERROR__", "Wrong token. Check gateway-token.txt and try again.");
-                ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
-                ctx.Response.ContentType = "text/html; charset=utf-8";
-                await ctx.Response.WriteAsync(html);
-                return;
-            }
-
-            ctx.Response.Cookies.Append(AuthMiddleware.CookieName, token, new CookieOptions
-            {
-                HttpOnly = true,
-                SameSite = SameSiteMode.Lax,
-                Expires = DateTimeOffset.UtcNow.AddDays(30),
-                IsEssential = true,
-            });
-            ctx.Response.Redirect(IsSafeRedirect(next) ? next : "/");
-        });
-
-        app.MapGet("/logout", (HttpContext ctx) =>
-        {
-            ctx.Response.Cookies.Delete(AuthMiddleware.CookieName);
-            return Results.Redirect("/login");
-        });
+        // login/logout pair remains (it guards the Gateway itself when auth is enabled). It lives in
+        // GatewayLoginEndpoint, which bind-breaks the whole /login surface on hosted (MH-2) and routes the
+        // self-host cookie write through the single GatewayTokenCookie helper.
+        GatewayLoginEndpoint.Map(app, token);
 
         // ===== REST =====
         app.MapGet("/healthz", () =>
@@ -3290,14 +3250,6 @@ internal static class GatewayEndpoints
     }
 
     internal sealed record GatewayEvent(string Type, string Id);
-
-    /// <summary>Only allow same-origin path redirects (defense against open-redirect).</summary>
-    private static bool IsSafeRedirect(string next)
-    {
-        return !string.IsNullOrEmpty(next)
-            && next.StartsWith("/", StringComparison.Ordinal)
-            && !next.StartsWith("//", StringComparison.Ordinal);
-    }
 
     /// <summary>One-line-safe log form of a caller-supplied string (reason fields etc.).</summary>
     private static string Truncate(string? s)

--- a/src/CcDirector.Gateway/Api/GatewayLoginEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayLoginEndpoint.cs
@@ -79,7 +79,10 @@ internal static class GatewayLoginEndpoint
 
         app.MapGet(LogoutPath, (HttpContext ctx) =>
         {
-            ctx.Response.Cookies.Delete(AuthMiddleware.CookieName);
+            // MH-2: clear the cookie through the single GatewayTokenCookie helper so the expiring Set-Cookie
+            // carries the same options as the write - including Secure=IsHosted - and no response-cookie mutation
+            // escapes the centralized policy. A bare Cookies.Delete() would emit a default (non-Secure) header.
+            GatewayTokenCookie.Delete(ctx);
             return Results.Redirect(Path);
         });
     }

--- a/src/CcDirector.Gateway/Api/GatewayLoginEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayLoginEndpoint.cs
@@ -1,0 +1,94 @@
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The break-glass raw-token login pair (<c>GET/POST /login</c>) and its <c>GET /logout</c>. This is the
+/// self-host owner's fallback way in: submit the shared machine token, receive it back as the
+/// <c>cc-gateway-token</c> cookie, and reach the Gateway. It is NOT the normal front door - a signed-out
+/// browser navigation is driven to per-device enrollment at <c>/signin</c> (issue #1088); this wall remains
+/// only as break-glass (issue #1077).
+///
+/// Production-readiness MH-2: the shared machine token authenticates with NO device - so no tenant - and must
+/// not be valid on a hosted, multi-tenant Gateway (<see cref="AuthMiddleware.HasValidToken"/> rejects it
+/// there). Since this endpoint exists solely to mint that shared-token cookie, the WHOLE surface is
+/// bind-broken on hosted: both <c>GET /login</c> (the form) and <c>POST /login</c> (the mint) return 404,
+/// exactly as if the route did not exist, so per-device enrollment is the only way in. Self-host is unchanged:
+/// single-owner, the shared token remains its credential, and <c>/login</c> stays the reachable break-glass.
+/// <see cref="GatewayHostedMode.IsHosted"/> is fixed at startup (<see cref="HostedStartupContract"/>), so the
+/// hosted/self-host branch is stable for the process lifetime.
+/// </summary>
+internal static class GatewayLoginEndpoint
+{
+    public const string Path = "/login";
+    public const string LogoutPath = "/logout";
+
+    /// <summary>
+    /// Map the login/logout routes. <paramref name="token"/> is the shared machine token the self-host form
+    /// checks against and mirrors into the cookie.
+    /// </summary>
+    public static void Map(IEndpointRouteBuilder app, string token)
+    {
+        app.MapGet(Path, (HttpContext ctx) =>
+        {
+            if (GatewayHostedMode.IsHosted)
+                return Results.NotFound();
+
+            var next = ctx.Request.Query["next"].ToString();
+            if (string.IsNullOrEmpty(next)) next = "/";
+            var html = EmbeddedResources.Load("login.html")
+                .Replace("__NEXT__", System.Web.HttpUtility.HtmlAttributeEncode(next))
+                .Replace("__ERROR__", "");
+            return Results.Content(html, "text/html; charset=utf-8");
+        });
+
+        app.MapPost(Path, async (HttpContext ctx) =>
+        {
+            if (GatewayHostedMode.IsHosted)
+            {
+                // Bind-break the shared-token mint on hosted: no cookie is ever written here.
+                ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+                return;
+            }
+
+            var form = await ctx.Request.ReadFormAsync();
+            var submitted = (form["token"].ToString() ?? "").Trim();
+            var next = form["next"].ToString();
+            if (string.IsNullOrEmpty(next)) next = "/";
+
+            if (!string.Equals(submitted, token, StringComparison.Ordinal))
+            {
+                var html = EmbeddedResources.Load("login.html")
+                    .Replace("__NEXT__", System.Web.HttpUtility.HtmlAttributeEncode(next))
+                    .Replace("__ERROR__", "Wrong token. Check gateway-token.txt and try again.");
+                ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                ctx.Response.ContentType = "text/html; charset=utf-8";
+                await ctx.Response.WriteAsync(html);
+                return;
+            }
+
+            // MH-2: route the cookie write through the single GatewayTokenCookie helper so /login can never
+            // write a non-Secure cookie - it sets HttpOnly/SameSite and Secure=IsHosted consistently with
+            // every other credential-cookie write. (Self-host only, so Secure is off here as before.)
+            GatewayTokenCookie.Set(ctx, token);
+            ctx.Response.Redirect(IsSafeRedirect(next) ? next : "/");
+        });
+
+        app.MapGet(LogoutPath, (HttpContext ctx) =>
+        {
+            ctx.Response.Cookies.Delete(AuthMiddleware.CookieName);
+            return Results.Redirect(Path);
+        });
+    }
+
+    /// <summary>Only allow same-origin path redirects (defense against open-redirect).</summary>
+    internal static bool IsSafeRedirect(string next)
+    {
+        return !string.IsNullOrEmpty(next)
+            && next.StartsWith("/", StringComparison.Ordinal)
+            && !next.StartsWith("//", StringComparison.Ordinal);
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayTokenCookie.cs
+++ b/src/CcDirector.Gateway/Api/GatewayTokenCookie.cs
@@ -47,4 +47,27 @@ internal static class GatewayTokenCookie
             IsEssential = true,
         });
     }
+
+    /// <summary>
+    /// Clears the <c>cc-gateway-token</c> cookie by writing an expired <c>Set-Cookie</c> with the SAME
+    /// security options the <see cref="Set"/> write used (<c>HttpOnly</c>, <c>SameSite=Lax</c>, default Path,
+    /// and <c>Secure = IsHosted</c>). The delete MUST carry the same options as the set: a browser only clears a
+    /// cookie whose attributes match, and - critically - the expired header is itself subject to <c>Secure</c>,
+    /// so on hosted (HTTPS) it is marked Secure and on self-host (plain-HTTP loopback/tailnet) it is not, which
+    /// is exactly what lets the logout cookie be delivered and take effect over HTTP there. Routing <c>/logout</c>
+    /// through here keeps EVERY response-cookie mutation inside this single helper, so none can drift non-Secure.
+    /// </summary>
+    /// <param name="ctx">The HTTP context whose response the expired cookie is written to. Required.</param>
+    public static void Delete(HttpContext ctx)
+    {
+        if (ctx is null) throw new ArgumentNullException(nameof(ctx));
+
+        ctx.Response.Cookies.Delete(Util.AuthMiddleware.CookieName, new CookieOptions
+        {
+            HttpOnly = true,
+            SameSite = SameSiteMode.Lax,
+            Secure = GatewayHostedMode.IsHosted,
+            IsEssential = true,
+        });
+    }
 }

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -216,8 +216,27 @@ internal static class AuthMiddleware
     /// that omitted the registry silently 401'd every per-device key (it bit voice-turn). Pass
     /// <c>null</c> for <paramref name="devices"/> ONLY when per-device-key auth is genuinely
     /// inapplicable (there is no registry on this host).
+    ///
+    /// Production-readiness MH-2: on a HOSTED Gateway (<see cref="GatewayHostedMode.IsHosted"/>) the shared
+    /// machine token is NOT accepted here. A hosted deployment serves many tenants, and the shared token
+    /// authenticates with NO device - so no tenant - which would reach every tenant-blind route with zero
+    /// scoping. On hosted the per-device key issued at enrollment is therefore the ONLY accepted credential
+    /// (it carries the tenant), so a shared-token Bearer or cookie is rejected. Self-host is untouched: it is
+    /// single-owner, the shared token remains its credential, and this overload reads
+    /// <see cref="GatewayHostedMode.IsHosted"/> (false off hosted) so behavior there is byte-identical.
     /// </summary>
     public static bool HasValidToken(HttpContext ctx, string token, DeviceRegistry? devices)
+        => HasValidToken(ctx, token, devices, GatewayHostedMode.IsHosted);
+
+    /// <summary>
+    /// Testable core of <see cref="HasValidToken(HttpContext, string, DeviceRegistry?)"/> with the hosted
+    /// policy passed explicitly. When <paramref name="rejectSharedToken"/> is true (hosted), the shared
+    /// machine <paramref name="token"/> is not accepted on Bearer or cookie - only an active per-device key
+    /// authenticates. When false (self-host), the shared token is accepted exactly as before. The seam lets a
+    /// test drive both the hosted-rejection and the self-host-accept paths deterministically, without touching
+    /// the process environment.
+    /// </summary>
+    internal static bool HasValidToken(HttpContext ctx, string token, DeviceRegistry? devices, bool rejectSharedToken)
     {
         // Bearer
         if (ctx.Request.Headers.TryGetValue("Authorization", out var header))
@@ -227,7 +246,9 @@ internal static class AuthMiddleware
             if (raw.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             {
                 var provided = raw.Substring(prefix.Length).Trim();
-                if (string.Equals(provided, token, StringComparison.Ordinal))
+                // MH-2: the shared machine token authenticates with no device (no tenant), so it is refused on
+                // hosted - the per-device key below is the only accepted credential there.
+                if (!rejectSharedToken && string.Equals(provided, token, StringComparison.Ordinal))
                     return true;
                 // Issue #469: a unique per-device key issued at enrollment is equally valid. DevThrottle
                 // Stats: stash the matched device's type so a remote prompt can be tagged with its surface.
@@ -244,9 +265,10 @@ internal static class AuthMiddleware
         }
 
         // Cookie. A browser WebSocket cannot set an Authorization header, so the live terminal stream
-        // authenticates via this cookie. It accepts the shared machine token OR, per issue #908, an
-        // active per-device key - so a phone that enrolled with its own device key (and mirrors that key
-        // into the cookie) can open the stream, exactly as it can call the Bearer-authenticated endpoints.
+        // authenticates via this cookie. It accepts the shared machine token (self-host only - see MH-2 above)
+        // OR, per issue #908, an active per-device key - so a phone that enrolled with its own device key (and
+        // mirrors that key into the cookie) can open the stream, exactly as it can call the Bearer-authenticated
+        // endpoints.
         //
         // Issue #1088: tolerate duplicate cc-gateway-token cookies. A browser can temporarily send both
         // a stale HttpOnly raw-token cookie from /login and a fresh device-key cookie from enrollment.
@@ -254,7 +276,8 @@ internal static class AuthMiddleware
         // accept if ANY cc-gateway-token value is valid.
         foreach (var cookieValue in CookieValues(ctx, CookieName))
         {
-            if (string.Equals(cookieValue, token, StringComparison.Ordinal))
+            // MH-2: same as the Bearer branch - the shared machine token cookie is not accepted on hosted.
+            if (!rejectSharedToken && string.Equals(cookieValue, token, StringComparison.Ordinal))
                 return true;
             // DevThrottle Stats: same device-key surface stash as the Bearer branch (the live terminal
             // stream authenticates via this cookie).


### PR DESCRIPTION
## Production-readiness MH-2 (BLOCKER/P0)

The single shared machine/gateway token bypassed tenancy on a hosted, multi-tenant Gateway.

### The defect (on origin/main)
- `AuthMiddleware.HasValidToken` accepted the shared `token` via Bearer OR cookie and returned authenticated **without** setting `DeviceKeyItemKey` - authenticated with **no device, so no tenant**. A shared-token caller reached every tenant-blind route with zero scoping (the root enabler behind the vault / recordings / machine-control / netdiag surfaces).
- The break-glass `POST /login` minted the raw master token into a 30-day cookie **without the `Secure` flag**, writing it inline instead of through the `GatewayTokenCookie` helper.

### The fix
On hosted (`GatewayHostedMode.IsHosted`, guaranteed true at boot for the hosted image by `HostedStartupContract`):
- **The shared/master token no longer authenticates public HTTP.** The per-device key issued at enrollment is the only accepted credential on Bearer and cookie, and it still resolves the request's tenant. `HasValidToken` gains an internal overload taking the hosted policy explicitly; the public 3-arg form reads `IsHosted`, so one policy read covers every call site (middleware, dictation, endpoints).
- **The break-glass `/login` surface is bind-broken** - `GET` and `POST` both return 404, so even the correct token writes no cookie. Extracted into `GatewayLoginEndpoint` so it is wire-testable in isolation.
- **The self-host `/login` cookie write routes through the single `GatewayTokenCookie` helper** (`HttpOnly`/`SameSite`/`Secure = IsHosted`), so `/login` can never write a non-Secure cookie again.

Self-host is byte-identical: single-owner, the shared token remains its credential, `/login` stays the reachable break-glass, and its cookie is (correctly) not `Secure` so it survives plain-HTTP loopback/tailnet.

### Tests
- `AuthMiddlewareTests` - shared token refused on Bearer + cookie on hosted; a per-device key still authenticates and stashes the tenant-resolving `DeviceKeyItemKey`; self-host still accepts the shared token.
- `GatewayLoginEndpointTests` (new) - hosted GET/POST `/login` -> 404 with no cookie; self-host serves the form, 302 + cookie via the helper (HttpOnly/SameSite, not Secure on HTTP), wrong token -> 401.
- Updated two `CockpitUrlEndpointTests` that asserted the pre-fix behavior (shared token valid on hosted) to enroll a per-device key instead.
- Full `CcDirector.Gateway.Tests` suite: **3124 passed, 0 failed, 12 skipped**.

### Set-aside (ops, out of code scope)
Any hosted machine token previously minted into a browser cookie should be **rotated** - the code now refuses it on hosted, but a previously-leaked shared token is only fully neutralized once the on-disk `gateway-token.txt` value is rotated.

Do not merge - architect merges after Codex review.
