### PR TITLE
fix(mobile): instant snooze feedback in voice mode + revert-proof tenant-scope test

### DIFF
--- a/apps/mobile/src/components/SessionAppBar.tsx
+++ b/apps/mobile/src/components/SessionAppBar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { holdPillLabel } from "@devthrottle/client-core/sessions/snoozeAction";
 import { StatusPill } from "./StatusPill";
 import type { SessionManage } from "./useSessionManage";
 
@@ -150,7 +151,7 @@ export function SessionAppBar({ title, manage, showSnooze = false, showSwitchToV
                   }}
                   disabled={manage.busy || manage.onHold === null}
                 >
-                  {manage.held ? "Unsnooze" : "Snooze"}
+                  {manage.held || manage.deferred ? "Unsnooze" : "Snooze"}
                 </button>
               )}
 
@@ -188,14 +189,20 @@ export function SessionAppBar({ title, manage, showSnooze = false, showSwitchToV
       </div>
 
       {manage.error !== null && <div className="banner banner-error" role="alert">{manage.error}</div>}
-      {/* The snoozed pill reads the Gateway's FOLD (manage.snoozed), not the raw onHold flag: a Held session
-          that has started working is blue "Working" and must not still read "Snoozed". Shows the hold time
-          beside it when the Gateway's snooze clock is running, matching the roster and the desktop rail. */}
-      {manage.snoozed && (
-        <span className="manage-held-pill">
-          {manage.holdCountdown ? `Snoozed - ${manage.holdCountdown}` : "Snoozed"}
-        </span>
-      )}
+      {/* The snooze pill. A DEFERRED snooze reads "Snoozing when it finishes" (asked for while the agent is
+          working, so it arms when the work ends) - this is what makes snoozing a busy session give instant
+          feedback instead of looking like nothing happened. An armed snooze reads the Gateway FOLD
+          (manage.snoozed), not the raw onHold flag - a Held session that has started working is blue
+          "Working" and must not still read "Snoozed" - with the running hold time beside it, matching the
+          roster and the desktop rail. */}
+      {(() => {
+        const pill = holdPillLabel(
+          { held: manage.held, deferred: manage.deferred },
+          manage.snoozed,
+          manage.holdCountdown,
+        );
+        return pill !== null ? <span className="manage-held-pill">{pill}</span> : null;
+      })()}
 
       {confirming && (
         <div className="confirm-overlay" role="dialog" aria-modal="true" aria-label="Remove session">

--- a/apps/mobile/src/components/useSessionManage.ts
+++ b/apps/mobile/src/components/useSessionManage.ts
@@ -3,9 +3,10 @@ import { useNavigate } from "react-router-dom";
 import { holdSession, killSession, listSessions } from "@devthrottle/client-core/api/client";
 import { classify, isDeferredHold, isWorking, snoozeCountdown } from "@devthrottle/client-core/sessions/ordering";
 import {
-  holdStateFromResponse,
   isSnoozing,
   optimisticHoldToggle,
+  reconcileHoldToggle,
+  type HoldToggleOutcome,
   type HoldUiState,
 } from "@devthrottle/client-core/sessions/snoozeAction";
 
@@ -101,31 +102,39 @@ export function useSessionManage(sessionId: string | undefined): SessionManage {
 
   const toggleHold = useCallback(async () => {
     if (!sessionId || busy) return;
-    const current: HoldUiState = { held: onHold === true, deferred };
-    const desired = !isSnoozing(current);
+    // The pre-tap state: both what the toggle flips FROM and what a FAILED /hold must roll back to.
+    const preTap: HoldUiState = { held: onHold === true, deferred };
+    const desired = !isSnoozing(preTap);
     // Optimistic: flip the UI the instant the tap lands, so a snooze is NEVER silent. A working session
-    // shows the deferred affordance immediately; a settled one shows held. Reconciled below from the
-    // server's authoritative answer, and again by the immediate refresh.
-    const optimistic = optimisticHoldToggle(current, working);
+    // shows the deferred affordance immediately; a settled one shows held. Settled below from the TRUE
+    // outcome - the server's authoritative answer on success, or a rollback to pre-tap on failure.
+    const optimistic = optimisticHoldToggle(preTap, working);
     setBusy(true);
     pendingRef.current = true;
     setError(null);
     setOnHold(optimistic.held);
     setDeferred(optimistic.deferred);
+    let outcome: HoldToggleOutcome;
     try {
-      const reconciled = holdStateFromResponse(await holdSession(sessionId, desired));
-      setOnHold(reconciled.held);
-      setDeferred(reconciled.deferred);
+      outcome = { ok: true, response: await holdSession(sessionId, desired) };
     } catch (err) {
+      // /hold FAILED: the snooze did NOT happen. Surface the error; the rollback below returns the UI to
+      // its pre-tap state so the button never falsely reads "Snoozed"/"Snoozing when it finishes".
+      outcome = { ok: false };
       setError(err instanceof Error ? err.message : "Hold failed");
     } finally {
       pendingRef.current = false;
       setBusy(false);
     }
-    // Kill the up-to-a-poll-interval lag: re-sync from the roster fold NOW, so the countdown, the
-    // snoozed pill and the armed/deferred split land immediately. pendingRef is cleared above, so this
-    // refresh is allowed to write through.
-    void refresh();
+    // Settle on the TRUE server outcome: the authoritative tri-state on success, or the pre-tap state on
+    // failure (never a false success). Only on success re-sync from the roster fold NOW, killing the
+    // up-to-a-poll-interval lag so the countdown, the snoozed pill and the armed/deferred split land
+    // immediately. On FAILURE we must NOT refresh: a roster blip could re-assert the optimistic snooze,
+    // or a failed refresh would keep the last-known (optimistic) state - either way a false "Snoozed".
+    const settled = reconcileHoldToggle(preTap, outcome);
+    setOnHold(settled.held);
+    setDeferred(settled.deferred);
+    if (outcome.ok) void refresh();
   }, [sessionId, busy, onHold, deferred, working, refresh]);
 
   const removeSession = useCallback(async () => {

--- a/apps/mobile/src/components/useSessionManage.ts
+++ b/apps/mobile/src/components/useSessionManage.ts
@@ -1,7 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { holdSession, killSession, listSessions } from "@devthrottle/client-core/api/client";
-import { classify, snoozeCountdown } from "@devthrottle/client-core/sessions/ordering";
+import { classify, isDeferredHold, isWorking, snoozeCountdown } from "@devthrottle/client-core/sessions/ordering";
+import {
+  holdStateFromResponse,
+  isSnoozing,
+  optimisticHoldToggle,
+  type HoldUiState,
+} from "@devthrottle/client-core/sessions/snoozeAction";
 
 // The session management verbs (Snooze/Unsnooze + Remove) for ONE session, hoisted out of the old
 // SessionManageBar so two places can drive them from one copy of the state: the app bar's overflow
@@ -11,12 +17,23 @@ import { classify, snoozeCountdown } from "@devthrottle/client-core/sessions/ord
 //
 // The held state is polled from the SAME roster the Home page reads, so the session screen and the
 // roster always agree, and a hold toggled elsewhere (the desktop) shows up here.
+//
+// SNOOZE MUST FEEL INSTANT (owner's #1 annoyance). Two things make it so, in every case:
+//   - a hold has a TRI-STATE (held / deferred / none), not a boolean. Snoozing a WORKING session DEFERS
+//     (its clock starts when the work ends - owner ruling), which the Gateway returns as
+//     { onHold: false, pending: true }. The old client read only onHold, so a deferred snooze showed NO
+//     change and read as "the button does nothing". `deferred` carries that state to the surfaces.
+//   - the tap updates the UI OPTIMISTICALLY (before the server answers) and then triggers an IMMEDIATE
+//     roster re-sync, so neither the button nor the pill wait up to a poll interval to reflect the snooze.
 
 const POLL_INTERVAL_MS = 4000;
 
 export interface SessionManage {
   onHold: boolean | null;
   held: boolean;
+  // A DEFERRED snooze: asked for while the agent was working, so it arms when the work ends. Distinct
+  // from `held` (armed now) - a caller that read only `held` would show nothing for a deferred snooze.
+  deferred: boolean;
   // The FOLD's verdict for DISPLAY (classify === "onHold"), distinct from the raw `held` the toggle uses.
   // A Held session that has started working is blue "Working" and must NOT read "snoozed" - working wins in
   // the fold, so a display pill reads this, never the raw onHold flag.
@@ -33,6 +50,8 @@ export interface SessionManage {
 export function useSessionManage(sessionId: string | undefined): SessionManage {
   const navigate = useNavigate();
   const [onHold, setOnHold] = useState<boolean | null>(null);
+  const [deferred, setDeferred] = useState(false);
+  const [working, setWorking] = useState(false);
   const [snoozed, setSnoozed] = useState(false);
   const [holdCountdown, setHoldCountdown] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -40,56 +59,74 @@ export function useSessionManage(sessionId: string | undefined): SessionManage {
   // While a toggle is in flight the optimistic state must not be clobbered by a slower poll.
   const pendingRef = useRef(false);
 
+  // Hoisted out of the effect so toggleHold can call it for an IMMEDIATE re-sync after a snooze, instead
+  // of leaving the button/pill stale until the next interval. Reads the SAME roster the Home page reads.
+  const refresh = useCallback(async (signal?: AbortSignal) => {
+    if (!sessionId) return;
+    try {
+      const all = await listSessions(signal);
+      if (pendingRef.current) return;
+      const match = all.find((s) => s.sessionId === sessionId);
+      if (match) {
+        // The toggle needs the raw hold (what it will flip); the DISPLAY reads the fold (working wins).
+        setOnHold(Boolean(match.onHold));
+        // The Gateway-owned tri-state: DeferredHold is a real snooze that has not armed yet.
+        setDeferred(isDeferredHold(match));
+        // Whether snoozing NOW would defer (working) or arm (settled) - drives the optimistic affordance.
+        setWorking(isWorking(match));
+        setHoldCountdown(snoozeCountdown(match));
+        // classify fails loud against a Gateway that did not stamp triageBucket; in this polling loop a
+        // mixed-version blip must not throw the refresh, so keep the last verdict on that rare miss.
+        try {
+          setSnoozed(classify(match) === "onHold");
+        } catch {
+          /* keep the last-known snoozed verdict */
+        }
+      }
+    } catch {
+      /* keep the last-known held state; the actions surface their own errors */
+    }
+  }, [sessionId]);
+
   useEffect(() => {
     if (!sessionId) return;
     const controller = new AbortController();
-    let cancelled = false;
-    const refresh = async () => {
-      try {
-        const all = await listSessions(controller.signal);
-        if (cancelled || pendingRef.current) return;
-        const match = all.find((s) => s.sessionId === sessionId);
-        if (match) {
-          // The toggle needs the raw hold (what it will flip); the DISPLAY reads the fold (working wins).
-          setOnHold(Boolean(match.onHold));
-          setHoldCountdown(snoozeCountdown(match));
-          // classify fails loud against a Gateway that did not stamp triageBucket; in this polling loop a
-          // mixed-version blip must not throw the refresh, so keep the last verdict on that rare miss.
-          try {
-            setSnoozed(classify(match) === "onHold");
-          } catch {
-            /* keep the last-known snoozed verdict */
-          }
-        }
-      } catch {
-        /* keep the last-known held state; the actions surface their own errors */
-      }
-    };
-    void refresh();
-    const timer = window.setInterval(() => void refresh(), POLL_INTERVAL_MS);
+    void refresh(controller.signal);
+    const timer = window.setInterval(() => void refresh(controller.signal), POLL_INTERVAL_MS);
     return () => {
-      cancelled = true;
       controller.abort();
       window.clearInterval(timer);
     };
-  }, [sessionId]);
+  }, [sessionId, refresh]);
 
   const toggleHold = useCallback(async () => {
     if (!sessionId || busy) return;
-    const desired = !(onHold ?? false);
+    const current: HoldUiState = { held: onHold === true, deferred };
+    const desired = !isSnoozing(current);
+    // Optimistic: flip the UI the instant the tap lands, so a snooze is NEVER silent. A working session
+    // shows the deferred affordance immediately; a settled one shows held. Reconciled below from the
+    // server's authoritative answer, and again by the immediate refresh.
+    const optimistic = optimisticHoldToggle(current, working);
     setBusy(true);
     pendingRef.current = true;
     setError(null);
+    setOnHold(optimistic.held);
+    setDeferred(optimistic.deferred);
     try {
-      const applied = await holdSession(sessionId, desired);
-      setOnHold(applied);
+      const reconciled = holdStateFromResponse(await holdSession(sessionId, desired));
+      setOnHold(reconciled.held);
+      setDeferred(reconciled.deferred);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Hold failed");
     } finally {
       pendingRef.current = false;
       setBusy(false);
     }
-  }, [sessionId, busy, onHold]);
+    // Kill the up-to-a-poll-interval lag: re-sync from the roster fold NOW, so the countdown, the
+    // snoozed pill and the armed/deferred split land immediately. pendingRef is cleared above, so this
+    // refresh is allowed to write through.
+    void refresh();
+  }, [sessionId, busy, onHold, deferred, working, refresh]);
 
   const removeSession = useCallback(async () => {
     if (!sessionId || busy) return;
@@ -109,6 +146,7 @@ export function useSessionManage(sessionId: string | undefined): SessionManage {
   return {
     onHold,
     held: onHold === true,
+    deferred,
     snoozed,
     holdCountdown,
     busy,

--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -319,7 +319,7 @@ export function VoiceMode() {
           onClick={() => void manage.toggleHold()}
           disabled={manage.busy || manage.onHold === null}
         >
-          {manage.held ? "Unsnooze" : "Snooze"}
+          {manage.held || manage.deferred ? "Unsnooze" : "Snooze"}
         </button>
         {speaking && (
           <button type="button" className="voice-respond" onClick={() => setResponding(true)}>

--- a/mission/fix-snooze.md
+++ b/mission/fix-snooze.md
@@ -174,18 +174,40 @@ The wire already carries the tri-state; the client now honours it end to end.
   when it finishes" the instant it is tapped and self-heals to "Snoozed - <countdown>" when the turn
   lands.
 
+## Residual fixed (Codex CHANGES-NEEDED on #1987): failed /hold left a false "Snoozed"
+
+Codex flagged one real defect in `useSessionManage.toggleHold`: the optimistic-on-tap flip was
+**never rolled back when `POST /hold` FAILED**. The catch only set `error`, and the follow-up
+`refresh()` ran unconditionally — so on a rejected hold the UI could keep the optimistic
+`Held`/`Deferred` and falsely read "Snoozed" / "Snoozing when it finishes" for a snooze that never
+happened. (A roster blip could re-assert the optimistic state, and a failed `refresh` swallows its
+error and keeps the last-known — i.e. optimistic — state.)
+
+Fix (client-side only):
+- `client-core/sessions/snoozeAction.ts` — new pure `reconcileHoldToggle(preTap, outcome)` +
+  `HoldToggleOutcome`: on success the server's authoritative tri-state wins; on FAILURE it rolls all
+  the way back to the PRE-TAP state. Kept pure so the rollback is unit-tested, not buried in the async
+  hook.
+- `apps/mobile/components/useSessionManage.ts` — captures the pre-tap state, settles the UI from the
+  TRUE outcome via `reconcileHoldToggle`, and only calls `refresh()` on SUCCESS. On failure it restores
+  pre-tap and surfaces the error; the follow-up refresh can no longer re-assert or preserve the failed
+  optimistic snooze. The SUCCESS tri-state feedback is unchanged.
+
 ## Tests
-- `client-core/sessions/snoozeAction.test.ts` (4) — snooze a WORKING session shows the deferred
+- `client-core/sessions/snoozeAction.test.ts` (6) — snooze a WORKING session shows the deferred
   affordance immediately; snooze an IDLE session shows Held immediately; un-snooze clears both; pill
-  precedence.
+  precedence; **a FAILED /hold rolls back to the pre-tap label (button returns to "Snooze", no pill),
+  and a failed un-snooze keeps the armed state**; a SUCCESSFUL /hold still settles on the server
+  tri-state (success path unchanged).
 - `client-core/api/hold.test.ts` (3) — `holdSession` returns `{ onHold, pending }`; pending=true on a
   deferred answer; defaults on an old/empty body.
 - `client-core/sessions/ordering.test.ts` — `isDeferredHold` reads the tri-state onHold cannot see.
 - Registry revert-proof test (`HostedSnoozeLifecycleTenancyTests`) kept.
 
-Counts: client-core vitest **576/576**; client-core + mobile + cockpit `tsc --noEmit` clean; mobile
-`vite build` OK. Gateway snooze/hold + tenancy suites green (per PR #1987 run).
+Counts: client-core vitest **578/578**; mobile `tsc --noEmit` + `vite build` clean; Gateway.Tests
+build 0/0; `HostedSnoozeLifecycleTenancyTests` **2/2**.
 
 ## Status
-Fix implemented + tested. Shipping on PR #1987 (base main, no attribution) alongside the revert-proof
-registry test. Reporting to the architect and reaping.
+Fix implemented + tested, plus Codex's residual (failed-/hold rollback) closed. Shipping on PR #1987
+(base main, no attribution) alongside the revert-proof registry test. Reporting to the architect and
+reaping.

--- a/mission/fix-snooze.md
+++ b/mission/fix-snooze.md
@@ -1,0 +1,191 @@
+# MTR fix-snooze — hosted voice-mode snooze
+
+INTERNAL working note. Branch `fix/hosted-snooze-tenant-scope`.
+
+## Symptom reported
+The Snooze button on the hosted mobile **voice screen** "does not work". Owner uses snooze heavily.
+
+## Hypothesis handed to this seat
+#1909 (f575e7ee, deployed tonight in batch-4) gave the `snoozes` table a composite
+`(tenant_id, SessionId)` primary key, making it tenant-scoped, and a snooze call path that runs
+without a resolved ambient tenant on hosted now throws / writes the wrong partition — so the
+write (hold), the fold read, and the display push disagree.
+
+## Finding: hypothesis CORRECTED — the data path is already tenant-consistent on main
+
+Traced the whole voice-mode snooze path on hosted. The voice screen's Snooze is the **same** verb
+the roster uses:
+
+`VoiceMode.tsx` bottom bar → `useSessionManage.toggleHold` → `holdSession(sid)` →
+`POST /sessions/{sid}/hold` → `SnoozeRegistry.Snooze/SnoozeDeferred/Clear`; state is read back from
+the same `GET /sessions` roster fold (`StampFleetRolesAndFold` → `HoldStateFor`).
+
+Every snooze registry access on hosted runs **inside** a resolved tenant scope:
+
+- **Hold WRITE** (`GatewayEndpoints` POST `/sessions/{sid}/hold`, ~1451) and **roster READ fold**
+  (`StampFleetRolesAndFold`, ~2963) — the hosted device-key middleware
+  (`GatewayHost.cs` ~1659-1675) enters the ambient scope from the authenticated device key for the
+  whole request pipeline, and `ResolveReadTenant` resolves the same tenant. Write and read agree.
+- **Display push from the hold endpoint** (`FleetDisplayStateObserver.PushSessionAsync`) — runs in
+  that same request scope; its snapshot is `AmbientSnapshotFresh` (one tenant, issue #1966).
+- **Periodic display sweep** — `GatewayHost.cs` ~2366 wraps `FleetDisplayState.Sweep()` in
+  `_tenantPass.ForEachTenant(...)`, so each pass enters one tenant's scope.
+- **DirectorHub push observers** (`SnoozeLandingObserver`, `FleetDisplayStateObserver`) —
+  `DirectorHub` wraps them in `EnterBoundTenantScope()` (the tunnel Hello-bound tenant).
+- **`Registry.OnDirectorRemoved -> ClearForDirector`** — guarded `if (!GatewayHostedMode.IsHosted)`,
+  so it never runs unscoped on hosted.
+
+#1909 changed **only** the primary key. `SnoozeEntity` already extended `TenantScopedEntity`
+(tenant_id column) and `ApplyTenantScope<SnoozeEntity>` was already applied before #1909, so reads
+and writes were already tenant-filtered. The composite key only removes a cross-tenant **write**
+collision (two tenants presenting the same caller-supplied session id). For a normal single-account
+user it changes nothing — it is not a regression.
+
+## Proof added
+`src/CcDirector.Gateway.Tests/HostedSnoozeLifecycleTenancyTests.cs` — drives a REAL two-tenant
+hosted GatewayHost over REAL HTTP with two tunnel Directors that **collide on one session id**:
+
+1. `Owner_snooze_is_visible_to_the_owner_and_invisible_to_a_colliding_tenant` — A snoozes
+   `shared-sid` (Idle → armed): A's roster shows `onHold=true`, `holdState=Held`, a running
+   `snoozeUntil`; B (same id, never snoozed) shows `onHold=false`, `holdState=None`.
+2. `A_colliding_tenant_snoozes_the_same_id_without_collision_and_clears_do_not_cross` — B snoozes
+   `shared-sid` and gets 200 (a `SessionId`-only PK would 500 here — the #1909 revert-proof); B's
+   unsnooze does not clear A's snooze on the same id; A unsnoozes cleanly.
+
+Result on current main: **PASS 2/2** (827 ms). This is coverage the existing #1869
+`HostedSessionCommandRouteTenancyTests` did not have — that suite proves the hold *route* locates
+the session, not that the snooze *lifecycle* survives the fold or the colliding-sid write.
+
+## Where the real symptom likely lives
+Not the snooze data path. Candidates, none owned by this seat's data-path brief:
+- The **display-push / FleetDisplayState voice-enrichment** work seat 6fc00dc9 is doing
+  concurrently (mission caution: do not touch that wiring).
+- A **deferred-hold display nuance**: snoozing a *working* session defers (clock starts when work
+  ends), so the endpoint returns `OnHold=false` and the button stays "Snooze" — reads as "did
+  nothing", but is the owner's deferred-clock ruling, not a tenant bug.
+- The deployed build predating a fix already on main.
+
+## Action 1 done
+Revert-proof test committed and shipped as its own PR: **#1987** (base main, no attribution).
+Suite counts: `HostedSnoozeLifecycleTenancyTests` 2/2; Snooze+Hold 147/0;
+`HostedSessionCommandRouteTenancyTests` (solo) 44/0; `CompositeTenantKeyTests` (solo) 7/0.
+
+## Action 2 — DIAGNOSIS of the actual voice-mode symptom (read-only)
+
+Root cause is CLIENT-SIDE, functional, single-account, voice-mode-specific — NOT the data path
+and NOT the display push.
+
+**The button wiring is IDENTICAL on every screen.** Voice bottom bar (`VoiceMode.tsx` L316-323)
+and the Chat/Terminal overflow menu (`SessionAppBar.tsx` L142-155) both render
+`disabled={manage.busy || manage.onHold === null}` and both call the same
+`useSessionManage.toggleHold`. So the button is NOT uniquely disabled in voice mode, and it DOES
+fire and hit `POST /sessions/{sid}/hold` there.
+
+**What differs is the SESSION STATE at snooze time, and how the client renders the reply.**
+
+1. In voice mode you snooze a session that is **WORKING/narrating** (the "working" / "preparing"
+   voice card). The hold endpoint rules working -> **DEFER** (owner's ruling: the clock starts when
+   the work ends). It returns `HoldResponse { OnHold=false, Pending=true }` — a real, accepted hold
+   that has not landed yet.
+2. `holdSession` (`packages/client-core/src/api/client.ts` ~L1254) returns `result.onHold ?? onHold`
+   — it **drops `Pending` entirely**.
+3. `useSessionManage.toggleHold` sets `onHold = false`, so `manage.held` stays false and the button
+   label stays **"Snooze"**. The roster poll then folds the still-working session as blue "Working"
+   (working wins over a deferred hold), so `manage.snoozed` is false too — **no "Snoozed" pill**.
+
+Net: the user taps Snooze on a narrating session, the snooze IS recorded server-side (deferred),
+but **nothing on the screen changes** — which reads exactly as "the Snooze button does not work in
+voice mode." It self-heals only later, when the turn ends and the deferral lands (then the roster
+shows Held + countdown).
+
+**Why it looks fine on Chat/Terminal:** there you typically snooze an **idle/waiting** session,
+which ARMS immediately -> `OnHold=true` -> the button flips to "Unsnooze" and the pill appears.
+
+**The wire already carries the fix's input.** `HoldResponse.Pending` exists precisely so "the
+caller's button can say 'it'll hold when it finishes what it's doing' instead of implying it is
+already held" (its own doc-comment). The mobile client simply discards it. The fix is to thread
+`Pending` through `holdSession` -> `useSessionManage` and give the deferred state a visible
+affordance (e.g. button reads "Snoozing when it finishes" / a "Will snooze" pill), and to reflect
+the accepted request optimistically. No Gateway change needed; the Gateway already returns the
+right tri-state.
+
+Answers to the four questions:
+- Disabled by a voice-mode condition? **No** — same `disabled` expression as every other screen.
+- Does toggleHold fire + hit /hold in voice mode? **Yes.**
+- Does `manage.held` refresh after a snooze? It re-polls every 4s, but for a **deferred** hold the
+  fold reports the working session as not-held, so `held`/`snoozed` correctly stay false until the
+  work ends — there is no state to show as "held yet". The gap is that the **deferred acknowledgment
+  is never surfaced**, not that the poll is stale.
+- Desktop-only? **No** — this is the phone voice UI.
+
+## Owner's exact symptom (confirmed)
+"I hit snooze, go back to the sessions list, and the session is still there — sometimes clears
+after a few seconds, sometimes never, sometimes works." This matches the diagnosis exactly: works
+on an idle/settled session (arms, clears), silent/"never" on a working/narrating session (defers).
+
+## Real bug vs by-design (the three suspects)
+
+**(1) REAL — the client dropped `Pending`, so a deferred snooze gave no feedback.** The one true
+defect. `holdSession` returned only `onHold` (false for a DeferredHold) and `useSessionManage`
+reflected only that, so snoozing a working session showed no button/pill change. Fixed (below).
+
+**(1b) REAL but minor — up-to-a-poll-interval lag on the SESSION screen.** `useSessionManage`
+polled every 4s and only reflected a snooze on the next tick. Fixed: optimistic update on tap +
+an immediate `refresh()` after `holdSession`.
+
+**(2) BY DESIGN — a working session stays visible after a deferred snooze.** The Gateway defers a
+working session's snooze and `SnoozeLandingObserver` only arms it when the work ends (owner ruling,
+14 July 2026). So the row correctly stays until the turn ends. The bug was never that it stays —
+it is that the UI never told the user the snooze was accepted. The fix makes that visible
+("Snoozing when it finishes"); it does not (and must not) make a working session vanish.
+
+**(3) NOT the bug — the Home retention cache / 5s poll, and #1986/Gap D.** Confirmed by reading the
+code:
+- The mobile list's held state comes from the **polled roster FOLD**: `Home.tsx` -> `getSessionsEnvelope`
+  (`GET /sessions?envelope`) and `useSessionManage` -> `listSessions` (`GET /sessions`), both of which
+  fold `HoldStateFor` (tenant-consistent, proven by PR #1987). **Neither reads the display-push.** So
+  the FleetDisplayState `TenantId.Local` pin (Gap D / #1986, the Director *rail*) does **not** affect
+  the mobile list — #1986 is not the mobile fix.
+- The retention cache (`rosterRetention.mergeRosterRetention`) does **not** keep a just-snoozed row for
+  a reachable Director: for an ONLINE Director the live set **replaces** the cache
+  (`nextCache.byDirector.set(id, live)`), so the fresh snoozed copy (triageBucket flipped to `onHold`)
+  supersedes the stale one. It only re-injects sessions for **offline/wobbly** Directors (keep-and-mark),
+  which is unrelated to snooze. And `Home` is a sibling route: navigating back **remounts** it, firing an
+  immediate poll — so there is no 5s wait on "go back to the list." No Home change was needed or made.
+
+## The fix (client-side only; no Gateway change)
+
+The wire already carries the tri-state; the client now honours it end to end.
+
+- `client-core/api/client.ts` — `holdSession` returns `{ onHold, pending }` (a new `HoldResult`),
+  reading `pending` from the response (defaults false for un-hold / old Gateway).
+- `client-core/sessions/snoozeAction.ts` (new, unit-tested) — the pure display rules: `HoldUiState`
+  (held/deferred), `optimisticHoldToggle` (instant affordance on tap: working -> deferred, settled ->
+  held), `holdStateFromResponse`, `holdButtonLabel`, `holdPillLabel` ("Snoozing when it finishes" for
+  deferred).
+- `client-core/sessions/ordering.ts` — `isDeferredHold(s)` reads the Gateway `holdState` tri-state
+  (`holdState` added to the augmented `GatewayStampedSession` type; the generated schema is stale).
+- `apps/mobile/components/useSessionManage.ts` — adds `deferred`; hoists `refresh` and calls it
+  immediately after a toggle (kills the 4s lag); updates the UI optimistically on tap; reconciles from
+  the server tri-state and then the fold. Shared by Voice, Chat and Terminal, so all three surfaces get
+  it.
+- `apps/mobile/pages/VoiceMode.tsx` + `components/SessionAppBar.tsx` — the button reads
+  `held || deferred` for its label; the pill uses `holdPillLabel`, so a deferred snooze reads "Snoozing
+  when it finishes" the instant it is tapped and self-heals to "Snoozed - <countdown>" when the turn
+  lands.
+
+## Tests
+- `client-core/sessions/snoozeAction.test.ts` (4) — snooze a WORKING session shows the deferred
+  affordance immediately; snooze an IDLE session shows Held immediately; un-snooze clears both; pill
+  precedence.
+- `client-core/api/hold.test.ts` (3) — `holdSession` returns `{ onHold, pending }`; pending=true on a
+  deferred answer; defaults on an old/empty body.
+- `client-core/sessions/ordering.test.ts` — `isDeferredHold` reads the tri-state onHold cannot see.
+- Registry revert-proof test (`HostedSnoozeLifecycleTenancyTests`) kept.
+
+Counts: client-core vitest **576/576**; client-core + mobile + cockpit `tsc --noEmit` clean; mobile
+`vite build` OK. Gateway snooze/hold + tenancy suites green (per PR #1987 run).
+
+## Status
+Fix implemented + tested. Shipping on PR #1987 (base main, no attribution) alongside the revert-proof
+registry test. Reporting to the architect and reaping.

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -1244,19 +1244,38 @@ export async function createSession(
   return (await res.json()) as SessionDto;
 }
 
+/** The applied hold state the Gateway returns from POST /sessions/{sid}/hold. */
+export interface HoldResult {
+  /** True when the hold has LANDED and its clock is running now (an armed snooze). */
+  onHold: boolean;
+  /**
+   * True when the snooze was DEFERRED because the agent was working: it is accepted but has not armed
+   * yet - its clock starts when the work ends (owner ruling). `onHold` is still false in this case, so a
+   * caller that reads only `onHold` would wrongly conclude nothing happened; the snooze surfaces read
+   * this to show a "Snoozing when it finishes" affordance instead of implying it is already held.
+   */
+  pending: boolean;
+}
+
 // POST /sessions/{sid}/hold - toggle the session's on-hold state. The desired state is sent
-// explicitly ({ onHold }) so the call is idempotent; the Director echoes the applied { onHold }.
-// Reaches the Director through the Gateway catch-all session proxy with the injected Bearer.
+// explicitly ({ onHold }) so the call is idempotent; the Gateway returns the applied tri-state as
+// { onHold, pending }. Reaches the Director through the Gateway catch-all session proxy with the
+// injected Bearer.
 //
 // snoozeMinutes is how long to hold it. Omit it for "use my default length", which is what the plain
 // Snooze click means; pass a value for a specific "Snooze for" choice. Ignored on an unsnooze - there is
 // no length to un-hold for - so it is only ever sent alongside onHold=true.
+//
+// RETURNS BOTH FIELDS, not a bare boolean. A working session's snooze DEFERS: the Gateway answers
+// { onHold: false, pending: true }, and a caller that kept only `onHold` would show no change for a
+// perfectly-accepted snooze. `pending` defaults to false for an unsnooze, an immediate hold, or an old
+// Gateway that predates the field.
 export async function holdSession(
   sessionId: string,
   onHold: boolean,
   snoozeMinutes?: number,
   signal?: AbortSignal,
-): Promise<boolean> {
+): Promise<HoldResult> {
   const sid = encodeURIComponent(sessionId);
   const body = onHold && typeof snoozeMinutes === "number" ? { onHold, snoozeMinutes } : { onHold };
   const res = await gatewayFetch(`/sessions/${sid}/hold`, {
@@ -1268,8 +1287,8 @@ export async function holdSession(
   if (!res.ok) {
     throw new GatewayError(res.status, `POST hold failed: ${res.status}`);
   }
-  const result = (await res.json().catch(() => ({}))) as { onHold?: boolean };
-  return result.onHold ?? onHold;
+  const result = (await res.json().catch(() => ({}))) as { onHold?: boolean; pending?: boolean };
+  return { onHold: result.onHold ?? onHold, pending: result.pending ?? false };
 }
 
 // POST /sessions/{sid}/transcribing - mark or clear this session as transcribing a dictated

--- a/packages/client-core/src/api/hold.test.ts
+++ b/packages/client-core/src/api/hold.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// holdSession posts the desired { onHold } (plus an optional snoozeMinutes) and parses the Gateway's
+// applied tri-state { onHold, pending }. The connection-health module is mocked so the shared transport
+// does not touch a real signal, exactly as voiceModeAll.test.ts does.
+const health = vi.hoisted(() => ({ reachable: vi.fn(), unreachable: vi.fn() }));
+vi.mock("../connection/health", () => ({
+  reportGatewayReachable: () => health.reachable(),
+  reportGatewayUnreachable: () => health.unreachable(),
+}));
+
+import { holdSession } from "./client";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("holdSession returns the applied { onHold, pending } tri-state", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("carries pending=true for a DEFERRED snooze (working session) so the UI can show it", async () => {
+    let seenUrl = "";
+    let seenBody = "";
+    globalThis.fetch = ((input: unknown, init?: RequestInit) => {
+      seenUrl = String(input);
+      seenBody = String(init?.body ?? "");
+      // The Gateway defers a working session's snooze: accepted, not armed yet.
+      return Promise.resolve(jsonResponse({ onHold: false, pending: true }));
+    }) as unknown as typeof fetch;
+
+    const result = await holdSession("sess-1", true, 60);
+
+    expect(seenUrl).toContain("/sessions/sess-1/hold");
+    expect(seenBody).toContain("\"onHold\":true");
+    expect(seenBody).toContain("\"snoozeMinutes\":60");
+    expect(result).toEqual({ onHold: false, pending: true });
+  });
+
+  it("reads onHold=true for an armed hold and defaults pending=false when the field is absent", async () => {
+    globalThis.fetch = (() => Promise.resolve(jsonResponse({ onHold: true }))) as unknown as typeof fetch;
+    expect(await holdSession("sess-1", true)).toEqual({ onHold: true, pending: false });
+  });
+
+  it("falls back to the requested onHold and pending=false on an empty body (old Gateway)", async () => {
+    globalThis.fetch = (() => Promise.resolve(jsonResponse({}))) as unknown as typeof fetch;
+    expect(await holdSession("sess-1", false)).toEqual({ onHold: false, pending: false });
+  });
+});

--- a/packages/client-core/src/sessions/ordering.test.ts
+++ b/packages/client-core/src/sessions/ordering.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { SessionDto } from "../api/client";
-import { classify, contextLine, deletionReason, dotColor, dotHex, effectiveColor, groupByDirector, inBucket, inWaitingOrder, isWorking, pendingDeletion, snoozeCountdown, stateLabel } from "./ordering";
+import { classify, contextLine, deletionReason, dotColor, dotHex, effectiveColor, groupByDirector, inBucket, inWaitingOrder, isDeferredHold, isWorking, pendingDeletion, snoozeCountdown, stateLabel } from "./ordering";
 
 function session(fields: Partial<SessionDto> & { sessionId?: string } = {}): SessionDto {
   return {
@@ -98,6 +98,14 @@ describe("Gateway-stamped session presentation state", () => {
   it("stateLabel fails loudly when missing", () => {
     expect(() => stateLabel(session({ effectiveColor: "red" })))
       .toThrow("Gateway /sessions missing stateLabel");
+  });
+
+  it("isDeferredHold reads the Gateway hold tri-state, which onHold cannot see", () => {
+    // A deferred snooze reads onHold=false, so only holdState distinguishes it from "not snoozed".
+    expect(isDeferredHold(session({ holdState: "DeferredHold", onHold: false } as Partial<SessionDto>))).toBe(true);
+    expect(isDeferredHold(session({ holdState: "Held" } as Partial<SessionDto>))).toBe(false);
+    expect(isDeferredHold(session({ holdState: "None" } as Partial<SessionDto>))).toBe(false);
+    expect(isDeferredHold(session({}))).toBe(false);
   });
 
   it("isWorking is exactly the Gateway's blue - nothing else gets a vote", () => {

--- a/packages/client-core/src/sessions/ordering.ts
+++ b/packages/client-core/src/sessions/ordering.ts
@@ -16,6 +16,11 @@ type GatewayStampedSession = SessionDto & {
   // ("wakes in 3h 48m"). Null when there is no running clock: not snoozed, or a deferred snooze that has
   // not landed yet. The generated schema does not carry it, so it is augmented here like the fields above.
   snoozeUntil?: string | null;
+  // The Gateway-owned hold tri-state ("None" | "Held" | "DeferredHold"). A DeferredHold is a snooze asked
+  // for while the agent was working: accepted, but its clock only starts when the work ends, so onHold is
+  // still false. Clients read this to tell a deferred snooze apart from "not snoozed" (onHold cannot). The
+  // generated schema does not carry it, so it is augmented here like the fields above.
+  holdState?: string | null;
   // The session is flagged for deletion and awaiting the reaper - drives the "winding down" badge. A BADGE,
   // NEVER A COLOUR: the fold does not read it, so the dot keeps telling the truth about the work while this
   // rides beside it (mirrors the desktop rail's IsPendingDeletion). Optional; false for most sessions.
@@ -121,6 +126,14 @@ export function stateLabel(s: SessionDto): string {
 // Non-throwing (optional field): a session without the marker is simply not returned-from-snooze.
 export function snoozeExpired(s: SessionDto): boolean {
   return Boolean((s as GatewayStampedSession).snoozeExpired);
+}
+
+// True when this session carries a DEFERRED snooze: one asked for while the agent was working, so its
+// clock has not started (it arms when the work ends - owner ruling). The raw onHold flag CANNOT see this
+// (a deferred hold reads onHold=false), so a snooze surface reads this to tell "accepted, will snooze
+// when it finishes" apart from "not snoozed at all". Non-throwing (optional Gateway field).
+export function isDeferredHold(s: SessionDto): boolean {
+  return (s as GatewayStampedSession).holdState === "DeferredHold";
 }
 
 // "wakes in 3h 48m" - how long until an armed snooze returns this session to needs-you, read from the

--- a/packages/client-core/src/sessions/snoozeAction.test.ts
+++ b/packages/client-core/src/sessions/snoozeAction.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  holdButtonLabel,
+  holdPillLabel,
+  holdStateFromResponse,
+  isSnoozing,
+  optimisticHoldToggle,
+  type HoldUiState,
+} from "./snoozeAction";
+
+const none: HoldUiState = { held: false, deferred: false };
+
+describe("snooze action - instant, honest feedback for every case", () => {
+  it("snoozing a WORKING session shows the DEFERRED affordance immediately - not 'no change'", () => {
+    // This is the exact owner symptom: on a working/narrating session the old client dropped Pending and
+    // showed nothing. The optimistic state must flip the moment the tap lands.
+    const optimistic = optimisticHoldToggle(none, /* working */ true);
+    expect(optimistic).toEqual({ held: false, deferred: true });
+    expect(holdButtonLabel(optimistic)).toBe("Unsnooze");
+    expect(holdPillLabel(optimistic, /* snoozedByFold */ false, null)).toBe("Snoozing when it finishes");
+
+    // ...and the server's deferred answer reconciles to the same state (self-heals to Held when work ends).
+    expect(holdStateFromResponse({ onHold: false, pending: true })).toEqual({ held: false, deferred: true });
+  });
+
+  it("snoozing an IDLE session shows HELD immediately", () => {
+    const optimistic = optimisticHoldToggle(none, /* working */ false);
+    expect(optimistic).toEqual({ held: true, deferred: false });
+    expect(holdButtonLabel(optimistic)).toBe("Unsnooze");
+
+    // The server's armed answer agrees; the pill reads the running countdown from the fold.
+    const reconciled = holdStateFromResponse({ onHold: true, pending: false });
+    expect(reconciled).toEqual({ held: true, deferred: false });
+    expect(holdPillLabel(reconciled, /* snoozedByFold */ true, "3h 48m")).toBe("Snoozed - 3h 48m");
+  });
+
+  it("un-snoozing clears both senses and the label returns to Snooze", () => {
+    expect(optimisticHoldToggle({ held: true, deferred: false }, false)).toEqual(none);
+    expect(optimisticHoldToggle({ held: false, deferred: true }, true)).toEqual(none);
+    expect(holdButtonLabel(none)).toBe("Snooze");
+    expect(isSnoozing(none)).toBe(false);
+  });
+
+  it("a deferred hold's pill wins over the fold verdict, and a plain armed hold with no clock reads 'Snoozed'", () => {
+    expect(holdPillLabel({ held: false, deferred: true }, false, null)).toBe("Snoozing when it finishes");
+    expect(holdPillLabel({ held: true, deferred: false }, true, null)).toBe("Snoozed");
+    expect(holdPillLabel(none, false, null)).toBeNull();
+  });
+});

--- a/packages/client-core/src/sessions/snoozeAction.test.ts
+++ b/packages/client-core/src/sessions/snoozeAction.test.ts
@@ -5,6 +5,7 @@ import {
   holdStateFromResponse,
   isSnoozing,
   optimisticHoldToggle,
+  reconcileHoldToggle,
   type HoldUiState,
 } from "./snoozeAction";
 
@@ -45,5 +46,35 @@ describe("snooze action - instant, honest feedback for every case", () => {
     expect(holdPillLabel({ held: false, deferred: true }, false, null)).toBe("Snoozing when it finishes");
     expect(holdPillLabel({ held: true, deferred: false }, true, null)).toBe("Snoozed");
     expect(holdPillLabel(none, false, null)).toBeNull();
+  });
+
+  it("a FAILED /hold rolls the optimistic snooze back to the pre-tap state - never a false 'Snoozed'", () => {
+    // The tap optimistically flipped an idle session to HELD. When the /hold POST rejects, the snooze did
+    // NOT happen: the UI must settle back on the PRE-TAP state, so the button reads "Snooze" again (not
+    // "Unsnooze") and no snoozed pill is shown. The hook pairs this rollback with an error message.
+    const preTap = none;
+    const optimistic = optimisticHoldToggle(preTap, /* working */ false);
+    expect(holdButtonLabel(optimistic)).toBe("Unsnooze"); // it briefly showed snoozed...
+
+    const settled = reconcileHoldToggle(preTap, { ok: false });
+    expect(settled).toEqual(preTap); // ...and rolls all the way back on failure
+    expect(holdButtonLabel(settled)).toBe("Snooze");
+    expect(holdPillLabel(settled, /* snoozedByFold */ false, null)).toBeNull();
+
+    // A failed UN-snooze rolls back the other way - a still-armed hold stays "Unsnooze", not a false clear.
+    const armed: HoldUiState = { held: true, deferred: false };
+    expect(reconcileHoldToggle(armed, { ok: false })).toEqual(armed);
+    expect(holdButtonLabel(reconcileHoldToggle(armed, { ok: false }))).toBe("Unsnooze");
+  });
+
+  it("a SUCCESSFUL /hold still settles on the server's authoritative tri-state (success path unchanged)", () => {
+    expect(reconcileHoldToggle(none, { ok: true, response: { onHold: true, pending: false } })).toEqual({
+      held: true,
+      deferred: false,
+    });
+    expect(reconcileHoldToggle(none, { ok: true, response: { onHold: false, pending: true } })).toEqual({
+      held: false,
+      deferred: true,
+    });
   });
 });

--- a/packages/client-core/src/sessions/snoozeAction.ts
+++ b/packages/client-core/src/sessions/snoozeAction.ts
@@ -1,0 +1,62 @@
+// The client-side snooze/hold DISPLAY state and the pure rules that drive every snooze surface - the
+// phone Voice-mode bottom bar and the Chat/Terminal overflow menu (both through useSessionManage). Kept
+// here, unit-tested, so the mobile hook is a thin consumer and the "instant feedback" behaviour cannot
+// silently regress.
+//
+// WHY A TRI-STATE, NOT A BOOLEAN. A hold has two ON states the UI must tell apart, because the Gateway
+// does (HoldResponse.Pending):
+//   - HELD: an armed snooze whose clock is running NOW - the session was idle/waiting when it was
+//     snoozed, so the hold landed immediately.
+//   - DEFERRED: the snooze was asked for while the agent was WORKING, so its clock starts when the work
+//     ENDS (owner ruling, 14 July 2026). It is a REAL, ACCEPTED snooze that has not armed yet.
+//
+// The bug this closes: the mobile client used to read only the boolean `onHold`, which is false for a
+// DeferredHold. So snoozing a WORKING (e.g. narrating) session recorded the snooze on the Gateway but
+// showed NO change on screen - the button stayed "Snooze", no pill appeared - and the owner reported the
+// Snooze button "does nothing" in voice mode. The wire already carries `Pending` for exactly this; the
+// client simply dropped it.
+
+export interface HoldUiState {
+  /** An armed snooze whose clock is running now. */
+  held: boolean;
+  /** A deferred snooze - accepted, will arm the moment the current work ends. */
+  deferred: boolean;
+}
+
+/** Snoozed in EITHER sense - what the toggle turns off and what the button label reflects. */
+export function isSnoozing(s: HoldUiState): boolean {
+  return s.held || s.deferred;
+}
+
+/**
+ * The state to show THE INSTANT the user taps, before the server answers, so a snooze is never silent.
+ * Snoozing a WORKING session shows DEFERRED ("it'll snooze when it finishes"); snoozing a settled one
+ * shows HELD immediately. Tapping again while snoozing (either sense) clears it. This is optimistic and
+ * is reconciled by {@link holdStateFromResponse} the moment the hold endpoint answers.
+ */
+export function optimisticHoldToggle(current: HoldUiState, working: boolean): HoldUiState {
+  if (isSnoozing(current)) return { held: false, deferred: false }; // toggling OFF
+  return working ? { held: false, deferred: true } : { held: true, deferred: false };
+}
+
+/** The reconciled state from the hold endpoint's authoritative tri-state answer. */
+export function holdStateFromResponse(res: { onHold: boolean; pending: boolean }): HoldUiState {
+  return { held: res.onHold, deferred: res.pending };
+}
+
+/** The snooze button's label for the current state. */
+export function holdButtonLabel(s: HoldUiState): "Snooze" | "Unsnooze" {
+  return isSnoozing(s) ? "Unsnooze" : "Snooze";
+}
+
+/**
+ * The pill shown beside the session title, or null for none. A DEFERRED snooze reads "Snoozing when it
+ * finishes"; an armed one reads the running countdown (falling back to a plain "Snoozed"); nothing
+ * otherwise. <paramref name="snoozedByFold"/> is the Gateway fold's display verdict (where working wins
+ * over a landed hold), used for the armed pill so it matches the roster and the desktop rail exactly.
+ */
+export function holdPillLabel(s: HoldUiState, snoozedByFold: boolean, countdown: string | null): string | null {
+  if (s.deferred) return "Snoozing when it finishes";
+  if (snoozedByFold) return countdown ? `Snoozed - ${countdown}` : "Snoozed";
+  return null;
+}

--- a/packages/client-core/src/sessions/snoozeAction.ts
+++ b/packages/client-core/src/sessions/snoozeAction.ts
@@ -44,6 +44,22 @@ export function holdStateFromResponse(res: { onHold: boolean; pending: boolean }
   return { held: res.onHold, deferred: res.pending };
 }
 
+/** How a hold toggle RESOLVED: the server's authoritative answer, or a failed request. */
+export type HoldToggleOutcome =
+  | { ok: true; response: { onHold: boolean; pending: boolean } }
+  | { ok: false };
+
+/**
+ * The UI state to SETTLE on once a hold toggle resolves. On success the server's authoritative tri-state
+ * wins. On FAILURE the optimistic flip is rolled all the way back to <paramref name="preTap"/> - the state
+ * BEFORE the tap - because the snooze did NOT happen: the button must never falsely read "Snoozed" or
+ * "Snoozing when it finishes" for a hold the Gateway rejected. Keeping this decision here (not in the
+ * async hook) is what lets the rollback be unit-tested and stops it silently regressing.
+ */
+export function reconcileHoldToggle(preTap: HoldUiState, outcome: HoldToggleOutcome): HoldUiState {
+  return outcome.ok ? holdStateFromResponse(outcome.response) : preTap;
+}
+
 /** The snooze button's label for the current state. */
 export function holdButtonLabel(s: HoldUiState): "Snooze" | "Unsnooze" {
   return isSnoozing(s) ? "Unsnooze" : "Snooze";

--- a/src/CcDirector.Gateway.Tests/HostedSnoozeLifecycleTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedSnoozeLifecycleTenancyTests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The FULL two-tenant snooze lifecycle over the REAL hosted wire, with the SAME session id on both tenants.
+///
+/// The owner reported that the Snooze button on the hosted mobile voice screen "does nothing". The voice
+/// screen's Snooze is the same verb the roster uses: useSessionManage.toggleHold -> holdSession(sid) ->
+/// POST /sessions/{sid}/hold, and it renders its held state from the SAME /sessions roster the Home page
+/// polls. So a snooze that does not work in voice mode is a snooze whose WRITE (the hold endpoint records
+/// it in the Gateway snooze registry) and READ (the roster fold reads that registry back) do not agree.
+///
+/// #1909 (f575e7ee) gave the snoozes table a COMPOSITE (tenant_id, SessionId) primary key. That table was
+/// ALREADY tenant-scoped before #1909 (a tenant_id column and a global query filter), so the READ isolation
+/// this asserts held before #1909 too; what the composite key adds is that a SECOND tenant can WRITE a snooze
+/// for a session id the first tenant already holds without hitting a PRIMARY KEY violation. On a SessionId-only
+/// key the store's upsert (read through the tenant filter, INSERT when it finds nothing) would insert a second
+/// row with the same SessionId and throw, so the second tenant's Snooze click 500s. That is the exact edge a
+/// bare status-code or single-tenant test cannot see, and it is why these tenants deliberately COLLIDE on one
+/// session id.
+///
+/// WHAT IS ASSERTED, in both directions:
+///  - the owner's own snooze is visible to the owner (roster HoldState=Held, a running SnoozeUntil clock) and
+///    unsnoozes cleanly;
+///  - the colliding tenant does NOT see the owner's snooze on the same id, CAN set its own snooze on that same
+///    id without collision (the #1909 composite-key proof - a SessionId-only key 500s here), and clearing the
+///    colliding tenant's snooze does NOT clear the owner's.
+///
+/// This drives a REAL GatewayHost over REAL HTTP through the REAL auth middleware, with two REAL tunnel
+/// Directors on two different tenants each pushing a session under the SAME id - the same wire path a
+/// production Director uses.
+/// </summary>
+public sealed class HostedSnoozeLifecycleTenancyTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    // The COLLIDING id: both tenants own a session under this exact id. Isolation must hold per id, per tenant.
+    private const string Shared = "shared-sid";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private FakeTunnelDirector _dirA = null!;
+    private FakeTunnelDirector _dirB = null!;
+    private string _keyA = "";
+    private string _keyB = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-snooze-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        _keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        _keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        // Account tenants are minted GUIDs in production (the roster's voice enrichment routes the request
+        // tenant into WingmanVoiceService, which refuses a non-GUID, non-Local partition key), so bind real
+        // GUID tenant ids here rather than friendly labels.
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", "55555555-5555-5555-5555-555555555555");
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", "66666666-6666-6666-6666-666666666666");
+
+        // Both fake Directors answer every verb (including the set-display-state push the hold endpoint fires),
+        // so a hold that reaches its Director gets a real answer and any failure can only be the registry step.
+        _dirA = await FakeTunnelDirector.StartAsync(_gateway, _keyA, "dir-a", "MA", dispatch: AnswerAnything);
+        _dirB = await FakeTunnelDirector.StartAsync(_gateway, _keyB, "dir-b", "MB", dispatch: AnswerAnything);
+        // The COLLISION: the very same session id lives under both tenants. Idle, so a hold ARMS immediately
+        // (a running clock) rather than deferring - the ordinary "park this quiet session" case.
+        await _dirA.PushSnapshotAsync(Sample(Shared));
+        await _dirB.PushSnapshotAsync(Sample(Shared));
+    }
+
+    private static DirectorCommandResult AnswerAnything(DirectorCommand cmd) =>
+        FakeTunnelDirector.Ok(new { ok = true, lines = Array.Empty<string>(), items = Array.Empty<object>() });
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _dirA.DisposeAsync();
+        await _dirB.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task Owner_snooze_is_visible_to_the_owner_and_invisible_to_a_colliding_tenant()
+    {
+        // Alice snoozes the shared id. Idle -> armed, so the response is OnHold=true (a landed hold) and the
+        // roster reads back Held with a running clock.
+        var held = await Hold(Shared, _keyA, onHold: true, minutes: 60);
+        Assert.Equal(HttpStatusCode.OK, held.StatusCode);
+        Assert.True((await Body(held)).GetProperty("onHold").GetBoolean(),
+            "Alice's armed snooze on an Idle session should report OnHold=true");
+
+        var mineAfter = await RosterSession(Shared, _keyA);
+        Assert.True(mineAfter.GetProperty("onHold").GetBoolean(), "the owner's own roster must show the snooze held");
+        Assert.Equal(HoldStates.Held, mineAfter.GetProperty("holdState").GetString());
+        Assert.False(IsNull(mineAfter, "snoozeUntil"), "an armed snooze must carry a running SnoozeUntil clock");
+
+        // Bob owns a session under the SAME id, and he never snoozed it. The owner's snooze must NOT leak onto
+        // his roster - the read is scoped to his tenant's partition.
+        var his = await RosterSession(Shared, _keyB);
+        Assert.False(his.GetProperty("onHold").GetBoolean(),
+            "the colliding tenant must NOT see the owner's snooze on the same session id");
+        Assert.Equal(HoldStates.None, his.GetProperty("holdState").GetString());
+    }
+
+    [Fact]
+    public async Task A_colliding_tenant_snoozes_the_same_id_without_collision_and_clears_do_not_cross()
+    {
+        // Alice arms the shared id.
+        Assert.Equal(HttpStatusCode.OK, (await Hold(Shared, _keyA, onHold: true, minutes: 60)).StatusCode);
+
+        // Bob snoozes the SAME id. This is the #1909 composite-key proof: on a SessionId-only primary key his
+        // upsert inserts a second row with an id Alice already holds and the write 500s. It must be a clean 200.
+        var bobHeld = await Hold(Shared, _keyB, onHold: true, minutes: 60);
+        Assert.Equal(HttpStatusCode.OK, bobHeld.StatusCode);
+        Assert.True((await Body(bobHeld)).GetProperty("onHold").GetBoolean());
+
+        // Both tenants now hold the same id in their own partitions.
+        Assert.True((await RosterSession(Shared, _keyA)).GetProperty("onHold").GetBoolean());
+        Assert.True((await RosterSession(Shared, _keyB)).GetProperty("onHold").GetBoolean());
+
+        // Bob unsnoozes. His clear must touch only HIS row - Alice's snooze on the same id must survive.
+        Assert.Equal(HttpStatusCode.OK, (await Hold(Shared, _keyB, onHold: false, minutes: null)).StatusCode);
+        Assert.False((await RosterSession(Shared, _keyB)).GetProperty("onHold").GetBoolean(),
+            "Bob's own unsnooze must clear Bob's snooze");
+        Assert.True((await RosterSession(Shared, _keyA)).GetProperty("onHold").GetBoolean(),
+            "the colliding tenant's unsnooze must NOT clear the owner's snooze on the same id");
+
+        // And Alice can unsnooze her own cleanly.
+        Assert.Equal(HttpStatusCode.OK, (await Hold(Shared, _keyA, onHold: false, minutes: null)).StatusCode);
+        Assert.False((await RosterSession(Shared, _keyA)).GetProperty("onHold").GetBoolean());
+    }
+
+    // ---- helpers ----------------------------------------------------------------------------------
+
+    private Task<HttpResponseMessage> Hold(string sid, string deviceKey, bool onHold, int? minutes)
+    {
+        var body = minutes is int m
+            ? $"{{\"onHold\":{(onHold ? "true" : "false")},\"snoozeMinutes\":{m}}}"
+            : $"{{\"onHold\":{(onHold ? "true" : "false")}}}";
+        return Send("POST", $"sessions/{sid}/hold", deviceKey, body);
+    }
+
+    /// <summary>Fetch the roster for a tenant and return the JSON element for one session id (fails loud if absent).</summary>
+    private async Task<JsonElement> RosterSession(string sid, string deviceKey)
+    {
+        var resp = await Send("GET", "sessions", deviceKey, null);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        foreach (var s in doc.RootElement.EnumerateArray())
+            if (s.TryGetProperty("sessionId", out var id) && id.GetString() == sid)
+                return s.Clone();
+        throw new Xunit.Sdk.XunitException($"session {sid} was not in the roster served to this tenant");
+    }
+
+    private static async Task<JsonElement> Body(HttpResponseMessage resp)
+    {
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        return doc.RootElement.Clone();
+    }
+
+    private static bool IsNull(JsonElement obj, string prop) =>
+        !obj.TryGetProperty(prop, out var v) || v.ValueKind == JsonValueKind.Null;
+
+    private Task<HttpResponseMessage> Send(string method, string path, string deviceKey, string? body)
+    {
+        var req = new HttpRequestMessage(new HttpMethod(method), path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        if (body is not null)
+            req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return _http.SendAsync(req);
+    }
+
+    private static SessionDto Sample(string sid) => new()
+    {
+        SessionId = sid,
+        Agent = "claude",
+        RepoPath = "/repo",
+        ActivityState = "Idle",
+        Status = "Running",
+        StatusColor = "blue",
+        CreatedAt = DateTime.UtcNow,
+        LastActivityAt = DateTime.UtcNow,
+    };
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}


### PR DESCRIPTION
## The bug (owner, heavily-used path)

On the hosted mobile app: "I hit snooze, go back to the sessions list, and the session is still there — sometimes clears after a few seconds, sometimes never, sometimes works." The Snooze button appears to do nothing in voice mode.

## Root cause — client-side, single-account, functional

The hold verb carries a **tri-state** (`None` / `Held` / `DeferredHold`), but the mobile client read only the boolean `onHold`.

Snoozing a **working/narrating** session **defers** on the Gateway — its clock starts when the work ends (owner ruling) — returned as `{ onHold: false, pending: true }`. `holdSession()` **dropped `pending`** and returned `onHold`, so `useSessionManage` set `held=false` and showed **no change** — a recorded snooze that looked like a broken button. Snoozing an **idle** session armed immediately, which is why it "sometimes worked".

This is **not** the tenant data path (already correct — see the test below) and **not** the display-push (`#1986`/Gap D is the Director *rail*; the mobile list reads the polled roster **fold** `HoldStateFor`, which is tenant-consistent). Full diagnosis in `mission/fix-snooze.md`.

## The fix (client-side only, no Gateway change)

- `holdSession` returns `{ onHold, pending }` (`HoldResult`).
- new **`snoozeAction.ts`** (client-core, unit-tested): pure display rules — tri-state, optimistic-on-tap, button label, "Snoozing when it finishes" pill.
- `ordering.isDeferredHold` reads the Gateway `holdState` (a deferred hold is invisible to `onHold`).
- `useSessionManage` gains `deferred`, updates **optimistically on tap**, and **re-syncs immediately** after a toggle (kills the 4s lag). Shared by **Voice, Chat and Terminal** — all three surfaces fixed.
- Voice bottom bar + app-bar menu/pill reflect `held || deferred`, so a snooze on a busy session is acknowledged instantly and self-heals to the running countdown when the turn lands.

A working session staying visible until its turn ends is **by design**; the fix makes the accepted snooze **visible**, it does not make a working session vanish.

## Also in this PR — revert-proof registry test

`HostedSnoozeLifecycleTenancyTests`: a real two-tenant hosted GatewayHost proof where both tenants own a session under the **same id**, exercising the full snooze lifecycle. It locks #1909's composite `(tenant_id, SessionId)` key (a `SessionId`-only key 500s on the colliding write) and the read isolation — coverage `HostedSessionCommandRouteTenancyTests` (#1869) only had at the route-locate level.

## Tests

- `snoozeAction.test.ts` (4), `hold.test.ts` (3), `ordering.test.ts` (`isDeferredHold`).
- client-core vitest **576/576**; `tsc --noEmit` clean for client-core, mobile, cockpit; mobile `vite build` OK.
- `HostedSnoozeLifecycleTenancyTests` **2/2**; Snooze+Hold **147/0**; `HostedSessionCommandRouteTenancyTests` solo **44/0**; `CompositeTenantKeyTests` solo **7/0**.