### PR TITLE
fix(dictation): one shared capture-health measurement on every finish path

### DIFF
--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -1482,6 +1482,13 @@ export interface DictationUploadArgs {
   prefix: string;
   baselineBufferBytes: number;
   resumed: boolean;
+  /** Capture-health (issue #863), optional: the recording wall-clock, the decoded audio duration, and
+   *  the source blob size, measured once at Send time. Forwarded on the complete call so the Gateway
+   *  persists the audio-loss deficit for the fire-and-forget Send path (which never transcodes
+   *  on-device). Omitted when the on-device decode failed - diagnostics only, never blocks delivery. */
+  clientRecordedMs?: number;
+  clientDecodedSeconds?: number;
+  clientSourceBytes?: number;
 }
 
 /** The honest, plain-English line for a dictation whose delivery is paused because the connection
@@ -1562,6 +1569,11 @@ export async function uploadDictationToSession(
     prefix: args.prefix,
     baselineBufferBytes: args.baselineBufferBytes,
     resumed: args.resumed,
+    // Capture-health (issue #863): forwarded so the Gateway persists this path's audio-loss deficit
+    // into the same dictation session log every other surface writes. Undefined fields are omitted.
+    clientRecordedMs: args.clientRecordedMs,
+    clientDecodedSeconds: args.clientDecodedSeconds,
+    clientSourceBytes: args.clientSourceBytes,
   };
   const complete = (): Promise<Response> =>
     gatewayFetch(`/dictation/${id}/complete`, {

--- a/packages/client-core/src/api/dictationCaptureHealthForward.test.ts
+++ b/packages/client-core/src/api/dictationCaptureHealthForward.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { uploadDictationToSession, type DictationUploadArgs } from "./client";
+
+// Capture-health forwarding (issue #863): the durable Terminal/Chat Send path measures the clip once at
+// Send time and must FORWARD those numbers on the /dictation/{id}/complete call, so the Gateway can
+// persist this path's audio-loss deficit into the same log every other surface writes. This drives
+// uploadDictationToSession against a mocked fetch and asserts the complete body carries the measurements
+// (and that a send WITHOUT them omits them rather than sending nulls-as-zero).
+
+const UPLOAD_ID = "33333333-3333-3333-3333-333333333333";
+
+function fakeResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function baseArgs(): DictationUploadArgs {
+  return {
+    sessionId: "11111111-1111-1111-1111-111111111111",
+    uploadId: UPLOAD_ID,
+    audio: new Blob(["hello world"], { type: "audio/webm" }),
+    before: "",
+    after: "",
+    prefix: "",
+    baselineBufferBytes: 0,
+    resumed: false,
+  };
+}
+
+interface CompleteBody {
+  clientRecordedMs?: number;
+  clientDecodedSeconds?: number;
+  clientSourceBytes?: number;
+}
+
+// Drive a full happy send (register -> first complete reports the chunk missing -> upload it -> second
+// complete submits) and return the LAST /complete request body so the test can inspect what was sent.
+function driveAndCaptureCompleteBody(): { completeBodies: CompleteBody[] } {
+  const completeBodies: CompleteBody[] = [];
+  let completeCalls = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown, init?: { method?: string; body?: unknown }) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (url.includes("/dictation/upload")) return fakeResponse(200, { upload_id: UPLOAD_ID, terminal: false });
+      if (url.includes(`/dictation/${UPLOAD_ID}/complete`) && method === "POST") {
+        completeBodies.push(JSON.parse(String(init?.body ?? "{}")) as CompleteBody);
+        completeCalls += 1;
+        // First complete: nothing uploaded yet, so report chunk 0 missing. Second complete: submitted.
+        return completeCalls === 1
+          ? fakeResponse(409, { missing: [0] })
+          : fakeResponse(200, { submitted: true });
+      }
+      if (url.includes(`/dictation/${UPLOAD_ID}/chunk/`) && method === "PUT") return fakeResponse(200, { ok: true });
+      if (url.includes("/ack")) return fakeResponse(200, { ok: true });
+      throw new Error("unexpected fetch: " + method + " " + url);
+    }),
+  );
+  return { completeBodies };
+}
+
+describe("dictation Send forwards capture-health on complete (issue #863)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("forwards recordedMs, decodedSeconds and sourceBytes in the complete body", async () => {
+    const { completeBodies } = driveAndCaptureCompleteBody();
+
+    await uploadDictationToSession({
+      ...baseArgs(),
+      clientRecordedMs: 120_000,
+      clientDecodedSeconds: 108.5,
+      clientSourceBytes: 1_500_000,
+    });
+
+    expect(completeBodies.length).toBeGreaterThan(0);
+    const body = completeBodies[completeBodies.length - 1];
+    expect(body.clientRecordedMs).toBe(120_000);
+    expect(body.clientDecodedSeconds).toBe(108.5);
+    expect(body.clientSourceBytes).toBe(1_500_000);
+  });
+
+  it("omits the fields (does not send zeros) when the client did not measure", async () => {
+    const { completeBodies } = driveAndCaptureCompleteBody();
+
+    await uploadDictationToSession(baseArgs());
+
+    const body = completeBodies[completeBodies.length - 1];
+    expect(body.clientRecordedMs).toBeUndefined();
+    expect(body.clientDecodedSeconds).toBeUndefined();
+    expect(body.clientSourceBytes).toBeUndefined();
+  });
+});

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -1,6 +1,8 @@
 import { abandonDictation, sendPrompt, uploadDictationToSession } from "../api/client";
+import { logCaptureHealth } from "./captureHealth";
 import { deletePending, getPending, listPending, savePending, type PendingDictation } from "./pendingStore";
 import { clearDictationStatus, publishDictationStatus } from "./status";
+import { blobToWav16kMono } from "./wav";
 
 // The durable Send pipeline + background retry driver for the mobile Speak dialog (issue #1006,
 // strengthened for #1182). The instant the user hits Send the dialog hands the recorded audio here and
@@ -132,11 +134,37 @@ export async function backgroundTranscribeAndSend(
 ): Promise<void> {
   ensureRetryListeners();
 
+  // Capture-health (issue #863): the fire-and-forget Send path releases the screen the instant Send is
+  // pressed and never transcodes on-device, so it was the ONE finish path that measured no audio loss at
+  // all. Decode the clip ONCE here - the screen has already closed, so this is off the critical path - to
+  // get the decoded audio duration, log the recorded-vs-decoded deficit on this surface the same way every
+  // other finish path does, and stash the numbers on the durable record so the upload forwards them to the
+  // Gateway (which persists them into the same dictation session log). Diagnostics only: a decode failure
+  // is logged loudly but NEVER blocks delivery - the user's words are the guarantee, the measurement is not.
+  let decodedSeconds: number | undefined;
+  let sourceBytes: number | undefined;
+  try {
+    const transcoded = await blobToWav16kMono(captured.blob);
+    decodedSeconds = transcoded.decodedSeconds;
+    sourceBytes = transcoded.sourceBytes;
+    logCaptureHealth("mobile-send", {
+      recordedMs: captured.recordedMs,
+      decodedSeconds: transcoded.decodedSeconds,
+      sourceBytes: transcoded.sourceBytes,
+    });
+  } catch (err) {
+    console.warn(
+      `[backgroundSend] capture-health decode failed (delivery is unaffected): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
   const rec: PendingDictation = {
     id: crypto.randomUUID(),
     sessionId,
     blob: captured.blob,
     recordedMs: captured.recordedMs,
+    decodedSeconds,
+    sourceBytes,
     before: hooks.composeParts?.before ?? "",
     after: hooks.composeParts?.after ?? "",
     prefix: captured.prefixText ?? "",
@@ -430,6 +458,11 @@ async function driveRecord(rec: PendingDictation, opts: DriveOptions): Promise<v
       prefix: rec.prefix,
       baselineBufferBytes: rec.baselineBufferBytes,
       resumed: opts.resumed,
+      // Capture-health (issue #863): forward the Send-time measurement so the Gateway persists the
+      // audio-loss deficit for this path. Absent when the on-device decode failed.
+      clientRecordedMs: rec.recordedMs,
+      clientDecodedSeconds: rec.decodedSeconds,
+      clientSourceBytes: rec.sourceBytes,
     });
 
     if (outcome.terminal) {

--- a/packages/client-core/src/dictation/pendingStore.ts
+++ b/packages/client-core/src/dictation/pendingStore.ts
@@ -21,6 +21,12 @@ export interface PendingDictation {
   /** The raw recorded audio exactly as the microphone produced it (WebM/Opus etc.). */
   blob: Blob;
   recordedMs: number;
+  /** Capture-health (issue #863): the decoded audio duration and source blob size, measured once at
+   *  Send time by decoding the clip. The fire-and-forget Send path never transcodes on-device, so these
+   *  are stashed here and forwarded with the upload for the Gateway to persist the audio-loss deficit
+   *  (recording wall-clock vs decoded audio duration). Absent when the on-device decode failed. */
+  decodedSeconds?: number;
+  sourceBytes?: number;
   /** Typed text before the caret (Terminal Speak compose); empty for the voice case. */
   before: string;
   /** Typed text after the caret; empty for the voice case. */

--- a/src/CcDirector.Gateway.Tests/MobileCaptureHealthLogTests.cs
+++ b/src/CcDirector.Gateway.Tests/MobileCaptureHealthLogTests.cs
@@ -1,0 +1,56 @@
+using CcDirector.Gateway.Api;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The one shared mobile capture-health record builder (issue #863) feeds BOTH the Voice-mode complete
+/// path and the durable Terminal/Chat Send complete path, so these guard its two behaviours: it emits
+/// nothing when the client did not measure (recordedMs null), and when it did it maps the recorded
+/// wall-clock, decoded duration, source tag, and transcribed byte count onto the record faithfully.
+/// </summary>
+public sealed class MobileCaptureHealthLogTests
+{
+    [Fact]
+    public void BuildRecord_NoClientRecordedMs_ReturnsNull()
+    {
+        // The client did not opt in (or its on-device decode failed): there is nothing to persist, and a
+        // fabricated deficit would be worse than no record at all.
+        var record = MobileCaptureHealthLog.BuildRecord(
+            uploadId: "u1", source: "mobile-send", recordedMs: null, decodedSeconds: 12.0,
+            sourceBytes: 4096, audioBytes: 8192, cleaned: "hello");
+
+        Assert.Null(record);
+    }
+
+    [Fact]
+    public void BuildRecord_WithMeasurements_MapsWallClockDecodedSourceAndBytes()
+    {
+        var record = MobileCaptureHealthLog.BuildRecord(
+            uploadId: "upload-123", source: "mobile-send", recordedMs: 120_000, decodedSeconds: 108.5,
+            sourceBytes: 1_500_000, audioBytes: 3_840_000, cleaned: "the whole sentence");
+
+        Assert.NotNull(record);
+        Assert.Equal("mobile-send", record!.Source);
+        Assert.Equal(120_000, record.RecordedWallMs);
+        Assert.Equal(108.5, record.DecodedAudioSeconds);
+        Assert.Equal(120_000, record.RecordingDurationMs);
+        Assert.Equal(3_840_000, record.AudioBytesReceived);
+        Assert.Equal("upload-123", record.SessionId);
+        Assert.Equal("the whole sentence", record.CleanedTranscript);
+    }
+
+    [Fact]
+    public void BuildRecord_MissingDecodedSeconds_DefaultsToZeroNotNegative()
+    {
+        // A recorded clip whose decode duration did not come through reads as zero decoded audio (a total
+        // deficit), never a negative or fabricated value.
+        var record = MobileCaptureHealthLog.BuildRecord(
+            uploadId: "u2", source: "mobile", recordedMs: 5_000, decodedSeconds: null,
+            sourceBytes: null, audioBytes: 1024, cleaned: null);
+
+        Assert.NotNull(record);
+        Assert.Equal(0, record!.DecodedAudioSeconds);
+        Assert.Equal("", record.CleanedTranscript);
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -525,6 +525,13 @@ internal static class GatewayDictationEndpoint
                 return nonOk;
 
             var transcript = (result.Text ?? "").Trim();
+            // Capture-health (issue #863): persist the fire-and-forget Send path's audio-loss deficit into
+            // the SAME dictation session log the Voice-mode and desktop paths write, via the one shared
+            // helper. The assembled audio byte count is what the server actually transcribed. When the client
+            // did not send its measurements this is a no-op. Fire-and-forget - never affects the outcome.
+            MobileCaptureHealthLog.Persist(
+                uploadId, "mobile-send", req.ClientRecordedMs, req.ClientDecodedSeconds, req.ClientSourceBytes,
+                audio.Length, transcript);
             // Compose the final message: any typed text the caret split the dictation around (before /
             // after), any earlier paused dictation segments already turned to text (prefix), and this
             // clip's transcript, space-joined skipping empties. The common voice case is transcript alone.
@@ -684,6 +691,13 @@ public sealed class DictationCompleteRequest
     public long BaselineBufferBytes { get; set; }
     /// <summary>True when this complete is a resume after a reload/relaunch (applies the moved-on guard).</summary>
     public bool Resumed { get; set; }
+    /// <summary>Capture-health (issue #863), optional - present when the mobile Send path measured the clip:
+    /// recording wall-clock, decoded audio duration, and source blob size. When present the complete handler
+    /// persists a dictation session record so the fire-and-forget Send path's audio loss lands in the same
+    /// log as the Voice-mode and desktop paths. Diagnostics only; omitting it changes nothing.</summary>
+    public double? ClientRecordedMs { get; set; }
+    public double? ClientDecodedSeconds { get; set; }
+    public long? ClientSourceBytes { get; set; }
 }
 
 /// <summary>Terminal or retryable outcome of a dictation complete, mapped to an HTTP result.</summary>

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -1014,36 +1014,8 @@ internal static class GatewayWingmanVoiceEndpoint
     /// left at their defaults here. Fire-and-forget; a logging failure never affects the response.
     /// </summary>
     private static void PersistMobileCaptureHealth(string uploadId, UtteranceCompleteRequest req, int wavBytes, string? cleaned)
-    {
-        if (req.ClientRecordedMs is not { } recordedMs) return; // client did not opt in - nothing to persist
-
-        var decodedSeconds = req.ClientDecodedSeconds ?? 0;
-        FileLog.Write($"[GatewayWingmanVoice] capture-health mobile {uploadId}: recordedMs={recordedMs:F0}, "
-            + $"decodedSec={decodedSeconds:F2}, wavBytes={wavBytes}, sourceBytes={req.ClientSourceBytes ?? 0}");
-
-        var record = new DictationSessionRecord(
-            TimestampUtc: DateTime.UtcNow.ToString("o"),
-            SessionId: uploadId,
-            Profile: "default",
-            VocabularyTermCount: 0,
-            MistranscriptionPatternCount: 0,
-            RecordingDurationMs: (long)recordedMs,
-            StopToTranscribedMs: 0,
-            StopToCleanedMs: 0,
-            AudioBytesReceived: (int)Math.Min(wavBytes, int.MaxValue),
-            RawTranscript: "",
-            CleanedTranscript: cleaned ?? "",
-            CleanupApplied: false,
-            CleanupReason: null,
-            CleanupModel: "",
-            RemoteIp: null,
-            ClientError: null,
-            Source: "mobile",
-            RecordedWallMs: recordedMs,
-            DecodedAudioSeconds: decodedSeconds);
-
-        Task.Run(() => DictationSessionLog.TryAppend(record));
-    }
+        => MobileCaptureHealthLog.Persist(
+            uploadId, "mobile", req.ClientRecordedMs, req.ClientDecodedSeconds, req.ClientSourceBytes, wavBytes, cleaned);
 
     /// <summary>Shape a <see cref="WingmanMenu"/> for the JSON response (camelCase the phone reads).</summary>
     private static object MenuJson(WingmanMenu m) => new

--- a/src/CcDirector.Gateway/Api/MobileCaptureHealthLog.cs
+++ b/src/CcDirector.Gateway/Api/MobileCaptureHealthLog.cs
@@ -1,0 +1,80 @@
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The single place the Gateway persists a MOBILE dictation capture-health record (issue #863) - the
+/// audio-loss deficit measured as recording wall-clock versus decoded audio duration. Both the Wingman
+/// voice complete path (<see cref="GatewayWingmanVoiceEndpoint"/>) and the durable dictation complete
+/// path (<see cref="GatewayDictationEndpoint"/>) call THIS, so a Voice-mode utterance and a Terminal/Chat
+/// Send land the same-shaped record in the same log - one implementation, never two drifting copies.
+///
+/// The measurement is diagnostics only: it changes no transcription behaviour, and a logging failure
+/// never affects the response (fire-and-forget on a background task).
+/// </summary>
+internal static class MobileCaptureHealthLog
+{
+    /// <summary>
+    /// Append one capture-health record when the client supplied its measurements. A null
+    /// <paramref name="recordedMs"/> means the client did not opt in (or its on-device decode failed),
+    /// so there is nothing to persist and this is a no-op. The transcription-context fields a desktop
+    /// record carries (dictionary counts, cleanup model) are left at their defaults - this record exists
+    /// only to carry the audio-loss deficit.
+    /// </summary>
+    /// <param name="uploadId">The upload id, used as the record's session id (as the desktop log does).</param>
+    /// <param name="source">Surface tag: "mobile" for the Voice-mode path, "mobile-send" for the durable
+    /// Terminal/Chat Send path, so the two surfaces are told apart in the log.</param>
+    /// <param name="recordedMs">Recording wall-clock the client measured; null when the client did not opt in.</param>
+    /// <param name="decodedSeconds">Decoded audio duration the client measured; the deficit yardstick.</param>
+    /// <param name="sourceBytes">Size of the client's source (compressed) blob, for reference only.</param>
+    /// <param name="audioBytes">Bytes of audio the server actually transcribed (the assembled clip).</param>
+    /// <param name="cleaned">The cleaned transcript, stored for context (never re-transcribed here).</param>
+    public static void Persist(
+        string uploadId, string source, double? recordedMs, double? decodedSeconds, long? sourceBytes,
+        int audioBytes, string? cleaned)
+    {
+        var record = BuildRecord(uploadId, source, recordedMs, decodedSeconds, sourceBytes, audioBytes, cleaned);
+        if (record is null) return; // client did not opt in - nothing to persist
+
+        FileLog.Write($"[MobileCaptureHealth] {source} {uploadId}: recordedMs={record.RecordedWallMs:F0}, "
+            + $"decodedSec={record.DecodedAudioSeconds:F2}, audioBytes={audioBytes}, sourceBytes={sourceBytes ?? 0}");
+
+        Task.Run(() => DictationSessionLog.TryAppend(record));
+    }
+
+    /// <summary>
+    /// The pure half of <see cref="Persist"/>: the dictation session record to append, or null when the
+    /// client sent no measurement (<paramref name="recordedMs"/> is null) and there is nothing to persist.
+    /// Split out so the null-guard and the field mapping are unit-testable without the fire-and-forget
+    /// append to the shared log.
+    /// </summary>
+    internal static DictationSessionRecord? BuildRecord(
+        string uploadId, string source, double? recordedMs, double? decodedSeconds, long? sourceBytes,
+        int audioBytes, string? cleaned)
+    {
+        if (recordedMs is not { } wallMs) return null; // client did not opt in - nothing to persist
+
+        var decoded = decodedSeconds ?? 0;
+        return new DictationSessionRecord(
+            TimestampUtc: DateTime.UtcNow.ToString("o"),
+            SessionId: uploadId,
+            Profile: "default",
+            VocabularyTermCount: 0,
+            MistranscriptionPatternCount: 0,
+            RecordingDurationMs: (long)wallMs,
+            StopToTranscribedMs: 0,
+            StopToCleanedMs: 0,
+            AudioBytesReceived: (int)Math.Min(audioBytes, int.MaxValue),
+            RawTranscript: "",
+            CleanedTranscript: cleaned ?? "",
+            CleanupApplied: false,
+            CleanupReason: null,
+            CleanupModel: "",
+            RemoteIp: null,
+            ClientError: null,
+            Source: source,
+            RecordedWallMs: wallMs,
+            DecodedAudioSeconds: decoded);
+    }
+}


### PR DESCRIPTION
Closes the biggest hole in thefrederiksen/devthrottle_internal#918.

## What was wrong
The audio-loss measurement (recording wall-clock versus decoded audio duration, #863) was wired at a single call site. As a result:

- The mobile Terminal/Chat **Send** button - the fire-and-forget path that releases the screen the instant Send is pressed and never transcodes on-device - measured and logged **nothing**. This is the exact path where "the end of what I said is missing" was reported, and we had no telemetry on it to tell capture loss from transcription loss.
- The Gateway **dictation** endpoint had no capture-health at all, while the Gateway **voice** endpoint did - the same idea, wired on one endpoint and not the other.

## What this does
- The durable Send path decodes the clip **once** (off the critical path, after the screen has already closed), logs the recorded-versus-decoded deficit on the client, and forwards the recorded milliseconds, decoded seconds, and source bytes with the upload complete call.
- The Gateway dictation complete handler persists the forwarded measurement through **one shared `MobileCaptureHealthLog` helper** - the same helper the voice endpoint now routes through - so both endpoints emit the same-shaped record instead of two drifting copies.

## Scope
Measurement only. The trailing-word fix (padding the end so the transcription model always has run-out room) stays a **separate follow-up**. Car Mode is the **next phase** - its rolling-snapshot capture has no clean per-utterance wall-clock, so measuring it honestly needs a small timestamp added first (fabricating a deficit there would be worse than none).

## Proof
- Gateway build: clean, 0 warnings (TreatWarningsAsErrors on).
- TypeScript: all three workspaces typecheck; client-core suite 570/570; new forwarding test asserts the complete body carries the three fields and omits them when unmeasured; dedupe regression stays green.
- C#: 3 new `MobileCaptureHealthLog` tests (null measurement -> no record; measurements map through; missing decoded defaults to zero, never negative).
- Runtime log proof on a real mobile Send / desktop recording is the QA follow-up.
