### PR TITLE
fix(gateway): make the role push seam tenant-aware on the hosted Gateway

### DIFF
--- a/src/CcDirector.Gateway.Tests/FleetRoleObserverTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetRoleObserverTests.cs
@@ -139,6 +139,40 @@ public sealed class FleetRoleObserverTests
     }
 
     /// <summary>
+    /// THE ROLE-STAMP STORM the per-tenant gate exists to prevent (issue #1966 follow-up). On the hosted
+    /// Gateway the hub push path folds one tenant's fleet at a time (the snapshot reads the ambient tenant),
+    /// each pass seeing only that tenant's sessions. With a SINGLE flat gate, tenant t2's pass would prune s1
+    /// (not in t2's live set) out of the gate every round, so the next round re-sends s1 - and t1's pass evicts
+    /// s2 likewise - a re-send storm on every push. The gate is partitioned per tenant scope, so each session's
+    /// role is sent EXACTLY ONCE across many rounds. Model of the hub scope: set the ambient key, snapshot that
+    /// tenant's slice.
+    /// </summary>
+    [Fact]
+    public void PerTenantPasses_DoNotEvictEachOthersGate_NoRoleStormAcrossTenants()
+    {
+        var sender = new RecordingSender();
+        var byTenant = new Dictionary<string, List<(string, SessionDto)>>
+        {
+            ["t1"] = new() { ("dir-A", Session("s1")) },
+            ["t2"] = new() { ("dir-B", Session("s2")) },
+        };
+        var current = "t1";
+        var observer = new FleetRoleObserver(() => byTenant[current], sender.SendAsync, currentScopeKey: () => current);
+
+        // Three full rounds: each round sweeps t1's scope then t2's scope.
+        for (var round = 0; round < 3; round++)
+        {
+            current = "t1"; observer.Sweep();
+            current = "t2"; observer.Sweep();
+        }
+
+        // Exactly ONE send per session across all three rounds. A shared flat gate would show ~3 sends each.
+        Assert.Equal(2, sender.Sent.Count);
+        Assert.Contains(sender.Sent, x => x is { DirectorId: "dir-A", SessionId: "s1" });
+        Assert.Contains(sender.Sent, x => x is { DirectorId: "dir-B", SessionId: "s2" });
+    }
+
+    /// <summary>
     /// A Director with no tunnel gets no stamp, and the observer must NOT record that as delivered - the
     /// role has to be re-sent the moment it reconnects. Recording a failed send as done would leave that
     /// desktop permanently wrong, and silently.

--- a/src/CcDirector.Gateway/Fleet/FleetRoleObserver.cs
+++ b/src/CcDirector.Gateway/Fleet/FleetRoleObserver.cs
@@ -47,24 +47,52 @@ public sealed class FleetRoleObserver
     // takes one. Structurally identical - GatewayHost.SendCommandAsync satisfies both.
     private readonly Func<string, DirectorCommand, CancellationToken, Task<DirectorCommandResult?>> _sendCommand;
 
+    /// <summary>Resolves the current tenant scope's key (TenantId.Value) so the change gate can be partitioned
+    /// per tenant; null on self-host or when no seam is supplied (the unit tests), which resolves to the one
+    /// <see cref="DefaultScope"/> partition - byte-identical to the flat single-tenant gate before this.</summary>
+    private readonly Func<string?>? _currentScopeKey;
+
     /// <summary>
-    /// The change gate: session id -> the role we last successfully sent down. An entry is only written
-    /// AFTER the send is accepted, so a dropped send is retried on the next push rather than being recorded
-    /// as delivered. Bounded by pruning sessions that have left the fleet.
+    /// The change gate, PARTITIONED BY TENANT SCOPE: scope key -> (session id -> the role we last successfully
+    /// sent down). An entry is only written AFTER the send is accepted, so a dropped send is retried on the
+    /// next push rather than being recorded as delivered. Bounded by pruning sessions that have left the fleet.
+    ///
+    /// PARTITIONED because on the hosted Gateway the hub push path folds one tenant's fleet at a time (the
+    /// snapshot reads the AMBIENT tenant). A single flat gate pruned against one tenant's live set would delete
+    /// every OTHER tenant's entries, so the next push would re-send them all - a role-stamp storm. Each tenant's
+    /// pass reads and prunes ONLY its own partition. Self-host has one partition (<see cref="DefaultScope"/>),
+    /// unchanged. This is the partitioning the FleetRoles-on-Local comment in GatewayHost was blocked on.
     /// </summary>
-    private readonly ConcurrentDictionary<string, string> _lastSent = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, string>> _lastSentByScope
+        = new(StringComparer.Ordinal);
+
+    /// <summary>The one gate partition used when no tenant scope is in effect (self-host and the unit tests).</summary>
+    private const string DefaultScope = " single";
+
+    /// <summary>This pass's gate partition, resolved from the ambient tenant scope. MUST be captured once per
+    /// <see cref="Sweep"/> synchronously BEFORE any await, because the fire-and-forget sends can outlive the
+    /// scope that a hub push ran under.</summary>
+    private ConcurrentDictionary<string, string> GateForCurrentScope()
+        => _lastSentByScope.GetOrAdd(
+            _currentScopeKey?.Invoke() is { Length: > 0 } key ? key : DefaultScope,
+            _ => new ConcurrentDictionary<string, string>(StringComparer.Ordinal));
 
     /// <param name="snapshot">The fresh pushed sessions across every stream-connected Director, each paired
     /// with its owning directorId (PushedSessionStore.SnapshotFresh) - the same fleet read the auto-dismiss
     /// sweeper uses. Roles need the WHOLE fleet, not one Director's slice.</param>
     /// <param name="sendCommand">The down-channel command sender (GatewayHost.SendCommandAsync). A null
     /// RESULT means that Director has no stream, which is the documented "no Gateway, no role" floor.</param>
+    /// <param name="currentScopeKey">Resolves the ambient tenant scope's key so the change gate is partitioned
+    /// per tenant (GatewayHost passes <c>() =&gt; _tenantPass.Current?.Value</c>). Omit on self-host and in unit
+    /// tests: the gate then uses the single <see cref="DefaultScope"/> partition, unchanged.</param>
     public FleetRoleObserver(
         Func<IReadOnlyList<(string DirectorId, SessionDto Session)>> snapshot,
-        Func<string, DirectorCommand, CancellationToken, Task<DirectorCommandResult?>> sendCommand)
+        Func<string, DirectorCommand, CancellationToken, Task<DirectorCommandResult?>> sendCommand,
+        Func<string?>? currentScopeKey = null)
     {
         _snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
         _sendCommand = sendCommand ?? throw new ArgumentNullException(nameof(sendCommand));
+        _currentScopeKey = currentScopeKey;
     }
 
     /// <summary>Observe one pushed session. Any push can change any session's role, so this re-resolves the
@@ -110,6 +138,9 @@ public sealed class FleetRoleObserver
     /// </summary>
     internal void Sweep()
     {
+        // Capture THIS pass's per-tenant gate up front, synchronously: the hub push path runs inside one
+        // tenant's scope and the async sends below can outlive it, so the gate reference must be resolved here.
+        var gate = GateForCurrentScope();
         var fleet = _snapshot();
         if (fleet is null || fleet.Count == 0) return;
 
@@ -127,19 +158,20 @@ public sealed class FleetRoleObserver
             var role = s.SessionRole ?? SessionRoles.Standalone;
             // THE GATE. Unchanged role -> no send -> the echo of our own stamp dies here rather than
             // becoming the next push. Removing this makes the observer spin.
-            if (_lastSent.TryGetValue(s.SessionId, out var sent) && string.Equals(sent, role, StringComparison.Ordinal))
+            if (gate.TryGetValue(s.SessionId, out var sent) && string.Equals(sent, role, StringComparison.Ordinal))
                 continue;
 
-            _ = SendRoleAsync(directorId, s.SessionId, role);
+            _ = SendRoleAsync(directorId, s.SessionId, role, gate);
         }
 
-        // Keep the gate bounded: a session that has left the fleet keeps no entry.
-        foreach (var key in _lastSent.Keys)
+        // Keep the gate bounded: a session that has left THIS TENANT'S fleet keeps no entry. Prune only this
+        // tenant's partition against this tenant's live set - never another tenant's, which would re-send it.
+        foreach (var key in gate.Keys)
             if (!live.Contains(key))
-                _lastSent.TryRemove(key, out _);
+                gate.TryRemove(key, out _);
     }
 
-    private async Task SendRoleAsync(string directorId, string sessionId, string role)
+    private async Task SendRoleAsync(string directorId, string sessionId, string role, ConcurrentDictionary<string, string> gate)
     {
         try
         {
@@ -169,7 +201,7 @@ public sealed class FleetRoleObserver
             }
 
             // Recorded ONLY on a confirmed delivery, so a dropped stamp is re-sent on the next push.
-            _lastSent[sessionId] = role;
+            gate[sessionId] = role;
             FileLog.Write($"[FleetRoleObserver] sid={sessionId}: role '{role}' stamped down to director={directorId}");
         }
         catch (Exception ex)

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -807,16 +807,17 @@ public sealed class GatewayHost : IAsyncDisposable
         // (constructed per-invocation by SignalR) folds every pushed session through this ONE instance -
         // which matters here more than anywhere: the instance holds the change gate that stops the stamp
         // echoing back up and re-triggering itself forever.
-        // Hosted Multi-Tenancy (session-serving): NOT yet converted to the per-tenant pass.
-        // BLOCKED ON: partitioning FleetRoleObserver._lastSent by tenant. That change gate is keyed by session
-        // id alone and is PRUNED against the current pass's snapshot, so running this once per tenant would
-        // have each tenant's pass delete every other tenant's gate entries - inverting a suppressed no-op into
-        // a role-stamp storm every sweep. Converting the loop before partitioning the state it MUTATES makes
-        // things worse, not better. Until then it stays on Local: correct on self-host, and on hosted a Local
-        // read is empty, so it degrades to a no-op exactly as today (never a wrong-tenant read).
+        // Hosted Multi-Tenancy (issue #1966 follow-up): CONVERTED to the ambient tenant. FleetRoleObserver
+        // now partitions its change gate per tenant scope, which unblocks reading the AMBIENT tenant here:
+        // previously the snapshot was hard-coded to TenantId.Local, empty on the hosted Gateway, so role badges
+        // (M/A) never pushed to a hosted Director - the same tenant-blindness that greyed the display-state rail
+        // (see the display-state observer below). Roles are hub-only (no periodic sweep), and the DirectorHub
+        // push path already runs inside the bound tenant's scope, so reading the ambient tenant is all that is
+        // needed here; the per-tenant gate is what stops one tenant's pass pruning + re-storming the others.
         FleetRoles = new Fleet.FleetRoleObserver(
-            () => PushedSessions.SnapshotFresh(TenantId.Local, AutoDismissStaleAfter),
-            SendCommandAsync);
+            () => AmbientSnapshotFresh(AutoDismissStaleAfter),
+            SendCommandAsync,
+            currentScopeKey: () => _tenantPass.Current?.Value);
         // The fold push seam: stamps each session's folded display state down to its owning Director, so the
         // desktop rail stops re-folding from local facts it cannot see. Folds through the SAME method the
         // roster serves from (StampFleetRolesAndFold with THIS host's NeedsYouClock and snooze registry), so


### PR DESCRIPTION
Follow-up to #1966. `FleetRoleObserver` had the **identical** tenant-blindness the display-state observer had (fixed in #1971): its snapshot was hard-coded to `TenantId.Local`, which is empty on the hosted Gateway because sessions live under the signed-in account's tenant. So the resolved-role badges (Manager / Worker) never pushed to a hosted Director, exactly as the display-state colour never did.

## The fix

- Read the fleet from the **ambient tenant** (`AmbientSnapshotFresh`) instead of `Local`.
- **Partition the change gate per tenant scope** - the thing the GatewayHost comment said this was blocked on. A single flat gate pruned against one tenant's fleet would delete every other tenant's entries and re-send them on the next push (a role-stamp storm). Each tenant's pass now reads and prunes only its own partition.
- Roles are **hub-only** (no periodic sweep), and the DirectorHub push path already runs inside the bound tenant's scope, so reading the ambient tenant is all that's needed - no `ForEachTenant` wrap.

Verified locally: the roles fold does **not** throw on the hosted push path (all `HostedSessionCommandRouteTenancyTests` pass), so no repeat of the voice-enrichment cascade from #1971. This change adds **zero** new test failures.

Self-host is unchanged by construction (one tenant, the default partition). Adds a test proving the per-tenant gate does not evict another tenant's entries.

Relates to #1966