### PR TITLE
feat(gateway): shared hosted-refusal primitive with complete route-space validation (supersedes #1951)

### DIFF
--- a/src/CcDirector.Gateway.Tests/Tenancy/GatewayHostRefusalValidationCallSiteTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/GatewayHostRefusalValidationCallSiteTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.Builder;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Tenancy;
+
+/// <summary>
+/// Revert-proof for the PRODUCTION CALL SITE, not the helper. The pre-start fail-before-start harness
+/// (<see cref="HostedRefusalRouteSpaceFailBeforeStartTests"/>) proves the SELECTION and the VALIDATOR
+/// are correct, but it reaches them by calling <c>SelectFinalisedEndpoints</c> / <c>Validate</c> itself -
+/// it never drives <see cref="GatewayHost"/>. So reverting only the production call at
+/// <c>GatewayHost.StartAsync</c> (the <c>ValidateBeforeStart(_app)</c> line, back to the old empty-DI
+/// <c>EndpointDataSource</c> read) changes nothing that harness reaches; the missing route-space
+/// validation would ship silently.
+///
+/// No production family adopts the refusal primitive yet, so a really-started GatewayHost has zero refusal
+/// endpoints and the validator early-returns - there is no conflicting final route set to inject through the
+/// public surface, and production is locked, so a behavioural pre-listener-throw test on the real host is not
+/// reachable. What IS reachable, and is exactly the guarantee the call site must keep, is that the COMPILED
+/// <c>StartAsync</c> invokes <see cref="HostedRefusalRouteSpace.ValidateBeforeStart"/> at all. This guard
+/// inspects the compiled body and fails the moment GatewayHost bypasses that call. The revert-proof: reverting
+/// <c>GatewayHost.StartAsync</c>'s <c>ValidateBeforeStart(_app)</c> to the old DI-composite read removes the
+/// call and reddens this test.
+/// </summary>
+public sealed class GatewayHostRefusalValidationCallSiteTests
+{
+    [Fact]
+    public void GatewayHost_StartAsync_invokes_ValidateBeforeStart_on_the_finalised_route_space()
+    {
+        var calls = CalledMethodsIn(StartAsyncBody());
+
+        var validateBeforeStart = calls.FirstOrDefault(m =>
+            m.DeclaringType == typeof(HostedRefusalRouteSpace) &&
+            m.Name == nameof(HostedRefusalRouteSpace.ValidateBeforeStart));
+
+        Assert.True(validateBeforeStart is not null,
+            "GatewayHost.StartAsync must call HostedRefusalRouteSpace.ValidateBeforeStart before it binds a " +
+            "listener; the call is absent from the compiled method, so the finalised route space is not " +
+            "validated at the production call site.");
+    }
+
+    [Fact]
+    public void GatewayHost_StartAsync_validates_the_route_space_before_it_starts_the_app()
+    {
+        var (il, module, typeArgs, methodArgs) = StartAsyncBody();
+        var callSites = CallSitesIn(il, module, typeArgs, methodArgs);
+
+        var validateOffset = callSites
+            .Where(c => c.Method.DeclaringType == typeof(HostedRefusalRouteSpace) &&
+                        c.Method.Name == nameof(HostedRefusalRouteSpace.ValidateBeforeStart))
+            .Select(c => (int?)c.Offset)
+            .FirstOrDefault();
+
+        var startAppOffset = callSites
+            .Where(c => c.Method.DeclaringType == typeof(WebApplication) &&
+                        c.Method.Name == nameof(WebApplication.StartAsync))
+            .Select(c => (int?)c.Offset)
+            .FirstOrDefault();
+
+        Assert.True(validateOffset is not null, "GatewayHost.StartAsync must call ValidateBeforeStart.");
+        Assert.True(startAppOffset is not null, "GatewayHost.StartAsync must call WebApplication.StartAsync.");
+        Assert.True(validateOffset < startAppOffset,
+            "GatewayHost.StartAsync must validate the finalised route space BEFORE it starts the app and binds " +
+            "a listener, so a hosted-refusal conflict fails the start rather than surfacing as a request-time " +
+            $"failure. ValidateBeforeStart is at IL offset {validateOffset}, StartAsync at {startAppOffset}.");
+    }
+
+    // ---- compiled-body inspection ----
+
+    /// <summary>
+    /// GatewayHost.StartAsync is async, so its real body is the compiler-generated state machine's MoveNext.
+    /// Returns that MoveNext IL plus the generic context needed to resolve its metadata tokens (both empty
+    /// here - StartAsync and its state machine are non-generic).
+    /// </summary>
+    private static (byte[] Il, Module Module, Type[] TypeArgs, Type[] MethodArgs) StartAsyncBody()
+    {
+        var startAsync = typeof(GatewayHost).GetMethod(
+            nameof(GatewayHost.StartAsync), BindingFlags.Public | BindingFlags.Instance);
+        Assert.True(startAsync is not null, "GatewayHost.StartAsync must exist.");
+
+        var stateMachine = startAsync!.GetCustomAttribute<AsyncStateMachineAttribute>();
+        Assert.True(stateMachine is not null, "GatewayHost.StartAsync must be async.");
+
+        var moveNext = stateMachine!.StateMachineType.GetMethod(
+            "MoveNext", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+        Assert.True(moveNext is not null, "The StartAsync state machine must have a MoveNext.");
+
+        var body = moveNext!.GetMethodBody();
+        Assert.True(body is not null, "MoveNext must have an IL body.");
+
+        return (
+            body!.GetILAsByteArray()!,
+            moveNext.Module,
+            moveNext.DeclaringType!.GetGenericArguments(),
+            moveNext.GetGenericArguments());
+    }
+
+    private static IReadOnlyList<MethodBase> CalledMethodsIn(
+        (byte[] Il, Module Module, Type[] TypeArgs, Type[] MethodArgs) body)
+        => CallSitesIn(body.Il, body.Module, body.TypeArgs, body.MethodArgs).Select(c => c.Method).ToList();
+
+    /// <summary>
+    /// Walks the IL, resolving every method-token operand (call, callvirt, newobj, ldftn, ...) to the method
+    /// it targets, paired with the byte offset of its opcode so callers can reason about ordering. Operand
+    /// sizes come from the framework's own <see cref="OpCodes"/> table, so the walk cannot mistake an operand
+    /// byte for an opcode.
+    /// </summary>
+    private static IReadOnlyList<(MethodBase Method, int Offset)> CallSitesIn(
+        byte[] il, Module module, Type[] typeArgs, Type[] methodArgs)
+    {
+        var opcodes = OpcodeTable();
+        var result = new List<(MethodBase, int)>();
+        var pos = 0;
+
+        while (pos < il.Length)
+        {
+            var opcodeOffset = pos;
+            short key = il[pos];
+            if (il[pos] == 0xFE)
+            {
+                key = unchecked((short)(0xFE00 | il[pos + 1]));
+                pos += 2;
+            }
+            else
+            {
+                pos += 1;
+            }
+
+            Assert.True(opcodes.TryGetValue(key, out var opcode),
+                $"Unknown IL opcode 0x{key:X} at offset {opcodeOffset} in GatewayHost.StartAsync MoveNext.");
+
+            if (opcode.OperandType == OperandType.InlineMethod)
+            {
+                var token = BitConverter.ToInt32(il, pos);
+                MethodBase? method = null;
+                try { method = module.ResolveMethod(token, typeArgs, methodArgs); }
+                catch (ArgumentException) { /* not a method token we can resolve; not our call site */ }
+                if (method is not null) result.Add((method, opcodeOffset));
+            }
+
+            pos += OperandSize(opcode, il, pos);
+        }
+
+        return result;
+    }
+
+    private static int OperandSize(OpCode opcode, byte[] il, int operandPos) => opcode.OperandType switch
+    {
+        OperandType.InlineNone => 0,
+        OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or OperandType.ShortInlineVar => 1,
+        OperandType.InlineVar => 2,
+        OperandType.InlineBrTarget or OperandType.InlineField or OperandType.InlineI or
+        OperandType.InlineMethod or OperandType.InlineSig or OperandType.InlineString or
+        OperandType.InlineTok or OperandType.InlineType or OperandType.ShortInlineR => 4,
+        OperandType.InlineI8 or OperandType.InlineR => 8,
+        OperandType.InlineSwitch => 4 + (4 * BitConverter.ToInt32(il, operandPos)),
+        _ => throw new InvalidOperationException($"Unhandled operand type {opcode.OperandType}."),
+    };
+
+    private static Dictionary<short, OpCode> OpcodeTable()
+    {
+        var table = new Dictionary<short, OpCode>();
+        foreach (var field in typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (field.GetValue(null) is OpCode opcode)
+            {
+                table[opcode.Value] = opcode;
+            }
+        }
+        return table;
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Tenancy/HostedRefusalPatternTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/HostedRefusalPatternTests.cs
@@ -125,27 +125,6 @@ public sealed class HostedRefusalPatternTests
             partKinds);
     }
 
-    /// <summary>
-    /// The shape key is what the DUPLICATE check compares, and this is the case text comparison misses:
-    /// two patterns differing only in a parameter NAME are different strings and the same route. Mapping
-    /// both produces endpoints that tie, and the tie surfaces at request time on the denied route.
-    /// </summary>
-    [Theory]
-    [InlineData("/x/{id}", "/x/{name}", true)]              // same route, different spelling
-    [InlineData("/x/{id:int}", "/x/{name:alpha}", true)]    // policies are not part of the shape either
-    [InlineData("/x/{id}", "/x/{id?}", false)]              // optional does not compete with standard
-    [InlineData("/x/{id}", "/x/{**id}", false)]             // nor does a catch-all
-    [InlineData("/x/{id}", "/y/{id}", false)]               // different literal
-    [InlineData("/x/{id}", "/x/{id}/y", false)]             // different length
-    public void The_shape_key_sees_past_names_and_policies_but_not_past_kind_or_literals(
-        string left, string right, bool sameShape)
-    {
-        var leftKey = HostedRefusalPattern.ShapeKey(HostedRefusalPattern.WithoutPolicies(left, "probe"));
-        var rightKey = HostedRefusalPattern.ShapeKey(HostedRefusalPattern.WithoutPolicies(right, "probe"));
-
-        Assert.Equal(sameShape, leftKey == rightKey);
-    }
-
     private static System.Collections.Generic.IEnumerable<RoutePatternParameterPart> AllParameters(RoutePattern pattern)
         => pattern.PathSegments.SelectMany(s => s.Parts).OfType<RoutePatternParameterPart>();
 
@@ -158,17 +137,17 @@ public sealed class HostedRefusalPatternTests
 }
 
 /// <summary>
-/// The FINALISED route space check: the conflicts that only exist once everything has been mapped, and
-/// which the per-group duplicate check cannot see because it can only see its own group.
+/// The finalised route-space check, in the form it took AFTER review disproved the previous one.
 ///
-/// Two conflicts, in opposite directions, and only one of them is a leak:
-///   - refusal against refusal - a denied route answers 500 instead of refusing;
-///   - refusal against a LIVE route - a route nobody denied stops serving. That is an OUTAGE, and no
-///     leak-shaped test in this repository would ever notice it.
+/// The previous version tried to detect whether two patterns would TIE in the matcher, using a hand-rolled
+/// shape key. Three independent route pairs escaped it and returned HTTP 500 at request time. The reason is
+/// worth keeping: the matcher's ambiguity relation is not reachable from public API, so any check for it is
+/// a MODEL of framework semantics rather than the semantics themselves - and that was the SECOND time this
+/// primitive modelled a framework semantic and got it wrong.
 ///
-/// What is NOT a conflict is the ordinary case, and getting that wrong would refuse to start on every
-/// correct arrangement: refusal patterns are deliberately WIDE, so they overlap neighbours constantly, and
-/// route precedence resolves the overlap. Only an exact tie is rejected.
+/// So this no longer detects ambiguity. It checks the one thing that removes the conditions for it and that
+/// can be computed correctly: an EXCLUSIVE-PREFIX family claims a prefix nothing else may serve under, and
+/// that claim is verified by simple PREFIX CONTAINMENT.
 /// </summary>
 public sealed class HostedRefusalRouteSpaceTests
 {
@@ -178,72 +157,59 @@ public sealed class HostedRefusalRouteSpaceTests
         reason: "the probe family exists to prove the route-space check",
         unDenyInstruction: "nothing to un-deny: a test fixture");
 
-    private static readonly HostedDenial OtherDenial = new(
-        family: "other-probe",
-        message: "also not available on the hosted gateway",
-        reason: "a second family, to prove refusal-versus-refusal detection",
-        unDenyInstruction: "nothing to un-deny: a test fixture");
-
     [Fact]
-    public void Two_refusals_on_the_same_route_shape_fail_the_start_rather_than_the_request()
+    public void A_live_route_under_an_exclusively_claimed_prefix_fails_the_start()
     {
-        // Different spelling, same route. This is the pair a text comparison lets through.
+        // The over-refusal direction, which is an OUTAGE rather than a leak: the catch-all would swallow a
+        // route nobody denied. No leak-shaped test in this repository would notice that.
         var endpoints = new[]
         {
-            RefusalEndpoint("/x/{id}", Denial),
-            RefusalEndpoint("/x/{name}", OtherDenial),
+            ExclusiveRefusal("/family"),
+            LiveEndpoint("/family/still-serving"),
         };
 
         var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
 
-        Assert.Contains("probe", error.Message);
-        Assert.Contains("other-probe", error.Message);
+        Assert.Contains("EXCLUSIVELY", error.Message);
+        Assert.Contains("still-serving", error.Message);
     }
 
     [Fact]
-    public void A_refusal_tying_with_a_live_route_fails_the_start_because_that_is_an_outage()
+    public void A_prefix_with_nothing_else_underneath_it_is_allowed()
     {
         var endpoints = new[]
         {
-            RefusalEndpoint("/x/{id}", Denial),
-            LiveEndpoint("/x/{slug}"),
-        };
-
-        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
-
-        Assert.Contains("nobody denied", error.Message);
-    }
-
-    /// <summary>
-    /// The case that must NOT fail: a refusal is deliberately wider than the route it replaces, so it
-    /// overlaps live neighbours all the time. Precedence resolves it - a literal outranks a parameter - and
-    /// a validator that rejected overlap rather than ties would refuse to start on the normal arrangement.
-    /// </summary>
-    [Fact]
-    public void A_refusal_overlapping_a_more_specific_live_route_is_allowed()
-    {
-        var endpoints = new[]
-        {
-            RefusalEndpoint("/x/{id}", Denial),
-            LiveEndpoint("/x/summary"),      // literal beats the refusal's parameter
-            LiveEndpoint("/x/{id}/detail"),  // different length
-            LiveEndpoint("/y/{id}"),         // different literal
+            ExclusiveRefusal("/family"),
+            LiveEndpoint("/elsewhere/route"),
+            LiveEndpoint("/familyish/route"),   // shares a text prefix but not a PATH prefix
         };
 
         HostedRefusalRouteSpace.Validate(endpoints);
     }
 
     [Fact]
+    public void The_check_is_case_insensitive_about_the_prefix()
+    {
+        // Literal route matching is case-insensitive, so a containment check that was ordinal would miss a
+        // live route differing only in case - and would then be swallowed at runtime by the catch-all.
+        var endpoints = new[] { ExclusiveRefusal("/family"), LiveEndpoint("/FAMILY/still-serving") };
+
+        Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
+    }
+
+    [Fact]
     public void A_route_space_with_no_refusals_is_inert()
         => HostedRefusalRouteSpace.Validate(new[] { LiveEndpoint("/x/{id}"), LiveEndpoint("/y") });
 
-    private static RouteEndpoint RefusalEndpoint(string pattern, HostedDenial denial)
+    private static RouteEndpoint ExclusiveRefusal(string prefix)
         => new(
             _ => Task.CompletedTask,
-            HostedRefusalPattern.WithoutPolicies(pattern, denial.Family),
+            RoutePatternFactory.Parse(prefix + "/{**rest}"),
             order: 0,
-            new EndpointMetadataCollection(new HostedRefusalMarker(denial, pattern)),
-            displayName: pattern);
+            new EndpointMetadataCollection(
+                new HostedRefusalMarker(Denial, prefix),
+                new HostedExclusivePrefixMarker(Denial, prefix)),
+            displayName: prefix);
 
     private static RouteEndpoint LiveEndpoint(string pattern)
         => new(

--- a/src/CcDirector.Gateway.Tests/Tenancy/HostedRefusalPatternTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/HostedRefusalPatternTests.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Linq;
+using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Tenancy;
+
+/// <summary>
+/// The route-pattern normaliser: what the refusal is mapped on, and the grammar it claims to cover.
+///
+/// WHY THIS CLASS EXISTS AS ITS OWN THING. The normaliser was originally hand-written against the pattern
+/// TEXT and validated against simple inline policies only - and that is a narrower question set than the
+/// grammar it has to survive. The route grammar has optional parameters, default values, catch-alls with
+/// two sigils, escaped braces, and policy arguments that themselves contain the delimiters a text scan is
+/// looking for. A scan that is right on simple shapes and silently wrong on exotic ones does not produce a
+/// visible bug: it produces a refusal that does not cover its own route, while the family's author believes
+/// it does. That is manufactured coverage, which is the exact defect the boundary exists to remove.
+///
+/// So the normaliser now rebuilds the PARSED MODEL and this class states the grammar it covers, one test
+/// per element, plus the behaviour on something it does not model: it THROWS, and does not pass through.
+/// </summary>
+public sealed class HostedRefusalPatternTests
+{
+    /// <summary>
+    /// The ONE transformation. Everything else in these tests is a preservation claim; this is the change,
+    /// and it is the reason the whole class exists - a refusal carrying the real route's constraint is never
+    /// selected for the request that fails that constraint, which is the hole this closes.
+    /// </summary>
+    [Theory]
+    [InlineData("/x/{id:int}", "id")]
+    [InlineData("/x/{id:int:min(1)}", "id")]                    // several policies on one parameter
+    [InlineData("/x/{name:regex(^[[a-z]]+$)}", "name")]          // a policy argument containing delimiters
+    [InlineData("/x/{a:int}/y/{b:alpha}", "a")]                  // several constrained parameters
+    public void Every_parameter_policy_is_removed(string pattern, string firstParameterName)
+    {
+        var normalised = HostedRefusalPattern.WithoutPolicies(pattern, "probe");
+
+        Assert.All(AllParameters(normalised), p => Assert.Empty(p.ParameterPolicies));
+        Assert.Equal(firstParameterName, AllParameters(normalised).First().Name);
+    }
+
+    /// <summary>
+    /// Preservation, element by element. Each row is a piece of grammar the normaliser CLAIMS to cover, and
+    /// the claim is worth exactly as much as the row that tests it - which is why they are enumerated rather
+    /// than sampled. Losing any of these would change which requests the refusal matches.
+    /// </summary>
+    [Theory]
+    [InlineData("/x/{id?}")]                       // optional
+    [InlineData("/x/{id:int?}")]                   // optional AND constrained
+    [InlineData("/x/{id=7}")]                      // default value
+    [InlineData("/x/{id:int=7}")]                  // default AND constrained
+    [InlineData("/x/{**rest}")]                    // catch-all, slash-preserving
+    [InlineData("/x/{*rest}")]                     // catch-all, the other sigil
+    [InlineData("/x/y")]                           // pure literals
+    [InlineData("/x/{a}-{b}")]                     // two parameters in one complex segment
+    [InlineData("/x/file.{ext}")]                  // literal and parameter sharing a segment
+    [InlineData("/{a}/{b}/{c}")]                   // several segments
+    public void The_shape_of_the_route_survives_normalisation(string pattern)
+    {
+        var original = RoutePatternFactory.Parse(pattern);
+        var normalised = HostedRefusalPattern.WithoutPolicies(pattern, "probe");
+
+        // Same segment structure, part for part.
+        Assert.Equal(original.PathSegments.Count, normalised.PathSegments.Count);
+        foreach (var (before, after) in original.PathSegments.Zip(normalised.PathSegments))
+            Assert.Equal(before.Parts.Count, after.Parts.Count);
+
+        // Same parameters, with kind and default intact - optionality and catch-all semantics are the real
+        // route's, not something the normaliser decided.
+        var originalParameters = AllParameters(original).ToList();
+        var normalisedParameters = AllParameters(normalised).ToList();
+
+        Assert.Equal(originalParameters.Count, normalisedParameters.Count);
+        foreach (var (before, after) in originalParameters.Zip(normalisedParameters))
+        {
+            Assert.Equal(before.Name, after.Name);
+            Assert.Equal(before.ParameterKind, after.ParameterKind);
+            Assert.Equal(before.Default, after.Default);
+        }
+
+        // Literal text is untouched, which is what keeps a refusal from widening across a path boundary.
+        Assert.Equal(LiteralText(original), LiteralText(normalised));
+    }
+
+    /// <summary>
+    /// A pattern the framework itself rejects is not the normaliser's to reinterpret. It is parsed by the
+    /// framework's parser, so a malformed pattern fails there with the framework's own message rather than
+    /// being quietly accepted by a lenient hand-written scan.
+    /// </summary>
+    [Theory]
+    [InlineData("/x/{unclosed")]
+    [InlineData("/x/{}")]
+    public void A_malformed_pattern_is_refused_by_the_frameworks_own_parser(string pattern)
+        => Assert.ThrowsAny<Exception>(() => HostedRefusalPattern.WithoutPolicies(pattern, "probe"));
+
+    /// <summary>
+    /// THE EXHAUSTIVENESS CLAIM, which is what the fail-loud rule actually rests on here.
+    ///
+    /// The normaliser handles three route part kinds and THROWS on anything else. That throw is
+    /// unreachable today - and I would rather say so than imply it is covered: <c>RoutePatternPart</c> has
+    /// an internal constructor, so the framework's three subclasses are the entire hierarchy and no test in
+    /// this repository can manufacture a fourth. The defensive arm therefore has no test, deliberately, and
+    /// this is the test that guards the assumption UNDERNEATH it instead.
+    ///
+    /// If a framework upgrade ever adds a fourth part kind, this reddens - which is the moment somebody
+    /// needs to decide whether the normaliser handles it or refuses it. Without this, that upgrade would
+    /// land silently and the first sign would be a startup failure on somebody's exotic route, or worse, a
+    /// refusal that quietly did not cover it.
+    /// </summary>
+    [Fact]
+    public void The_route_part_kinds_the_normaliser_handles_are_still_the_only_ones_that_exist()
+    {
+        var partKinds = typeof(RoutePatternPart).Assembly
+            .GetTypes()
+            .Where(t => t.IsSubclassOf(typeof(RoutePatternPart)))
+            .Select(t => t.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(
+            new[] { "RoutePatternLiteralPart", "RoutePatternParameterPart", "RoutePatternSeparatorPart" },
+            partKinds);
+    }
+
+    /// <summary>
+    /// The shape key is what the DUPLICATE check compares, and this is the case text comparison misses:
+    /// two patterns differing only in a parameter NAME are different strings and the same route. Mapping
+    /// both produces endpoints that tie, and the tie surfaces at request time on the denied route.
+    /// </summary>
+    [Theory]
+    [InlineData("/x/{id}", "/x/{name}", true)]              // same route, different spelling
+    [InlineData("/x/{id:int}", "/x/{name:alpha}", true)]    // policies are not part of the shape either
+    [InlineData("/x/{id}", "/x/{id?}", false)]              // optional does not compete with standard
+    [InlineData("/x/{id}", "/x/{**id}", false)]             // nor does a catch-all
+    [InlineData("/x/{id}", "/y/{id}", false)]               // different literal
+    [InlineData("/x/{id}", "/x/{id}/y", false)]             // different length
+    public void The_shape_key_sees_past_names_and_policies_but_not_past_kind_or_literals(
+        string left, string right, bool sameShape)
+    {
+        var leftKey = HostedRefusalPattern.ShapeKey(HostedRefusalPattern.WithoutPolicies(left, "probe"));
+        var rightKey = HostedRefusalPattern.ShapeKey(HostedRefusalPattern.WithoutPolicies(right, "probe"));
+
+        Assert.Equal(sameShape, leftKey == rightKey);
+    }
+
+    private static System.Collections.Generic.IEnumerable<RoutePatternParameterPart> AllParameters(RoutePattern pattern)
+        => pattern.PathSegments.SelectMany(s => s.Parts).OfType<RoutePatternParameterPart>();
+
+    private static string LiteralText(RoutePattern pattern)
+        => string.Join("/", pattern.PathSegments
+            .SelectMany(s => s.Parts)
+            .OfType<RoutePatternLiteralPart>()
+            .Select(p => p.Content));
+
+}
+
+/// <summary>
+/// The FINALISED route space check: the conflicts that only exist once everything has been mapped, and
+/// which the per-group duplicate check cannot see because it can only see its own group.
+///
+/// Two conflicts, in opposite directions, and only one of them is a leak:
+///   - refusal against refusal - a denied route answers 500 instead of refusing;
+///   - refusal against a LIVE route - a route nobody denied stops serving. That is an OUTAGE, and no
+///     leak-shaped test in this repository would ever notice it.
+///
+/// What is NOT a conflict is the ordinary case, and getting that wrong would refuse to start on every
+/// correct arrangement: refusal patterns are deliberately WIDE, so they overlap neighbours constantly, and
+/// route precedence resolves the overlap. Only an exact tie is rejected.
+/// </summary>
+public sealed class HostedRefusalRouteSpaceTests
+{
+    private static readonly HostedDenial Denial = new(
+        family: "probe",
+        message: "not available on the hosted gateway",
+        reason: "the probe family exists to prove the route-space check",
+        unDenyInstruction: "nothing to un-deny: a test fixture");
+
+    private static readonly HostedDenial OtherDenial = new(
+        family: "other-probe",
+        message: "also not available on the hosted gateway",
+        reason: "a second family, to prove refusal-versus-refusal detection",
+        unDenyInstruction: "nothing to un-deny: a test fixture");
+
+    [Fact]
+    public void Two_refusals_on_the_same_route_shape_fail_the_start_rather_than_the_request()
+    {
+        // Different spelling, same route. This is the pair a text comparison lets through.
+        var endpoints = new[]
+        {
+            RefusalEndpoint("/x/{id}", Denial),
+            RefusalEndpoint("/x/{name}", OtherDenial),
+        };
+
+        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
+
+        Assert.Contains("probe", error.Message);
+        Assert.Contains("other-probe", error.Message);
+    }
+
+    [Fact]
+    public void A_refusal_tying_with_a_live_route_fails_the_start_because_that_is_an_outage()
+    {
+        var endpoints = new[]
+        {
+            RefusalEndpoint("/x/{id}", Denial),
+            LiveEndpoint("/x/{slug}"),
+        };
+
+        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
+
+        Assert.Contains("nobody denied", error.Message);
+    }
+
+    /// <summary>
+    /// The case that must NOT fail: a refusal is deliberately wider than the route it replaces, so it
+    /// overlaps live neighbours all the time. Precedence resolves it - a literal outranks a parameter - and
+    /// a validator that rejected overlap rather than ties would refuse to start on the normal arrangement.
+    /// </summary>
+    [Fact]
+    public void A_refusal_overlapping_a_more_specific_live_route_is_allowed()
+    {
+        var endpoints = new[]
+        {
+            RefusalEndpoint("/x/{id}", Denial),
+            LiveEndpoint("/x/summary"),      // literal beats the refusal's parameter
+            LiveEndpoint("/x/{id}/detail"),  // different length
+            LiveEndpoint("/y/{id}"),         // different literal
+        };
+
+        HostedRefusalRouteSpace.Validate(endpoints);
+    }
+
+    [Fact]
+    public void A_route_space_with_no_refusals_is_inert()
+        => HostedRefusalRouteSpace.Validate(new[] { LiveEndpoint("/x/{id}"), LiveEndpoint("/y") });
+
+    private static RouteEndpoint RefusalEndpoint(string pattern, HostedDenial denial)
+        => new(
+            _ => Task.CompletedTask,
+            HostedRefusalPattern.WithoutPolicies(pattern, denial.Family),
+            order: 0,
+            new EndpointMetadataCollection(new HostedRefusalMarker(denial, pattern)),
+            displayName: pattern);
+
+    private static RouteEndpoint LiveEndpoint(string pattern)
+        => new(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse(pattern),
+            order: 0,
+            EndpointMetadataCollection.Empty,
+            displayName: pattern);
+}

--- a/src/CcDirector.Gateway.Tests/Tenancy/HostedRefusalPatternTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/HostedRefusalPatternTests.cs
@@ -233,6 +233,29 @@ public sealed class HostedRefusalRouteSpaceTests
     }
 
     [Fact]
+    public void A_required_value_live_route_ties_with_a_literal_refusal_and_fails_the_start()
+    {
+        // The precedence source matters. The framework's RouteTemplate(RoutePattern) conversion DROPS a
+        // pattern's RequiredValues, but the pattern's OWN InboundPrecedence treats a parameter carrying a
+        // non-empty required value as a LITERAL. So a live /x/{slug} whose required value is slug=fixed
+        // matches ONLY /x/fixed, at the SAME precedence as the literal refusal /x/fixed - the two TIE. Method
+        // removal manufactures exactly this: a method-specific denied /x/fixed beside a verb-less
+        // required-value live endpoint. Reconstructing precedence through a RouteTemplate would score the live
+        // pattern as a plain parameter and miss the tie; reading the pattern's own InboundPrecedence sees it.
+        var live = RoutePatternFactory.Parse(
+            "/x/{slug}", defaults: null, parameterPolicies: null, requiredValues: new { slug = "fixed" });
+
+        // The tie is a precedence equality on the FINALISED patterns - documented here so the reason the
+        // start must fail is explicit, not just the throw below.
+        Assert.Equal(RoutePatternFactory.Parse("/x/fixed").InboundPrecedence, live.InboundPrecedence);
+
+        var endpoints = new[] { Refusal("/x/fixed"), LiveFromPattern(live) };
+
+        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
+        Assert.Contains("live route", error.Message);
+    }
+
+    [Fact]
     public void Refusals_on_distinct_shapes_beside_a_non_colliding_live_route_are_allowed()
     {
         // The other direction: distinct shapes do NOT tie, and a literal sibling is a different shape from a

--- a/src/CcDirector.Gateway.Tests/Tenancy/HostedRefusalPatternTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/HostedRefusalPatternTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Linq;
 using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests.Tenancy;
@@ -200,6 +202,104 @@ public sealed class HostedRefusalRouteSpaceTests
     [Fact]
     public void A_route_space_with_no_refusals_is_inert()
         => HostedRefusalRouteSpace.Validate(new[] { LiveEndpoint("/x/{id}"), LiveEndpoint("/y") });
+
+    // ---- CHANGE 1: a tie INTRODUCED by refusal substitution fails the start, rather than surfacing as a
+    //      request-time 500 on a denied route. These drive the production validator directly, over a
+    //      finalised endpoint set, which is where the promise at GatewayHost.cs was previously not kept. ----
+
+    [Fact]
+    public void Two_refusals_that_tie_after_case_folding_fail_the_start()
+    {
+        // The Codex counterexample, at the route-space level: GET /x/{id} and POST /X/{name} become verb-less
+        // refusals whose ONLY differences - method, literal case, parameter name - are exactly what
+        // substitution erases. They TIE, and an unvalidated route space would let that become a 500 on the
+        // denied route the first time a caller hit it. The validator is the backstop that fails the start.
+        var endpoints = new[] { Refusal("/x/{id}"), Refusal("/X/{name}") };
+
+        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
+        Assert.Contains("compete for the same route shape", error.Message);
+    }
+
+    [Fact]
+    public void A_refusal_that_ties_with_a_live_route_fails_the_start()
+    {
+        // The verb-less refusal matches every method, so it ties with any live route of the same shape - a
+        // denied family reaching over a route it does not own. Over-refusal, and a 500 rather than a clean
+        // answer; the start fails instead.
+        var endpoints = new[] { Refusal("/x/{id}"), LiveEndpoint("/x/{other}") };
+
+        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
+        Assert.Contains("live route", error.Message);
+    }
+
+    [Fact]
+    public void Refusals_on_distinct_shapes_beside_a_non_colliding_live_route_are_allowed()
+    {
+        // The other direction: distinct shapes do NOT tie, and a literal sibling is a different shape from a
+        // parameter segment - the neighbour must keep serving. A validator that reddened here would be an
+        // over-refusal in its own right.
+        HostedRefusalRouteSpace.Validate(new[] { Refusal("/x/{id}"), Refusal("/y/{id}"), LiveEndpoint("/x/summary") });
+    }
+
+    // ---- CHANGE 3: exclusive containment compares finalised patterns STRUCTURALLY, and a non-literal
+    //      exclusive prefix is refused at construction. ----
+
+    [Theory]
+    [InlineData("/family/{tenant:int}")]   // a parameter carrying a policy
+    [InlineData("/family/{tenant}")]       // a bare parameter, different name from any live route
+    [InlineData("/family/{**rest}")]       // a catch-all
+    public void A_non_literal_exclusive_prefix_is_refused_at_construction(string prefix)
+    {
+        // Exclusivity is verified by LITERAL prefix containment, which a parameterised prefix cannot support:
+        // /family/{tenant:int} normalises to /family/{tenant}, and a live /family/{scope}/still-serving would
+        // not textually start with the original prefix and would serve beneath the claim unseen. The prefix
+        // is rejected where it is declared, not left to slip the route-space check.
+        var outer = NewBuilder();
+
+        var error = Assert.Throws<ArgumentException>(() => HostedRouteDeny.ExclusiveGroup(outer, prefix, Denial));
+        Assert.Contains("route parameter", error.Message);
+    }
+
+    [Fact]
+    public void A_model_built_live_route_with_null_raw_text_under_the_prefix_fails_the_start()
+    {
+        // A pattern rebuilt from the route MODEL - exactly how the refusal patterns are built - has a null
+        // RawText. Reading a null RawText as the root "/" is what let a model-built live route pass
+        // containment while it served beneath the exclusively claimed prefix. The path is read from the
+        // parsed segments instead, so this fails the start.
+        var modelLive = RoutePatternFactory.Pattern(
+            RoutePatternFactory.Segment(RoutePatternFactory.LiteralPart("family")),
+            RoutePatternFactory.Segment(RoutePatternFactory.LiteralPart("still-serving")));
+        Assert.Null(modelLive.RawText);
+
+        var endpoints = new[] { ExclusiveRefusal("/family"), LiveFromPattern(modelLive) };
+
+        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(endpoints));
+        Assert.Contains("EXCLUSIVELY", error.Message);
+    }
+
+    private static IEndpointRouteBuilder NewBuilder()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        return builder.Build();
+    }
+
+    private static RouteEndpoint Refusal(string pattern)
+        => new(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse(pattern),
+            order: 0,
+            new EndpointMetadataCollection(new HostedRefusalMarker(Denial, pattern)),
+            displayName: pattern);
+
+    private static RouteEndpoint LiveFromPattern(RoutePattern pattern)
+        => new(
+            _ => Task.CompletedTask,
+            pattern,
+            order: 0,
+            EndpointMetadataCollection.Empty,
+            displayName: pattern.RawText ?? "model-built");
 
     private static RouteEndpoint ExclusiveRefusal(string prefix)
         => new(

--- a/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
@@ -11,6 +11,7 @@ using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -304,6 +305,204 @@ public sealed class HostedDenialValidationTests
             new HostedDenial("family", "message", "reason", "undeny", statusCode: StatusCodes.Status200OK));
     }
 
+}
+
+/// <summary>
+/// CHANGE 2, the exclusive-mode premise, proved over the FINALISED endpoint set and with a request probe.
+/// An exclusive family maps ONE catch-all refusal and NO per-route refusals, so conflicting declared shapes
+/// - the case/verb/policy ties a per-route family could manufacture - cannot become an ambiguous denied
+/// route. Before this fix, every <c>Map*</c> on an exclusive group ALSO installed a per-route refusal, so
+/// the exclusive family carried the exact ties its single catch-all was supposed to make impossible.
+/// </summary>
+[Collection(HostedRouteDenyCollection.Name)]
+public sealed class HostedExclusiveDenyTests
+{
+    [Fact]
+    public async Task An_exclusive_family_maps_one_catch_all_and_no_per_route_refusals()
+    {
+        await using var host = await ValidatedHostedApp.StartAsync(outer =>
+        {
+            var group = HostedRouteDeny.ExclusiveGroup(outer, "/exgroup", ProbeDenial());
+
+            // Declared shapes a per-route family would have turned into TYING verb-less refusals: the same
+            // path under two verbs and two cases, and a multi-verb path. On an exclusive family these are all
+            // discarded - the catch-all is the whole mechanism.
+            group.MapGet("/x/{id}", (int id) => Results.Json(new { id }));
+            group.MapPost("/X/{name}", (string name) => Results.Json(new { name }));
+            group.MapGet("/multi", () => Results.Json(new { m = "get" }));
+            group.MapPut("/multi", () => Results.Json(new { m = "put" }));
+        });
+
+        // The finalised endpoint set carries EXACTLY the catch-all and the prefix-root refusal - two refusal
+        // endpoints, no matter how many handlers were declared. That is the property that makes the ties
+        // impossible: there is no per-route refusal to tie with anything.
+        var refusals = host.Endpoints.OfType<RouteEndpoint>()
+            .Count(e => e.Metadata.GetMetadata<HostedRefusalMarker>() is not null);
+        Assert.Equal(2, refusals);
+
+        // The production validator is content: with no per-route refusal, nothing competes.
+        HostedRefusalRouteSpace.Validate(host.Endpoints);
+
+        // The request probe: every declared path, and one never declared at all, answers the refusal
+        // deterministically - a 404 refusal, never the 500 an ambiguous denied route would produce.
+        foreach (var path in new[]
+                 {
+                     "/exgroup/x/7", "/exgroup/x/anything", "/exgroup/X/7",
+                     "/exgroup/multi", "/exgroup", "/exgroup/never/declared/deep",
+                 })
+        {
+            var response = await host.GetAsync(path);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Equal("application/json; charset=utf-8", response.Content.Headers.ContentType?.ToString());
+        }
+    }
+
+    [Fact]
+    public async Task An_exclusive_family_serves_its_real_handlers_off_hosted()
+    {
+        // The control: off hosted the exclusive flag is inert, the catch-all is never mapped, and the real
+        // handlers serve exactly as any group's would. Without this, a bug that discarded handlers on
+        // self-host too would satisfy the hosted assertion above and silently break every desktop install.
+        await using var host = await ValidatedHostedApp.StartAsync(
+            outer =>
+            {
+                var group = HostedRouteDeny.ExclusiveGroup(outer, "/exgroup", ProbeDenial());
+                group.MapGet("/x/{id}", (int id) => Results.Json(new { id }));
+            },
+            hosted: false);
+
+        var response = await host.GetAsync("/exgroup/x/7");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("\"id\":7", await response.Content.ReadAsStringAsync());
+    }
+
+    private static HostedDenial ProbeDenial(string family = "probe") => ProbeDenialFactory.Make(family);
+}
+
+/// <summary>
+/// CHANGE 1, the finalised route-space check, proved through REAL mapping rather than hand-built endpoints:
+/// the tie is manufactured by two families that each map a refusal the way an adopting family does, and the
+/// production validator is shown to THROW over the actual finalised endpoint set - not to let the tie become
+/// a request-time 500. The companion single-family case shows the case-fold dedup already collapses the
+/// Codex counterexample to one refusal, so it never reaches the validator as a tie at all.
+/// </summary>
+[Collection(HostedRouteDenyCollection.Name)]
+public sealed class HostedRefusalRouteSpaceCrossGroupTests
+{
+    [Fact]
+    public async Task Two_families_denying_a_method_disambiguated_shape_fail_the_validator()
+    {
+        // Cross-group: family A denies GET /shared/{id}, family B denies POST /shared/{name}. Self-host holds
+        // them apart by method; hosted strips the method, so both become verb-less refusals on the same shape
+        // and TIE. Dedup is per-group and cannot see across families, so the finalised route-space check is
+        // the only thing that can - and it must fail the start rather than allow the request-time 500.
+        await using var host = await ValidatedHostedApp.StartAsync(outer =>
+        {
+            var a = HostedRouteDeny.Group(outer, "/shared", ProbeDenial("A"));
+            a.MapGet("/{id}", (int id) => Results.Json(new { id }));
+
+            var b = HostedRouteDeny.Group(outer, "/shared", ProbeDenial("B"));
+            b.MapPost("/{name}", (string name) => Results.Json(new { name }));
+        });
+
+        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(host.Endpoints));
+        Assert.Contains("compete for the same route shape", error.Message);
+    }
+
+    [Fact]
+    public async Task A_single_family_denying_one_shape_under_two_verbs_and_cases_dedups_to_one_refusal()
+    {
+        // The Codex counterexample within ONE family: GET /x/{id} and POST /X/{name}. The case-folded shape
+        // key collapses them to a SINGLE verb-less refusal, so the validator sees no tie and every denied
+        // path answers the refusal rather than the 500 the un-folded key would have produced.
+        await using var host = await ValidatedHostedApp.StartAsync(outer =>
+        {
+            var group = HostedRouteDeny.Group(outer, "", ProbeDenial());
+            group.MapGet("/x/{id}", (int id) => Results.Json(new { id }));
+            group.MapPost("/X/{name}", (string name) => Results.Json(new { name }));
+        });
+
+        HostedRefusalRouteSpace.Validate(host.Endpoints);
+
+        var refusals = host.Endpoints.OfType<RouteEndpoint>()
+            .Count(e => e.Metadata.GetMetadata<HostedRefusalMarker>() is not null);
+        Assert.Equal(1, refusals);
+
+        foreach (var path in new[] { "/x/7", "/x/anything", "/X/7" })
+        {
+            var response = await host.GetAsync(path);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+    }
+
+    private static HostedDenial ProbeDenial(string family = "probe") => ProbeDenialFactory.Make(family);
+}
+
+/// <summary>The refusal payload used by the exclusive and cross-group hosts.</summary>
+internal static class ProbeDenialFactory
+{
+    public static HostedDenial Make(string family = "probe") => new(
+        family: family,
+        message: "this family is not available on the hosted gateway",
+        reason: "the probe family exists only to prove the primitive",
+        unDenyInstruction: "nothing to un-deny: this family is a test fixture and stores nothing");
+}
+
+/// <summary>
+/// A minimal HOSTED (or, on request, self-host) app that lets a test map families the way an adopter does,
+/// then reads the FINALISED endpoint set and probes it. The endpoint set is captured the same way
+/// GatewayHost captures it - the aggregate <see cref="EndpointDataSource"/> after every Map - so the
+/// validator under test sees exactly what it sees in production.
+/// </summary>
+internal sealed class ValidatedHostedApp : IAsyncDisposable
+{
+    private readonly WebApplication _app;
+    private readonly HttpClient _http;
+    private readonly string? _priorHosted;
+
+    public IReadOnlyList<Endpoint> Endpoints { get; }
+
+    private ValidatedHostedApp(WebApplication app, HttpClient http, string? priorHosted, IReadOnlyList<Endpoint> endpoints)
+    {
+        _app = app;
+        _http = http;
+        _priorHosted = priorHosted;
+        Endpoints = endpoints;
+    }
+
+    public static async Task<ValidatedHostedApp> StartAsync(Action<IEndpointRouteBuilder> map, bool hosted = true)
+    {
+        var priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        map(app);
+
+        await app.StartAsync();
+
+        // The FINALISED endpoint set, read the same way GatewayHost reads it - the aggregate
+        // EndpointDataSource - but after Start, which is when the routing middleware materialises the group
+        // endpoints into it.
+        var endpoints = app.Services.GetRequiredService<EndpointDataSource>().Endpoints;
+
+        var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+        return new ValidatedHostedApp(app, http, priorHosted, endpoints);
+    }
+
+    public Task<HttpResponseMessage> GetAsync(string path) => _http.GetAsync(path);
+
+    public async ValueTask DisposeAsync()
+    {
+        _http.Dispose();
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+    }
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
@@ -131,6 +131,47 @@ public sealed class HostedRouteDenyOnHostedTests : IAsyncLifetime
         Assert.Contains("neighbour", await response.Content.ReadAsStringAsync());
     }
 
+    [Fact]
+    public async Task A_HEAD_request_meets_the_refusal_status_with_no_body()
+    {
+        // Stated deliberately rather than folded into "every request shape": HTTP says a HEAD carries the
+        // headers and no body, and the framework enforces that. So the uniformity claim is about the STATUS
+        // and the HEADERS here, not the bytes - and a reader is entitled to see which it is.
+        var response = await _host.SendAsync(HttpMethod.Head, "/family/echo");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal("application/json; charset=utf-8", response.Content.Headers.ContentType?.ToString());
+        Assert.Empty(await response.Content.ReadAsByteArrayAsync());
+    }
+
+    [Theory]
+    [InlineData("/family/multi")]
+    public async Task A_family_mapping_several_verbs_on_one_path_gets_ONE_refusal_and_not_a_tie(string path)
+    {
+        // The multi-verb path adopting families rely on, and it was previously unproved. Two verbs on one
+        // path must produce ONE verb-less refusal: a second would TIE with the first, and a tie surfaces as
+        // a 500 at request time - on the denied route, which is the one nobody exercises until a caller
+        // does. Every verb here must meet the refusal, including one the family never mapped.
+        foreach (var method in new[] { HttpMethod.Get, HttpMethod.Put, HttpMethod.Post, HttpMethod.Delete })
+        {
+            var response = await _host.SendAsync(method, path);
+            await AssertIsExactlyTheRefusal(response);
+        }
+    }
+
+    [Fact]
+    public async Task A_neighbouring_route_with_a_PARAMETER_segment_still_serves()
+    {
+        // The neighbour probe in its second direction. The literal case proves precedence protects a fixed
+        // sibling; this proves the refusal has not widened across a path boundary into a different route
+        // shape entirely. One case tests one thing, and over-refusal is the direction no leak-shaped test
+        // would ever notice.
+        var response = await _host.PostJsonAsync("/family/other/anything", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("neighbour", await response.Content.ReadAsStringAsync());
+    }
+
     /// <summary>
     /// Asserts the response is the family's refusal and NOTHING ELSE. Status and media type are asserted
     /// BEFORE the body is parsed, deliberately: parsing is itself an assertion about format, so a guard that
@@ -141,7 +182,11 @@ public sealed class HostedRouteDenyOnHostedTests : IAsyncLifetime
     private static async Task AssertIsExactlyTheRefusal(HttpResponseMessage response)
     {
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        // The WHOLE header value, parameters included. Asserting only the media type would pass on a
+        // refusal served with a different charset, and a refusal is a contract about exactly what is
+        // served - "close enough" on a content type is how a caller parses something other than it expected.
+        Assert.Equal("application/json; charset=utf-8", response.Content.Headers.ContentType?.ToString());
 
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
@@ -170,6 +215,27 @@ public sealed class HostedRouteDenySelfHostControlTests : IAsyncLifetime
     public async Task InitializeAsync() => _host = await DenyProbeHost.StartAsync(hosted: false);
 
     public Task DisposeAsync() => _host.DisposeAsync().AsTask();
+
+    /// <summary>
+    /// BOTH declared non-hosted forms, explicitly. The variable ABSENT and the variable present but not
+    /// "1" are two different states of the world, and a control exercising one of them proves the guard
+    /// for one of them. The absent case additionally must be SET rather than inherited: a control that
+    /// passes because the runner happened to leave the variable unset is reporting an ambient condition,
+    /// not a property of the code.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]      // absent
+    [InlineData("0")]       // present, not "1"
+    [InlineData("")]        // present, empty
+    public async Task The_family_serves_normally_in_EITHER_non_hosted_form(string? nonHostedForm)
+    {
+        await using var host = await DenyProbeHost.StartAsync(hosted: false, nonHostedForm: nonHostedForm);
+
+        var response = await host.PostJsonAsync("/family/echo", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("hello", await response.Content.ReadAsStringAsync());
+    }
 
     [Fact]
     public async Task The_family_serves_normally_off_hosted()
@@ -238,14 +304,6 @@ public sealed class HostedDenialValidationTests
             new HostedDenial("family", "message", "reason", "undeny", statusCode: StatusCodes.Status200OK));
     }
 
-    [Theory]
-    [InlineData("/x/{id:int}", "/x/{id}")]
-    [InlineData("/x/{id:int}/y/{name:alpha}", "/x/{id}/y/{name}")]
-    [InlineData("/x/{id}", "/x/{id}")]
-    [InlineData("/x/plain", "/x/plain")]
-    [InlineData("/x/{**rest}", "/x/{**rest}")]
-    public void The_refusal_pattern_drops_inline_constraints_and_nothing_else(string pattern, string expected)
-        => Assert.Equal(expected, HostedDenyGroup.StripInlineConstraints(pattern));
 }
 
 /// <summary>
@@ -278,10 +336,17 @@ internal sealed class DenyProbeHost : IAsyncDisposable
         _priorHosted = priorHosted;
     }
 
-    public static async Task<DenyProbeHost> StartAsync(bool hosted)
+    /// <param name="nonHostedForm">
+    /// WHICH non-hosted form to set when <paramref name="hosted"/> is false. There are TWO declared ways to
+    /// be non-hosted - the variable ABSENT, and the variable present but not "1" - and a control that only
+    /// ever exercises one of them proves the guard for one of them. Worse, a control that leans on the
+    /// variable being absent passes only because the test runner happened to leave it unset, which is an
+    /// ambient condition and not a proof.
+    /// </param>
+    public static async Task<DenyProbeHost> StartAsync(bool hosted, string? nonHostedForm = null)
     {
         var priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
-        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : nonHostedForm);
 
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
@@ -314,9 +379,16 @@ internal sealed class DenyProbeHost : IAsyncDisposable
         group.MapPost("/custom", (ObservableBinding probe) => Results.Json(new { probe = probe.Value }));
         group.MapPost("/typed/{id:int}", (int id, EchoBody body) => Results.Json(new { id, body.Text }));
 
-        // A literal sibling under the same path shape, mapped OUTSIDE the family: it is not denied and must
-        // keep serving on hosted. This is the over-refusal direction.
+        // TWO verbs on ONE path: the multi-verb shape adopting families rely on. On hosted these must
+        // collapse to a single verb-less refusal rather than two endpoints that tie.
+        group.MapGet("/multi", () => Results.Json(new { multi = "get" }));
+        group.MapPut("/multi", (EchoBody body) => Results.Json(new { multi = body.Text }));
+
+        // Neighbours mapped OUTSIDE the family: neither is denied and both must keep serving on hosted.
+        // A literal sibling under the same path shape (precedence protects it) and a route on a different
+        // path shape entirely (the refusal must not have widened across a path boundary).
         outer.MapPost("/family/typed/summary", () => Results.Json(new { neighbour = "still serving" }));
+        outer.MapPost("/family/other/{name}", (string name) => Results.Json(new { neighbour = name }));
 
         // Mapped LAST, with a bound body: the future route. A parameterless GET here would prove nothing,
         // because a parameterless GET is the one shape the original defect cannot be seen through.
@@ -330,6 +402,9 @@ internal sealed class DenyProbeHost : IAsyncDisposable
         => _http.PostAsync(path, new StringContent(content, Encoding.UTF8, mediaType));
 
     public Task<HttpResponseMessage> GetAsync(string path) => _http.GetAsync(path);
+
+    public Task<HttpResponseMessage> SendAsync(HttpMethod method, string path)
+        => _http.SendAsync(new HttpRequestMessage(method, path));
 
     public async ValueTask DisposeAsync()
     {

--- a/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
@@ -1,0 +1,365 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Tenancy;
+
+/// <summary>
+/// The shared hosted-refusal primitive: the ONE boundary every deny family adopts, proved here ONCE for all
+/// of them.
+///
+/// WHY IT EXISTS. A refusal attached as a route-group endpoint filter does not answer uniformly across
+/// request shapes. The mechanism and the measurements are in the PRIVATE architecture record; what belongs
+/// here is the guarantee being asserted, one test per shape.
+///
+/// WHAT IS PROVED HERE, AND WHY EACH FAMILY DOES NOT RE-PROVE IT. On hosted the family's handler is never
+/// mapped: a verb-less, constraint-free refusal route takes its place. An adopter therefore cannot be
+/// attached AND still bind, because attachment IS the substitution - there is no state of the world where
+/// attachment holds and the property fails. So the pre-binding property is proved once, here, and each
+/// adopting family owes only attachment, gate direction, and its own body-bound future-route probe.
+///
+/// THE SHAPE SET IS THE WHOLE POINT, and it is enumerated rather than sampled because this defect is
+/// invisible to the obvious probe: a parameterless GET is exactly the shape that CANNOT see it. Every shape
+/// below was measured to be answered by something other than the refusal under at least one candidate
+/// design that looked correct:
+///
+///   valid body | malformed body | wrong media type | custom binder | future route | wrong verb |
+///   route-constraint miss | route-constraint hit
+///
+/// A GUARD HAS TWO FAILURE DIRECTIONS AND ONLY ONE OF THEM IS A LEAK. Under-refusal leaks; OVER-refusal is
+/// an outage on a route nobody denied. The neighbour probe below is what tests the second direction, and it
+/// is the reason the alternative design - a host-wide matcher refusing by path prefix - was rejected: it was
+/// measured refusing a sibling route that was never part of the denied family. Every deny from here on
+/// carries a neighbour probe.
+/// </summary>
+[Collection(HostedRouteDenyCollection.Name)]
+public sealed class HostedRouteDenyOnHostedTests : IAsyncLifetime
+{
+    private DenyProbeHost _host = null!;
+
+    public async Task InitializeAsync() => _host = await DenyProbeHost.StartAsync(hosted: true);
+
+    public Task DisposeAsync() => _host.DisposeAsync().AsTask();
+
+    [Theory]
+    [InlineData("/family/echo")]        // a body-bound POST
+    [InlineData("/family/custom")]      // a parameter with a custom binder, whose execution is observable
+    [InlineData("/family/future")]      // mapped into the group AFTER everything else: the future route
+    public async Task Every_route_in_the_group_is_refused_on_hosted(string path)
+    {
+        var response = await _host.PostJsonAsync(path, "{\"text\":\"hello\"}");
+        await AssertIsExactlyTheRefusal(response);
+    }
+
+    [Fact]
+    public async Task A_malformed_body_meets_the_refusal_and_not_the_frameworks_own_400()
+    {
+        // A shape that an earlier boundary let the framework answer instead of the refusal.
+        var response = await _host.PostJsonAsync("/family/echo", "{ not json");
+        await AssertIsExactlyTheRefusal(response);
+    }
+
+    [Fact]
+    public async Task A_wrong_media_type_meets_the_refusal_and_not_the_frameworks_own_415()
+    {
+        // The shape that survived the longest across candidate designs: a body parameter makes the
+        // framework infer a media-type constraint that endpoint SELECTION enforces ahead of any handler.
+        // Mapping no handler at all is what removes the constraint along with the handler.
+        var response = await _host.PostAsync("/family/echo", "hello", "text/plain");
+        await AssertIsExactlyTheRefusal(response);
+    }
+
+    [Fact]
+    public async Task A_verb_the_family_never_mapped_meets_the_refusal_and_not_a_405()
+    {
+        // A 405 would disclose that the route EXISTS on a Gateway whose refusal says it does not. A wrong
+        // verb is a request shape, and the standard is that the refusal is uniform across shapes.
+        var response = await _host.GetAsync("/family/echo");
+        await AssertIsExactlyTheRefusal(response);
+    }
+
+    [Theory]
+    [InlineData("/family/typed/7")]     // satisfies the real route's {id:int}
+    [InlineData("/family/typed/abc")]   // FAILS it - and so would never select a refusal carrying it
+    public async Task A_constrained_route_is_refused_whether_or_not_the_constraint_is_satisfied(string path)
+    {
+        // The miss is the one that matters. A segment that fails an inline constraint fails endpoint
+        // selection, so a refusal mapped on the same constrained pattern is never selected either and the
+        // framework answers its own 404 with the refusal never running. The refusal is therefore mapped on
+        // the pattern with its constraints stripped.
+        var response = await _host.PostJsonAsync(path, "{\"text\":\"hello\"}");
+        await AssertIsExactlyTheRefusal(response);
+    }
+
+    [Fact]
+    public async Task No_argument_binder_runs_behind_the_refusal_on_any_shape()
+    {
+        // The claim is not "the response was right" - it is that NO handler-bound code executed at all. This
+        // is the assertion that separates a refusal placed before binding from one placed after it, and it
+        // is the one that was false under the filter on every shape including a valid body.
+        ObservableBinding.Reset();
+
+        await _host.PostJsonAsync("/family/custom", "{\"text\":\"hello\"}");
+        await _host.PostJsonAsync("/family/custom", "{ not json");
+        await _host.PostAsync("/family/custom", "hello", "text/plain");
+        await _host.GetAsync("/family/custom");
+
+        Assert.Equal(0, ObservableBinding.Count);
+    }
+
+    [Fact]
+    public async Task A_neighbouring_route_outside_the_family_still_serves()
+    {
+        // The OTHER failure direction. A guard that refuses a route nobody denied is an outage, and it is
+        // the measured defect of the rejected path-prefix design. Route precedence is what protects this:
+        // a literal segment outranks the refusal's loosened parameter segment.
+        var response = await _host.PostJsonAsync("/family/typed/summary", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("neighbour", await response.Content.ReadAsStringAsync());
+    }
+
+    /// <summary>
+    /// Asserts the response is the family's refusal and NOTHING ELSE. Status and media type are asserted
+    /// BEFORE the body is parsed, deliberately: parsing is itself an assertion about format, so a guard that
+    /// has gone and a route now serving HTML must redden as "expected application/json, got text/html"
+    /// rather than as a parser exception. A red that arrives as a crash proves the mutation landed, not that
+    /// the guard was the thing holding.
+    /// </summary>
+    private static async Task AssertIsExactlyTheRefusal(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
+
+        // The whole property set against a one-name allow-list. A deny-list of today's keys cannot see an
+        // extra field that leaks tomorrow; enumerating the set reddens on anything extra with no edit here.
+        Assert.Equal(new[] { "error" }, document.RootElement.EnumerateObject().Select(p => p.Name).ToArray());
+        Assert.Equal(DenyProbeHost.RefusalMessage, document.RootElement.GetProperty("error").GetString());
+    }
+}
+
+/// <summary>
+/// THE GATE DIRECTION, AND THE CONTROL. Off hosted the primitive maps the family's real handlers and creates
+/// no refusal at all, so the family is byte-identical to one mapped on an unguarded builder.
+///
+/// This class is what fails if the hosted condition is ever inverted or hard-wired: a refusal that fired
+/// everywhere would look perfect to every test in the class above and would silently break every self-host
+/// install. Absence of the refusal is asserted POSITIVELY - the real handler's own payload is required -
+/// because an assertion that merely checks "not the refusal" passes on a framework error too.
+/// </summary>
+[Collection(HostedRouteDenyCollection.Name)]
+public sealed class HostedRouteDenySelfHostControlTests : IAsyncLifetime
+{
+    private DenyProbeHost _host = null!;
+
+    public async Task InitializeAsync() => _host = await DenyProbeHost.StartAsync(hosted: false);
+
+    public Task DisposeAsync() => _host.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task The_family_serves_normally_off_hosted()
+    {
+        var response = await _host.PostJsonAsync("/family/echo", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("hello", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task A_route_added_to_the_group_later_serves_normally_off_hosted()
+    {
+        var response = await _host.PostJsonAsync("/family/future", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("hello", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task The_real_binder_runs_off_hosted()
+    {
+        // The positive twin of the hosted no-binding assertion. Without this, a primitive that broke binding
+        // outright on every deployment would satisfy the hosted class and nothing would notice.
+        ObservableBinding.Reset();
+
+        var response = await _host.PostJsonAsync("/family/custom", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, ObservableBinding.Count);
+    }
+
+    [Fact]
+    public async Task The_constrained_route_still_constrains_off_hosted()
+    {
+        // Self-host keeps the real route's constraint: the loosened pattern exists ONLY on hosted, so a
+        // constraint miss here is the framework's own 404 and carries no refusal body.
+        var response = await _host.PostJsonAsync("/family/typed/abc", "{\"text\":\"hello\"}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(0, (await response.Content.ReadAsStringAsync()).Length);
+    }
+}
+
+/// <summary>The refusal payload is validated where it is CONSTRUCTED, so a bad one fails at startup.</summary>
+[Collection(HostedRouteDenyCollection.Name)]
+public sealed class HostedDenialValidationTests
+{
+    [Theory]
+    [InlineData("", "message", "reason", "undeny")]
+    [InlineData("family", "", "reason", "undeny")]
+    [InlineData("family", "message", "", "undeny")]
+    [InlineData("family", "message", "reason", "")]
+    public void A_denial_that_would_refuse_meaninglessly_is_refused_at_construction(
+        string family, string message, string reason, string unDeny)
+    {
+        // Failing to boot is the correct direction. A blank refusal serves something a caller cannot act on
+        // and a proof cannot assert - which reads, from outside, like a working route.
+        Assert.Throws<ArgumentException>(() => new HostedDenial(family, message, reason, unDeny));
+    }
+
+    [Fact]
+    public void A_denial_must_refuse_with_a_failure_status()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new HostedDenial("family", "message", "reason", "undeny", statusCode: StatusCodes.Status200OK));
+    }
+
+    [Theory]
+    [InlineData("/x/{id:int}", "/x/{id}")]
+    [InlineData("/x/{id:int}/y/{name:alpha}", "/x/{id}/y/{name}")]
+    [InlineData("/x/{id}", "/x/{id}")]
+    [InlineData("/x/plain", "/x/plain")]
+    [InlineData("/x/{**rest}", "/x/{**rest}")]
+    public void The_refusal_pattern_drops_inline_constraints_and_nothing_else(string pattern, string expected)
+        => Assert.Equal(expected, HostedDenyGroup.StripInlineConstraints(pattern));
+}
+
+/// <summary>
+/// Serialises these classes. They set the process-wide <c>CC_GATEWAY_HOSTED</c> variable, and one class
+/// running while another flips it would produce exactly the kind of unexplained cross-class contamination
+/// this mission has already had to chase down inside its own instrument.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class HostedRouteDenyCollection
+{
+    public const string Name = "hosted-route-deny";
+}
+
+/// <summary>
+/// A minimal Gateway-shaped host carrying ONE denied family, mapped through the typed handle, plus a
+/// neighbouring route mapped OUTSIDE the family that must keep serving.
+/// </summary>
+internal sealed class DenyProbeHost : IAsyncDisposable
+{
+    public const string RefusalMessage = "this family is not available on the hosted gateway";
+
+    private readonly WebApplication _app;
+    private readonly HttpClient _http;
+    private readonly string? _priorHosted;
+
+    private DenyProbeHost(WebApplication app, HttpClient http, string? priorHosted)
+    {
+        _app = app;
+        _http = http;
+        _priorHosted = priorHosted;
+    }
+
+    public static async Task<DenyProbeHost> StartAsync(bool hosted)
+    {
+        var priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        MapFamily(app);
+
+        await app.StartAsync();
+        var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+        return new DenyProbeHost(app, http, priorHosted);
+    }
+
+    /// <summary>
+    /// The family, mapped the way an adopting family maps: the group is opened here and the routes go
+    /// through the typed handle. The neighbour is mapped on the OUTER builder, which is what a route outside
+    /// the denied family looks like.
+    /// </summary>
+    private static void MapFamily(IEndpointRouteBuilder outer)
+    {
+        var denial = new HostedDenial(
+            family: "probe",
+            message: RefusalMessage,
+            reason: "the probe family exists only to prove the primitive",
+            unDenyInstruction: "nothing to un-deny: this family is a test fixture and stores nothing");
+
+        var group = HostedRouteDeny.Group(outer, "/family", denial);
+
+        group.MapPost("/echo", (EchoBody body) => Results.Json(new { echoed = body.Text }));
+        group.MapPost("/custom", (ObservableBinding probe) => Results.Json(new { probe = probe.Value }));
+        group.MapPost("/typed/{id:int}", (int id, EchoBody body) => Results.Json(new { id, body.Text }));
+
+        // A literal sibling under the same path shape, mapped OUTSIDE the family: it is not denied and must
+        // keep serving on hosted. This is the over-refusal direction.
+        outer.MapPost("/family/typed/summary", () => Results.Json(new { neighbour = "still serving" }));
+
+        // Mapped LAST, with a bound body: the future route. A parameterless GET here would prove nothing,
+        // because a parameterless GET is the one shape the original defect cannot be seen through.
+        group.MapPost("/future", (EchoBody body) => Results.Json(new { future = body.Text }));
+    }
+
+    public Task<HttpResponseMessage> PostJsonAsync(string path, string json)
+        => PostAsync(path, json, "application/json");
+
+    public Task<HttpResponseMessage> PostAsync(string path, string content, string mediaType)
+        => _http.PostAsync(path, new StringContent(content, Encoding.UTF8, mediaType));
+
+    public Task<HttpResponseMessage> GetAsync(string path) => _http.GetAsync(path);
+
+    public async ValueTask DisposeAsync()
+    {
+        _http.Dispose();
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+    }
+
+    private sealed record EchoBody(string Text);
+}
+
+/// <summary>
+/// A parameter whose BINDING IS OBSERVABLE. Argument binding leaves no trace of its own, so proving that
+/// nothing bound requires a parameter that records the fact it was bound. This is the instrument for the
+/// central claim - not that the response was right, but that no handler-bound code ran at all.
+/// </summary>
+internal sealed class ObservableBinding
+{
+    private static int _count;
+
+    public string Value { get; init; } = "";
+
+    public static int Count => Volatile.Read(ref _count);
+
+    public static void Reset() => Interlocked.Exchange(ref _count, 0);
+
+    public static ValueTask<ObservableBinding?> BindAsync(HttpContext context)
+    {
+        Interlocked.Increment(ref _count);
+        return ValueTask.FromResult<ObservableBinding?>(new ObservableBinding { Value = "bound" });
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
@@ -684,12 +684,13 @@ internal sealed class UnstartedHostedApp : IAsyncDisposable
 
         map(app);
 
-        // The FINALISED set, read the way GatewayHost reads it - and, crucially, NOT started. The app's own
+        // The FINALISED set, selected through the SAME production helper GatewayHost uses
+        // (HostedRefusalRouteSpace.SelectFinalisedEndpoints) - and, crucially, NOT started. The app's own
         // data sources already carry the group endpoints; the DI CompositeEndpointDataSource would still be
-        // empty here, which is exactly the production trap this harness exists to keep honest.
-        var endpoints = ((IEndpointRouteBuilder)app).DataSources
-            .SelectMany(source => source.Endpoints)
-            .ToList();
+        // empty here, which is exactly the production trap this harness exists to keep honest. Sharing the
+        // ONE selection means a revert of that source to the DI composite empties these endpoints and reddens
+        // the tie tests below, rather than passing unnoticed while production silently regresses.
+        var endpoints = HostedRefusalRouteSpace.SelectFinalisedEndpoints(app);
 
         return new UnstartedHostedApp(app, priorHosted, endpoints);
     }

--- a/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/HostedRouteDenyTests.cs
@@ -9,6 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -439,6 +441,134 @@ public sealed class HostedRefusalRouteSpaceCrossGroupTests
     private static HostedDenial ProbeDenial(string family = "probe") => ProbeDenialFactory.Make(family);
 }
 
+/// <summary>
+/// The finalised-route-space check, proved to FAIL BEFORE StartAsync - the guarantee the round-1 harness
+/// could not make, because it started the listener first and only then read the endpoints. Here the families
+/// are mapped exactly as an adopter maps them, the FINALISED endpoint set is read the way GatewayHost reads
+/// it in production - from the app's OWN <see cref="IEndpointRouteBuilder"/> data sources, which carry the
+/// group endpoints (prefix and metadata applied) the moment they are mapped - and the production validator is
+/// shown to THROW over that set while NO listener has bound.
+///
+/// THE THREE PAIRS ARE THE ONES ROUND 1 MISSED. Each pair ties in the matcher but has DIFFERENT shape keys,
+/// so a check that only compared keys for EQUALITY let them through. Method removal is what manufactures the
+/// tie: off hosted each pair is held apart by its HTTP method, and the substitution drops the method.
+///   1. Standard vs Optional parameter in one denied group - keys differ by parameter kind.
+///   2. A denied refusal vs a LIVE route of the same shape - the exact-key live lookup could not see it.
+///   3. Two complex segments differing only by SEPARATOR - keys differ by separator text.
+/// </summary>
+[Collection(HostedRouteDenyCollection.Name)]
+public sealed class HostedRefusalRouteSpaceFailBeforeStartTests
+{
+    [Fact]
+    public async Task Case_1_standard_versus_optional_in_one_group_ties_and_fails_before_start()
+    {
+        await using var host = UnstartedHostedApp.Map(outer =>
+        {
+            // ONE denied group, two routes a family held apart by METHOD off hosted. Hosted strips the
+            // method: /x/{id} (Standard) and /x/{name?} (Optional) become verb-less refusals that a single
+            // path /x/value matches at EQUAL precedence. Their shape keys differ - Standard versus Optional -
+            // so the round-1 equality check missed them; the overlap check must not.
+            var group = HostedRouteDeny.Group(outer, "", ProbeDenial());
+            group.MapGet("/x/{id}", (int id) => Results.Json(new { id }));
+            group.MapPost("/x/{name?}", (string? name) => Results.Json(new { name }));
+        });
+
+        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(host.Endpoints));
+        Assert.Contains("compete for the same route shape", error.Message);
+        Assert.False(host.Started, "the validator must fail BEFORE the host starts and binds a listener");
+    }
+
+    [Fact]
+    public async Task Case_2_a_refusal_ties_with_a_live_route_of_a_different_kind_and_fails_before_start()
+    {
+        await using var host = UnstartedHostedApp.Map(outer =>
+        {
+            // A denied POST /x/{id} and a LIVE GET /x/{name?}. Off hosted the method holds them apart; hosted
+            // gives the family a verb-less refusal /x/{id} that competes with the live /x/{name?} on /x/value.
+            // The kinds differ (Standard versus Optional), so an exact-key live lookup could not see the tie.
+            var group = HostedRouteDeny.Group(outer, "", ProbeDenial());
+            group.MapPost("/x/{id}", (int id) => Results.Json(new { id }));
+
+            outer.MapGet("/x/{name?}", (string? name) => Results.Json(new { name }));
+        });
+
+        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(host.Endpoints));
+        Assert.Contains("competes for the same route shape as the live route", error.Message);
+        Assert.False(host.Started, "the validator must fail BEFORE the host starts and binds a listener");
+    }
+
+    [Fact]
+    public async Task Case_3_complex_segments_differing_only_by_separator_tie_and_fail_before_start()
+    {
+        await using var host = UnstartedHostedApp.Map(outer =>
+        {
+            // Two complex segments the framework ranks at EQUAL precedence: /x/{a}-{b} and /x/{c}.{d} both
+            // match /x/left-mid.right after the method is stripped. Their shape keys differ only by the
+            // separator character, so equality missed them; the overlap check treats two complex segments at
+            // equal precedence as able to share a value and fails the start.
+            var group = HostedRouteDeny.Group(outer, "", ProbeDenial());
+            group.MapGet("/x/{a}-{b}", (string a, string b) => Results.Json(new { a, b }));
+            group.MapPost("/x/{c}.{d}", (string c, string d) => Results.Json(new { c, d }));
+        });
+
+        var error = Assert.Throws<InvalidOperationException>(() => HostedRefusalRouteSpace.Validate(host.Endpoints));
+        Assert.Contains("compete for the same route shape", error.Message);
+        Assert.False(host.Started, "the validator must fail BEFORE the host starts and binds a listener");
+    }
+
+    [Fact]
+    public async Task A_non_tying_neighbour_of_a_different_kind_does_not_fail_the_start()
+    {
+        // THE OTHER FAILURE DIRECTION - over-rejection is an outage. A refusal /x/{id} (a parameter) and a
+        // LIVE literal /x/summary do NOT tie: the literal outranks the parameter, so the matcher never has to
+        // choose between them. The framework's own precedence is what tells the overlap check they differ, so
+        // the neighbour keeps serving and the Gateway starts. Without this a leak-shaped test set would never
+        // notice the validator had begun refusing routes nobody denied.
+        await using var host = UnstartedHostedApp.Map(outer =>
+        {
+            var group = HostedRouteDeny.Group(outer, "", ProbeDenial());
+            group.MapGet("/x/{id}", (int id) => Results.Json(new { id }));
+
+            outer.MapGet("/x/summary", () => Results.Json(new { neighbour = "still serving" }));
+        });
+
+        var exception = Record.Exception(() => HostedRefusalRouteSpace.Validate(host.Endpoints));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task The_finalised_refusals_are_visible_before_start_only_via_the_apps_own_data_sources()
+    {
+        // WHY GatewayHost reads the app's own data sources and not the DI CompositeEndpointDataSource, locked
+        // as a test so the production read cannot be "simplified" back into silence. Before StartAsync the DI
+        // composite has NOT been populated with the minimal-API / MapGroup endpoints, so reading it here
+        // returns an EMPTY set and the whole validation quietly does nothing; the app's own data sources carry
+        // the refusals as soon as they are mapped. If a future framework populates the composite eagerly this
+        // reddens and a human re-checks the production read - which is the point.
+        await using var host = UnstartedHostedApp.Map(outer =>
+        {
+            var group = HostedRouteDeny.Group(outer, "", ProbeDenial());
+            group.MapGet("/x/{id}", (int id) => Results.Json(new { id }));
+            group.MapPost("/x/{name?}", (string? name) => Results.Json(new { name }));
+        });
+
+        var viaDiComposite = host.App.Services
+            .GetRequiredService<EndpointDataSource>().Endpoints
+            .OfType<RouteEndpoint>()
+            .Count(e => e.Metadata.GetMetadata<HostedRefusalMarker>() is not null);
+
+        var viaAppDataSources = ((IEndpointRouteBuilder)host.App).DataSources
+            .SelectMany(source => source.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Count(e => e.Metadata.GetMetadata<HostedRefusalMarker>() is not null);
+
+        Assert.Equal(0, viaDiComposite);
+        Assert.Equal(2, viaAppDataSources);
+    }
+
+    private static HostedDenial ProbeDenial(string family = "probe") => ProbeDenialFactory.Make(family);
+}
+
 /// <summary>The refusal payload used by the exclusive and cross-group hosts.</summary>
 internal static class ProbeDenialFactory
 {
@@ -500,6 +630,73 @@ internal sealed class ValidatedHostedApp : IAsyncDisposable
     {
         _http.Dispose();
         await _app.StopAsync();
+        await _app.DisposeAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+    }
+}
+
+/// <summary>
+/// A HOSTED app that maps families the way an adopter does and then reads the FINALISED endpoint set WITHOUT
+/// starting the listener - the piece the round-1 harness lacked. It reads the endpoints the same way
+/// GatewayHost does in production: from the app's OWN <see cref="IEndpointRouteBuilder"/> data sources, which
+/// carry the group endpoints (prefix and metadata conventions applied) as soon as they are mapped, so the
+/// validator can be driven over the exact finalised set BEFORE <c>StartAsync</c> binds anything. Whether a
+/// listener ever bound is exposed so a test can assert the failure came first.
+/// </summary>
+internal sealed class UnstartedHostedApp : IAsyncDisposable
+{
+    private readonly WebApplication _app;
+    private readonly string? _priorHosted;
+
+    /// <summary>The app itself, so a test can contrast the app's own data sources with the DI composite.</summary>
+    public WebApplication App => _app;
+
+    /// <summary>The finalised endpoint set, read pre-Start from the app's own data sources.</summary>
+    public IReadOnlyList<Endpoint> Endpoints { get; }
+
+    private UnstartedHostedApp(WebApplication app, string? priorHosted, IReadOnlyList<Endpoint> endpoints)
+    {
+        _app = app;
+        _priorHosted = priorHosted;
+        Endpoints = endpoints;
+    }
+
+    /// <summary>
+    /// True once the host has actually STARTED - the application-started lifetime token is signalled inside
+    /// <c>StartAsync</c>, which is the moment a listener binds. This harness never calls <c>StartAsync</c>, so
+    /// a test asserting this is false is asserting the validation threw with no listener ever bound. The
+    /// server's addresses feature is NOT used for this: it is seeded from the configured URLs at build time,
+    /// so it reports addresses before anything has bound.
+    /// </summary>
+    public bool Started => _app.Lifetime.ApplicationStarted.IsCancellationRequested;
+
+    public static UnstartedHostedApp Map(Action<IEndpointRouteBuilder> map)
+    {
+        ArgumentNullException.ThrowIfNull(map);
+
+        var priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.UseRouting();
+
+        map(app);
+
+        // The FINALISED set, read the way GatewayHost reads it - and, crucially, NOT started. The app's own
+        // data sources already carry the group endpoints; the DI CompositeEndpointDataSource would still be
+        // empty here, which is exactly the production trap this harness exists to keep honest.
+        var endpoints = ((IEndpointRouteBuilder)app).DataSources
+            .SelectMany(source => source.Endpoints)
+            .ToList();
+
+        return new UnstartedHostedApp(app, priorHosted, endpoints);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // The app was never started, so there is nothing to stop - just dispose and restore the variable.
         await _app.DisposeAsync();
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
     }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2133,8 +2133,17 @@ public sealed class GatewayHost : IAsyncDisposable
         // undenied route off the air. Both would otherwise surface as a request-time failure on the one path
         // nobody exercises until a caller does. Fail the start instead. Inert on self-host, where no refusal
         // endpoint exists.
-        Tenancy.HostedRefusalRouteSpace.Validate(_app.Services
-            .GetRequiredService<Microsoft.AspNetCore.Routing.EndpointDataSource>().Endpoints);
+        //
+        // The finalised endpoints are read from the app's OWN data sources, not from the DI-resolved
+        // CompositeEndpointDataSource. The composite is not populated with the minimal-API / MapGroup
+        // endpoints until StartAsync builds the endpoint middleware, so reading it HERE - before StartAsync -
+        // returns an EMPTY set and the validation silently does nothing. The app's own
+        // IEndpointRouteBuilder.DataSources carry the group endpoints (prefix and metadata conventions
+        // applied) as soon as they are mapped, which is what lets this fail the start BEFORE any listener
+        // binds rather than after.
+        Tenancy.HostedRefusalRouteSpace.Validate(
+            ((Microsoft.AspNetCore.Routing.IEndpointRouteBuilder)_app).DataSources
+                .SelectMany(source => source.Endpoints));
 
         await _app.StartAsync();
         FileLog.Write($"[GatewayHost] listening on http://0.0.0.0:{Port} (all interfaces, auth-gated; version {version})");

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2140,10 +2140,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // returns an EMPTY set and the validation silently does nothing. The app's own
         // IEndpointRouteBuilder.DataSources carry the group endpoints (prefix and metadata conventions
         // applied) as soon as they are mapped, which is what lets this fail the start BEFORE any listener
-        // binds rather than after.
-        Tenancy.HostedRefusalRouteSpace.Validate(
-            ((Microsoft.AspNetCore.Routing.IEndpointRouteBuilder)_app).DataSources
-                .SelectMany(source => source.Endpoints));
+        // binds rather than after. That source selection lives in ONE place - ValidateBeforeStart - shared
+        // with the pre-start test harness, so reverting it to the DI composite reddens the tie tests rather
+        // than silently regressing this path.
+        Tenancy.HostedRefusalRouteSpace.ValidateBeforeStart(_app);
 
         await _app.StartAsync();
         FileLog.Write($"[GatewayHost] listening on http://0.0.0.0:{Port} (all interfaces, auth-gated; version {version})");

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2127,6 +2127,15 @@ public sealed class GatewayHost : IAsyncDisposable
         // Server Cockpit and its fallback reverse-proxy were retired in this cutover.
         Cockpit.CockpitReactApp.Map(_app);
 
+        // Every route is now mapped, which is the earliest moment the FINALISED route space exists - and the
+        // only moment a conflict between a hosted refusal and anything else can be seen. A refusal that ties
+        // with another refusal answers 500 on a denied route; a refusal that ties with a live route takes an
+        // undenied route off the air. Both would otherwise surface as a request-time failure on the one path
+        // nobody exercises until a caller does. Fail the start instead. Inert on self-host, where no refusal
+        // endpoint exists.
+        Tenancy.HostedRefusalRouteSpace.Validate(_app.Services
+            .GetRequiredService<Microsoft.AspNetCore.Routing.EndpointDataSource>().Endpoints);
+
         await _app.StartAsync();
         FileLog.Write($"[GatewayHost] listening on http://0.0.0.0:{Port} (all interfaces, auth-gated; version {version})");
 

--- a/src/CcDirector.Gateway/Tenancy/HostedRefusalPattern.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRefusalPattern.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Routing.Patterns;
+
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// Turns a family's real route pattern into the pattern its REFUSAL is mapped on, by rebuilding the parsed
+/// route MODEL rather than by editing the pattern text.
+///
+/// WHY THE MODEL AND NOT THE TEXT. The refusal has to match a request that the real route would REJECT -
+/// a segment that fails an inline constraint fails endpoint selection, so a refusal carrying that same
+/// constraint is never selected either and the framework answers instead of the refusal. Removing the
+/// constraint is therefore load-bearing. Doing that by editing the pattern string means hand-writing a
+/// parser for a grammar that is much richer than it first appears: optional parameters, default values,
+/// catch-alls with two sigils, escaped braces, and policy arguments that themselves contain the very
+/// delimiters the edit is scanning for. A hand-written scan is correct on the simple shapes it was tested
+/// against and silently wrong elsewhere - and silently wrong here means a denied route that answers with
+/// something other than the refusal, which is exactly the defect the whole primitive exists to remove.
+///
+/// So the pattern is PARSED by the framework's own parser, the parameter parts are rebuilt WITHOUT their
+/// policies and with everything else preserved, and the result is handed back as a
+/// <see cref="RoutePattern"/> - never re-serialised to text.
+///
+/// WHAT IT PRESERVES, exactly:
+///   - literal segments and literal parts, unchanged;
+///   - segment separators inside a complex segment, unchanged;
+///   - parameter NAME, unchanged;
+///   - parameter KIND - standard, optional, or catch-all - unchanged, so optionality and catch-all
+///     matching semantics are the real route's;
+///   - parameter DEFAULT VALUE, unchanged.
+/// The ONLY thing removed is the parameter's policies, which is the only thing that can make selection
+/// reject a request the refusal must answer.
+///
+/// WHAT IT REFUSES. A part kind this code does not recognise is a pattern it cannot claim to normalise, so
+/// it THROWS at startup rather than passing the pattern through. Passing through would map a refusal that
+/// still carried a constraint - the exact hole - while the family's author believed the route was covered.
+/// A loud failure at startup is recoverable; a refusal that silently does not cover its route is the
+/// false coverage this primitive was built to eliminate.
+/// </summary>
+internal static class HostedRefusalPattern
+{
+    /// <summary>
+    /// Parses <paramref name="pattern"/> and returns the equivalent pattern with every parameter policy
+    /// removed. Throws <see cref="NotSupportedException"/> on a pattern containing a part this code does
+    /// not recognise, and lets the framework's own parser throw on a malformed pattern.
+    /// </summary>
+    public static RoutePattern WithoutPolicies(string pattern, string family)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+
+        // The framework's parser, not ours. A malformed pattern throws here, with its message.
+        var parsed = RoutePatternFactory.Parse(pattern);
+        return WithoutPolicies(parsed, family);
+    }
+
+    /// <summary>The model-level rebuild, separated so a test can drive it from a parsed pattern.</summary>
+    public static RoutePattern WithoutPolicies(RoutePattern parsed, string family)
+    {
+        ArgumentNullException.ThrowIfNull(parsed);
+
+        var segments = new List<RoutePatternPathSegment>(parsed.PathSegments.Count);
+
+        foreach (var segment in parsed.PathSegments)
+        {
+            var parts = new List<RoutePatternPart>(segment.Parts.Count);
+
+            foreach (var part in segment.Parts)
+            {
+                parts.Add(part switch
+                {
+                    RoutePatternLiteralPart literal => RoutePatternFactory.LiteralPart(literal.Content),
+
+                    RoutePatternSeparatorPart separator => RoutePatternFactory.SeparatorPart(separator.Content),
+
+                    // The one transformation: same name, same kind, same default, NO policies.
+                    RoutePatternParameterPart parameter => RoutePatternFactory.ParameterPart(
+                        parameter.Name,
+                        parameter.Default,
+                        parameter.ParameterKind),
+
+                    _ => throw new NotSupportedException(
+                        $"The hosted denial for '{family}' cannot normalise the route pattern '{parsed.RawText}': " +
+                        $"it contains a route part of type '{part.GetType().Name}', which this boundary does not " +
+                        "recognise. Refusing at startup rather than mapping a refusal that might not cover the " +
+                        "route: a refusal that silently fails to cover its own route is worse than a Gateway " +
+                        "that does not start."),
+                });
+            }
+
+            segments.Add(RoutePatternFactory.Segment(parts));
+        }
+
+        return RoutePatternFactory.Pattern(segments);
+    }
+
+    /// <summary>
+    /// The SHAPE KEY of a pattern: what the route matcher actually competes on, with parameter names and
+    /// policies discarded.
+    ///
+    /// Two refusal patterns that differ only in the NAME of a parameter - <c>/x/{id}</c> and
+    /// <c>/x/{name}</c> - are different strings and the same route. Mapping both produces two endpoints
+    /// that tie, and the matcher throws at REQUEST time, on the denied route, which is the deny failing in
+    /// the one way nothing notices until a caller tries it. Text equality cannot see that; this key can.
+    ///
+    /// The key encodes, per segment: a literal's text, a separator's text, and for a parameter its KIND
+    /// only. Kind is included because an optional or catch-all parameter does not compete with a standard
+    /// one in the same position.
+    /// </summary>
+    public static string ShapeKey(RoutePattern pattern)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+
+        var key = new StringBuilder();
+
+        foreach (var segment in pattern.PathSegments)
+        {
+            key.Append('/');
+
+            foreach (var part in segment.Parts)
+            {
+                switch (part)
+                {
+                    case RoutePatternLiteralPart literal:
+                        key.Append("L:").Append(literal.Content);
+                        break;
+                    case RoutePatternSeparatorPart separator:
+                        key.Append("S:").Append(separator.Content);
+                        break;
+                    case RoutePatternParameterPart parameter:
+                        key.Append("P:").Append(parameter.ParameterKind);
+                        break;
+                    default:
+                        // Unreachable for a pattern that came through WithoutPolicies, which throws first.
+                        throw new NotSupportedException(
+                            $"Cannot compute a route shape key for a part of type '{part.GetType().Name}'.");
+                }
+
+                key.Append('|');
+            }
+        }
+
+        return key.ToString();
+    }
+}

--- a/src/CcDirector.Gateway/Tenancy/HostedRefusalPattern.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRefusalPattern.cs
@@ -107,6 +107,13 @@ internal static class HostedRefusalPattern
     /// The key encodes, per segment: a literal's text, a separator's text, and for a parameter its KIND
     /// only. Kind is included because an optional or catch-all parameter does not compete with a standard
     /// one in the same position.
+    ///
+    /// LITERAL TEXT IS FOLDED TO LOWER CASE, because ASP.NET matches route literals CASE-INSENSITIVELY.
+    /// <c>/x/{id}</c> and <c>/X/{name}</c> are the same route to the matcher; a case-sensitive key would
+    /// call them distinct and let both refusals register, and two verb-less refusals on the same route TIE.
+    /// Off hosted the same two shapes are held apart by their HTTP methods, so this only bites once method
+    /// constraints are removed - which is exactly what refusal substitution does, and exactly the tie the
+    /// finalised route-space check would otherwise have to catch after the fact.
     /// </summary>
     public static string ShapeKey(RoutePattern pattern)
     {
@@ -123,10 +130,10 @@ internal static class HostedRefusalPattern
                 switch (part)
                 {
                     case RoutePatternLiteralPart literal:
-                        key.Append("L:").Append(literal.Content);
+                        key.Append("L:").Append(literal.Content.ToLowerInvariant());
                         break;
                     case RoutePatternSeparatorPart separator:
-                        key.Append("S:").Append(separator.Content);
+                        key.Append("S:").Append(separator.Content.ToLowerInvariant());
                         break;
                     case RoutePatternParameterPart parameter:
                         key.Append("P:").Append(parameter.ParameterKind);

--- a/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using CcDirector.Core.Utilities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 
 namespace CcDirector.Gateway.Tenancy;
 
@@ -34,24 +36,34 @@ internal sealed record HostedExclusivePrefixMarker(HostedDenial Denial, string P
 /// differing only by their separator character.
 ///
 /// The reason it was wrong is worth keeping, because it is the second time this primitive made the same
-/// mistake: <b>the matcher's ambiguity relation is not reachable from public API, so any check for it is a
-/// MODEL of framework semantics rather than the semantics themselves.</b> The first instance was a
-/// hand-written scan standing in for the route parser; this was a hand-rolled key standing in for the
-/// matcher. Both were correct on the cases their author thought of and wrong on cases the framework
-/// already knew about.
+/// mistake: <b>the matcher's FULL ambiguity relation is not reachable from public API, so any check for the
+/// WHOLE of it is a MODEL of framework semantics rather than the semantics themselves.</b> The first
+/// instance was a hand-written scan standing in for the route parser; that one was a hand-rolled key
+/// standing in for the matcher. Both were correct on the cases their author thought of and wrong on cases
+/// the framework already knew about.
 ///
-/// So this no longer models ambiguity. It removes the conditions under which ambiguity can arise:
+/// So this does not try to decide the whole ambiguity relation. It removes the conditions under which
+/// ambiguity can arise, and it fails loud on the ONE class of tie that refusal substitution INTRODUCES -
+/// which is a strictly smaller and decidable question than "would these two patterns ever tie":
 ///
-///   - an EXCLUSIVE-PREFIX family maps ONE catch-all refusal under a prefix nothing else may serve. One
-///     refusal cannot tie with itself, and exclusivity is checked by simple PREFIX CONTAINMENT - a
-///     comparison this code can actually perform correctly, unlike an ambiguity relation.
+///   - an EXCLUSIVE-PREFIX family maps ONE catch-all refusal under a prefix nothing else may serve, and
+///     maps NO per-route refusal (the handle discards each handler). One refusal cannot tie with itself.
+///     Exclusivity is checked by PREFIX CONTAINMENT against the finalised route patterns STRUCTURALLY - the
+///     prefix is required to be literal at construction, and a live route's path is read from its parsed
+///     segments, never from RawText, which a model-built pattern leaves null.
 ///   - a PER-ROUTE family maps a refusal per route it actually declares. Nothing is synthesised, so no
-///     pattern exists that the family did not already have.
+///     pattern exists that the family did not already have. But substitution DROPS the HTTP method and the
+///     parameter policies, and folds literal case - so two routes the family held apart by METHOD, or two
+///     families denying the same path under different verbs, become verb-less refusals that TIE where the
+///     originals did not. That tie is introduced HERE, by this primitive, so it is caught HERE: any two
+///     refusals whose finalised patterns share a case-insensitive structural SHAPE would compete, and any
+///     refusal sharing a shape with a LIVE route would compete with it. Either fails the start.
 ///
-/// The residual case is stated rather than hidden: normalising a pattern WIDENS it, so two of a family's
-/// own routes that differ only by a parameter policy normalise to the same refusal and are de-duplicated
-/// by exact normalised text. Two routes that tie for some other reason would already tie in that family's
-/// own production route table, before any deny existed.
+/// What this still does NOT claim to catch is a tie that would ALREADY exist in a family's own production
+/// route table before any deny - an optional parameter against a shorter path, say. That tie is not
+/// introduced by substitution; it is the family's own, and it would surface off hosted too. Deciding it in
+/// general is the unreachable relation. Deciding the introduced subset - identical structural shape among
+/// verb-less endpoints - is not, and is what this checks.
 /// </summary>
 internal static class HostedRefusalRouteSpace
 {
@@ -71,43 +83,151 @@ internal static class HostedRefusalRouteSpace
             .Where(x => x.Marker is not null)
             .ToList();
 
-        var refusals = routes.Count(e => e.Metadata.GetMetadata<HostedRefusalMarker>() is not null);
+        var refusalEndpoints = routes
+            .Where(e => e.Metadata.GetMetadata<HostedRefusalMarker>() is not null)
+            .ToList();
 
-        if (refusals == 0 && exclusive.Count == 0)
+        if (refusalEndpoints.Count == 0 && exclusive.Count == 0)
         {
             FileLog.Write("[HostedRefusalRouteSpace] no hosted refusals mapped - nothing to validate (self-host)");
             return;
         }
 
+        ValidateNoRefusalTies(routes, refusalEndpoints);
+        ValidateExclusiveContainment(routes, exclusive);
+
+        FileLog.Write($"[HostedRefusalRouteSpace] validated {exclusive.Count} exclusive-prefix claim(s) and " +
+                      $"{refusalEndpoints.Count} refusal route(s) against {routes.Count} mapped route(s)");
+    }
+
+    /// <summary>
+    /// Fails the start on a tie INTRODUCED by refusal substitution: two verb-less refusals whose finalised
+    /// patterns share a case-insensitive structural shape, or a refusal that shares a shape with a live
+    /// route. Both compete in the matcher and answer 500/ambiguous at request time - on a DENIED route, the
+    /// one nobody exercises until a caller does. This is the introduced subset of the ambiguity relation, not
+    /// the whole of it: two verb-less endpoints on the same structural shape always tie, so equal shape keys
+    /// are a SOUND tie witness, never a false alarm.
+    /// </summary>
+    private static void ValidateNoRefusalTies(List<RouteEndpoint> routes, List<RouteEndpoint> refusalEndpoints)
+    {
+        // The live route space, keyed by structural shape. Refusals are excluded here - they are checked
+        // against each other and against these lives below.
+        var liveByShape = new Dictionary<string, RouteEndpoint>(StringComparer.Ordinal);
+        foreach (var live in routes)
+        {
+            if (live.Metadata.GetMetadata<HostedRefusalMarker>() is not null) continue;
+            liveByShape[HostedRefusalPattern.ShapeKey(live.RoutePattern)] = live;
+        }
+
+        var refusalByShape = new Dictionary<string, RouteEndpoint>(StringComparer.Ordinal);
+        foreach (var refusal in refusalEndpoints)
+        {
+            var shape = HostedRefusalPattern.ShapeKey(refusal.RoutePattern);
+            var family = refusal.Metadata.GetMetadata<HostedRefusalMarker>()!.Denial.Family;
+
+            if (refusalByShape.TryGetValue(shape, out var prior) && !ReferenceEquals(prior, refusal))
+            {
+                var priorFamily = prior.Metadata.GetMetadata<HostedRefusalMarker>()!.Denial.Family;
+                throw new InvalidOperationException(
+                    $"Two hosted refusals compete for the same route shape: '{PatternText(prior)}' (family " +
+                    $"'{priorFamily}') and '{PatternText(refusal)}' (family '{family}'). Refusal substitution " +
+                    "drops the HTTP method and folds literal case, so two routes held apart by verb or case " +
+                    "become verb-less refusals that TIE - a 500 on a denied route at request time. Refusing to " +
+                    "start instead. These two denied shapes must be reconciled to a single refusal.");
+            }
+
+            refusalByShape[shape] = refusal;
+
+            if (liveByShape.TryGetValue(shape, out var live))
+                throw new InvalidOperationException(
+                    $"The hosted refusal '{PatternText(refusal)}' (family '{family}') competes for the same route " +
+                    $"shape as the live route '{PatternText(live)}'. The verb-less refusal matches every method, so " +
+                    "it ties with the live route wherever their shapes coincide - a 500 on the denied route rather " +
+                    "than a clean answer. Refusing to start: either that live route belongs to the denied family, " +
+                    "or the family is denying a shape it does not own.");
+        }
+    }
+
+    /// <summary>
+    /// Fails the start when a live route serves BENEATH a prefix a family claimed exclusively - an OUTAGE on
+    /// a route nobody denied, which no leak-shaped test would notice. Containment is computed from the
+    /// finalised route patterns STRUCTURALLY: the exclusive prefix is literal (enforced at construction), and
+    /// the live route's path is read from its parsed segments, so a model-built pattern with a null RawText is
+    /// compared correctly rather than being read as the root "/".
+    /// </summary>
+    private static void ValidateExclusiveContainment(
+        List<RouteEndpoint> routes,
+        List<(RouteEndpoint Endpoint, HostedExclusivePrefixMarker? Marker)> exclusive)
+    {
         foreach (var (endpoint, marker) in exclusive)
         {
-            var prefix = marker!.Prefix.TrimEnd('/');
+            var prefix = marker!.Prefix.TrimEnd('/').ToLowerInvariant();
 
-            // EXCLUSIVITY, by prefix containment. Everything under this prefix belongs to the denied family;
-            // a live route there would be swallowed by the catch-all refusal, which is an OUTAGE on a route
-            // nobody denied - the over-refusal direction, and the one no leak-shaped test would notice.
             foreach (var other in routes)
             {
                 if (ReferenceEquals(other, endpoint)) continue;
                 if (other.Metadata.GetMetadata<HostedRefusalMarker>() is not null) continue;
                 if (other.Metadata.GetMetadata<HostedExclusivePrefixMarker>() is not null) continue;
 
-                var otherPath = "/" + (other.RoutePattern.RawText ?? string.Empty).TrimStart('/');
-                if (!otherPath.StartsWith(prefix + "/", StringComparison.OrdinalIgnoreCase) &&
-                    !string.Equals(otherPath, prefix, StringComparison.OrdinalIgnoreCase))
+                var otherPath = StructuralPath(other.RoutePattern);
+                if (!otherPath.StartsWith(prefix + "/", StringComparison.Ordinal) &&
+                    !string.Equals(otherPath, prefix, StringComparison.Ordinal))
                     continue;
 
                 throw new InvalidOperationException(
                     $"The hosted denial for family '{marker.Denial.Family}' claims the prefix '{marker.Prefix}' " +
-                    $"EXCLUSIVELY, but the live route '{other.RoutePattern.RawText}' serves underneath it. The " +
+                    $"EXCLUSIVELY, but the live route '{PatternText(other)}' serves underneath it. The " +
                     "catch-all refusal would take that route off the air. Refusing to start: an outage on an " +
                     "undenied route is as much a defect as a leak on a denied one. Either that route belongs to " +
                     "the denied family, or this family cannot claim the prefix exclusively and owes per-route " +
                     "refusals instead.");
             }
         }
-
-        FileLog.Write($"[HostedRefusalRouteSpace] validated {exclusive.Count} exclusive-prefix claim(s) and " +
-                      $"{refusals} refusal route(s) against {routes.Count} mapped route(s)");
     }
+
+    /// <summary>
+    /// A route's path as a comparable, case-folded string, built from its PARSED SEGMENTS and never its
+    /// RawText - a pattern rebuilt from the route model (as the refusal patterns are) has a null RawText, and
+    /// reading that as the root "/" is precisely the containment miss this closes. Literal text is folded to
+    /// lower case to match the matcher; a parameter part is emitted as a sentinel that cannot equal any
+    /// literal prefix segment, so a parameter never satisfies containment against a literal prefix.
+    /// </summary>
+    private static string StructuralPath(RoutePattern pattern)
+    {
+        var sb = new StringBuilder();
+
+        foreach (var segment in pattern.PathSegments)
+        {
+            sb.Append('/');
+            foreach (var part in segment.Parts)
+            {
+                switch (part)
+                {
+                    case RoutePatternLiteralPart literal:
+                        sb.Append(literal.Content.ToLowerInvariant());
+                        break;
+                    case RoutePatternSeparatorPart separator:
+                        sb.Append(separator.Content.ToLowerInvariant());
+                        break;
+                    case RoutePatternParameterPart:
+                        // A sentinel a literal path segment cannot contain - route literals never carry a
+                        // brace, and the exclusive prefix is required literal - so a parameter segment can
+                        // never be read as a literal match for an exclusive prefix segment.
+                        sb.Append("{}");
+                        break;
+                    default:
+                        throw new NotSupportedException(
+                            $"Cannot read a structural path for a route part of type '{part.GetType().Name}'.");
+                }
+            }
+        }
+
+        return sb.Length == 0 ? "/" : sb.ToString();
+    }
+
+    /// <summary>The pattern text for a human-facing message, falling back to the structural path when a
+    /// model-built pattern has no RawText - the message never decides anything, so a readable fallback is
+    /// fine here where it would be a bug in the containment check above.</summary>
+    private static string PatternText(RouteEndpoint endpoint)
+        => endpoint.RoutePattern.RawText ?? StructuralPath(endpoint.RoutePattern);
 }

--- a/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
@@ -6,6 +6,7 @@ using CcDirector.Core.Utilities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.Routing.Template;
 
 namespace CcDirector.Gateway.Tenancy;
 
@@ -27,43 +28,57 @@ internal sealed record HostedExclusivePrefixMarker(HostedDenial Denial, string P
 /// Validates the route space AFTER every endpoint has been mapped, and fails the Gateway at startup rather
 /// than letting a conflict surface as a 500 on a denied route the first time somebody calls it.
 ///
-/// WHAT THIS CHECKS, AND - MORE IMPORTANTLY - WHAT IT DELIBERATELY NO LONGER TRIES TO CHECK.
+/// WHAT THIS CHECKS, AND HOW IT AVOIDS RE-MODELLING THE MATCHER.
 ///
 /// A previous version of this file tried to detect whether two route patterns would TIE in the matcher, by
-/// comparing a hand-rolled "shape key". It was wrong, and it was wrong in the way that matters: three
-/// independent route pairs escaped it and returned HTTP 500 at request time - a standard parameter against
-/// an optional one on a present segment, literal case variants, and equal-precedence complex segments
-/// differing only by their separator character.
+/// comparing a hand-rolled "shape key" and then only ever testing that key for EQUALITY. It was wrong, and
+/// it was wrong in the way that matters: three independent route pairs escaped it and returned HTTP 500 at
+/// request time - a standard parameter against an optional one on a present segment, literal case variants,
+/// and equal-precedence complex segments differing only by their separator character. Equal keys are a
+/// SOUND witness of a tie, but they are not the ONLY tie: two patterns can tie with DIFFERENT keys, and the
+/// method-removal this primitive performs is exactly what manufactures those different-key ties.
 ///
-/// The reason it was wrong is worth keeping, because it is the second time this primitive made the same
-/// mistake: <b>the matcher's FULL ambiguity relation is not reachable from public API, so any check for the
-/// WHOLE of it is a MODEL of framework semantics rather than the semantics themselves.</b> The first
-/// instance was a hand-written scan standing in for the route parser; that one was a hand-rolled key
+/// The lesson from that miss is kept, because it is the second time this primitive made the same mistake:
+/// <b>the matcher's FULL ambiguity relation is not reachable from public API, so any hand-written check for
+/// the WHOLE of it is a MODEL of framework semantics rather than the semantics themselves.</b> The first
+/// instance was a hand-written scan standing in for the route parser; the second was a hand-rolled key
 /// standing in for the matcher. Both were correct on the cases their author thought of and wrong on cases
 /// the framework already knew about.
 ///
-/// So this does not try to decide the whole ambiguity relation. It removes the conditions under which
-/// ambiguity can arise, and it fails loud on the ONE class of tie that refusal substitution INTRODUCES -
-/// which is a strictly smaller and decidable question than "would these two patterns ever tie":
+/// So this does NOT reimplement the ambiguity relation. It asks a strictly smaller, DECIDABLE question -
+/// "could a single request path be matched by both of these patterns at EQUAL precedence?" - and it answers
+/// the precedence half by DELEGATING to the framework's own <see cref="RoutePrecedence"/>
+/// rather than by re-deriving precedence digits. That is the opposite of modelling: the specificity ranking
+/// that decides which of two matches wins is the framework's, computed by the framework. What is left for
+/// this file to decide is only whether a common concrete path EXISTS, which is structural and conservative:
+///
+///   - Two patterns of DIFFERENT segment count, or of DIFFERENT inbound precedence, cannot tie - a
+///     more-specific match always wins, so a literal never ties with the parameter that could cover it, and
+///     a constrained parameter never ties with an unconstrained one. These are dropped.
+///   - At EQUAL precedence, a position where BOTH sides are a single literal shares a path only if the two
+///     literals are equal (case-insensitively, as the matcher compares them); unequal literals mean no
+///     shared path and no tie. Every other position - a parameter, a catch-all, a complex segment - is
+///     treated as ABLE to share a value (a parameter matches anything; two complex segments differing only
+///     by separator still share values such as "a-b.c"). That is the fail-CLOSED direction: it can
+///     over-reject an ambiguous DEVELOPER DECLARATION at startup with a clear error, which is acceptable
+///     because it runs on the denied-route declarations, never on user traffic.
+///
+/// This is COMPLETE for the ties method-removal introduces. Two routes a family held apart by HTTP METHOD,
+/// or two families denying one path under different verbs, become verb-less refusals with identical
+/// precedence and intersecting value sets - Standard-vs-Optional, or separator-only complex differences
+/// included - and every such pair fails the start, whether or not their old shape keys were equal.
 ///
 ///   - an EXCLUSIVE-PREFIX family maps ONE catch-all refusal under a prefix nothing else may serve, and
 ///     maps NO per-route refusal (the handle discards each handler). One refusal cannot tie with itself.
 ///     Exclusivity is checked by PREFIX CONTAINMENT against the finalised route patterns STRUCTURALLY - the
 ///     prefix is required to be literal at construction, and a live route's path is read from its parsed
 ///     segments, never from RawText, which a model-built pattern leaves null.
-///   - a PER-ROUTE family maps a refusal per route it actually declares. Nothing is synthesised, so no
-///     pattern exists that the family did not already have. But substitution DROPS the HTTP method and the
-///     parameter policies, and folds literal case - so two routes the family held apart by METHOD, or two
-///     families denying the same path under different verbs, become verb-less refusals that TIE where the
-///     originals did not. That tie is introduced HERE, by this primitive, so it is caught HERE: any two
-///     refusals whose finalised patterns share a case-insensitive structural SHAPE would compete, and any
-///     refusal sharing a shape with a LIVE route would compete with it. Either fails the start.
 ///
 /// What this still does NOT claim to catch is a tie that would ALREADY exist in a family's own production
-/// route table before any deny - an optional parameter against a shorter path, say. That tie is not
-/// introduced by substitution; it is the family's own, and it would surface off hosted too. Deciding it in
-/// general is the unreachable relation. Deciding the introduced subset - identical structural shape among
-/// verb-less endpoints - is not, and is what this checks.
+/// route table before any deny - an optional parameter against a shorter path under a DIFFERENT segment
+/// count, say. That tie is not introduced by substitution; it is the family's own, it would surface off
+/// hosted too, and deciding the general variable-length case is the unreachable relation. Deciding the
+/// introduced subset - a shared path at equal precedence among same-length patterns - is what this checks.
 /// </summary>
 internal static class HostedRefusalRouteSpace
 {
@@ -101,51 +116,131 @@ internal static class HostedRefusalRouteSpace
     }
 
     /// <summary>
-    /// Fails the start on a tie INTRODUCED by refusal substitution: two verb-less refusals whose finalised
-    /// patterns share a case-insensitive structural shape, or a refusal that shares a shape with a live
-    /// route. Both compete in the matcher and answer 500/ambiguous at request time - on a DENIED route, the
-    /// one nobody exercises until a caller does. This is the introduced subset of the ambiguity relation, not
-    /// the whole of it: two verb-less endpoints on the same structural shape always tie, so equal shape keys
-    /// are a SOUND tie witness, never a false alarm.
+    /// Fails the start on a tie INTRODUCED by refusal substitution: two verb-less refusals that a single
+    /// request path could match at equal precedence, or a refusal that could be matched at equal precedence
+    /// with a LIVE route. Both compete in the matcher and answer 500/ambiguous at request time - on a DENIED
+    /// route, the one nobody exercises until a caller does.
+    ///
+    /// This is the introduced subset of the ambiguity relation, not the whole of it, and it is COMPLETE for
+    /// that subset: it does not rely on two patterns having EQUAL shape keys (the round-1 miss), it asks
+    /// whether they could match a common path at equal precedence - which is true for Standard-vs-Optional
+    /// parameters and for separator-only complex differences, exactly the different-key ties method-removal
+    /// manufactures. The precedence half is the framework's own (see <see cref="CouldMatchSamePath"/>), so
+    /// this file never re-derives the specificity ranking it was twice burned re-deriving.
     /// </summary>
     private static void ValidateNoRefusalTies(List<RouteEndpoint> routes, List<RouteEndpoint> refusalEndpoints)
     {
-        // The live route space, keyed by structural shape. Refusals are excluded here - they are checked
-        // against each other and against these lives below.
-        var liveByShape = new Dictionary<string, RouteEndpoint>(StringComparer.Ordinal);
-        foreach (var live in routes)
-        {
-            if (live.Metadata.GetMetadata<HostedRefusalMarker>() is not null) continue;
-            liveByShape[HostedRefusalPattern.ShapeKey(live.RoutePattern)] = live;
-        }
+        // The live route space. Refusals are excluded here - they are checked against each other and against
+        // these lives below.
+        var lives = routes
+            .Where(e => e.Metadata.GetMetadata<HostedRefusalMarker>() is null)
+            .ToList();
 
-        var refusalByShape = new Dictionary<string, RouteEndpoint>(StringComparer.Ordinal);
-        foreach (var refusal in refusalEndpoints)
+        // Refusal against refusal. Every unordered pair, so a tie is caught whichever family declared first.
+        for (var i = 0; i < refusalEndpoints.Count; i++)
         {
-            var shape = HostedRefusalPattern.ShapeKey(refusal.RoutePattern);
-            var family = refusal.Metadata.GetMetadata<HostedRefusalMarker>()!.Denial.Family;
-
-            if (refusalByShape.TryGetValue(shape, out var prior) && !ReferenceEquals(prior, refusal))
+            for (var j = i + 1; j < refusalEndpoints.Count; j++)
             {
-                var priorFamily = prior.Metadata.GetMetadata<HostedRefusalMarker>()!.Denial.Family;
+                var a = refusalEndpoints[i];
+                var b = refusalEndpoints[j];
+                if (!CouldMatchSamePath(a.RoutePattern, b.RoutePattern)) continue;
+
+                var familyA = a.Metadata.GetMetadata<HostedRefusalMarker>()!.Denial.Family;
+                var familyB = b.Metadata.GetMetadata<HostedRefusalMarker>()!.Denial.Family;
                 throw new InvalidOperationException(
-                    $"Two hosted refusals compete for the same route shape: '{PatternText(prior)}' (family " +
-                    $"'{priorFamily}') and '{PatternText(refusal)}' (family '{family}'). Refusal substitution " +
-                    "drops the HTTP method and folds literal case, so two routes held apart by verb or case " +
-                    "become verb-less refusals that TIE - a 500 on a denied route at request time. Refusing to " +
+                    $"Two hosted refusals compete for the same route shape: '{PatternText(a)}' (family " +
+                    $"'{familyA}') and '{PatternText(b)}' (family '{familyB}'). Refusal substitution drops the " +
+                    "HTTP method and folds literal case, so two routes held apart by verb - even ones whose " +
+                    "parameter kinds or separators differ - become verb-less refusals a single path can match " +
+                    "at equal precedence, and they TIE - a 500 on a denied route at request time. Refusing to " +
                     "start instead. These two denied shapes must be reconciled to a single refusal.");
             }
+        }
 
-            refusalByShape[shape] = refusal;
+        // Refusal against live. A verb-less refusal matches every method, so it ties with a live route
+        // wherever a single path could match both at equal precedence.
+        foreach (var refusal in refusalEndpoints)
+        {
+            var family = refusal.Metadata.GetMetadata<HostedRefusalMarker>()!.Denial.Family;
+            foreach (var live in lives)
+            {
+                if (!CouldMatchSamePath(refusal.RoutePattern, live.RoutePattern)) continue;
 
-            if (liveByShape.TryGetValue(shape, out var live))
                 throw new InvalidOperationException(
                     $"The hosted refusal '{PatternText(refusal)}' (family '{family}') competes for the same route " +
                     $"shape as the live route '{PatternText(live)}'. The verb-less refusal matches every method, so " +
-                    "it ties with the live route wherever their shapes coincide - a 500 on the denied route rather " +
-                    "than a clean answer. Refusing to start: either that live route belongs to the denied family, " +
-                    "or the family is denying a shape it does not own.");
+                    "it ties with the live route wherever a single path can match both at equal precedence - a 500 " +
+                    "on the denied route rather than a clean answer. Refusing to start: either that live route " +
+                    "belongs to the denied family, or the family is denying a shape it does not own.");
+            }
         }
+    }
+
+    /// <summary>
+    /// True when a SINGLE request path could be matched by both patterns at EQUAL precedence - the condition
+    /// under which the matcher ties and answers an ambiguous 500. This is the whole tie test, and it is
+    /// deliberately conservative (fail-CLOSED): it answers "could they tie", over-rejecting an ambiguous
+    /// declaration rather than under-reporting a real tie.
+    ///
+    /// The precedence half is NOT re-derived here. <see cref="RoutePrecedence"/> is the
+    /// framework's own inbound-precedence computation - the same ranking the matcher uses to decide which of
+    /// two candidate matches wins - so a literal never counts as tying with the parameter that could cover
+    /// it, and a constrained parameter never counts as tying with an unconstrained one, WITHOUT this file
+    /// re-implementing any of that ordering. Unequal precedence, or a different segment count, means no tie.
+    ///
+    /// What is left is only whether a common concrete path EXISTS at that shared precedence, decided
+    /// per-segment by <see cref="SegmentsCanShareValue"/>.
+    /// </summary>
+    private static bool CouldMatchSamePath(RoutePattern a, RoutePattern b)
+    {
+        if (a.PathSegments.Count != b.PathSegments.Count) return false;
+        if (InboundPrecedence(a) != InboundPrecedence(b)) return false;
+
+        for (var i = 0; i < a.PathSegments.Count; i++)
+            if (!SegmentsCanShareValue(a.PathSegments[i], b.PathSegments[i]))
+                return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// The framework's own inbound route precedence for a pattern - the exact ranking the matcher uses to
+    /// decide which of two candidate matches wins. The public entry point takes a <see cref="RouteTemplate"/>,
+    /// and a <see cref="RouteTemplate"/> is built from a <see cref="RoutePattern"/> directly, so this works on
+    /// the model-built refusal patterns whose RawText is null. Nothing about precedence is re-derived here.
+    /// </summary>
+    private static decimal InboundPrecedence(RoutePattern pattern)
+        => RoutePrecedence.ComputeInbound(new RouteTemplate(pattern));
+
+    /// <summary>
+    /// Whether two segments AT EQUAL PRECEDENCE could be filled by a common value. Only when BOTH sides are a
+    /// single literal is non-overlap structurally decidable: the two match a common path iff the literals are
+    /// equal, case-insensitively, as the matcher compares route literals. Any other segment - a parameter, a
+    /// catch-all, or a complex mix - is treated as ABLE to share a value (a parameter matches anything; two
+    /// complex segments differing only by their separator still share values such as "a-b.c"), which is the
+    /// fail-CLOSED direction: a false "yes" over-rejects an ambiguous declaration at startup, a false "no"
+    /// would ship a request-time 500 on a denied route. Since the two segments are already known to be at
+    /// equal precedence, "one side literal, the other a parameter" does not reach here as a shared-path case.
+    /// </summary>
+    private static bool SegmentsCanShareValue(RoutePatternPathSegment a, RoutePatternPathSegment b)
+    {
+        if (IsSingleLiteral(a, out var literalA) && IsSingleLiteral(b, out var literalB))
+            return string.Equals(literalA, literalB, StringComparison.OrdinalIgnoreCase);
+
+        return true;
+    }
+
+    /// <summary>True when the segment is exactly one literal part, handing back its text.</summary>
+    private static bool IsSingleLiteral(RoutePatternPathSegment segment, out string literal)
+    {
+        if (segment.Parts.Count == 1 && segment.Parts[0] is RoutePatternLiteralPart part)
+        {
+            literal = part.Content;
+            return true;
+        }
+
+        literal = string.Empty;
+        return false;
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
@@ -6,7 +6,6 @@ using CcDirector.Core.Utilities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
-using Microsoft.AspNetCore.Routing.Template;
 
 namespace CcDirector.Gateway.Tenancy;
 
@@ -47,10 +46,12 @@ internal sealed record HostedExclusivePrefixMarker(HostedDenial Denial, string P
 ///
 /// So this does NOT reimplement the ambiguity relation. It asks a strictly smaller, DECIDABLE question -
 /// "could a single request path be matched by both of these patterns at EQUAL precedence?" - and it answers
-/// the precedence half by DELEGATING to the framework's own <see cref="RoutePrecedence"/>
-/// rather than by re-deriving precedence digits. That is the opposite of modelling: the specificity ranking
-/// that decides which of two matches wins is the framework's, computed by the framework. What is left for
-/// this file to decide is only whether a common concrete path EXISTS, which is structural and conservative:
+/// the precedence half by reading each pattern's OWN <see cref="RoutePattern.InboundPrecedence"/> - the exact
+/// value the endpoint comparer uses - rather than by re-deriving precedence digits. That is the opposite of
+/// modelling: the specificity ranking that decides which of two matches wins is the framework's, computed by
+/// the framework, and it is read from the FINALISED pattern so a parameter carrying a required value counts
+/// as the literal it actually matches. What is left for this file to decide is only whether a common concrete
+/// path EXISTS, which is structural and conservative:
 ///
 ///   - Two patterns of DIFFERENT segment count, or of DIFFERENT inbound precedence, cannot tie - a
 ///     more-specific match always wins, so a literal never ties with the parameter that could cover it, and
@@ -87,6 +88,33 @@ internal static class HostedRefusalRouteSpace
     /// all mapping is done and before the host serves. Inert when nothing is refused, so it does nothing on
     /// self-host, where no refusal endpoint exists.
     /// </summary>
+    /// <summary>
+    /// Selects the finalised endpoint set the way it MUST be read before StartAsync, then validates it. This
+    /// is the ONE place the pre-start data source is chosen, and both GatewayHost (immediately before its own
+    /// StartAsync) and the pre-start test harness call it - so the test drives the exact selection production
+    /// uses, and a revert of the source back to the DI composite reddens the tie tests instead of passing
+    /// unnoticed. See <see cref="SelectFinalisedEndpoints"/> for why the app's own data sources are the only
+    /// correct source here.
+    /// </summary>
+    public static void ValidateBeforeStart(IEndpointRouteBuilder app)
+        => Validate(SelectFinalisedEndpoints(app));
+
+    /// <summary>
+    /// The pre-start source SELECTION, factored to a single definition. The finalised endpoints are read from
+    /// the app's OWN <see cref="IEndpointRouteBuilder.DataSources"/>, which carry the group / minimal-API
+    /// endpoints (prefix and metadata conventions applied) the moment they are mapped. The DI-resolved
+    /// <see cref="EndpointDataSource"/> composite is deliberately NOT read here: it is not populated with those
+    /// endpoints until StartAsync builds the endpoint middleware, so before start it is EMPTY and the whole
+    /// validation would silently do nothing. Because this selection has exactly one definition shared by
+    /// production and the harness, reverting it to the DI composite fails the pre-start tie tests rather than
+    /// only regressing production.
+    /// </summary>
+    public static IReadOnlyList<Endpoint> SelectFinalisedEndpoints(IEndpointRouteBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        return app.DataSources.SelectMany(source => source.Endpoints).ToList();
+    }
+
     public static void Validate(IEnumerable<Endpoint> endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
@@ -182,11 +210,13 @@ internal static class HostedRefusalRouteSpace
     /// deliberately conservative (fail-CLOSED): it answers "could they tie", over-rejecting an ambiguous
     /// declaration rather than under-reporting a real tie.
     ///
-    /// The precedence half is NOT re-derived here. <see cref="RoutePrecedence"/> is the
-    /// framework's own inbound-precedence computation - the same ranking the matcher uses to decide which of
-    /// two candidate matches wins - so a literal never counts as tying with the parameter that could cover
-    /// it, and a constrained parameter never counts as tying with an unconstrained one, WITHOUT this file
-    /// re-implementing any of that ordering. Unequal precedence, or a different segment count, means no tie.
+    /// The precedence half is NOT re-derived here. Each pattern's own <see cref="RoutePattern.InboundPrecedence"/>
+    /// is the framework's inbound-precedence value - the same ranking the matcher uses to decide which of two
+    /// candidate matches wins - so a literal never counts as tying with the parameter that could cover it, and
+    /// a constrained parameter never counts as tying with an unconstrained one, WITHOUT this file re-implementing
+    /// any of that ordering. Reading the FINALISED pattern's own value (rather than reconstructing it through a
+    /// RouteTemplate, which drops the pattern's required values) means a parameter carrying a required value is
+    /// scored as the literal it actually matches. Unequal precedence, or a different segment count, means no tie.
     ///
     /// What is left is only whether a common concrete path EXISTS at that shared precedence, decided
     /// per-segment by <see cref="SegmentsCanShareValue"/>.
@@ -194,7 +224,7 @@ internal static class HostedRefusalRouteSpace
     private static bool CouldMatchSamePath(RoutePattern a, RoutePattern b)
     {
         if (a.PathSegments.Count != b.PathSegments.Count) return false;
-        if (InboundPrecedence(a) != InboundPrecedence(b)) return false;
+        if (a.InboundPrecedence != b.InboundPrecedence) return false;
 
         for (var i = 0; i < a.PathSegments.Count; i++)
             if (!SegmentsCanShareValue(a.PathSegments[i], b.PathSegments[i]))
@@ -202,15 +232,6 @@ internal static class HostedRefusalRouteSpace
 
         return true;
     }
-
-    /// <summary>
-    /// The framework's own inbound route precedence for a pattern - the exact ranking the matcher uses to
-    /// decide which of two candidate matches wins. The public entry point takes a <see cref="RouteTemplate"/>,
-    /// and a <see cref="RouteTemplate"/> is built from a <see cref="RoutePattern"/> directly, so this works on
-    /// the model-built refusal patterns whose RawText is null. Nothing about precedence is re-derived here.
-    /// </summary>
-    private static decimal InboundPrecedence(RoutePattern pattern)
-        => RoutePrecedence.ComputeInbound(new RouteTemplate(pattern));
 
     /// <summary>
     /// Whether two segments AT EQUAL PRECEDENCE could be filled by a common value. Only when BOTH sides are a

--- a/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CcDirector.Core.Utilities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// Marks an endpoint as a hosted refusal, so the FINALISED route space can be checked once everything has
+/// been mapped. Carries the family and the pattern the family actually asked for, which is what makes a
+/// failure message name the two routes a human has to go and look at.
+/// </summary>
+internal sealed record HostedRefusalMarker(HostedDenial Denial, string SourcePattern);
+
+/// <summary>
+/// Validates the route space AFTER every endpoint has been mapped, and fails the Gateway at startup on a
+/// conflict rather than letting it surface as a 500 on a denied route the first time somebody calls it.
+///
+/// WHY THIS EXISTS SEPARATELY FROM THE PER-GROUP CHECK. <see cref="HostedDenyGroup"/> can only see its own
+/// group: it prevents one family from mapping two refusals that tie. It cannot see
+///   - two DIFFERENT denied families whose refusal patterns land on the same route shape, or
+///   - a refusal that ties with an UNDENIED neighbour mapped somewhere else entirely.
+/// Both are decided by the whole route space, so both can only be checked once the whole route space
+/// exists. The first is a refusal that answers 500 instead of refusing. The second is worse in a different
+/// direction: a tie against a live route is an OUTAGE on something nobody denied.
+///
+/// WHY A TIE AND NOT AN OVERLAP. Refusal patterns are deliberately WIDE - policies are stripped, so
+/// <c>/x/{id}</c> refuses where the real route wanted an integer. Widening is the point, and it overlaps
+/// neighbours constantly and harmlessly, because route precedence resolves it: a literal segment outranks a
+/// parameter segment, so a live <c>/x/summary</c> still wins over a refusing <c>/x/{id}</c>. What precedence
+/// CANNOT resolve is an exact tie - the same shape in the same positions - and that is the only case this
+/// validator rejects. Rejecting mere overlap would refuse to start on the normal, correct arrangement.
+/// </summary>
+internal static class HostedRefusalRouteSpace
+{
+    /// <summary>
+    /// Reads every endpoint the application has mapped and throws on the first conflict. Call ONCE, after
+    /// all mapping is done and before the host starts serving. A no-op when nothing is refused, so it is
+    /// inert on self-host where no refusal endpoint exists.
+    /// </summary>
+    public static void Validate(IEnumerable<Endpoint> endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var routes = endpoints.OfType<RouteEndpoint>().ToList();
+
+        var refusals = routes
+            .Select(e => (Endpoint: e, Marker: e.Metadata.GetMetadata<HostedRefusalMarker>()))
+            .Where(x => x.Marker is not null)
+            .ToList();
+
+        if (refusals.Count == 0)
+        {
+            FileLog.Write("[HostedRefusalRouteSpace] no hosted refusals mapped - nothing to validate (self-host)");
+            return;
+        }
+
+        var seen = new Dictionary<string, (HostedRefusalMarker Marker, RouteEndpoint Endpoint)>(StringComparer.Ordinal);
+
+        foreach (var (endpoint, marker) in refusals)
+        {
+            var key = HostedRefusalPattern.ShapeKey(endpoint.RoutePattern);
+
+            // REFUSAL versus REFUSAL. Two families whose refusals land on one shape tie at request time, and
+            // the caller gets a 500 from the route that was supposed to refuse them.
+            if (seen.TryGetValue(key, out var prior))
+            {
+                throw new InvalidOperationException(
+                    $"Two hosted refusals occupy the same route shape and would tie at request time: " +
+                    $"family '{prior.Marker!.Denial.Family}' pattern '{prior.Marker.SourcePattern}' and " +
+                    $"family '{marker!.Denial.Family}' pattern '{marker.SourcePattern}'. " +
+                    "A denied route that answers 500 is not a refusal. Give one family the route, or narrow one pattern.");
+            }
+
+            seen[key] = (marker!, endpoint);
+
+            // REFUSAL versus a LIVE NEIGHBOUR. A tie here is an outage on a route nobody denied - the
+            // over-refusal direction, which no leak-shaped test would ever notice.
+            foreach (var other in routes)
+            {
+                if (ReferenceEquals(other, endpoint)) continue;
+                if (other.Metadata.GetMetadata<HostedRefusalMarker>() is not null) continue;
+                if (!SharesShape(endpoint.RoutePattern, other.RoutePattern)) continue;
+
+                throw new InvalidOperationException(
+                    $"The hosted refusal for family '{marker!.Denial.Family}' (pattern '{marker.SourcePattern}') " +
+                    $"occupies the same route shape as the live route '{other.RoutePattern.RawText}', so the two " +
+                    "would tie at request time and a route nobody denied would stop serving. " +
+                    "Refusing to start: an outage on an undenied route is as much a defect as a leak on a denied one.");
+            }
+        }
+
+        FileLog.Write($"[HostedRefusalRouteSpace] validated {refusals.Count} hosted refusal route(s) against " +
+                      $"{routes.Count} mapped route(s) - no ties");
+    }
+
+    /// <summary>
+    /// True when two patterns occupy the SAME shape, which is the only relation route precedence cannot
+    /// resolve. Compared through the shape key so parameter names and policies are ignored - a live
+    /// <c>/x/{name:alpha}</c> ties with a refusing <c>/x/{id}</c>, and the differing name and policy are
+    /// exactly the details that would hide it from a text comparison.
+    /// </summary>
+    private static bool SharesShape(RoutePattern left, RoutePattern right)
+    {
+        try
+        {
+            return string.Equals(HostedRefusalPattern.ShapeKey(left), HostedRefusalPattern.ShapeKey(right),
+                StringComparison.Ordinal);
+        }
+        catch (NotSupportedException)
+        {
+            // A live route may legitimately contain a part shape the refusal normaliser does not model. It
+            // cannot be a refusal (those are built by the normaliser), so it cannot be compared - and an
+            // uncomparable route is not evidence of a tie.
+            return false;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRefusalRouteSpace.cs
@@ -4,42 +4,61 @@ using System.Linq;
 using CcDirector.Core.Utilities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.Routing.Patterns;
 
 namespace CcDirector.Gateway.Tenancy;
 
 /// <summary>
 /// Marks an endpoint as a hosted refusal, so the FINALISED route space can be checked once everything has
-/// been mapped. Carries the family and the pattern the family actually asked for, which is what makes a
-/// failure message name the two routes a human has to go and look at.
+/// been mapped. Carries the family and the pattern the family asked for, so a failure message names the
+/// two routes a human has to go and look at.
 /// </summary>
 internal sealed record HostedRefusalMarker(HostedDenial Denial, string SourcePattern);
 
 /// <summary>
-/// Validates the route space AFTER every endpoint has been mapped, and fails the Gateway at startup on a
-/// conflict rather than letting it surface as a 500 on a denied route the first time somebody calls it.
+/// Marks a group as claiming a prefix EXCLUSIVELY on hosted - nothing outside the denied family may serve
+/// a path underneath it. Recorded as metadata so the claim is checked against the finalised route space
+/// rather than trusted.
+/// </summary>
+internal sealed record HostedExclusivePrefixMarker(HostedDenial Denial, string Prefix);
+
+/// <summary>
+/// Validates the route space AFTER every endpoint has been mapped, and fails the Gateway at startup rather
+/// than letting a conflict surface as a 500 on a denied route the first time somebody calls it.
 ///
-/// WHY THIS EXISTS SEPARATELY FROM THE PER-GROUP CHECK. <see cref="HostedDenyGroup"/> can only see its own
-/// group: it prevents one family from mapping two refusals that tie. It cannot see
-///   - two DIFFERENT denied families whose refusal patterns land on the same route shape, or
-///   - a refusal that ties with an UNDENIED neighbour mapped somewhere else entirely.
-/// Both are decided by the whole route space, so both can only be checked once the whole route space
-/// exists. The first is a refusal that answers 500 instead of refusing. The second is worse in a different
-/// direction: a tie against a live route is an OUTAGE on something nobody denied.
+/// WHAT THIS CHECKS, AND - MORE IMPORTANTLY - WHAT IT DELIBERATELY NO LONGER TRIES TO CHECK.
 ///
-/// WHY A TIE AND NOT AN OVERLAP. Refusal patterns are deliberately WIDE - policies are stripped, so
-/// <c>/x/{id}</c> refuses where the real route wanted an integer. Widening is the point, and it overlaps
-/// neighbours constantly and harmlessly, because route precedence resolves it: a literal segment outranks a
-/// parameter segment, so a live <c>/x/summary</c> still wins over a refusing <c>/x/{id}</c>. What precedence
-/// CANNOT resolve is an exact tie - the same shape in the same positions - and that is the only case this
-/// validator rejects. Rejecting mere overlap would refuse to start on the normal, correct arrangement.
+/// A previous version of this file tried to detect whether two route patterns would TIE in the matcher, by
+/// comparing a hand-rolled "shape key". It was wrong, and it was wrong in the way that matters: three
+/// independent route pairs escaped it and returned HTTP 500 at request time - a standard parameter against
+/// an optional one on a present segment, literal case variants, and equal-precedence complex segments
+/// differing only by their separator character.
+///
+/// The reason it was wrong is worth keeping, because it is the second time this primitive made the same
+/// mistake: <b>the matcher's ambiguity relation is not reachable from public API, so any check for it is a
+/// MODEL of framework semantics rather than the semantics themselves.</b> The first instance was a
+/// hand-written scan standing in for the route parser; this was a hand-rolled key standing in for the
+/// matcher. Both were correct on the cases their author thought of and wrong on cases the framework
+/// already knew about.
+///
+/// So this no longer models ambiguity. It removes the conditions under which ambiguity can arise:
+///
+///   - an EXCLUSIVE-PREFIX family maps ONE catch-all refusal under a prefix nothing else may serve. One
+///     refusal cannot tie with itself, and exclusivity is checked by simple PREFIX CONTAINMENT - a
+///     comparison this code can actually perform correctly, unlike an ambiguity relation.
+///   - a PER-ROUTE family maps a refusal per route it actually declares. Nothing is synthesised, so no
+///     pattern exists that the family did not already have.
+///
+/// The residual case is stated rather than hidden: normalising a pattern WIDENS it, so two of a family's
+/// own routes that differ only by a parameter policy normalise to the same refusal and are de-duplicated
+/// by exact normalised text. Two routes that tie for some other reason would already tie in that family's
+/// own production route table, before any deny existed.
 /// </summary>
 internal static class HostedRefusalRouteSpace
 {
     /// <summary>
-    /// Reads every endpoint the application has mapped and throws on the first conflict. Call ONCE, after
-    /// all mapping is done and before the host starts serving. A no-op when nothing is refused, so it is
-    /// inert on self-host where no refusal endpoint exists.
+    /// Reads every endpoint the application has mapped and throws on the first violation. Call ONCE, after
+    /// all mapping is done and before the host serves. Inert when nothing is refused, so it does nothing on
+    /// self-host, where no refusal endpoint exists.
     /// </summary>
     public static void Validate(IEnumerable<Endpoint> endpoints)
     {
@@ -47,75 +66,48 @@ internal static class HostedRefusalRouteSpace
 
         var routes = endpoints.OfType<RouteEndpoint>().ToList();
 
-        var refusals = routes
-            .Select(e => (Endpoint: e, Marker: e.Metadata.GetMetadata<HostedRefusalMarker>()))
+        var exclusive = routes
+            .Select(e => (Endpoint: e, Marker: e.Metadata.GetMetadata<HostedExclusivePrefixMarker>()))
             .Where(x => x.Marker is not null)
             .ToList();
 
-        if (refusals.Count == 0)
+        var refusals = routes.Count(e => e.Metadata.GetMetadata<HostedRefusalMarker>() is not null);
+
+        if (refusals == 0 && exclusive.Count == 0)
         {
             FileLog.Write("[HostedRefusalRouteSpace] no hosted refusals mapped - nothing to validate (self-host)");
             return;
         }
 
-        var seen = new Dictionary<string, (HostedRefusalMarker Marker, RouteEndpoint Endpoint)>(StringComparer.Ordinal);
-
-        foreach (var (endpoint, marker) in refusals)
+        foreach (var (endpoint, marker) in exclusive)
         {
-            var key = HostedRefusalPattern.ShapeKey(endpoint.RoutePattern);
+            var prefix = marker!.Prefix.TrimEnd('/');
 
-            // REFUSAL versus REFUSAL. Two families whose refusals land on one shape tie at request time, and
-            // the caller gets a 500 from the route that was supposed to refuse them.
-            if (seen.TryGetValue(key, out var prior))
-            {
-                throw new InvalidOperationException(
-                    $"Two hosted refusals occupy the same route shape and would tie at request time: " +
-                    $"family '{prior.Marker!.Denial.Family}' pattern '{prior.Marker.SourcePattern}' and " +
-                    $"family '{marker!.Denial.Family}' pattern '{marker.SourcePattern}'. " +
-                    "A denied route that answers 500 is not a refusal. Give one family the route, or narrow one pattern.");
-            }
-
-            seen[key] = (marker!, endpoint);
-
-            // REFUSAL versus a LIVE NEIGHBOUR. A tie here is an outage on a route nobody denied - the
-            // over-refusal direction, which no leak-shaped test would ever notice.
+            // EXCLUSIVITY, by prefix containment. Everything under this prefix belongs to the denied family;
+            // a live route there would be swallowed by the catch-all refusal, which is an OUTAGE on a route
+            // nobody denied - the over-refusal direction, and the one no leak-shaped test would notice.
             foreach (var other in routes)
             {
                 if (ReferenceEquals(other, endpoint)) continue;
                 if (other.Metadata.GetMetadata<HostedRefusalMarker>() is not null) continue;
-                if (!SharesShape(endpoint.RoutePattern, other.RoutePattern)) continue;
+                if (other.Metadata.GetMetadata<HostedExclusivePrefixMarker>() is not null) continue;
+
+                var otherPath = "/" + (other.RoutePattern.RawText ?? string.Empty).TrimStart('/');
+                if (!otherPath.StartsWith(prefix + "/", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(otherPath, prefix, StringComparison.OrdinalIgnoreCase))
+                    continue;
 
                 throw new InvalidOperationException(
-                    $"The hosted refusal for family '{marker!.Denial.Family}' (pattern '{marker.SourcePattern}') " +
-                    $"occupies the same route shape as the live route '{other.RoutePattern.RawText}', so the two " +
-                    "would tie at request time and a route nobody denied would stop serving. " +
-                    "Refusing to start: an outage on an undenied route is as much a defect as a leak on a denied one.");
+                    $"The hosted denial for family '{marker.Denial.Family}' claims the prefix '{marker.Prefix}' " +
+                    $"EXCLUSIVELY, but the live route '{other.RoutePattern.RawText}' serves underneath it. The " +
+                    "catch-all refusal would take that route off the air. Refusing to start: an outage on an " +
+                    "undenied route is as much a defect as a leak on a denied one. Either that route belongs to " +
+                    "the denied family, or this family cannot claim the prefix exclusively and owes per-route " +
+                    "refusals instead.");
             }
         }
 
-        FileLog.Write($"[HostedRefusalRouteSpace] validated {refusals.Count} hosted refusal route(s) against " +
-                      $"{routes.Count} mapped route(s) - no ties");
-    }
-
-    /// <summary>
-    /// True when two patterns occupy the SAME shape, which is the only relation route precedence cannot
-    /// resolve. Compared through the shape key so parameter names and policies are ignored - a live
-    /// <c>/x/{name:alpha}</c> ties with a refusing <c>/x/{id}</c>, and the differing name and policy are
-    /// exactly the details that would hide it from a text comparison.
-    /// </summary>
-    private static bool SharesShape(RoutePattern left, RoutePattern right)
-    {
-        try
-        {
-            return string.Equals(HostedRefusalPattern.ShapeKey(left), HostedRefusalPattern.ShapeKey(right),
-                StringComparison.Ordinal);
-        }
-        catch (NotSupportedException)
-        {
-            // A live route may legitimately contain a part shape the refusal normaliser does not model. It
-            // cannot be a refusal (those are built by the normaliser), so it cannot be compared - and an
-            // uncomparable route is not evidence of a tie.
-            return false;
-        }
+        FileLog.Write($"[HostedRefusalRouteSpace] validated {exclusive.Count} exclusive-prefix claim(s) and " +
+                      $"{refusals} refusal route(s) against {routes.Count} mapped route(s)");
     }
 }

--- a/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
@@ -161,11 +161,19 @@ public sealed class HostedDenyGroup
     private readonly RouteGroupBuilder _group;
     private readonly HostedDenial _denial;
 
-    // On hosted, one refusal route per PATTERN. A family that maps two verbs on one path (GET /x and PUT /x)
-    // would otherwise produce two verb-less routes on the same pattern, and the matcher throws
-    // AmbiguousMatchException at REQUEST time - a 500 in place of the refusal, on the denied route, which is
-    // the deny failing in the one way nothing would notice until a caller tried it.
-    private readonly Dictionary<string, IEndpointConventionBuilder> _refusals = new(StringComparer.Ordinal);
+    // On hosted, one refusal route per route SHAPE - not per pattern TEXT.
+    //
+    // A family that maps two verbs on one path (GET /x and PUT /x) would otherwise produce two verb-less
+    // routes that tie, and the matcher throws at REQUEST time - a 500 in place of the refusal, on the denied
+    // route, which is the deny failing in the one way nothing notices until a caller tries it.
+    //
+    // Text equality is not enough to prevent that. Two patterns differing only in a parameter NAME -
+    // /x/{id} and /x/{name} - are different strings and the SAME ROUTE, so a text-keyed dictionary maps both
+    // and produces exactly the tie it was meant to prevent. The key is therefore the route SHAPE (see
+    // HostedRefusalPattern.ShapeKey), which is what the matcher actually competes on.
+    private readonly Dictionary<string, RegisteredRefusal> _refusals = new(StringComparer.Ordinal);
+
+    private sealed record RegisteredRefusal(string SourcePattern, IEndpointConventionBuilder Builder);
 
     internal HostedDenyGroup(RouteGroupBuilder group, HostedDenial denial)
     {
@@ -203,64 +211,32 @@ public sealed class HostedDenyGroup
         if (!GatewayHostedMode.IsHosted)
             return mapHandler();
 
-        // The refusal is mapped on the pattern with its inline route CONSTRAINTS removed. Keeping them would
-        // leave a measured hole: a segment that fails a constraint - a non-integer where the real route
-        // declares {id:int} - fails endpoint SELECTION, so a refusal carrying that same constraint is never
-        // selected either and the framework answers its own 404 with the refusal never running. Loosening the
-        // refusal pattern means a value that fails the real constraint still MATCHES the refusal.
+        // The refusal is mapped on the family's pattern with its parameter POLICIES removed, rebuilt from the
+        // parsed route MODEL rather than by editing the pattern text (see HostedRefusalPattern). Keeping a
+        // policy would leave a measured hole: a segment that fails an inline constraint fails endpoint
+        // SELECTION, so a refusal carrying that same constraint is never selected either and the framework
+        // answers instead of the refusal. Everything else - literals, separators, parameter names, optionality,
+        // catch-alls and defaults - is preserved exactly.
         //
-        // Loosening cannot steal a neighbouring route that must keep serving: a literal segment outranks a
-        // parameter segment in route precedence, so a sibling literal on the same path shape still wins. That
-        // is measured, not assumed - over-refusing an undenied route would be an outage, which is the same
-        // defect as under-refusing a denied one, pointed the other way.
-        var refusalPattern = StripInlineConstraints(pattern);
+        // A pattern containing a part the normaliser does not recognise THROWS here, at startup. That is
+        // deliberate: passing it through would map a refusal that still carried a constraint while the
+        // family's author believed the route was covered, which is the false coverage this boundary exists to
+        // remove.
+        var refusalPattern = HostedRefusalPattern.WithoutPolicies(pattern, _denial.Family);
+        var shapeKey = HostedRefusalPattern.ShapeKey(refusalPattern);
 
-        if (_refusals.TryGetValue(refusalPattern, out var existing))
-            return existing;
+        // Same route shape, already refused: a family mapping several verbs on one path needs exactly ONE
+        // verb-less refusal, and mapping a second would tie with the first.
+        if (_refusals.TryGetValue(shapeKey, out var existing))
+            return existing.Builder;
 
-        // Verb-less and handler-less: nothing constrains the match and nothing binds, so every request shape
-        // - including a verb this family never mapped - meets the refusal below.
+        // Verb-less and handler-less: nothing constrains the match and nothing binds, so every request shape -
+        // including a verb this family never mapped - meets the refusal below.
         var refusal = _group.Map(refusalPattern, context => WriteRefusalAsync(context, _denial));
-        _refusals[refusalPattern] = refusal;
+        refusal.WithMetadata(new HostedRefusalMarker(_denial, pattern));
+
+        _refusals[shapeKey] = new RegisteredRefusal(pattern, refusal);
         return refusal;
-    }
-
-    /// <summary>
-    /// Removes the inline constraint from every route parameter: <c>/x/{id:int}</c> becomes <c>/x/{id}</c>.
-    /// A default value or a catch-all marker is left alone - only the constraint portion, everything from the
-    /// first colon to the closing brace, is dropped, because it is the constraint alone that can fail
-    /// selection and leave the refusal unreachable.
-    /// </summary>
-    internal static string StripInlineConstraints(string pattern)
-    {
-        if (pattern.IndexOf(':') < 0) return pattern;
-
-        var result = new System.Text.StringBuilder(pattern.Length);
-        var insideParameter = false;
-        var skipping = false;
-
-        foreach (var c in pattern)
-        {
-            switch (c)
-            {
-                case '{':
-                    insideParameter = true;
-                    skipping = false;
-                    break;
-                case '}':
-                    insideParameter = false;
-                    skipping = false;
-                    break;
-                case ':' when insideParameter:
-                    skipping = true;
-                    continue;
-            }
-
-            if (skipping && c != '}') continue;
-            result.Append(c);
-        }
-
-        return result.ToString();
     }
 
     private static async Task WriteRefusalAsync(HttpContext context, HostedDenial denial)
@@ -269,6 +245,15 @@ public sealed class HostedDenyGroup
                       $"method={context.Request.Method} path={context.Request.Path} reason={denial.Reason}");
 
         context.Response.StatusCode = denial.StatusCode;
+
+        // The media type is set EXPLICITLY, with its charset parameter, because the proof asserts the whole
+        // header value and not just the type: a refusal is a contract about what is served, and "close enough"
+        // on a content type is how a caller ends up parsing something other than what it expected.
+        context.Response.ContentType = "application/json; charset=utf-8";
+
+        // A HEAD request is answered with the refusal's status and headers and no body - the framework
+        // suppresses the body for HEAD. That is correct HTTP and it is stated here so the proof can assert it
+        // deliberately rather than a reader assuming "every request shape" includes a body on HEAD.
         await context.Response.WriteAsJsonAsync(new HostedRefusalBody(denial.Message));
     }
 

--- a/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
@@ -38,14 +38,22 @@ namespace CcDirector.Gateway.Tenancy;
 /// says it does not. A wrong verb IS a request shape, and the standard being enforced is that the refusal is
 /// uniform across shapes.
 ///
-/// WHY A TYPED HANDLE. The pre-binding property is proven ONCE, here, for every adopting family: an adopter
-/// cannot be attached AND post-binding, because attachment is what maps the refusal in place of the handler.
-/// That puts the whole weight on ATTACHMENT, so attachment is made structurally impossible to get wrong
-/// rather than merely conventional - routes are mapped through <see cref="HostedDenyGroup"/>, a distinct
-/// type obtainable only from <see cref="Group"/>. A family maps into the guarded group or it does not
-/// compile. The earlier shape kept a guarded and an unguarded builder in scope, differing only by variable
-/// name, so one changed receiver silently opened one route on hosted; here that is a signature change rather
-/// than a typo.
+/// WHY A TYPED HANDLE, AND WHAT IT DOES *NOT* GIVE US - corrected after review disproved the stronger claim.
+///
+/// Routes are mapped through <see cref="HostedDenyGroup"/>, a distinct type obtainable only from this class.
+/// It was claimed that this made unguarded mapping structurally UNEXPRESSIBLE, and that claim was FALSE:
+/// review changed one mapping receiver from the guarded group to the outer builder, it compiled with zero
+/// errors, and the hosted assertions reddened. So the handle is a CANARY - the bypass compiles and tests
+/// catch it - not a boundary.
+///
+/// The correction matters because a one-proof discharge for every adopting family rested on it. What
+/// survives is narrower and is stated as such: a family that maps its routes in a private STATIC method
+/// taking only the handle cannot see an outer builder at all, so its routes are not INDIVIDUALLY movable -
+/// redirecting one means changing the signature, which moves all of them together. That earns a family ONE
+/// attachment arm rather than one per route. It does not earn an exemption from arms altogether.
+///
+/// Do not restore the stronger claim without a mechanism that actually enforces the shape - an analyzer,
+/// not a convention. The bypass was measured; it is not hypothetical.
 ///
 /// SELF-HOST IS UNTOUCHED, AND THAT IS THE CONTROL. Off hosted every <c>Map</c> below maps the family's real
 /// handler on the group exactly as an unguarded builder would, and no refusal route is created at all.
@@ -59,9 +67,47 @@ namespace CcDirector.Gateway.Tenancy;
 public static class HostedRouteDeny
 {
     /// <summary>
-    /// Opens a route group whose every route - including routes mapped into it later, by anyone, with no
-    /// deny written for them - is refused on the hosted Gateway, on every request shape, without any
-    /// argument binding taking place. Returns the typed handle the family must map through.
+    /// Opens an EXCLUSIVE-PREFIX denied group: on hosted the family's handlers are not mapped and ONE
+    /// catch-all refusal claims everything under the prefix, including paths that do not exist. Use this
+    /// wherever the family owns its prefix outright - it is the stronger shape, because one refusal cannot
+    /// tie with anything and the exclusivity claim is checked by simple prefix containment at startup
+    /// rather than by reasoning about which patterns compete.
+    ///
+    /// It also gives the family FUTURE-ROUTE coverage for free: a path added under the prefix later is
+    /// already refused, because the catch-all never needed to know the route existed.
+    ///
+    /// The claim is CHECKED, not trusted: if any live route serves under this prefix, the Gateway refuses
+    /// to start, because the catch-all would take that route off the air.
+    /// </summary>
+    public static HostedDenyGroup ExclusiveGroup(IEndpointRouteBuilder outer, string prefix, HostedDenial denial)
+    {
+        ArgumentNullException.ThrowIfNull(outer);
+        ArgumentNullException.ThrowIfNull(denial);
+
+        if (string.IsNullOrWhiteSpace(prefix) || prefix == "/")
+            throw new ArgumentException(
+                $"The hosted denial for '{denial.Family}' asked to claim a prefix exclusively, but gave an empty " +
+                "prefix - which would claim the entire Gateway. An exclusive claim needs a real prefix.",
+                nameof(prefix));
+
+        var group = Group(outer, prefix, denial);
+
+        if (GatewayHostedMode.IsHosted)
+            group.MapExclusiveCatchAll(prefix);
+
+        return group;
+    }
+
+    /// <summary>
+    /// Opens a PER-ROUTE denied group: on hosted each route the family declares gets its own refusal in
+    /// place of its handler. Use this where the family's paths sit under a prefix that also carries LIVE
+    /// routes, so an exclusive claim would take undenied routes off the air.
+    ///
+    /// THE COST, STATED RATHER THAN DISCOVERED: a per-route family does NOT inherit future-route coverage.
+    /// A route added to it later has no refusal unless somebody writes one - which is the very property the
+    /// group mechanism exists to provide. A family using this mode therefore owes a test enumerating its
+    /// own mapped routes and asserting each has a refusal, so that adding one without a refusal REDDENS.
+    /// That converts the lost property from a thing to remember into a thing that fails.
     /// </summary>
     /// <param name="outer">The builder the group hangs off.</param>
     /// <param name="prefix">The group prefix, or <c>""</c> to keep route paths written out in full.</param>
@@ -72,10 +118,30 @@ public static class HostedRouteDeny
         ArgumentNullException.ThrowIfNull(prefix);
         ArgumentNullException.ThrowIfNull(denial);
 
-        FileLog.Write($"[HostedRouteDeny] group family={denial.Family} prefix='{prefix}' hosted={GatewayHostedMode.IsHosted}" +
+        // THE PREFIX IS NORMALISED TOO, on hosted. A group prefix can carry its own parameter policies -
+        // /family/{scope:int} - and a route's full pattern is the prefix plus the local pattern. Normalising
+        // only the local half leaves the constraint-miss hole one level up: a request whose PREFIX segment
+        // fails its policy fails endpoint selection, so the refusal is never selected and the framework
+        // answers instead. That was measured on the previous head, and it is the same defect the local
+        // normalisation exists to close, which is exactly why it was easy to miss - the fix had already been
+        // applied once and looked done.
+        //
+        // Off hosted the prefix is used verbatim, so self-host route matching is byte-identical to a group
+        // created without this primitive at all. Normalising off hosted would WIDEN the family's real routes,
+        // which would be a behaviour change on the control.
+        // Handed to MapGroup as a PATTERN, never re-serialised to text. A text round-trip would need a
+        // fallback for the case where the rebuilt pattern has no raw text - and that fallback would quietly
+        // reinstate the constrained prefix, which is the hole this is closing, restored by the very line
+        // meant to close it.
+        FileLog.Write($"[HostedRouteDeny] group family={denial.Family} prefix='{prefix}' " +
+                      $"hosted={GatewayHostedMode.IsHosted}" +
                       " - on hosted EVERY route in this group is refused on EVERY request shape, with no argument binding");
 
-        return new HostedDenyGroup(outer.MapGroup(prefix), denial);
+        var group = GatewayHostedMode.IsHosted
+            ? outer.MapGroup(HostedRefusalPattern.WithoutPolicies(prefix, denial.Family))
+            : outer.MapGroup(prefix);
+
+        return new HostedDenyGroup(group, denial);
     }
 }
 
@@ -161,16 +227,24 @@ public sealed class HostedDenyGroup
     private readonly RouteGroupBuilder _group;
     private readonly HostedDenial _denial;
 
-    // On hosted, one refusal route per route SHAPE - not per pattern TEXT.
+    // On hosted, one refusal per route shape WITHIN THIS FAMILY - a de-duplication, and nothing more.
     //
-    // A family that maps two verbs on one path (GET /x and PUT /x) would otherwise produce two verb-less
-    // routes that tie, and the matcher throws at REQUEST time - a 500 in place of the refusal, on the denied
-    // route, which is the deny failing in the one way nothing notices until a caller tries it.
+    // WHAT IT IS FOR: a family mapping several verbs on one path needs ONE verb-less refusal, because a
+    // second on the same path would tie with the first and the tie surfaces as a 500 at request time, on the
+    // denied route, which is the one nobody exercises until a caller does.
     //
-    // Text equality is not enough to prevent that. Two patterns differing only in a parameter NAME -
-    // /x/{id} and /x/{name} - are different strings and the SAME ROUTE, so a text-keyed dictionary maps both
-    // and produces exactly the tie it was meant to prevent. The key is therefore the route SHAPE (see
-    // HostedRefusalPattern.ShapeKey), which is what the matcher actually competes on.
+    // WHAT IT IS EXPLICITLY NOT: this key is NOT the matcher's ambiguity relation, and it must never be read
+    // as one. An earlier version of this primitive treated it as one, and review found three route pairs it
+    // called distinct that the live matcher ties - a standard parameter against an optional one on a present
+    // segment, literal case variants, and equal-precedence complex segments differing only by their
+    // separator. The matcher's relation is not reachable from public API, so any check for it here is a MODEL
+    // of framework semantics rather than the semantics, which is the same mistake as hand-scanning pattern
+    // text instead of using the parser.
+    //
+    // The safety of this mode therefore does NOT rest on this key being complete. It rests on refusals
+    // MIRRORING routes the family already declares: nothing is synthesised, so no pattern exists here that
+    // the family did not already have. Two of its routes that tie would already tie in its own production
+    // route table, before any deny existed.
     private readonly Dictionary<string, RegisteredRefusal> _refusals = new(StringComparer.Ordinal);
 
     private sealed record RegisteredRefusal(string SourcePattern, IEndpointConventionBuilder Builder);
@@ -198,6 +272,23 @@ public sealed class HostedDenyGroup
 
     public IEndpointConventionBuilder MapMethods(string pattern, IEnumerable<string> methods, Delegate handler)
         => Map(pattern, handler, () => _group.MapMethods(pattern, methods, handler));
+
+    /// <summary>
+    /// Maps the single catch-all refusal for an exclusive-prefix family, and records the exclusivity claim
+    /// as metadata so the finalised route space can CHECK it rather than take it on trust.
+    /// </summary>
+    internal void MapExclusiveCatchAll(string prefix)
+    {
+        var refusal = _group.Map("/{**hostedDeniedPath}", context => WriteRefusalAsync(context, _denial));
+        refusal.WithMetadata(new HostedRefusalMarker(_denial, prefix + "/{**hostedDeniedPath}"));
+        refusal.WithMetadata(new HostedExclusivePrefixMarker(_denial, prefix));
+
+        // The prefix ITSELF, which the catch-all above does not cover - a request to exactly the prefix has
+        // no remaining segment for the catch-all to match. Without this the family's own root answers from
+        // the fallback rather than from the refusal.
+        var root = _group.Map("", context => WriteRefusalAsync(context, _denial));
+        root.WithMetadata(new HostedRefusalMarker(_denial, prefix));
+    }
 
     /// <summary>
     /// The one decision, in one place: on hosted map the refusal and never the handler; off hosted map the

--- a/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
@@ -90,12 +90,43 @@ public static class HostedRouteDeny
                 "prefix - which would claim the entire Gateway. An exclusive claim needs a real prefix.",
                 nameof(prefix));
 
-        var group = Group(outer, prefix, denial);
+        // THE EXCLUSIVE PREFIX MUST BE PURELY LITERAL. Exclusivity is verified by simple PREFIX CONTAINMENT
+        // in HostedRefusalRouteSpace, and containment is only well-defined against a literal prefix. A
+        // parameterised prefix - /family/{tenant:int} - normalises on hosted to /family/{tenant}, so a live
+        // route /family/{scope}/still-serving does not TEXTUALLY start with the original prefix and slips the
+        // containment check, then serves BENEATH a prefix the family claimed exclusively: an outage on the
+        // more-specific live route hidden behind a claim that reads as airtight. Rejecting the parameterised
+        // prefix at CONSTRUCTION is the fail-loud fix: a prefix a family cannot claim literally is a prefix it
+        // cannot claim exclusively, and it must use per-route Group instead.
+        if (ContainsRouteParameter(prefix))
+            throw new ArgumentException(
+                $"The hosted denial for '{denial.Family}' asked to claim the prefix '{prefix}' exclusively, but it " +
+                "contains a route parameter. An exclusive claim is verified by literal prefix containment, which a " +
+                "parameterised prefix cannot support - a more-specific live route could serve beneath it unseen. " +
+                "Use a literal prefix, or open a per-route Group so each declared route carries its own refusal.",
+                nameof(prefix));
+
+        var group = CreateGroup(outer, prefix, denial, exclusive: true);
 
         if (GatewayHostedMode.IsHosted)
             group.MapExclusiveCatchAll(prefix);
 
         return group;
+    }
+
+    /// <summary>
+    /// True when <paramref name="prefix"/> carries a route parameter part - <c>{id}</c>, <c>{id:int}</c>,
+    /// <c>{**rest}</c>. Parsed by the framework's own parser, never scanned by hand: a hand scan for a brace
+    /// is exactly the kind of pattern-text model this primitive has already been burned by twice.
+    /// </summary>
+    private static bool ContainsRouteParameter(string prefix)
+    {
+        var parsed = Microsoft.AspNetCore.Routing.Patterns.RoutePatternFactory.Parse(prefix);
+        foreach (var segment in parsed.PathSegments)
+            foreach (var part in segment.Parts)
+                if (part is Microsoft.AspNetCore.Routing.Patterns.RoutePatternParameterPart)
+                    return true;
+        return false;
     }
 
     /// <summary>
@@ -113,6 +144,15 @@ public static class HostedRouteDeny
     /// <param name="prefix">The group prefix, or <c>""</c> to keep route paths written out in full.</param>
     /// <param name="denial">This family's refusal payload - the only per-family configuration.</param>
     public static HostedDenyGroup Group(IEndpointRouteBuilder outer, string prefix, HostedDenial denial)
+        => CreateGroup(outer, prefix, denial, exclusive: false);
+
+    /// <summary>
+    /// The shared group construction behind <see cref="Group"/> and <see cref="ExclusiveGroup"/>. The
+    /// <paramref name="exclusive"/> flag rides onto the handle so its <c>Map</c> knows whether a per-route
+    /// refusal is owed (per-route mode) or whether the ONE catch-all already covers the route and a per-route
+    /// refusal would only manufacture a tie (exclusive mode).
+    /// </summary>
+    private static HostedDenyGroup CreateGroup(IEndpointRouteBuilder outer, string prefix, HostedDenial denial, bool exclusive)
     {
         ArgumentNullException.ThrowIfNull(outer);
         ArgumentNullException.ThrowIfNull(prefix);
@@ -141,7 +181,7 @@ public static class HostedRouteDeny
             ? outer.MapGroup(HostedRefusalPattern.WithoutPolicies(prefix, denial.Family))
             : outer.MapGroup(prefix);
 
-        return new HostedDenyGroup(group, denial);
+        return new HostedDenyGroup(group, denial, exclusive);
     }
 }
 
@@ -227,6 +267,16 @@ public sealed class HostedDenyGroup
     private readonly RouteGroupBuilder _group;
     private readonly HostedDenial _denial;
 
+    // WHETHER THIS FAMILY CLAIMED ITS PREFIX EXCLUSIVELY. It changes ONE thing, and it is the thing the
+    // review found missing: an exclusive family already maps ONE catch-all refusal under a prefix nothing
+    // else may serve, so it does NOT also owe a per-route refusal for each declared route. Mapping one would
+    // not add coverage - the catch-all already refuses the path - but it WOULD re-introduce exactly the
+    // per-route ties (case/optional/policy) the exclusive shape exists to avoid, because two verb-less
+    // refusals under one prefix can compete. So on hosted an exclusive family DISCARDS each handler and maps
+    // no per-route refusal at all; the catch-all is the whole mechanism. Off hosted the flag is inert and the
+    // real handlers map exactly as any group's would.
+    private readonly bool _exclusive;
+
     // On hosted, one refusal per route shape WITHIN THIS FAMILY - a de-duplication, and nothing more.
     //
     // WHAT IT IS FOR: a family mapping several verbs on one path needs ONE verb-less refusal, because a
@@ -249,10 +299,11 @@ public sealed class HostedDenyGroup
 
     private sealed record RegisteredRefusal(string SourcePattern, IEndpointConventionBuilder Builder);
 
-    internal HostedDenyGroup(RouteGroupBuilder group, HostedDenial denial)
+    internal HostedDenyGroup(RouteGroupBuilder group, HostedDenial denial, bool exclusive)
     {
         _group = group;
         _denial = denial;
+        _exclusive = exclusive;
     }
 
     /// <summary>This family's refusal payload, so a test can assert against the same strings that are served.</summary>
@@ -302,6 +353,19 @@ public sealed class HostedDenyGroup
         if (!GatewayHostedMode.IsHosted)
             return mapHandler();
 
+        // EXCLUSIVE MODE: the ONE catch-all refusal under this prefix already refuses this route and every
+        // path beneath it, including ones the family never declared. The handler is discarded - it is never
+        // mapped, so nothing binds - and NO per-route refusal is added. Adding one would not extend coverage;
+        // it would only give the family a second verb-less endpoint under the prefix that could tie with the
+        // first. There is nothing to configure on a route that was never mapped, so a no-op handle is
+        // returned rather than a builder pointing at some other endpoint.
+        if (_exclusive)
+        {
+            FileLog.Write($"[HostedRouteDeny] exclusive family={_denial.Family} pattern='{pattern}' " +
+                          "- handler discarded, covered by the catch-all refusal, no per-route refusal mapped");
+            return NoOpConventionBuilder.Instance;
+        }
+
         // The refusal is mapped on the family's pattern with its parameter POLICIES removed, rebuilt from the
         // parsed route MODEL rather than by editing the pattern text (see HostedRefusalPattern). Keeping a
         // policy would leave a measured hole: a segment that fails an inline constraint fails endpoint
@@ -350,4 +414,18 @@ public sealed class HostedDenyGroup
 
     /// <summary>The refusal body: one property, so the assertion can be an exact property set.</summary>
     private sealed record HostedRefusalBody(string Error);
+
+    /// <summary>
+    /// The handle returned when an exclusive family maps a route on hosted: the handler was discarded and no
+    /// endpoint was created, so there is nothing to apply a convention to. It accepts and ignores conventions
+    /// rather than returning null, which would break a family that chains one onto the result.
+    /// </summary>
+    private sealed class NoOpConventionBuilder : IEndpointConventionBuilder
+    {
+        public static readonly NoOpConventionBuilder Instance = new();
+
+        public void Add(Action<EndpointBuilder> convention) { }
+
+        public void Finally(Action<EndpointBuilder> finalConvention) { }
+    }
 }

--- a/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedRouteDeny.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CcDirector.Core.Utilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// The ONE hosted-refusal boundary every deny family adopts. It exists because a refusal attached as a
+/// route-group endpoint filter does NOT answer uniformly across request shapes, and the shapes it misses
+/// are not the ones an obvious test exercises. The mechanism, the shapes, and the measurements behind that
+/// are recorded in the PRIVATE architecture record; this file carries what a maintainer needs in order not
+/// to undo the design, and no more.
+///
+/// The consequence that matters to anyone writing a proof: a future-route probe on a deny family MUST
+/// include a BODY-BOUND POST and not only a parameterless GET, because a parameterless GET is precisely the
+/// shape through which this class of defect cannot be seen.
+///
+/// HOW THIS CLOSES IT. On hosted the family's handler is NEVER MAPPED. In its place goes a verb-less
+/// refusal route on the same pattern. So there is no binding step to get ahead of, no body parameter, no
+/// inferred media-type constraint, and no method constraint - which means no request shape can be answered
+/// by the framework ahead of the refusal:
+///
+/// | Request shape           | Answered by |
+/// |-------------------------|-------------|
+/// | valid body              | the refusal |
+/// | malformed body          | the refusal |
+/// | wrong media type        | the refusal |
+/// | a verb never mapped     | the refusal |
+/// | a route added LATER     | the refusal |
+///
+/// The wrong-verb row is why this is a verb-less route rather than a convention that replaces the endpoint's
+/// request delegate. That convention closes the three body shapes but still lets endpoint SELECTION answer
+/// 405 for a verb the group never mapped - which discloses that a route exists on a Gateway whose refusal
+/// says it does not. A wrong verb IS a request shape, and the standard being enforced is that the refusal is
+/// uniform across shapes.
+///
+/// WHY A TYPED HANDLE. The pre-binding property is proven ONCE, here, for every adopting family: an adopter
+/// cannot be attached AND post-binding, because attachment is what maps the refusal in place of the handler.
+/// That puts the whole weight on ATTACHMENT, so attachment is made structurally impossible to get wrong
+/// rather than merely conventional - routes are mapped through <see cref="HostedDenyGroup"/>, a distinct
+/// type obtainable only from <see cref="Group"/>. A family maps into the guarded group or it does not
+/// compile. The earlier shape kept a guarded and an unguarded builder in scope, differing only by variable
+/// name, so one changed receiver silently opened one route on hosted; here that is a signature change rather
+/// than a typo.
+///
+/// SELF-HOST IS UNTOUCHED, AND THAT IS THE CONTROL. Off hosted every <c>Map</c> below maps the family's real
+/// handler on the group exactly as an unguarded builder would, and no refusal route is created at all.
+///
+/// FAIL DIRECTION. The refusal payload is validated when it is CONSTRUCTED, so a family supplying a blank
+/// message fails the Gateway at STARTUP - loudly, before serving - rather than serving an empty refusal that
+/// reads like a working route. The hosted decision is read from <see cref="GatewayHostedMode.IsHosted"/>
+/// directly, never from an optional argument a caller can omit: a security branch that depends on an
+/// argument fails OPEN the moment somebody forgets it.
+/// </summary>
+public static class HostedRouteDeny
+{
+    /// <summary>
+    /// Opens a route group whose every route - including routes mapped into it later, by anyone, with no
+    /// deny written for them - is refused on the hosted Gateway, on every request shape, without any
+    /// argument binding taking place. Returns the typed handle the family must map through.
+    /// </summary>
+    /// <param name="outer">The builder the group hangs off.</param>
+    /// <param name="prefix">The group prefix, or <c>""</c> to keep route paths written out in full.</param>
+    /// <param name="denial">This family's refusal payload - the only per-family configuration.</param>
+    public static HostedDenyGroup Group(IEndpointRouteBuilder outer, string prefix, HostedDenial denial)
+    {
+        ArgumentNullException.ThrowIfNull(outer);
+        ArgumentNullException.ThrowIfNull(prefix);
+        ArgumentNullException.ThrowIfNull(denial);
+
+        FileLog.Write($"[HostedRouteDeny] group family={denial.Family} prefix='{prefix}' hosted={GatewayHostedMode.IsHosted}" +
+                      " - on hosted EVERY route in this group is refused on EVERY request shape, with no argument binding");
+
+        return new HostedDenyGroup(outer.MapGroup(prefix), denial);
+    }
+}
+
+/// <summary>
+/// A family's refusal payload - the ONLY thing that differs between adopting families. Validated on
+/// construction so a malformed one fails the Gateway at startup rather than serving a refusal that says
+/// nothing.
+/// </summary>
+public sealed record HostedDenial
+{
+    /// <summary>The family name, for the log line and for telling refusals apart in a proof run.</summary>
+    public string Family { get; }
+
+    /// <summary>
+    /// The single error string the caller receives. The refusal body carries this and nothing else, so the
+    /// adopting family's test can assert an EXACT property set rather than the absence of today's payload
+    /// keys - an absence-only assertion passes on a framework error too, and therefore cannot fail for the
+    /// right reason.
+    /// </summary>
+    public string Message { get; }
+
+    /// <summary>Why this family has no per-tenant answer to serve. Logged with every refusal.</summary>
+    public string Reason { get; }
+
+    /// <summary>
+    /// What must happen before this deny is ever lifted. A deny stops the READ but not necessarily the
+    /// WRITE, so data can keep accumulating behind it and be there in full on the day the deny lifts.
+    /// Un-denying therefore means REMOVE the deny PLUS purge or migrate whatever accumulated - and that
+    /// instruction is written here, AT the deny, rather than held as a general principle somebody has to
+    /// remember at the moment they are least likely to.
+    /// </summary>
+    public string UnDenyInstruction { get; }
+
+    /// <summary>
+    /// The refusal status. 404 where the route does not exist as a concept on hosted: 403 would imply some
+    /// credential could reach it, and none can.
+    /// </summary>
+    public int StatusCode { get; }
+
+    /// <summary>
+    /// Fails LOUDLY at startup on a payload that would produce a meaningless refusal. This is the
+    /// no-fallback rule applied to a security primitive: a blank message would serve a refusal a caller
+    /// cannot act on and a proof cannot assert, which is worse than not booting.
+    /// </summary>
+    public HostedDenial(
+        string family,
+        string message,
+        string reason,
+        string unDenyInstruction,
+        int statusCode = StatusCodes.Status404NotFound)
+    {
+        Family = family;
+        Message = message;
+        Reason = reason;
+        UnDenyInstruction = unDenyInstruction;
+        StatusCode = statusCode;
+
+        if (string.IsNullOrWhiteSpace(Family))
+            throw new ArgumentException("A hosted denial must name its family.", nameof(Family));
+        if (string.IsNullOrWhiteSpace(Message))
+            throw new ArgumentException($"The hosted denial for '{Family}' must carry a message; a blank refusal tells a caller nothing.", nameof(Message));
+        if (string.IsNullOrWhiteSpace(Reason))
+            throw new ArgumentException($"The hosted denial for '{Family}' must state why the family has no per-tenant answer.", nameof(Reason));
+        if (string.IsNullOrWhiteSpace(UnDenyInstruction))
+            throw new ArgumentException($"The hosted denial for '{Family}' must state what un-denying requires, including what to purge or migrate.", nameof(UnDenyInstruction));
+        if (StatusCode is < 400 or > 599)
+            throw new ArgumentException($"The hosted denial for '{Family}' must refuse with a 4xx or 5xx status, not {StatusCode}.", nameof(StatusCode));
+    }
+}
+
+/// <summary>
+/// The typed handle a denied family maps its routes through. Obtainable only from
+/// <see cref="HostedRouteDeny.Group"/>, which is what makes attachment structurally impossible to get wrong:
+/// a family's mapping method takes ONE of these and therefore cannot be handed an unguarded builder without
+/// changing its signature.
+///
+/// On hosted every method here maps a verb-less refusal on the pattern and DISCARDS the handler - the
+/// handler is never mapped, so nothing binds. Off hosted every method maps the handler exactly as an
+/// unguarded builder would.
+/// </summary>
+public sealed class HostedDenyGroup
+{
+    private readonly RouteGroupBuilder _group;
+    private readonly HostedDenial _denial;
+
+    // On hosted, one refusal route per PATTERN. A family that maps two verbs on one path (GET /x and PUT /x)
+    // would otherwise produce two verb-less routes on the same pattern, and the matcher throws
+    // AmbiguousMatchException at REQUEST time - a 500 in place of the refusal, on the denied route, which is
+    // the deny failing in the one way nothing would notice until a caller tried it.
+    private readonly Dictionary<string, IEndpointConventionBuilder> _refusals = new(StringComparer.Ordinal);
+
+    internal HostedDenyGroup(RouteGroupBuilder group, HostedDenial denial)
+    {
+        _group = group;
+        _denial = denial;
+    }
+
+    /// <summary>This family's refusal payload, so a test can assert against the same strings that are served.</summary>
+    public HostedDenial Denial => _denial;
+
+    public IEndpointConventionBuilder MapGet(string pattern, Delegate handler)
+        => Map(pattern, handler, () => _group.MapGet(pattern, handler));
+
+    public IEndpointConventionBuilder MapPost(string pattern, Delegate handler)
+        => Map(pattern, handler, () => _group.MapPost(pattern, handler));
+
+    public IEndpointConventionBuilder MapPut(string pattern, Delegate handler)
+        => Map(pattern, handler, () => _group.MapPut(pattern, handler));
+
+    public IEndpointConventionBuilder MapDelete(string pattern, Delegate handler)
+        => Map(pattern, handler, () => _group.MapDelete(pattern, handler));
+
+    public IEndpointConventionBuilder MapMethods(string pattern, IEnumerable<string> methods, Delegate handler)
+        => Map(pattern, handler, () => _group.MapMethods(pattern, methods, handler));
+
+    /// <summary>
+    /// The one decision, in one place: on hosted map the refusal and never the handler; off hosted map the
+    /// handler and never a refusal.
+    /// </summary>
+    private IEndpointConventionBuilder Map(string pattern, Delegate handler, Func<IEndpointConventionBuilder> mapHandler)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        ArgumentNullException.ThrowIfNull(handler);
+
+        if (!GatewayHostedMode.IsHosted)
+            return mapHandler();
+
+        // The refusal is mapped on the pattern with its inline route CONSTRAINTS removed. Keeping them would
+        // leave a measured hole: a segment that fails a constraint - a non-integer where the real route
+        // declares {id:int} - fails endpoint SELECTION, so a refusal carrying that same constraint is never
+        // selected either and the framework answers its own 404 with the refusal never running. Loosening the
+        // refusal pattern means a value that fails the real constraint still MATCHES the refusal.
+        //
+        // Loosening cannot steal a neighbouring route that must keep serving: a literal segment outranks a
+        // parameter segment in route precedence, so a sibling literal on the same path shape still wins. That
+        // is measured, not assumed - over-refusing an undenied route would be an outage, which is the same
+        // defect as under-refusing a denied one, pointed the other way.
+        var refusalPattern = StripInlineConstraints(pattern);
+
+        if (_refusals.TryGetValue(refusalPattern, out var existing))
+            return existing;
+
+        // Verb-less and handler-less: nothing constrains the match and nothing binds, so every request shape
+        // - including a verb this family never mapped - meets the refusal below.
+        var refusal = _group.Map(refusalPattern, context => WriteRefusalAsync(context, _denial));
+        _refusals[refusalPattern] = refusal;
+        return refusal;
+    }
+
+    /// <summary>
+    /// Removes the inline constraint from every route parameter: <c>/x/{id:int}</c> becomes <c>/x/{id}</c>.
+    /// A default value or a catch-all marker is left alone - only the constraint portion, everything from the
+    /// first colon to the closing brace, is dropped, because it is the constraint alone that can fail
+    /// selection and leave the refusal unreachable.
+    /// </summary>
+    internal static string StripInlineConstraints(string pattern)
+    {
+        if (pattern.IndexOf(':') < 0) return pattern;
+
+        var result = new System.Text.StringBuilder(pattern.Length);
+        var insideParameter = false;
+        var skipping = false;
+
+        foreach (var c in pattern)
+        {
+            switch (c)
+            {
+                case '{':
+                    insideParameter = true;
+                    skipping = false;
+                    break;
+                case '}':
+                    insideParameter = false;
+                    skipping = false;
+                    break;
+                case ':' when insideParameter:
+                    skipping = true;
+                    continue;
+            }
+
+            if (skipping && c != '}') continue;
+            result.Append(c);
+        }
+
+        return result.ToString();
+    }
+
+    private static async Task WriteRefusalAsync(HttpContext context, HostedDenial denial)
+    {
+        FileLog.Write($"[HostedRouteDeny] DENIED on hosted: family={denial.Family} " +
+                      $"method={context.Request.Method} path={context.Request.Path} reason={denial.Reason}");
+
+        context.Response.StatusCode = denial.StatusCode;
+        await context.Response.WriteAsJsonAsync(new HostedRefusalBody(denial.Message));
+    }
+
+    /// <summary>The refusal body: one property, so the assertion can be an exact property set.</summary>
+    private sealed record HostedRefusalBody(string Error);
+}


### PR DESCRIPTION
The one shared hosted refusal boundary every deny family rebases onto, with startup route-space validation that fails-closed before StartAsync for every ambiguous match the hosted method-removal can introduce (structural overlap via InboundPrecedence + value-intersection), exclusive-mode with no per-route refusals, and structural exclusive-prefix containment. Codex-reviewed to APPROVE over 5 rounds; supersedes #1951.