### PR TITLE
fix(gateway): reject traversal session ids on the voice-audio clip path (audit B1)

### DIFF
--- a/docs/reviews/production-readiness/mission/fix-b1.md
+++ b/docs/reviews/production-readiness/mission/fix-b1.md
@@ -1,0 +1,73 @@
+# B1 - Voice-audio session-id path traversal (BLOCKER) - FIXED
+
+## Verdict
+
+REAL gap, reproduced on main, fixed, revert-proofed.
+
+## The gap
+
+`WingmanVoiceService` partitions voice state per tenant and validates the TENANT id hard
+(`CanonicalTenantKey` / `PartitionDirectoryFor` refuse traversal, case-variants, and non-minted
+shapes, with a canonical-containment belt-and-braces). But the SESSION id, which becomes the clip
+FILE NAME under `<tenant>/voice-audio/`, was concatenated raw with no validation:
+
+- `SaveReadyAudio`: `File.WriteAllBytes(Path.Combine(audioDir, sid + ".mp3"), ...)` and the `.json`.
+- `DeleteReadyAudio`: `Path.Combine(audioDir, sid + ".json")` / `+ ".mp3"`, then `File.Delete`.
+
+The session id is caller-controlled on the PERSISTING path. A hostile Director advertises any
+non-empty string as a pushed session id; the `/sessions/voice-mode/all` fan-out
+(`GatewayWingmanVoiceEndpoint.cs`, only a `!string.IsNullOrEmpty(s.SessionId)` gate) and the
+turn-end narration sweep carry that id into `GenerateAsync -> StoreSpokenAsync -> StoreReady ->
+SaveReadyAudio` with no `Guid.TryParse` gate (the interactive request endpoints that DO gate on
+`Guid.TryParse` are a different door and do not cover this path).
+
+A session id of the shape `"../../<other-tenant>/voice-audio/<victim>"` therefore walks the write
+out of the caller's own partition and into another tenant's directory - overwriting that tenant's
+clip on the save path, or deleting it on the delete path. Cross-tenant disclosure/destruction of
+customer content on the hosted Gateway.
+
+## Reproduction (on main, before the fix)
+
+`WingmanVoiceSidPathTraversalTests` - three attack tests failed on unpatched main:
+
+- `A_traversal_session_id_cannot_write_into_another_tenants_voice_audio_directory` - a planted
+  file appeared in tenant B's `voice-audio` directory.
+- `A_traversal_session_id_cannot_overwrite_another_tenants_clip` - tenant B's clip bytes were
+  overwritten with the attacker's.
+- `A_traversal_session_id_cannot_delete_another_tenants_clip` - tenant B's clip was deleted.
+
+## The fix
+
+New private `SafeClipPath(tenant, sid, extension)` in `WingmanVoiceService`, applied on BOTH the
+save and the delete sink. It refuses the id (returns null -> the sink writes/deletes NOTHING) unless
+it is a single safe path segment AND its resolved path stays inside the tenant's voice-audio dir:
+
+- single ordinary file-name component: equals its own `Path.GetFileName`, not `.` / `..`, no
+  `/ \ :`, no `Path.GetInvalidFileNameChars`; and
+- canonical containment: `Path.GetFullPath(combined)` must start with the tenant's voice-audio root.
+
+A legitimate GUID session id has none of these traits and passes untouched. This mirrors, one level
+down, the exact rule the tenant partition already applies to the directory name.
+
+## Revert-proof
+
+Each guard is independently pinned (single-primitive reverts, full-assembly build confirmed 0/0):
+
+- Remove the DELETE guard only -> `..._cannot_delete_another_tenants_clip` reddens; the other four
+  stay green.
+- Remove the SAVE guard only -> the write and overwrite tests redden (and the delete test, whose
+  victim is overwritten before delete).
+
+## Test evidence (after fix)
+
+- `WingmanVoiceSidPathTraversalTests`: 5/5 pass (3 attack + 2 controls: separator id writes nothing,
+  normal GUID still persists).
+- All voice + wingman Gateway tests: 366/366 pass.
+- `WingmanVoiceTenantPartitionTests` (solo): 20/20 pass.
+- `VoiceUploadStoreTenantPartitionTests` (solo): 15/15 pass.
+- Gateway + Gateway.Tests build: 0 warnings / 0 errors.
+
+## Files
+
+- `src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs` - `SafeClipPath` + guarded save/delete.
+- `src/CcDirector.Gateway.Tests/WingmanVoiceSidPathTraversalTests.cs` - reproduction + revert-proof.

--- a/docs/reviews/production-readiness/mission/fix-b1.md
+++ b/docs/reviews/production-readiness/mission/fix-b1.md
@@ -40,14 +40,30 @@ customer content on the hosted Gateway.
 
 New private `SafeClipPath(tenant, sid, extension)` in `WingmanVoiceService`, applied on BOTH the
 save and the delete sink. It refuses the id (returns null -> the sink writes/deletes NOTHING) unless
-it is a single safe path segment AND its resolved path stays inside the tenant's voice-audio dir:
+it passes a strict allow-list AND its resolved path stays inside the tenant's voice-audio dir:
 
-- single ordinary file-name component: equals its own `Path.GetFileName`, not `.` / `..`, no
-  `/ \ :`, no `Path.GetInvalidFileNameChars`; and
+- strict safe-id allow-list: non-empty, not `.` / `..`, no longer than `MaxSidLength` (128), and
+  every character drawn from `[A-Za-z0-9._-]`; and
 - canonical containment: `Path.GetFullPath(combined)` must start with the tenant's voice-audio root.
 
-A legitimate GUID session id has none of these traits and passes untouched. This mirrors, one level
-down, the exact rule the tenant partition already applies to the directory name.
+A legitimate GUID session id is entirely allow-list characters, well under the length bound, and
+passes untouched. This mirrors, one level down, the exact rule the tenant partition already applies
+to the directory name.
+
+### Harden after Codex review (audit B1, PR #1990)
+
+Codex's review of the first cut found the guard was a separator/invalid-char DENYLIST that equals
+its own `Path.GetFileName` and bans `/ \ :` plus the platform's invalid chars. That still ACCEPTED
+two shapes:
+
+- a PERCENT-ENCODED traversal such as `%2e%2e%2f%2e%2e%2fescape` - no literal separator, no invalid
+  char, so it slipped the denylist and built a bizarrely-named clip file; and
+- an UNBOUNDED, over-long segment (a 300-char id) - no length check at all.
+
+The denylist was replaced with a strict ALLOW-LIST (`[A-Za-z0-9._-]` only, so `%` is rejected) plus
+a `MaxSidLength = 128` bound, applied BEFORE any path is built. This is defense in depth on TOP of
+the canonical containment, which is unchanged. An allow-list cannot be out-guessed the way a
+denylist can.
 
 ## Revert-proof
 
@@ -58,11 +74,16 @@ Each guard is independently pinned (single-primitive reverts, full-assembly buil
 - Remove the SAVE guard only -> the write and overwrite tests redden (and the delete test, whose
   victim is overwritten before delete).
 
-## Test evidence (after fix)
+## Test evidence (after fix + harden)
 
-- `WingmanVoiceSidPathTraversalTests`: 5/5 pass (3 attack + 2 controls: separator id writes nothing,
-  normal GUID still persists).
-- All voice + wingman Gateway tests: 366/366 pass.
+- `WingmanVoiceSidPathTraversalTests`: 7/7 pass - 3 traversal attacks, 1 separator id, 1 normal-GUID
+  control, plus the two Codex-review additions: a percent-encoded traversal id
+  (`%2e%2e%2f%2e%2e%2fescape`) writes nothing, and a 300-char id is refused before any directory is
+  created. Both new tests are revert-proofed: restore the old separator/invalid-char denylist and
+  both redden (the percent id writes its clip file; the over-long id's refused save no longer skips
+  `Directory.CreateDirectory`, so the voice-audio directory appears), while the original five stay
+  green.
+- All voice + wingman Gateway tests: 368/368 pass.
 - `WingmanVoiceTenantPartitionTests` (solo): 20/20 pass.
 - `VoiceUploadStoreTenantPartitionTests` (solo): 15/15 pass.
 - Gateway + Gateway.Tests build: 0 warnings / 0 errors.

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceSidPathTraversalTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceSidPathTraversalTests.cs
@@ -1,0 +1,164 @@
+using System.Text;
+using CcDirector.AgentBrain;
+using CcDirector.Core;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Wingman;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// VOICE V1 (audit B1): the tenant partition validates the TENANT id, but the SESSION id becomes a FILE
+/// NAME inside that partition - <c>&lt;sid&gt;.mp3</c> / <c>&lt;sid&gt;.json</c> under the tenant's
+/// voice-audio directory - and it was concatenated RAW, with no validation. A session id is
+/// caller-controlled on the persisting path: a hostile Director advertises any non-empty string as a
+/// pushed session id, and the /sessions/voice-mode/all fan-out plus the turn-end narration sweep persist
+/// whatever id they are handed with no GUID gate (the request endpoints that DO gate on
+/// <c>Guid.TryParse</c> are a different door). So a session id of the shape
+/// "../../&lt;other-tenant&gt;/voice-audio/&lt;victim&gt;" walks the write straight out of the caller's
+/// own partition and into another tenant's - overwriting or, on the delete path, deleting that tenant's
+/// clip.
+///
+/// These tests reproduce the escape on the SAVE and the DELETE sinks independently, and pin the two
+/// guards independently: the save test fails if the save guard is removed (a planted file appears in the
+/// other tenant's directory); the delete test fails if the delete guard is removed (the other tenant's
+/// clip is deleted). The save guard alone is not enough to keep the delete test green, and vice versa,
+/// so neither guard can be dropped without a red.
+/// </summary>
+public sealed class WingmanVoiceSidPathTraversalTests
+{
+    private static readonly TenantId TenantA = new("aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa");
+    private static readonly TenantId TenantB = new("bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb");
+
+    private static byte[] Mp3(string marker) => Encoding.ASCII.GetBytes("ID3" + marker);
+
+    private static string NewBaseDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cc-voice-traversal-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static WingmanVoiceService ServiceAt(string baseDir)
+    {
+        Func<Core.Configuration.WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
+            (_, _) => Task.FromResult<IAgentBrain>(null!);
+        var vault = new KeyVault(Path.Combine(baseDir, "vault.json"));
+        return new WingmanVoiceService(brain, vault, Path.Combine(baseDir, "voice-sessions.json"));
+    }
+
+    /// <summary>
+    /// The SAVE sink: a traversal session id must NOT write a file into another tenant's voice-audio
+    /// directory. Tenant B's directory is made to exist first (a legitimate clip), so that on unpatched
+    /// code the unguarded write actually lands rather than failing on a missing directory - the reproduction
+    /// has to be a real escape, not a swallowed IOException that only looks like containment.
+    /// </summary>
+    [Fact]
+    public void A_traversal_session_id_cannot_write_into_another_tenants_voice_audio_directory()
+    {
+        var svc = ServiceAt(NewBaseDir());
+
+        // Tenant B legitimately stores a clip, so B's voice-audio directory exists on disk.
+        svc.StoreReadyAudioForTest(TenantB, "existing", "spoken B", "reply B", Mp3("B"));
+        var bAudioDir = Path.Combine(svc.PartitionDirectoryFor(TenantB), "voice-audio");
+        Assert.True(File.Exists(Path.Combine(bAudioDir, "existing.mp3")));   // control: B's own write works
+
+        // Tenant A stores under a session id crafted to resolve into B's voice-audio directory. From A's
+        // own voice-audio dir, "../../<B>/voice-audio/planted" walks up to base/tenants and back down into B.
+        var evil = "../../" + TenantB.Value + "/voice-audio/planted";
+        svc.StoreReadyAudioForTest(TenantA, evil, "spoken EVIL", "reply EVIL", Mp3("EVIL"));
+
+        // The write must NOT have escaped into B's directory. On unpatched code both of these exist.
+        Assert.False(File.Exists(Path.Combine(bAudioDir, "planted.mp3")));
+        Assert.False(File.Exists(Path.Combine(bAudioDir, "planted.json")));
+
+        // And B's own clip is untouched (a traversal id aimed at "existing" would have overwritten it).
+        Assert.Equal(Mp3("B"), File.ReadAllBytes(Path.Combine(bAudioDir, "existing.mp3")));
+    }
+
+    /// <summary>
+    /// The same escape aimed at an EXISTING victim clip: the write must not overwrite another tenant's bytes.
+    /// </summary>
+    [Fact]
+    public void A_traversal_session_id_cannot_overwrite_another_tenants_clip()
+    {
+        var svc = ServiceAt(NewBaseDir());
+
+        svc.StoreReadyAudioForTest(TenantB, "victim", "spoken B", "reply B", Mp3("VICTIM"));
+        var victimMp3 = Path.Combine(svc.PartitionDirectoryFor(TenantB), "voice-audio", "victim.mp3");
+        Assert.True(File.Exists(victimMp3));   // control
+
+        var evil = "../../" + TenantB.Value + "/voice-audio/victim";
+        svc.StoreReadyAudioForTest(TenantA, evil, "spoken EVIL", "reply EVIL", Mp3("EVIL"));
+
+        // B's victim bytes are unchanged - A's write did not reach across the partition.
+        Assert.Equal(Mp3("VICTIM"), File.ReadAllBytes(victimMp3));
+    }
+
+    /// <summary>
+    /// The DELETE sink: a traversal session id must NOT delete another tenant's clip. An in-memory Ready
+    /// entry under the traversal id (its own save is refused, so nothing lands on disk) is then removed via
+    /// <see cref="WingmanVoiceService.Unmark"/>, which calls the delete sink for that id. Unguarded, that
+    /// delete resolves into B's directory and removes B's files.
+    ///
+    /// This test is sensitive to the DELETE guard specifically: with the save guard in place but the delete
+    /// guard removed, the victim is not overwritten (save refused) yet IS deleted (delete escaped), so it
+    /// still fails.
+    /// </summary>
+    [Fact]
+    public void A_traversal_session_id_cannot_delete_another_tenants_clip()
+    {
+        var svc = ServiceAt(NewBaseDir());
+
+        svc.StoreReadyAudioForTest(TenantB, "victim", "spoken B", "reply B", Mp3("VICTIM"));
+        var victimMp3 = Path.Combine(svc.PartitionDirectoryFor(TenantB), "voice-audio", "victim.mp3");
+        var victimJson = Path.Combine(svc.PartitionDirectoryFor(TenantB), "voice-audio", "victim.json");
+        Assert.True(File.Exists(victimMp3));    // control
+        Assert.True(File.Exists(victimJson));   // control
+
+        // Seed A's in-memory Ready map under the traversal id, then unmark it. Unmark removes the Ready
+        // entry and calls the delete sink for the same id.
+        var evil = "../../" + TenantB.Value + "/voice-audio/victim";
+        svc.StoreReadyAudioForTest(TenantA, evil, "x", "y", Mp3("EVIL"));
+        svc.Unmark(TenantA, evil);
+
+        // B's victim survives, bytes intact - A's delete did not reach across the partition.
+        Assert.True(File.Exists(victimMp3));
+        Assert.True(File.Exists(victimJson));
+        Assert.Equal(Mp3("VICTIM"), File.ReadAllBytes(victimMp3));
+    }
+
+    /// <summary>
+    /// A separator-bearing session id is refused rather than written as a nested path. This is the plain
+    /// "single path segment" property: a legitimate session id (a GUID) has no separators and is unaffected.
+    /// </summary>
+    [Fact]
+    public void A_session_id_with_a_directory_separator_writes_nothing()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        var aAudioDir = Path.Combine(svc.PartitionDirectoryFor(TenantA), "voice-audio");
+
+        svc.StoreReadyAudioForTest(TenantA, "sub/child", "spoken", "reply", Mp3("X"));
+
+        // No "child" file created under a "sub" subdirectory of A's own voice-audio dir either.
+        Assert.False(File.Exists(Path.Combine(aAudioDir, "sub", "child.mp3")));
+        Assert.False(Directory.Exists(Path.Combine(aAudioDir, "sub")));
+    }
+
+    /// <summary>
+    /// CONTROL: an ordinary GUID session id still round-trips through the save sink unchanged, so the guard
+    /// refuses only the unsafe shapes and never a legitimate id.
+    /// </summary>
+    [Fact]
+    public void A_normal_guid_session_id_still_persists()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        var sid = Guid.NewGuid().ToString();
+        svc.StoreReadyAudioForTest(TenantA, sid, "spoken", "reply", Mp3("OK"));
+
+        var mp3 = Path.Combine(svc.PartitionDirectoryFor(TenantA), "voice-audio", sid + ".mp3");
+        Assert.True(File.Exists(mp3));
+        Assert.Equal(Mp3("OK"), File.ReadAllBytes(mp3));
+        Assert.True(svc.HasVoice(TenantA, sid));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceSidPathTraversalTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceSidPathTraversalTests.cs
@@ -146,6 +146,54 @@ public sealed class WingmanVoiceSidPathTraversalTests
     }
 
     /// <summary>
+    /// A PERCENT-ENCODED traversal id must write nothing. This is the shape a separator/invalid-char denylist
+    /// lets through: "%2e%2e%2f%2e%2e%2fescape" carries no literal separator and no filesystem-invalid char,
+    /// so the earlier "single file-name component" check accepted it and built a file literally named that
+    /// inside A's own directory. The strict allow-list refuses it because '%' is not an allowed character, so
+    /// nothing is written at all - neither an escape nor a bizarrely-named clip.
+    /// </summary>
+    [Fact]
+    public void A_percent_encoded_traversal_session_id_writes_nothing()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        var aAudioDir = Path.Combine(svc.PartitionDirectoryFor(TenantA), "voice-audio");
+
+        var evil = "%2e%2e%2f%2e%2e%2fescape";
+        svc.StoreReadyAudioForTest(TenantA, evil, "spoken", "reply", Mp3("X"));
+
+        // The percent-encoded id is refused: no clip file is created under it on disk.
+        Assert.False(File.Exists(Path.Combine(aAudioDir, evil + ".mp3")));
+        Assert.False(File.Exists(Path.Combine(aAudioDir, evil + ".json")));
+    }
+
+    /// <summary>
+    /// An OVER-LONG session id must be refused by the length bound BEFORE any path work happens. A 300-char
+    /// id is all allow-list characters yet far past any real session id, so the bound rejects it - closing
+    /// the unbounded-segment shape (which could push a file name past a filesystem's component limit).
+    ///
+    /// The observable is the voice-audio DIRECTORY, not a clip file: a 300-char file name would blow past the
+    /// platform path limit and throw on the write regardless of the guard, so a "no .mp3 file" assertion would
+    /// pass for the wrong reason (the OS, not our bound) and fail to pin the guard. The guard instead returns
+    /// null and the save sink bails out BEFORE it calls Directory.CreateDirectory, so the tenant's voice-audio
+    /// directory is never even created. Drop the length bound and the sink runs on to CreateDirectory (then
+    /// throws on the over-long write), so the directory appears - reddening this test.
+    /// </summary>
+    [Fact]
+    public void An_over_long_session_id_is_refused_before_any_directory_is_created()
+    {
+        var svc = ServiceAt(NewBaseDir());
+        var aAudioDir = Path.Combine(svc.PartitionDirectoryFor(TenantA), "voice-audio");
+        Assert.False(Directory.Exists(aAudioDir));   // precondition: nothing created yet
+
+        var evil = new string('a', 300);
+        svc.StoreReadyAudioForTest(TenantA, evil, "spoken", "reply", Mp3("X"));
+
+        // The length bound refused the id before the sink touched the filesystem, so the directory the sink
+        // would have created for the write was never created.
+        Assert.False(Directory.Exists(aAudioDir));
+    }
+
+    /// <summary>
     /// CONTROL: an ordinary GUID session id still round-trips through the save sink unchanged, so the guard
     /// refuses only the unsafe shapes and never a legitimate id.
     /// </summary>

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -155,6 +155,44 @@ public sealed class WingmanVoiceService
     private string AudioDirFor(TenantId tenant) => Path.Combine(PartitionDirectoryFor(tenant), "voice-audio");
 
     /// <summary>
+    /// Resolve the on-disk path of one clip file (the <c>.mp3</c> or the <c>.json</c>) inside a tenant's
+    /// voice-audio directory, REFUSING a session id that is not a single safe path segment - returning null,
+    /// on which the caller writes or deletes NOTHING.
+    ///
+    /// The session id becomes a FILE NAME here, exactly as the tenant id becomes a DIRECTORY NAME in
+    /// <see cref="CanonicalTenantKey"/> - so it gets the same treatment for the same reason. The tenant is a
+    /// shape this system mints and is validated; the session id, on the PERSISTING path, is NOT. A hostile
+    /// Director can advertise any non-empty string as a pushed session id, and the persisting callers - the
+    /// <c>/sessions/voice-mode/all</c> fan-out and the turn-end narration sweep - carry whatever id they are
+    /// handed with no <c>Guid.TryParse</c> gate (the interactive request endpoints that DO gate are a
+    /// different door). So <c>"../../&lt;other-tenant&gt;/voice-audio/&lt;victim&gt;"</c> is a real input, and
+    /// concatenated raw it walks the write out of this tenant's partition and into another's. Two independent
+    /// checks, BOTH required - a shape that slips one is caught by the other:
+    ///  - the id must be a single ordinary file-name component: equal to its own <see cref="Path.GetFileName"/>,
+    ///    not <c>"."</c> or <c>".."</c>, and free of any directory separator, volume marker, or char the
+    ///    platform rejects in a file name; and
+    ///  - the fully-resolved path must still lie INSIDE this tenant's voice-audio directory (canonical
+    ///    containment), so even a separator this list did not anticipate cannot escape the partition.
+    /// A legitimate session id (a GUID) has none of these traits and passes untouched; anything else is
+    /// refused rather than coerced, the same rule the tenant partition already applies one level up.
+    /// </summary>
+    private string? SafeClipPath(TenantId tenant, string sid, string extension)
+    {
+        if (string.IsNullOrWhiteSpace(sid)) return null;
+        if (sid is "." or "..") return null;
+        if (!string.Equals(sid, Path.GetFileName(sid), StringComparison.Ordinal)) return null;
+        if (sid.IndexOfAny(new[] { '/', '\\', ':' }) >= 0) return null;
+        if (sid.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0) return null;
+
+        var audioDir = AudioDirFor(tenant);
+        var combined = Path.Combine(audioDir, sid + extension);
+        var root = Path.GetFullPath(audioDir) + Path.DirectorySeparatorChar;
+        var full = Path.GetFullPath(combined);
+        if (!full.StartsWith(root, StringComparison.OrdinalIgnoreCase)) return null;
+        return full;
+    }
+
+    /// <summary>
     /// The one HTTP client for the narration speech leg, used whenever no test client is injected.
     ///
     /// Static and never disposed, matching the hosted-call pattern used across this codebase
@@ -391,12 +429,21 @@ public sealed class WingmanVoiceService
     {
         try
         {
-            var audioDir = AudioDirFor(tenant);
-            Directory.CreateDirectory(audioDir);
+            // The session id is a file name here, and on the persisting path it is caller-controlled (see
+            // SafeClipPath): refuse a traversal / separator-bearing / non-canonical id rather than let it
+            // write outside this tenant's partition. Refused -> write NOTHING (both files or neither).
+            var mp3Path = SafeClipPath(tenant, sid, ".mp3");
+            var metaPath = SafeClipPath(tenant, sid, ".json");
+            if (mp3Path is null || metaPath is null)
+            {
+                FileLog.Write($"[WingmanVoiceService] save ready audio REFUSED (session id is not a safe path segment) tenant={tenant.ToLogString()} sid={sid}");
+                return;
+            }
+            Directory.CreateDirectory(AudioDirFor(tenant));
             // Write the audio first, then the metadata, so a startup load (which requires BOTH the
             // .mp3 and the .json) never sees a session ready before its bytes are on disk.
-            File.WriteAllBytes(Path.Combine(audioDir, sid + ".mp3"), ready.Audio);
-            File.WriteAllText(Path.Combine(audioDir, sid + ".json"),
+            File.WriteAllBytes(mp3Path, ready.Audio);
+            File.WriteAllText(metaPath,
                 JsonSerializer.Serialize(new PersistedVoice(ready.Spoken, ready.Reply, ready.AtUtc, ready.ContentType, ready.ServedViaFallback)));
         }
         catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] save ready audio FAILED tenant={tenant.ToLogString()} sid={sid}: {Redact(ex.Message, tenant)}"); }
@@ -406,9 +453,16 @@ public sealed class WingmanVoiceService
     {
         try
         {
-            var audioDir = AudioDirFor(tenant);
-            var meta = Path.Combine(audioDir, sid + ".json");
-            var audio = Path.Combine(audioDir, sid + ".mp3");
+            // Same guard as the save sink: the session id is a caller-controlled file name, so a traversal
+            // id must not let a delete reach another tenant's clip. Refused -> delete NOTHING. A safe id
+            // could only ever have written its own files, so there is nothing legitimate to miss here.
+            var meta = SafeClipPath(tenant, sid, ".json");
+            var audio = SafeClipPath(tenant, sid, ".mp3");
+            if (meta is null || audio is null)
+            {
+                FileLog.Write($"[WingmanVoiceService] delete ready audio REFUSED (session id is not a safe path segment) tenant={tenant.ToLogString()} sid={sid}");
+                return;
+            }
             if (File.Exists(meta)) File.Delete(meta);
             if (File.Exists(audio)) File.Delete(audio);
         }

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -154,6 +154,11 @@ public sealed class WingmanVoiceService
     /// <summary>The folder holding one tenant's cached narration clips and their metadata.</summary>
     private string AudioDirFor(TenantId tenant) => Path.Combine(PartitionDirectoryFor(tenant), "voice-audio");
 
+    /// <summary>Upper bound on an accepted session id (see <see cref="SafeClipPath"/>). A real session id is a
+    /// GUID or short token - well under this - so a longer one is a malformed/hostile input, refused before a
+    /// path is built. Also keeps the clip file name comfortably inside any filesystem's component limit.</summary>
+    private const int MaxSidLength = 128;
+
     /// <summary>
     /// Resolve the on-disk path of one clip file (the <c>.mp3</c> or the <c>.json</c>) inside a tenant's
     /// voice-audio directory, REFUSING a session id that is not a single safe path segment - returning null,
@@ -168,21 +173,30 @@ public sealed class WingmanVoiceService
     /// different door). So <c>"../../&lt;other-tenant&gt;/voice-audio/&lt;victim&gt;"</c> is a real input, and
     /// concatenated raw it walks the write out of this tenant's partition and into another's. Two independent
     /// checks, BOTH required - a shape that slips one is caught by the other:
-    ///  - the id must be a single ordinary file-name component: equal to its own <see cref="Path.GetFileName"/>,
-    ///    not <c>"."</c> or <c>".."</c>, and free of any directory separator, volume marker, or char the
-    ///    platform rejects in a file name; and
+    ///  - the id must be a single safe file-name atom: non-empty, not <c>"."</c> or <c>".."</c>, no longer
+    ///    than <see cref="MaxSidLength"/> characters, and every character drawn from a strict ALLOW-LIST
+    ///    (<c>[A-Za-z0-9._-]</c>). An allow-list is used deliberately rather than a separator/invalid-char
+    ///    denylist: a denylist that only bans <c>/ \ :</c> and the platform's invalid chars still ACCEPTS a
+    ///    percent-encoded traversal such as <c>"%2e%2e%2f%2e%2e%2fescape"</c> (no separator, all "legal"
+    ///    file-name chars) and an unbounded, over-long segment (a 300-char id). The allow-list rejects both
+    ///    - the <c>'%'</c> is not on it and the length is bounded - BEFORE any path is built; and
     ///  - the fully-resolved path must still lie INSIDE this tenant's voice-audio directory (canonical
-    ///    containment), so even a separator this list did not anticipate cannot escape the partition.
-    /// A legitimate session id (a GUID) has none of these traits and passes untouched; anything else is
-    /// refused rather than coerced, the same rule the tenant partition already applies one level up.
+    ///    containment), so even a shape this list did not anticipate cannot escape the partition.
+    /// A legitimate session id (a GUID) is entirely allow-list characters and well under the length bound, so
+    /// it passes untouched; anything else is refused rather than coerced, the same rule the tenant partition
+    /// already applies one level up.
     /// </summary>
     private string? SafeClipPath(TenantId tenant, string sid, string extension)
     {
         if (string.IsNullOrWhiteSpace(sid)) return null;
         if (sid is "." or "..") return null;
-        if (!string.Equals(sid, Path.GetFileName(sid), StringComparison.Ordinal)) return null;
-        if (sid.IndexOfAny(new[] { '/', '\\', ':' }) >= 0) return null;
-        if (sid.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0) return null;
+        if (sid.Length > MaxSidLength) return null;
+        foreach (var c in sid)
+        {
+            var allowed = c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9')
+                or '.' or '_' or '-';
+            if (!allowed) return null;
+        }
 
         var audioDir = AudioDirFor(tenant);
         var combined = Path.Combine(audioDir, sid + extension);


### PR DESCRIPTION
## Root cause

`WingmanVoiceService` partitions voice state per tenant and validates the tenant id hard, but the
session id - which becomes the clip file name under `<tenant>/voice-audio/` (`<sid>.mp3` / `<sid>.json`)
- was concatenated raw in `SaveReadyAudio` and `DeleteReadyAudio` with no validation.

On the persisting path the session id is caller-controlled. A hostile Director advertises any non-empty
string as a pushed session id; the `/sessions/voice-mode/all` fan-out (only a non-empty check) and the
turn-end narration sweep carry it into `GenerateAsync -> StoreSpokenAsync -> StoreReady -> SaveReadyAudio`
with no `Guid.TryParse` gate (the interactive request endpoints that DO gate are a different door). A
session id of the shape `../../<other-tenant>/voice-audio/<victim>` therefore walked the write out of the
caller's own partition and into another tenant's directory - overwriting that tenant's clip on save, or
deleting it on delete. Cross-tenant disclosure/destruction of customer content on the hosted Gateway.

## Fix

New `SafeClipPath(tenant, sid, extension)`, applied on BOTH the save and delete sinks. It refuses the id
(returns null -> the sink writes/deletes nothing) unless:

- the id is a single ordinary file-name component (equals its own `Path.GetFileName`, not `.` / `..`, no
  `/ \ :`, no `Path.GetInvalidFileNameChars`); and
- the fully-resolved path still lies inside the tenant's voice-audio directory (canonical containment).

A legitimate GUID session id passes untouched. This mirrors, one level down, the rule the tenant
partition already applies to the directory name.

## Verification

- Reproduced on main: `WingmanVoiceSidPathTraversalTests` - three attack tests fail unpatched (planted
  file in another tenant's dir, overwrite, delete).
- After fix: 5/5 pass (3 attack + 2 controls: separator id writes nothing, normal GUID still persists).
- Revert-proof per guard: removing only the delete guard reddens the delete test alone; removing only the
  save guard reddens the write/overwrite tests.
- All voice + wingman Gateway tests: 366/366. `WingmanVoiceTenantPartitionTests` (solo): 20/20.
  `VoiceUploadStoreTenantPartitionTests` (solo): 15/15.
- Gateway + Gateway.Tests build: 0 warnings / 0 errors.
