### PR TITLE
fix(gateway): deny the turn-brief surface on hosted (MTR gap H5)

### DIFF
--- a/mission/fix-h5.md
+++ b/mission/fix-h5.md
@@ -1,0 +1,84 @@
+# MTR gap H5 - turn-brief surface deny + internal-reader quarantine
+
+Branch `fix/audit-h5-turnbrief`, pull request #1994.
+
+## What H5 is
+
+The Gateway turn-brief store (`GatewayTurnBriefStore`) addresses briefs, explain reports,
+packages, the latest cache, and the feedback corpus by BARE session id under one shared
+directory, with no tenant in any path, file name, or record. Issue #549 retired the only writer,
+so it is legacy read-only data that cannot be attributed to a tenant after the fact. On a hosted
+Gateway the surface leaked and could be overwritten across tenants:
+
+- the six HTTP read/feedback routes served or overwrote another account's material;
+- TWO INTERNAL readers wired in `GatewayHost` embedded a foreign tenant's brief into this
+  caller's plane:
+  - `interruptedBriefFor(sid)` - enriches each `GET /interrupted` row with the store's last
+    RailLine/Headline;
+  - `briefHistoryFor(sid)` - seeds `POST /interrupted/{dir}/{pid}/restore`'s continuation prompt
+    from the store's full brief history.
+
+The honest fix is a DENY + QUARANTINE (the store cannot be partitioned after the fact), matching
+the transcription-analysis (#1897) and recording denies.
+
+## Fix (two parts)
+
+1. ROUTE DENY - the six HTTP routes are refused on hosted through the shared
+   `HostedRouteDeny.Group` per-route primitive in `TurnBriefGatewayEndpoints`. Self-host (one
+   tenant) is byte-identical. Proven revert-proof by `HostedTurnBriefDenyTests` (17 assertions).
+   THIS PART WAS CORRECT AND UNCHANGED.
+
+2. INTERNAL-READER QUARANTINE - the two `GatewayHost` reader lambdas return nothing on hosted:
+   `interruptedBriefFor` returns `(null, null)`, `briefHistoryFor` returns an empty list.
+
+## The Codex CHANGES-NEEDED residual (this increment)
+
+The route-deny half was revert-proof. The two internal-reader guards were NOT: removing both
+built 0/0 and all 17 turn-brief tests still passed, because NO test drove the ACTUAL
+`/interrupted` + restore production path with a seeded foreign-tenant brief. The guards were
+untested.
+
+### Added: `HostedInterruptedBriefQuarantineTests` (+ self-host control)
+
+Drives the REAL production paths - a real hosted `GatewayHost`, a real tunnel-connected
+`FakeTunnelDirector` answering `interrupted-list` / `create` / `patch` over the stream, tenant
+resolved from an authenticated device key - with a foreign brief seeded on disk under the exact
+session id the crash journal reports. The same wire path production uses.
+
+- `The_interrupted_list_is_not_enriched_with_a_foreign_brief_on_hosted` - the row is served (its
+  own Director reported the journal, which proves the fan-out reached `interruptedBriefFor`), and
+  it carries NO foreign RailLine/Headline.
+- `The_restore_prompt_carries_no_foreign_brief_history_on_hosted` - the restore returns 201, and
+  `ContextSent` (the exact continuation prompt) takes the "No turn briefs survived" branch and
+  never embeds the foreign headline / rail line / intent.
+- `SelfHostInterruptedBriefControlTests` proves the SAME paths DO embed the brief off hosted, so
+  the hosted absence is a gate firing, not a route that never carries a brief.
+
+If the Director is absent the fan-out surfaces no row and the restore 502s, so both hosted
+assertions fail loud - no false green.
+
+### Revert-proof (RUN, not described)
+
+In `GatewayHost.cs`, removing EACH guard independently reddens a DISTINCT test with the symptom:
+
+- remove `interruptedBriefFor` guard ->
+  `The_interrupted_list_is_not_enriched_with_a_foreign_brief_on_hosted` FAILS:
+  `Assert.Null() Failure ... Actual: "Another tenant's private headline"`.
+- remove `briefHistoryFor` guard ->
+  `The_restore_prompt_carries_no_foreign_brief_history_on_hosted` FAILS: the continuation prompt
+  embeds the brief state instead of "No turn briefs survived".
+
+Each guard is individually load-bearing. The route-deny was not touched.
+
+## Gates
+
+- `CcDirector.Gateway` + `CcDirector.Gateway.Tests` build 0 warnings / 0 errors.
+- Targeted run - the new interrupted-brief tests, the turn-brief deny + self-host + future-route
+  suites, `GatewayInterruptedTests`, and the two solo tenancy filters
+  (`OnOneRoute_TheCredentialAloneDecidesWhetherATenantScopeExists`,
+  `The_roster_and_the_commands_agree`): 33 passed, 0 failed.
+
+## Merge note
+
+Touches `GatewayHost.cs` (unchanged in this increment - only the test file is new) - serializes
+at merge with other `GatewayHost.cs` work.

--- a/src/CcDirector.Gateway.Tests/HostedInterruptedBriefQuarantineTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedInterruptedBriefQuarantineTests.cs
@@ -1,0 +1,358 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+// ============================================================================
+// MTR audit gap H5 - the TWO INTERNAL readers of the untenanted turn-brief store are QUARANTINED on hosted.
+//
+// The deny in TurnBriefGatewayEndpoints (HostedTurnBriefDenyTests) closes the HTTP surface, but the same
+// bare-session-id store is also read by two INTERNAL callers wired in GatewayHost:
+//   - interruptedBriefFor(sid) - enriches each GET /interrupted row with the store's last RailLine/Headline;
+//   - briefHistoryFor(sid)     - seeds POST /interrupted/{dir}/{pid}/restore's continuation prompt from the
+//                                store's full brief history.
+// Both key on BARE session id with no tenant, so on a hosted box a brief left under a session id (issue #549
+// retired the writer, so it is legacy data attributable to no tenant) would be embedded into THIS caller's
+// Interrupted list and into a NEW continuation session's first prompt. The GatewayHost wiring quarantines
+// both on hosted - interruptedBriefFor returns (null, null), briefHistoryFor returns an empty list.
+//
+// These two classes drive the REAL production paths (a real hosted GatewayHost, a real tunnel-connected
+// Director answering interrupted-list / create / patch over the stream) with a foreign brief seeded on disk
+// under the exact session id the crash journal reports - the same wire path production uses. The self-host
+// control proves the same paths DO embed the brief off hosted, so the hosted absence is a gate firing, not a
+// route that never carries a brief. Without a running Director the fan-out surfaces no row and the restore
+// 502s, so both hosted assertions fail loud (no false green) if the path never reaches the store at all.
+//
+// REVERT-PROOF - the recipe to RUN, not describe. In src/CcDirector.Gateway/GatewayHost.cs remove the two
+// hosted guards so the readers serve the untenanted store on hosted too:
+//   interruptedBriefFor: sid => { var b = _turnBriefStore.Latest(sid); return (b?.NeedsYou?.RailLine, b?.Headline); }
+//   briefHistoryFor:     sid => _turnBriefStore.List(sid)
+// Rebuild, CONFIRM ZERO ERRORS (a run after a failed build executes the previous binary and reports a false
+// pass), then run this file and record every red BY NAME:
+//   - The_interrupted_list_is_not_enriched_with_a_foreign_brief_on_hosted reddens: the row's Headline/RailLine
+//     become the seeded foreign text ("expected null, got 'Another tenant's private headline'");
+//   - The_restore_prompt_carries_no_foreign_brief_history_on_hosted reddens: ContextSent embeds
+//     "Headline: Another tenant's private headline" instead of taking the "No turn briefs survived" branch.
+// A red only counts if it fails WITH THE SYMPTOM - the disclosed foreign text - not a crash.
+// ============================================================================
+[Collection("GatewayHostedMode")]
+public sealed class HostedInterruptedBriefQuarantineTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    // Legacy brief text left in the untenanted store under a bare session id, from BEFORE #549 retired the
+    // writer. It belongs to no tenant this hosted caller can be shown.
+    private const string ForeignHeadline = "Another tenant's private headline";
+    private const string ForeignRailLine = "another tenant's private rail line";
+    private const string ForeignIntent = "another tenant's private mission";
+
+    private const string DeadDir = "dead-1";
+    private const int DeadPid = 9001;
+    // The interrupted session id the caller's OWN Director reports - and, by coincidence of the store's only
+    // key being the bare session id, also the id a foreign brief sits under on disk.
+    private static readonly string Sid = "restored-" + Guid.NewGuid().ToString("N")[..8];
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private FakeTunnelDirector _dir = null!;
+    private string _key = "";
+    private string? _lastCreatePrePrompt;
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-interrupted-tb-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            turnBriefDirectory: Path.Combine(_instancesDir, "gateway-turnbriefs"),
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // A hosted caller resolves its tenant from an authenticated device key (bound to a real GUID tenant,
+        // as production mints them). Without it every read route 403s with no bound tenant.
+        _key = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", "55555555-5555-5555-5555-555555555555");
+
+        // The caller's OWN live Director, tunnel-connected under that device key's tenant. It reports the crash
+        // journal (interrupted-list) and answers the restore continuation verbs (create + patch).
+        _dir = await FakeTunnelDirector.StartAsync(_gateway, _key, "live-a", "MA", dispatch: Dispatch);
+
+        // Legacy untenanted brief on disk under the bare session id the journal reports. A read that is NOT
+        // quarantined has real foreign material to hand back.
+        _gateway.TurnBriefs.Append(Sid, new TurnBriefDto
+        {
+            SessionId = Sid,
+            TurnNumber = 3,
+            Headline = ForeignHeadline,
+            Intent = ForeignIntent,
+            NeedsYou = new TurnBriefNeedsYou { Statement = "pending decision", RailLine = ForeignRailLine },
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _dir.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch (Exception) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task The_interrupted_list_is_not_enriched_with_a_foreign_brief_on_hosted()
+    {
+        // The row IS served - the caller's own Director reported the journal, which proves the fan-out reached
+        // interruptedBriefFor for this id. On hosted the enrichment is quarantined: no foreign RailLine/Headline.
+        var row = (await GetInterrupted()).Single(r => r.SessionId == Sid);
+
+        Assert.Null(row.Headline);
+        Assert.Null(row.RailLine);
+        var raw = JsonSerializer.Serialize(row);
+        Assert.DoesNotContain(ForeignHeadline, raw, StringComparison.Ordinal);
+        Assert.DoesNotContain(ForeignRailLine, raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task The_restore_prompt_carries_no_foreign_brief_history_on_hosted()
+    {
+        var resp = await _http.SendAsync(Post($"interrupted/{DeadDir}/{DeadPid}/restore",
+            new RestoreInterruptedRequest { SessionId = Sid, Via = _dir.DirectorId }));
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+
+        var body = await resp.Content.ReadFromJsonAsync<RestoreInterruptedResponse>();
+        Assert.NotNull(body);
+        Assert.True(body!.Restored);
+
+        // ContextSent is the exact continuation prompt seeded into the new session. On hosted briefHistoryFor
+        // is empty, so it takes the "no briefs survived" branch and never embeds the foreign brief. A positive
+        // branch assertion (not absence alone) proves the empty-history path was actually taken.
+        var context = body.ContextSent ?? "";
+        Assert.Contains("No turn briefs survived", context, StringComparison.Ordinal);
+        Assert.DoesNotContain(ForeignHeadline, context, StringComparison.Ordinal);
+        Assert.DoesNotContain(ForeignRailLine, context, StringComparison.Ordinal);
+        Assert.DoesNotContain(ForeignIntent, context, StringComparison.Ordinal);
+
+        // Belt and braces: the prompt actually handed to the Director over the tunnel (create verb) is the
+        // same text, and it too is clean.
+        Assert.NotNull(_lastCreatePrePrompt);
+        Assert.DoesNotContain(ForeignHeadline, _lastCreatePrePrompt!, StringComparison.Ordinal);
+    }
+
+    private DirectorCommandResult Dispatch(DirectorCommand cmd)
+    {
+        switch (cmd.Verb)
+        {
+            case "interrupted-list":
+                return FakeTunnelDirector.Ok(new[] { Journal() });
+            case "create":
+                var req = JsonSerializer.Deserialize<NewSessionRequest>(cmd.PayloadJson, FakeTunnelDirector.WebJson);
+                _lastCreatePrePrompt = req?.PrePrompt;
+                return FakeTunnelDirector.Ok(new SessionDto { SessionId = "new-1", RepoPath = req?.RepoPath ?? "" });
+            case "patch":
+                var pr = JsonSerializer.Deserialize<SessionUpdateRequest>(cmd.PayloadJson, FakeTunnelDirector.WebJson);
+                return FakeTunnelDirector.Ok(new SessionDto { SessionId = cmd.SessionId, Name = pr?.Name });
+            case "interrupted-remove":
+                return FakeTunnelDirector.Ok(new { removed = true });
+            default:
+                return FakeTunnelDirector.Ok(new { ok = true });
+        }
+    }
+
+    private static CrashJournalDto Journal() => new()
+    {
+        DirectorId = DeadDir,
+        Pid = DeadPid,
+        MachineName = "MA",
+        User = "alice",
+        LastUpdatedUtc = DateTimeOffset.UtcNow.AddMinutes(-5),
+        Sessions =
+        {
+            new CrashJournalSessionDto
+            {
+                SessionId = Sid, Name = "alpha work", RepoPath = "/repo/a", ClaudeSessionId = "claude-abc",
+            },
+        },
+    };
+
+    private async Task<List<InterruptedSessionDto>> GetInterrupted()
+    {
+        var resp = await _http.SendAsync(Get("interrupted"));
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        return (await resp.Content.ReadFromJsonAsync<List<InterruptedSessionDto>>()) ?? new();
+    }
+
+    private HttpRequestMessage Get(string path) => Authed(new HttpRequestMessage(HttpMethod.Get, path));
+
+    private HttpRequestMessage Post(string path, object body)
+    {
+        var req = Authed(new HttpRequestMessage(HttpMethod.Post, path));
+        req.Content = JsonContent.Create(body);
+        return req;
+    }
+
+    private HttpRequestMessage Authed(HttpRequestMessage req)
+    {
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        return req;
+    }
+
+    private static int FreePort()
+    {
+        var l = new TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        try { return ((IPEndPoint)l.LocalEndpoint).Port; } finally { l.Stop(); }
+    }
+}
+
+/// <summary>
+/// THE SELF-HOST CONTROL for the two internal brief readers. Self-host is the mission's control: the same
+/// interrupted-list enrichment and restore continuation-prompt build DO embed the brief off hosted, so the
+/// hosted absence proven above is a gate firing rather than a path that never carries a brief. This drives the
+/// same real GatewayHost + tunnel Director path with CC_GATEWAY_HOSTED explicitly NOT hosted (auth is by the
+/// shared token, and the tenant resolves to Local), asserts REAL PRESENCE of the seeded headline and rail line,
+/// and must stay GREEN through the revert described on HostedInterruptedBriefQuarantineTests.
+/// </summary>
+[Collection("GatewayHostedMode")]
+public sealed class SelfHostInterruptedBriefControlTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string OwnHeadline = "The owner's own headline";
+    private const string OwnRailLine = "the owner's own rail line";
+
+    private const string DeadDir = "dead-1";
+    private const int DeadPid = 9001;
+    private static readonly string Sid = "restored-" + Guid.NewGuid().ToString("N")[..8];
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private FakeTunnelDirector _dir = null!;
+    private string? _lastCreatePrePrompt;
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-interrupted-tb-self-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        // Explicitly NOT hosted, and prove the statement took.
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "0");
+        Assert.False(GatewayHostedMode.IsHosted);
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            turnBriefDirectory: Path.Combine(_instancesDir, "gateway-turnbriefs"),
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        _dir = await FakeTunnelDirector.StartAsync(_gateway, Token, "live-a", "MA", dispatch: Dispatch);
+
+        _gateway.TurnBriefs.Append(Sid, new TurnBriefDto
+        {
+            SessionId = Sid,
+            TurnNumber = 3,
+            Headline = OwnHeadline,
+            Intent = "the owner's mission",
+            NeedsYou = new TurnBriefNeedsYou { Statement = "pending", RailLine = OwnRailLine },
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _dir.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch (Exception) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task The_interrupted_list_is_enriched_with_the_owners_brief_on_self_host()
+    {
+        var row = (await _http.GetFromJsonAsync<List<InterruptedSessionDto>>("interrupted"))!
+            .Single(r => r.SessionId == Sid);
+
+        Assert.Equal(OwnHeadline, row.Headline);
+        Assert.Equal(OwnRailLine, row.RailLine);
+    }
+
+    [Fact]
+    public async Task The_restore_prompt_carries_the_owners_brief_history_on_self_host()
+    {
+        var resp = await _http.PostAsJsonAsync($"interrupted/{DeadDir}/{DeadPid}/restore",
+            new RestoreInterruptedRequest { SessionId = Sid, Via = _dir.DirectorId });
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+
+        var body = await resp.Content.ReadFromJsonAsync<RestoreInterruptedResponse>();
+        var context = body!.ContextSent ?? "";
+        Assert.Contains($"Headline: {OwnHeadline}", context, StringComparison.Ordinal);
+        Assert.NotNull(_lastCreatePrePrompt);
+        Assert.Contains(OwnHeadline, _lastCreatePrePrompt!, StringComparison.Ordinal);
+    }
+
+    private DirectorCommandResult Dispatch(DirectorCommand cmd)
+    {
+        switch (cmd.Verb)
+        {
+            case "interrupted-list":
+                return FakeTunnelDirector.Ok(new[] { Journal() });
+            case "create":
+                var req = JsonSerializer.Deserialize<NewSessionRequest>(cmd.PayloadJson, FakeTunnelDirector.WebJson);
+                _lastCreatePrePrompt = req?.PrePrompt;
+                return FakeTunnelDirector.Ok(new SessionDto { SessionId = "new-1", RepoPath = req?.RepoPath ?? "" });
+            case "patch":
+                var pr = JsonSerializer.Deserialize<SessionUpdateRequest>(cmd.PayloadJson, FakeTunnelDirector.WebJson);
+                return FakeTunnelDirector.Ok(new SessionDto { SessionId = cmd.SessionId, Name = pr?.Name });
+            case "interrupted-remove":
+                return FakeTunnelDirector.Ok(new { removed = true });
+            default:
+                return FakeTunnelDirector.Ok(new { ok = true });
+        }
+    }
+
+    private static CrashJournalDto Journal() => new()
+    {
+        DirectorId = DeadDir,
+        Pid = DeadPid,
+        MachineName = "MA",
+        User = "owner",
+        LastUpdatedUtc = DateTimeOffset.UtcNow.AddMinutes(-5),
+        Sessions =
+        {
+            new CrashJournalSessionDto
+            {
+                SessionId = Sid, Name = "alpha work", RepoPath = "/repo/a", ClaudeSessionId = "claude-abc",
+            },
+        },
+    };
+
+    private static int FreePort()
+    {
+        var l = new TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        try { return ((IPEndPoint)l.LocalEndpoint).Port; } finally { l.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedTurnBriefDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedTurnBriefDenyTests.cs
@@ -1,0 +1,444 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Briefing;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+// ============================================================================
+// MTR audit gap H5 - the turn-brief surface is DENIED IN WHOLE on the hosted Gateway.
+//
+// The store behind these routes (GatewayTurnBriefStore) addresses briefs, explain reports,
+// packages and feedback by BARE session id under one shared directory, with no tenant in any
+// path, file name, or record. The read routes resolve NO tenant and prove NO session ownership,
+// and POST feedback overwrites a caller-named record without proving ownership. Issue #549 retired
+// the only writer, so the store is legacy read-only data that cannot be attributed to a tenant
+// after the fact - which is why the fix is a DENY (quarantine-not-serve), not a half-partition.
+//
+// The reproduction is faithful because these routes carry no tenant awareness at all: whatever a
+// PRIOR account left under bare session id S is exactly what ANY hosted caller receives for S. The
+// self-host control class proves the same routes really serve that data (so the hosted 404 is a
+// gate firing, not a route that never existed), and the same feedback POST really overwrites a
+// record (so the hosted survival assertion is a capable operation being stopped).
+//
+// REVERT-PROOF - the recipe to RUN, not describe. In
+// src/CcDirector.Gateway/Api/TurnBriefGatewayEndpoints.cs change
+//   var group = HostedRouteDeny.Group(app, "", Denial());
+// so the family maps its real handlers on hosted too - the simplest such mutation returns an
+// unguarded group (e.g. build a HostedDenyGroup that maps handlers regardless of mode, or map the
+// handlers on `app` directly). Rebuild, CONFIRM ZERO ERRORS (a run after a failed build executes the
+// previous binary and reports a false pass), then run this file and record every red BY NAME:
+// Every_turnbrief_route_is_refused flips to "expected NotFound, got OK", and
+// The_refused_feedback_did_not_overwrite_the_seeded_record reddens because the seeded vote/reason is
+// really changed. A red only counts if it fails WITH THE SYMPTOM - an assertion naming what was
+// served or changed - not a crash.
+// ============================================================================
+[Collection("DirectorRoot")]
+public sealed class HostedTurnBriefDenyTests : IAsyncLifetime
+{
+    internal const string RefusalMessage = TurnBriefGatewayEndpoints.RefusalMessage;
+
+    // A session id that "tenant B" produced briefs/feedback under, before the writer was retired.
+    private static readonly string SeededSid = Guid.NewGuid().ToString();
+    private const string SeededHeadline = "Another tenant's private headline";
+    private const string SeededReason = "another tenant wrote this reason";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _briefsDir;
+    private string? _priorHosted;
+
+    private GatewayTurnBriefStore _store = null!;
+    private WebApplication _app = null!;
+    private HttpClient _http = null!;
+    private string _seededFeedbackFile = "";
+
+    public HostedTurnBriefDenyTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-hosted-tb-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        _briefsDir = Path.Combine(_root, "gateway-turnbriefs");
+    }
+
+    public async Task InitializeAsync()
+    {
+        // EXPLICIT, not ambient: this class asserts hosted behaviour, so it states hosted mode itself and
+        // proves the statement took, rather than inheriting whatever the runner happened to leave set.
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+
+        // Legacy data from BEFORE the deny: a real brief and a real feedback record under bare session id,
+        // seeded through the production store so a read that WRONGLY got through would have something real
+        // to hand back and a write would have a real record to overwrite. A deny tested against an empty
+        // store proves nothing.
+        _store = new GatewayTurnBriefStore(_briefsDir);
+        _store.Append(SeededSid, new TurnBriefDto
+        {
+            SessionId = SeededSid, TurnNumber = 3, Headline = SeededHeadline, Intent = "intent",
+        });
+        var seeded = _store.SaveFeedback(SeededSid,
+            new TurnBriefDto { SessionId = SeededSid, TurnNumber = 3, Headline = SeededHeadline },
+            "up", SeededReason);
+        _seededFeedbackFile = seeded.File;
+
+        (_app, _http) = await TurnBriefProbeHost.StartAsync(_store);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _app.DisposeAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch (Exception) { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Every production route in the group, in one theory. Every verb is here, because the feedback POST is
+    /// the tampering half of this defect and a deny that closed only the value-returning reads would leave
+    /// the overwrite path open. The last row is a verb the group NEVER mapped on a mapped path - the
+    /// verb-less refusal must answer it too rather than leaking the route's existence through a 405.
+    /// </summary>
+    [Theory]
+    [InlineData("GET", "sessions/{S}/turnbriefs", null)]
+    [InlineData("GET", "sessions/{S}/turnbriefs/latest", null)]
+    [InlineData("POST", "sessions/{S}/turnbriefs/feedback", "{\"turnNumber\":3,\"vote\":\"down\"}")]
+    [InlineData("GET", "turnbriefs/feedback", null)]
+    [InlineData("POST", "sessions/{S}/explain", null)]
+    [InlineData("GET", "sessions/{S}/explain/latest", null)]
+    [InlineData("DELETE", "sessions/{S}/turnbriefs", null)] // a verb the group never mapped
+    public async Task Every_turnbrief_route_is_refused(string method, string path, string? body)
+    {
+        var resp = await Send(new HttpMethod(method), path.Replace("{S}", SeededSid), body);
+        await AssertBodyIsNothingButTheRefusal(resp);
+    }
+
+    [Fact]
+    public async Task The_refused_list_did_not_disclose_the_seeded_brief()
+    {
+        // Refuse, never serve an empty list: an empty "items" array is a FALSE statement about a session that
+        // has a brief on disk, where an absent one is merely absent. The exact-property assertion proves there
+        // is no items array at all, and the headline of another tenant's brief never appears.
+        var resp = await Send(HttpMethod.Get, $"sessions/{SeededSid}/turnbriefs");
+        Assert.DoesNotContain(SeededHeadline, await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        await AssertBodyIsNothingButTheRefusal(resp);
+    }
+
+    [Fact]
+    public async Task The_refused_feedback_list_did_not_disclose_the_corpus()
+    {
+        // /turnbriefs/feedback enumerates EVERY feedback file with no tenant filter - the disclosure half of
+        // the defect. On hosted it is refused and the seeded reason never appears.
+        var resp = await Send(HttpMethod.Get, "turnbriefs/feedback");
+        Assert.DoesNotContain(SeededReason, await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        Assert.DoesNotContain(SeededSid, await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        await AssertBodyIsNothingButTheRefusal(resp);
+    }
+
+    [Fact]
+    public async Task The_refused_feedback_did_not_overwrite_the_seeded_record()
+    {
+        // The tampering path: POST feedback takes a caller-supplied feedbackId, turns it into the shared
+        // filename, and rewrites the record's vote/reason with no ownership proof. Here the caller names the
+        // seeded record and tries to flip it to a down-vote with hijacked text. On hosted the refusal
+        // short-circuits before SaveFeedback runs, so the record on disk still reads exactly as seeded.
+        var seededId = Path.GetFileNameWithoutExtension(_seededFeedbackFile);
+        var resp = await Send(HttpMethod.Post, $"sessions/{SeededSid}/turnbriefs/feedback",
+            $"{{\"turnNumber\":3,\"vote\":\"down\",\"note\":\"hijacked\",\"feedbackId\":\"{seededId}\"}}");
+        await AssertBodyIsNothingButTheRefusal(resp);
+
+        // Read the store back: the seeded record must be untouched.
+        Assert.True(File.Exists(_seededFeedbackFile), "the seeded feedback file must survive a refused POST");
+        using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(_seededFeedbackFile));
+        Assert.Equal("up", doc.RootElement.GetProperty("vote").GetString());
+        Assert.Equal(SeededReason, doc.RootElement.GetProperty("reason").GetString());
+    }
+
+    private Task<HttpResponseMessage> Send(HttpMethod method, string path, string? body = null)
+    {
+        var req = new HttpRequestMessage(method, path);
+        if (body is not null)
+            req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return _http.SendAsync(req);
+    }
+
+    /// <summary>
+    /// AN ALLOW-LIST, NOT A DENY-LIST, and FORMAT FACTS BEFORE PARSING. Asserting the property set is EXACTLY
+    /// one error field inverts a rotting deny-list: anything that leaked reddens automatically. The status and
+    /// media type are asserted FIRST so a revert reddens as a STATEMENT - "expected NotFound, got OK" - rather
+    /// than as a parser exception on a non-JSON body.
+    /// </summary>
+    internal static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp)
+    {
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+
+        var properties = doc.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Equal(new[] { "error" }, properties);
+        Assert.Equal(RefusalMessage, doc.RootElement.GetProperty("error").GetString());
+    }
+}
+
+/// <summary>
+/// Boots ONLY the turn-brief endpoint group on an ephemeral port and hands the caller the store it reads
+/// plus the denied group handle back, so a test can seed data, drive the routes, and map a future route
+/// through the returned handle. There is no auth middleware here on purpose: these routes carry no auth of
+/// their own (the host-wide token gate does), so the mode gate in the route MAPPING is exactly what this
+/// harness isolates.
+/// </summary>
+internal static class TurnBriefProbeHost
+{
+    public static async Task<(WebApplication app, HttpClient http)> StartAsync(
+        GatewayTurnBriefStore store,
+        Action<HostedDenyGroup>? mapIntoGroup = null,
+        Action<IEndpointRouteBuilder>? mapOutsideGroup = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        var group = TurnBriefGatewayEndpoints.Map(app, store, _ => "None", requestExplainAsync: null);
+        mapIntoGroup?.Invoke(group);
+        mapOutsideGroup?.Invoke(app);
+
+        await app.StartAsync();
+        var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+        return (app, http);
+    }
+
+    public static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp)
+    {
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var properties = doc.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Equal(new[] { "error" }, properties);
+        Assert.Equal(HostedTurnBriefDenyTests.RefusalMessage, doc.RootElement.GetProperty("error").GetString());
+    }
+}
+
+/// <summary>
+/// THE SELF-HOST CONTROL, in BOTH non-hosted forms, with real payloads and real effects.
+///
+/// Self-host is the control for this whole mission, so it is PROVEN rather than INHERITED. This class sets
+/// CC_GATEWAY_HOSTED itself, to both non-hosted values that occur in practice - absent, and
+/// present-but-not-"1" - and asserts the mode took before driving anything. It asserts REAL PAYLOADS AND REAL
+/// EFFECTS, not the absence of the refusal string: an empty-but-successful response would satisfy "the
+/// refusal is absent" while still being a broken self-host. It also carries the CAPABILITY CONTROL for the
+/// hosted survival assertion: the same feedback POST that is refused on hosted really overwrites the record
+/// here. Every test here must stay GREEN through the revert described on HostedTurnBriefDenyTests.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class SelfHostTurnBriefControlTests : IDisposable
+{
+    private static readonly string Sid = Guid.NewGuid().ToString();
+    private const string Headline = "The owner's own headline";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _briefsDir;
+    private readonly string? _priorHosted;
+
+    public SelfHostTurnBriefControlTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-selfhost-tb-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        _briefsDir = Path.Combine(_root, "gateway-turnbriefs");
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch (Exception) { /* best effort */ }
+    }
+
+    private static void DeclareSelfHost(string? value)
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", value);
+        Assert.False(GatewayHostedMode.IsHosted);
+    }
+
+    /// <summary>null = absent. "0" = present and explicitly not hosted. Both are real non-hosted deployments.</summary>
+    public static TheoryData<string?> NonHostedValues => new() { null, "0" };
+
+    /// <summary>HANDLER-POSITIVE RECEIPT for the list route: the route really exists and really answers with
+    /// the owner's brief. A 404 deny is indistinguishable from a route that was never mapped, so without a
+    /// receipt like this the hosted 404 would prove nothing about a gate.</summary>
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task The_owner_still_reads_his_brief_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+        var store = new GatewayTurnBriefStore(_briefsDir);
+        store.Append(Sid, new TurnBriefDto { SessionId = Sid, TurnNumber = 1, Headline = Headline, Intent = "i" });
+
+        var (app, http) = await TurnBriefProbeHost.StartAsync(store);
+        try
+        {
+            var resp = await http.GetAsync($"sessions/{Sid}/turnbriefs");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            var headlines = doc.RootElement.GetProperty("items").EnumerateArray()
+                .Select(e => e.GetProperty("headline").GetString()).ToArray();
+            Assert.Contains(Headline, headlines);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>CAPABILITY CONTROL for the hosted survival assertion: the same feedback POST really overwrites
+    /// the record on self-host. The hosted test asserts a seeded record SURVIVES a refused POST; that claim is
+    /// only meaningful if the same operation is CAPABLE of changing it.</summary>
+    [Theory]
+    [MemberData(nameof(NonHostedValues))]
+    public async Task The_same_feedback_post_overwrites_the_record_on_self_host(string? hostedValue)
+    {
+        DeclareSelfHost(hostedValue);
+        var store = new GatewayTurnBriefStore(_briefsDir);
+        store.Append(Sid, new TurnBriefDto { SessionId = Sid, TurnNumber = 1, Headline = Headline });
+        var seeded = store.SaveFeedback(Sid, new TurnBriefDto { SessionId = Sid, TurnNumber = 1 }, "up", "original");
+        var seededId = Path.GetFileNameWithoutExtension(seeded.File);
+
+        var (app, http) = await TurnBriefProbeHost.StartAsync(store);
+        try
+        {
+            var resp = await http.PostAsync($"sessions/{Sid}/turnbriefs/feedback", new StringContent(
+                $"{{\"turnNumber\":1,\"vote\":\"down\",\"note\":\"changed\",\"feedbackId\":\"{seededId}\"}}",
+                Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(seeded.File));
+            Assert.Equal("down", doc.RootElement.GetProperty("vote").GetString());
+            Assert.Equal("changed", doc.RootElement.GetProperty("reason").GetString());
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+}
+
+/// <summary>
+/// THE POINT OF THE PER-ROUTE DENY: the hosted refusal covers routes not written yet. A guard line repeated
+/// in every handler passes exactly the same tests as this deny for the routes that exist today - the
+/// difference only shows on the route somebody adds NEXT. So this maps a BRAND-NEW route through the group
+/// handle and asserts it is already refused on hosted with no deny of its own, and the self-host mirror shows
+/// the same route SERVES off hosted - one direction alone cannot tell a working gate from a brick that
+/// refuses everything.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class TurnBriefGroupFutureRouteTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string? _priorHosted;
+
+    public TurnBriefGroupFutureRouteTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-tb-future-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch (Exception) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task A_route_added_to_the_group_later_is_refused_on_hosted()
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+        var store = new GatewayTurnBriefStore(Path.Combine(_root, "gateway-turnbriefs"));
+
+        var (app, http) = await TurnBriefProbeHost.StartAsync(store,
+            mapIntoGroup: group => group.MapPost("/turnbriefs/added-after-the-deny",
+                (FutureBody body) => Results.Json(new { echoed = body.Text })),
+            mapOutsideGroup: routes => routes.MapPost("/undenied-equivalent",
+                (FutureBody body) => Results.Json(new { echoed = body.Text })));
+        try
+        {
+            // Every shape meets the refusal: a valid body, a malformed body, a wrong media type, and a verb
+            // the route never mapped.
+            foreach (var resp in new[]
+                     {
+                         await http.PostAsync("/turnbriefs/added-after-the-deny",
+                             new StringContent("{\"text\":\"hi\"}", Encoding.UTF8, "application/json")),
+                         await http.PostAsync("/turnbriefs/added-after-the-deny",
+                             new StringContent("{ not json", Encoding.UTF8, "application/json")),
+                         await http.PostAsync("/turnbriefs/added-after-the-deny",
+                             new StringContent("hi", Encoding.UTF8, "text/plain")),
+                         await http.GetAsync("/turnbriefs/added-after-the-deny"),
+                     })
+            {
+                await TurnBriefProbeHost.AssertBodyIsNothingButTheRefusal(resp);
+                Assert.DoesNotContain("echoed", await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+            }
+
+            // FRAMEWORK-400 CONTROL: the identical malformed body reaches the framework's own 400 on the
+            // undenied equivalent, so the denied route short-circuits BEFORE framework binding.
+            var undeniedMalformed = await http.PostAsync("/undenied-equivalent",
+                new StringContent("{ not json", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.BadRequest, undeniedMalformed.StatusCode);
+
+            // FRAMEWORK-415 CONTROL: a wrong media type reaches the framework's own 415 on the undenied
+            // equivalent, so the denied route's wrong-media refusal short-circuits BEFORE endpoint selection.
+            var undeniedWrongMedia = await http.PostAsync("/undenied-equivalent",
+                new StringContent("hi", Encoding.UTF8, "text/plain"));
+            Assert.Equal(HttpStatusCode.UnsupportedMediaType, undeniedWrongMedia.StatusCode);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    [Theory]
+    [MemberData(nameof(SelfHostTurnBriefControlTests.NonHostedValues), MemberType = typeof(SelfHostTurnBriefControlTests))]
+    public async Task A_route_added_to_the_group_still_serves_on_self_host(string? hostedValue)
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hostedValue);
+        Assert.False(GatewayHostedMode.IsHosted);
+        var store = new GatewayTurnBriefStore(Path.Combine(_root, "gateway-turnbriefs"));
+
+        var (app, http) = await TurnBriefProbeHost.StartAsync(store,
+            mapIntoGroup: group => group.MapPost("/turnbriefs/added-after-the-deny",
+                (FutureBody body) => Results.Json(new { echoed = body.Text })));
+        try
+        {
+            var served = await http.PostAsync("/turnbriefs/added-after-the-deny",
+                new StringContent("{\"text\":\"hi\"}", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.OK, served.StatusCode);
+            using var doc = JsonDocument.Parse(await served.Content.ReadAsStringAsync());
+            Assert.Equal("hi", doc.RootElement.GetProperty("echoed").GetString());
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    /// <summary>The future route's body, bound by the FRAMEWORK, so a malformed body off hosted reaches the
+    /// framework's own 400 and the hosted refusal is proven to short-circuit before that binding.</summary>
+    internal sealed record FutureBody(string Text);
+}

--- a/src/CcDirector.Gateway/Api/TurnBriefGatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/TurnBriefGatewayEndpoints.cs
@@ -1,5 +1,7 @@
+using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Briefing;
 using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -27,14 +29,107 @@ namespace CcDirector.Gateway.Api;
 /// no caller has ever received that, because neither the state nor the 202 is producible. The roster's
 /// matching orange rule has been deleted for the same reason - see the tombstone in
 /// <c>SessionOrdering.EffectiveColor</c>. Re-enabling the deep dive is a feature, not a repair.
+///
+/// DENIED IN WHOLE ON HOSTED (MTR audit gap H5). Every route in this file is refused on the hosted
+/// Gateway. The store behind them (<see cref="GatewayTurnBriefStore"/>) addresses briefs, explain
+/// reports, packages and feedback by BARE session id under one shared directory, with no tenant in any
+/// path, file name, or record. On a hosted box those legacy files hold whatever any account produced
+/// while the writer still existed, mixed together with nothing to tell them apart - and none of these
+/// read routes resolves the request tenant or proves the requested session belongs to it, so tenant A
+/// calling <c>/sessions/{S}/turnbriefs</c>, <c>/latest</c>, <c>/explain/latest</c>, or listing
+/// <c>/turnbriefs/feedback</c> receives tenant B's material. <c>POST .../feedback</c> is worse: it takes
+/// a caller-supplied feedback id, turns it straight into the shared filename, and overwrites an existing
+/// record's vote/reason without proving ownership.
+///
+/// IT IS A DENY, NOT A PARTITION, because there is nothing left to partition INTO. Issue #549 retired the
+/// only writer (GatewayTurnBriefAgent), so no new brief is ever produced - the store is read-only-serving
+/// legacy data. Records written with no tenant on them cannot be attributed after the fact, so a
+/// per-tenant answer would have to be INVENTED rather than read; that is a half-partition, which reads
+/// like isolation while being a guess. The honest move is to refuse and quarantine, exactly as the
+/// transcription-analysis deny (#1897) and the recording deny did for their untenanted shared stores.
+///
+/// IT REFUSES rather than returning an empty result: an empty brief list is a FALSE statement (it says
+/// "no brief was ever produced for this session", which need not be true), whereas a refusal is merely an
+/// absent answer. The two internal readers of this same store - the Interrupted-list rail-line enrichment
+/// and the restore continuation-prompt history - are separately quarantined on hosted at their wiring in
+/// <c>GatewayHost</c> (they return nothing on hosted), so no foreign brief text is embedded into a
+/// tenant's Interrupted list or a new continuation prompt.
+///
+/// HOW THE DENY IS EXPRESSED - THE SHARED REFUSAL PRIMITIVE. This group is denied through
+/// <see cref="HostedRouteDeny.Group"/> (PER-ROUTE), the ONE hosted-refusal boundary every deny family on
+/// this Gateway adopts (reference adoption: the transcription-analysis deny in
+/// <see cref="TranscriptionAnalysisEndpoint"/>). Per-route, NOT <see cref="HostedRouteDeny.ExclusiveGroup"/>,
+/// because these paths sit under <c>/sessions/{sid}/...</c> and <c>/turnbriefs</c> - prefixes that carry
+/// many LIVE routes which must keep serving on hosted, so an exclusive catch-all would take them off the
+/// air. On hosted the six handlers are NEVER MAPPED; in their place a verb-less refusal is mapped on each
+/// route shape, so EVERY request shape (a valid request, a wrong media type, a verb the group never
+/// mapped, and a route added LATER through the returned handle) meets the refusal rather than being
+/// answered by the framework ahead of it. Off hosted the primitive maps the six real handlers exactly as
+/// an unguarded builder would and creates no refusal at all, so self-host - one tenant, whose shared store
+/// holds only the owner's own briefs - is byte-identical to before.
 /// </summary>
 internal static class TurnBriefGatewayEndpoints
 {
-    public static void Map(
+    /// <summary>The single error string the hosted refusal serves. Held here so a test can assert against
+    /// the exact string that is served rather than a copy that could drift.</summary>
+    internal const string RefusalMessage = "turn briefs are not available on the hosted gateway";
+
+    /// <summary>
+    /// The hosted refusal payload for the whole turn-brief group (MTR gap H5). Validated on construction,
+    /// so a blank field fails the Gateway at startup rather than serving a refusal a caller cannot act on.
+    /// 404 rather than 403: on hosted this surface does not exist as a concept - there is no per-tenant
+    /// brief store for it to read - so "not here" is the truthful answer; 403 would imply the right
+    /// credential could reach it, and none can.
+    /// </summary>
+    private static HostedDenial Denial() => new(
+        family: "turn-briefs",
+        message: RefusalMessage,
+        reason: "the turn-brief store addresses briefs, explain reports, packages and feedback by bare " +
+                "session id under one shared directory with no tenant in any path, file name, or record, so " +
+                "on a hosted box its legacy files hold what every account produced with nothing to tell them " +
+                "apart - and no read route resolves the request tenant or proves session ownership, while the " +
+                "feedback POST overwrites a caller-named record without proving ownership",
+        unDenyInstruction: "do NOT simply remove this deny. The writer was already retired in #549 so nothing " +
+                "new accumulates, but a shared, untenanted legacy store (gateway-turnbriefs briefs/explain/" +
+                "packages plus the BriefFeedback corpus) predates it - so tenant-partition those stores, purge " +
+                "or quarantine the pre-existing shared data (records written with no tenant cannot be " +
+                "attributed afterwards - the choice is deletion or quarantine, never a later migration), and " +
+                "only then restore a tenant-scoped read that also proves session ownership; the two internal " +
+                "readers gated in GatewayHost (interruptedBriefFor / briefHistoryFor) must be un-gated in the " +
+                "same pass",
+        statusCode: StatusCodes.Status404NotFound);
+
+    /// <summary>
+    /// Maps the turn-brief routes and RETURNS the denied group they were mapped through, so the refusal can
+    /// be proved to cover routes that do not exist yet: a test maps a NEW probe route onto the returned
+    /// handle and finds it already refused on hosted with no deny written for it. Returning the handle is
+    /// the only way to state that property from outside this file.
+    /// </summary>
+    public static HostedDenyGroup Map(
         IEndpointRouteBuilder app,
         GatewayTurnBriefStore store,
         Func<string, string> briefingStateFor,
         Func<string, Task<(bool Ok, string Error)>>? requestExplainAsync = null)
+    {
+        FileLog.Write($"[TurnBriefGatewayEndpoints] mapping the turn-brief surface; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in this group is refused via the shared refusal primitive (MTR gap H5)");
+
+        // The whole group through ONE primitive-created handle, rather than a guard line repeated in every
+        // handler. The empty prefix keeps every route path written out in full (the routes span two prefixes,
+        // /sessions and /turnbriefs), so the self-host surface is byte-identical to before.
+        var group = HostedRouteDeny.Group(app, "", Denial());
+        MapRoutes(group, store, briefingStateFor, requestExplainAsync);
+        return group;
+    }
+
+    /// <summary>
+    /// The six turn-brief routes. Takes the denied GROUP HANDLE and nothing else: the ungrouped route
+    /// builder is deliberately out of scope here so no route can be mapped around the hosted refusal.
+    /// </summary>
+    private static void MapRoutes(
+        HostedDenyGroup app,
+        GatewayTurnBriefStore store,
+        Func<string, string> briefingStateFor,
+        Func<string, Task<(bool Ok, string Error)>>? requestExplainAsync)
     {
         app.MapGet("/sessions/{sid}/turnbriefs", (string sid) =>
         {

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1878,13 +1878,25 @@ public sealed class GatewayHost : IAsyncDisposable
             // the Director that died - which is exactly when we need it.
             interruptedBriefFor: sid =>
             {
+                // Hosted quarantine (MTR audit gap H5): the brief store is bare-session-id-keyed legacy data
+                // with no tenant in its path or records (issue #549 retired the writer). On a hosted box it
+                // cannot be attributed to the caller's tenant, so serving it here would embed another account's
+                // rail line/headline into this tenant's Interrupted list. Refuse by returning nothing; the read
+                // routes over the same store are denied in TurnBriefGatewayEndpoints. Self-host (one tenant) is
+                // byte-identical - IsHosted is false there.
+                if (GatewayHostedMode.IsHosted) return (null, null);
                 var b = _turnBriefStore.Latest(sid);
                 return (b?.NeedsYou?.RailLine, b?.Headline);
             },
             // Issue #212 W4: the restore endpoint builds its continuation context from the
             // full brief history; the store outlives the dead Director, so this serves
             // sessions whose owner is gone.
-            briefHistoryFor: sid => _turnBriefStore.List(sid),
+            // Hosted quarantine (MTR audit gap H5): the same untenanted legacy store must not seed a new
+            // continuation prompt with another account's brief history on hosted. Empty on hosted,
+            // byte-identical on self-host.
+            briefHistoryFor: sid => GatewayHostedMode.IsHosted
+                ? new List<TurnBriefDto>()
+                : _turnBriefStore.List(sid),
             // Issue #288: record session->Director ownership as the fleet is aggregated, so the WS
             // proxy can return 503 (owner offline) rather than 404 for a session whose Director went dark.
             owners: SessionOwners,
@@ -2274,6 +2286,9 @@ public sealed class GatewayHost : IAsyncDisposable
         // so the store is read-only-serving (effectively empty going forward); the read endpoints
         // stay so existing callers degrade cleanly. The explain trigger (#217) rode the brief agent,
         // which is gone - pass null and the explain endpoint answers 503.
+        // MTR audit gap H5: on HOSTED the whole surface is refused inside Map (the store is bare-session-id
+        // keyed legacy data with no tenant, so it cannot be served cross-tenant); self-host is byte-identical.
+        // The two internal readers of the same store are quarantined at their wiring above.
         TurnBriefGatewayEndpoints.Map(_app, _turnBriefStore,
             sid => _turnBriefStore.Latest(sid) is not null ? "Briefed" : "None",
             requestExplainAsync: null);


### PR DESCRIPTION
## Root cause

The Gateway turn-brief store (`GatewayTurnBriefStore`) addresses briefs, explain reports, packages, the latest cache, and the feedback corpus by **bare session id** under one shared directory, with no tenant in any path, file name, or record. The read routes in `TurnBriefGatewayEndpoints` were mapped unconditionally and none resolved the request tenant or proved the requested session belonged to it:

- `GET /sessions/{sid}/turnbriefs`, `.../latest`, `GET /sessions/{sid}/explain/latest` served whatever legacy file existed under bare `sid` to any caller.
- `GET /turnbriefs/feedback` enumerated the entire feedback corpus with no tenant filter.
- `POST /sessions/{sid}/turnbriefs/feedback` took a caller-supplied `feedbackId`, turned it straight into the shared filename, and overwrote an existing record's vote/reason with no ownership proof.
- The `/interrupted` list enrichment and the restore continuation-prompt builder also looked briefs up by bare session id, embedding a foreign tenant's brief text into a new session's prompt.

So on a hosted Gateway tenant A could read or overwrite tenant B's briefs and feedback, and B's brief history could seed A's restored session.

## Fix

Issue #549 retired the only writer, so the store is **legacy read-only data** that cannot be attributed to a tenant after the fact. A per-tenant answer would have to be invented rather than read (a half-partition that reads like isolation), so the honest fix is a **deny + quarantine**, matching the transcription-analysis (#1897) and recording denies.

- The six routes are refused on hosted through the shared `HostedRouteDeny.Group` per-route primitive (per-route, not exclusive, because they share `/sessions` and `/turnbriefs` with live routes). Every request shape meets the refusal; a route added to the group later is refused for free.
- The two internal readers of the same store (`interruptedBriefFor`, `briefHistoryFor`) are quarantined at their `GatewayHost` wiring so they return nothing on hosted.
- Self-host has one tenant and is **byte-identical** — the primitive maps the real handlers with no refusal off hosted.
- `GatewayEndpoints.cs` was deliberately **not** touched (the enrichment call sites at 1108/1217 are unchanged); the quarantine lives in the `GatewayHost` lambdas.

## Reproduced-real (verify-first)

`HostedTurnBriefDenyTests` seeds a real brief and a real feedback record under a bare session id and drives every route as a different caller. Reverting the deny reddens **ten** assertions with the symptom — "expected NotFound, got OK", the foreign headline disclosed, and the seeded feedback record overwritten. Self-host control tests carry the handler-positive receipts and the overwrite-capability control; a future-route probe proves a later-added route is already refused on hosted and still serves off it.

## Gates

- Gateway + test project build 0 warnings / 0 errors.
- Targeted turn-brief tests + the two solo tenancy filters (`OnOneRoute...`, `The_roster_and_the_commands_agree`) pass; a full hosted `GatewayHost` boot (`HostedRecordingDenyTests`) confirms `ValidateBeforeStart` accepts the new refusals with no route collision.

## Merge note

Touches `GatewayHost.cs` (two reader lambdas + the Map call-site comment) — serializes at merge with other `GatewayHost.cs` work. Does **not** touch `GatewayEndpoints.cs`.