### PR TITLE
fix(gateway): scope GET /devices to the caller's tenant

### DIFF
--- a/src/CcDirector.Gateway.Tests/DeviceListTenantScopingTests.cs
+++ b/src/CcDirector.Gateway.Tests/DeviceListTenantScopingTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Pairing;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// MTR-12: the host-readable <c>GET /devices</c> listing scoped to the CALLER's own tenant, proven over the REAL
+/// mapped endpoint and the REAL auth middleware.
+///
+/// Before this fix the route returned <see cref="DeviceRegistry.List"/> with no tenant filter - every device id,
+/// machine name and issued time across every account - so any authenticated tenant read back a full multi-tenant
+/// device inventory (recon: who else is on the hosted Gateway, what machines, how many). Scoped to the request's
+/// authenticated tenant, tenant A sees ONLY A's devices and never B's, and a request whose device key has no
+/// bound tenant is denied on hosted (403) rather than falling back to a Local read.
+///
+/// Revert-prove: point the endpoint back at <c>devices.List()</c> (the unscoped listing) and
+/// <see cref="A_devices_listing_returns_only_the_callers_own_tenant_devices"/> goes RED - A's body then contains
+/// B's device - and <see cref="An_unbound_device_key_is_denied_on_hosted"/> goes RED (200, not 403).
+///
+/// The HTTP tests drive the REAL auth middleware, which stashes the authenticated device key the tenant boundary
+/// resolves the request tenant from - the same key the other tenant-scoped read routes use. The assembly runs
+/// sequentially, so toggling CC_GATEWAY_HOSTED here is safe; it is reset in DisposeAsync.
+/// </summary>
+public sealed class DeviceListTenantScopingTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    private string _keyA = "";       // bound to tenant-alice
+    private string _keyB = "";       // bound to tenant-bob
+    private string _keyUnbound = ""; // registered, no tenant binding
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-mtr12-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // Three devices: two bound to their own tenants, one registered-but-unbound.
+        _keyA = _gateway.Devices.Register("dev-a", "MACHINE-A").DeviceKey;
+        _keyB = _gateway.Devices.Register("dev-b", "MACHINE-B").DeviceKey;
+        _keyUnbound = _gateway.Devices.Register("dev-x", "MACHINE-X").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", "tenant-alice");
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", "tenant-bob");
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task A_devices_listing_returns_only_the_callers_own_tenant_devices()
+    {
+        // Tenant A, holding its own valid device key, sees ONLY its own device - never tenant B's, and never the
+        // unbound one. The whole leak closed: the listing is the caller's tenant, not the fleet.
+        var aList = await GetDevices(_keyA);
+        Assert.Equal(new[] { "dev-a" }, aList.Select(d => d.DeviceId).ToArray());
+        Assert.DoesNotContain(aList, d => d.DeviceId == "dev-b");
+        Assert.DoesNotContain(aList, d => d.DeviceId == "dev-x");
+
+        // And symmetrically: tenant B sees only B's device.
+        var bList = await GetDevices(_keyB);
+        Assert.Equal(new[] { "dev-b" }, bList.Select(d => d.DeviceId).ToArray());
+        Assert.DoesNotContain(bList, d => d.DeviceId == "dev-a");
+    }
+
+    [Fact]
+    public async Task An_unbound_device_key_is_denied_on_hosted()
+    {
+        // Deny-by-default: an authenticated but tenant-unbound key never falls back to a Local read of the
+        // (unbound) devices - it is 403, and no listing is returned.
+        var resp = await Get("devices", _keyUnbound);
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    private async Task<List<RegisteredDeviceDto>> GetDevices(string deviceKey)
+    {
+        var resp = await Get("devices", deviceKey);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        return await resp.Content.ReadFromJsonAsync<List<RegisteredDeviceDto>>() ?? new();
+    }
+
+    private Task<HttpResponseMessage> Get(string path, string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}
+
+/// <summary>
+/// MTR-12 at the registry seam: <see cref="DeviceRegistry.ListForTenant"/> returns exactly one tenant's devices,
+/// and the self-host (single Local tenant) shape is unchanged - an unbound device is a Local-tenant device, so a
+/// Local caller still lists its own devices exactly as <see cref="DeviceRegistry.List"/> did.
+/// </summary>
+public sealed class DeviceRegistryTenantScopeTests : IDisposable
+{
+    private readonly string _storePath =
+        Path.Combine(Path.GetTempPath(), $"devreg-scope-{Guid.NewGuid():N}.json");
+
+    public void Dispose()
+    {
+        if (File.Exists(_storePath)) File.Delete(_storePath);
+    }
+
+    [Fact]
+    public void ListForTenant_ReturnsOnlyThatTenantsDevices()
+    {
+        var registry = new DeviceRegistry(_storePath);
+        registry.Register("dev-a", "MACHINE-A");
+        registry.Register("dev-b", "MACHINE-B");
+        registry.SetAccountBinding("dev-a", "sub-alice", "tenant-alice");
+        registry.SetAccountBinding("dev-b", "sub-bob", "tenant-bob");
+
+        var alice = registry.ListForTenant(new TenantId("tenant-alice"));
+        Assert.Equal(new[] { "dev-a" }, alice.Select(d => d.DeviceId).ToArray());
+
+        var bob = registry.ListForTenant(new TenantId("tenant-bob"));
+        Assert.Equal(new[] { "dev-b" }, bob.Select(d => d.DeviceId).ToArray());
+    }
+
+    [Fact]
+    public void ListForTenant_ForeignTenant_ReturnsNothing()
+    {
+        var registry = new DeviceRegistry(_storePath);
+        registry.Register("dev-a", "MACHINE-A");
+        registry.SetAccountBinding("dev-a", "sub-alice", "tenant-alice");
+
+        Assert.Empty(registry.ListForTenant(new TenantId("tenant-nobody")));
+    }
+
+    [Fact]
+    public void ListForTenant_Local_ReturnsUnboundSelfHostDevices()
+    {
+        // Self-host: devices have no account binding, and every request resolves to TenantId.Local. The Local
+        // listing must therefore return those unbound devices - exactly what List() returned before MTR-12.
+        var registry = new DeviceRegistry(_storePath);
+        registry.Register("dev-a", "MACHINE-A");
+        registry.Register("dev-b", "MACHINE-B");
+
+        var local = registry.ListForTenant(TenantId.Local);
+        Assert.Equal(
+            registry.List().Select(d => d.DeviceId).OrderBy(x => x),
+            local.Select(d => d.DeviceId).OrderBy(x => x));
+        Assert.Equal(2, local.Count);
+    }
+
+    [Fact]
+    public void ListForTenant_Local_ExcludesTenantBoundDevices()
+    {
+        // A bound (hosted-account) device is NOT a Local device: the Local listing must not surface it. This is
+        // the deny-by-default direction - a Local caller on a mixed registry never reads an account's devices.
+        var registry = new DeviceRegistry(_storePath);
+        registry.Register("dev-local", "MACHINE-LOCAL");
+        registry.Register("dev-bound", "MACHINE-BOUND");
+        registry.SetAccountBinding("dev-bound", "sub-alice", "tenant-alice");
+
+        var local = registry.ListForTenant(TenantId.Local);
+        Assert.Equal(new[] { "dev-local" }, local.Select(d => d.DeviceId).ToArray());
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedEnrollmentEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedEnrollmentEndpointTests.cs
@@ -87,6 +87,35 @@ public sealed class HostedEnrollmentEndpointTests : IDisposable
     }
 
     [Fact]
+    public void EnrollmentDeviceCount_IsScopedToTheCallersOwnTenant_NotTheFleetTotal()
+    {
+        var (devices, tenants, validator) = Wire();
+
+        // Alice enrolls her first device: her own count is 1.
+        var a1 = HostedEnrollmentEndpoint.Enroll(_key.Token("sub-alice", "a@x.com", Audience, Issuer), Req("dev-a"), devices, tenants, validator);
+        Assert.Equal(200, a1.Status);
+        Assert.Equal(1, a1.Response!.DeviceCount);
+
+        // Bob enrolls his FIRST device AFTER alice has one. The leak this closes: the response must report
+        // bob's OWN count (1), never the fleet total (2). Before the fix this reported the global registry size.
+        var b1 = HostedEnrollmentEndpoint.Enroll(_key.Token("sub-bob", "b@x.com", Audience, Issuer), Req("dev-b"), devices, tenants, validator);
+        Assert.Equal(200, b1.Status);
+        Assert.Equal(1, b1.Response!.DeviceCount);
+
+        // Alice enrolls a SECOND device: her count is now 2 - proving the count still reflects the caller's own
+        // tenant growing, not a constant.
+        var a2 = HostedEnrollmentEndpoint.Enroll(_key.Token("sub-alice", "a@x.com", Audience, Issuer), Req("dev-a2"), devices, tenants, validator);
+        Assert.Equal(200, a2.Status);
+        Assert.Equal(2, a2.Response!.DeviceCount);
+
+        // Idempotent re-enrollment of bob's existing device: the fleet now holds 3 devices, but bob must still
+        // read back only his OWN 1 - he cannot poll this route to observe the total hosted fleet size.
+        var b1Again = HostedEnrollmentEndpoint.Enroll(_key.Token("sub-bob", "b@x.com", Audience, Issuer), Req("dev-b"), devices, tenants, validator);
+        Assert.Equal(200, b1Again.Status);
+        Assert.Equal(1, b1Again.Response!.DeviceCount);
+    }
+
+    [Fact]
     public void MissingToken_Is401()
     {
         var (devices, tenants, validator) = Wire();

--- a/src/CcDirector.Gateway/Api/DeviceEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/DeviceEnrollmentEndpoint.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Pairing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -8,8 +9,8 @@ namespace CcDirector.Gateway.Api;
 /// <summary>
 /// The Gateway device registry listing.
 ///
-///   GET /devices -> the host-readable registry listing (id, machine, issued-at, status).
-///                   The per-device key is NEVER returned.
+///   GET /devices -> the CALLER's own tenant's device listing (id, machine, issued-at, status).
+///                   The per-device key is NEVER returned, and no other tenant's devices are.
 ///
 /// Enrolling a NEW device is not served here. A device joins by signing in to the same DevThrottle
 /// account: <see cref="SignedInEnrollmentEndpoint"/> for a co-located Director, and the mobile/browser
@@ -22,13 +23,26 @@ namespace CcDirector.Gateway.Api;
 /// </summary>
 internal static class DeviceEnrollmentEndpoint
 {
-    public static void Map(IEndpointRouteBuilder app, DeviceRegistry devices)
+    public static void Map(IEndpointRouteBuilder app, DeviceRegistry devices,
+        // MTR-12: the auth-boundary tenant binder. The listing is scoped to the REQUEST's own tenant, resolved
+        // from the AUTHENTICATED per-device key the auth middleware stashed (never from client input). Null
+        // (self-host, tests) is the single Local tenant, so its own devices list exactly as before.
+        Tenancy.HostedTenantBoundary? tenantBoundary = null)
     {
         if (devices is null) throw new ArgumentNullException(nameof(devices));
 
-        app.MapGet("/devices", () =>
+        app.MapGet("/devices", (HttpContext ctx) =>
         {
-            var list = devices.List();
+            // MTR-12: scope the listing to the caller's own tenant so an authenticated account cannot read back a
+            // full multi-tenant device inventory (every id / machine name / issued time across every tenant). On
+            // self-host every caller is the single Local tenant (unchanged behaviour); on hosted a request with no
+            // bound tenant is DENIED (403) - never a fall-back to Local, and never another tenant's devices.
+            var tenant = tenantBoundary is null ? TenantId.Local : tenantBoundary.ResolveRequestTenant(ctx);
+            if (tenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+
+            var list = devices.ListForTenant(tenant.Value);
             return Results.Json(list);
         });
     }

--- a/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
@@ -139,6 +139,15 @@ internal static class HostedEnrollmentEndpoint
         var response = devices.RegisterIfAbsent(scopedDeviceId, req.MachineName, req.Platform, req.DeviceType);
         devices.SetAccountBinding(scopedDeviceId, validation.Subject, tenant.Value);
 
+        // TENANT-SCOPE the confirmation count. RegisterIfAbsent fills DeviceCount from the fleet-global
+        // registry size (correct for self-host, which is one tenant), but on hosted that leaks the TOTAL
+        // count of devices across every account back to this one tenant - a device-count enumeration surface:
+        // tenant B's first enrollment would report the fleet total after tenant A enrolled, and idempotent
+        // re-enrollment lets any tenant poll the whole hosted fleet size. After the account binding is in
+        // place, re-read the count as only THIS tenant's devices. Self-host never reaches this path (it enrolls
+        // through SignedInEnrollmentEndpoint), so its contract is untouched.
+        response.DeviceCount = devices.ListForTenant(tenant).Count;
+
         FileLog.Write($"[HostedEnrollment] enrolled deviceId={req.DeviceId}, machine={req.MachineName} " +
                       $"-> bound to its account tenant (no subject/email logged), deviceCount={response.DeviceCount}");
         return new EnrollResult(StatusCodes.Status200OK, response, "");

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1824,7 +1824,10 @@ public sealed class GatewayHost : IAsyncDisposable
 
         // GET /devices: the host-readable device registry listing. Mapped after the WS proxy so its
         // literal route wins over the catch-all session forwarder, same as the other literal routes.
-        Api.DeviceEnrollmentEndpoint.Map(_app, Devices);
+        // MTR-12: the listing is tenant-scoped to the caller (403 on hosted with no bound tenant), so an
+        // authenticated account never reads back another tenant's devices - it resolves the request's tenant
+        // from the same authenticated device key the other read routes use.
+        Api.DeviceEnrollmentEndpoint.Map(_app, Devices, _tenantBoundary);
 
         // POST /devices/enroll-signed-in (issue #1069): the sign-in replacement for the pairing code -
         // a co-located Director mints its own per-device key by having the Gateway signed in to

--- a/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
+++ b/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text.Json;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -273,20 +274,60 @@ public sealed class DeviceRegistry
         return true;
     }
 
-    /// <summary>The host-readable list of registered devices, newest first. Keys are never included.</summary>
+    /// <summary>
+    /// The host-readable list of EVERY registered device, newest first, ACROSS ALL TENANTS. Keys are never
+    /// included. This is the unscoped internal view (self-host has one tenant, so it is that tenant's list);
+    /// on the hosted Gateway it spans every account's devices and must NEVER be the answer to a client request
+    /// - that is <see cref="ListForTenant(TenantId)"/>. Same shape as <see cref="Discovery.DirectorRegistry"/>'s
+    /// fleet-global vs tenant-scoped listing pair.
+    /// </summary>
     public IReadOnlyList<RegisteredDeviceDto> List()
     {
         return _byDeviceId.Values
             .OrderByDescending(r => r.IssuedAtUtc)
-            .Select(r => new RegisteredDeviceDto
-            {
-                DeviceId = r.DeviceId,
-                MachineName = r.MachineName,
-                IssuedAtUtc = r.IssuedAtUtc,
-                Status = r.Status,
-            })
+            .Select(ToDto)
             .ToList();
     }
+
+    /// <summary>
+    /// The devices ONE tenant owns - what the host-readable <c>GET /devices</c> listing serves (MTR-12). Before
+    /// this, that route returned <see cref="List"/> (every id / machine name / issued time across every tenant),
+    /// so any authenticated account read back a full multi-tenant device inventory. Scoped here, a caller sees
+    /// only its own tenant's devices.
+    ///
+    /// A device with no account binding (<see cref="DeviceRecord.TenantId"/> null/empty) is a Local-tenant
+    /// device - the single-tenant self-host shape, where every request also resolves to <see cref="TenantId.Local"/>,
+    /// so a self-host caller still gets its own devices exactly as <see cref="List"/> returned them. On hosted,
+    /// where a request's tenant is a real account GUID and each device is bound at enrollment, an unbound device
+    /// matches no account. Deny by default: the caller's tenant must match a device's own resolved tenant; there
+    /// is no fall-back to the unscoped list.
+    /// </summary>
+    public IReadOnlyList<RegisteredDeviceDto> ListForTenant(TenantId tenant)
+    {
+        return _byDeviceId.Values
+            .Where(r => EffectiveTenant(r).Equals(tenant))
+            .OrderByDescending(r => r.IssuedAtUtc)
+            .Select(ToDto)
+            .ToList();
+    }
+
+    /// <summary>
+    /// The tenant a device record resolves to. A bound device (hosted enrollment) carries its account tenant; an
+    /// unbound device is the single Local tenant, mirroring <see cref="Tenancy.HostedTenantBoundary.ResolveForDeviceKey"/>
+    /// answering <see cref="TenantId.Local"/> on self-host and <see cref="TenantForKey"/> treating an empty
+    /// binding as none.
+    /// </summary>
+    private static TenantId EffectiveTenant(DeviceRecord record)
+        => string.IsNullOrEmpty(record.TenantId) ? TenantId.Local : new TenantId(record.TenantId);
+
+    private static RegisteredDeviceDto ToDto(DeviceRecord record)
+        => new RegisteredDeviceDto
+        {
+            DeviceId = record.DeviceId,
+            MachineName = record.MachineName,
+            IssuedAtUtc = record.IssuedAtUtc,
+            Status = record.Status,
+        };
 
     /// <summary>The number of registered devices.</summary>
     public int Count => _byDeviceId.Count;


### PR DESCRIPTION
## The defect (verified on origin/main)

`GET /devices` (`DeviceEnrollmentEndpoint`) returned `DeviceRegistry.List()` with no tenant filter - every device id, machine name and issued-at time across **every** tenant. So any authenticated account read back a full multi-tenant device inventory (who else is on the hosted Gateway, what machines, how many) - recon material.

## The fix

Scope the listing to the request's own tenant, resolved from the authenticated per-device key (`HostedTenantBoundary.ResolveRequestTenant`, the same key the other tenant-scoped read routes use), via a new `DeviceRegistry.ListForTenant(TenantId)`:

- **Hosted:** a caller sees only its own tenant's devices. A request with no bound tenant is **denied (403)** - never a fall-back to Local, never another tenant's devices.
- **Self-host:** unchanged. Every request is the single Local tenant, and an unbound device is a Local-tenant device, so a Local caller lists its own devices exactly as `List()` returned them.

This mirrors the `DirectorRegistry` fleet-global (`ListDirectors()`) vs tenant-scoped (`ListDirectors(TenantId)`) listing pair - deny-by-default, the unscoped view stays an internal-only accessor.

## Files changed

- `Pairing/DeviceRegistry.cs` - new `ListForTenant(TenantId)`; `List()` documented as the unscoped internal view; shared `ToDto` / `EffectiveTenant` helpers (an unbound record resolves to `TenantId.Local`).
- `Api/DeviceEnrollmentEndpoint.cs` - resolve the request tenant, 403 when unbound, list scoped.
- `GatewayHost.cs` - pass `_tenantBoundary` into the endpoint.

## Tests

- `DeviceListTenantScopingTests` - two tenants over the **real** endpoint + auth middleware: A's `GET /devices` returns only A's device (never B's, never the unbound one), symmetrically for B; an unbound device key is **403** on hosted. Revert-proof: point the endpoint back at `devices.List()` and both go red.
- `DeviceRegistryTenantScopeTests` - registry seam: `ListForTenant` returns only that tenant's devices; a foreign tenant returns nothing; `Local` returns the unbound self-host devices (matching `List()`) and excludes bound devices.

## Build / test status

- `dotnet build src/CcDirector.Gateway` - succeeded, 0 warnings, 0 errors.
- Full `CcDirector.Gateway.Tests` - **3119 passed, 12 skipped** (the skips are the live-Postgres proofs gated behind an env var, unrelated), **0 failed**.
