### PR TITLE
fix(gateway): make the stats retention prune per-tenant on writes

### DIFF
--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -1022,6 +1022,62 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         Assert.Equal(3, Turns(agg.CurrentTotals(TenantB), "typed", "desktop"));
     }
 
+    // ---- Retention prune is PER-PARTITION (H6, same class as the car-mode #1933 global-prune bug) ----
+    //
+    // The retention prune runs inside a caller's per-tenant write transaction. It must archive and delete only
+    // the CALLER'S OWN tenant's expired detail rows. Before the fix every prune statement selected EVERY
+    // tenant older than the cutoff, so one tenant's fold archived+deleted another tenant's old working-day
+    // detail - a caller's write mutating a partition that is not its own. The all-time total survives either
+    // way (the departing rows are archived first), so the LEAK is the lost hourly DETAIL, which HourlyTurns
+    // reads (it excludes the archive marker).
+
+    [Fact]
+    public void OneTenantsFold_DoesNotPruneAnotherTenantsOldDetailRows()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        var now = new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+        var old = now.AddDays(-100); // past the 90-day retention window, relative to "now"
+
+        // Tenant B records a turn 100 days ago. B's own write cannot prune it (B's cutoff is 190 days back),
+        // so B's working-day detail row is present and untouched.
+        agg.Observe(Session("b1", ("typed", "desktop", 4, 80)), nowUtc: old, tenant: TenantB);
+        Assert.Single(agg.HourlyTurns(TenantB));
+
+        // An UNRELATED tenant A folds a fresh turn at "now". Its prune must touch ONLY tenant A's partition.
+        agg.Observe(Session("a1", ("typed", "desktop", 1, 10)), nowUtc: now, tenant: TenantA);
+
+        // B's 100-day-old detail row SURVIVES: A's write pruned A's tenant only. On the pre-fix global prune,
+        // A's write archived+deleted B's old row and B's hourly series dropped to empty - revert-proof.
+        Assert.Single(agg.HourlyTurns(TenantB));
+        Assert.Equal(4, agg.HourlyTurns(TenantB).Single().Turns);
+        // B's all-time total is unaffected in either case (archiving preserves it) - the leak is the DETAIL.
+        Assert.Equal(4, Turns(agg.CurrentTotals(TenantB), "typed", "desktop"));
+    }
+
+    [Fact]
+    public void ATenantsOwnFold_StillPrunesItsOwnExpiredDetail()
+    {
+        // The control for the test above: per-partition retention is still LIVE, not switched off. When the
+        // owning tenant B writes at "now", ITS OWN 100-day-old detail is aged out - proving the seeded row
+        // really is past the window (so the test above is not vacuously green) and that the fix narrowed the
+        // prune's scope without disabling retention.
+        var agg = new GatewayInputStatsAggregator(_path);
+        var now = new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+        var old = now.AddDays(-100);
+
+        agg.Observe(Session("b-old", ("typed", "desktop", 4, 80)), nowUtc: old, tenant: TenantB);
+        Assert.Single(agg.HourlyTurns(TenantB));
+
+        agg.Observe(Session("b-new", ("typed", "desktop", 1, 10)), nowUtc: now, tenant: TenantB);
+
+        // The 100-day-old hour is gone from the detail series; only the fresh hour (1 turn) remains.
+        var hours = agg.HourlyTurns(TenantB);
+        Assert.Single(hours);
+        Assert.Equal(1, hours.Single().Turns);
+        // The archived old turns are still counted in the all-time total: 4 (archived) + 1 (fresh) = 5.
+        Assert.Equal(5, Turns(agg.CurrentTotals(TenantB), "typed", "desktop"));
+    }
+
     [Fact]
     public void TwoTenants_SameSessionId_SameRepo_DoNotCoalesce()
     {

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -772,7 +772,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                 ("$i", Resolve(display, kind)), ("$s", sessionId));
         }
 
-        if (batch.Rows.Count > 0 || batch.TokenRows.Count > 0) PruneLocked(batch.NowUtc, tx);
+        if (batch.Rows.Count > 0 || batch.TokenRows.Count > 0) PruneLocked(tenant, batch.NowUtc, tx);
 
         tx.Commit();
 
@@ -826,7 +826,15 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         }
     }
 
-    // Prune the working-day detail past the retention window. Caller holds the lock.
+    // Prune the working-day detail past the retention window, for ONE tenant only. Caller holds the lock.
+    //
+    // PER-PARTITION (MTR-08, same class as the car-mode #1933 global-prune bug): this runs inside a caller's
+    // per-tenant write transaction, so it archives and deletes ONLY that caller's own tenant's expired rows.
+    // Every statement below is constrained to tenant=$tn - without that, a caller's write would archive and
+    // delete EVERY tenant's rows older than the cutoff, a cross-tenant mutation that violates the invariant
+    // that a caller's write only ever touches its own partition. A quiet tenant's expired detail is reclaimed
+    // when THAT tenant next writes; a global age-sweep, if ever wanted, is a non-caller-triggered background
+    // job, never a side effect of an unrelated tenant's fold.
     //
     // The original prunes only the hourly buckets and the all-time totals survive because they live in
     // separate dictionaries. Here ONE row feeds both, so deleting it would silently shrink the all-time
@@ -834,7 +842,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     // preserving every dimension any all-time answer groups by: modality, surface, is_voice, repository and
     // the wingman flag. Pruning collapses the hour and the session id, and nothing else. agent_delta and
     // agent_driven_delta carry no hour and are never pruned, matching the all-time agent tally.
-    private void PruneLocked(DateTime nowUtc, SqliteTransaction tx)
+    private void PruneLocked(string tenant, DateTime nowUtc, SqliteTransaction tx)
     {
         var cutoff = HourKey(nowUtc.AddDays(-RetentionDays));
         // model_id and checkout_id are carried through the archive fold, and each MUST be in BOTH lists. Left
@@ -854,11 +862,11 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         Execute(@"INSERT INTO stat_delta(tenant, hour_utc, session_id, modality, surface, is_voice, repo_id, checkout_id, model_id, wingman, turns, chars)
                   SELECT tenant, $marker, $marker, modality, surface, is_voice, repo_id, checkout_id, model_id, wingman, SUM(turns), SUM(chars)
                     FROM stat_delta
-                   WHERE hour_utc <> $marker AND hour_utc < $cutoff
+                   WHERE tenant = $tn AND hour_utc <> $marker AND hour_utc < $cutoff
                    GROUP BY tenant, modality, surface, is_voice, repo_id, checkout_id, model_id, wingman", tx,
-            ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
-        Execute("DELETE FROM stat_delta WHERE hour_utc <> $marker AND hour_utc < $cutoff", tx,
-            ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
+            ("$tn", tenant), ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
+        Execute("DELETE FROM stat_delta WHERE tenant = $tn AND hour_utc <> $marker AND hour_utc < $cutoff", tx,
+            ("$tn", tenant), ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
 
         // token_delta prunes on the SAME rule and the same care: its one dimension, model_id, is carried in
         // both the SELECT and the GROUP BY, or the ninety-day fold turns every archived model's spend into
@@ -867,11 +875,11 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         Execute(@"INSERT INTO token_delta(tenant, hour_utc, model_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
                   SELECT tenant, $marker, model_id, SUM(input_tokens), SUM(output_tokens), SUM(cache_read_tokens), SUM(cache_creation_tokens)
                     FROM token_delta
-                   WHERE hour_utc <> $marker AND hour_utc < $cutoff
+                   WHERE tenant = $tn AND hour_utc <> $marker AND hour_utc < $cutoff
                    GROUP BY tenant, model_id", tx,
-            ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
-        Execute("DELETE FROM token_delta WHERE hour_utc <> $marker AND hour_utc < $cutoff", tx,
-            ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
+            ("$tn", tenant), ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
+        Execute("DELETE FROM token_delta WHERE tenant = $tn AND hour_utc <> $marker AND hour_utc < $cutoff", tx,
+            ("$tn", tenant), ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
     }
 
     /// <summary>


### PR DESCRIPTION
## Root cause

`GatewayInputStatsAggregator.CommitLocked` runs inside a single tenant's write transaction (`batch.Tenant`), and at the end it calls the retention prune. Both archive `INSERT ... SELECT` statements and both `DELETE` statements selected **every tenant** whose rows were older than the 90-day cutoff:

```
WHERE hour_utc <> $marker AND hour_utc < $cutoff
```

`tenant` was in the archive `GROUP BY` but never constrained to the writing tenant. So one tenant's stats fold archived and deleted **another tenant's** old working-day detail rows - a caller's write mutating a partition that is not its own. Same class as the car-mode #1933 global-prune bug.

The all-time totals survived (departing rows are folded into archive rows first), so the observable damage was another tenant's hourly detail (`HourlyTurns`) disappearing the moment an unrelated tenant wrote.

## Fix

`PruneLocked` now takes the caller's tenant, and every archive/delete is constrained to `tenant = $tn`. A fold reclaims only its own tenant's expired detail. A quiet tenant's expired rows are reclaimed when that tenant next writes; a global age-sweep, if ever wanted, is a non-caller-triggered background job, never a side effect of an unrelated tenant's fold.

## Reproduced real (verify-first)

- `OneTenantsFold_DoesNotPruneAnotherTenantsOldDetailRows` - tenant B records a turn 100 days ago; an unrelated tenant A folds a fresh turn at "now"; B's 100-day-old detail row must survive. **This test FAILS on the pre-fix global prune** (A's write archived+deleted B's old row) and passes with the fix - revert-proof.
- `ATenantsOwnFold_StillPrunesItsOwnExpiredDetail` - control proving per-partition retention is still live: B's own later write ages out B's own 100-day-old detail, and the archived turns remain in B's all-time total.

## Gates

- Build gateway test project: 0 warnings / 0 errors.
- `GatewayInputStatsAggregatorTests` (full class, 60 tests): pass.
- Solo tenancy filters `OnOneRoute` and `The_roster_and_the_commands_agree`: pass.
- Revert-proof verified: reverting the four `tenant = $tn` clauses reddens the leak test while the control stays green.

Does not touch GatewayHost.cs or GatewayEndpoints.cs.
