### PR TITLE
fix(gateway): tenant-key the input-stats aggregator (census 49-67)

### DIFF
--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Stats;
 using Xunit;
@@ -448,20 +449,20 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
     {
         var first = new DateTime(2026, 7, 15, 9, 0, 0, DateTimeKind.Utc);
         var agg = new GatewayInputStatsAggregator(_path);
-        Assert.Equal("", agg.AgentsSinceUtc); // nothing observed yet - no claim about a window
+        Assert.Equal("", agg.AgentsSinceUtc()); // nothing observed yet - no claim about a window
 
         agg.Observe(SessionOnAgent("s1", "ClaudeCode", ("typed", "desktop", 1, 10)), first);
-        var stamped = agg.AgentsSinceUtc;
+        var stamped = agg.AgentsSinceUtc();
         Assert.NotEqual("", stamped);
         Assert.StartsWith("2026-07-15T09:00:00", stamped);
 
         // A later observation must NOT move the since-date, or the page would understate its own window.
         agg.Observe(SessionOnAgent("s1", "ClaudeCode", ("typed", "desktop", 9, 90)), first.AddHours(5));
-        Assert.Equal(stamped, agg.AgentsSinceUtc);
+        Assert.Equal(stamped, agg.AgentsSinceUtc());
 
         // It survives a Gateway restart, so the window does not reset every time the Gateway starts.
         var reloaded = new GatewayInputStatsAggregator(_path);
-        Assert.Equal(stamped, reloaded.AgentsSinceUtc);
+        Assert.Equal(stamped, reloaded.AgentsSinceUtc());
     }
 
     [Fact]
@@ -653,6 +654,9 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
 
     private static ModelStatBucketDto? Model(GatewayInputStatsAggregator agg, string? model) =>
         agg.ModelTotals().FirstOrDefault(m => m.Model == model);
+
+    private static ModelStatBucketDto? Model(GatewayInputStatsAggregator agg, string? model, TenantId tenant) =>
+        agg.ModelTotals(tenant).FirstOrDefault(m => m.Model == model);
 
     [Fact]
     public void Model_ReportedByTheDirector_IsAttributedToThatModel()
@@ -984,4 +988,179 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         // The all-time total did not shrink because detail was pruned.
         Assert.Equal(beforeInput + 10, agg.TokenSpend().InputTokens);
     }
+
+    // ---- MTR-08: cross-tenant isolation (production-readiness census rows 49-67) ----
+    //
+    // Two tenants that push the SAME bare session id, and drive the SAME repository / agent / model, must
+    // keep entirely separate tallies, membership and identity. Before the fix the aggregator was
+    // process-global: their turns coalesced into one total and one could suppress the other's high-water,
+    // wingman-seen and seed accounting. Each test below is written so it FAILS on the pre-fix code (a shared
+    // total, a suppressed count) and passes only when the store is partitioned by tenant. TenantA and TenantB
+    // stand in for two hosted accounts; they are ordinary GUID-shaped tenant ids, not the reserved Local one.
+
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void TwoTenants_SameSessionId_Totals_DoNotCoalesceOrSuppress()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        // Same bare session id "s1", same bucket, different tenants and different counts.
+        agg.Observe(Session("s1", ("typed", "desktop", 5, 100)), tenant: TenantA);
+        agg.Observe(Session("s1", ("typed", "desktop", 3, 60)), tenant: TenantB);
+
+        // Neither tenant's total is the other's, and neither is the sum: the two are partitioned.
+        Assert.Equal(5, Turns(agg.CurrentTotals(TenantA), "typed", "desktop"));
+        Assert.Equal(3, Turns(agg.CurrentTotals(TenantB), "typed", "desktop"));
+
+        // A re-push of A's session must not be inflated by B having written the same bare id in between. On
+        // the pre-fix global high-water, B's lower count reset the shared watermark, so A's re-push folded a
+        // spurious positive delta and A's total climbed past 5.
+        agg.Observe(Session("s1", ("typed", "desktop", 5, 100)), tenant: TenantA);
+        Assert.Equal(5, Turns(agg.CurrentTotals(TenantA), "typed", "desktop"));
+        Assert.Equal(3, Turns(agg.CurrentTotals(TenantB), "typed", "desktop"));
+    }
+
+    [Fact]
+    public void TwoTenants_SameSessionId_SameRepo_DoNotCoalesce()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(SessionWithRepoName("s1", "owner/app", @"D:\a\app", ("voice", "phone", 6, 600)), tenant: TenantA);
+        agg.Observe(SessionWithRepoName("s1", "owner/app", @"D:\b\app", ("typed", "desktop", 2, 40)), tenant: TenantB);
+
+        var repoA = agg.RepoTotals(TenantA).Single(r => r.RepoName == "app");
+        var repoB = agg.RepoTotals(TenantB).Single(r => r.RepoName == "app");
+
+        // Same "owner/app" repo name, but a DIFFERENT surrogate identity per tenant, so their turns do not sum.
+        Assert.Equal(6, repoA.Turns);
+        Assert.Equal(1, repoA.Sessions);
+        Assert.Equal(2, repoB.Turns);
+        Assert.Equal(1, repoB.Sessions);
+    }
+
+    [Fact]
+    public void TwoTenants_SameSessionId_SameAgent_DoNotCoalesce()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(SessionOnAgent("s1", "ClaudeCode", ("voice", "phone", 6, 600)), tenant: TenantA);
+        agg.Observe(SessionOnAgent("s1", "ClaudeCode", ("typed", "desktop", 2, 40)), tenant: TenantB);
+
+        var agentA = agg.AgentTotals(TenantA).Single(a => a.AgentName == "Claude Code");
+        var agentB = agg.AgentTotals(TenantB).Single(a => a.AgentName == "Claude Code");
+        Assert.Equal(6, agentA.Turns);
+        Assert.Equal(2, agentB.Turns);
+
+        // The Agents page for A must NOT list B's agents (a cross-tenant leak of who-runs-what), and vice
+        // versa. Here both ran only Claude Code, so each tenant's list is exactly one agent.
+        Assert.Single(agg.AgentTotals(TenantA));
+        Assert.Single(agg.AgentTotals(TenantB));
+    }
+
+    [Fact]
+    public void TwoTenants_DistinctAgents_AreNotVisibleToEachOther()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(SessionOnAgent("s1", "ClaudeCode", ("typed", "desktop", 4, 40)), tenant: TenantA);
+        agg.Observe(SessionOnAgent("s2", "Codex", ("typed", "desktop", 3, 30)), tenant: TenantB);
+
+        // A sees only Claude Code; B sees only Codex. On the pre-fix global id->display iteration, each page
+        // listed BOTH agents (the other tenant's as a zero-turn row).
+        Assert.Equal(new[] { "Claude Code" }, agg.AgentTotals(TenantA).Select(a => a.AgentName).ToArray());
+        Assert.Equal(new[] { "Codex" }, agg.AgentTotals(TenantB).Select(a => a.AgentName).ToArray());
+    }
+
+    [Fact]
+    public void TwoTenants_SameSessionId_SameModel_DoNotCoalesce()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(SessionOnModel("s1", "claude-opus-4-8", ("typed", "desktop", 5, 50)), tenant: TenantA);
+        agg.Observe(SessionOnModel("s1", "claude-opus-4-8", ("typed", "desktop", 8, 80)), tenant: TenantB);
+
+        Assert.Equal(5, Model(agg, "claude-opus-4-8", TenantA)!.Turns);
+        Assert.Equal(8, Model(agg, "claude-opus-4-8", TenantB)!.Turns);
+    }
+
+    [Fact]
+    public void TwoTenants_Wingman_SeenMarkersAreNotSuppressed()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        // Both tenants use voice mode on the SAME bare session id "s1". Each is a distinct wingman session for
+        // its own tenant; neither's presence may suppress or coalesce the other's count.
+        agg.Observe(VoiceSession("s1", ("voice", "phone", 3, 120)), tenant: TenantA);
+        agg.Observe(VoiceSession("s1", ("voice", "phone", 4, 160)), tenant: TenantB);
+
+        var wingA = agg.WingmanUsage(TenantA);
+        var wingB = agg.WingmanUsage(TenantB);
+        Assert.Equal(1, wingA.Sessions);
+        Assert.Equal(3, wingA.Turns);
+        Assert.Equal(1, wingB.Sessions);
+        Assert.Equal(4, wingB.Turns);
+    }
+
+    [Fact]
+    public void TwoTenants_SeedMarkerAndHighWater_SurviveRestart_PerTenant()
+    {
+        // The seed marker and high-water both persist and both are keyed by tenant. Across a restart, one
+        // tenant's re-push of a shared session id must not be re-back-filled (double counted) and must not
+        // disturb the other tenant's tally.
+        using (var first = new GatewayInputStatsAggregator(_path))
+        {
+            first.Observe(SessionOnAgent("s1", "ClaudeCode", ("typed", "desktop", 4, 80)), tenant: TenantA);
+            first.Observe(SessionOnAgent("s1", "Codex", ("typed", "desktop", 6, 120)), tenant: TenantB);
+        }
+
+        using var reopened = new GatewayInputStatsAggregator(_path);
+        // Re-push the SAME counts after the restart. agents_seeded and session_highwater were reloaded per
+        // tenant, so neither re-back-fills and neither double-counts.
+        reopened.Observe(SessionOnAgent("s1", "ClaudeCode", ("typed", "desktop", 4, 80)), tenant: TenantA);
+        reopened.Observe(SessionOnAgent("s1", "Codex", ("typed", "desktop", 6, 120)), tenant: TenantB);
+
+        Assert.Equal(4, agg_AgentTurns(reopened, TenantA, "Claude Code"));
+        Assert.Equal(6, agg_AgentTurns(reopened, TenantB, "Codex"));
+        // And the tenants still cannot see each other's agent.
+        Assert.Single(reopened.AgentTotals(TenantA));
+        Assert.Single(reopened.AgentTotals(TenantB));
+    }
+
+    [Fact]
+    public void TwoTenants_Forget_OnlyDropsThatTenantsHighWater()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(Session("s1", ("typed", "desktop", 5, 100)), tenant: TenantA);
+        agg.Observe(Session("s1", ("typed", "desktop", 3, 60)), tenant: TenantB);
+
+        // Forgetting A's s1 drops only A's high-water. B's s1 high-water is untouched, so a B re-push of the
+        // same counts still folds nothing (no spurious delta from a wrongly-cleared watermark).
+        agg.Forget("s1", TenantA);
+        agg.Observe(Session("s1", ("typed", "desktop", 3, 60)), tenant: TenantB);
+
+        Assert.Equal(3, Turns(agg.CurrentTotals(TenantB), "typed", "desktop"));
+        // A's contribution stays in A's totals (Forget drops the high-water, not the recorded turns).
+        Assert.Equal(5, Turns(agg.CurrentTotals(TenantA), "typed", "desktop"));
+    }
+
+    [Fact]
+    public void ExistingData_Reloads_UnderTheLocalTenant()
+    {
+        // The self-host control: data written with no explicit tenant lands under Local and reads back under
+        // Local, unchanged - the composite key degenerates to the bare key it was.
+        using (var first = new GatewayInputStatsAggregator(_path))
+            first.Observe(SessionWithRepoName("s1", "owner/app", @"D:\a\app", ("voice", "phone", 7, 700)));
+
+        using var reopened = new GatewayInputStatsAggregator(_path);
+        Assert.Equal(7, Turns(reopened.CurrentTotals(), "voice", "phone")); // default tenant == Local
+        Assert.Equal(7, Turns(reopened.CurrentTotals(TenantId.Local), "voice", "phone"));
+        // ...and a hosted tenant that never folded sees nothing here.
+        Assert.Empty(reopened.CurrentTotals(TenantA).Buckets);
+    }
+
+    private static long agg_AgentTurns(GatewayInputStatsAggregator agg, TenantId tenant, string agentName) =>
+        agg.AgentTotals(tenant).Single(a => a.AgentName == agentName).Turns;
 }

--- a/src/CcDirector.Gateway.Tests/GatewaySessionConcurrencyStatsTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewaySessionConcurrencyStatsTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Stats;
 using Xunit;
@@ -125,5 +126,73 @@ public sealed class GatewaySessionConcurrencyStatsTests : IDisposable
         Assert.Single(snap.Hourly);                 // only the recent hour survives the history
         Assert.Equal("2026-07-11T20", snap.Hourly[0].Hour);
         Assert.Equal(15, snap.Live.AllTimeMax);     // the peak is not history-derived, so it stands
+    }
+
+    // ---- MTR-08: two tenants' concurrency does not mix ----
+
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void TwoTenants_ConcurrencyAggregates_DoNotMix()
+    {
+        var s = new GatewaySessionConcurrencyStats(_path);
+
+        // Each tenant's /sessions roster is its own; the peak, current and hourly distinct counts are kept per
+        // tenant, so tenant A's 28-live peak never shows up in tenant B's snapshot and vice versa.
+        s.Observe(Roster(28, 7), T0, TenantA);
+        s.Observe(Roster(4, 1), T0, TenantB);
+
+        var snapA = s.Snapshot(T0.AddMinutes(1), TenantA);
+        var snapB = s.Snapshot(T0.AddMinutes(1), TenantB);
+
+        Assert.Equal(28, snapA.Live.AllTimeMax);
+        Assert.Equal(7, snapA.Working.AllTimeMax);
+        Assert.Equal(4, snapB.Live.AllTimeMax);
+        Assert.Equal(1, snapB.Working.AllTimeMax);
+
+        // The hourly distinct-session counts are per tenant too - A saw 28 distinct sessions that hour, B saw
+        // 4, and neither is the sum.
+        Assert.Equal(28, Assert.Single(snapA.Hourly).Sessions);
+        Assert.Equal(4, Assert.Single(snapB.Hourly).Sessions);
+    }
+
+    [Fact]
+    public void TwoTenants_Concurrency_SurvivesRestart_PerTenant()
+    {
+        var a = new GatewaySessionConcurrencyStats(_path);
+        a.Observe(Roster(28, 7), T0, TenantA);
+        a.Observe(Roster(4, 1), T0, TenantB);
+
+        var b = new GatewaySessionConcurrencyStats(_path); // reload the version-2 per-tenant store from disk
+        Assert.Equal(28, b.Snapshot(T0.AddMinutes(1), TenantA).Live.AllTimeMax);
+        Assert.Equal(4, b.Snapshot(T0.AddMinutes(1), TenantB).Live.AllTimeMax);
+    }
+
+    [Fact]
+    public void PreTenantStoreFile_Reloads_UnderTheLocalTenant()
+    {
+        // A version-1 file (the pre-tenant single-object shape) written by an older build migrates its numbers
+        // into the Local tenant, so a self-host upgrade keeps its all-time peak rather than quarantining it.
+        var legacy = """
+        {
+          "LiveAllTimeMax": 42,
+          "LiveAllTimeMaxAtUtc": "2026-07-11T20:00:00Z",
+          "WorkingAllTimeMax": 9,
+          "WorkingAllTimeMaxAtUtc": "2026-07-11T20:00:00Z",
+          "Hours": { "2026-07-11T20": { "MaxLive": 42, "MaxWorking": 9, "DistinctSessions": 42, "DistinctMachines": 3, "DistinctRepos": 5 } },
+          "CurrentHourKey": "2026-07-11T20",
+          "CurrentSessions": [],
+          "CurrentMachines": [],
+          "CurrentRepos": []
+        }
+        """;
+        File.WriteAllText(_path, legacy);
+
+        var s = new GatewaySessionConcurrencyStats(_path);
+        var snap = s.Snapshot(T0.AddMinutes(1)); // default tenant == Local
+        Assert.Equal(42, snap.Live.AllTimeMax);
+        Assert.Equal(9, snap.Working.AllTimeMax);
+        Assert.Equal(42, Assert.Single(snap.Hourly).Sessions);
     }
 }

--- a/src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs
@@ -104,7 +104,8 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         using (var first = new GatewayStatsDatabase(_path))
         {
             using var cmd = first.Connection.CreateCommand();
-            cmd.CommandText = "INSERT INTO meta(name, value) VALUES ('probe', '42')";
+            // meta is keyed by (tenant, name) from schema v5 (MTR-08).
+            cmd.CommandText = "INSERT INTO meta(tenant, name, value) VALUES ('local', 'probe', '42')";
             cmd.ExecuteNonQuery();
         }
 
@@ -182,11 +183,15 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
 
         var expected = new[]
         {
-            "id", "hour_utc", "session_id", "modality", "surface",
+            "id", "tenant", "hour_utc", "session_id", "modality", "surface",
             "is_voice", "repo_id", "checkout_id", "model_id", "wingman", "turns", "chars",
         };
         Assert.Equal(expected.OrderBy(c => c, StringComparer.Ordinal),
                      columns.Keys.OrderBy(c => c, StringComparer.Ordinal));
+
+        // The tenant is a TEXT partition key (MTR-08): every read filters by it and it is stated here
+        // deliberately, exactly as the whitelist requires of any new column.
+        Assert.Equal("TEXT", columns["tenant"]);
 
         // The repository and model dimensions are integers, so SQLite cannot be asked to compare a
         // repository or model string here even by accident. model_id is stated here deliberately, which is
@@ -331,6 +336,91 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         return Convert.ToInt64(cmd.ExecuteScalar());
     }
 
+    // A hand-built schema-VERSION-4 store (the shape before MTR-08's tenant dimension): the full v4 schema
+    // with a couple of real rows, user_version=4. Used to prove the v4 -> v5 forward migration is FAITHFUL -
+    // it adds the tenant column, backfills every existing row to the local tenant, and keeps every row -
+    // rather than retiring the store the way a genuinely incompatible (pre-v4) one is.
+    private void WriteVersion4Database()
+    {
+        using var connection = new SqliteConnection($"Data Source={_path}");
+        connection.Open();
+        void Run(string sql)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        // stat_delta in its v4 shape: the v1 columns, then model_id (v2 ADD COLUMN), then checkout_id (v4).
+        Run(@"CREATE TABLE stat_delta (
+                  id INTEGER PRIMARY KEY AUTOINCREMENT, hour_utc TEXT NOT NULL, session_id TEXT NOT NULL,
+                  modality TEXT NOT NULL, surface TEXT NOT NULL, is_voice INTEGER NOT NULL, repo_id INTEGER NOT NULL,
+                  wingman INTEGER NOT NULL, turns INTEGER NOT NULL, chars INTEGER NOT NULL,
+                  model_id INTEGER, checkout_id INTEGER)");
+        Run("CREATE TABLE session_highwater (session_id TEXT NOT NULL, modality TEXT NOT NULL, surface TEXT NOT NULL, turns INTEGER NOT NULL, chars INTEGER NOT NULL, PRIMARY KEY (session_id, modality, surface))");
+        Run("CREATE TABLE wingman_session (session_id TEXT PRIMARY KEY)");
+        Run("CREATE TABLE repo_session (repo_id INTEGER NOT NULL, session_id TEXT NOT NULL, PRIMARY KEY (repo_id, session_id))");
+        Run("CREATE TABLE agent_session (agent_id INTEGER NOT NULL, session_id TEXT NOT NULL, PRIMARY KEY (agent_id, session_id))");
+        Run("CREATE TABLE repo_identity (repo_id INTEGER PRIMARY KEY AUTOINCREMENT, repo_display TEXT NOT NULL)");
+        Run("CREATE TABLE agent_identity (agent_id INTEGER PRIMARY KEY AUTOINCREMENT, agent_display TEXT NOT NULL)");
+        Run("CREATE TABLE model_identity (model_id INTEGER PRIMARY KEY AUTOINCREMENT, model_display TEXT NOT NULL)");
+        Run("CREATE TABLE checkout_identity (checkout_id INTEGER PRIMARY KEY AUTOINCREMENT, checkout_display TEXT NOT NULL)");
+        Run("CREATE TABLE agent_delta (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id INTEGER NOT NULL, is_voice INTEGER NOT NULL, turns INTEGER NOT NULL, chars INTEGER NOT NULL)");
+        Run("CREATE TABLE agent_driven_delta (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id INTEGER NOT NULL, turns INTEGER NOT NULL, chars INTEGER NOT NULL)");
+        Run("CREATE TABLE agent_driven_highwater (session_id TEXT PRIMARY KEY, turns INTEGER NOT NULL, chars INTEGER NOT NULL)");
+        Run("CREATE TABLE agents_seeded (session_id TEXT PRIMARY KEY)");
+        Run("CREATE TABLE token_delta (id INTEGER PRIMARY KEY AUTOINCREMENT, hour_utc TEXT NOT NULL, model_id INTEGER, input_tokens INTEGER NOT NULL, output_tokens INTEGER NOT NULL, cache_read_tokens INTEGER NOT NULL, cache_creation_tokens INTEGER NOT NULL)");
+        Run("CREATE TABLE token_highwater (session_id TEXT PRIMARY KEY, input_tokens INTEGER NOT NULL, output_tokens INTEGER NOT NULL, cache_read_tokens INTEGER NOT NULL, cache_creation_tokens INTEGER NOT NULL)");
+        Run("CREATE TABLE meta (name TEXT PRIMARY KEY, value TEXT NOT NULL)");
+
+        // A repo identity and a stat_delta row that references it, plus a high-water row, a wingman row, a
+        // seeded row and the models-since stamp - one of each shape a rebuild or an add-column must preserve.
+        Run("INSERT INTO repo_identity(repo_display) VALUES ('owner/app')");
+        Run("INSERT INTO stat_delta(hour_utc, session_id, modality, surface, is_voice, repo_id, wingman, turns, chars, model_id, checkout_id) VALUES ('2026-07-16T09', 's1', 'typed', 'desktop', 0, 1, 0, 12, 240, NULL, NULL)");
+        Run("INSERT INTO session_highwater(session_id, modality, surface, turns, chars) VALUES ('s1', 'typed', 'desktop', 12, 240)");
+        Run("INSERT INTO wingman_session(session_id) VALUES ('s1')");
+        Run("INSERT INTO agents_seeded(session_id) VALUES ('s1')");
+        Run("INSERT INTO meta(name, value) VALUES ('models_since_utc', '2026-07-01T00:00:00.0000000Z')");
+
+        Run("PRAGMA user_version=4");
+        connection.Close();
+        SqliteConnection.ClearAllPools();
+    }
+
+    [Fact]
+    public void Open_Version4Store_MigratesForwardToV5_BackfillsLocalTenant_AndKeepsEveryRow()
+    {
+        // The v4 -> v5 migration is a FORWARD migration, not a retire: v5 only adds the tenant dimension, and
+        // every existing row belongs to the single self-host tenant. So a self-host upgrade must keep all of
+        // its numbers, now owned by the local tenant.
+        WriteVersion4Database();
+
+        using var db = new GatewayStatsDatabase(_path);
+
+        // Migrated, not retired: the store is at the current version, no retired copy was minted, and the row
+        // is still here - backfilled to the local tenant.
+        Assert.Equal(GatewayStatsDatabase.SchemaVersion, UserVersion(db));
+        Assert.Empty(Directory.GetFiles(_dir, "gateway-stats.db.superseded-*"));
+        Assert.Equal(1, ScalarLong(db, "SELECT COUNT(*) FROM stat_delta"));
+        Assert.Equal(12, ScalarLong(db, "SELECT turns FROM stat_delta WHERE tenant='local'"));
+
+        // The tenant joined the primary key of the rebuilt tables, and the copied rows landed under 'local'.
+        Assert.Contains("tenant", ColumnsOf(db, "session_highwater"));
+        Assert.Equal(1, ScalarLong(db, "SELECT COUNT(*) FROM session_highwater WHERE tenant='local' AND session_id='s1'"));
+        Assert.Equal(1, ScalarLong(db, "SELECT COUNT(*) FROM wingman_session WHERE tenant='local' AND session_id='s1'"));
+        Assert.Equal(1, ScalarLong(db, "SELECT COUNT(*) FROM agents_seeded WHERE tenant='local' AND session_id='s1'"));
+
+        // The repo identity gained the tenant column (backfilled local), so the reload rebuilds its per-tenant
+        // display->id map.
+        Assert.Contains("tenant", ColumnsOf(db, "repo_identity"));
+        Assert.Equal(1, ScalarLong(db, "SELECT COUNT(*) FROM repo_identity WHERE tenant='local' AND repo_display='owner/app'"));
+
+        // meta became (tenant, name) and the schema fact rode the local tenant's row.
+        using var read = db.Connection.CreateCommand();
+        read.CommandText = "SELECT value FROM meta WHERE tenant='local' AND name='models_since_utc'";
+        Assert.Equal("2026-07-01T00:00:00.0000000Z", read.ExecuteScalar() as string);
+    }
+
     [Fact]
     public void Open_IncompatibleStore_IsRetiredAsideUnread_AndStartsEmpty()
     {
@@ -384,7 +474,7 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         using (var first = new GatewayStatsDatabase(_path))
         {
             using var cmd = first.Connection.CreateCommand();
-            cmd.CommandText = "INSERT INTO meta(name, value) VALUES ('probe', 'kept')";
+            cmd.CommandText = "INSERT INTO meta(tenant, name, value) VALUES ('local', 'probe', 'kept')";
             cmd.ExecuteNonQuery();
         }
         SqliteConnection.ClearAllPools();
@@ -408,7 +498,7 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         var columns = ColumnsOf(db, "token_delta");
         var expected = new[]
         {
-            "id", "hour_utc", "model_id",
+            "id", "tenant", "hour_utc", "model_id",
             "input_tokens", "output_tokens", "cache_read_tokens", "cache_creation_tokens",
         };
         Assert.Equal(expected.OrderBy(c => c, StringComparer.Ordinal),

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1031,14 +1031,17 @@ internal static class GatewayEndpoints
             // fold only runs when stream mode is on, which it is not in production). The aggregator's
             // per-session high-water logic makes folding the full roster on every read idempotent - only a
             // genuine increase is added, so repeated /sessions polls never double-count.
-            inputStats?.ObserveSnapshot(all, DateTime.UtcNow);
+            // MTR-08: stamp the REQUEST TENANT. The roster assembled above is this tenant's own (the
+            // owned-Director gate filtered it), so its input tallies fold into this tenant's partition and can
+            // never coalesce with another account's.
+            inputStats?.ObserveSnapshot(all, DateTime.UtcNow, reqTenant.Value);
 
             // DevThrottle Stats: record fleet concurrency and the hourly activity log from the same
             // assembled roster - max concurrent loaded/running (live) and actively working, plus how many
-            // distinct sessions/machines/repositories ran each hour. Fleet-wide with no per-Director
-            // instrumentation, since the roster already sees every session on every machine. The tracker
-            // keeps only the higher value per hour, so folding on every /sessions read never inflates.
-            concurrency?.Observe(all, DateTime.UtcNow);
+            // distinct sessions/machines/repositories ran each hour. Per-tenant with no per-Director
+            // instrumentation, since the roster already sees this tenant's sessions on every machine. The
+            // tracker keeps only the higher value per hour, so folding on every /sessions read never inflates.
+            concurrency?.Observe(all, DateTime.UtcNow, reqTenant.Value);
 
             // Issue #1292: adopt every observed number into the fleet allocator's in-use set. This is how
             // the Gateway learns numbers it did not hand out - a number a Director assigned offline, or any

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -1,4 +1,5 @@
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using Microsoft.Data.Sqlite;
@@ -37,6 +38,18 @@ namespace CcDirector.Gateway.Stats;
 ///      recorded this?" - which is what keeps an IDLE roster poll at zero writes, exactly as it is today.
 ///      The mirror only advances AFTER the write commits, so a failed write is a loud failure retried on the
 ///      next poll, never a silent mirror-only success.
+///
+/// MTR-08 (production-readiness census rows 49-67): EVERY tally, membership set and identity is now keyed by
+/// the OWNING TENANT as well as its old key, and every stored row carries the tenant. Before this the whole
+/// aggregator was process-global: two tenants pushing the SAME bare session id shared one high-water entry
+/// (so one could suppress the other's first-seen/seed accounting), and two tenants that drove the same
+/// "owner/repo" repository, agent or model shared one surrogate identity (so their turns coalesced into one
+/// total). The tenant is carried from the Director-statistics ingress - the same authenticated tenant the
+/// tunnel/DirectorHub binds - stamped by the producer and required by the reader. On the single-tenant self
+/// host there is exactly one tenant (<see cref="TenantId.Local"/>), so the composite key degenerates to the
+/// bare key it was and behavior is unchanged; on hosted the private dashboard that reads this is refused in
+/// whole (issue #1848), so a reader here only ever runs for Local. A null/invalid tenant is a DENY, never a
+/// default: the producer paths pass the bound tenant, and the reader passes the request tenant.
 /// </summary>
 public sealed class GatewayInputStatsAggregator : IDisposable
 {
@@ -49,42 +62,60 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     private readonly object _lock = new();
 
     // ---- The mirror. Membership and identity ONLY - never a tally (Decision 6). ----
+    //
+    // MTR-08: every map below is keyed by (tenant, ...) so one tenant's membership and identity can never be
+    // read, suppressed, or coalesced by another. The session-keyed maps carry the tenant in a composite tuple
+    // key (default tuple equality is Ordinal on the tenant value and Ordinal on the session id - exactly the
+    // StringComparer.Ordinal they used before). The identity display->id maps nest a per-tenant dictionary so
+    // the OrdinalIgnoreCase comparer that DECIDES identity is preserved byte-for-byte per tenant; the id->
+    // display maps stay flat because a surrogate id is globally unique (AUTOINCREMENT) and already names its
+    // tenant's row.
 
-    private readonly Dictionary<string, Dictionary<(string Modality, string Surface), Counters>> _highWater = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, Counters> _agentDrivenHighWater = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _wingmanSessions = new(StringComparer.Ordinal);
+    private readonly Dictionary<(TenantId Tenant, string SessionId), Dictionary<(string Modality, string Surface), Counters>> _highWater = new();
+    private readonly Dictionary<(TenantId Tenant, string SessionId), Counters> _agentDrivenHighWater = new();
+    private readonly HashSet<(TenantId Tenant, string SessionId)> _wingmanSessions = new();
 
     // The last cumulative token spend seen per session (issue #1637), so only the INCREASE folds - the same
     // high-water discipline as _highWater, one dimension over. A dropped count is a restart and folds fresh
     // from zero.
-    private readonly Dictionary<string, TokenCounters> _tokenHighWater = new(StringComparer.Ordinal);
+    private readonly Dictionary<(TenantId Tenant, string SessionId), TokenCounters> _tokenHighWater = new();
 
     // Sessions whose already-counted turns have been attributed to their agent (issue #1633). MUST persist:
     // session_highwater survives a restart, so without this the back-fill would run a second time against a
     // non-empty high-water and double every agent's numbers.
-    private readonly HashSet<string> _agentsSeeded = new(StringComparer.Ordinal);
+    private readonly HashSet<(TenantId Tenant, string SessionId)> _agentsSeeded = new();
 
-    // Display spelling -> surrogate id. THE COMPARER HERE IS THE WHOLE REASON THE SCHEMA USES SURROGATE IDS:
-    // it is the same StringComparer.OrdinalIgnoreCase the old dictionaries used, so grouping is decided by
-    // the identical object with identical semantics and SQLite is never asked to compare a repository,
-    // agent or model string. First-seen-wins on the display spelling, which is what a Dictionary does.
-    private readonly Dictionary<string, long> _repoIds = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Dictionary<string, long> _agentIds = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Dictionary<string, long> _modelIds = new(StringComparer.OrdinalIgnoreCase);
+    // Display spelling -> surrogate id, PER TENANT (MTR-08). THE INNER COMPARER IS THE WHOLE REASON THE SCHEMA
+    // USES SURROGATE IDS: it is the same StringComparer.OrdinalIgnoreCase the old dictionaries used, so
+    // grouping is decided by the identical object with identical semantics and SQLite is never asked to
+    // compare a repository, agent or model string. First-seen-wins on the display spelling, which is what a
+    // Dictionary does. Nesting per tenant keeps that comparer exact while making tenant A's "owner/repo" a
+    // DIFFERENT surrogate id than tenant B's, so their turns cannot coalesce.
+    private readonly Dictionary<TenantId, Dictionary<string, long>> _repoIds = new();
+    private readonly Dictionary<TenantId, Dictionary<string, long>> _agentIds = new();
+    private readonly Dictionary<TenantId, Dictionary<string, long>> _modelIds = new();
     // The checkout (local working directory) dimension retained beside the repository (issue: group the
     // Repos page by repository). repo_id is now the repo name, so worktrees and per-machine clones
     // of one repository share a repo_id; checkout_id keeps the path each turn actually ran in so it is not
-    // lost. Same first-seen-wins OrdinalIgnoreCase identity as the others.
-    private readonly Dictionary<string, long> _checkoutIds = new(StringComparer.OrdinalIgnoreCase);
+    // lost. Same first-seen-wins OrdinalIgnoreCase identity as the others, per tenant.
+    private readonly Dictionary<TenantId, Dictionary<string, long>> _checkoutIds = new();
+    // id -> display stays flat: a surrogate id is globally unique and belongs to exactly one tenant's row.
     private readonly Dictionary<long, string> _repoDisplay = new();
     private readonly Dictionary<long, string> _agentDisplay = new();
     private readonly Dictionary<long, string> _modelDisplay = new();
     private readonly Dictionary<long, string> _checkoutDisplay = new();
 
+    // The distinct-session sets stay keyed by (surrogate id, session id): the id is already tenant-specific
+    // (minted per tenant above), so (idA, "s1") and (idB, "s1") are distinct entries for two tenants that
+    // happen to share a bare session id. No tenant is needed in the key.
     private readonly HashSet<(long Id, string SessionId)> _repoSessions = new();
     private readonly HashSet<(long Id, string SessionId)> _agentSessions = new();
 
-    private string _agentsSinceUtc = "";
+    // When the per-agent tally started counting, PER TENANT (MTR-08): each tenant's first fold stamps its own
+    // start, so the Agents page states the window for THAT tenant rather than a fleet-global first observation.
+    private readonly Dictionary<TenantId, string> _agentsSinceUtc = new();
+    // When the model DIMENSION started recording. A schema fact (stamped once by the version-2 migration),
+    // not a per-tenant statistic, so it stays a single value read tenant-agnostically.
     private string _modelsSinceUtc = "";
 
     /// <summary>Every statement executed against the database. The seam acceptance criterion 3 measures: an
@@ -125,7 +156,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     /// </summary>
     private enum IdentityKind { Repo, Agent, Model, Checkout }
 
-    private Dictionary<string, long> IdsFor(IdentityKind kind) => kind switch
+    private Dictionary<TenantId, Dictionary<string, long>> OuterIdsFor(IdentityKind kind) => kind switch
     {
         IdentityKind.Repo => _repoIds,
         IdentityKind.Agent => _agentIds,
@@ -133,6 +164,20 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         IdentityKind.Checkout => _checkoutIds,
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown identity kind."),
     };
+
+    // The per-tenant display->id map for one kind, created on first use with the OrdinalIgnoreCase comparer
+    // that is the whole point of the surrogate scheme. Creating an empty map for a read-only probe is
+    // harmless - it just answers "no identity yet for this tenant".
+    private Dictionary<string, long> IdsFor(TenantId tenant, IdentityKind kind)
+    {
+        var outer = OuterIdsFor(kind);
+        if (!outer.TryGetValue(tenant, out var inner))
+        {
+            inner = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+            outer[tenant] = inner;
+        }
+        return inner;
+    }
 
     private Dictionary<long, string> DisplayFor(IdentityKind kind) => kind switch
     {
@@ -206,88 +251,115 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     {
         lock (_lock)
         {
-            Read("SELECT session_id, modality, surface, turns, chars FROM session_highwater", r =>
+            // Every row carries its owning tenant (MTR-08), so the mirror is rebuilt per tenant - exactly the
+            // partition that was written. A surrogate id lands in the flat id->display map (ids are globally
+            // unique) AND in its tenant's display->id map.
+            Read("SELECT tenant, session_id, modality, surface, turns, chars FROM session_highwater", r =>
             {
-                var sid = r.GetString(0);
-                if (!_highWater.TryGetValue(sid, out var hw))
+                var key = (new TenantId(r.GetString(0)), r.GetString(1));
+                if (!_highWater.TryGetValue(key, out var hw))
                 {
                     hw = new Dictionary<(string, string), Counters>();
-                    _highWater[sid] = hw;
+                    _highWater[key] = hw;
                 }
-                hw[(r.GetString(1), r.GetString(2))] = new Counters { Turns = r.GetInt64(3), Characters = r.GetInt64(4) };
+                hw[(r.GetString(2), r.GetString(3))] = new Counters { Turns = r.GetInt64(4), Characters = r.GetInt64(5) };
             });
-            Read("SELECT session_id, turns, chars FROM agent_driven_highwater",
-                r => _agentDrivenHighWater[r.GetString(0)] = new Counters { Turns = r.GetInt64(1), Characters = r.GetInt64(2) });
-            Read("SELECT session_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens FROM token_highwater",
-                r => _tokenHighWater[r.GetString(0)] = new TokenCounters
+            Read("SELECT tenant, session_id, turns, chars FROM agent_driven_highwater",
+                r => _agentDrivenHighWater[(new TenantId(r.GetString(0)), r.GetString(1))] = new Counters { Turns = r.GetInt64(2), Characters = r.GetInt64(3) });
+            Read("SELECT tenant, session_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens FROM token_highwater",
+                r => _tokenHighWater[(new TenantId(r.GetString(0)), r.GetString(1))] = new TokenCounters
                 {
-                    Input = r.GetInt64(1), Output = r.GetInt64(2), CacheRead = r.GetInt64(3), CacheCreation = r.GetInt64(4),
+                    Input = r.GetInt64(2), Output = r.GetInt64(3), CacheRead = r.GetInt64(4), CacheCreation = r.GetInt64(5),
                 });
-            Read("SELECT session_id FROM wingman_session", r => _wingmanSessions.Add(r.GetString(0)));
-            Read("SELECT session_id FROM agents_seeded", r => _agentsSeeded.Add(r.GetString(0)));
-            Read("SELECT repo_id, repo_display FROM repo_identity", r =>
+            Read("SELECT tenant, session_id FROM wingman_session", r => _wingmanSessions.Add((new TenantId(r.GetString(0)), r.GetString(1))));
+            Read("SELECT tenant, session_id FROM agents_seeded", r => _agentsSeeded.Add((new TenantId(r.GetString(0)), r.GetString(1))));
+            Read("SELECT tenant, repo_id, repo_display FROM repo_identity", r =>
             {
-                var id = r.GetInt64(0); var d = r.GetString(1);
-                _repoIds[d] = id; _repoDisplay[id] = d;
+                var t = new TenantId(r.GetString(0)); var id = r.GetInt64(1); var d = r.GetString(2);
+                IdsFor(t, IdentityKind.Repo)[d] = id; _repoDisplay[id] = d;
             });
-            Read("SELECT agent_id, agent_display FROM agent_identity", r =>
+            Read("SELECT tenant, agent_id, agent_display FROM agent_identity", r =>
             {
-                var id = r.GetInt64(0); var d = r.GetString(1);
-                _agentIds[d] = id; _agentDisplay[id] = d;
+                var t = new TenantId(r.GetString(0)); var id = r.GetInt64(1); var d = r.GetString(2);
+                IdsFor(t, IdentityKind.Agent)[d] = id; _agentDisplay[id] = d;
             });
-            Read("SELECT model_id, model_display FROM model_identity", r =>
+            Read("SELECT tenant, model_id, model_display FROM model_identity", r =>
             {
-                var id = r.GetInt64(0); var d = r.GetString(1);
-                _modelIds[d] = id; _modelDisplay[id] = d;
+                var t = new TenantId(r.GetString(0)); var id = r.GetInt64(1); var d = r.GetString(2);
+                IdsFor(t, IdentityKind.Model)[d] = id; _modelDisplay[id] = d;
             });
-            Read("SELECT checkout_id, checkout_display FROM checkout_identity", r =>
+            Read("SELECT tenant, checkout_id, checkout_display FROM checkout_identity", r =>
             {
-                var id = r.GetInt64(0); var d = r.GetString(1);
-                _checkoutIds[d] = id; _checkoutDisplay[id] = d;
+                var t = new TenantId(r.GetString(0)); var id = r.GetInt64(1); var d = r.GetString(2);
+                IdsFor(t, IdentityKind.Checkout)[d] = id; _checkoutDisplay[id] = d;
             });
+            // repo_session/agent_session need no tenant: repo_id/agent_id are already tenant-specific.
             Read("SELECT repo_id, session_id FROM repo_session", r => _repoSessions.Add((r.GetInt64(0), r.GetString(1))));
             Read("SELECT agent_id, session_id FROM agent_session", r => _agentSessions.Add((r.GetInt64(0), r.GetString(1))));
-            _agentsSinceUtc = ReadScalarString("SELECT value FROM meta WHERE name=$n", ("$n", AgentsSinceKey)) ?? "";
+            // agents_since is PER TENANT now (one row per tenant that has folded).
+            Read("SELECT tenant, value FROM meta WHERE name=$n",
+                r => _agentsSinceUtc[new TenantId(r.GetString(0))] = r.GetString(1), ("$n", AgentsSinceKey));
 
             // Written by the version 2 migration, so it is present on every database this build can open -
-            // the migration runs before this does. Read into the mirror because the stats surface reports it
-            // on every request and it never changes at runtime.
-            _modelsSinceUtc = ReadScalarString("SELECT value FROM meta WHERE name=$n",
+            // the migration runs before this does. A schema fact, not per-tenant, so it is read once with no
+            // tenant filter. Read into the mirror because the stats surface reports it on every request and it
+            // never changes at runtime.
+            _modelsSinceUtc = ReadScalarString("SELECT value FROM meta WHERE name=$n LIMIT 1",
                 ("$n", GatewayStatsDatabase.ModelsSinceKey)) ?? "";
 
             FileLog.Write($"[GatewayInputStatsAggregator] LoadMirror: {_highWater.Count} live session(s), " +
-                          $"{_wingmanSessions.Count} wingman session(s), {_repoIds.Count} repo(s), {_agentIds.Count} agent(s), " +
-                          $"{_modelIds.Count} model(s), {_checkoutIds.Count} checkout(s), {_agentsSeeded.Count} seeded, agentsSince='{_agentsSinceUtc}', " +
+                          $"{_wingmanSessions.Count} wingman session(s), {_repoDisplay.Count} repo(s), {_agentDisplay.Count} agent(s), " +
+                          $"{_modelDisplay.Count} model(s), {_checkoutDisplay.Count} checkout(s), {_agentsSeeded.Count} seeded, " +
+                          $"{_agentsSinceUtc.Count} tenant(s) with an agents-since stamp, " +
                           $"modelsSince='{_modelsSinceUtc}' from {_db.Path}");
         }
     }
 
-    /// <summary>Fold every session in a full snapshot into the totals and the per-hour turn log.</summary>
-    public void ObserveSnapshot(IEnumerable<SessionDto>? sessions, DateTime? nowUtc = null)
+    /// <summary>
+    /// Fold every session in a full snapshot into the totals and the per-hour turn log, under
+    /// <paramref name="tenant"/> - the authenticated tenant the Director-statistics ingress bound. The whole
+    /// snapshot belongs to one tenant (the ingress is per-tenant), so a single tenant scopes the batch.
+    /// Defaults to <see cref="TenantId.Local"/> for the self-host shape and the unit-test default; the
+    /// production producer paths pass the bound tenant explicitly.
+    /// </summary>
+    public void ObserveSnapshot(IEnumerable<SessionDto>? sessions, DateTime? nowUtc = null, TenantId? tenant = null)
     {
         if (sessions is null) return;
+        var t = RequireTenant(tenant);
         var now = nowUtc ?? DateTime.UtcNow;
         lock (_lock)
         {
-            var batch = new FoldBatch(now, HourKey(now));
+            var batch = new FoldBatch(t, now, HourKey(now));
             StampAgentsSinceLocked(batch);
             foreach (var s in sessions) FoldLocked(s, batch);
             CommitLocked(batch);
         }
     }
 
-    /// <summary>Fold one session (a delta) into the totals and the per-hour turn log.</summary>
-    public void Observe(SessionDto? session, DateTime? nowUtc = null)
+    /// <summary>Fold one session (a delta) into the totals and the per-hour turn log, under
+    /// <paramref name="tenant"/> (the bound ingress tenant; defaults to <see cref="TenantId.Local"/>).</summary>
+    public void Observe(SessionDto? session, DateTime? nowUtc = null, TenantId? tenant = null)
     {
         if (session is null) return;
+        var t = RequireTenant(tenant);
         var now = nowUtc ?? DateTime.UtcNow;
         lock (_lock)
         {
-            var batch = new FoldBatch(now, HourKey(now));
+            var batch = new FoldBatch(t, now, HourKey(now));
             StampAgentsSinceLocked(batch);
             FoldLocked(session, batch);
             CommitLocked(batch);
         }
+    }
+
+    // Resolve the tenant a producer or reader supplied. Null means the self-host / unit-test default (Local);
+    // an explicitly-passed tenant must be valid - an invalid one is a DENY, never silently defaulted, so a
+    // caller that resolved "no tenant" (hosted, unbound) can never file under a guessed owner.
+    private static TenantId RequireTenant(TenantId? tenant)
+    {
+        if (tenant is not { } t) return TenantId.Local;
+        if (!t.IsValid) throw new ArgumentException("a valid tenant is required", nameof(tenant));
+        return t;
     }
 
     /// <summary>
@@ -298,7 +370,11 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     /// </summary>
     private sealed class FoldBatch
     {
-        public FoldBatch(DateTime nowUtc, string hourKey) { NowUtc = nowUtc; HourKey = hourKey; }
+        public FoldBatch(TenantId tenant, DateTime nowUtc, string hourKey) { Tenant = tenant; NowUtc = nowUtc; HourKey = hourKey; }
+
+        // MTR-08: the one tenant this whole batch belongs to. Every row written and every mirror entry
+        // advanced by this batch is keyed by it - the producer stamps it once here, never per row.
+        public TenantId Tenant { get; }
         public DateTime NowUtc { get; }
         public string HourKey { get; }
 
@@ -331,7 +407,9 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
     private void StampAgentsSinceLocked(FoldBatch batch)
     {
-        if (_agentsSinceUtc.Length > 0) return;
+        // Per tenant (MTR-08): only stamp when THIS tenant has no start yet, so each account's Agents page
+        // states its own window rather than a fleet-global first observation.
+        if (_agentsSinceUtc.TryGetValue(batch.Tenant, out var existing) && existing.Length > 0) return;
         batch.StampAgentsSince = batch.NowUtc.ToUniversalTime()
             .ToString("o", System.Globalization.CultureInfo.InvariantCulture);
     }
@@ -356,8 +434,9 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
         // A session "uses the wingman" the moment it is seen with voice mode on - recorded even with no
         // input this fold. BEFORE the empty-buckets return, deliberately; the membership mirror is what
-        // keeps it free on an idle poll.
-        if (wingman && !_wingmanSessions.Contains(s.SessionId) && !batch.NewWingmanSessions.Contains(s.SessionId))
+        // keeps it free on an idle poll. Keyed by (tenant, session id) so another tenant's same session id
+        // neither counts this one nor is counted by it (MTR-08).
+        if (wingman && !_wingmanSessions.Contains((batch.Tenant, s.SessionId)) && !batch.NewWingmanSessions.Contains(s.SessionId))
             batch.NewWingmanSessions.Add(s.SessionId);
 
         // Issue #1636: turns other agents drove into this session, on their own lane. Folded BEFORE the
@@ -373,13 +452,14 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
         if (s.InputStats?.Buckets is null || s.InputStats.Buckets.Count == 0) return;
 
-        _highWater.TryGetValue(s.SessionId, out var hw);
+        _highWater.TryGetValue((batch.Tenant, s.SessionId), out var hw);
 
         // Issue #1633: the first time this session is folded, attribute what it has ALREADY counted to its
         // agent. Read before the loop below moves the high-water on. On a fresh database this contributes
         // nothing (the high-water is empty); after a RESTART it would contribute real turns, which is why
-        // agents_seeded is persisted.
-        if (!_agentsSeeded.Contains(s.SessionId))
+        // agents_seeded is persisted. Keyed by (tenant, session id) so one tenant seeding a session id can
+        // never suppress another tenant's back-fill of the same id (MTR-08).
+        if (!_agentsSeeded.Contains((batch.Tenant, s.SessionId)))
         {
             batch.NewSeeded.Add(s.SessionId);
             if (hw is not null)
@@ -499,7 +579,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         var chars = s.InputStats?.AgentDrivenCharacters ?? 0;
         if (turns == 0 && chars == 0) return;
 
-        _agentDrivenHighWater.TryGetValue(s.SessionId, out var prev);
+        _agentDrivenHighWater.TryGetValue((batch.Tenant, s.SessionId), out var prev);
         var prevTurns = prev?.Turns ?? 0;
         var prevChars = prev?.Characters ?? 0;
 
@@ -533,7 +613,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         var t = s.TokenTotals;
         if (t is null) return;
 
-        _tokenHighWater.TryGetValue(s.SessionId, out var prev);
+        _tokenHighWater.TryGetValue((batch.Tenant, s.SessionId), out var prev);
         var prevIn = prev?.Input ?? 0;
         var prevOut = prev?.Output ?? 0;
         var prevCacheR = prev?.CacheRead ?? 0;
@@ -568,9 +648,12 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
     private void NeedIdentity(string display, IdentityKind kind, FoldBatch batch)
     {
-        if (IdsFor(kind).ContainsKey(display)) return;
+        // Resolve within THIS batch's tenant (MTR-08): a display spelling already known to another tenant is
+        // NOT known here, so the two tenants mint separate surrogate ids and their turns never coalesce.
+        if (IdsFor(batch.Tenant, kind).ContainsKey(display)) return;
         // The pending list is compared with the SAME comparer, so two spellings differing only by case
-        // inside one batch resolve to one identity, exactly as the dictionary would.
+        // inside one batch resolve to one identity, exactly as the dictionary would. The whole batch is one
+        // tenant, so no tenant test is needed on the pending list.
         foreach (var (d, k) in batch.NewIdentities)
             if (k == kind && StringComparer.OrdinalIgnoreCase.Equals(d, display)) return;
         batch.NewIdentities.Add((display, kind));
@@ -578,7 +661,9 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
     private bool KnownIdentitySession(string display, string sessionId, IdentityKind kind, FoldBatch batch)
     {
-        if (IdsFor(kind).TryGetValue(display, out var id) && SessionsFor(kind).Contains((id, sessionId)))
+        // The display->id lookup is per tenant; the distinct-session set is keyed by the resolved (tenant-
+        // specific) id, so no tenant test is needed on it.
+        if (IdsFor(batch.Tenant, kind).TryGetValue(display, out var id) && SessionsFor(kind).Contains((id, sessionId)))
             return true;
         foreach (var (d, sid, k) in batch.NewIdentitySessions)
             if (k == kind && sid == sessionId && StringComparer.OrdinalIgnoreCase.Equals(d, display)) return true;
@@ -591,13 +676,17 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     {
         if (batch.IsEmpty) return;
 
+        var tenant = batch.Tenant.Value;
+
         using var tx = _db.Connection.BeginTransaction();
 
+        // agents_since is per tenant (MTR-08): (tenant, name) is the key.
         if (batch.StampAgentsSince is not null)
-            Execute("INSERT OR REPLACE INTO meta(name, value) VALUES ($n, $v)", tx,
-                ("$n", AgentsSinceKey), ("$v", batch.StampAgentsSince));
+            Execute("INSERT OR REPLACE INTO meta(tenant, name, value) VALUES ($tn, $n, $v)", tx,
+                ("$tn", tenant), ("$n", AgentsSinceKey), ("$v", batch.StampAgentsSince));
 
-        // Freshly minted ids, per kind, keyed with the SAME comparer as the mirror they will join.
+        // Freshly minted ids, per kind, keyed with the SAME comparer as the mirror they will join. Every
+        // identity row carries this batch's tenant, so the reload rebuilds the per-tenant display->id map.
         var newIds = new Dictionary<IdentityKind, Dictionary<string, long>>
         {
             [IdentityKind.Repo] = new(StringComparer.OrdinalIgnoreCase),
@@ -608,14 +697,15 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         foreach (var (display, kind) in batch.NewIdentities)
         {
             var (table, column) = IdentityTableFor(kind);
-            var id = ExecuteScalarLong($"INSERT INTO {table}({column}) VALUES ($d); SELECT last_insert_rowid()", tx, ("$d", display));
+            var id = ExecuteScalarLong($"INSERT INTO {table}({column}, tenant) VALUES ($d, $tn); SELECT last_insert_rowid()", tx,
+                ("$d", display), ("$tn", tenant));
             newIds[kind][display] = id;
         }
 
         long Resolve(string display, IdentityKind kind)
         {
             if (newIds[kind].TryGetValue(display, out var fresh)) return fresh;
-            return IdsFor(kind)[display];
+            return IdsFor(batch.Tenant, kind)[display];
         }
 
         // An absent model resolves to nothing at all - DBNull, so the column is SQL NULL rather than a
@@ -624,50 +714,50 @@ public sealed class GatewayInputStatsAggregator : IDisposable
             display is null ? DBNull.Value : Resolve(display, IdentityKind.Model);
 
         foreach (var r in batch.Rows)
-            Execute(@"INSERT INTO stat_delta(hour_utc, session_id, modality, surface, is_voice, repo_id, checkout_id, model_id, wingman, turns, chars)
-                      VALUES ($h, $s, $m, $u, $v, $r, $k, $d, $w, $t, $c)", tx,
-                ("$h", r.Hour), ("$s", r.SessionId), ("$m", r.Modality), ("$u", r.Surface),
+            Execute(@"INSERT INTO stat_delta(tenant, hour_utc, session_id, modality, surface, is_voice, repo_id, checkout_id, model_id, wingman, turns, chars)
+                      VALUES ($tn, $h, $s, $m, $u, $v, $r, $k, $d, $w, $t, $c)", tx,
+                ("$tn", tenant), ("$h", r.Hour), ("$s", r.SessionId), ("$m", r.Modality), ("$u", r.Surface),
                 ("$v", r.IsVoice ? 1 : 0), ("$r", Resolve(r.Repo, IdentityKind.Repo)),
                 ("$k", Resolve(r.Checkout, IdentityKind.Checkout)),
                 ("$d", ResolveModel(r.Model)), ("$w", r.Wingman ? 1 : 0),
                 ("$t", r.Turns), ("$c", r.Chars));
 
         foreach (var a in batch.AgentRows)
-            Execute("INSERT INTO agent_delta(agent_id, is_voice, turns, chars) VALUES ($a, $v, $t, $c)", tx,
-                ("$a", Resolve(a.Agent, IdentityKind.Agent)), ("$v", a.IsVoice ? 1 : 0), ("$t", a.Turns), ("$c", a.Chars));
+            Execute("INSERT INTO agent_delta(tenant, agent_id, is_voice, turns, chars) VALUES ($tn, $a, $v, $t, $c)", tx,
+                ("$tn", tenant), ("$a", Resolve(a.Agent, IdentityKind.Agent)), ("$v", a.IsVoice ? 1 : 0), ("$t", a.Turns), ("$c", a.Chars));
 
         foreach (var a in batch.AgentDrivenRows)
-            Execute("INSERT INTO agent_driven_delta(agent_id, turns, chars) VALUES ($a, $t, $c)", tx,
-                ("$a", Resolve(a.Agent, IdentityKind.Agent)), ("$t", a.Turns), ("$c", a.Chars));
+            Execute("INSERT INTO agent_driven_delta(tenant, agent_id, turns, chars) VALUES ($tn, $a, $t, $c)", tx,
+                ("$tn", tenant), ("$a", Resolve(a.Agent, IdentityKind.Agent)), ("$t", a.Turns), ("$c", a.Chars));
 
         foreach (var h in batch.HighWater)
-            Execute(@"INSERT INTO session_highwater(session_id, modality, surface, turns, chars)
-                      VALUES ($s, $m, $u, $t, $c)
-                      ON CONFLICT(session_id, modality, surface) DO UPDATE SET turns=$t, chars=$c", tx,
-                ("$s", h.SessionId), ("$m", h.Modality), ("$u", h.Surface), ("$t", h.Turns), ("$c", h.Chars));
+            Execute(@"INSERT INTO session_highwater(tenant, session_id, modality, surface, turns, chars)
+                      VALUES ($tn, $s, $m, $u, $t, $c)
+                      ON CONFLICT(tenant, session_id, modality, surface) DO UPDATE SET turns=$t, chars=$c", tx,
+                ("$tn", tenant), ("$s", h.SessionId), ("$m", h.Modality), ("$u", h.Surface), ("$t", h.Turns), ("$c", h.Chars));
 
         foreach (var h in batch.AgentDrivenHighWater)
-            Execute(@"INSERT INTO agent_driven_highwater(session_id, turns, chars) VALUES ($s, $t, $c)
-                      ON CONFLICT(session_id) DO UPDATE SET turns=$t, chars=$c", tx,
-                ("$s", h.SessionId), ("$t", h.Turns), ("$c", h.Chars));
+            Execute(@"INSERT INTO agent_driven_highwater(tenant, session_id, turns, chars) VALUES ($tn, $s, $t, $c)
+                      ON CONFLICT(tenant, session_id) DO UPDATE SET turns=$t, chars=$c", tx,
+                ("$tn", tenant), ("$s", h.SessionId), ("$t", h.Turns), ("$c", h.Chars));
 
         foreach (var r in batch.TokenRows)
-            Execute(@"INSERT INTO token_delta(hour_utc, model_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
-                      VALUES ($h, $d, $i, $o, $cr, $cc)", tx,
-                ("$h", r.Hour), ("$d", ResolveModel(r.Model)),
+            Execute(@"INSERT INTO token_delta(tenant, hour_utc, model_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
+                      VALUES ($tn, $h, $d, $i, $o, $cr, $cc)", tx,
+                ("$tn", tenant), ("$h", r.Hour), ("$d", ResolveModel(r.Model)),
                 ("$i", r.Input), ("$o", r.Output), ("$cr", r.CacheRead), ("$cc", r.CacheCreation));
 
         foreach (var h in batch.TokenHighWater)
-            Execute(@"INSERT INTO token_highwater(session_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
-                      VALUES ($s, $i, $o, $cr, $cc)
-                      ON CONFLICT(session_id) DO UPDATE SET input_tokens=$i, output_tokens=$o, cache_read_tokens=$cr, cache_creation_tokens=$cc", tx,
-                ("$s", h.SessionId), ("$i", h.Input), ("$o", h.Output), ("$cr", h.CacheRead), ("$cc", h.CacheCreation));
+            Execute(@"INSERT INTO token_highwater(tenant, session_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
+                      VALUES ($tn, $s, $i, $o, $cr, $cc)
+                      ON CONFLICT(tenant, session_id) DO UPDATE SET input_tokens=$i, output_tokens=$o, cache_read_tokens=$cr, cache_creation_tokens=$cc", tx,
+                ("$tn", tenant), ("$s", h.SessionId), ("$i", h.Input), ("$o", h.Output), ("$cr", h.CacheRead), ("$cc", h.CacheCreation));
 
         foreach (var sid in batch.NewWingmanSessions)
-            Execute("INSERT OR IGNORE INTO wingman_session(session_id) VALUES ($s)", tx, ("$s", sid));
+            Execute("INSERT OR IGNORE INTO wingman_session(tenant, session_id) VALUES ($tn, $s)", tx, ("$tn", tenant), ("$s", sid));
 
         foreach (var sid in batch.NewSeeded)
-            Execute("INSERT OR IGNORE INTO agents_seeded(session_id) VALUES ($s)", tx, ("$s", sid));
+            Execute("INSERT OR IGNORE INTO agents_seeded(tenant, session_id) VALUES ($tn, $s)", tx, ("$tn", tenant), ("$s", sid));
 
         foreach (var (display, sessionId, kind) in batch.NewIdentitySessions)
         {
@@ -686,48 +776,53 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
         tx.Commit();
 
-        // ---- Committed. Only now does the mirror move. ----
-        if (batch.StampAgentsSince is not null) _agentsSinceUtc = batch.StampAgentsSince;
+        // ---- Committed. Only now does the mirror move. Every advance is keyed by the batch's tenant. ----
+        if (batch.StampAgentsSince is not null) _agentsSinceUtc[batch.Tenant] = batch.StampAgentsSince;
         foreach (var (kind, minted) in newIds)
-            foreach (var (d, id) in minted) { IdsFor(kind)[d] = id; DisplayFor(kind)[id] = d; }
+            foreach (var (d, id) in minted) { IdsFor(batch.Tenant, kind)[d] = id; DisplayFor(kind)[id] = d; }
         foreach (var h in batch.HighWater)
         {
-            if (!_highWater.TryGetValue(h.SessionId, out var hw))
+            var key = (batch.Tenant, h.SessionId);
+            if (!_highWater.TryGetValue(key, out var hw))
             {
                 hw = new Dictionary<(string, string), Counters>();
-                _highWater[h.SessionId] = hw;
+                _highWater[key] = hw;
             }
             hw[(h.Modality, h.Surface)] = new Counters { Turns = h.Turns, Characters = h.Chars };
         }
         foreach (var h in batch.AgentDrivenHighWater)
-            _agentDrivenHighWater[h.SessionId] = new Counters { Turns = h.Turns, Characters = h.Chars };
+            _agentDrivenHighWater[(batch.Tenant, h.SessionId)] = new Counters { Turns = h.Turns, Characters = h.Chars };
         foreach (var h in batch.TokenHighWater)
-            _tokenHighWater[h.SessionId] = new TokenCounters
+            _tokenHighWater[(batch.Tenant, h.SessionId)] = new TokenCounters
             {
                 Input = h.Input, Output = h.Output, CacheRead = h.CacheRead, CacheCreation = h.CacheCreation,
             };
-        foreach (var sid in batch.NewWingmanSessions) _wingmanSessions.Add(sid);
-        foreach (var sid in batch.NewSeeded) _agentsSeeded.Add(sid);
+        foreach (var sid in batch.NewWingmanSessions) _wingmanSessions.Add((batch.Tenant, sid));
+        foreach (var sid in batch.NewSeeded) _agentsSeeded.Add((batch.Tenant, sid));
         foreach (var (display, sessionId, kind) in batch.NewIdentitySessions)
-            SessionsFor(kind).Add((IdsFor(kind)[display], sessionId));
+            SessionsFor(kind).Add((IdsFor(batch.Tenant, kind)[display], sessionId));
     }
 
     /// <summary>
     /// Forget a removed session's high-water entry. Its contribution stays in the totals (it was folded in
     /// as it happened); dropping the high-water entry just stops the map growing without bound.
     /// </summary>
-    public void Forget(string? sessionId)
+    public void Forget(string? sessionId, TenantId? tenant = null)
     {
         if (string.IsNullOrEmpty(sessionId)) return;
+        var t = RequireTenant(tenant);
         lock (_lock)
         {
+            // Scoped to (tenant, session id) (MTR-08): forgetting one tenant's session must not drop another
+            // tenant's high-water for the same bare session id.
+            //
             // The token high-water is cleaned up on its own, not under the session_highwater guard: a session
             // has both, and dropping only one would leave the other's map growing without bound. Each is
             // removed only if present, so forgetting a session that never spent a token is still a no-op.
-            if (_highWater.Remove(sessionId))
-                Execute("DELETE FROM session_highwater WHERE session_id=$s", null, ("$s", sessionId));
-            if (_tokenHighWater.Remove(sessionId))
-                Execute("DELETE FROM token_highwater WHERE session_id=$s", null, ("$s", sessionId));
+            if (_highWater.Remove((t, sessionId)))
+                Execute("DELETE FROM session_highwater WHERE tenant=$tn AND session_id=$s", null, ("$tn", t.Value), ("$s", sessionId));
+            if (_tokenHighWater.Remove((t, sessionId)))
+                Execute("DELETE FROM token_highwater WHERE tenant=$tn AND session_id=$s", null, ("$tn", t.Value), ("$s", sessionId));
         }
     }
 
@@ -752,11 +847,15 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         // SQLite groups NULLs together, so every unknown-model row of a bucket archives into ONE row that is
         // still honestly NULL. That is the wanted behaviour: absence aggregates as absence. (checkout_id is
         // never NULL on a row this build wrote, but it rides the same fold for the same reason.)
-        Execute(@"INSERT INTO stat_delta(hour_utc, session_id, modality, surface, is_voice, repo_id, checkout_id, model_id, wingman, turns, chars)
-                  SELECT $marker, $marker, modality, surface, is_voice, repo_id, checkout_id, model_id, wingman, SUM(turns), SUM(chars)
+        // MTR-08: tenant is carried through the archive fold in BOTH the SELECT and the GROUP BY, exactly as
+        // model_id and checkout_id are - left out of either, a pruned tenant's turns would either read the
+        // wrong tenant or collapse across tenants ninety days later. Each tenant's departing rows fold into
+        // that tenant's own archive row.
+        Execute(@"INSERT INTO stat_delta(tenant, hour_utc, session_id, modality, surface, is_voice, repo_id, checkout_id, model_id, wingman, turns, chars)
+                  SELECT tenant, $marker, $marker, modality, surface, is_voice, repo_id, checkout_id, model_id, wingman, SUM(turns), SUM(chars)
                     FROM stat_delta
                    WHERE hour_utc <> $marker AND hour_utc < $cutoff
-                   GROUP BY modality, surface, is_voice, repo_id, checkout_id, model_id, wingman", tx,
+                   GROUP BY tenant, modality, surface, is_voice, repo_id, checkout_id, model_id, wingman", tx,
             ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
         Execute("DELETE FROM stat_delta WHERE hour_utc <> $marker AND hour_utc < $cutoff", tx,
             ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
@@ -765,11 +864,11 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         // both the SELECT and the GROUP BY, or the ninety-day fold turns every archived model's spend into
         // "model unknown". Its all-time totals INCLUDE archive rows (that is the point of archiving), so the
         // spend must not shrink when detail is pruned.
-        Execute(@"INSERT INTO token_delta(hour_utc, model_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
-                  SELECT $marker, model_id, SUM(input_tokens), SUM(output_tokens), SUM(cache_read_tokens), SUM(cache_creation_tokens)
+        Execute(@"INSERT INTO token_delta(tenant, hour_utc, model_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
+                  SELECT tenant, $marker, model_id, SUM(input_tokens), SUM(output_tokens), SUM(cache_read_tokens), SUM(cache_creation_tokens)
                     FROM token_delta
                    WHERE hour_utc <> $marker AND hour_utc < $cutoff
-                   GROUP BY model_id", tx,
+                   GROUP BY tenant, model_id", tx,
             ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
         Execute("DELETE FROM token_delta WHERE hour_utc <> $marker AND hour_utc < $cutoff", tx,
             ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
@@ -780,33 +879,35 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     /// volume. NOT part of the human totals: this is the fleet driving itself, which is a different
     /// question from how the owner drives.
     /// </summary>
-    public (long Turns, long Characters) AgentDrivenUsage()
+    public (long Turns, long Characters) AgentDrivenUsage(TenantId? tenant = null)
     {
+        var t = RequireTenant(tenant);
         lock (_lock)
         {
             long turns = 0, chars = 0;
-            Read("SELECT COALESCE(SUM(turns),0), COALESCE(SUM(chars),0) FROM agent_driven_delta",
-                r => { turns = r.GetInt64(0); chars = r.GetInt64(1); });
+            Read("SELECT COALESCE(SUM(turns),0), COALESCE(SUM(chars),0) FROM agent_driven_delta WHERE tenant=$tn",
+                r => { turns = r.GetInt64(0); chars = r.GetInt64(1); }, ("$tn", t.Value));
             return (turns, chars);
         }
     }
 
     /// <summary>An immutable snapshot of the all-time totals for the dashboard, buckets in a stable order.</summary>
-    public InputStatsDto CurrentTotals()
+    public InputStatsDto CurrentTotals(TenantId? tenant = null)
     {
+        var t = RequireTenant(tenant);
         lock (_lock)
         {
             var rows = new List<InputStatBucketDto>();
             // ARCHIVE rows are INCLUDED - that is the point of archiving: an all-time total must not shrink
-            // when the hourly detail behind it is pruned.
-            Read(@"SELECT modality, surface, SUM(turns), SUM(chars) FROM stat_delta GROUP BY modality, surface", r =>
+            // when the hourly detail behind it is pruned. Scoped to the request tenant (MTR-08).
+            Read(@"SELECT modality, surface, SUM(turns), SUM(chars) FROM stat_delta WHERE tenant=$tn GROUP BY modality, surface", r =>
                 rows.Add(new InputStatBucketDto
                 {
                     Modality = r.GetString(0),
                     Surface = r.GetString(1),
                     Turns = r.GetInt64(2),
                     Characters = r.GetInt64(3),
-                }));
+                }), ("$tn", t.Value));
 
             var dto = new InputStatsDto();
             // Ordered in C#, ordinal - the comparer the original projection used.
@@ -819,33 +920,36 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
     /// <summary>All-time wingman usage: the number of submitted turns folded while a session had voice mode
     /// on, and the count of distinct sessions ever seen with voice mode on.</summary>
-    public WingmanUsageDto WingmanUsage()
+    public WingmanUsageDto WingmanUsage(TenantId? tenant = null)
     {
+        var t = RequireTenant(tenant);
         lock (_lock)
         {
             // SUM(turns) WHERE wingman=1 - never anything keyed on modality. A turn TYPED while voice mode
-            // was on is a wingman turn.
-            var turns = ScalarLong("SELECT COALESCE(SUM(turns),0) FROM stat_delta WHERE wingman=1");
-            var sessions = ScalarLong("SELECT COUNT(*) FROM wingman_session");
+            // was on is a wingman turn. Both halves scoped to the request tenant (MTR-08).
+            var turns = ExecuteScalarLong("SELECT COALESCE(SUM(turns),0) FROM stat_delta WHERE tenant=$tn AND wingman=1", null, ("$tn", t.Value));
+            var sessions = ExecuteScalarLong("SELECT COUNT(*) FROM wingman_session WHERE tenant=$tn", null, ("$tn", t.Value));
             return new WingmanUsageDto { Turns = turns, Sessions = (int)sessions };
         }
     }
 
     /// <summary>The per-hour turn log (the "working day" series: turns by modality and character volume per
     /// UTC clock hour), oldest hour first.</summary>
-    public IReadOnlyList<InputHourDto> HourlyTurns()
+    public IReadOnlyList<InputHourDto> HourlyTurns(TenantId? tenant = null)
     {
+        var t = RequireTenant(tenant);
         lock (_lock)
         {
             var list = new List<InputHourDto>();
             // ARCHIVE rows are EXCLUDED: they are real all-time data with no real hour, so letting them
-            // through would invent a bucket in this series that was never an hour of the working day.
+            // through would invent a bucket in this series that was never an hour of the working day. Scoped
+            // to the request tenant (MTR-08).
             Read(@"SELECT hour_utc,
                           COALESCE(SUM(CASE WHEN is_voice = 1 THEN turns ELSE 0 END), 0),
                           COALESCE(SUM(CASE WHEN is_voice = 0 THEN turns ELSE 0 END), 0),
                           SUM(chars)
                      FROM stat_delta
-                    WHERE hour_utc <> $marker
+                    WHERE tenant = $tn AND hour_utc <> $marker
                     GROUP BY hour_utc", r =>
             {
                 var voice = r.GetInt64(1);
@@ -858,7 +962,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                     Turns = voice + typed,
                     Characters = r.GetInt64(3),
                 });
-            }, ("$marker", GatewayStatsDatabase.ArchiveMarker));
+            }, ("$tn", t.Value), ("$marker", GatewayStatsDatabase.ArchiveMarker));
             list.Sort((a, b) => string.CompareOrdinal(a.Hour, b.Hour));
             return list;
         }
@@ -866,10 +970,13 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
     /// <summary>The per-repository all-time tally (turns by modality, character volume, distinct sessions),
     /// ranked most-driven first, for the private Repos page. Repos with no counted turns are omitted.</summary>
-    public IReadOnlyList<RepoStatBucketDto> RepoTotals()
+    public IReadOnlyList<RepoStatBucketDto> RepoTotals(TenantId? tenant = null)
     {
+        var t = RequireTenant(tenant);
         lock (_lock)
         {
+            // SessionCounts groups by repo_id, which is tenant-specific, so only this tenant's repo ids (read
+            // from the tenant-filtered stat_delta below) are ever looked up out of it (MTR-08).
             var sessions = SessionCounts("repo_session", "repo_id");
 
             // The local checkouts (worktrees, per-machine clones) that rolled up into each repository, kept so
@@ -877,7 +984,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
             // lost when the repo name collapses them. Display spellings come from the identity mirror, never from a
             // SQL join; sorted here so the retained list is stable rather than in row-insert order.
             var checkoutsByRepo = new Dictionary<long, List<string>>();
-            Read("SELECT DISTINCT repo_id, checkout_id FROM stat_delta WHERE checkout_id IS NOT NULL", r =>
+            Read("SELECT DISTINCT repo_id, checkout_id FROM stat_delta WHERE tenant=$tn AND checkout_id IS NOT NULL", r =>
             {
                 var repoId = r.GetInt64(0);
                 var checkoutId = r.GetInt64(1);
@@ -885,7 +992,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                 if (!checkoutsByRepo.TryGetValue(repoId, out var paths))
                     checkoutsByRepo[repoId] = paths = new List<string>();
                 paths.Add(path);
-            });
+            }, ("$tn", t.Value));
             foreach (var paths in checkoutsByRepo.Values)
                 paths.Sort(StringComparer.OrdinalIgnoreCase);
 
@@ -894,7 +1001,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                           COALESCE(SUM(CASE WHEN is_voice = 1 THEN turns ELSE 0 END), 0),
                           COALESCE(SUM(CASE WHEN is_voice = 0 THEN turns ELSE 0 END), 0),
                           SUM(chars)
-                     FROM stat_delta GROUP BY repo_id", r =>
+                     FROM stat_delta WHERE tenant=$tn GROUP BY repo_id", r =>
             {
                 var id = r.GetInt64(0);
                 var voice = r.GetInt64(1);
@@ -913,7 +1020,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                     Sessions = sessions.TryGetValue(id, out var n) ? n : 0,
                     Checkouts = checkoutsByRepo.TryGetValue(id, out var cks) ? cks : new List<string>(),
                 });
-            });
+            }, ("$tn", t.Value));
             // Ranked in C#, matching the original ordering exactly.
             list.Sort((a, b) =>
             {
@@ -928,8 +1035,9 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
     /// <summary>The per-agent all-time tally (turns by modality, character volume, distinct sessions),
     /// ranked most-driven first, for the private Agents page.</summary>
-    public IReadOnlyList<AgentStatBucketDto> AgentTotals()
+    public IReadOnlyList<AgentStatBucketDto> AgentTotals(TenantId? tenant = null)
     {
+        var t = RequireTenant(tenant);
         lock (_lock)
         {
             var sessions = SessionCounts("agent_session", "agent_id");
@@ -939,18 +1047,22 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                           COALESCE(SUM(CASE WHEN is_voice = 1 THEN turns ELSE 0 END), 0),
                           COALESCE(SUM(CASE WHEN is_voice = 0 THEN turns ELSE 0 END), 0),
                           SUM(chars)
-                     FROM agent_delta GROUP BY agent_id",
-                r => human[r.GetInt64(0)] = (r.GetInt64(1), r.GetInt64(2), r.GetInt64(3)));
+                     FROM agent_delta WHERE tenant=$tn GROUP BY agent_id",
+                r => human[r.GetInt64(0)] = (r.GetInt64(1), r.GetInt64(2), r.GetInt64(3)), ("$tn", t.Value));
 
             var driven = new Dictionary<long, (long Turns, long Chars)>();
-            Read("SELECT agent_id, SUM(turns), SUM(chars) FROM agent_driven_delta GROUP BY agent_id",
-                r => driven[r.GetInt64(0)] = (r.GetInt64(1), r.GetInt64(2)));
+            Read("SELECT agent_id, SUM(turns), SUM(chars) FROM agent_driven_delta WHERE tenant=$tn GROUP BY agent_id",
+                r => driven[r.GetInt64(0)] = (r.GetInt64(1), r.GetInt64(2)), ("$tn", t.Value));
 
             // Every agent EVER attributed appears, including one registered with no turns - the original
             // creates the tally entry on attribution regardless, so the page describes the agents actually
-            // being run rather than only those that submitted a turn in the window.
+            // being run rather than only those that submitted a turn in the window. Iterate THIS TENANT'S
+            // identity map (MTR-08), not the global id->display: iterating the global map would list every
+            // other tenant's agents (each as a zero-turn row) - a cross-tenant leak of who runs what. The
+            // per-tenant map holds exactly the ids this tenant minted, so both the zero-turn agents and the
+            // active ones are its own.
             var list = new List<AgentStatBucketDto>();
-            foreach (var (id, display) in _agentDisplay)
+            foreach (var (display, id) in IdsFor(t, IdentityKind.Agent))
             {
                 human.TryGetValue(id, out var h);
                 driven.TryGetValue(id, out var d);
@@ -985,10 +1097,12 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         return counts;
     }
 
-    /// <summary>When the per-agent tally started counting (round-trip UTC), or "" if never stamped.</summary>
-    public string AgentsSinceUtc
+    /// <summary>When the per-agent tally started counting for <paramref name="tenant"/> (round-trip UTC), or
+    /// "" if that tenant has never folded (MTR-08: the window is per tenant).</summary>
+    public string AgentsSinceUtc(TenantId? tenant = null)
     {
-        get { lock (_lock) { return _agentsSinceUtc; } }
+        var t = RequireTenant(tenant);
+        lock (_lock) { return _agentsSinceUtc.TryGetValue(t, out var v) ? v : ""; }
     }
 
     /// <summary>
@@ -1013,18 +1127,20 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     /// count of sessions here would be a number that looks like the neighbouring ones and means something
     /// weaker, so it is absent rather than approximated.
     /// </summary>
-    public IReadOnlyList<ModelStatBucketDto> ModelTotals()
+    public IReadOnlyList<ModelStatBucketDto> ModelTotals(TenantId? tenant = null)
     {
+        var t = RequireTenant(tenant);
         lock (_lock)
         {
             var list = new List<ModelStatBucketDto>();
             // Archive rows are INCLUDED - the marker convention only excludes them from hourly and
             // working-day series, and an all-time tally that dropped them would shrink as history is pruned.
+            // Scoped to the request tenant (MTR-08).
             Read(@"SELECT model_id,
                           COALESCE(SUM(CASE WHEN is_voice = 1 THEN turns ELSE 0 END), 0),
                           COALESCE(SUM(CASE WHEN is_voice = 0 THEN turns ELSE 0 END), 0),
                           SUM(chars)
-                     FROM stat_delta GROUP BY model_id", r =>
+                     FROM stat_delta WHERE tenant=$tn GROUP BY model_id", r =>
             {
                 var voice = r.GetInt64(1);
                 var typed = r.GetInt64(2);
@@ -1042,7 +1158,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                     TypedTurns = typed,
                     Characters = r.GetInt64(3),
                 });
-            });
+            }, ("$tn", t.Value));
             // Ranked in C#, matching the repository and agent tallies. The null bucket sorts by its numbers
             // like any other and is deliberately not pinned anywhere: it is a bucket, not a footnote.
             list.Sort((a, b) =>
@@ -1062,20 +1178,21 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     /// all-time figure that dropped them would shrink as history is pruned. No context occupancy here; it is
     /// not spend and was never stored.
     /// </summary>
-    public TokenSpendDto TokenSpend()
+    public TokenSpendDto TokenSpend(TenantId? tenant = null)
     {
+        var t = RequireTenant(tenant);
         lock (_lock)
         {
             var dto = new TokenSpendDto();
             Read(@"SELECT COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
                           COALESCE(SUM(cache_read_tokens),0), COALESCE(SUM(cache_creation_tokens),0)
-                     FROM token_delta", r =>
+                     FROM token_delta WHERE tenant=$tn", r =>
             {
                 dto.InputTokens = r.GetInt64(0);
                 dto.OutputTokens = r.GetInt64(1);
                 dto.CacheReadTokens = r.GetInt64(2);
                 dto.CacheCreationTokens = r.GetInt64(3);
-            });
+            }, ("$tn", t.Value));
             return dto;
         }
     }
@@ -1085,8 +1202,9 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     /// archive marker, exactly as the hourly turn series does: an archive row is not a real hour and would
     /// grow a phantom bucket. Ordered by hour.
     /// </summary>
-    public IReadOnlyList<TokenHourDto> TokenSpendByHour()
+    public IReadOnlyList<TokenHourDto> TokenSpendByHour(TenantId? tenant = null)
     {
+        var t = RequireTenant(tenant);
         lock (_lock)
         {
             var list = new List<TokenHourDto>();
@@ -1094,7 +1212,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                           COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
                           COALESCE(SUM(cache_read_tokens),0), COALESCE(SUM(cache_creation_tokens),0)
                      FROM token_delta
-                    WHERE hour_utc <> $marker
+                    WHERE tenant=$tn AND hour_utc <> $marker
                     GROUP BY hour_utc", r => list.Add(new TokenHourDto
             {
                 Hour = r.GetString(0),
@@ -1102,7 +1220,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                 OutputTokens = r.GetInt64(2),
                 CacheReadTokens = r.GetInt64(3),
                 CacheCreationTokens = r.GetInt64(4),
-            }), ("$marker", GatewayStatsDatabase.ArchiveMarker));
+            }), ("$tn", t.Value), ("$marker", GatewayStatsDatabase.ArchiveMarker));
             list.Sort((a, b) => string.CompareOrdinal(a.Hour, b.Hour));
             return list;
         }
@@ -1113,15 +1231,16 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     /// archive rows. The null-model bucket is a REAL bucket - spend folded before the session's model was
     /// recorded - and is reported, not filtered, so the per-model spend sums to the all-time total.
     /// </summary>
-    public IReadOnlyList<ModelSpendDto> TokenSpendByModel()
+    public IReadOnlyList<ModelSpendDto> TokenSpendByModel(TenantId? tenant = null)
     {
+        var t = RequireTenant(tenant);
         lock (_lock)
         {
             var list = new List<ModelSpendDto>();
             Read(@"SELECT model_id,
                           COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
                           COALESCE(SUM(cache_read_tokens),0), COALESCE(SUM(cache_creation_tokens),0)
-                     FROM token_delta GROUP BY model_id", r =>
+                     FROM token_delta WHERE tenant=$tn GROUP BY model_id", r =>
             {
                 // A null model_id is the "not recorded" bucket and stays null to the page; the display
                 // spelling comes from the identity mirror, never a SQL join over the string.
@@ -1136,7 +1255,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                     CacheReadTokens = r.GetInt64(3),
                     CacheCreationTokens = r.GetInt64(4),
                 });
-            });
+            }, ("$tn", t.Value));
             list.Sort((a, b) =>
             {
                 var byTotal = b.TotalTokens.CompareTo(a.TotalTokens);
@@ -1204,8 +1323,6 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         StatementsExecuted++;
         while (reader.Read()) onRow(reader);
     }
-
-    private long ScalarLong(string sql) => ExecuteScalarLong(sql, null);
 
     private string? ReadScalarString(string sql, params (string Name, object Value)[] args)
     {

--- a/src/CcDirector.Gateway/Stats/GatewaySessionConcurrencyStats.cs
+++ b/src/CcDirector.Gateway/Stats/GatewaySessionConcurrencyStats.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -25,6 +26,13 @@ namespace CcDirector.Gateway.Stats;
 /// Weekly max (or any window) is DERIVED from the hourly log. Persisted (atomic temp-write + rename,
 /// corrupt file quarantined); hourly buckets past the retention window are pruned so the store stays
 /// bounded.
+///
+/// MTR-08 (production-readiness census rows 49-67): every peak, hour bucket and current-hour dedup set is
+/// kept PER TENANT. The /sessions roster is assembled per request tenant, so the concurrency it folds
+/// belongs to one tenant; keeping the peaks per tenant means one account's "how many at once" can never mix
+/// with another's. On the single-tenant self host there is exactly one tenant (<see cref="TenantId.Local"/>)
+/// and the on-disk shape is the same numbers it always held, now under one tenant key. The dashboard that
+/// reads a snapshot is refused in whole on hosted (issue #1848), so a reader here only ever runs for Local.
 /// </summary>
 public sealed class GatewaySessionConcurrencyStats
 {
@@ -32,25 +40,36 @@ public sealed class GatewaySessionConcurrencyStats
     private const int RetentionDays = 90;
     private const string HourFormat = "yyyy-MM-ddTHH";
 
+    /// <summary>The on-disk envelope version. 1 = the pre-tenant single-object shape (migrated to the local
+    /// tenant on load); 2 = the per-tenant shape written from here on.</summary>
+    private const int StoreVersion = 2;
+
     private readonly string _path;
     private readonly object _lock = new();
 
-    private int _liveCurrent;
-    private int _workingCurrent;
-    private int _liveAllTimeMax;
-    private DateTime? _liveAllTimeMaxAtUtc;
-    private int _workingAllTimeMax;
-    private DateTime? _workingAllTimeMaxAtUtc;
+    // Per tenant (MTR-08). Created on first observation of a tenant; the whole of the pre-tenant state now
+    // lives inside one of these.
+    private readonly Dictionary<TenantId, TenantState> _tenants = new();
 
-    // Per-hour log, keyed by UTC clock hour.
-    private readonly Dictionary<string, HourStat> _hours = new(StringComparer.Ordinal);
+    private sealed class TenantState
+    {
+        public int LiveCurrent;
+        public int WorkingCurrent;
+        public int LiveAllTimeMax;
+        public DateTime? LiveAllTimeMaxAtUtc;
+        public int WorkingAllTimeMax;
+        public DateTime? WorkingAllTimeMaxAtUtc;
 
-    // Dedup sets for the CURRENT hour only, so distinct counts are correct across many observations. Rolled
-    // when the clock hour changes; persisted so a restart mid-hour resumes the same hour's dedup.
-    private string _currentHourKey = "";
-    private readonly HashSet<string> _curSessions = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _curMachines = new(StringComparer.OrdinalIgnoreCase);
-    private readonly HashSet<string> _curRepos = new(StringComparer.OrdinalIgnoreCase);
+        // Per-hour log, keyed by UTC clock hour.
+        public readonly Dictionary<string, HourStat> Hours = new(StringComparer.Ordinal);
+
+        // Dedup sets for the CURRENT hour only, so distinct counts are correct across many observations.
+        // Rolled when the clock hour changes; persisted so a restart mid-hour resumes the same hour's dedup.
+        public string CurrentHourKey = "";
+        public readonly HashSet<string> CurSessions = new(StringComparer.Ordinal);
+        public readonly HashSet<string> CurMachines = new(StringComparer.OrdinalIgnoreCase);
+        public readonly HashSet<string> CurRepos = new(StringComparer.OrdinalIgnoreCase);
+    }
 
     private sealed class HourStat
     {
@@ -74,24 +93,47 @@ public sealed class GatewaySessionConcurrencyStats
     private static string HourKey(DateTime utc) =>
         utc.ToUniversalTime().ToString(HourFormat, CultureInfo.InvariantCulture);
 
+    // Resolve the tenant a producer or reader supplied. Null is the self-host / unit-test default (Local); an
+    // explicitly-passed tenant must be valid - an invalid one is a DENY, never silently defaulted.
+    private static TenantId RequireTenant(TenantId? tenant)
+    {
+        if (tenant is not { } t) return TenantId.Local;
+        if (!t.IsValid) throw new ArgumentException("a valid tenant is required", nameof(tenant));
+        return t;
+    }
+
+    private TenantState StateFor(TenantId tenant)
+    {
+        if (!_tenants.TryGetValue(tenant, out var st))
+        {
+            st = new TenantState();
+            _tenants[tenant] = st;
+        }
+        return st;
+    }
+
     /// <summary>
-    /// Observe the current fleet <paramref name="roster"/> at <paramref name="nowUtc"/>: update the live and
-    /// working current values and all-time peaks, and fold this hour's max concurrency plus its distinct
-    /// session / machine / repository counts. Idempotent within an hour - a peak or distinct count only ever
-    /// grows - so folding on every /sessions read captures the hourly log without inflating anything.
+    /// Observe the current fleet <paramref name="roster"/> for <paramref name="tenant"/> at
+    /// <paramref name="nowUtc"/>: update that tenant's live and working current values and all-time peaks, and
+    /// fold this hour's max concurrency plus its distinct session / machine / repository counts. Idempotent
+    /// within an hour - a peak or distinct count only ever grows - so folding on every /sessions read captures
+    /// the hourly log without inflating anything. Defaults to <see cref="TenantId.Local"/> for the self-host
+    /// shape and the unit-test default; the production /sessions path passes the request tenant.
     /// </summary>
-    public void Observe(IReadOnlyCollection<SessionDto>? roster, DateTime nowUtc)
+    public void Observe(IReadOnlyCollection<SessionDto>? roster, DateTime nowUtc, TenantId? tenant = null)
     {
         if (roster is null) return;
+        var t = RequireTenant(tenant);
         var key = HourKey(nowUtc);
         lock (_lock)
         {
-            if (key != _currentHourKey)
+            var st = StateFor(t);
+            if (key != st.CurrentHourKey)
             {
-                _currentHourKey = key;
-                _curSessions.Clear();
-                _curMachines.Clear();
-                _curRepos.Clear();
+                st.CurrentHourKey = key;
+                st.CurSessions.Clear();
+                st.CurMachines.Clear();
+                st.CurRepos.Clear();
             }
 
             var liveCount = 0;
@@ -101,49 +143,55 @@ public sealed class GatewaySessionConcurrencyStats
                 if (string.Equals(s.ActivityState, "Exited", StringComparison.OrdinalIgnoreCase)) continue;
                 liveCount++;
                 if (string.Equals(s.ActivityState, "Working", StringComparison.OrdinalIgnoreCase)) workingCount++;
-                if (!string.IsNullOrEmpty(s.SessionId)) _curSessions.Add(s.SessionId);
-                if (!string.IsNullOrWhiteSpace(s.MachineName)) _curMachines.Add(s.MachineName);
-                if (!string.IsNullOrWhiteSpace(s.RepoPath)) _curRepos.Add(s.RepoPath);
+                if (!string.IsNullOrEmpty(s.SessionId)) st.CurSessions.Add(s.SessionId);
+                if (!string.IsNullOrWhiteSpace(s.MachineName)) st.CurMachines.Add(s.MachineName);
+                if (!string.IsNullOrWhiteSpace(s.RepoPath)) st.CurRepos.Add(s.RepoPath);
             }
 
-            _liveCurrent = liveCount;
-            _workingCurrent = workingCount;
+            st.LiveCurrent = liveCount;
+            st.WorkingCurrent = workingCount;
 
             var changed = false;
-            if (liveCount > _liveAllTimeMax) { _liveAllTimeMax = liveCount; _liveAllTimeMaxAtUtc = nowUtc; changed = true; }
-            if (workingCount > _workingAllTimeMax) { _workingAllTimeMax = workingCount; _workingAllTimeMaxAtUtc = nowUtc; changed = true; }
+            if (liveCount > st.LiveAllTimeMax) { st.LiveAllTimeMax = liveCount; st.LiveAllTimeMaxAtUtc = nowUtc; changed = true; }
+            if (workingCount > st.WorkingAllTimeMax) { st.WorkingAllTimeMax = workingCount; st.WorkingAllTimeMaxAtUtc = nowUtc; changed = true; }
 
-            if (!_hours.TryGetValue(key, out var h))
+            if (!st.Hours.TryGetValue(key, out var h))
             {
                 h = new HourStat();
-                _hours[key] = h;
+                st.Hours[key] = h;
                 changed = true;
             }
             if (liveCount > h.MaxLive) { h.MaxLive = liveCount; changed = true; }
             if (workingCount > h.MaxWorking) { h.MaxWorking = workingCount; changed = true; }
-            if (_curSessions.Count > h.DistinctSessions) { h.DistinctSessions = _curSessions.Count; changed = true; }
-            if (_curMachines.Count > h.DistinctMachines) { h.DistinctMachines = _curMachines.Count; changed = true; }
-            if (_curRepos.Count > h.DistinctRepos) { h.DistinctRepos = _curRepos.Count; changed = true; }
+            if (st.CurSessions.Count > h.DistinctSessions) { h.DistinctSessions = st.CurSessions.Count; changed = true; }
+            if (st.CurMachines.Count > h.DistinctMachines) { h.DistinctMachines = st.CurMachines.Count; changed = true; }
+            if (st.CurRepos.Count > h.DistinctRepos) { h.DistinctRepos = st.CurRepos.Count; changed = true; }
 
             if (changed)
             {
-                PruneLocked(nowUtc);
+                PruneLocked(st, nowUtc);
                 Save();
             }
         }
     }
 
-    /// <summary>A read-only snapshot for the dashboard / agent API: the live and working series (current,
-    /// all-time peak, derived weekly max) and the full hourly log.</summary>
-    public ConcurrencySnapshot Snapshot(DateTime nowUtc)
+    /// <summary>A read-only snapshot for the dashboard / agent API for <paramref name="tenant"/>: the live and
+    /// working series (current, all-time peak, derived weekly max) and the full hourly log. An unseen tenant
+    /// returns an all-zero snapshot with no hours (MTR-08).</summary>
+    public ConcurrencySnapshot Snapshot(DateTime nowUtc, TenantId? tenant = null)
     {
+        var t = RequireTenant(tenant);
         lock (_lock)
         {
+            if (!_tenants.TryGetValue(t, out var st))
+                return new ConcurrencySnapshot(
+                    new ConcurrencySeriesDto(), new ConcurrencySeriesDto(), Array.Empty<ConcurrencyHourDto>());
+
             var weeklyCutoff = nowUtc.AddDays(-7);
             var liveWeekly = 0;
             var workingWeekly = 0;
-            var hourly = new List<ConcurrencyHourDto>(_hours.Count);
-            foreach (var kvp in _hours)
+            var hourly = new List<ConcurrencyHourDto>(st.Hours.Count);
+            foreach (var kvp in st.Hours)
             {
                 var h = kvp.Value;
                 hourly.Add(new ConcurrencyHourDto
@@ -163,17 +211,17 @@ public sealed class GatewaySessionConcurrencyStats
             }
             hourly.Sort((a, b) => string.CompareOrdinal(a.Hour, b.Hour));
             return new ConcurrencySnapshot(
-                new ConcurrencySeriesDto { Current = _liveCurrent, AllTimeMax = _liveAllTimeMax, AllTimeMaxAtUtc = _liveAllTimeMaxAtUtc, WeeklyMax = liveWeekly },
-                new ConcurrencySeriesDto { Current = _workingCurrent, AllTimeMax = _workingAllTimeMax, AllTimeMaxAtUtc = _workingAllTimeMaxAtUtc, WeeklyMax = workingWeekly },
+                new ConcurrencySeriesDto { Current = st.LiveCurrent, AllTimeMax = st.LiveAllTimeMax, AllTimeMaxAtUtc = st.LiveAllTimeMaxAtUtc, WeeklyMax = liveWeekly },
+                new ConcurrencySeriesDto { Current = st.WorkingCurrent, AllTimeMax = st.WorkingAllTimeMax, AllTimeMaxAtUtc = st.WorkingAllTimeMaxAtUtc, WeeklyMax = workingWeekly },
                 hourly);
         }
     }
 
-    private void PruneLocked(DateTime nowUtc)
+    private void PruneLocked(TenantState st, DateTime nowUtc)
     {
         var cutoff = nowUtc.AddDays(-RetentionDays);
-        var stale = _hours.Keys.Where(k => TryParseHour(k, out var dt) && dt < cutoff).ToList();
-        foreach (var k in stale) _hours.Remove(k);
+        var stale = st.Hours.Keys.Where(k => TryParseHour(k, out var dt) && dt < cutoff).ToList();
+        foreach (var k in stale) st.Hours.Remove(k);
     }
 
     private static bool TryParseHour(string key, out DateTime utc) =>
@@ -189,7 +237,9 @@ public sealed class GatewaySessionConcurrencyStats
         public int DistinctRepos { get; set; }
     }
 
-    private sealed class StoreFile
+    // One tenant's persisted state. This is EXACTLY the pre-tenant StoreFile shape, so a version-1 file (which
+    // held one of these at the root) is read straight into the local tenant's slot with no field remapping.
+    private sealed class TenantStoreFile
     {
         public int LiveAllTimeMax { get; set; }
         public DateTime? LiveAllTimeMaxAtUtc { get; set; }
@@ -202,6 +252,13 @@ public sealed class GatewaySessionConcurrencyStats
         public List<string> CurrentRepos { get; set; } = new();
     }
 
+    // The version-2 envelope: the version tag plus one TenantStoreFile per tenant.
+    private sealed class StoreEnvelope
+    {
+        public int Version { get; set; }
+        public Dictionary<string, TenantStoreFile> Tenants { get; set; } = new();
+    }
+
     private void Load()
     {
         if (!File.Exists(_path))
@@ -210,28 +267,62 @@ public sealed class GatewaySessionConcurrencyStats
             return;
         }
 
-        StoreFile? parsed;
+        string text;
+        bool isVersioned;
         try
         {
-            parsed = JsonSerializer.Deserialize<StoreFile>(File.ReadAllText(_path), FileJsonOptions);
+            text = File.ReadAllText(_path);
+            // The version-1 file is a bare TenantStoreFile (LiveAllTimeMax at the root); the version-2 file is
+            // an envelope with a "Tenants" object. Detect by presence of the envelope's tenants property
+            // (case-insensitively, so a serializer naming-policy change cannot silently misclassify the file)
+            // so an upgrade migrates the old numbers into the local tenant rather than quarantining them.
+            using var probe = JsonDocument.Parse(text);
+            isVersioned = probe.RootElement.ValueKind == JsonValueKind.Object
+                          && probe.RootElement.EnumerateObject()
+                                  .Any(p => string.Equals(p.Name, "tenants", StringComparison.OrdinalIgnoreCase));
         }
         catch (JsonException ex)
         {
             Quarantine(ex.Message);
             return;
         }
-        if (parsed is null)
+
+        try
         {
-            Quarantine("file deserialized to null (no store document)");
+            if (isVersioned)
+            {
+                var env = JsonSerializer.Deserialize<StoreEnvelope>(text, FileJsonOptions);
+                if (env is null) { Quarantine("file deserialized to null (no store envelope)"); return; }
+                foreach (var (tenantValue, tsf) in env.Tenants)
+                    LoadTenant(new TenantId(tenantValue), tsf);
+            }
+            else
+            {
+                // Version 1: the whole file is the local tenant's state.
+                var tsf = JsonSerializer.Deserialize<TenantStoreFile>(text, FileJsonOptions);
+                if (tsf is null) { Quarantine("file deserialized to null (no store document)"); return; }
+                LoadTenant(TenantId.Local, tsf);
+            }
+        }
+        catch (JsonException ex)
+        {
+            Quarantine(ex.Message);
             return;
         }
 
-        _liveAllTimeMax = parsed.LiveAllTimeMax;
-        _liveAllTimeMaxAtUtc = parsed.LiveAllTimeMaxAtUtc;
-        _workingAllTimeMax = parsed.WorkingAllTimeMax;
-        _workingAllTimeMaxAtUtc = parsed.WorkingAllTimeMaxAtUtc;
+        var totalHours = _tenants.Values.Sum(s => s.Hours.Count);
+        FileLog.Write($"[GatewaySessionConcurrencyStats] Load: {_tenants.Count} tenant(s), {totalHours} hourly bucket(s) total from {_path}");
+    }
+
+    private void LoadTenant(TenantId tenant, TenantStoreFile parsed)
+    {
+        var st = StateFor(tenant);
+        st.LiveAllTimeMax = parsed.LiveAllTimeMax;
+        st.LiveAllTimeMaxAtUtc = parsed.LiveAllTimeMaxAtUtc;
+        st.WorkingAllTimeMax = parsed.WorkingAllTimeMax;
+        st.WorkingAllTimeMaxAtUtc = parsed.WorkingAllTimeMaxAtUtc;
         foreach (var (hour, hs) in parsed.Hours)
-            _hours[hour] = new HourStat
+            st.Hours[hour] = new HourStat
             {
                 MaxLive = hs.MaxLive,
                 MaxWorking = hs.MaxWorking,
@@ -239,11 +330,10 @@ public sealed class GatewaySessionConcurrencyStats
                 DistinctMachines = hs.DistinctMachines,
                 DistinctRepos = hs.DistinctRepos,
             };
-        _currentHourKey = parsed.CurrentHourKey ?? "";
-        foreach (var s in parsed.CurrentSessions) _curSessions.Add(s);
-        foreach (var m in parsed.CurrentMachines) _curMachines.Add(m);
-        foreach (var r in parsed.CurrentRepos) _curRepos.Add(r);
-        FileLog.Write($"[GatewaySessionConcurrencyStats] Load: live peak {_liveAllTimeMax}, working peak {_workingAllTimeMax}, {_hours.Count} hourly bucket(s) from {_path}");
+        st.CurrentHourKey = parsed.CurrentHourKey ?? "";
+        foreach (var s in parsed.CurrentSessions) st.CurSessions.Add(s);
+        foreach (var m in parsed.CurrentMachines) st.CurMachines.Add(m);
+        foreach (var r in parsed.CurrentRepos) st.CurRepos.Add(r);
     }
 
     private void Quarantine(string reason)
@@ -264,28 +354,33 @@ public sealed class GatewaySessionConcurrencyStats
             if (!string.IsNullOrEmpty(dir))
                 Directory.CreateDirectory(dir);
 
-            var file = new StoreFile
+            var env = new StoreEnvelope { Version = StoreVersion };
+            foreach (var (tenant, st) in _tenants)
             {
-                LiveAllTimeMax = _liveAllTimeMax,
-                LiveAllTimeMaxAtUtc = _liveAllTimeMaxAtUtc,
-                WorkingAllTimeMax = _workingAllTimeMax,
-                WorkingAllTimeMaxAtUtc = _workingAllTimeMaxAtUtc,
-                CurrentHourKey = _currentHourKey,
-                CurrentSessions = _curSessions.ToList(),
-                CurrentMachines = _curMachines.ToList(),
-                CurrentRepos = _curRepos.ToList(),
-            };
-            foreach (var (hour, h) in _hours)
-                file.Hours[hour] = new HourStatStore
+                var tsf = new TenantStoreFile
                 {
-                    MaxLive = h.MaxLive,
-                    MaxWorking = h.MaxWorking,
-                    DistinctSessions = h.DistinctSessions,
-                    DistinctMachines = h.DistinctMachines,
-                    DistinctRepos = h.DistinctRepos,
+                    LiveAllTimeMax = st.LiveAllTimeMax,
+                    LiveAllTimeMaxAtUtc = st.LiveAllTimeMaxAtUtc,
+                    WorkingAllTimeMax = st.WorkingAllTimeMax,
+                    WorkingAllTimeMaxAtUtc = st.WorkingAllTimeMaxAtUtc,
+                    CurrentHourKey = st.CurrentHourKey,
+                    CurrentSessions = st.CurSessions.ToList(),
+                    CurrentMachines = st.CurMachines.ToList(),
+                    CurrentRepos = st.CurRepos.ToList(),
                 };
+                foreach (var (hour, h) in st.Hours)
+                    tsf.Hours[hour] = new HourStatStore
+                    {
+                        MaxLive = h.MaxLive,
+                        MaxWorking = h.MaxWorking,
+                        DistinctSessions = h.DistinctSessions,
+                        DistinctMachines = h.DistinctMachines,
+                        DistinctRepos = h.DistinctRepos,
+                    };
+                env.Tenants[tenant.Value] = tsf;
+            }
 
-            var json = JsonSerializer.Serialize(file, FileJsonOptions);
+            var json = JsonSerializer.Serialize(env, FileJsonOptions);
             var tmp = _path + ".tmp";
             File.WriteAllText(tmp, json);
             File.Move(tmp, _path, overwrite: true);

--- a/src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs
@@ -1,4 +1,5 @@
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using Microsoft.Data.Sqlite;
 
@@ -35,7 +36,18 @@ public sealed class GatewayStatsDatabase : IDisposable
 {
     /// <summary>The schema version this build understands. Bump it and add a migration step; never reshape
     /// an existing table in place without one.</summary>
-    public const int SchemaVersion = 4;
+    public const int SchemaVersion = 5;
+
+    /// <summary>
+    /// The oldest schema version this build can migrate FORWARD without losing data. Below it the store is
+    /// retired aside unread (<see cref="RetireIncompatibleStore"/>): version 4 changed what repo_id MEANS
+    /// (local path -> "owner/repo" repo name), and the Gateway cannot re-key a stored path, so a pre-v4 store
+    /// has no faithful forward migration. A v4 store DOES: version 5 (MTR-08) only ADDS a tenant column and
+    /// backfills every existing row to the single self-host tenant, so v4 is migrated, never retired. This is
+    /// a FIXED boundary, deliberately NOT <see cref="SchemaVersion"/> - raising the schema version must not
+    /// silently start retiring stores that have a faithful migration.
+    /// </summary>
+    private const int OldestForwardMigratableVersion = 4;
 
     /// <summary>The meta key holding when the model dimension started recording - an ISO-8601 UTC stamp
     /// written once, by the migration that added the dimension. See <see cref="MigrateToVersion2"/> for why
@@ -136,6 +148,9 @@ public sealed class GatewayStatsDatabase : IDisposable
 
         if (current < 4)
             MigrateToVersion4(tx);
+
+        if (current < 5)
+            MigrateToVersion5(tx);
 
         Execute($"PRAGMA user_version={SchemaVersion}", tx);
         tx.Commit();
@@ -505,6 +520,128 @@ public sealed class GatewayStatsDatabase : IDisposable
             )", tx);
     }
 
+    // Version 5: the TENANT dimension (MTR-08, production-readiness census rows 49-67) - the owning tenant of
+    // every recorded fact, so a hosted Gateway that folds several accounts' pushes into this one store keeps
+    // each account's tally, membership and identity PHYSICALLY separate instead of coalescing them.
+    //
+    // WHY A FORWARD MIGRATION AND NOT A RETIRE. Unlike version 4 (which changed what repo_id MEANS and had no
+    // faithful re-key), this only ADDS a column. Every row already in the store was written by a single-tenant
+    // build, so it belongs to exactly one tenant: the self-host tenant. Backfilling each existing row to
+    // TenantId.Local is therefore not a guess - it is the true owner. No numbers are lost and no data is
+    // invented.
+    //
+    // TWO SHAPES OF CHANGE:
+    //   - ADD COLUMN with a NOT NULL DEFAULT of the local tenant, for the delta tables and the identity
+    //     tables. SQLite backfills every existing row to 'local' in one statement, and the column keeps
+    //     NOT NULL going forward (the fold always stamps a tenant).
+    //   - A TABLE REBUILD for the five membership/high-water tables and meta, because the tenant must join
+    //     their PRIMARY KEY and SQLite cannot alter a primary key in place. Without the tenant in the key,
+    //     two tenants pushing the same bare session id would collide on the key and one would silently
+    //     overwrite the other's high-water - the exact suppression this fix closes. Each rebuild copies every
+    //     existing row under the local tenant, so a self-host store keeps all of its rows.
+    //
+    // Runs inside the migration transaction (see Migrate()), so a crash mid-rebuild rolls the whole thing back
+    // rather than leaving a half-keyed store claiming to be version 5.
+    private void MigrateToVersion5(SqliteTransaction tx)
+    {
+        var local = TenantId.Local.Value;
+
+        // The delta and identity tables: the tenant is a plain column (not part of any primary key), so an
+        // ADD COLUMN with a NOT NULL default backfills every existing row to the self-host tenant in place.
+        foreach (var table in new[]
+                 {
+                     "stat_delta", "token_delta", "agent_delta", "agent_driven_delta",
+                     "repo_identity", "agent_identity", "model_identity", "checkout_identity",
+                 })
+            Execute($"ALTER TABLE {table} ADD COLUMN tenant TEXT NOT NULL DEFAULT '{local}'", tx);
+
+        // Read speed: the tenant-scoped aggregate reads all filter by tenant, and the working-day series also
+        // by hour. A composite index keeps those from scanning another tenant's rows.
+        Execute("CREATE INDEX IF NOT EXISTS ix_stat_delta_tenant_hour ON stat_delta(tenant, hour_utc)", tx);
+        Execute("CREATE INDEX IF NOT EXISTS ix_token_delta_tenant_hour ON token_delta(tenant, hour_utc)", tx);
+
+        // The membership / high-water tables and meta: the tenant must join the PRIMARY KEY, so each is
+        // rebuilt with the tenant in the key and every existing row copied under the local tenant.
+        RebuildWithTenant(tx, "session_highwater",
+            @"CREATE TABLE session_highwater (
+                  tenant     TEXT    NOT NULL,
+                  session_id TEXT    NOT NULL,
+                  modality   TEXT    NOT NULL,
+                  surface    TEXT    NOT NULL,
+                  turns      INTEGER NOT NULL,
+                  chars      INTEGER NOT NULL,
+                  PRIMARY KEY (tenant, session_id, modality, surface)
+              )",
+            "tenant, session_id, modality, surface, turns, chars",
+            "session_id, modality, surface, turns, chars", local);
+
+        RebuildWithTenant(tx, "agent_driven_highwater",
+            @"CREATE TABLE agent_driven_highwater (
+                  tenant     TEXT    NOT NULL,
+                  session_id TEXT    NOT NULL,
+                  turns      INTEGER NOT NULL,
+                  chars      INTEGER NOT NULL,
+                  PRIMARY KEY (tenant, session_id)
+              )",
+            "tenant, session_id, turns, chars",
+            "session_id, turns, chars", local);
+
+        RebuildWithTenant(tx, "token_highwater",
+            @"CREATE TABLE token_highwater (
+                  tenant                TEXT    NOT NULL,
+                  session_id            TEXT    NOT NULL,
+                  input_tokens          INTEGER NOT NULL,
+                  output_tokens         INTEGER NOT NULL,
+                  cache_read_tokens     INTEGER NOT NULL,
+                  cache_creation_tokens INTEGER NOT NULL,
+                  PRIMARY KEY (tenant, session_id)
+              )",
+            "tenant, session_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens",
+            "session_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens", local);
+
+        RebuildWithTenant(tx, "wingman_session",
+            @"CREATE TABLE wingman_session (
+                  tenant     TEXT NOT NULL,
+                  session_id TEXT NOT NULL,
+                  PRIMARY KEY (tenant, session_id)
+              )",
+            "tenant, session_id", "session_id", local);
+
+        RebuildWithTenant(tx, "agents_seeded",
+            @"CREATE TABLE agents_seeded (
+                  tenant     TEXT NOT NULL,
+                  session_id TEXT NOT NULL,
+                  PRIMARY KEY (tenant, session_id)
+              )",
+            "tenant, session_id", "session_id", local);
+
+        // meta becomes per (tenant, name). agents_since_utc is per tenant from here on; models_since_utc is a
+        // schema fact and simply rides the local tenant's row (it is read tenant-agnostically).
+        RebuildWithTenant(tx, "meta",
+            @"CREATE TABLE meta (
+                  tenant TEXT NOT NULL,
+                  name   TEXT NOT NULL,
+                  value  TEXT NOT NULL,
+                  PRIMARY KEY (tenant, name)
+              )",
+            "tenant, name, value", "name, value", local);
+    }
+
+    // Rebuild one table so the tenant can join its primary key: create the new shape, copy every existing row
+    // under the local tenant, drop the old table, rename the new one into its place. The copy stamps the
+    // local-tenant literal as the first selected column, which is why <paramref name="oldColumns"/> lists the
+    // ORIGINAL columns (no tenant) and <paramref name="newColumns"/> lists them WITH tenant first.
+    private void RebuildWithTenant(SqliteTransaction tx, string table, string createNewSql,
+        string newColumns, string oldColumns, string local)
+    {
+        var tmp = table + "_v5";
+        // createNewSql names `table`; build it under the temp name, then rename after the drop.
+        Execute(createNewSql.Replace($"CREATE TABLE {table} ", $"CREATE TABLE {tmp} "), tx);
+        Execute($"INSERT INTO {tmp}({newColumns}) SELECT '{local}', {oldColumns} FROM {table}", tx);
+        Execute($"DROP TABLE {table}", tx);
+        Execute($"ALTER TABLE {tmp} RENAME TO {table}", tx);
+    }
+
     // Retire an incompatible pre-version-4 statistics store aside UNREAD, exactly as the legacy JSON store was
     // retired (GatewayInputStatsAggregator.RetireLegacyJsonStore). Runs once, before the database is opened.
     //
@@ -542,9 +679,10 @@ public sealed class GatewayStatsDatabase : IDisposable
             return;
         }
 
-        // A valid store already at version 4 (or, defensively, beyond it) is current; version 0 is not a real
-        // stamped store. Only a genuine version 1..3 file is the incompatible store this retires.
-        if (version <= 0 || version >= SchemaVersion) return;
+        // A store at version 4 or beyond has a faithful forward migration (v5 only adds a tenant column), so
+        // it is NOT retired - it is migrated. Version 0 is not a real stamped store. Only a genuine version
+        // 1..3 file is the incompatible store this retires (its repo_id is a path this build cannot re-key).
+        if (version <= 0 || version >= OldestForwardMigratableVersion) return;
 
         var aside = _path + ".superseded-" +
             DateTime.UtcNow.ToString("yyyyMMdd-HHmmss", System.Globalization.CultureInfo.InvariantCulture);
@@ -552,7 +690,7 @@ public sealed class GatewayStatsDatabase : IDisposable
         MoveAsideIfExists(_path + "-wal", aside + "-wal");
         MoveAsideIfExists(_path + "-shm", aside + "-shm");
         FileLog.Write($"[GatewayStatsDatabase] RetireIncompatibleStore: the repository dimension changed from " +
-                      $"local path to repo name at schema v{SchemaVersion}; renamed the superseded store " +
+                      $"local path to repo name at schema v{OldestForwardMigratableVersion}; renamed the superseded store " +
                       $"(v{version}) to {aside} UNREAD; starting empty");
     }
 

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -104,7 +105,10 @@ public static class StatsPageEndpoint
 
         app.MapGet("/stats/data", () =>
         {
-            var totals = aggregator.CurrentTotals();
+            // MTR-08: this whole route group is refused on hosted (the filter above), so it serves ONLY the
+            // single-tenant self host. There the sole tenant is Local, so every read scopes to it explicitly.
+            var tenant = TenantId.Local;
+            var totals = aggregator.CurrentTotals(tenant);
             return Results.Json(new
             {
                 generatedAtUtc = DateTime.UtcNow,
@@ -113,46 +117,46 @@ public static class StatsPageEndpoint
                 timeZone = CcDirector.Core.Configuration.TimeZoneConfig.Get(),
                 buckets = totals.Buckets,
                 // DevThrottle Stats: the "working day" series - turns (by modality) + characters per UTC hour.
-                hourlyTurns = aggregator.HourlyTurns(),
+                hourlyTurns = aggregator.HourlyTurns(tenant),
                 // Wingman usage: turns submitted while a session had voice mode on, and the count of distinct
                 // sessions ever in voice mode ("using the wingman" = voice mode on for that session).
-                wingman = aggregator.WingmanUsage(),
+                wingman = aggregator.WingmanUsage(tenant),
                 // DevThrottle Stats: fleet concurrency (both series: live loaded/running, and actively
                 // working). Null until the aggregator is wired (old callers / tests).
-                concurrency = concurrency?.Snapshot(DateTime.UtcNow),
+                concurrency = concurrency?.Snapshot(DateTime.UtcNow, tenant),
                 // DevThrottle Stats (private Repos page): the per-repository all-time tally, ranked
                 // most-driven first, so the owner can see where development actually happens. Same
                 // owner-only auth as the rest of this feed; rendered on a SEPARATE page from Your Throttle
                 // so it never rides along when the throttle is shared.
-                repos = aggregator.RepoTotals(),
+                repos = aggregator.RepoTotals(tenant),
                 // DevThrottle Stats (private Agents page): the per-agent all-time tally, ranked most-driven
                 // first, so the owner can see which agent CLI the work actually goes through. Unlike the
                 // other series this one starts at agentsSinceUtc - the breakdown was added after the totals
                 // had been accumulating - so the page states that window rather than implying the earlier
                 // turns ran under no agent.
-                agents = aggregator.AgentTotals(),
-                agentsSinceUtc = aggregator.AgentsSinceUtc,
+                agents = aggregator.AgentTotals(tenant),
+                agentsSinceUtc = aggregator.AgentsSinceUtc(tenant),
                 // DevThrottle Stats (issue #1637): the per-model all-time tally - which model actually did
                 // the work, ranked most-driven first. Like the agents series it starts at modelsSinceUtc
                 // rather than at the beginning of the totals, so the page states that window instead of
                 // implying the earlier turns ran under no model. A null model in this list is the honest
                 // "the agent had not recorded one yet" bucket, not a missing value to hide.
-                models = aggregator.ModelTotals(),
+                models = aggregator.ModelTotals(tenant),
                 modelsSinceUtc = aggregator.ModelsSinceUtc,
                 // DevThrottle Stats (issue #1637): TOKEN SPEND - what the work actually cost. Three views of
                 // one number: the all-time total, the per-hour series for "what did I spend today / this
                 // week / this month", and the per-model split for "which model cost what". Cumulative,
                 // additive tokens only (input / output / cache) - never context-window occupancy, which is a
                 // gauge and cannot be summed. Claude-only until other agents' drivers report cumulative spend.
-                tokenSpend = aggregator.TokenSpend(),
-                tokenSpendByHour = aggregator.TokenSpendByHour(),
-                tokenSpendByModel = aggregator.TokenSpendByModel(),
+                tokenSpend = aggregator.TokenSpend(tenant),
+                tokenSpendByHour = aggregator.TokenSpendByHour(tenant),
+                tokenSpendByModel = aggregator.TokenSpendByModel(tenant),
                 // DevThrottle Stats (issue #1636): turns the fleet drove into ITSELF - one agent prompting
                 // another. Reported alongside the human tally but never inside it: "how do you drive" and
                 // "how much does the fleet drive itself" are different questions, and the ratio between
                 // them is the leverage the owner actually gets per turn they spend.
-                agentDrivenTurns = aggregator.AgentDrivenUsage().Turns,
-                agentDrivenCharacters = aggregator.AgentDrivenUsage().Characters,
+                agentDrivenTurns = aggregator.AgentDrivenUsage(tenant).Turns,
+                agentDrivenCharacters = aggregator.AgentDrivenUsage(tenant).Characters,
                 notCaptured = NotCaptured,
             });
         });

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -128,8 +128,9 @@ public sealed class DirectorHub : Hub
         using var tenantScope = EnterBoundTenantScope();
         var set = sessions ?? Array.Empty<SessionDto>();
         var accepted = _store.ApplySnapshot(RequireBoundTenant(), directorId, Context.ConnectionId, sequence, set);
-        // DevThrottle Stats: fold each session's input tally into the always-available aggregate.
-        _inputStats.ObserveSnapshot(set);
+        // DevThrottle Stats: fold each session's input tally into the always-available aggregate, under this
+        // connection's bound tenant (MTR-08) so one account's tallies never coalesce with another's.
+        _inputStats.ObserveSnapshot(set, tenant: RequireBoundTenant());
         // A push the store REJECTED (from a superseded connection, or a stale sequence) is NOT authoritative,
         // so it must not drive the snooze observer - whose edges MUTATE the authoritative registry
         // (ClearIfArmed deletes an armed snooze, Land converts a deferral). A rejected stale Working push
@@ -164,8 +165,9 @@ public sealed class DirectorHub : Hub
         // below writes the snooze/spend EF stores, which must stamp and filter by this connection's tenant).
         using var tenantScope = EnterBoundTenantScope();
         var accepted = _store.ApplyDelta(RequireBoundTenant(), directorId, Context.ConnectionId, sequence, session);
-        // DevThrottle Stats: fold this session's tally into the always-available aggregate.
-        _inputStats.Observe(session);
+        // DevThrottle Stats: fold this session's tally into the always-available aggregate, under this
+        // connection's bound tenant (MTR-08).
+        _inputStats.Observe(session, tenant: RequireBoundTenant());
         // A push the store REJECTED (superseded connection, or a stale sequence) is NOT authoritative, so it
         // must not drive the snooze observer, whose edges MUTATE the authoritative registry (ClearIfArmed
         // deletes an armed snooze, Land converts a deferral). See the note in PushSnapshot. The roles/display
@@ -199,8 +201,9 @@ public sealed class DirectorHub : Hub
         // can touch tenant-scoped state through the observers below).
         using var tenantScope = EnterBoundTenantScope();
         _store.ApplyRemove(RequireBoundTenant(), directorId, Context.ConnectionId, sequence, sessionId);
-        // DevThrottle Stats: its contribution stays in the totals; drop only its high-water entry.
-        _inputStats.Forget(sessionId);
+        // DevThrottle Stats: its contribution stays in the totals; drop only its high-water entry, scoped to
+        // this connection's bound tenant (MTR-08) so it cannot drop another tenant's same-id high-water.
+        _inputStats.Forget(sessionId, RequireBoundTenant());
         // A DEPARTURE RE-ROLES THE SURVIVORS, exactly as an arrival does: a controller leaving should stop
         // its workers being Workers. Must run AFTER ApplyRemove so the sweep resolves the fleet that now
         // exists rather than the one that just left.


### PR DESCRIPTION
## What

Tenant-partition the DevThrottle Stats aggregator cluster (`GatewayInputStatsAggregator`, `GatewayStatsDatabase`, `GatewaySessionConcurrencyStats`) so one hosted account's stats can never coalesce with or suppress another's. Production-readiness census rows 49-67 (MTR-08, HIGH).

This is the in-memory + SQLite stats half only. The composite-PK collision half (snoozes / session_spend / push) is PR #1909 and is untouched here.

## The defect

The cluster was process-global. On a hosted Gateway folding several accounts' pushes into one store:

- **Identity coalescence** - `repo_id`/`agent_id`/`model_id`/`checkout_id` were minted from a process-global `display -> id` map, so two tenants' `owner/app` shared one surrogate id and their turns, characters and token spend summed into one row.
- **Session-id suppression** - `session_highwater`, `token_highwater`, `agent_driven_highwater`, `wingman_session`, `agents_seeded` were keyed by the bare session id, so two tenants sharing a session id collided: one overwrote the other's high-water (spurious delta / double count) and suppressed its wingman-seen / seed markers.
- **Concurrency mixing** - the peaks/hours/dedup sets were process-global.

Only the blanket hosted deny on `/stats` (#1848) kept it from being read cross-tenant, so the store was the single point of failure for any future per-tenant reader.

## The fix

Partition by the owning tenant, following the MTR-01 event-ring pattern (commit 4355dd60): every in-memory map and every stored row is keyed by `(tenant, ...)`, the producer stamps the bound ingress tenant and the reader scopes to the request tenant. Self-host has one tenant (`Local`), so the composite key degenerates to the bare key it was and behavior is unchanged; an invalid tenant is a hard deny, never silently defaulted.

- **Aggregator maps** - session-keyed maps take a `(TenantId, sessionId)` tuple key; identity `display -> id` maps nest per tenant so the `OrdinalIgnoreCase` comparer that decides identity is preserved byte-for-byte; `id -> display` and the distinct-session sets stay flat (the surrogate id is already tenant-specific). Every reader takes the tenant; every read filters `WHERE tenant`, every write stamps it, the prune archives per tenant.
- **Schema v4 -> v5** - ADD COLUMN `tenant` on the delta/identity tables; rebuild the five membership/high-water tables and `meta` with the tenant in the primary key. A v4 store migrates **forward** (every row backfilled to the local tenant), not retired - the retire boundary is now a fixed constant independent of the schema version, so a genuine pre-v4 store is still retired while a v4 store keeps all its numbers.
- **Concurrency store** - state kept per tenant; JSON gains a version-2 per-tenant envelope; a version-1 (pre-tenant) file migrates into the local tenant on load.
- **Wiring** - `DirectorHub` (stream) passes `RequireBoundTenant()`; the `/sessions` aggregation passes `reqTenant.Value`; `StatsPageEndpoint` (self-host only, denied on hosted) passes `Local`.

## Tests

Two-tenant tests (added, all green): no-coalesce for repo/agent/model/totals; no cross-tenant suppression of wingman/seed/high-water; no cross-tenant agent visibility; per-tenant concurrency; per-tenant `Forget`; restart durability; a hand-built v4 store migrating forward and keeping every row backfilled to `local`; the version-1 concurrency file migrating. Schema whitelists updated to state `tenant` deliberately.

- Build: `CcDirector.Gateway` + `CcDirector.Gateway.Tests` clean, 0 warnings.
- Full Gateway suite: **3126 passed, 0 failed, 12 skipped** (Postgres-live proofs, no server) - no collateral red.

Do **not** merge - Architect lands it.