### PR TITLE
fix(cockpit): Send-direct from the Speak recording box sends the transcribed text

### DIFF
--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -18,10 +18,13 @@
     "react-router-dom": "6.28.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "10.4.1",
+    "@testing-library/react": "16.3.2",
     "@types/node": "22.20.0",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "4.3.4",
+    "jsdom": "25.0.1",
     "typescript": "5.7.2",
     "vite": "6.0.3",
     "vitest": "2.1.8"

--- a/apps/cockpit/src/sessions/SessionComposer.tsx
+++ b/apps/cockpit/src/sessions/SessionComposer.tsx
@@ -7,7 +7,6 @@ import {
   gatewayErrorMessage,
   type QueueItem,
 } from "@devthrottle/client-core/api/client";
-import { backgroundTranscribeAndSend, type CapturedUtterance } from "@devthrottle/client-core/dictation/backgroundSend";
 import { DictationDialog } from "@devthrottle/client-core/dictation/DictationDialog";
 import { insertAt } from "@devthrottle/client-core/dictation/transcript";
 
@@ -17,7 +16,20 @@ import { insertAt } from "@devthrottle/client-core/dictation/transcript";
 //   Send  -> POST /sessions/{sid}/prompt { appendEnter: true }  (submit the typed line; Ctrl+Enter)
 //   Speak -> mounts the shared DictationDialog (packages/client-core), exactly as the mobile
 //            SessionControls does; the transcript inserts at the caret (Insert) or inserts + submits
-//            (Send). One transcription path through the Gateway, unchanged.
+//            (Send). Both Insert and Send go through the SAME synchronous transcribe-then-act path
+//            (transcribeUtterance -> the Gateway's /wingman/utterance/* transcription, which is
+//            tenant-aware on hosted), so Send-direct sends exactly the text Insert would place.
+//
+// The Cockpit deliberately does NOT wire the DictationDialog's fire-and-forget onSendAudio path (the
+// durable background pipeline the phone uses so mobile Speak does not hold the screen). That pipeline
+// injects the turn server-side through the /dictation/* routes, which are NOT tenant-aware on the
+// hosted Gateway (they still resolve the session in the Local partition - documented blocker #1884),
+// so a hosted-Cockpit Send-direct through it resolves an empty partition, holds, and retries forever
+// with no visible status - "Send basically sends nothing". The Cockpit also never mounts the mobile's
+// DictationStatusStrip / resumePendingDictations, so a held send has no feedback here at all. Omitting
+// onSendAudio makes the dialog fall back to the blocking commit-then-onSend path (the same fallback the
+// mobile Voice-mode reply panel uses), which reuses the proven Insert transcription path. See
+// mission/cockpit-speak-send.md.
 //   Queue -> POST /sessions/{sid}/queue { text }                (append to the queue; Ctrl+Shift+Enter)
 //   Attach -> POST /sessions/{sid}/upload-image                 (upload a device-local image, then
 //             insert the Director-side saved path into the composer for the agent to read)
@@ -195,8 +207,7 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
 
   // Speak: mount the shared dictation dialog, exactly like the mobile SessionControls. Insert drops the
   // transcript at the caret (no submit); Send inserts at the caret and submits via the same POST /prompt
-  // path; SendAudio hands the raw clip to the durable background pipeline (one transcription path
-  // through the Gateway).
+  // path. Both transcribe synchronously through the tenant-aware /wingman/utterance/* path.
   const onSpeak = useCallback(() => {
     caretRef.current = textareaRef.current?.selectionStart ?? value.length;
     setError(null);
@@ -231,32 +242,6 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
       } finally {
         setBusy(false);
       }
-    },
-    [sessionId, value, onChange],
-  );
-
-  // Immediate (fire-and-forget) Send from the Speak dialog: the dialog captured the audio buffer and
-  // closed itself. The durable pipeline transcodes + uploads + transcribes + submits in the background
-  // (the roster shows the session orange, "Transcribing..."), so the browser is free immediately.
-  const onDictateSendAudio = useCallback(
-    (captured: CapturedUtterance) => {
-      setDictating(false);
-      if (!sessionId) return;
-      const composerText = value;
-      const caret = caretRef.current;
-      onChange("");
-      setStatus("Transcribing...");
-      void backgroundTranscribeAndSend(sessionId, captured, {
-        onError: (message) => setError(message),
-        // Insert the dictated words at the snapshotted caret inside the typed text: the Gateway submits
-        // before + dictation + after.
-        composeParts: { before: composerText.slice(0, caret), after: composerText.slice(caret) },
-        // If the send does not complete, the audio is kept durably for resume, but the typed text is
-        // client-only: put it back so Send never silently loses it.
-        onFailed: () => {
-          if (composerText.trim().length > 0) onChange(composerText);
-        },
-      });
     },
     [sessionId, value, onChange],
   );
@@ -322,7 +307,6 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
         <DictationDialog
           onInsert={onDictateInsert}
           onSend={onDictateSend}
-          onSendAudio={onDictateSendAudio}
           onClose={() => setDictating(false)}
         />
       )}

--- a/apps/cockpit/src/sessions/composerSpeakSend.test.tsx
+++ b/apps/cockpit/src/sessions/composerSpeakSend.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { useState } from "react";
+
+// Behavioral regression for the Cockpit Speak Send-direct fix (PR #1975).
+//
+// The bug: pressing Send WHILE RECORDING in the Cockpit Speak box "basically sent nothing" on the
+// hosted Gateway, because the recording-stage Send was wired to the phone's fire-and-forget durable
+// pipeline (backgroundTranscribeAndSend -> the /dictation/* routes), which the hosted Gateway still
+// resolves in the Local tenant partition (blocker #1884). Insert worked because it transcribes
+// synchronously through the tenant-aware /wingman/utterance/* path and submits via POST /prompt.
+//
+// The fix (SessionComposer.tsx): stop passing the DictationDialog's onSendAudio prop, so a
+// recording-stage Send falls back to the blocking commit-then-onSend path - the SAME synchronous
+// transcribe-then-send Insert already uses. The RMS-meter unit tests do not exercise this; only a
+// render of the real composer + real dialog, pressing Send while recording, proves the repaired path.
+//
+// This test presses Send while RECORDING and asserts the transcript (composed with the typed text at
+// the snapshotted caret) is submitted via sendPrompt for the SELECTED session id, through the
+// synchronous transcription path, and that the durable /dictation/* pipeline is NEVER touched.
+//
+// Revert-proof: re-add `onSendAudio={onDictateSendAudio}` to the DictationDialog mount (undo the fix)
+// and a recording-stage Send calls backgroundTranscribeAndSend instead of sendPrompt - every
+// assertion below flips, so the test reddens.
+
+// vi.mock is hoisted above module scope, so the spies it references must be created in the same
+// hoisted phase (vi.hoisted) rather than as ordinary consts.
+const { sendPrompt, transcribeUtterance, backgroundTranscribeAndSend } = vi.hoisted(() => ({
+  // The synchronous POST /prompt the fix routes Send-direct through.
+  sendPrompt: vi.fn(async () => {}),
+  // The tenant-aware /wingman/utterance/* transcription.
+  transcribeUtterance: vi.fn(async () => "the dictated words"),
+  // The durable background pipeline (POST /dictation/*) the fix routes Send-direct AWAY from.
+  backgroundTranscribeAndSend: vi.fn(async () => {}),
+}));
+
+// The Gateway client boundary.
+vi.mock("@devthrottle/client-core/api/client", () => ({
+  sendPrompt,
+  transcribeUtterance,
+  enqueuePrompt: vi.fn(async () => []),
+  uploadImage: vi.fn(async () => ""),
+  gatewayErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+
+// The durable background pipeline. This test asserts it is never invoked; reverting the fix makes the
+// recording-stage Send call it.
+vi.mock("@devthrottle/client-core/dictation/backgroundSend", () => ({
+  backgroundTranscribeAndSend,
+}));
+
+// Mic + audio-decode boundaries jsdom cannot provide. The fake recorder fires onCaptureLive on start
+// so the dialog flips to RECORDING (the state under test) without a real microphone, and returns a
+// fixed clip on stop. A 1000 ms clip that decodes to 1.0 s means zero capture deficit, so the dialog
+// commits instead of parking on a dropped-audio warning.
+vi.mock("@devthrottle/client-core/dictation/recorder", () => {
+  class MicRecorder {
+    onCaptureLive: (() => void) | null = null;
+    lastRecordedMs = 1000;
+    async start() {
+      this.onCaptureLive?.();
+    }
+    async stop() {
+      return new Blob(["clip"], { type: "audio/webm" });
+    }
+    level() {
+      return 0;
+    }
+    dispose() {}
+  }
+  return { MicRecorder, rmsLevel: () => 0 };
+});
+vi.mock("@devthrottle/client-core/dictation/wav", () => ({
+  blobToWav16kMono: async () => ({ wav: new Blob(["wav"]), decodedSeconds: 1, sourceBytes: 1000 }),
+}));
+vi.mock("@devthrottle/client-core/dictation/readyCue", () => ({
+  playReadyCue: () => {},
+  primeCueAudio: () => {},
+  releaseCueAudio: () => {},
+  startThinkingCue: () => () => {},
+  playYourTurnCue: () => {},
+}));
+
+import { SessionComposer } from "./SessionComposer";
+
+// A parent that owns the composer text exactly like SessionDetail does, so onChange updates the value
+// the composer reads back when it composes the dictation at the caret.
+function Harness({ sessionId }: { sessionId?: string }) {
+  const [value, setValue] = useState("");
+  return (
+    <SessionComposer sessionId={sessionId} value={value} onChange={setValue} onQueued={() => {}} />
+  );
+}
+
+describe("Cockpit Speak Send-direct (recording-stage)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // jsdom has no requestAnimationFrame; the dialog's display-only equalizer loop uses it. A no-op
+    // that never calls back keeps the animation out of the test without affecting behaviour.
+    globalThis.requestAnimationFrame = (() => 0) as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = (() => {}) as typeof globalThis.cancelAnimationFrame;
+  });
+
+  it("submits the transcript composed at the caret via sendPrompt for the selected session, not the durable /dictation path", async () => {
+    render(<Harness sessionId="sess-42" />);
+
+    // Type "AB" and drop the caret BETWEEN A and B, so a correct compose lands the dictation at the
+    // caret ("A ... B"), not appended at the end.
+    const textarea = screen.getByPlaceholderText(/Type a message/i) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "AB" } });
+    textarea.selectionStart = 1;
+    textarea.selectionEnd = 1;
+
+    // Open the Speak dialog (snapshots the caret) and wait for it to reach RECORDING.
+    fireEvent.click(screen.getByRole("button", { name: "Speak" }));
+    const dialog = await screen.findByRole("dialog", { name: "Dictate" });
+    await within(dialog).findByText("RECORDING");
+
+    // Press Send WHILE RECORDING - the exact action that "sent nothing" before the fix.
+    fireEvent.click(within(dialog).getByText("Send"));
+
+    // The dictated words are transcribed synchronously and submitted, composed at the snapshotted
+    // caret, to the SELECTED session, via POST /prompt (appendEnter true).
+    await waitFor(() =>
+      expect(sendPrompt).toHaveBeenCalledWith("sess-42", "A the dictated words B", true),
+    );
+    expect(transcribeUtterance).toHaveBeenCalledTimes(1);
+
+    // The durable, Local-pinned /dictation/* pipeline that caused the bug is never touched.
+    expect(backgroundTranscribeAndSend).not.toHaveBeenCalled();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,10 +26,13 @@
         "react-router-dom": "6.28.0"
       },
       "devDependencies": {
+        "@testing-library/dom": "10.4.1",
+        "@testing-library/react": "16.3.2",
         "@types/node": "22.20.0",
         "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1",
         "@vitejs/plugin-react": "4.3.4",
+        "jsdom": "25.0.1",
         "typescript": "5.7.2",
         "vite": "6.0.3",
         "vitest": "2.1.8"
@@ -53,6 +56,27 @@
         "vite": "6.0.3",
         "vite-plugin-pwa": "0.21.1"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -1678,6 +1702,121 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@devthrottle/client-core": {
       "resolved": "packages/client-core",
       "link": true
@@ -3022,6 +3161,54 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
       "version": "3.0.0-pre1",
       "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
@@ -3037,6 +3224,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3571,6 +3765,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3593,6 +3797,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -3659,6 +3873,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -3992,6 +4213,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -4062,12 +4296,84 @@
         "node": ">=8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4141,6 +4447,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -4204,6 +4517,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4241,6 +4581,19 @@
       "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -4863,6 +5216,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -5250,6 +5620,33 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -5262,6 +5659,19 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/idb": {
@@ -5616,6 +6026,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5871,6 +6288,84 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6041,6 +6536,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6095,6 +6600,29 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -6162,6 +6690,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -6347,6 +6882,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6510,6 +7058,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6565,6 +7141,13 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -6808,6 +7391,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6885,6 +7475,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7322,6 +7932,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -7475,6 +8092,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7486,6 +8123,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -9017,12 +9667,49 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",
@@ -9428,6 +10115,45 @@
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "7.4.1"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/packages/client-core/src/dictation/recorder.test.ts
+++ b/packages/client-core/src/dictation/recorder.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { MicRecorder } from "./recorder";
+import { MicRecorder, rmsLevel } from "./recorder";
 
 // snapshotFlushed() is the tail-loss fix for the turn-taking paths (Car Mode "Over and out" and the
 // end-phrase watch): a bare snapshot() only sees chunks MediaRecorder has already delivered, so the
@@ -125,5 +125,56 @@ describe("MicRecorder.snapshotFlushed", () => {
     expect(flushed.size).toBe(2);
     // The backstop timer was cleared on delivery; advancing time must not blow up on a settled promise.
     await vi.advanceTimersByTimeAsync(1000);
+  });
+});
+
+// The equalizer meter (issue: the Cockpit Speak bars were sluggish/near-flat). rmsLevel reads the live
+// WAVEFORM (getByteTimeDomainData: bytes centred on 128, silence = 128) as instantaneous loudness, so the
+// bars track the speaker in real time. These pin the shape the equalizer relies on.
+describe("rmsLevel", () => {
+  // A window of pure silence is every sample sitting at the 128 centre.
+  function silence(n: number): Uint8Array {
+    return new Uint8Array(n).fill(128);
+  }
+  // A full-scale square wave: samples alternate between the two rails (0 and 255), the loudest possible
+  // read.
+  function fullScale(n: number): Uint8Array {
+    const buf = new Uint8Array(n);
+    for (let i = 0; i < n; i++) buf[i] = i % 2 === 0 ? 0 : 255;
+    return buf;
+  }
+
+  it("reads silence (all samples at the centre) as zero", () => {
+    expect(rmsLevel(silence(512))).toBe(0);
+  });
+
+  it("reads a full-scale waveform as the clamped maximum of 1", () => {
+    expect(rmsLevel(fullScale(512))).toBe(1);
+  });
+
+  it("reads an empty window as zero rather than dividing by zero", () => {
+    expect(rmsLevel(new Uint8Array(0))).toBe(0);
+  });
+
+  it("rises monotonically as the waveform gets louder", () => {
+    const quiet = new Uint8Array(512);
+    const loud = new Uint8Array(512);
+    for (let i = 0; i < 512; i++) {
+      // Small deviation from centre vs a larger one - louder audio swings further from 128.
+      quiet[i] = i % 2 === 0 ? 118 : 138; // +-10
+      loud[i] = i % 2 === 0 ? 88 : 168; // +-40
+    }
+    const q = rmsLevel(quiet);
+    const l = rmsLevel(loud);
+    expect(q).toBeGreaterThan(0);
+    expect(l).toBeGreaterThan(q);
+  });
+
+  it("stays within 0..1 for any input", () => {
+    const random = new Uint8Array(512);
+    for (let i = 0; i < 512; i++) random[i] = (i * 37) % 256;
+    const v = rmsLevel(random);
+    expect(v).toBeGreaterThanOrEqual(0);
+    expect(v).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/client-core/src/dictation/recorder.ts
+++ b/packages/client-core/src/dictation/recorder.ts
@@ -30,6 +30,28 @@ const CHUNK_MS = 100;
 // logged so a real occurrence is visible.
 const FLUSH_BACKSTOP_MS = 500;
 
+// The equalizer time window. getByteTimeDomainData fills this many samples of the live waveform; at a
+// typical 48 kHz that is ~11 ms, a long enough window for a steady loudness reading yet short enough to
+// track speech syllables so the bars actually bob rather than crawl.
+const LEVEL_FFT_SIZE = 512;
+
+// Turn a window of live waveform samples (getByteTimeDomainData: bytes centred on 128, silence = 128)
+// into a 0..1 loudness for the equalizer. Root-mean-square of the samples' deviation from the centre is
+// the instantaneous loudness - it responds immediately to how loud the speaker is right now, unlike the
+// old frequency-bin average (which diluted voice energy across mostly-empty high bins) and needs no
+// analyser smoothing (which only lagged the meter). A modest gain lets normal speech fill the bars while
+// the clamp keeps a shout at full scale. Pure and display-only: it never touches the captured audio.
+export function rmsLevel(timeDomain: Uint8Array): number {
+  if (timeDomain.length === 0) return 0;
+  let sumSquares = 0;
+  for (let i = 0; i < timeDomain.length; i++) {
+    const deviation = (timeDomain[i] - 128) / 128; // -1..1, silence -> 0
+    sumSquares += deviation * deviation;
+  }
+  const rms = Math.sqrt(sumSquares / timeDomain.length); // 0..1
+  return Math.min(1, rms * 3.2);
+}
+
 export class MicRecorder {
   private stream: MediaStream | null = null;
   private recorder: MediaRecorder | null = null;
@@ -79,10 +101,13 @@ export class MicRecorder {
     this.audioCtx = new AudioCtor();
     const source = this.audioCtx.createMediaStreamSource(this.stream);
     this.analyser = this.audioCtx.createAnalyser();
-    this.analyser.fftSize = 64;
-    this.analyser.smoothingTimeConstant = 0.5;
+    // Sized for a live-waveform (time-domain) read: the buffer holds fftSize samples of the raw
+    // waveform, which rmsLevel() turns into an instantaneous loudness. No smoothingTimeConstant is set
+    // because that only shapes frequency-domain reads (which we no longer use) and only ever lagged the
+    // meter.
+    this.analyser.fftSize = LEVEL_FFT_SIZE;
     source.connect(this.analyser);
-    this.levelData = new Uint8Array(this.analyser.frequencyBinCount);
+    this.levelData = new Uint8Array(this.analyser.fftSize);
 
     this.mimeType = pickMimeType();
     this.recorder = this.mimeType
@@ -169,14 +194,11 @@ export class MicRecorder {
     return this.snapshot();
   }
 
-  /** Current input level in 0..1, sampled live. Returns 0 when not recording. */
+  /** Current input level in 0..1, sampled live from the waveform. Returns 0 when not recording. */
   level(): number {
     if (!this.analyser || !this.levelData) return 0;
-    this.analyser.getByteFrequencyData(this.levelData);
-    let sum = 0;
-    for (let i = 0; i < this.levelData.length; i++) sum += this.levelData[i];
-    const avg = sum / this.levelData.length; // 0..255
-    return Math.min(1, avg / 180);
+    this.analyser.getByteTimeDomainData(this.levelData);
+    return rmsLevel(this.levelData);
   }
 
   /**


### PR DESCRIPTION
## Symptom (hosted Cockpit)
The Speak recording box's **Send** button "basically sends nothing". **Insert** works (drops the transcript into the composer), and Insert-then-Send works. Transcription itself is fine; only Send-direct from the recording box is broken. Secondary: the audio-level bars are sluggish/near-flat.

## Root cause (primary): client wired to the wrong, non-tenant-aware server path
Insert and Send-direct took **different** server paths:

- **Insert** -> `transcribeUtterance` -> `/wingman/utterance/*`, which was made **tenant-aware on hosted in thefrederiksen/devthrottle#1973**. Works.
- **Send-direct** -> the phone's fire-and-forget durable pipeline `backgroundTranscribeAndSend` -> `/dictation/*`. The hosted Gateway still resolves that path's session in the **Local** tenant partition (`GatewayDictationEndpoint.RunCompleteCoreAsync` passes `TenantId.Local` to `LocateSessionAsync`) - a **documented blocker, thefrederiksen/devthrottle_internal#889**. On hosted the session lives in the caller's tenant, so the lookup returns 404, the send is **held and retried forever**, and the Cockpit never mounts the mobile's `DictationStatusStrip` / `resumePendingDictations`, so the held send is **completely invisible** - "sends nothing".

The full server fix (#1884) requires partitioning the currently-global dictation upload store by tenant first; a `/complete`-only tenant fix was tried and **removed in review** because it arms a cross-tenant identifier space. That is out of scope here and deliberately not reopened.

## Fix
Route the Cockpit's Speak **Send** through the **same synchronous transcribe-then-send path Insert already uses**: stop passing `DictationDialog`'s `onSendAudio`, so it falls back to the blocking `commit -> onSend` path (the same mode the mobile Voice-mode reply panel uses). Send-direct now submits exactly the text Insert would place, at the caret, to the correct session, through the tenant-aware `/wingman/utterance/*` transcription path. No durable-pipeline state and no cross-tenant identifier space is touched.

## Secondary fix: laggy equalizer bars
The level meter averaged **frequency-domain** FFT bins (voice energy sits in a few low bins, so the average barely moved) with `smoothingTimeConstant = 0.5` (a low-pass that added visible lag). Switched to instantaneous **time-domain RMS** via a new pure, unit-tested `rmsLevel` helper, so the bars track the speaker in real time. This helper is shared, so mobile Speak gets the snappier meter too.

## Verification
- `packages/client-core`: 568 tests pass (5 new `rmsLevel` cases), `tsc --noEmit` clean.
- `apps/cockpit`: 150 tests pass; `tsc --noEmit && vite build` clean.
- The transcription path Send-direct now uses is byte-for-byte the one owner-confirmed working via Insert-then-Send.

## Not merging
Architect gates + merges.