### PR TITLE
fix(desktop): fail loud when the Gateway stops stamping, instead of a silent grey

### DIFF
--- a/src/CcDirector.Avalonia.Tests/OfflineFloorRailColorTests.cs
+++ b/src/CcDirector.Avalonia.Tests/OfflineFloorRailColorTests.cs
@@ -24,16 +24,33 @@ public sealed class OfflineFloorRailColorTests
     public void Online_RendersGatewayStampVerbatim_RegardlessOfLocalActivity(string stamp)
     {
         // Even a locally-working session shows the Gateway's stamp when online - e.g. yellow "preparing
-        // voice", which the Director could never compute for itself.
+        // voice", which the Director could never compute for itself. A present stamp renders verbatim whether
+        // or not the tunnel has settled.
         Assert.Equal(stamp, SessionViewModel.RailColor(
-            gatewayOffline: false, gatewayStamp: stamp, localActivity: ActivityState.Working));
+            gatewayOffline: false, gatewayStamp: stamp, localActivity: ActivityState.Working, gatewaySettled: true));
+        Assert.Equal(stamp, SessionViewModel.RailColor(
+            gatewayOffline: false, gatewayStamp: stamp, localActivity: ActivityState.Working, gatewaySettled: false));
     }
 
     [Fact]
-    public void Online_NoStamp_IsNeutralUnknown()
+    public void Online_NoStamp_NotYetSettled_IsNeutralUnknown()
     {
+        // The tunnel just connected and the first push has not arrived yet - the normal warm-up. Show the
+        // neutral placeholder, not an alarm.
         Assert.Equal("unknown", SessionViewModel.RailColor(
-            gatewayOffline: false, gatewayStamp: null, localActivity: ActivityState.Working));
+            gatewayOffline: false, gatewayStamp: null, localActivity: ActivityState.Working, gatewaySettled: false));
+    }
+
+    [Fact]
+    public void Online_NoStamp_Settled_IsTheMagentaUnstampedSentinel()
+    {
+        // Connected and settled past the grace, yet still no stamp: the push seam is not delivering (issue
+        // #1966). Fail LOUD with the magenta sentinel, never a grey that reads as "parked".
+        Assert.Equal(SessionViewModel.UnstampedSentinel, SessionViewModel.RailColor(
+            gatewayOffline: false, gatewayStamp: null, localActivity: ActivityState.Working, gatewaySettled: true));
+        // Independent of local activity - the desktop is not computing a colour, it is raising an alarm.
+        Assert.Equal(SessionViewModel.UnstampedSentinel, SessionViewModel.RailColor(
+            gatewayOffline: false, gatewayStamp: null, localActivity: ActivityState.WaitingForInput, gatewaySettled: true));
     }
 
     // ----- OFFLINE FLOOR: blue when working, red otherwise, ignoring the stale stamp -----
@@ -43,9 +60,10 @@ public sealed class OfflineFloorRailColorTests
     [InlineData(ActivityState.Starting)]
     public void Offline_Working_IsBlue(ActivityState state)
     {
-        // The stale stamp says yellow (frozen "preparing voice"), but the agent is working -> blue.
+        // The stale stamp says yellow (frozen "preparing voice"), but the agent is working -> blue. The offline
+        // floor ignores settledness entirely (there is no live Gateway to have settled with).
         Assert.Equal("blue", SessionViewModel.RailColor(
-            gatewayOffline: true, gatewayStamp: "yellow", localActivity: state));
+            gatewayOffline: true, gatewayStamp: "yellow", localActivity: state, gatewaySettled: false));
     }
 
     [Theory]
@@ -58,7 +76,7 @@ public sealed class OfflineFloorRailColorTests
         // Stale stamp says yellow; the agent is idle/waiting -> red. Never yellow: the Director cannot know
         // VoiceAudioReady, so it must not paint "preparing voice".
         Assert.Equal("red", SessionViewModel.RailColor(
-            gatewayOffline: true, gatewayStamp: "yellow", localActivity: state));
+            gatewayOffline: true, gatewayStamp: "yellow", localActivity: state, gatewaySettled: false));
     }
 
     [Fact]
@@ -66,8 +84,8 @@ public sealed class OfflineFloorRailColorTests
     {
         // Whatever the Gateway last stamped before it dropped, the offline floor is a pure function of local
         // activity - a working session is blue even if the frozen stamp was red/grey/orange.
-        Assert.Equal("blue", SessionViewModel.RailColor(true, "red", ActivityState.Working));
-        Assert.Equal("blue", SessionViewModel.RailColor(true, "grey", ActivityState.Working));
-        Assert.Equal("red", SessionViewModel.RailColor(true, "blue", ActivityState.WaitingForInput));
+        Assert.Equal("blue", SessionViewModel.RailColor(true, "red", ActivityState.Working, gatewaySettled: false));
+        Assert.Equal("blue", SessionViewModel.RailColor(true, "grey", ActivityState.Working, gatewaySettled: false));
+        Assert.Equal("red", SessionViewModel.RailColor(true, "blue", ActivityState.WaitingForInput, gatewaySettled: false));
     }
 }

--- a/src/CcDirector.Avalonia.Tests/StatusPaletteTests.cs
+++ b/src/CcDirector.Avalonia.Tests/StatusPaletteTests.cs
@@ -61,6 +61,19 @@ public sealed class StatusPaletteTests
     }
 
     [Fact]
+    public void BrushFor_Unstamped_IsTheMagentaSentinel_NeverGrey()
+    {
+        // "unstamped" is the desktop's OWN sentinel (SessionViewModel.UnstampedSentinel): connected and
+        // settled but the Gateway stamped nothing (issue #1966). It must render the magenta BROKEN pixel, not
+        // grey - grey would read as "parked". It is deliberately NOT a Known fold colour; it routes to the
+        // dedicated ReportMissingStamp log rather than the generic unknown-colour path.
+        Assert.Equal(Color.Parse("#FF00FF"), ((ISolidColorBrush)StatusPalette.BrushFor("unstamped")).Color);
+        Assert.NotEqual(Color.Parse(StatusPalette.Grey), ((ISolidColorBrush)StatusPalette.BrushFor("unstamped")).Color);
+        Assert.False(StatusPalette.Knows("unstamped"));
+        Assert.Equal(StatusPalette.Broken, StatusPalette.HexFor("unstamped"));
+    }
+
+    [Fact]
     public void BrushFor_ANameTheFoldNeverEmits_IsTheBrokenSentinel_NeverGrey()
     {
         // Grey MEANS snoozed-or-exited. So a colour we do not know must never render grey - that

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -513,6 +513,30 @@ public partial class MainWindow : Window
         _boxGatewayHost = SafeHost(config.Url);
     }
 
+    private global::Avalonia.Threading.DispatcherTimer? _settleRepaintTimer;
+
+    /// <summary>
+    /// One-shot repaint a beat after the Gateway settle grace. A row that is online but still holds no Gateway
+    /// stamp flips to the magenta "unstamped" sentinel only once the connection has SETTLED (see
+    /// <see cref="SessionViewModel"/>), and settling is the passage of time, which fires no per-row event.
+    /// Without this, a broken push would leave a non-working row on the neutral placeholder until some unrelated
+    /// event happened to repaint it. Re-armed on every connection change; a healthy connection stamps every row
+    /// before this fires, making the repaint a no-op. 18s covers the 15s grace with margin.
+    /// </summary>
+    private void ScheduleSettleRepaint()
+    {
+        if (_gatewayMonitor is null || _gatewayMonitor.Status != GatewayConnectionStatus.Connected) return;
+        _settleRepaintTimer?.Stop();
+        _settleRepaintTimer = new global::Avalonia.Threading.DispatcherTimer { Interval = TimeSpan.FromSeconds(18) };
+        _settleRepaintTimer.Tick += (_, _) =>
+        {
+            _settleRepaintTimer?.Stop();
+            _settleRepaintTimer = null;
+            foreach (var vm in _sessions) vm.RefreshGatewayFloor();
+        };
+        _settleRepaintTimer.Start();
+    }
+
     private void TryAttachGatewayMonitor()
     {
         if (_gatewayMonitor is not null) return;
@@ -535,6 +559,7 @@ public partial class MainWindow : Window
                 // place that owns the GatewayConnectionMonitor subscription - or a settled row keeps its old dot
                 // until an unrelated event happens to repaint it.
                 foreach (var vm in _sessions) vm.RefreshGatewayFloor();
+                ScheduleSettleRepaint();
             }
             catch (Exception ex)
             {

--- a/src/CcDirector.Avalonia/SessionViewModel.cs
+++ b/src/CcDirector.Avalonia/SessionViewModel.cs
@@ -190,15 +190,19 @@ public class SessionViewModel : INotifyPropertyChanged
     /// unrecognised stamp value still falls through to the magenta sentinel in <see cref="StatusColorBrush"/>,
     /// which is the real fail-loud. (docs/new_architecture/session-state.html.)
     /// </summary>
-    private string EffectiveColor => RailColor(IsGatewayOffline, FoldInput.EffectiveColor, Session.ActivityState);
+    private string EffectiveColor => RailColor(IsGatewayOffline, FoldInput.EffectiveColor, Session.ActivityState, IsGatewaySettled);
 
     /// <summary>
     /// The rail dot's colour name. Pure so it is tested without an Avalonia app - the getter above binds the
     /// three live inputs.
     ///
-    /// ONLINE (<paramref name="gatewayOffline"/> false): render the Gateway's stamped answer VERBATIM, or a
-    /// neutral placeholder ("unknown" -&gt; grey) when there is no stamp yet. The desktop computes NOTHING; the
-    /// Gateway owns every colour. This is the law.
+    /// ONLINE (<paramref name="gatewayOffline"/> false): render the Gateway's stamped answer VERBATIM. When
+    /// there is NO stamp, tell the connect warm-up apart from a broken push by whether the tunnel has SETTLED
+    /// (<paramref name="gatewaySettled"/>): not yet settled -&gt; the neutral placeholder ("unknown" -&gt; grey),
+    /// waiting for the first push; settled but STILL unstamped -&gt; the loud magenta <see cref="UnstampedSentinel"/>,
+    /// because the push seam is not delivering the Gateway's verdict and a grey would read as "parked". The
+    /// desktop computes NO session colour; the Gateway owns every one. The magenta is an ALARM that the seam is
+    /// broken, not a state the desktop invented - the same missing-stamp condition the cockpit fails loud on.
     ///
     /// GATEWAY-OFFLINE FLOOR (owner's ruling, 2026-07-19): the desktop HOSTS these sessions and is the one
     /// surface that can still tell the truth with no Gateway to ask. When the tunnel is down the Gateway
@@ -211,13 +215,28 @@ public class SessionViewModel : INotifyPropertyChanged
     /// the neutral placeholder when offline because, unlike the Director, they do not host the session and
     /// cannot know what it is doing. (docs/new_architecture/session-state.html.)
     /// </summary>
-    internal static string RailColor(bool gatewayOffline, string? gatewayStamp, ActivityState localActivity)
+    internal static string RailColor(bool gatewayOffline, string? gatewayStamp, ActivityState localActivity, bool gatewaySettled)
     {
         if (gatewayOffline)
             return localActivity is ActivityState.Working or ActivityState.Starting ? "blue" : "red";
 
-        return gatewayStamp ?? "unknown";
+        if (gatewayStamp is not null)
+            return gatewayStamp;
+
+        // Online, but the Gateway has stamped no display state for this session. Until the tunnel has SETTLED
+        // (the first stamps arrive within the Gateway's ~5s fold sweep) this is the normal connect warm-up, so
+        // show the neutral placeholder and wait. Once settled and STILL unstamped, the push seam is not
+        // delivering - the exact fault that let a working session sit grey while the Gateway folded it blue
+        // (issue #1966) - so raise the loud magenta sentinel, never a grey that reads as "parked".
+        return gatewaySettled ? UnstampedSentinel : "unknown";
     }
+
+    /// <summary>The colour name <see cref="RailColor"/> returns when the Director is CONNECTED and settled yet
+    /// holds no Gateway stamp for a session - a broken display-state push, not a real state. It renders the
+    /// magenta <see cref="StatusPalette.Broken"/> pixel and a specific loud log line
+    /// (<see cref="StatusPalette.ReportMissingStamp"/>). Distinct from a Gateway-emitted "unknown" COLOUR,
+    /// which is a genuine indeterminate activity state and renders grey.</summary>
+    internal const string UnstampedSentinel = "unstamped";
 
     /// <summary>
     /// The owning Director's tunnel to its Gateway is not up, so no fresh fold can arrive and the last stamp
@@ -236,6 +255,30 @@ public class SessionViewModel : INotifyPropertyChanged
             return monitor is not null && monitor.Status != GatewayConnectionStatus.Connected;
         }
     }
+
+    /// <summary>
+    /// The tunnel is Connected AND has been for longer than <see cref="GatewayStampGrace"/> - long enough that
+    /// the Gateway's fold sweep (~5s) should have stamped every session at least once. <see cref="RailColor"/>
+    /// uses it to tell a normal connect warm-up (no stamp yet -&gt; neutral placeholder) from a broken push seam
+    /// (settled but still unstamped -&gt; the loud magenta sentinel). Resolved off the same single
+    /// <see cref="GatewayConnectionMonitor"/> the sidebar reads;
+    /// <see cref="GatewayConnectionMonitor.LastVerifiedAt"/> is stamped once when the tunnel comes up and is not
+    /// churned while it stays up, so it marks the moment this connection settled.
+    /// </summary>
+    private static bool IsGatewaySettled
+    {
+        get
+        {
+            var monitor = (global::Avalonia.Application.Current as App)?.ControlApiHost?.GatewayMonitor;
+            if (monitor is null || monitor.Status != GatewayConnectionStatus.Connected) return false;
+            return monitor.LastVerifiedAt is { } since && DateTime.UtcNow - since > GatewayStampGrace;
+        }
+    }
+
+    /// <summary>How long after the tunnel connects the rail waits for the first Gateway stamp before it treats
+    /// a still-unstamped session as a broken push (magenta) rather than a warm-up (neutral). Covers the
+    /// Gateway's ~5s fold sweep with margin.</summary>
+    private static readonly TimeSpan GatewayStampGrace = TimeSpan.FromSeconds(15);
 
     /// <summary>Repaint the rail dot because the Gateway connection flipped (connected &lt;-&gt; offline).
     /// The offline floor in <see cref="EffectiveColor"/> reads the connection status, and that status change
@@ -260,7 +303,10 @@ public class SessionViewModel : INotifyPropertyChanged
             if (!StatusPalette.Knows(color) && color != _lastUnknownColorLogged)
             {
                 _lastUnknownColorLogged = color;
-                StatusPalette.ReportUnknownColor(color, Session.Id.ToString());
+                if (color == UnstampedSentinel)
+                    StatusPalette.ReportMissingStamp(Session.Id.ToString());
+                else
+                    StatusPalette.ReportUnknownColor(color, Session.Id.ToString());
             }
             return StatusPalette.BrushFor(color);
         }

--- a/src/CcDirector.Avalonia/StatusPalette.cs
+++ b/src/CcDirector.Avalonia/StatusPalette.cs
@@ -101,6 +101,10 @@ public static class StatusPalette
         "error"      => ErrorBrush,
         "grey"       => GreyBrush,
         "unknown"    => GreyBrush,
+        // The Director is connected and settled but the Gateway has stamped nothing (SessionViewModel
+        // .UnstampedSentinel): a broken display-state push, rendered the magenta sentinel on purpose - never
+        // grey, which would read as "parked". Explicit so it is intentional, not the catch-all fallback below.
+        "unstamped"  => BrokenBrush,
         _            => BrokenBrush,
     };
 
@@ -118,6 +122,7 @@ public static class StatusPalette
         "error"      => Error,
         "grey"       => Grey,
         "unknown"    => Grey,
+        "unstamped"  => Broken,
         _            => Broken,
     };
 
@@ -140,4 +145,18 @@ public static class StatusPalette
         => FileLog.Write($"[StatusPalette] UNKNOWN FOLD COLOUR '{foldColor}' for session {sessionId} - " +
                          "not in the desktop palette, rendering the BROKEN magenta sentinel. The Gateway is " +
                          "emitting a colour name this build does not know; see docs/new_architecture/session-state.html.");
+
+    /// <summary>
+    /// Report that the Director is CONNECTED and settled but the Gateway has stamped NO display state for a
+    /// session - the display-state push is not delivering, so the rail shows the magenta sentinel instead of a
+    /// grey that would read as "parked" (issue #1966). Distinct from <see cref="ReportUnknownColor"/>: there
+    /// the Gateway sent a colour NAME this build does not know; here it sent nothing at all. Edge-triggered by
+    /// the caller, once per change, so a per-frame binding getter does not flood the log.
+    /// </summary>
+    public static void ReportMissingStamp(string sessionId)
+        => FileLog.Write($"[StatusPalette] NO GATEWAY DISPLAY-STATE STAMP for session {sessionId} while the " +
+                         "tunnel is connected and settled - the set-display-state push is not delivering the " +
+                         "Gateway's verdict. Rendering the BROKEN magenta sentinel (never grey). Likely a " +
+                         "Gateway/Director version or tenancy mismatch; redeploy the Gateway and Director " +
+                         "together. See docs/new_architecture/session-state.html.");
 }


### PR DESCRIPTION
Follow-up to #1966. The Gateway-side fix (PR #1971) stopped the display-state push from breaking on the hosted Gateway. This is the **client-side alarm** so the same class of failure can never again hide.

## The problem

The desktop rail renders the Gateway's pushed display state. When it holds no stamp for a session it showed a neutral **grey** - which is indistinguishable from a *parked* (snoozed or exited) session. So while #1966 was live, a working session sat grey and looked parked: a silent lie. The cockpit already fails loud on the same missing-stamp condition; the desktop did not.

## The fix

`RailColor` now splits the no-stamp case by whether the tunnel has **settled** (connected longer than a short grace, read from `GatewayConnectionMonitor.LastVerifiedAt`):

- **Not yet settled** (the normal connect warm-up): neutral placeholder, as before - so a healthy launch never flashes an alarm.
- **Settled but still unstamped**: the push seam is not delivering, so the rail raises the magenta **BROKEN sentinel** and a specific log line naming the session (`ReportMissingStamp`), never a grey.

`MainWindow` schedules a one-shot repaint just past the grace so a non-working row flips to the sentinel without waiting for an unrelated event; a healthy connection stamps every row first, making it a no-op. The gateway-offline blue/red floor is unchanged.

## Tests

Split the online no-stamp test into warm-up (neutral) vs settled (sentinel); added a StatusPalette test that `unstamped` renders magenta, never grey. Full desktop suite green (230 passed, 0 failed).

Relates to #1966