### PR TITLE
fix(gateway): make the Wingman voice path tenant-aware on hosted

### DIFF
--- a/src/CcDirector.Gateway.Tests/GatewayTurnBriefTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTurnBriefTests.cs
@@ -165,7 +165,7 @@ public sealed class TurnEndWatcherTests
     {
         var turnEnds = new List<TurnEndSignal>();
         var working = new List<string>();
-        var watcher = new TurnEndWatcher(turnEnds.Add, working.Add);
+        var watcher = new TurnEndWatcher(turnEnds.Add, (sid, _) => working.Add(sid));
         return (watcher, turnEnds, working);
     }
 

--- a/src/CcDirector.Gateway.Tests/SessionServingReadIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionServingReadIsolationTests.cs
@@ -75,8 +75,11 @@ public sealed class SessionServingReadIsolationTests : IAsyncLifetime
         _keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
         _keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
         _keyUnbound = _gateway.Devices.Register("dev-x", "MX").DeviceKey;
-        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", "tenant-alice");
-        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", "tenant-bob");
+        // Account tenants are minted GUIDs in production (the roster's voice enrichment now routes the
+        // request tenant into WingmanVoiceService, which refuses a non-GUID, non-Local partition key), so
+        // bind real GUID tenant ids here rather than friendly labels.
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", "33333333-3333-3333-3333-333333333333");
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", "44444444-4444-4444-4444-444444444444");
 
         // Each Director authenticates with its OWN device key -> the tunnel Hello binds its tenant -> its pushed
         // session lands in that tenant's partition. dir-B answers the screenshots-list verb so the same-tenant

--- a/src/CcDirector.Gateway.Tests/TurnEndWatcherVoiceRefreshTests.cs
+++ b/src/CcDirector.Gateway.Tests/TurnEndWatcherVoiceRefreshTests.cs
@@ -47,7 +47,7 @@ public sealed class TurnEndWatcherVoiceRefreshTests
                 if (voice.IsVoiceSession(signal.SessionId))
                     voice.GenerateAsync(signal.SessionId, signal.DirectorId, signal.IsNewTurn);
             },
-            onSessionWorking: sid => voice.OnSessionWorking(sid));
+            onSessionWorking: (sid, _) => voice.OnSessionWorking(sid));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/VoiceServingLoopIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceServingLoopIsolationTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Hosted Multi-Tenancy (hosted voice-serving): the Gateway's BACKGROUND VOICE loops are tenant-aware. Both
+/// the idle voice sweep and the turn-end voice refresh resolve each session's OWNING tenant from the push
+/// store and act only within it - a tunnel read for one tenant's session must never reach another tenant's
+/// Director, or that Director could be asked to hand over a session whose audio belongs to someone else.
+///
+/// Two Directors connect on two DIFFERENT tenants over the real tunnel, each authenticated with its OWN
+/// per-device key, exactly as the read/loop session-serving harnesses arrange. The tests drive the REAL
+/// production functions - <c>GatewayHost.SweepVoiceSessionsAsync</c> and the real turn-end callback via the
+/// live <c>TurnEndWatcher.Observe</c> transition - not a re-implementation.
+///
+/// Every absence claim is preceded by a POSITIVE CONTROL in the same test: we first prove the tunnel read DOES
+/// arrive for the tenant that owns the session, then prove it never reaches the other tenant's Director.
+/// Without that ordering a total failure to deliver anything would satisfy every "did not arrive" assertion
+/// and the test would pass vacuously.
+///
+/// REVERT-PROOFS (each against the real production line):
+///  - <c>SweepVoiceSessionsAsync</c>: replace its <c>_tenantPass.ForEachTenant</c> per-tenant pass with the
+///    old single <c>TenantId.Local</c> pass and <see cref="Voice_sweep_reaches_only_the_owning_tenants_director"/>
+///    goes RED - the Local partition holds no marked voice session, so the tunnel read that must reach dir-B is
+///    never sent.
+///  - the turn-end callback: replace its <c>ResolveOwningTenant(signal.DirectorId)</c> + tenant-passed
+///    <c>IsVoiceSession</c>/<c>GenerateAsync</c> with the old <c>TenantId.Local</c> and
+///    <see cref="Turn_end_voice_refresh_reaches_only_the_owning_tenants_director"/> goes RED - IsVoiceSession is
+///    false in the Local partition, so no refresh is issued.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is
+/// reset in DisposeAsync.
+/// </summary>
+public sealed class VoiceServingLoopIsolationTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string SessA = "voice-loop-sess-a";
+    private const string SessB = "voice-loop-sess-b";
+    // Account tenants are minted GUIDs in production (WingmanVoiceService refuses a non-GUID, non-Local tenant
+    // as a voice-state partition), so the device bindings here use real GUID tenant ids, not friendly labels.
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    private GatewayHost _gateway = null!;
+    private FakeTunnelDirector _dirA = null!;
+    private FakeTunnelDirector _dirB = null!;
+
+    private readonly ConcurrentQueue<DirectorCommand> _seenByA = new();
+    private readonly ConcurrentQueue<DirectorCommand> _seenByB = new();
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-voice-loop-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+
+        var keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", TenantA.Value);
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", TenantB.Value);
+
+        // Each Director captures every command it receives. A "turns" read answers with an empty widget set so
+        // the generation reaches its "nothing to narrate" branch and never attempts a live hosted brain call -
+        // the ARRIVAL of the read at the right Director is the whole point, not what it produces.
+        _dirA = await FakeTunnelDirector.StartAsync(_gateway, keyA, "dir-a", "MA",
+            dispatch: cmd => { _seenByA.Enqueue(cmd); return TurnsOrOk(cmd); });
+        _dirB = await FakeTunnelDirector.StartAsync(_gateway, keyB, "dir-b", "MB",
+            dispatch: cmd => { _seenByB.Enqueue(cmd); return TurnsOrOk(cmd); });
+
+        // Both tenants have a settled session in their OWN partition; only B's is a marked voice session, so a
+        // correctly tenant-scoped loop issues a voice read for B and NONE for A.
+        await _dirA.PushSnapshotAsync(Sample(SessA));
+        await _dirB.PushSnapshotAsync(Sample(SessB));
+        _gateway.VoiceService!.Mark(TenantB, SessB);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _dirA.DisposeAsync();
+        await _dirB.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task Voice_sweep_reaches_only_the_owning_tenants_director()
+    {
+        // The REAL idle voice sweep - the production timer callback, not a helper.
+        await _gateway.SweepVoiceSessionsAsync();
+
+        // POSITIVE CONTROL FIRST: the sweep's tunnel read for B's marked voice session reached dir-B. If this
+        // did not hold the absence assertion below would pass vacuously in a sweep that did nothing.
+        Assert.NotNull(await WaitForVerb(_seenByB, "turns", SessB));
+
+        // ABSENCE: dir-A was never asked to read B's session, and TenantA's own pass (its session is not a
+        // voice session) issued no voice read at all - so dir-A saw no "turns" command whatsoever.
+        Assert.DoesNotContain(_seenByA, c => c.Verb == "turns");
+    }
+
+    [Fact]
+    public async Task Turn_end_voice_refresh_reaches_only_the_owning_tenants_director()
+    {
+        // Drive a REAL Working -> Waiting transition for B's session on dir-B through the live watcher, which
+        // fires the production onSessionWorking (clear) then onTurnEnd (refresh) callbacks. Both resolve the
+        // owning tenant from the director id the signal carries.
+        _gateway.TurnEndWatcherForTest!.Observe(SessB, "Working", "dir-b");
+        _gateway.TurnEndWatcherForTest!.Observe(SessB, "WaitingForInput", "dir-b");
+
+        // POSITIVE CONTROL FIRST: the turn-end refresh's tunnel read for B's session reached dir-B.
+        Assert.NotNull(await WaitForVerb(_seenByB, "turns", SessB));
+
+        // ABSENCE: dir-A was never asked to read B's session.
+        Assert.DoesNotContain(_seenByA, c => c.Verb == "turns" && c.SessionId == SessB);
+    }
+
+    [Fact]
+    public void Voice_state_is_partitioned_per_tenant()
+    {
+        // A completed narration leaves a ready clip in exactly ONE tenant's partition. Seeding it under B and
+        // asserting it is invisible to Local and to A is the direct proof that B's audio can never be read for
+        // another tenant - the property the sweep/turn-end routing above protects at the boundary.
+        _gateway.VoiceService!.StoreReadyAudioForTest(TenantB, SessB, "spoken", "reply", new byte[] { 1, 2, 3 });
+
+        Assert.True(_gateway.VoiceService.HasVoice(TenantB, SessB));         // present for its own tenant
+        Assert.False(_gateway.VoiceService.HasVoice(TenantId.Local, SessB)); // never the Local partition
+        Assert.False(_gateway.VoiceService.HasVoice(TenantA, SessB));        // never another account's tenant
+    }
+
+    /// <summary>
+    /// Poll for a verb+session rather than sleeping a fixed time: the loop fires generation onto the thread
+    /// pool and the tunnel round-trip is asynchronous, so a fixed wait would be either flaky or slow.
+    /// </summary>
+    private static async Task<DirectorCommand?> WaitForVerb(ConcurrentQueue<DirectorCommand> seen, string verb, string sessionId)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            var hit = seen.FirstOrDefault(c => c.Verb == verb && c.SessionId == sessionId);
+            if (hit is not null) return hit;
+            await Task.Delay(50);
+        }
+        return null;
+    }
+
+    // A "turns" read answers with an empty widget set (no text reply -> generation stops before any hosted
+    // call); everything else is a harmless ok.
+    private static DirectorCommandResult TurnsOrOk(DirectorCommand cmd) =>
+        cmd.Verb == "turns"
+            ? FakeTunnelDirector.Ok(new { widgets = Array.Empty<object>() })
+            : FakeTunnelDirector.Ok(new { ok = true });
+
+    private static SessionDto Sample(string sid) => new()
+    {
+        SessionId = sid,
+        Agent = "claude",
+        RepoPath = "/repo",
+        // Settled at a turn end - the idle sweep only pre-builds Idle / WaitingForInput / WaitingForPerm.
+        ActivityState = "WaitingForInput",
+        Status = "Running",
+        StatusColor = "red",
+        CreatedAt = DateTime.UtcNow,
+        LastActivityAt = DateTime.UtcNow,
+    };
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/VoiceServingReadIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceServingReadIsolationTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Hosted Multi-Tenancy (hosted voice-serving): the wingman VOICE read surface is tenant-aware end-to-end over
+/// real HTTP. Two Directors connect on two DIFFERENT tenants, each authenticated with its OWN per-device key;
+/// the Gateway resolves the request's tenant from that same authenticated key and serves ONLY that tenant's
+/// voice state. Voice audio is the sensitive payload here - a wrong-tenant read would play one account's
+/// narration to another - so every route is proven isolated with a same-tenant POSITIVE CONTROL next to each
+/// cross-tenant negative:
+///   - GET /wingman/voice/ready lists ONLY the requesting tenant's ready session ids (key B sees sess-b, key A
+///     does not);
+///   - GET /sessions/{sid}/wingman/voice for B's session is ready:false under key A, ready:true under key B;
+///   - GET /sessions/{sid}/wingman/voice/audio for B's session is 404 under key A, 200 bytes under key B;
+///   - a request whose authenticated device key has NO bound tenant is DENIED 403 (deny-by-default), never
+///     served the Local partition.
+///
+/// Revert-prove: change any of these routes back to passing TenantId.Local into WingmanVoiceService (instead
+/// of the request tenant) and key B reads the empty Local partition, so every same-tenant positive control
+/// (key B sees / plays sess-b's voice) goes RED.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is
+/// reset in DisposeAsync.
+/// </summary>
+public sealed class VoiceServingReadIsolationTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string SessB = "voice-read-sess-b";
+    // Account tenants are minted GUIDs in production (WingmanVoiceService refuses a non-GUID, non-Local tenant
+    // as a voice-state partition), so the device bindings here use real GUID tenant ids, not friendly labels.
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+    private static readonly byte[] AudioBytes = { 1, 2, 3, 4, 5 };
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private FakeTunnelDirector _dirA = null!;
+    private FakeTunnelDirector _dirB = null!;
+
+    private string _keyA = "";
+    private string _keyB = "";
+    private string _keyUnbound = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-voice-read-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // Two accounts (each a device key bound to its OWN tenant) plus one registered-but-unbound key.
+        _keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        _keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        _keyUnbound = _gateway.Devices.Register("dev-x", "MX").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", TenantA.Value);
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", TenantB.Value);
+
+        _dirA = await FakeTunnelDirector.StartAsync(_gateway, _keyA, "dir-a", "MA");
+        _dirB = await FakeTunnelDirector.StartAsync(_gateway, _keyB, "dir-b", "MB");
+
+        // Seed a ready, playable voice clip for B's session UNDER TENANT B only. This is what a completed
+        // narration leaves behind; seeding it directly avoids a live hosted brain / speech call the test
+        // harness cannot make, while still proving the read path partitions by tenant.
+        _gateway.VoiceService!.StoreReadyAudioForTest(
+            TenantB, SessB, spoken: "The build finished cleanly.", reply: "Build succeeded.", audio: AudioBytes,
+            contentType: "audio/mpeg");
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _dirA.DisposeAsync();
+        await _dirB.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task Voice_ready_list_serves_only_the_requesting_tenants_sessions()
+    {
+        // POSITIVE CONTROL: B's own key lists B's ready voice session. Without this the negative below would
+        // pass vacuously for a route that simply lists nothing for anyone.
+        Assert.Contains(SessB, await ReadySids(_keyB));
+
+        // ABSENCE: A's key never sees B's ready voice session (A resolves tenant-alice, an empty partition).
+        Assert.DoesNotContain(SessB, await ReadySids(_keyA));
+    }
+
+    [Fact]
+    public async Task Voice_by_id_ready_is_isolated_across_tenants()
+    {
+        // POSITIVE CONTROL: B's key reads its own session's voice as ready.
+        Assert.True(await VoiceReady($"sessions/{SessB}/wingman/voice", _keyB));
+
+        // ABSENCE: A's key sees it as not-ready (never the cross-tenant clip).
+        Assert.False(await VoiceReady($"sessions/{SessB}/wingman/voice", _keyA));
+    }
+
+    [Fact]
+    public async Task Voice_audio_is_isolated_across_tenants()
+    {
+        // POSITIVE CONTROL: B's key can fetch B's session audio - the exact bytes that were seeded.
+        var ownResp = await Get($"sessions/{SessB}/wingman/voice/audio", _keyB);
+        Assert.Equal(HttpStatusCode.OK, ownResp.StatusCode);
+        Assert.Equal(AudioBytes, await ownResp.Content.ReadAsByteArrayAsync());
+
+        // ABSENCE: A's key cannot fetch B's session audio - 404, never another tenant's narration.
+        var crossResp = await Get($"sessions/{SessB}/wingman/voice/audio", _keyA);
+        Assert.Equal(HttpStatusCode.NotFound, crossResp.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_device_key_with_no_bound_tenant_is_denied()
+    {
+        // Deny-by-default across the voice read surface: an authenticated but tenant-unbound key never falls
+        // back to the Local partition - it is refused outright on every voice read route.
+        Assert.Equal(HttpStatusCode.Forbidden, (await Get("wingman/voice/ready", _keyUnbound)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await Get($"sessions/{SessB}/wingman/voice", _keyUnbound)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await Get($"sessions/{SessB}/wingman/voice/audio", _keyUnbound)).StatusCode);
+    }
+
+    private Task<HttpResponseMessage> Get(string path, string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private async Task<string[]> ReadySids(string deviceKey)
+    {
+        var resp = await Get("wingman/voice/ready", deviceKey);
+        resp.EnsureSuccessStatusCode();
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("sids").EnumerateArray().Select(e => e.GetString()!).ToArray();
+    }
+
+    private async Task<bool> VoiceReady(string path, string deviceKey)
+    {
+        var resp = await Get(path, deviceKey);
+        resp.EnsureSuccessStatusCode();
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("ready").GetBoolean();
+    }
+
+    private static int FreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -47,11 +47,11 @@ internal static class GatewayEndpoints
     /// <see cref="GatewayVoiceTurnEndpoint"/>; null (old callers) maps nothing.</param>
     public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, string version, string token, bool authEnabled = false, Func<bool>? requestShutdown = null,
         Action<string, string, string>? onSessionState = null,
-        Func<string, bool>? voiceGeneratingFor = null,
-        Func<string, bool>? voiceAudioReadyFor = null,
-        Func<string, Core.HostedAi.HostedAiState?>? voiceUnavailableFor = null,
-        Func<string, bool>? nothingToNarrateFor = null,
-        Func<string, bool>? servedViaFallbackFor = null,
+        Func<TenantId, string, bool>? voiceGeneratingFor = null,
+        Func<TenantId, string, bool>? voiceAudioReadyFor = null,
+        Func<TenantId, string, Core.HostedAi.HostedAiState?>? voiceUnavailableFor = null,
+        Func<TenantId, string, bool>? nothingToNarrateFor = null,
+        Func<TenantId, string, bool>? servedViaFallbackFor = null,
         Func<string, bool, DateTime?>? needsYouStampFor = null,
         Func<string, bool>? transcribingFor = null,
         Func<string, string?>? dictationStatusFor = null,
@@ -936,14 +936,14 @@ internal static class GatewayEndpoints
                     // (the SINGLE truthful "there is voice you can play right now" signal). VoiceGenerating
                     // is the only "preparing voice" hold; VoiceAudioReady controls playback affordances.
                     if (voiceGeneratingFor is not null)
-                        s.VoiceGenerating = voiceGeneratingFor(s.SessionId);
+                        s.VoiceGenerating = voiceGeneratingFor(reqTenant.Value, s.SessionId);
                     if (voiceAudioReadyFor is not null)
-                        s.VoiceAudioReady = voiceAudioReadyFor(s.SessionId);
+                        s.VoiceAudioReady = voiceAudioReadyFor(reqTenant.Value, s.SessionId);
                     // Issue #939: when the gateway could not keep this session's voice because hosted AI
                     // is unavailable (out of credits / cap / no key), stamp the ONE shared message so the
                     // owning UI shows the consistent add-credit / add-key state instead of a silently
                     // missing play triangle. Null (voice fine) leaves the field unset.
-                    if (voiceUnavailableFor is not null && voiceUnavailableFor(s.SessionId) is Core.HostedAi.HostedAiState reason)
+                    if (voiceUnavailableFor is not null && voiceUnavailableFor(reqTenant.Value, s.SessionId) is Core.HostedAi.HostedAiState reason)
                         s.VoiceUnavailable = HostedAi.HostedAiHttp.Dto(reason);
                     // The FOLDED voice-mode display verdict the Voice screen renders VERBATIM. Every piece
                     // of ruling the phone used to do for itself - the badge, the message, and crucially
@@ -957,9 +957,9 @@ internal static class GatewayEndpoints
                                    || string.Equals(s.ActivityState, "Starting", StringComparison.OrdinalIgnoreCase),
                         hasAudio: s.VoiceAudioReady,
                         generating: s.VoiceGenerating,
-                        unavailable: voiceUnavailableFor?.Invoke(s.SessionId),
-                        nothingToNarrate: nothingToNarrateFor?.Invoke(s.SessionId) ?? false,
-                        servedViaFallback: servedViaFallbackFor?.Invoke(s.SessionId) ?? false);
+                        unavailable: voiceUnavailableFor?.Invoke(reqTenant.Value, s.SessionId),
+                        nothingToNarrate: nothingToNarrateFor?.Invoke(reqTenant.Value, s.SessionId) ?? false,
+                        servedViaFallback: servedViaFallbackFor?.Invoke(reqTenant.Value, s.SessionId) ?? false);
                     // Orange "Transcribing..." while a dictated utterance is uploading/transcribing in
                     // the background for this session (mobile Speak -> Send released the screen). Stamped
                     // BEFORE the NeedsYouSince clock below so the EffectiveColor fold already sees orange
@@ -2744,7 +2744,7 @@ internal static class GatewayEndpoints
     /// bound tenant is refused, NEVER served the Local partition (which would be a wrong-tenant read waiting to
     /// happen). Self-host, or no boundary (older callers / tests), is always Local - behavior unchanged.
     /// </summary>
-    private static TenantId? ResolveReadTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
+    internal static TenantId? ResolveReadTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
         => boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
 
     /// <summary>

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -119,7 +119,8 @@ internal static class GatewayWingmanVoiceEndpoint
         HttpClient? ttsHttpClient = null,
         Voice.VoiceUploadStore? uploadStore = null,
         Transcription.TranscriptionTelemetryLog? telemetry = null,
-        Transcription.TranscriptionAudioArchive? audioArchive = null)
+        Transcription.TranscriptionAudioArchive? audioArchive = null,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null)
     {
         // The speech transport: the shared static in production, an injected stub in a test. This is the
         // same seam WingmanVoiceService already exposes for its narration leg (ttsHttpClient) and it
@@ -133,16 +134,16 @@ internal static class GatewayWingmanVoiceEndpoint
         // (turns / buffer / prompt) through the tunnel-only SessionVerbClient, so the wingman voice surface
         // never HTTP-dials the Director.
         var stale = streamStale ?? TimeSpan.FromSeconds(GatewayConfig.DefaultStreamStaleAfterSeconds);
-        Task<SessionVerbClient?> ResolveRouteAsync(string sid) =>
-            SessionVerbClient.ResolveAsync(sid, registry, pushedSessions, stale, owners, sendCommand);
+        Task<SessionVerbClient?> ResolveRouteAsync(TenantId tenant, string sid) =>
+            SessionVerbClient.ResolveAsync(sid, tenant, registry, pushedSessions, stale, owners, sendCommand);
 
         // The session's title, which the wingman speaks before the summary so a listener who cannot
         // see the screen knows which session is talking (WingmanTranslator.FidelityPrompt v5.2). Same
         // push-store read as ResolveRouteAsync above - no dial. Null (unknown session, or no name) is
         // the honest answer and simply means no title is spoken; see GatewayHost.ResolveSessionTitle.
-        string? SessionTitle(string sid)
+        string? SessionTitle(TenantId tenant, string sid)
         {
-            var name = pushedSessions?.TryLocate(TenantId.Local, sid, stale)?.Session.Name;
+            var name = pushedSessions?.TryLocate(tenant, sid, stale)?.Session.Name;
             return string.IsNullOrWhiteSpace(name) ? null : name;
         }
 
@@ -154,23 +155,35 @@ internal static class GatewayWingmanVoiceEndpoint
 
         // Which voice sessions have a ready, playable spoken summary right now (the phone's list
         // shows a play button on these and can play without entering).
-        app.MapGet("/wingman/voice/ready", () => Results.Json(new { sids = voice.ReadySessionIds(TenantId.Local) }));
+        app.MapGet("/wingman/voice/ready", (HttpContext ctx) =>
+        {
+            var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
+            return Results.Json(new { sids = voice.ReadySessionIds(reqTenant.Value) });
+        });
 
         // The precomputed spoken summary for a session (instant on entry - no re-read needed).
-        app.MapGet("/sessions/{sid}/wingman/voice", (string sid) =>
+        app.MapGet("/sessions/{sid}/wingman/voice", (string sid, HttpContext ctx) =>
         {
-            var v = voice.Get(TenantId.Local, sid);
+            var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
+            var v = voice.Get(reqTenant.Value, sid);
             return v is null
                 ? Results.Json(new { ready = false })
                 : Results.Json(new { ready = true, spoken = v.Spoken, reply = v.Reply, generatedAt = v.AtUtc });
         });
 
         // The precomputed audio for a session - streamed so the list can play it with one tap.
-        app.MapGet("/sessions/{sid}/wingman/voice/audio", (string sid) =>
+        app.MapGet("/sessions/{sid}/wingman/voice/audio", (string sid, HttpContext ctx) =>
         {
-            var audio = voice.GetAudio(TenantId.Local, sid);
+            var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
+            var audio = voice.GetAudio(reqTenant.Value, sid);
             return audio is { Length: > 0 }
-                ? Results.Bytes(audio, voice.GetAudioContentType(TenantId.Local, sid) ?? "audio/mpeg", enableRangeProcessing: true)
+                ? Results.Bytes(audio, voice.GetAudioContentType(reqTenant.Value, sid) ?? "audio/mpeg", enableRangeProcessing: true)
                 : Results.Json(new { error = "no voice ready for this session" }, statusCode: StatusCodes.Status404NotFound);
         });
 
@@ -180,12 +193,15 @@ internal static class GatewayWingmanVoiceEndpoint
         // phone's "Turn voice off" calls it alongside the Director's /voice-mode { enabled:false }.
         // Gateway-side only and read-only - it clears the voice marker + cached clip and sends nothing
         // into the session. Idempotent: stopping a session that was not a voice session is a no-op 200.
-        app.MapPost("/sessions/{sid}/wingman/voice/stop", (string sid) =>
+        app.MapPost("/sessions/{sid}/wingman/voice/stop", (string sid, HttpContext ctx) =>
         {
             FileLog.Write($"[GatewayWingmanVoice] voice/stop sid={sid}");
+            var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
             if (!Guid.TryParse(sid, out _))
                 return Results.Json(new { error = "invalid session id format" }, statusCode: StatusCodes.Status400BadRequest);
-            voice.Unmark(TenantId.Local, sid);
+            voice.Unmark(reqTenant.Value, sid);
             return Results.Json(new { stopped = true });
         });
 
@@ -205,8 +221,11 @@ internal static class GatewayWingmanVoiceEndpoint
         // thread and never raced. Idempotent: enabling a session already on, or disabling one already off,
         // is a harmless no-op. This endpoint sends NO prompt into any session - it only sets voice marking,
         // exactly like the single-session /voice-mode and /wingman/voice/stop it fans out to.
-        app.MapPost("/sessions/voice-mode/all", async (VoiceModeAllRequest? req, CancellationToken ct) =>
+        app.MapPost("/sessions/voice-mode/all", async (VoiceModeAllRequest? req, HttpContext ctx, CancellationToken ct) =>
         {
+            var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
             var enabled = req?.Enabled ?? true;
             FileLog.Write($"[GatewayWingmanVoice] voice-mode/all requested: enabled={enabled}");
 
@@ -216,10 +235,10 @@ internal static class GatewayWingmanVoiceEndpoint
 
             // Every session the Gateway can see right now, de-duplicated by id. A session belongs to exactly
             // one Director, but the guard keeps a duplicated roster entry from being toggled (and counted) twice.
-            // Hosted Multi-Tenancy: voice-mode/all is a fleet fan-out WRITE (voice family); a later slice adds
-            // the request context and scopes this to the caller's tenant. For now it serves Local - correct on
-            // self-host, and on hosted the empty Local fleet means it toggles nothing (degrades, never leaks).
-            var byDirector = GatewayEndpoints.FleetByDirector(registry, pushedSessions, stale, TenantId.Local);
+            // Hosted Multi-Tenancy: voice-mode/all is a fleet fan-out WRITE (voice family), scoped to the
+            // caller's tenant resolved from its authenticated device key - so it toggles only the requester's
+            // own sessions, never another tenant's, and a request with no bound tenant is denied above.
+            var byDirector = GatewayEndpoints.FleetByDirector(registry, pushedSessions, stale, reqTenant.Value);
             var targets = new List<(string DirectorId, string Machine, string Sid, string? Name)>();
             var seen = new HashSet<string>(StringComparer.Ordinal);
             foreach (var (directorId, sessions) in byDirector)
@@ -246,7 +265,7 @@ internal static class GatewayWingmanVoiceEndpoint
                 var ok = result is { Ok: true };
                 if (ok)
                 {
-                    if (enabled) voice.Mark(TenantId.Local, t.Sid); else voice.Unmark(TenantId.Local, t.Sid);
+                    if (enabled) voice.Mark(reqTenant.Value, t.Sid); else voice.Unmark(reqTenant.Value, t.Sid);
                     changed++;
                 }
                 var reason = ok
@@ -500,15 +519,18 @@ internal static class GatewayWingmanVoiceEndpoint
             }
         });
 
-        app.MapPost("/sessions/{sid}/wingman/voice-turn", async (string sid, WingmanVoiceTurnRequest? req, CancellationToken ct) =>
+        app.MapPost("/sessions/{sid}/wingman/voice-turn", async (string sid, WingmanVoiceTurnRequest? req, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}, textLen={req?.Text?.Length ?? 0}");
+            var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
             if (!Guid.TryParse(sid, out _))
                 return Results.Json(new { error = "invalid session id format" }, statusCode: StatusCodes.Status400BadRequest);
             if (req is null || string.IsNullOrWhiteSpace(req.Text))
                 return Results.Json(new { error = "text is required" }, statusCode: StatusCodes.Status400BadRequest);
 
-            var route = await ResolveRouteAsync(sid);
+            var route = await ResolveRouteAsync(reqTenant.Value, sid);
             if (route is null)
                 return Results.Json(new { error = "session not found on any director" }, statusCode: StatusCodes.Status404NotFound);
 
@@ -541,7 +563,7 @@ internal static class GatewayWingmanVoiceEndpoint
             // Clear them DETERMINISTICALLY here (do not rely on observing the Working state, which is
             // racy for fast turns) - the list stops showing it ready and nothing stale plays. The
             // fresh summary is stored below once the agent replies.
-            voice.OnSessionWorking(TenantId.Local, sid);
+            voice.OnSessionWorking(reqTenant.Value, sid);
 
             // Snapshot the widget list BEFORE sending: gives both (a) the count for the issue #366
             // guard (only read widgets that are new after the send) and (b) the prior conversation
@@ -564,7 +586,7 @@ internal static class GatewayWingmanVoiceEndpoint
             // The agent replied; now the wingman translates it. This is gateway-owned work
             // (CancellationToken.None) so navigating away does not lose the summary, and the
             // session shows YELLOW while the wingman runs, then back to red (issue #531 voice mode).
-            voice.BeginGenerating(TenantId.Local, sid);
+            voice.BeginGenerating(reqTenant.Value, sid);
             try
             {
                 // Full context: prior exchanges from the pre-send snapshot + the current question,
@@ -572,8 +594,8 @@ internal static class GatewayWingmanVoiceEndpoint
                 var recentContext = string.IsNullOrWhiteSpace(priorContext)
                     ? "You: " + req.Text.Trim()
                     : priorContext + "\n\nYou: " + req.Text.Trim();
-                var t = await translator.TranslateAsync(recentContext, reply, SessionTitle(sid), CancellationToken.None);
-                await voice.StoreSpokenAsync(TenantId.Local, sid, t.Spoken, reply, CancellationToken.None);   // make it a voice session + cache audio
+                var t = await translator.TranslateAsync(recentContext, reply, SessionTitle(reqTenant.Value, sid), CancellationToken.None);
+                await voice.StoreSpokenAsync(reqTenant.Value, sid, t.Spoken, reply, CancellationToken.None);   // make it a voice session + cache audio
                 FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: replyLen={reply.Length}, spokenLen={t.Spoken.Length}");
                 // Training capture (no-op unless the setting is on); fire-and-forget so it adds no latency.
                 _ = voice.CaptureTrainingAsync(route, sid, "voice-turn", reply, recentContext, t.Spoken, t.ReplySeconds, CancellationToken.None);
@@ -585,7 +607,7 @@ internal static class GatewayWingmanVoiceEndpoint
                 return Results.Json(new { error = "wingman translation failed: " + ex.Message },
                     statusCode: StatusCodes.Status502BadGateway);
             }
-            finally { voice.EndGenerating(TenantId.Local, sid); }
+            finally { voice.EndGenerating(reqTenant.Value, sid); }
         });
 
         // Transcription (issue #531 follow-up): the phone records audio locally (survives a bad
@@ -645,13 +667,16 @@ internal static class GatewayWingmanVoiceEndpoint
         // LAST completed turn and speaks a faithful summary of it - WITHOUT sending anything into
         // the session. This is what the mobile Voice screen fires the moment you open a session,
         // so you get a spoken summary even though a normal (text) session never produced voice.
-        app.MapPost("/sessions/{sid}/wingman/explain", async (string sid, CancellationToken ct) =>
+        app.MapPost("/sessions/{sid}/wingman/explain", async (string sid, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[GatewayWingmanVoice] explain sid={sid}");
+            var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
             if (!Guid.TryParse(sid, out _))
                 return Results.Json(new { error = "invalid session id format" }, statusCode: StatusCodes.Status400BadRequest);
 
-            var route = await ResolveRouteAsync(sid);
+            var route = await ResolveRouteAsync(reqTenant.Value, sid);
             if (route is null)
                 return Results.Json(new { error = "session not found on any director" }, statusCode: StatusCodes.Status404NotFound);
 
@@ -661,13 +686,13 @@ internal static class GatewayWingmanVoiceEndpoint
             // Recent conversation so the wingman can give context to a short/terse reply.
             var recentContext = WingmanTranslator.BuildRecentContext(widgets);
 
-            voice.Mark(TenantId.Local, sid);   // opening voice on a session makes it a voice session (kept fresh on turn-end)
+            voice.Mark(reqTenant.Value, sid);   // opening voice on a session makes it a voice session (kept fresh on turn-end)
             if (string.IsNullOrWhiteSpace(lastReply))
             {
                 // No text reply to read aloud (waiting on a prompt / menu). Record the honest "nothing to
                 // narrate" fact so the Voice screen shows it via VoiceDisplayFold instead of a dead-end
                 // Generate button, then return the truthful canned line - no brain call.
-                voice.SetNothingToNarrate(TenantId.Local, sid, true);
+                voice.SetNothingToNarrate(reqTenant.Value, sid, true);
                 return Results.Json(new
                 {
                     reply = "",
@@ -682,12 +707,12 @@ internal static class GatewayWingmanVoiceEndpoint
             // navigates away or the request is abandoned mid-read - returning to the session then
             // loads the finished summary from cache instead of losing it. Mark the session generating
             // so it shows YELLOW ("not ready yet") for the duration, then back to red.
-            voice.SetNothingToNarrate(TenantId.Local, sid, false);   // there IS a text reply - clear any stale "nothing to narrate"
-            voice.BeginGenerating(TenantId.Local, sid);
+            voice.SetNothingToNarrate(reqTenant.Value, sid, false);   // there IS a text reply - clear any stale "nothing to narrate"
+            voice.BeginGenerating(reqTenant.Value, sid);
             try
             {
-                var t = await translator.TranslateAsync(recentContext, lastReply, SessionTitle(sid), CancellationToken.None);
-                await voice.StoreSpokenAsync(TenantId.Local, sid, t.Spoken, lastReply, CancellationToken.None);   // cache spoken + audio, ready to play
+                var t = await translator.TranslateAsync(recentContext, lastReply, SessionTitle(reqTenant.Value, sid), CancellationToken.None);
+                await voice.StoreSpokenAsync(reqTenant.Value, sid, t.Spoken, lastReply, CancellationToken.None);   // cache spoken + audio, ready to play
                 FileLog.Write($"[GatewayWingmanVoice] explain sid={sid}: replyLen={lastReply.Length}, spokenLen={t.Spoken.Length}");
                 // Training capture (no-op unless the setting is on); fire-and-forget so it adds no latency.
                 _ = voice.CaptureTrainingAsync(route, sid, "explain", lastReply, recentContext, t.Spoken, t.ReplySeconds, CancellationToken.None);
@@ -701,7 +726,7 @@ internal static class GatewayWingmanVoiceEndpoint
                 // return a benign 200, NOT the 502 the phone used to mislabel "this session's computer looks
                 // offline". Before this, a stalled model hung the request the full 180s and then 502'd, which
                 // is exactly the "I hit generate and nothing happens" the owner reported.
-                voice.NoteRetrying(TenantId.Local, sid);
+                voice.NoteRetrying(reqTenant.Value, sid);
                 FileLog.Write($"[GatewayWingmanVoice] explain sid={sid} model did not answer: {ex.Message} - Retrying (audio on its way)");
                 return Results.Json(new
                 {
@@ -717,7 +742,7 @@ internal static class GatewayWingmanVoiceEndpoint
                 return Results.Json(new { error = "wingman could not summarize: " + ex.Message },
                     statusCode: StatusCodes.Status502BadGateway);
             }
-            finally { voice.EndGenerating(TenantId.Local, sid); }
+            finally { voice.EndGenerating(reqTenant.Value, sid); }
         });
 
         app.MapPost("/wingman/ask-direct", async (WingmanVoiceTurnRequest? req, CancellationToken ct) =>
@@ -762,12 +787,15 @@ internal static class GatewayWingmanVoiceEndpoint
         // Menu handling (issue #531): is the agent showing an on-screen menu right now, and what are
         // the options? The phone reads this on entry to render pressable option buttons and speak the
         // choices. { isMenu, question, spoken, selectionMode, submit, options:[{key,send,note,recommended}] }.
-        app.MapGet("/sessions/{sid}/wingman/menu", async (string sid, CancellationToken ct) =>
+        app.MapGet("/sessions/{sid}/wingman/menu", async (string sid, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[GatewayWingmanVoice] menu sid={sid}");
+            var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
             if (!Guid.TryParse(sid, out _))
                 return Results.Json(new { error = "invalid session id format" }, statusCode: StatusCodes.Status400BadRequest);
-            var route = await ResolveRouteAsync(sid);
+            var route = await ResolveRouteAsync(reqTenant.Value, sid);
             if (route is null)
                 return Results.Json(new { error = "session not found on any director" }, statusCode: StatusCodes.Status404NotFound);
             var menu = await DetectMenuAtAsync(route, translator, sid, ct);

--- a/src/CcDirector.Gateway/Api/SessionVerbClient.cs
+++ b/src/CcDirector.Gateway/Api/SessionVerbClient.cs
@@ -51,15 +51,15 @@ internal sealed class SessionVerbClient
     /// tunnel-only caller. Returns null when no Director owns the session.
     /// </summary>
     public static async Task<SessionVerbClient?> ResolveAsync(
-        string sid, DirectorRegistry registry,
+        string sid, TenantId tenant, DirectorRegistry registry,
         PushedSessionStore? pushedSessions, TimeSpan streamStale, SessionOwnerCache? owners,
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand)
     {
-        // Hosted Multi-Tenancy: SessionVerbClient is the tunnel-only RELAY caller (voice/verb sends); a later
-        // slice threads the request tenant here. For now it serves Local - correct on self-host, and an empty
-        // Local read on hosted means no wrong-tenant session is ever resolved (degrades to null, never leaks).
+        // Hosted Multi-Tenancy: SessionVerbClient is the tunnel-only RELAY caller (voice/verb sends). The
+        // caller resolves the tenant - the request tenant on the wingman voice surface, the owning tenant in
+        // background loops - and passes it here, so a session is only ever located inside its own partition.
         var (director, session) = await GatewayEndpoints.LocateSessionAsync(
-            registry, sid, pushedSessions, streamStale, TenantId.Local, owners);
+            registry, sid, pushedSessions, streamStale, tenant, owners);
         if (director is null || session is null)
             return null;
         return new SessionVerbClient(director, sendCommand);

--- a/src/CcDirector.Gateway/Briefing/TurnEndWatcher.cs
+++ b/src/CcDirector.Gateway/Briefing/TurnEndWatcher.cs
@@ -51,7 +51,9 @@ public sealed class TurnEndWatcher : IDisposable
     private readonly PushedSessionStore? _pushedSessions;
     private readonly TimeSpan _streamStale;
     private readonly Action<TurnEndSignal> _onTurnEnd;
-    private readonly Action<string> _onSessionWorking;
+    // (sessionId, directorId): the director id is carried so the handler can resolve the session's OWNING
+    // tenant (Hosted Multi-Tenancy voice-serving) and clear the stale voice cache in the right partition.
+    private readonly Action<string, string> _onSessionWorking;
     private readonly TimeSpan _interval;
     private readonly ConcurrentDictionary<string, string> _lastActivity = new();
     private Timer? _timer;
@@ -65,7 +67,7 @@ public sealed class TurnEndWatcher : IDisposable
     /// <param name="streamStale">Freshness window for the push store read; defaults to the roster's window.</param>
     public TurnEndWatcher(
         Action<TurnEndSignal> onTurnEnd,
-        Action<string> onSessionWorking,
+        Action<string, string> onSessionWorking,
         TimeSpan? reconcileInterval = null,
         PushedSessionStore? pushedSessions = null,
         TimeSpan? streamStale = null)
@@ -110,7 +112,7 @@ public sealed class TurnEndWatcher : IDisposable
 
         if (IsWorking(activityState))
         {
-            _onSessionWorking(sessionId);
+            _onSessionWorking(sessionId, directorId);
             return;
         }
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -475,6 +475,15 @@ public sealed class GatewayHost : IAsyncDisposable
     // HostedInferenceBrain (a hosted model call), not the spawned BrainSupervisor.
     private TurnEndWatcher? _turnEndWatcher;
     private Wingman.WingmanVoiceService? _voiceService;
+
+    /// <summary>Test-only: the tenant-partitioned voice state, so an isolation test can seed a ready clip
+    /// under one tenant and prove another tenant never reads it. Null until StartAsync builds it.</summary>
+    internal Wingman.WingmanVoiceService? VoiceService => _voiceService;
+
+    /// <summary>Test-only: the turn-end watcher, so an isolation test can drive a real session-state
+    /// transition (Working -&gt; Waiting) into the REAL onTurnEnd / onSessionWorking callbacks rather than a
+    /// re-implementation. Null until StartAsync builds it.</summary>
+    internal TurnEndWatcher? TurnEndWatcherForTest => _turnEndWatcher;
     // Editable/versioned wingman instructions (issue #537); the voice translator reads the active set.
     // Constructed in the constructor body once the EF database is built (it persists to the data layer).
     private readonly Wingman.WingmanInstructionsStore _instructionsStore;
@@ -1203,10 +1212,26 @@ public sealed class GatewayHost : IAsyncDisposable
 
     private string? ResolveSessionTitle(string sessionId)
     {
-        var located = PushedSessions.TryLocate(TenantId.Local, sessionId, _streamStaleAfter);
+        // Read within the tenant of the CURRENT unit of work (AmbientTryLocate uses _tenantPass.Current):
+        // the wingman resolves a session's spoken title while a per-tenant scope is in effect (the voice
+        // sweep pass, or a request/turn-end scope), so it never reads another tenant's session name.
+        var located = AmbientTryLocate(sessionId, _streamStaleAfter);
         var name = located?.Session.Name;
         return string.IsNullOrWhiteSpace(name) ? null : name;
     }
+
+    /// <summary>
+    /// The tenant that OWNS a Director (Hosted Multi-Tenancy voice-serving): the push store is the authoritative
+    /// session-&gt;tenant map, so a Director id belongs to exactly the tenant whose partition lists it. The
+    /// background voice callbacks (turn-end, session-working, session-state clear) carry a director id but no
+    /// request scope, so they resolve the owning tenant HERE and enter it before touching the voice state -
+    /// getting it wrong would leak audio across tenants. Null when no tenant claims the director (deny: the
+    /// callback skips rather than defaulting to Local, which on hosted would be a wrong-tenant write).
+    /// </summary>
+    private TenantId? ResolveOwningTenant(string directorId) =>
+        PushedSessions.KnownTenants()
+            .FirstOrDefault(t => PushedSessions.DirectorIdsFor(t).Contains(directorId, StringComparer.OrdinalIgnoreCase))
+            is { IsValid: true } t ? t : (TenantId?)null;
 
     /// <summary>
     /// Pre-build voice for voice sessions that are idle and missing it, so the session list shows
@@ -1214,48 +1239,49 @@ public sealed class GatewayHost : IAsyncDisposable
     /// session set is persisted). Gentle: at most a few per cycle, idle sessions only (a working
     /// session regenerates on its turn-end). Best-effort; never throws into the timer.
     /// </summary>
-    private async Task SweepVoiceSessionsAsync()
+    internal Task SweepVoiceSessionsAsync()
     {
         var vs = _voiceService;
-        if (vs is null) return;
+        if (vs is null) return Task.CompletedTask;
         try
         {
-            if (Registry.ListDirectors().Count == 0) return;
-            // Gateway Cleanup mission, Phase 2: locate each voice session's owner push-store-first (no HTTP
-            // fan-out) and reach it through the tunnel-only SessionVerbClient - an unconnected Director yields
-            // an error, never an HTTP dial.
+            if (Registry.ListDirectors().Count == 0) return Task.CompletedTask;
+            // Hosted Multi-Tenancy voice-serving: run ONE pass per tenant, each inside that tenant's own scope
+            // (_tenantPass.ForEachTenant). Within a pass, locate each of THAT tenant's voice sessions in ITS
+            // OWN partition (push-store TryLocate - no HTTP dial) and generate into that tenant's voice state,
+            // with the tenant passed to GenerateAsync explicitly so the write lands in the right partition even
+            // after this synchronous pass (and its scope) returns. Self-host runs exactly one Local pass,
+            // unchanged. The generated cap is GLOBAL across tenants - the wingman brain is one serialized
+            // resource, so the whole cycle stays gentle no matter how many tenants are live.
             var stale = TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
             Api.DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = SendCommandAsync;
             var generated = 0;
-            foreach (var sid in vs.VoiceSessionIds(TenantId.Local))
+            _tenantPass.ForEachTenant(() =>
             {
-                if (generated >= 3) break;          // gentle on the serialized brain
-                if (vs.HasVoice(TenantId.Local, sid)) continue;     // already cached, nothing to do
-                // Hosted Multi-Tenancy (session-serving): the voice sweep is NOT yet per-tenant.
-                // The state it fills IS now partitioned (VOICE V1 - WingmanVoiceService holds a separate
-                // bucket and a separate directory per tenant, and every read and mutate takes the tenant),
-                // so the old blocker is gone. What remains is this loop and the /wingman/voice* routes: the
-                // routes still resolve no tenant and pass Local, and /wingman/voice/ready still lists the
-                // Local partition's ready ids. Converting THIS loop before those routes would generate into
-                // per-tenant buckets that no route can read, so it stays on Local until the route work lands:
-                // correct on self-host, and on hosted a Local read is empty (never a wrong-tenant read).
-                // The per-tenant form is a loop over WingmanVoiceService.PartitionedTenants().
-                var (director, session) = await Api.GatewayEndpoints.LocateSessionAsync(
-                    Registry, sid, PushedSessions, stale, TenantId.Local, SessionOwners);
-                if (director is null || session is null) continue;   // not owned by any known Director
-                var st = session.ActivityState ?? "";
-                if (st is "Idle" or "WaitingForInput" or "WaitingForPerm")
+                if (_tenantPass.Current is not { } tenant) return;   // deny: no scope in effect -> sweep nothing
+                foreach (var sid in vs.VoiceSessionIds(tenant))
                 {
-                    FileLog.Write($"[GatewayHost] voice sweep: pre-building voice for idle session {sid}");
-                    // A pre-build is not a new turn - generate quietly so an idle session a client
-                    // may be listening to is never flipped yellow mid-play (issue #1322).
-                    var route = new Api.SessionVerbClient(director, sendCommand);
-                    await vs.GenerateAsync(TenantId.Local, sid, route, CancellationToken.None, showReadingWindow: false);
-                    generated++;
+                    if (generated >= 3) break;                       // gentle on the serialized brain (global cap)
+                    if (vs.HasVoice(tenant, sid)) continue;          // already cached, nothing to do
+                    var located = PushedSessions.TryLocate(tenant, sid, stale);
+                    if (located is not { } loc) continue;            // not owned by any of this tenant's directors
+                    var director = Registry.Get(loc.DirectorId);
+                    if (director is null) continue;
+                    var st = loc.Session.ActivityState ?? "";
+                    if (st is "Idle" or "WaitingForInput" or "WaitingForPerm")
+                    {
+                        FileLog.Write($"[GatewayHost] voice sweep: pre-building voice for idle session {sid} (tenant {tenant.ToLogString()})");
+                        // A pre-build is not a new turn - generate quietly so an idle session a client
+                        // may be listening to is never flipped yellow mid-play (issue #1322). Fire-and-forget.
+                        var route = new Api.SessionVerbClient(director, sendCommand);
+                        _ = vs.GenerateAsync(tenant, sid, route, CancellationToken.None, showReadingWindow: false);
+                        generated++;
+                    }
                 }
-            }
+            });
         }
         catch (Exception ex) { FileLog.Write($"[GatewayHost] voice sweep error: {ex.Message}"); }
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -1353,13 +1379,23 @@ public sealed class GatewayHost : IAsyncDisposable
         _turnEndWatcher = new TurnEndWatcher(
             onTurnEnd: signal =>
             {
+                // Hosted Multi-Tenancy voice-serving: the turn-end signal carries the owning director id but no
+                // request scope, so resolve the OWNING tenant from the push store and act only within it. Null =
+                // deny (skip): a director with no claiming tenant must never fall back to Local, which on hosted
+                // would emit spend and generate audio into the wrong partition. Self-host resolves to Local.
+                if (ResolveOwningTenant(signal.DirectorId) is not { } tenant)
+                {
+                    FileLog.Write($"[GatewayHost] turn-end: no owning tenant for director {signal.DirectorId} sid={signal.SessionId} - skipped");
+                    return;
+                }
+
                 // Governance capture (issue #1771, spine item 3): record this session's cumulative spend at
                 // turn-end from the pushed roster snapshot. Runs for EVERY session (not just voice), and is
                 // isolated so a spend hiccup never breaks the voice refresh below - the failure is logged loud,
                 // not swallowed into a fabricated value.
                 try
                 {
-                    if (PushedSessions.TryLocate(TenantId.Local, signal.SessionId, _streamStaleAfter) is { } spendLoc)
+                    if (PushedSessions.TryLocate(tenant, signal.SessionId, _streamStaleAfter) is { } spendLoc)
                         _sessionSpendEmitter.Emit(spendLoc.Session);
                 }
                 catch (Exception ex)
@@ -1370,7 +1406,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 // Voice sessions (issue #531): the turn just finished on its own, so re-make the
                 // spoken summary + audio in the background. It is then "voice ready" in the session
                 // list with no wait. Non-voice sessions do nothing here - the watcher is voice-only.
-                if (_voiceService is { } vs && vs.IsVoiceSession(TenantId.Local, signal.SessionId))
+                if (_voiceService is { } vs && vs.IsVoiceSession(tenant, signal.SessionId))
                 {
                     // Gateway Cleanup mission, Phase 2: reach the owning Director (carried on the signal as
                     // its DirectorId) through the tunnel-first SessionVerbClient - no HTTP dial. The Director
@@ -1379,19 +1415,24 @@ public sealed class GatewayHost : IAsyncDisposable
                     if (director is null) return;
                     Api.DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = SendCommandAsync;
                     var route = new Api.SessionVerbClient(director, sendCommand);
-                    FileLog.Write($"[GatewayHost] turn-end -> voice auto-refresh: sid={signal.SessionId} director={signal.DirectorId} newTurn={signal.IsNewTurn}");
+                    FileLog.Write($"[GatewayHost] turn-end -> voice auto-refresh: sid={signal.SessionId} director={signal.DirectorId} newTurn={signal.IsNewTurn} tenant={tenant.ToLogString()}");
                     // Show the yellow "wingman reading" hold only for a genuinely new turn; a startup
                     // catch-up of an earlier turn refreshes quietly so a listening client is not
-                    // dropped out of the speaking screen (issue #1322).
-                    _ = vs.GenerateAsync(TenantId.Local, signal.SessionId, route, CancellationToken.None, showReadingWindow: signal.IsNewTurn);
+                    // dropped out of the speaking screen (issue #1322). Enter the owning tenant's scope so the
+                    // generation runs within it; the tenant is also passed explicitly so the write lands in the
+                    // right partition even after this fire-and-forget returns.
+                    using (_tenantBoundary.EnterScope(tenant))
+                        _ = vs.GenerateAsync(tenant, signal.SessionId, route, CancellationToken.None, showReadingWindow: signal.IsNewTurn);
                 }
             },
-            onSessionWorking: sid =>
+            onSessionWorking: (sid, directorId) =>
             {
-                // Working again: the cached voice/text summary is now stale - clear it so the list
-                // stops showing it ready and nothing stale plays (issue #531). It regenerates on the
-                // next turn-end.
-                _voiceService?.OnSessionWorking(TenantId.Local, sid);
+                // Working again: the cached voice/text summary is now stale - clear it so the list stops
+                // showing it ready and nothing stale plays (issue #531). It regenerates on the next turn-end.
+                // Hosted Multi-Tenancy voice-serving: clear it in the OWNING tenant's partition (resolved from
+                // the director id the watcher carries); null = deny (skip), never a Local fall back on hosted.
+                if (ResolveOwningTenant(directorId) is { } tenant)
+                    _voiceService?.OnSessionWorking(tenant, sid);
             },
             // Gateway Cleanup mission, Phase 2: under stream mode the catch-up / reconcile reads the push
             // store instead of HTTP-pulling each Director's session list (no dial).
@@ -1631,8 +1672,11 @@ public sealed class GatewayHost : IAsyncDisposable
                 // Any observed Working state means a new turn is in progress, so the cached voice/text
                 // summary is stale - clear it (broad net for turns started outside the voice app, e.g.
                 // the desktop cockpit). The voice-turn endpoint also clears deterministically on send.
-                if (string.Equals(newState, "Working", StringComparison.OrdinalIgnoreCase))
-                    _voiceService?.OnSessionWorking(TenantId.Local, sessionId);
+                // Hosted Multi-Tenancy voice-serving: clear it in the OWNING tenant's partition (resolved from
+                // the director id this observation carries); null = deny (skip), never a Local fall back.
+                if (string.Equals(newState, "Working", StringComparison.OrdinalIgnoreCase)
+                    && ResolveOwningTenant(directorId) is { } workingTenant)
+                    _voiceService?.OnSessionWorking(workingTenant, sessionId);
                 if (_turnEndWatcher is null) return;
                 // Gateway Cleanup mission, Phase 2: the doorbell/heartbeat already carries the owning
                 // directorId, so feed THAT to the watcher (the voice-refresh path reaches the Director
@@ -1658,23 +1702,23 @@ public sealed class GatewayHost : IAsyncDisposable
             // Voice mode (issue #531): while the gateway's wingman is producing a session's spoken
             // summary, paint it yellow ("not ready yet") and back to red. Independent of any brief
             // agent and never via the Director's --print explain.
-            voiceGeneratingFor: sid => _voiceService?.IsGenerating(TenantId.Local, sid) == true,
+            voiceGeneratingFor: (tenant, sid) => _voiceService?.IsGenerating(tenant, sid) == true,
             // Issue #553: whether the gateway has fetchable, playable cached audio for this session -
             // the single truthful "voice you can play right now" signal. Holds a voice-mode waiting
             // session yellow until this is true, then lets it go red (SessionOrdering.IsVoicePreparing).
-            voiceAudioReadyFor: sid => _voiceService?.HasVoice(TenantId.Local, sid) == true,
+            voiceAudioReadyFor: (tenant, sid) => _voiceService?.HasVoice(tenant, sid) == true,
             // Issue #939: when turn-end voice could not be kept because hosted AI is unavailable (out
             // of credits / cap / no key), stamp the shared unavailable state onto the session so the UI
             // shows the consistent add-credit / add-key message instead of a silently missing triangle.
-            voiceUnavailableFor: sid => _voiceService?.VoiceUnavailableFor(TenantId.Local, sid),
+            voiceUnavailableFor: (tenant, sid) => _voiceService?.VoiceUnavailableFor(tenant, sid),
             // The last turn has no text reply to read aloud (waiting on a prompt / menu). Feeds the folded
             // VoiceDisplay so the screen shows an honest "nothing to read aloud" instead of a Generate
             // button that cannot work - the client no longer rules on this.
-            nothingToNarrateFor: sid => _voiceService?.NothingToNarrateFor(TenantId.Local, sid) == true,
+            nothingToNarrateFor: (tenant, sid) => _voiceService?.NothingToNarrateFor(tenant, sid) == true,
             // TTS fallback: this session's ready clip was made by the backup voice provider (the primary
             // was overloaded and the cloud proxy failed over). Feeds the folded VoiceDisplay so the screen
             // shows the generic backup-voice notice. A success-with-a-note, never an outage state.
-            servedViaFallbackFor: sid => _voiceService?.ServedViaFallbackFor(TenantId.Local, sid) == true,
+            servedViaFallbackFor: (tenant, sid) => _voiceService?.ServedViaFallbackFor(tenant, sid) == true,
             // Issue #218: stamp the Gateway-owned NeedsYouSince entry clock onto each session.
             needsYouStampFor: (sid, isRed) => _needsYouClock.Stamp(sid, isRed),
             // Stamp the orange "Transcribing..." flag while a dictated utterance is being uploaded
@@ -1859,7 +1903,8 @@ public sealed class GatewayHost : IAsyncDisposable
             // host's transcription telemetry + audio archive, so it stops newing its own copies.
             uploadStore: _voiceTurnUploads,
             telemetry: _transcriptionTelemetry,
-            audioArchive: _transcriptionAudioArchive);
+            audioArchive: _transcriptionAudioArchive,
+            tenantBoundary: _tenantBoundary);
 
         // Car Mode brain (Car Mode mission, New build A): the fleet tool-calling loop behind
         // POST /carmode/turn. The chat transport resolves the fast wingman model + the vault key at CALL


### PR DESCRIPTION
Hosted mobile voice mode was dead ("this session's computer looks offline", "No narration yet") because the entire Gateway voice path was pinned to `TenantId.Local`, hitting an empty partition on a multi-tenant Gateway. The voice state was already partitioned per tenant; only the call sites never passed the caller's real tenant.

This threads the caller's tenant through the whole voice path: request routes resolve it via `ResolveReadTenant` (deny 403 when unbound, never Local); the roster's five voice-display lambdas take the request tenant; the idle sweep runs one scoped pass per tenant; the turn-end refresh and working-clear resolve each session's OWNING tenant from the push store and enter its scope. A director with no claiming tenant is skipped, never defaulted to Local (a wrong tenant would leak audio across accounts).

Proof: two new two-tenant isolation suites over real HTTP/tunnel driving the real production functions - `VoiceServingReadIsolationTests` (each voice read route: cross-tenant negative + same-tenant positive control; unbound key 403) and `VoiceServingLoopIsolationTests` (the real sweep + turn-end reach only the owning Director; state partitioned per tenant). Full Gateway test project green (existing SessionServingReadIsolationTests updated to GUID tenant ids, matching production). FleetDisplayState push enrichment and dictation /complete stay Local (documented blockers, thefrederiksen/devthrottle_internal#889).