### PR TITLE
fix(gateway): skip the transcription-audio archive on hosted (MTR-10 Gap A)

### DIFF
--- a/src/CcDirector.Gateway.Tests/Transcription/TranscriptionAudioArchiveHostedTests.cs
+++ b/src/CcDirector.Gateway.Tests/Transcription/TranscriptionAudioArchiveHostedTests.cs
@@ -1,0 +1,73 @@
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Transcription;
+
+/// <summary>
+/// MTR-10 Gap A. The transcription-audio archive has ONE directory with no tenant in its path or API and
+/// a GLOBAL age/count prune, so on a multi-tenant hosted Gateway it would mix every account's raw speech
+/// at rest and let one tenant's traffic prune another's diagnostic clips. It is a LOCAL self-host
+/// diagnostic aid - write-only, no read method, no public archive-read route - so the fix is the same one
+/// the telemetry log beside it already takes on hosted (#1897): stop the write. These tests pin BOTH
+/// directions of that gate, because a guard has two failure directions: under-refusing on hosted leaks
+/// cross-tenant audio at rest, and over-refusing on self-host silently deletes the diagnostic the archive
+/// exists to provide.
+///
+/// In the <c>GatewayHostedMode</c> collection because it sets the process-wide <c>CC_GATEWAY_HOSTED</c>
+/// variable (that collection runs alone, so no other test reads the mode this one is flipping).
+/// </summary>
+[Collection("GatewayHostedMode")]
+public sealed class TranscriptionAudioArchiveHostedTests : IDisposable
+{
+    private readonly string? _prevHosted;
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "cc-audio-archive-hosted-tests", Guid.NewGuid().ToString("N"));
+
+    public TranscriptionAudioArchiveHostedTests()
+    {
+        _prevHosted = Environment.GetEnvironmentVariable(GatewayHostedMode.HostedEnvVar);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(GatewayHostedMode.HostedEnvVar, _prevHosted);
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { /* scratch cleanup is best-effort */ }
+    }
+
+    private static byte[] Clip(byte fill = 0x42) => Enumerable.Repeat(fill, 64).ToArray();
+
+    [Fact]
+    public void TrySave_OnHosted_TwoTenantsWriteNothingAndCannotPruneEachOther()
+    {
+        // The Gap A property: on hosted, no raw speech lands at rest, so two tenants can neither SHARE the
+        // one archive directory nor let one tenant's clip prune the other's. Both saves are refused and the
+        // directory stays empty - there is nothing to mix and nothing to prune.
+        Environment.SetEnvironmentVariable(GatewayHostedMode.HostedEnvVar, "1");
+        var archive = new TranscriptionAudioArchive(_dir);
+
+        var tenantAClip = archive.TrySave("tenant-a-turn", Clip(0x0A), "audio/wav");
+        var tenantBClip = archive.TrySave("tenant-b-turn", Clip(0x0B), "audio/wav");
+
+        Assert.Null(tenantAClip);
+        Assert.Null(tenantBClip);
+        // No file for either tenant - the shared, unpartitioned archive is never populated on hosted, so
+        // neither tenant's traffic can consume the global clip cap against the other.
+        Assert.False(Directory.Exists(_dir) && Directory.GetFiles(_dir, "turn-*").Length > 0);
+    }
+
+    [Fact]
+    public void TrySave_OnSelfHost_StillWritesTheClip()
+    {
+        // The OTHER failure direction: the hosted gate must not become a blanket break. Self-host is
+        // single-tenant, the archive is the diagnostic that catches a transcription that silently drops
+        // half the speech, and it must keep working exactly as before. CC_GATEWAY_HOSTED explicitly not "1".
+        Environment.SetEnvironmentVariable(GatewayHostedMode.HostedEnvVar, "0");
+        var archive = new TranscriptionAudioArchive(_dir);
+
+        var saved = archive.TrySave("self-host-turn", Clip(), "audio/wav");
+
+        Assert.NotNull(saved);
+        Assert.True(File.Exists(saved));
+    }
+}

--- a/src/CcDirector.Gateway/Transcription/TranscriptionAudioArchive.cs
+++ b/src/CcDirector.Gateway/Transcription/TranscriptionAudioArchive.cs
@@ -91,6 +91,19 @@ public sealed class TranscriptionAudioArchive
     /// <param name="contentType">The clip's MIME type, used to pick a playable file extension.</param>
     public string? TrySave(string turnId, byte[] audio, string contentType)
     {
+        // HOSTED WRITE GATE (MTR-10 Gap A). This archive has ONE process/user directory with no tenant in
+        // its path or API and a GLOBAL age/count prune, so on a multi-tenant hosted Gateway it would mix
+        // every account's raw speech at rest and let one tenant's traffic prune another's clips. It is a
+        // LOCAL self-host diagnostic aid - write-only, no read method, no public archive-read route - so
+        // there is nothing on hosted to serve it. This is the exact reasoning, and the exact fix, applied
+        // to the telemetry log that sits beside it (GatewayTranscriptionService.RecordTelemetry, issue
+        // #1897): stop the write on hosted. Self-host is single-tenant and byte-identical to today.
+        if (GatewayHostedMode.IsHosted)
+        {
+            FileLog.Write($"[TranscriptionAudioArchive] TrySave SKIPPED on hosted for turn {turnId}: the archive has no tenant partition and no reader on hosted (MTR-10 Gap A; mirrors the telemetry skip #1897)");
+            return null;
+        }
+
         if (string.IsNullOrWhiteSpace(turnId)) return null;
         if (audio is null || audio.Length == 0) return null;
 


### PR DESCRIPTION
## The gap (MTR-10 Gap A)

`POST /transcription` and `POST /wingman/transcribe` are live on the hosted Gateway. Both call `GatewayTranscriptionService.TranscribeAsync`, which **unconditionally** archived the raw clip through `TranscriptionAudioArchive.TrySave` *before* transcribing.

`TranscriptionAudioArchive` has:
- **one** process/user directory (`CcStorage.TranscriptionAudio()`),
- **no tenant** in its path, file name, or API, and
- a **global** age (24h) / count (500 clips) prune.

So on a multi-tenant hosted Gateway it mixes every account's raw customer speech at rest in one directory, and one tenant's traffic can prune another tenant's diagnostic audio. That is a cross-tenant integrity and data-at-rest problem. There is no public archive-read route, so it is not a direct tenant-to-tenant download today, but the mixed-at-rest speech and the shared prune cap are real.

thefrederiksen/devthrottle#1903 host-gated the shared transcription **telemetry** writer, but not this raw-audio archive; none of thefrederiksen/devthrottle#1973 / thefrederiksen/devthrottle#1907 / thefrederiksen/devthrottle#1900 / thefrederiksen/devthrottle#1945 touched it.

## The fix

The archive is a **local self-host diagnostic aid**: write-only (no read method, no public archive-read route), it exists so a transcription that silently drops half the speech can be proven against the audio that produced it, and it is never transmitted. That is the same profile as the transcription telemetry log sitting beside it, which already stops its write on hosted (`GatewayTranscriptionService.RecordTelemetry`, thefrederiksen/devthrottle_internal#896).

Take the same, matching fix: `TranscriptionAudioArchive.TrySave` returns `null` when `GatewayHostedMode.IsHosted`, so no raw speech lands at rest on hosted **regardless of caller**. Self-host is single-tenant and byte-identical to today.

## Test (revert-proof)

`TranscriptionAudioArchiveHostedTests` (in the `GatewayHostedMode` collection, which serializes on the process-wide `CC_GATEWAY_HOSTED`) pins **both** directions of the guard:
- **on hosted** two tenants' `TrySave` calls both return null and the shared archive directory stays empty - nothing to mix, nothing to prune;
- **on self-host** the clip still writes - the diagnostic must not become an outage.

Reverting the hosted gate makes the hosted assertion fail.

## Verification

- `dotnet build` Gateway + Gateway.Tests: succeeded.
- Transcription tests (`TranscriptionAudioArchive*`, `GatewayTranscriptionService*`): 34 passed.
- New hosted class solo: 2 passed.
- `ContextLessRouteTenancyMechanismProofTests` solo: 3 passed.
- `HostedContentReadDenyTests` solo: 29 passed.