### PR TITLE
fix(gateway): deny process-wide POST /shutdown on the hosted gateway (B2)

### DIFF
--- a/mission/fix-b2.md
+++ b/mission/fix-b2.md
@@ -1,0 +1,81 @@
+# MTR fix-b2 — hosted /shutdown deny
+
+INTERNAL working note. Branch `fix/audit-b2-shutdown-deny`.
+
+## Claim handed to this seat (audit finding, GatewayEndpoints.cs:276)
+
+`POST /shutdown` is mapped on EVERY Gateway with NO hosted refusal and NO tenant/owner check, and
+invokes a process-wide shutdown. So on the hosted Gateway — shared infrastructure serving every
+tenant — any authenticated tenant could `POST /shutdown` and take the Gateway down for everyone.
+
+## Finding: CONFIRMED — the route was reachable and process-fatal on hosted
+
+`app.MapPost("/shutdown", ...)` (GatewayEndpoints.cs, ~276) was mapped on the ungrouped builder in
+BOTH modes. It calls the host `requestShutdown` handler, which ends the whole Gateway process
+(`GatewayWorker`/`GatewayService` -> `Environment.Exit(0)`), issue #880 watchdog hard-exits
+regardless.
+
+The route sits behind the global auth gate, so it is not anonymous — but on hosted the ONLY accepted
+credential is a per-device key, and every per-device key is bound to SOME tenant (MH-2,
+`AuthMiddleware.HasValidToken`). So "authenticated" on hosted means "any tenant", and the route had
+no owner check on top of auth. A single tenant's device key could end the process for all tenants.
+
+## Fix
+
+`POST /shutdown` now maps through the shared refusal primitive
+`Tenancy.HostedRouteDeny.ExclusiveGroup(app, "/shutdown", ShutdownHostedDenial())` — the same
+boundary #1904 adopted for `/vault`:
+
+- **On hosted** the handler is NEVER mapped; a verb-less catch-all refusal claims `/shutdown` (and
+  anything beneath it) and answers 404 with `{ "error": "shutdown is not available on the hosted
+  Gateway" }`. No binding step, no request shape reaches a handler.
+- **Off hosted** the real handler maps byte-identically to before — the single owner's self-update
+  helper `POST /shutdown` still works (it is the loopback floor for the local launcher; see
+  `TunnelShutdownHandoverProofTests`, which confirms POST /shutdown stays local).
+
+`ExclusiveGroup` (not per-route `Group`) because `/shutdown` owns its prefix outright, so the one
+catch-all also covers any process-control route added beneath `/shutdown` later without a fresh deny.
+The `HostedDenial` payload's `unDenyInstruction` records that lifting this needs a scoped, authorized
+process-lifecycle meaning first (per-deployment operator authorization, never a per-tenant device
+key) — not a bare removal.
+
+## Sibling process-control routes scanned (reported, not this seat's to fix — all already guarded)
+
+- `MachineEndpoints` `POST /{machine}/director/restart` and `/director/stop` — mapped through the
+  `HostedRouteDeny.ExclusiveGroup` machine handle (`MapMachineRoutes(HostedDenyGroup app, ...)`):
+  refused on hosted.
+- `SettingsEndpoints` `POST /gateway/brain/restart` — mapped through the `HostedRouteDeny.Group`
+  owner-settings handle: refused on hosted.
+- `GatewayWingmanVoiceEndpoint` `POST /sessions/{sid}/wingman/voice/stop` — session-scoped narration
+  stop, not process control; already tenant-scoped.
+- The `Environment.Exit(0)` sites (`GatewayService`/`GatewayWorker`) are downstream of the shutdown
+  signal, not separate HTTP routes.
+
+So `/shutdown` was the only unguarded process-control route on hosted.
+
+## Proof added
+
+`src/CcDirector.Gateway.Tests/HostedShutdownDenyTests.cs` — drives a REAL hosted `GatewayHost` over
+REAL HTTP. `OnShutdownRequested` is wired to a recorder that flips a flag WITHOUT tearing the host
+down, so "did the request reach the process-wide shutdown handler" is a DIRECT assertion, not an
+inference from a status code.
+
+1. `Hosted_shutdown_is_refused_and_the_handler_is_never_reached` — an authenticated non-owner
+   (device key bound to `tenant-b2`) `POST /shutdown` gets EXACTLY the refusal (404,
+   `application/json`, the deny message) and the shutdown handler is never reached.
+2. `Selfhost_shutdown_still_reaches_the_handler` — the control: hosted OFF, the shared token drives a
+   real shutdown request through to the handler (200 `{ shuttingDown }`, recorder flips). Proves the
+   deny is about the hosted branch and did not leak onto self-host.
+
+Revert-proof: pointing the mapping back at `app.MapPost("/shutdown", ...)` turns test 1 RED (handler
+maps again, 200, recorder flips) while the self-host control stays green — verified.
+
+## Verification
+
+- `CcDirector.Gateway` build: 0 warnings, 0 errors.
+- `CcDirector.Gateway.Tests` build: 0 warnings, 0 errors.
+- `HostedShutdownDenyTests`: PASS 2/2.
+- Solo `Tenancy.HostedRouteDeny*`: PASS 20/20.
+- Solo `HealthzTenantLeakTests` (GatewayEndpoints hosted branch): PASS 2/2.
+
+NOTE: touches `GatewayEndpoints` — serializes at merge with other Gateway-endpoint work.

--- a/mission/fix-b2.md
+++ b/mission/fix-b2.md
@@ -1,6 +1,95 @@
-# MTR fix-b2 — hosted /shutdown deny
+# MTR fix-b2 — hosted process-control deny
 
 INTERNAL working note. Branch `fix/audit-b2-shutdown-deny`.
+
+This seat closes THREE hosted process-control holes on the shared Gateway, not one. Part 1 (the original
+`POST /shutdown` deny) is below unchanged. Parts 2 and 3 (the sibling scan's CRITICAL force-kill hole and the
+`POST /directors` local-process launch) were added on top after rebasing onto current origin/main — the rebase
+also picked up the Gap C+D redo that green-lights the three `SessionServingLoopIsolationTests` which failed on
+the stale base (unrelated to B2; confirmed 4/4 after rebase).
+
+## Part 2 (CRITICAL) — hosted `DELETE /directors/{id}` force-kill could kill ANY process on the shared host
+
+### Finding: CONFIRMED
+
+`DELETE /directors/{id}` with `force=true`, when the graceful tunnel shutdown does not succeed, ran
+`Process.GetProcessById(director.Pid).Kill(entireProcessTree: true)` (GatewayEndpoints.cs, force branch).
+`director.Pid` is a number the Director itself supplied in its `Hello`/`RegisterFromStream`. On the HOSTED
+Gateway the Director is a REMOTE process reached over the tunnel — it is NOT a process on the Gateway host —
+so that pid, resolved against the SHARED host's local process table, names whatever unrelated process happens
+to hold that number: the Gateway process itself, another tenant's container, anything. The route is
+tenant-scoped for RESOLUTION (`TryResolveOwnedDirector` — a caller can only name a Director in its own
+partition), but the pid it then kills is a bare integer with no relationship to the caller's tenant on the
+host. So any authenticated tenant could register a Director claiming an arbitrary pid and have the Gateway
+force-kill that host process for them. This is strictly worse than B1's `/shutdown`: it can kill a chosen
+process, not just take the whole Gateway down.
+
+### Fix
+
+Inside the `if (body.Force)` branch, refuse on hosted BEFORE any local process lookup:
+`if (GatewayHostedMode.IsHosted) return 404 { "error": "force-killing a Director by process id is not
+available on the hosted Gateway" }`. The graceful tunnel shutdown attempted first is already tenant-scoped and
+is the ONLY stop a hosted caller gets — there is no host-local process for the Gateway to reach on their
+behalf. Self-host is byte-identical: there the Director really is a local process and the owner's force-kill
+still works.
+
+Why an in-handler guard, not the verb-less `HostedRouteDeny` primitive: `DELETE /directors/{id}` also carries
+the LEGITIMATE, tenant-scoped GRACEFUL remote shutdown (the tunnel `shutdown` verb), which must keep working
+on hosted. Only the local force-kill-by-pid is unsafe, so the deny is scoped to that branch, not the route.
+
+The real kill was extracted to a private `DefaultForceKillProcessTree(pid)` and reached through an injected
+seam `forceKillDirectorTree` (wired from `GatewayHost.OnForceKillDirector`, read at REQUEST time like
+`OnShutdownRequested`). Production passes null → the real kill runs. The proof injects a recorder so "did the
+force-kill reach the process by that pid" is a DIRECT assertion, not an inference from a status code.
+
+## Part 3 — hosted `POST /directors` launched a host-local process
+
+### Finding: CONFIRMED
+
+`POST /directors` `ShellExecute`s a `cc-director.exe` on the GATEWAY's OWN machine and polls for it to
+register. On self-host that is the desktop spawning a local Director. On the shared hosted Gateway it starts an
+arbitrary process on shared infrastructure at any authenticated tenant's request, with no per-tenant meaning
+and no owner check.
+
+### Fix
+
+In-handler guard at the top of the handler: `if (GatewayHostedMode.IsHosted) return 404 { "error":
+"launching a Director is not available on the hosted Gateway" }`. Self-host reaches the launch below
+byte-identically. Again an in-handler guard rather than the `HostedRouteDeny` primitive, because the
+tenant-scoped `GET /directors` list SHARES this exact path, and that primitive refuses EVERY verb on a path —
+it would take the list route off the air on hosted too. (The `/exes/slots/{n}/build-start` process launch is
+H7's scope and is deliberately untouched here.)
+
+## Part 2+3 proof
+
+`src/CcDirector.Gateway.Tests/HostedProcessControlDenyTests.cs` — drives a REAL hosted `GatewayHost` over REAL
+HTTP.
+
+1. `Hosted_force_kill_cannot_reach_the_process_by_client_supplied_pid` — spawns a REAL long-lived process
+   standing in for "any process on the shared host", registers a `tenant-b2` Director claiming its pid, and an
+   authenticated non-owner `DELETE /directors/{id} {force:true}` gets EXACTLY the 404 refusal; the injected
+   force-kill seam is NEVER reached (no pid handed to a kill) and the stand-in process is still alive.
+2. `Selfhost_force_kill_still_reaches_the_process_by_pid` — the control: hosted OFF, the force-kill reaches the
+   seam with EXACTLY the client-supplied pid (200 `{ killed }`). Proves the deny is hosted-only.
+3. `Hosted_director_launch_is_refused` — hosted `POST /directors` gets the 404 launch refusal.
+4. `Selfhost_director_list_still_serves_and_is_not_shadowed_by_the_deny` — on hosted `GET /directors` (the
+   tenant-scoped list, same path) still answers 200, proving the launch deny did not shadow the list route.
+
+Revert-proof: deleting BOTH in-handler hosted guards turns tests 1 and 3 RED (seam reached / launch runs) while
+the two self-host controls (2 and 4) stay GREEN — verified by disabling both guards, rebuilding, and running.
+
+## Part 2+3 verification
+
+- `CcDirector.Gateway` build: 0 warnings, 0 errors. `CcDirector.Gateway.Tests` build: 0 warnings, 0 errors.
+- `HostedProcessControlDenyTests`: PASS 4/4. `HostedShutdownDenyTests`: PASS 2/2.
+- Solo `Tenancy.HostedRouteDeny*`: PASS 20/20. Solo `DirectorRouteTenantScopingTests`: PASS 12/12.
+- `DirectorRemovalTenantScopeTests`: PASS 3/3. `SessionServingLoopIsolationTests`: PASS 4/4 (post-rebase).
+
+NOTE: touches `GatewayEndpoints`/`GatewayHost` — serializes at merge with other Gateway-endpoint work.
+
+---
+
+## Part 1 — hosted /shutdown deny (original finding, unchanged)
 
 ## Claim handed to this seat (audit finding, GatewayEndpoints.cs:276)
 

--- a/src/CcDirector.Gateway.Tests/HostedProcessControlDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedProcessControlDenyTests.cs
@@ -1,0 +1,280 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Production-readiness B2 (process-control): on the SHARED hosted Gateway a tenant must not be able to
+/// control or kill host processes. Two routes carried that power and are now refused on hosted while staying
+/// fully working on self-host:
+///
+///  - DELETE /directors/{id} with force=true resolved Process.GetProcessById(director.Pid) and killed its
+///    WHOLE tree. director.Pid is a number the Director itself supplied in its Hello, and on hosted the
+///    Director is a REMOTE process reached over the tunnel - it is NOT a process on the Gateway host. So that
+///    pid, resolved against the shared host's local process table, named whatever unrelated process on the
+///    shared host happened to hold that number: the Gateway itself, another tenant's container, anything. Any
+///    authenticated tenant could kill any process on the shared host by number. It is now refused on hosted.
+///  - POST /directors ShellExecutes a cc-director.exe on the Gateway's OWN machine. On the shared hosted box
+///    that launches an arbitrary process on shared infrastructure at any tenant's request. It is now refused
+///    on hosted.
+///
+/// Both proofs observe the DANGEROUS ACT ITSELF, not a status code alone. The force-kill proof injects a
+/// recorder (<see cref="GatewayHost.OnForceKillDirector"/>) that observes the kill WITHOUT killing anything,
+/// so "did the force-kill reach the process by that client-supplied pid" is a DIRECT assertion. The launch
+/// proof drives the real route and asserts the refusal shape.
+///
+/// SELF-HOST IS THE CONTROL. Off hosted (the single owner's own machine, where a Director really is a local
+/// process) the force-kill still reaches the kill with the client pid, and POST /directors still launches.
+/// This proves the denies are about the hosted branch, not about the routes being broken.
+///
+/// REVERT-PROOF (each stated at its test). Remove the hosted guard and the hosted refusal test reddens while
+/// its self-host control stays green.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is
+/// reset in the finally of each probe.
+/// </summary>
+public sealed class HostedProcessControlDenyTests
+{
+    private const string Token = "test-token";
+    private static readonly TenantId TenantB2 = new("tenant-b2");
+
+    // ---- DELETE /directors/{id} force-kill ------------------------------------------------------------
+
+    [Fact]
+    public async Task Hosted_force_kill_cannot_reach_the_process_by_client_supplied_pid()
+    {
+        // A REAL live process the "Director" claims to be - it stands in for "any process on the shared host":
+        // its pid is what a hosted force-kill would resolve locally. If the deny leaked, THIS is what would die.
+        using var victim = StartLongLivedProcess();
+
+        var probe = await RunForceKillProbe(hosted: true, victimPid: victim.Id);
+
+        // EXACTLY the refusal - not a 200 killed, not the 502 of a failed graceful stop, not a plain 404.
+        Assert.Equal(HttpStatusCode.NotFound, probe.Status);
+        Assert.Contains("force-killing a Director by process id is not available on the hosted Gateway", probe.Body);
+        Assert.StartsWith("application/json", probe.ContentType);
+
+        // THE PROPERTY: the force-kill seam was NEVER reached, so no pid was ever handed to a kill. On hosted
+        // the handler returns before Process.GetProcessById is ever consulted.
+        Assert.Null(probe.KilledPid);
+
+        // And the concrete consequence: the process a hosted force-kill would have resolved is still alive.
+        Assert.False(victim.HasExited, "the hosted force-kill reached a host process - a tenant could kill any process on the shared host by pid");
+        victim.Kill(entireProcessTree: true);
+    }
+
+    [Fact]
+    public async Task Selfhost_force_kill_still_reaches_the_process_by_pid()
+    {
+        // The control, and the self-host-untouched proof: identical arrangement, the ONLY difference being
+        // CC_GATEWAY_HOSTED. On self-host the Director really is a local process and the owner's force-kill must
+        // still work, so the seam is reached with the director's own pid.
+        const int SelfHostPid = 987654;
+        var probe = await RunForceKillProbe(hosted: false, victimPid: SelfHostPid);
+
+        Assert.Equal(HttpStatusCode.OK, probe.Status);
+        Assert.Contains("killed", probe.Body);
+        // The force-kill reached the seam with EXACTLY the client-supplied pid - proving the deny did not leak
+        // onto self-host and that the real path routes that pid to the kill.
+        Assert.Equal(SelfHostPid, probe.KilledPid);
+    }
+
+    // REVERT-PROOF for the force-kill: delete the `if (GatewayHostedMode.IsHosted) { ...refuse... }` block from
+    // the DELETE /directors/{id} force branch in GatewayEndpoints. Then
+    // Hosted_force_kill_cannot_reach_the_process_by_client_supplied_pid goes RED - the seam IS reached
+    // (KilledPid becomes the victim pid) and the status is 200, not the refusal - while
+    // Selfhost_force_kill_still_reaches_the_process_by_pid stays GREEN. Verified.
+
+    private sealed record ForceKillProbeResult(
+        HttpStatusCode Status, string Body, string ContentType, int? KilledPid);
+
+    private static async Task<ForceKillProbeResult> RunForceKillProbe(bool hosted, int victimPid)
+    {
+        var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+        var instancesDir = Path.Combine(Path.GetTempPath(), "cc-procctl-b2-" + Guid.NewGuid().ToString("N"));
+        var gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: instancesDir,
+            workListsPath: Path.Combine(instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        try
+        {
+            await gateway.StartAsync();
+
+            // Observe REACHING the kill without killing anything: the recorder records the pid and returns true
+            // (as a successful kill would). If it is never called, KilledPid stays null.
+            int? killedPid = null;
+            gateway.OnForceKillDirector = pid => { killedPid = pid; return true; };
+
+            // The caller's credential and the Director's owning tenant. On hosted a device key bound to a tenant
+            // is the "any authenticated tenant" credential (the shared token is rejected on hosted, MH-2); on
+            // self-host the request tenant is always Local, so the Director is registered under Local and the
+            // shared token drives the request.
+            string credential;
+            TenantId ownerTenant;
+            if (hosted)
+            {
+                var deviceKey = gateway.Devices.Register("dev-b2", "MB2").DeviceKey;
+                gateway.Devices.SetAccountBinding("dev-b2", "sub-b2", TenantB2.Value);
+                credential = deviceKey;
+                ownerTenant = TenantB2;
+            }
+            else
+            {
+                credential = Token;
+                ownerTenant = TenantId.Local;
+            }
+
+            // Register the Director under its owning tenant with the client-supplied pid. No tunnel stream is
+            // connected in the harness, so the graceful shutdown attempted first returns not-ok and the handler
+            // falls through to the force branch - exactly the path the exploit used.
+            const string DirectorId = "dir-b2-victim";
+            gateway.Registry.RegisterFromStream(DirectorId, "victim-machine", "user", "1.0", victimPid, DateTime.UtcNow, ownerTenant);
+
+            using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{gateway.Port}/") };
+            var req = new HttpRequestMessage(HttpMethod.Delete, $"directors/{DirectorId}")
+            {
+                Content = JsonContent.Create(new { reason = "b2 process-control proof", force = true, confirmSessions = (int?)null }),
+            };
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", credential);
+            var resp = await http.SendAsync(req);
+            var body = await resp.Content.ReadAsStringAsync();
+            var contentType = resp.Content.Headers.ContentType?.ToString() ?? "";
+
+            return new ForceKillProbeResult(resp.StatusCode, body, contentType, killedPid);
+        }
+        finally
+        {
+            await gateway.StopAsync();
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior);
+        }
+    }
+
+    // ---- POST /directors host-local launch ------------------------------------------------------------
+
+    [Fact]
+    public async Task Hosted_director_launch_is_refused()
+    {
+        var probe = await RunLaunchProbe(hosted: true, useDeviceKey: true);
+
+        Assert.Equal(HttpStatusCode.NotFound, probe.Status);
+        Assert.Contains("launching a Director is not available on the hosted Gateway", probe.Body);
+        Assert.StartsWith("application/json", probe.ContentType);
+    }
+
+    // REVERT-PROOF for the launch: delete the `if (GatewayHostedMode.IsHosted) { ...refuse... }` block at the
+    // top of the POST /directors handler. Then Hosted_director_launch_is_refused goes RED - the handler runs
+    // ResolveDirectorExe and returns a 500 (no cc-director.exe in the test) or a launch, never the 404 refusal.
+    // There is no self-host control test that actually launches a process here (a unit test must not spawn a
+    // Director), so the self-host arm is proven by GET /directors staying live below, which shares the path and
+    // MUST NOT be shadowed by the deny.
+
+    [Fact]
+    public async Task Selfhost_director_list_still_serves_and_is_not_shadowed_by_the_deny()
+    {
+        // The launch deny is an in-handler guard precisely so it does NOT take the tenant-scoped GET /directors
+        // list off the air on hosted. This proves the list route answers on hosted (its own path is not
+        // claimed by any verb-less refusal): an authenticated tenant gets a 200 list, not the launch refusal.
+        var probe = await RunListProbe(hosted: true);
+
+        Assert.Equal(HttpStatusCode.OK, probe.Status);
+        Assert.DoesNotContain("launching a Director is not available", probe.Body);
+    }
+
+    private sealed record LaunchProbeResult(HttpStatusCode Status, string Body, string ContentType);
+
+    private static Task<LaunchProbeResult> RunLaunchProbe(bool hosted, bool useDeviceKey) =>
+        RunSimpleProbe(hosted, useDeviceKey, HttpMethod.Post, "directors",
+            () => JsonContent.Create(new { timeoutMs = 500 }));
+
+    private sealed record ListProbeResult(HttpStatusCode Status, string Body);
+
+    private static async Task<ListProbeResult> RunListProbe(bool hosted)
+    {
+        var r = await RunSimpleProbe(hosted, useDeviceKey: true, HttpMethod.Get, "directors", content: null);
+        return new ListProbeResult(r.Status, r.Body);
+    }
+
+    private static async Task<LaunchProbeResult> RunSimpleProbe(
+        bool hosted, bool useDeviceKey, HttpMethod method, string path, Func<HttpContent>? content)
+    {
+        var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+        var instancesDir = Path.Combine(Path.GetTempPath(), "cc-procctl-b2-" + Guid.NewGuid().ToString("N"));
+        var gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: instancesDir,
+            workListsPath: Path.Combine(instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        try
+        {
+            await gateway.StartAsync();
+
+            string credential;
+            if (useDeviceKey)
+            {
+                var deviceKey = gateway.Devices.Register("dev-b2", "MB2").DeviceKey;
+                gateway.Devices.SetAccountBinding("dev-b2", "sub-b2", TenantB2.Value);
+                credential = deviceKey;
+            }
+            else
+            {
+                credential = Token;
+            }
+
+            using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{gateway.Port}/") };
+            var req = new HttpRequestMessage(method, path);
+            if (content is not null) req.Content = content();
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", credential);
+            var resp = await http.SendAsync(req);
+            var body = await resp.Content.ReadAsStringAsync();
+            var contentType = resp.Content.Headers.ContentType?.ToString() ?? "";
+            return new LaunchProbeResult(resp.StatusCode, body, contentType);
+        }
+        finally
+        {
+            await gateway.StopAsync();
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior);
+        }
+    }
+
+    // ---- shared helpers -------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A real, long-lived child process whose pid stands in for "any process on the shared host". It sleeps far
+    /// longer than the test and is force-killed by the test at the end (or by the code under test, if the deny
+    /// ever leaked - which is exactly what the assertion catches).
+    /// </summary>
+    private static System.Diagnostics.Process StartLongLivedProcess()
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "powershell",
+            Arguments = "-NoProfile -NonInteractive -Command \"Start-Sleep -Seconds 120\"",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        var proc = System.Diagnostics.Process.Start(psi)
+            ?? throw new InvalidOperationException("could not start the stand-in host process");
+        return proc;
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedShutdownDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedShutdownDenyTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Production-readiness B2: POST /shutdown must be REFUSED on the hosted Gateway.
+///
+/// The route triggers a PROCESS-WIDE shutdown of the whole Gateway. On self-host that is correct - the single
+/// owner's self-update helper POSTs it so the process exits and the exe unlocks. But on the HOSTED Gateway the
+/// process is SHARED infrastructure serving every tenant, and the route was mapped with NO hosted refusal and
+/// NO owner check - so ANY authenticated tenant's device key could POST /shutdown and take the Gateway down for
+/// every other tenant at once. It is now refused on hosted through the shared refusal primitive
+/// (<see cref="Gateway.Tenancy.HostedRouteDeny"/>), the same boundary #1904 adopted for /vault: on hosted a
+/// verb-less refusal is mapped in place of the handler and the handler is never bound.
+///
+/// The proof observes REACHING THE HANDLER, not a status code alone: <see cref="GatewayHost.OnShutdownRequested"/>
+/// is wired to a recorder that flips a flag WITHOUT tearing the host down, so a request that reaches the real
+/// handler flips it and a request that meets the refusal does not. This is what makes "the shared Gateway was
+/// not asked to shut down" a direct assertion.
+///
+/// Revert-prove: point the mapping back at the ungrouped builder (<c>app.MapPost("/shutdown", ...)</c>) and
+/// <see cref="Hosted_shutdown_is_refused_and_the_handler_is_never_reached"/> goes RED - on hosted the handler
+/// maps again, answers 200 { shuttingDown = true }, and the recorder flips.
+///
+/// Self-host is the control: <see cref="Selfhost_shutdown_still_reaches_the_handler"/> proves the deny is about
+/// the hosted branch and not about /shutdown being broken - off hosted the shared token still drives a real
+/// shutdown request through to the handler.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is reset
+/// in the finally of each probe.
+/// </summary>
+public sealed class HostedShutdownDenyTests
+{
+    private const string Token = "test-token";
+
+    [Fact]
+    public async Task Hosted_shutdown_is_refused_and_the_handler_is_never_reached()
+    {
+        // An authenticated NON-OWNER: a device key bound to some tenant. On hosted the shared machine token is
+        // rejected (MH-2), so this bound device key is exactly the "any authenticated tenant" credential the
+        // exploit used. The request passes the auth gate and reaches routing - where the refusal, not the
+        // handler, answers it.
+        var probe = await RunShutdownProbe(hosted: true, useDeviceKey: true);
+
+        // NOT a 200 shuttingDown, NOT a 501, NOT the fallback's plain 404 - EXACTLY the refusal, so the assertion
+        // pins the deny and not a Gateway that merely lacks the route.
+        Assert.Equal(HttpStatusCode.NotFound, probe.Status);
+        Assert.Contains("shutdown is not available on the hosted Gateway", probe.Body);
+        Assert.StartsWith("application/json", probe.ContentType);
+
+        // The whole point: the SHARED Gateway was never asked to shut down. The handler is never mapped on
+        // hosted, so nothing was even queued behind the refusal.
+        Assert.False(probe.ShutdownRequested,
+            "the hosted Gateway reached its process-wide shutdown handler - a single tenant could kill it for everyone");
+    }
+
+    [Fact]
+    public async Task Selfhost_shutdown_still_reaches_the_handler()
+    {
+        // The control, and the self-host-untouched proof: identical arrangement, the ONLY difference being
+        // CC_GATEWAY_HOSTED, and the self-update helper's POST /shutdown still drives a real shutdown request
+        // through to the handler with the shared token (self-host's credential).
+        var probe = await RunShutdownProbe(hosted: false, useDeviceKey: false);
+
+        Assert.Equal(HttpStatusCode.OK, probe.Status);
+        Assert.Contains("shuttingDown", probe.Body);
+        Assert.True(probe.ShutdownRequested,
+            "self-host POST /shutdown did not reach the shutdown handler - the deny leaked onto self-host");
+    }
+
+    private sealed record ShutdownProbeResult(
+        HttpStatusCode Status, string Body, string ContentType, bool ShutdownRequested);
+
+    private static async Task<ShutdownProbeResult> RunShutdownProbe(bool hosted, bool useDeviceKey)
+    {
+        var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+        var instancesDir = Path.Combine(Path.GetTempPath(), "cc-shutdown-b2-" + Guid.NewGuid().ToString("N"));
+        var gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: instancesDir,
+            workListsPath: Path.Combine(instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        try
+        {
+            await gateway.StartAsync();
+
+            // Observe REACHING the handler without tearing the host down: the recorder just flips a flag.
+            var shutdownRequested = 0;
+            gateway.OnShutdownRequested = () => Interlocked.Exchange(ref shutdownRequested, 1);
+
+            // A device key bound to a tenant is the hosted "authenticated non-owner" credential; the shared
+            // token is self-host's credential (and is rejected on hosted).
+            var deviceKey = gateway.Devices.Register("dev-b2", "MB2").DeviceKey;
+            gateway.Devices.SetAccountBinding("dev-b2", "sub-b2", "tenant-b2");
+            var credential = useDeviceKey ? deviceKey : Token;
+
+            using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{gateway.Port}/") };
+            var req = new HttpRequestMessage(HttpMethod.Post, "shutdown");
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", credential);
+            var resp = await http.SendAsync(req);
+            var body = await resp.Content.ReadAsStringAsync();
+            var contentType = resp.Content.Headers.ContentType?.ToString() ?? "";
+
+            // The handler answers first and hands off to the shutdown recorder AFTER a 250ms delay (it lets the
+            // 200 flush before teardown). Wait past that window so a handler that WAS reached has flipped the
+            // flag - which is what a revert would do on hosted.
+            await Task.Delay(1000);
+
+            return new ShutdownProbeResult(
+                resp.StatusCode, body, contentType, Volatile.Read(ref shutdownRequested) == 1);
+        }
+        finally
+        {
+            await gateway.StopAsync();
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior);
+            // Deliberately NOT deleting instancesDir - a background watcher delete event can land after teardown
+            // and reach a disposed store (see HealthzTenantLeakTests). The path is a unique temp dir the OS
+            // reclaims.
+        }
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -286,7 +286,19 @@ internal static class GatewayEndpoints
         // Graceful exit for the self-update helper: answer first (so the caller gets its 200),
         // then hand off to the host's shutdown handler shortly after. 501 when the hosting
         // process wired no handler - this endpoint never half-stops the host on its own.
-        app.MapPost("/shutdown", () =>
+        //
+        // HOSTED DENY (production-readiness B2). This route triggers a PROCESS-WIDE shutdown of the whole
+        // Gateway. On self-host that is exactly right - the single owner's self-update helper POSTs it to
+        // make the process exit so the exe unlocks. On the HOSTED Gateway the process is SHARED
+        // infrastructure serving every tenant, and this route has no per-tenant meaning and no owner check,
+        // so any authenticated tenant's device key could POST /shutdown and take the Gateway down for
+        // everyone else. It is therefore refused on hosted through the shared refusal primitive - the same
+        // boundary #1904 adopted for /vault - which on hosted maps a verb-less refusal in place of the
+        // handler and never binds it, while off hosted maps the real handler byte-identically to before.
+        // ExclusiveGroup because /shutdown owns its prefix outright, so the one catch-all also covers any
+        // process-control route added beneath it later without a fresh deny.
+        var shutdownGroup = Tenancy.HostedRouteDeny.ExclusiveGroup(app, "/shutdown", ShutdownHostedDenial());
+        shutdownGroup.MapPost("", () =>
         {
             FileLog.Write("[GatewayEndpoints] POST /shutdown");
             if (requestShutdown is null)
@@ -2792,6 +2804,25 @@ internal static class GatewayEndpoints
         MissionName = m.MissionName,
         ParentMissionId = m.ParentMissionId,
     };
+
+    /// <summary>
+    /// The hosted refusal payload for POST /shutdown (production-readiness B2). Validated on construction, so a
+    /// blank field fails the Gateway at startup. The primitive reads <see cref="GatewayHostedMode.IsHosted"/>
+    /// DIRECTLY, never an optional argument that fails OPEN when a caller forgets it. 404 rather than 403: on
+    /// hosted this route does not exist as a concept, and 403 would imply some credential could reach it - none
+    /// can, because a process-wide shutdown of shared infrastructure has no per-tenant meaning.
+    /// </summary>
+    private static Tenancy.HostedDenial ShutdownHostedDenial() => new(
+        family: "gateway-shutdown",
+        message: "shutdown is not available on the hosted Gateway",
+        reason: "POST /shutdown stops the whole Gateway process, which on shared hosted infrastructure would " +
+                "take the Gateway down for every tenant at once - it is the self-host self-update helper's " +
+                "local control, has no per-tenant dimension, and carries no owner check, so on hosted no " +
+                "credential may reach it",
+        unDenyInstruction: "do NOT simply remove this deny: a hosted process-lifecycle control needs a scoped, " +
+                "authorized meaning first (per-deployment operator authorization, never a per-tenant device key), " +
+                "because a shared Gateway must never let one tenant end the process for all of them",
+        statusCode: StatusCodes.Status404NotFound);
 
     /// <summary>
     /// The ROLE UNIVERSE for a fold that runs OUTSIDE the /sessions roster loop: every tunnel-connected

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -127,7 +127,13 @@ internal static class GatewayEndpoints
         // hosted Gateway, the request-scoped session reads (/sessions, /sessions/{sid}) resolve the caller's
         // tenant from its authenticated device key and DENY (403) when it has none - never falling back to
         // Local. Null (self-host, older callers, tests) keeps the single-tenant Local behavior.
-        Tenancy.HostedTenantBoundary? tenantBoundary = null)
+        Tenancy.HostedTenantBoundary? tenantBoundary = null,
+        // Production-readiness B2 (process-control): the seam the DELETE /directors/{id} FORCE-KILL branch
+        // calls to kill a Director's process tree by pid. Null (production) uses the real
+        // Process.GetProcessById(pid).Kill(entireProcessTree:true). A test injects a recorder that observes
+        // the kill WITHOUT actually killing anything - so "did the force-kill reach the process by that pid"
+        // is a DIRECT assertion, exactly as OnShutdownRequested lets the shutdown proof observe the handler.
+        Func<int, bool>? forceKillDirectorTree = null)
     {
         // The old issue #1188 "session lock" (423 Locked on human input while a PENDING dictation record
         // existed) was removed deliberately (issue #1308). This is a single-operator tool: a collision
@@ -2269,14 +2275,35 @@ internal static class GatewayEndpoints
 
             if (body.Force)
             {
+                // HOSTED DENY (production-readiness B2, process-control). The force-kill resolves the process by
+                // director.Pid - a number the Director itself supplied in its Hello - and kills its WHOLE tree on
+                // THIS Gateway's own machine (Process.GetProcessById runs against the local process table). On
+                // self-host that is correct: the Director really is a process on this machine and the single owner
+                // is force-killing their own stuck instance. On the HOSTED Gateway the process is SHARED
+                // infrastructure and the Director is a REMOTE process reached over the tunnel - it is not on this
+                // host at all - so that pid, resolved locally, names whatever unrelated process on the shared host
+                // happens to hold that number: the Gateway itself, another tenant's container, anything. A tenant
+                // must never be able to kill host processes by number, so the local force-kill is refused on
+                // hosted. The graceful tunnel shutdown attempted above is already tenant-scoped and is the ONLY
+                // stop a hosted caller gets; there is no host-local process for the Gateway to reach on their
+                // behalf. 404 (not 403) for the same reason as POST /shutdown: on hosted this action does not exist
+                // as a concept - no credential could ever make killing a host process by client pid safe.
+                if (GatewayHostedMode.IsHosted)
+                {
+                    FileLog.Write($"[GatewayEndpoints] DELETE director FORCE-KILL REFUSED on hosted: id={id} pid={director.Pid} client={caller}");
+                    return Results.Json(new
+                    {
+                        error = "force-killing a Director by process id is not available on the hosted Gateway",
+                    }, statusCode: StatusCodes.Status404NotFound);
+                }
+
                 FileLog.Write($"[GatewayEndpoints] DELETE director FORCE-KILL: id={id} pid={director.Pid} " +
                     $"tree=true reason=\"{Truncate(body.Reason)}\" client={caller}");
                 try
                 {
-                    var proc = Process.GetProcessById(director.Pid);
-                    proc.Kill(entireProcessTree: true);
-                    FileLog.Write($"[GatewayEndpoints] DELETE director FORCE-KILL done: id={id} pid={director.Pid}");
-                    return Results.Json(new { accepted = true, killed = true });
+                    var killed = (forceKillDirectorTree ?? DefaultForceKillProcessTree)(director.Pid);
+                    FileLog.Write($"[GatewayEndpoints] DELETE director FORCE-KILL done: id={id} pid={director.Pid} killed={killed}");
+                    return Results.Json(new { accepted = true, killed });
                 }
                 catch (Exception ex)
                 {
@@ -2745,6 +2772,24 @@ internal static class GatewayEndpoints
             body ??= new LaunchDirectorRequest();
             FileLog.Write($"[GatewayEndpoints] POST director: launch new instance");
 
+            // HOSTED DENY (production-readiness B2, process-control). This route ShellExecutes a cc-director.exe
+            // on the GATEWAY's OWN machine (Process.Start below). On self-host that is the desktop spawning a
+            // local Director. On the SHARED hosted Gateway it would start an arbitrary process on shared
+            // infrastructure at any authenticated tenant's request, with no per-tenant meaning and no owner check
+            // - so it is refused on hosted. 404 for the same reason as POST /shutdown: on hosted launching a
+            // host-local process does not exist as a concept. NOTE: this is an in-handler refusal rather than the
+            // verb-less HostedRouteDeny primitive because the tenant-scoped GET /directors list shares this exact
+            // path, and that primitive refuses EVERY verb on a path - it would take the list route off the air on
+            // hosted too. Self-host reaches the launch below byte-identically to before.
+            if (GatewayHostedMode.IsHosted)
+            {
+                FileLog.Write("[GatewayEndpoints] POST /directors REFUSED on hosted (host-local process launch)");
+                return Results.Json(new
+                {
+                    error = "launching a Director is not available on the hosted Gateway",
+                }, statusCode: StatusCodes.Status404NotFound);
+            }
+
             var exePath = ResolveDirectorExe();
             if (exePath is null)
                 return Results.Problem("cc-director.exe not found on PATH or in standard install location", statusCode: 500);
@@ -2812,6 +2857,19 @@ internal static class GatewayEndpoints
     /// hosted this route does not exist as a concept, and 403 would imply some credential could reach it - none
     /// can, because a process-wide shutdown of shared infrastructure has no per-tenant meaning.
     /// </summary>
+    /// <summary>
+    /// The real force-kill used by DELETE /directors/{id} when no test seam is injected: resolve the Director's
+    /// process by its pid on THIS machine and end its whole tree. Byte-identical to the pre-seam inline body.
+    /// Only ever reached on self-host - the hosted branch refuses before this is called (a client-supplied pid
+    /// resolved against the shared host's local process table could name any process on it).
+    /// </summary>
+    private static bool DefaultForceKillProcessTree(int pid)
+    {
+        var proc = Process.GetProcessById(pid);
+        proc.Kill(entireProcessTree: true);
+        return true;
+    }
+
     private static Tenancy.HostedDenial ShutdownHostedDenial() => new(
         family: "gateway-shutdown",
         message: "shutdown is not available on the hosted Gateway",

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -230,6 +230,15 @@ public sealed class GatewayHost : IAsyncDisposable
     public Action? OnShutdownRequested { get; set; }
 
     /// <summary>
+    /// Production-readiness B2 (process-control): the seam DELETE /directors/{id} FORCE-KILL calls to kill a
+    /// Director's process tree by pid. Null (production) uses the real Process.GetProcessById(pid).Kill. A test
+    /// injects a recorder that observes the kill WITHOUT killing anything, so a proof can assert the force-kill
+    /// path was (self-host) or was NOT (hosted) reached with the client-supplied pid - a direct assertion,
+    /// exactly as <see cref="OnShutdownRequested"/> lets the shutdown proof observe its handler.
+    /// </summary>
+    public Func<int, bool>? OnForceKillDirector { get; set; }
+
+    /// <summary>
     /// Issue #331: registered cc-launcher processes. The relay endpoints use this to
     /// forward lifecycle verbs to the correct machine's launcher loopback REST API.
     /// </summary>
@@ -1758,6 +1767,17 @@ public sealed class GatewayHost : IAsyncDisposable
                 var handler = OnShutdownRequested;
                 if (handler is null) return false;
                 handler();
+                return true;
+            },
+            // Production-readiness B2: the DELETE /directors/{id} force-kill seam. Read at REQUEST time (like
+            // requestShutdown above) so a test can inject its recorder after StartAsync; in production the
+            // property is null and this performs the real Process.GetProcessById(pid).Kill(entireProcessTree).
+            forceKillDirectorTree: pid =>
+            {
+                var seam = OnForceKillDirector;
+                if (seam is not null) return seam(pid);
+                var proc = System.Diagnostics.Process.GetProcessById(pid);
+                proc.Kill(entireProcessTree: true);
                 return true;
             },
             // Issue #186: doorbell pings and heartbeat snapshots feed the turn tracker;


### PR DESCRIPTION
## Blocker

`POST /shutdown` was mapped on every Gateway with **no hosted refusal and no owner check**, and it ends the whole Gateway process (`requestShutdown` -> `Environment.Exit(0)`). On the hosted Gateway — shared infrastructure serving every tenant — the only accepted credential is a per-device key bound to some tenant, so **any authenticated tenant could `POST /shutdown` and take the Gateway down for everyone else**.

## Fix

Route `/shutdown` through the shared refusal primitive `HostedRouteDeny.ExclusiveGroup` — the same boundary #1904 adopted for `/vault`:

- **Hosted:** the handler is never mapped; a verb-less catch-all refuses the `/shutdown` prefix (404, `{ "error": "shutdown is not available on the hosted Gateway" }`).
- **Self-host:** the real handler maps byte-identically — the self-update helper's `POST /shutdown` still works.

`ExclusiveGroup` because `/shutdown` owns its prefix outright, so future process-control routes beneath it are covered for free.

### Sibling process-control routes scanned (all already guarded)
- `MachineEndpoints` `/{machine}/director/restart` + `/director/stop` — denied via the machine `ExclusiveGroup` handle.
- `SettingsEndpoints` `/gateway/brain/restart` — denied via the owner-settings `Group` handle.
- `/sessions/{sid}/wingman/voice/stop` — session-scoped narration stop, not process control.

`/shutdown` was the only unguarded one.

## Proof

`HostedShutdownDenyTests` drives a real hosted `GatewayHost` over real HTTP; `OnShutdownRequested` is wired to a recorder that flips a flag **without tearing the host down**, so "the shared Gateway was never asked to shut down" is a direct assertion:

1. `Hosted_shutdown_is_refused_and_the_handler_is_never_reached` — authenticated non-owner device key -> exactly the refusal, handler never reached.
2. `Selfhost_shutdown_still_reaches_the_handler` — control: hosted off, shared token drives a real shutdown through to the handler.

Revert-proof verified (test 1 goes RED when the mapping is pointed back at the ungrouped builder; self-host control stays green).

## Verification
- Gateway build 0/0; Tests build 0/0.
- `HostedShutdownDenyTests` 2/2; solo `Tenancy.HostedRouteDeny*` 20/20; solo `HealthzTenantLeakTests` 2/2.

NOTE: touches `GatewayEndpoints` — serializes at merge with other Gateway-endpoint work.