### PR TITLE
fix(gateway): tenant-scope the wingman voice sweep director lookup (unbreak main)

### DIFF
--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1286,7 +1286,7 @@ public sealed class GatewayHost : IAsyncDisposable
                     if (vs.HasVoice(tenant, sid)) continue;          // already cached, nothing to do
                     var located = PushedSessions.TryLocate(tenant, sid, stale);
                     if (located is not { } loc) continue;            // not owned by any of this tenant's directors
-                    var director = Registry.Get(loc.DirectorId);
+                    var director = Registry.Get(tenant, loc.DirectorId);
                     if (director is null) continue;
                     var st = loc.Session.ActivityState ?? "";
                     if (st is "Idle" or "WaitingForInput" or "WaitingForPerm")


### PR DESCRIPTION
main did not compile: the wingman voice sweep at GatewayHost.cs:1289 called the deleted bare-id Registry.Get(directorId) (semantic conflict between the per-director tenant-scoping and the parallel wingman-voice merge). The director is already tenant-owned via PushedSessions.TryLocate(tenant,...), so use Get(tenant, id). Verified: builds 0/0, no other single-arg Get calls remain. Emergency build-unbreak.