### PR TITLE
fix(gateway): resolve the voice Director in its owning tenant (fix build + hosted turn-end)

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedSessionCommandRouteTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedSessionCommandRouteTenancyTests.cs
@@ -78,8 +78,11 @@ public sealed class HostedSessionCommandRouteTenancyTests : IAsyncLifetime
 
         _keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
         _keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
-        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", "tenant-alice");
-        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", "tenant-bob");
+        // Account tenants are minted GUIDs in production (the roster's voice enrichment routes the request
+        // tenant into WingmanVoiceService, which refuses a non-GUID, non-Local partition key), so bind real
+        // GUID tenant ids here rather than friendly labels.
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", "55555555-5555-5555-5555-555555555555");
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", "66666666-6666-6666-6666-666666666666");
 
         // Both fake Directors answer every verb, so a route that reaches its Director gets a real answer and
         // any not-found body can only have come from the locate step - the step under test.

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1286,7 +1286,7 @@ public sealed class GatewayHost : IAsyncDisposable
                     if (vs.HasVoice(tenant, sid)) continue;          // already cached, nothing to do
                     var located = PushedSessions.TryLocate(tenant, sid, stale);
                     if (located is not { } loc) continue;            // not owned by any of this tenant's directors
-                    var director = Registry.Get(loc.DirectorId);
+                    var director = Registry.Get(tenant, loc.DirectorId);
                     if (director is null) continue;
                     var st = loc.Session.ActivityState ?? "";
                     if (st is "Idle" or "WaitingForInput" or "WaitingForPerm")
@@ -1432,10 +1432,9 @@ public sealed class GatewayHost : IAsyncDisposable
                     // Gateway Cleanup mission, Phase 2: reach the owning Director (carried on the signal as
                     // its DirectorId) through the tunnel-first SessionVerbClient - no HTTP dial. The Director
                     // may be push-only (empty control URL); the tunnel path still reaches it by id.
-                    // MTR-01: this voice/turn-end sweep is Local-pinned (like every TenantId.Local read around
-                    // it - the voice state it mutates is not yet partitioned; see the note on
-                    // LocateSessionForRequestAsync), so resolve the Director in Local, not by a bare scan.
-                    var director = Registry.Get(TenantId.Local, signal.DirectorId);
+                    // Hosted Multi-Tenancy voice-serving: resolve the Director in its OWNING tenant (the
+                    // registry is keyed by (tenant, director id)); Local would miss it on a hosted Gateway.
+                    var director = Registry.Get(tenant, signal.DirectorId);
                     if (director is null) return;
                     Api.DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = SendCommandAsync;
                     var route = new Api.SessionVerbClient(director, sendCommand);


### PR DESCRIPTION
Follow-up to #1973. Two `DirectorRegistry.Get` calls on the voice path were wrong once merged onto current main:

- The idle voice sweep called the bare-id `Registry.Get(directorId)` overload that a concurrently-landed hardening commit deleted (`Get` is now `(TenantId, directorId)`), so the merged tree did **not compile in Release** - main was broken. Now passes the sweep's tenant.
- The turn-end voice refresh resolved the Director under `TenantId.Local`; the registry is keyed by `(tenant, director id)`, so on hosted the Director lives under its real tenant and the Local lookup returned null - turn-end auto-narration silently never fired. Now resolved in the owning tenant.

Also gives `HostedSessionCommandRouteTenancyTests` GUID tenant ids (the roster voice enrichment routes the request tenant into WingmanVoiceService, which refuses a non-GUID partition key, so a friendly-label tenant 500'd GET /sessions). Full Gateway suite green (0 failed, 3132 passed).