### PR TITLE
fix(gateway): partition the fleet session-number allocator by tenant (audit H2)

### DIFF
--- a/mission/fix-h2-allocator.md
+++ b/mission/fix-h2-allocator.md
@@ -1,0 +1,67 @@
+# MTR fix H2 — the fleet session-number allocator was process-global, not tenant-scoped
+
+INTERNAL working note. Branch `fix/audit-h2-allocator`. Gap: audit H2 (audit-a),
+`src/CcDirector.Gateway/Discovery/FleetSessionNumberAllocator.cs`.
+
+## The gap as handed to this seat
+
+`FleetSessionNumberAllocator` (the Gateway authority for the 100-999 rail session numbers, issue
+#1292) kept one process-global store keyed by BARE session/director ids: `_bySession`, `_inUse`, the
+100-999 pool, and the lock. `Allocate` / `Adopt` / `Release` / `ReleaseForDirector` took bare ids, and
+the `OnDirectorRemoved` subscriber in `GatewayHost` DROPPED `DirectorRemoval.Tenant` before calling
+`ReleaseForDirector(removal.DirectorId)`. A director id and a session id are unique only WITHIN a tenant,
+so on the hosted multi-tenant Gateway two tenants collide.
+
+## Verify-first — the leak reproduces on current main
+
+Wrote two reproduction tests against the current bare-id API and ran them GREEN on main (leak is real):
+
+- **Cross-tenant Director removal.** Two tenants each own a Director under the same id `dir-shared`,
+  each with a session. `ReleaseForDirector("dir-shared")` (fired for tenant A's removal) freed BOTH
+  tenants' numbers — tenant B's rail number vanished and could be re-handed, surfacing as a duplicated
+  rail number for the innocent account.
+- **Global pool exhaustion.** One tenant allocating all 900 numbers left a second tenant with `null`
+  (no number) — the pool was one shared 900-number space, so one busy account starved every other.
+
+The same shape also lets tenant A's `Allocate` idempotently read tenant B's assignment for a shared id,
+and tenant A's `DELETE /session-numbers/{id}` free tenant B's number for an identically-named session.
+
+## Fix — partition every piece of state by tenant
+
+- **Allocator.** State now lives in a per-tenant partition (`Dictionary<TenantId, TenantPool>`, each
+  holding its own `BySession` map, `InUse` set, and 100-999 pool). Every method takes a `TenantId` and
+  only ever reads/writes that tenant's own partition. Each tenant draws from its OWN pool, so exhaustion
+  is confined to the tenant that caused it. Self-host resolves to `TenantId.Local` — one partition,
+  behavior unchanged. Log lines use `TenantId.ToLogString()` (no raw account id in logs).
+- **Endpoints** (`GatewayEndpoints`). `POST /session-numbers/allocate` and `DELETE /session-numbers/{id}`
+  resolve the caller's tenant SERVER-SIDE from the authenticated device key (`ResolveReadTenant`, never
+  from the request body). No bound tenant on hosted → 403 (deny by default), never the Local partition.
+  The `/sessions` aggregation's `Adopt` loop stamps the request's own tenant (`reqTenant.Value`), the
+  same tenant that filtered the roster it iterates.
+- **Removal subscriber** (`GatewayHost`). Threads `removal.Tenant` straight into
+  `ReleaseForDirector(removal.Tenant, removal.DirectorId)` — the tenant is no longer dropped. The
+  allocator's signature now REQUIRES the tenant, so it cannot be forgotten.
+
+Server-resolved tenant only; self-host/`TenantId.Local` paths stay correct off-hosted.
+
+## Reproduced-real / revert-proof
+
+- `FleetSessionNumberAllocatorTenancyTests` — director-removal, release, idempotent-read, and
+  pool-exhaustion isolation, each with a destructibility control (the owner's own op really frees /
+  hands out / exhausts) beside the isolation assertion.
+- `HostedSessionNumberRouteTenancyTests` — two device keys on two account tenants over REAL HTTP through
+  the REAL auth middleware: same session-id string allocates independently per tenant, one tenant's
+  DELETE never frees the other's, and an unbound-tenant allocate is 403.
+- Revert-proof CONFIRMED by experiment: collapsing the allocator back to one shared pool reddened all
+  four isolation assertions while the destructibility controls stayed green; restoring the partition
+  greened them. The existing `FleetSessionNumberAllocatorTests` were updated to the tenant API.
+
+## Gates
+
+- Build `CcDirector.Gateway` + `CcDirector.Gateway.Tests`: 0 warnings, 0 errors.
+- Targeted tests + the two solo tenancy filters (`OnOneRoute_TheCredentialAloneDecidesWhetherATenantScopeExists`,
+  `The_roster_and_the_commands_agree`): all green.
+
+## Merge note
+
+Touches `GatewayHost.cs` and `GatewayEndpoints.cs` — both SERIALIZE at merge.

--- a/mission/fix-h2-allocator.md
+++ b/mission/fix-h2-allocator.md
@@ -28,11 +28,17 @@ and tenant A's `DELETE /session-numbers/{id}` free tenant B's number for an iden
 
 ## Fix — partition every piece of state by tenant
 
-- **Allocator.** State now lives in a per-tenant partition (`Dictionary<TenantId, TenantPool>`, each
-  holding its own `BySession` map, `InUse` set, and 100-999 pool). Every method takes a `TenantId` and
-  only ever reads/writes that tenant's own partition. Each tenant draws from its OWN pool, so exhaustion
-  is confined to the tenant that caused it. Self-host resolves to `TenantId.Local` — one partition,
-  behavior unchanged. Log lines use `TenantId.ToLogString()` (no raw account id in logs).
+- **Allocator.** State now lives in a per-tenant partition (`ConcurrentDictionary<TenantId, TenantPool>`,
+  each holding its own `BySession` map, `InUse` set, 100-999 pool, AND its own lock). Every method takes a
+  `TenantId` and only ever reads/writes that tenant's own partition. Each tenant draws from its OWN pool, so
+  exhaustion is confined to the tenant that caused it. Self-host resolves to `TenantId.Local` — one
+  partition, behavior unchanged. Log lines use `TenantId.ToLogString()` (no raw account id in logs).
+- **Per-tenant locking (Codex residual).** The first cut kept ONE process-global `_lock` that every tenant
+  operation took, so tenants still serialized on a shared lock — a busy tenant's allocations stalled every
+  other tenant. Fixed: the tenant->pool map is a `ConcurrentDictionary` (thread-safe lookup, no outer lock),
+  and each `TenantPool` carries its OWN lock. A caller's allocate / adopt / release / director-removal only
+  ever takes ITS tenant's partition lock, so two tenants operating at once never contend. There is no
+  process-global lock across tenants.
 - **Endpoints** (`GatewayEndpoints`). `POST /session-numbers/allocate` and `DELETE /session-numbers/{id}`
   resolve the caller's tenant SERVER-SIDE from the authenticated device key (`ResolveReadTenant`, never
   from the request body). No bound tenant on hosted → 403 (deny by default), never the Local partition.
@@ -48,7 +54,11 @@ Server-resolved tenant only; self-host/`TenantId.Local` paths stay correct off-h
 
 - `FleetSessionNumberAllocatorTenancyTests` — director-removal, release, idempotent-read, and
   pool-exhaustion isolation, each with a destructibility control (the owner's own op really frees /
-  hands out / exhausts) beside the isolation assertion.
+  hands out / exhausts) beside the isolation assertion. Plus `One_tenant_holding_its_pool_lock_does_not_
+  block_another_tenants_allocation` — a CROSS-TENANT CONCURRENCY proof: while tenant A's partition lock is
+  held, tenant B allocates concurrently and completes, while a same-tenant A allocation blocks (the control,
+  proving the held lock is the one A's own ops take). Confirmed to redden under a collapsed shared lock while
+  the four correctness assertions stay green.
 - `HostedSessionNumberRouteTenancyTests` — two device keys on two account tenants over REAL HTTP through
   the REAL auth middleware: same session-id string allocates independently per tenant, one tenant's
   DELETE never frees the other's, and an unbound-tenant allocate is 403.

--- a/src/CcDirector.Gateway.Tests/FleetSessionNumberAllocatorTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetSessionNumberAllocatorTenancyTests.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections;
+using System.Reflection;
+using System.Threading;
 using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Discovery;
 using Xunit;
@@ -109,5 +113,79 @@ public sealed class FleetSessionNumberAllocatorTenancyTests
         // THE PROPERTY - tenant B still has a completely fresh pool; A's flood never touched it.
         var bFirst = a.Allocate(TenantB, "bob-1", "dir-b");
         Assert.Equal(FleetSessionNumberAllocator.MinNumber, bFirst);
+    }
+
+    /// <summary>
+    /// CROSS-TENANT CONCURRENCY (audit H2, Codex residual). Correctness partitioning is not enough: the
+    /// allocator must also not SERIALIZE tenants on a shared lock. With one process-global lock, tenant A
+    /// holding it (mid-allocation, or just contending) stalls every other tenant's allocation. The fix gives
+    /// each tenant's partition its OWN lock, so a caller only ever takes ITS tenant's lock.
+    ///
+    /// This test holds tenant A's partition lock and proves tenant B allocates concurrently WITHOUT waiting,
+    /// while a same-tenant A allocation DOES wait (the destructibility control - it proves the held lock is
+    /// the one A's own operations take, so "B proceeded" is real independence, not a lock we grabbed that
+    /// nobody uses). Revert to a single shared lock and the tenant-B property assertion reddens: B would then
+    /// block on the very lock this test holds.
+    /// </summary>
+    [Fact]
+    public void One_tenant_holding_its_pool_lock_does_not_block_another_tenants_allocation()
+    {
+        var a = new FleetSessionNumberAllocator();
+        // Materialize both partitions so each has a lock object to reach.
+        a.Allocate(TenantA, "alice-seed", "dir-a");
+        a.Allocate(TenantB, "bob-seed", "dir-b");
+
+        var tenantALock = PoolLockFor(a, TenantA);
+        var aBlockedAllocationDone = new ManualResetEventSlim(false);
+
+        lock (tenantALock)
+        {
+            // Tenant A's partition lock is HELD by this thread; any operation on A's partition must wait.
+
+            // THE PROPERTY - tenant B allocates on ANOTHER thread and completes without waiting on A's lock.
+            int? bNumber = null;
+            var bDone = new ManualResetEventSlim(false);
+            var bThread = new Thread(() =>
+            {
+                bNumber = a.Allocate(TenantB, "bob-concurrent", "dir-b");
+                bDone.Set();
+            }) { IsBackground = true };
+            bThread.Start();
+
+            Assert.True(bDone.Wait(TimeSpan.FromSeconds(5)),
+                "Tenant B's allocation blocked while tenant A held ITS OWN pool lock - the allocator is serializing tenants on a shared lock.");
+            Assert.NotNull(bNumber);
+
+            // DESTRUCTIBILITY CONTROL - a same-tenant (A) allocation really DOES block on the held lock.
+            var aThread = new Thread(() =>
+            {
+                a.Allocate(TenantA, "alice-concurrent", "dir-a");
+                aBlockedAllocationDone.Set();
+            }) { IsBackground = true };
+            aThread.Start();
+
+            Assert.False(aBlockedAllocationDone.Wait(TimeSpan.FromSeconds(1)),
+                "Tenant A's own allocation completed while A's pool lock was held - the lock held is not the one A's partition uses, so the property assertion above proves nothing.");
+        }
+
+        // Once A's lock is released, the previously-blocked A allocation completes - closing the control.
+        Assert.True(aBlockedAllocationDone.Wait(TimeSpan.FromSeconds(5)),
+            "Tenant A's allocation never completed after its pool lock was released.");
+    }
+
+    /// <summary>
+    /// Reach the per-tenant partition's own lock object by reflection. This is a concurrency proof, so it must
+    /// hold the EXACT lock a caller for that tenant takes - there is no public seam for that by design.
+    /// </summary>
+    private static object PoolLockFor(FleetSessionNumberAllocator allocator, TenantId tenant)
+    {
+        var mapField = typeof(FleetSessionNumberAllocator).GetField("_byTenant", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(mapField);
+        var map = (IDictionary)mapField!.GetValue(allocator)!;
+        var pool = map[tenant];
+        Assert.NotNull(pool);
+        var lockField = pool!.GetType().GetField("Lock", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(lockField);
+        return lockField!.GetValue(pool)!;
     }
 }

--- a/src/CcDirector.Gateway.Tests/FleetSessionNumberAllocatorTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetSessionNumberAllocatorTenancyTests.cs
@@ -1,0 +1,113 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Discovery;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Audit H2: one tenant's session numbers must be invisible to another tenant's operations.
+///
+/// WHAT THIS PINS. The allocator was a single process-global pool keyed by BARE session/director ids. A
+/// director id and a session id are unique only WITHIN a tenant, not across the fleet, so two tenants
+/// sharing an id collided: tenant A's allocate could read tenant B's assignment for that id, A's release
+/// could free B's number, A's same-id Director removal freed B's assignments (a duplicated rail number for
+/// the innocent tenant), and the one 900-number pool meant one busy tenant starved every other.
+///
+/// The fix partitions every piece of state by <see cref="TenantId"/>. Each test below has a
+/// DESTRUCTIBILITY CONTROL beside its isolation assertion: the owner's OWN operation really does the thing
+/// (frees / hands out / exhausts), so "the other tenant survived" cannot be satisfied by an operation that
+/// simply did nothing.
+///
+/// REVERT-PROOF. Collapse the allocator back to one global pool (drop the per-tenant partition so every
+/// method shares one BySession/InUse) and every isolation assertion here goes RED while its destructibility
+/// control stays GREEN. Separately, restore the removal subscriber to
+/// <c>ReleaseForDirector(removal.DirectorId)</c> without the tenant and
+/// <see cref="Removal_in_one_tenant_keeps_the_other_tenants_numbers"/> reddens.
+/// </summary>
+public sealed class FleetSessionNumberAllocatorTenancyTests
+{
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    /// <summary>An id held in both tenants at once - legitimate, since an id is unique only within a tenant.</summary>
+    private const string SharedDirector = "dir-shared";
+    private const string SharedSession = "sess-shared";
+
+    [Fact]
+    public void Removal_in_one_tenant_keeps_the_other_tenants_numbers()
+    {
+        var a = new FleetSessionNumberAllocator();
+        // Both tenants own a Director under the SAME id, each with a session.
+        a.Allocate(TenantA, "alice-s1", SharedDirector);
+        var bobsNumber = a.Allocate(TenantB, "bob-s1", SharedDirector);
+        Assert.NotNull(bobsNumber);
+
+        // Tenant A's Director leaves the fleet.
+        a.ReleaseForDirector(TenantA, SharedDirector);
+
+        // DESTRUCTIBILITY CONTROL - A's own number really is gone (the removal did fire and did free).
+        Assert.Null(a.NumberFor(TenantA, "alice-s1"));
+        Assert.Equal(0, a.InUseCount(TenantA));
+
+        // THE PROPERTY - Bob keeps the number the shared-id removal used to free out from under him.
+        Assert.Equal(bobsNumber, a.NumberFor(TenantB, "bob-s1"));
+        Assert.Equal(1, a.InUseCount(TenantB));
+    }
+
+    [Fact]
+    public void Release_in_one_tenant_keeps_the_other_tenants_number_for_the_same_session_id()
+    {
+        var a = new FleetSessionNumberAllocator();
+        // The same session-id string used by both tenants (they cannot see each other's, so this is legal).
+        var aNum = a.Allocate(TenantA, SharedSession, "dir-a");
+        var bNum = a.Allocate(TenantB, SharedSession, "dir-b");
+        Assert.NotNull(aNum);
+        Assert.NotNull(bNum);
+
+        // Tenant A releases its session.
+        a.Release(TenantA, SharedSession);
+
+        // DESTRUCTIBILITY CONTROL - A's own number really was freed.
+        Assert.Null(a.NumberFor(TenantA, SharedSession));
+
+        // THE PROPERTY - B's identically-named session still holds its own number.
+        Assert.Equal(bNum, a.NumberFor(TenantB, SharedSession));
+    }
+
+    [Fact]
+    public void Allocate_in_one_tenant_never_reads_the_other_tenants_assignment()
+    {
+        var a = new FleetSessionNumberAllocator();
+        // Advance tenant A's pool first, so A's assignment for the shared id is NOT the lowest number - that
+        // way "B read A's" and "B drew its own lowest" produce different values the assertion can tell apart.
+        Assert.Equal(FleetSessionNumberAllocator.MinNumber, a.Allocate(TenantA, "alice-filler", "dir-a"));
+        var aShared = a.Allocate(TenantA, SharedSession, "dir-a");
+        Assert.Equal(FleetSessionNumberAllocator.MinNumber + 1, aShared);
+
+        // Tenant B allocating the SAME id must NOT idempotently read A's assignment across a shared map (the
+        // old bug handed A's number back to B). B draws from its OWN empty pool, so it gets the lowest number.
+        var bShared = a.Allocate(TenantB, SharedSession, "dir-b");
+        Assert.Equal(FleetSessionNumberAllocator.MinNumber, bShared);
+        Assert.NotEqual(aShared, bShared);
+        Assert.Equal(2, a.InUseCount(TenantA));
+        Assert.Equal(1, a.InUseCount(TenantB));
+    }
+
+    [Fact]
+    public void One_tenant_exhausting_its_pool_leaves_the_other_tenant_a_full_pool()
+    {
+        var a = new FleetSessionNumberAllocator();
+        var total = FleetSessionNumberAllocator.MaxNumber - FleetSessionNumberAllocator.MinNumber + 1;
+
+        // Tenant A allocates every number in its own pool.
+        for (int i = 0; i < total; i++)
+            Assert.NotNull(a.Allocate(TenantA, $"alice-{i}", "dir-a"));
+
+        // DESTRUCTIBILITY CONTROL - A's pool really is exhausted.
+        Assert.Null(a.Allocate(TenantA, "alice-overflow", "dir-a"));
+
+        // THE PROPERTY - tenant B still has a completely fresh pool; A's flood never touched it.
+        var bFirst = a.Allocate(TenantB, "bob-1", "dir-b");
+        Assert.Equal(FleetSessionNumberAllocator.MinNumber, bFirst);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/FleetSessionNumberAllocatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetSessionNumberAllocatorTests.cs
@@ -1,21 +1,28 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Discovery;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// Unit tests for the fleet-wide session-number authority (issue #1292): the Gateway hands out
-/// three-digit numbers unique across every Director, prefers the low band, is idempotent per session,
+/// Unit tests for the per-tenant session-number authority (issue #1292): the Gateway hands out
+/// three-digit numbers unique across a tenant's Directors, prefers the low band, is idempotent per session,
 /// reuses freed numbers, adopts numbers it did not hand out, and frees a removed Director's numbers.
+///
+/// Every operation is scoped to a <see cref="TenantId"/>; the single-tenant behaviour these tests pin uses
+/// one tenant (<see cref="T"/>). The cross-tenant isolation the partitioning exists for is pinned in
+/// <see cref="FleetSessionNumberAllocatorTenancyTests"/>.
 /// </summary>
 public class FleetSessionNumberAllocatorTests
 {
+    private static readonly TenantId T = TenantId.Local;
+
     [Fact]
     public void Allocate_FirstNumber_IsTheLowestCoordinatedNumber()
     {
         var a = new FleetSessionNumberAllocator();
 
-        var n = a.Allocate("s1", "dirA");
+        var n = a.Allocate(T, "s1", "dirA");
 
         Assert.Equal(FleetSessionNumberAllocator.MinNumber, n);
     }
@@ -27,7 +34,7 @@ public class FleetSessionNumberAllocatorTests
 
         for (int i = 0; i < 100; i++)
         {
-            var n = a.Allocate($"s{i}", "dirA");
+            var n = a.Allocate(T, $"s{i}", "dirA");
             Assert.NotNull(n);
             // The coordinated band is 100-799; the offline band (800-999) is left clear until it is full.
             Assert.InRange(n!.Value, FleetSessionNumberAllocator.MinNumber, FleetSessionNumberAllocator.CoordinatedMaxNumber);
@@ -42,7 +49,7 @@ public class FleetSessionNumberAllocatorTests
 
         for (int i = 0; i < 200; i++)
         {
-            var n = a.Allocate($"s{i}", i % 2 == 0 ? "dirA" : "dirB");
+            var n = a.Allocate(T, $"s{i}", i % 2 == 0 ? "dirA" : "dirB");
             Assert.NotNull(n);
             Assert.True(seen.Add(n!.Value), $"number {n.Value} was handed to two sessions");
         }
@@ -53,26 +60,26 @@ public class FleetSessionNumberAllocatorTests
     {
         var a = new FleetSessionNumberAllocator();
 
-        var first = a.Allocate("s1", "dirA");
-        var again = a.Allocate("s1", "dirA");
+        var first = a.Allocate(T, "s1", "dirA");
+        var again = a.Allocate(T, "s1", "dirA");
 
         Assert.Equal(first, again);
-        Assert.Equal(1, a.InUseCount);
+        Assert.Equal(1, a.InUseCount(T));
     }
 
     [Fact]
     public void Release_FreesTheNumber_ForReuse()
     {
         var a = new FleetSessionNumberAllocator();
-        var n = a.Allocate("s1", "dirA");
+        var n = a.Allocate(T, "s1", "dirA");
         Assert.NotNull(n);
 
-        a.Release("s1");
+        a.Release(T, "s1");
 
-        Assert.Equal(0, a.InUseCount);
-        Assert.Null(a.NumberFor("s1"));
+        Assert.Equal(0, a.InUseCount(T));
+        Assert.Null(a.NumberFor(T, "s1"));
         // The freed number is available again (the pool is empty, so the lowest is handed back out).
-        var reused = a.Allocate("s2", "dirA");
+        var reused = a.Allocate(T, "s2", "dirA");
         Assert.Equal(n, reused);
     }
 
@@ -82,55 +89,55 @@ public class FleetSessionNumberAllocatorTests
         var a = new FleetSessionNumberAllocator();
 
         // A Director assigned 100 offline (or it survived a restart); the Gateway learns it via adopt.
-        a.Adopt("offline1", "dirB", FleetSessionNumberAllocator.MinNumber);
+        a.Adopt(T, "offline1", "dirB", FleetSessionNumberAllocator.MinNumber);
 
         // A fresh allocation must skip the adopted number.
-        var n = a.Allocate("s1", "dirA");
+        var n = a.Allocate(T, "s1", "dirA");
         Assert.NotEqual(FleetSessionNumberAllocator.MinNumber, n);
-        Assert.Equal(2, a.InUseCount);
+        Assert.Equal(2, a.InUseCount(T));
     }
 
     [Fact]
     public void Adopt_NeverFreesANumber_OnAbsence()
     {
         var a = new FleetSessionNumberAllocator();
-        var n = a.Allocate("s1", "dirA");
+        var n = a.Allocate(T, "s1", "dirA");
         Assert.NotNull(n);
 
         // Re-adopting an already-known session is a no-op; absence from a later view never reclaims.
-        a.Adopt("s1", "dirA", n!.Value);
-        Assert.Equal(1, a.InUseCount);
-        Assert.Equal(n, a.NumberFor("s1"));
+        a.Adopt(T, "s1", "dirA", n!.Value);
+        Assert.Equal(1, a.InUseCount(T));
+        Assert.Equal(n, a.NumberFor(T, "s1"));
     }
 
     [Fact]
     public void Adopt_IsIdempotent_ForItsOwnHandOut()
     {
         var a = new FleetSessionNumberAllocator();
-        var n = a.Allocate("s1", "dirA");
+        var n = a.Allocate(T, "s1", "dirA");
 
         // The /sessions aggregation observes the session it just handed a number to.
-        a.Adopt("s1", "dirA", n!.Value);
-        a.Adopt("s1", "dirA", n.Value);
+        a.Adopt(T, "s1", "dirA", n!.Value);
+        a.Adopt(T, "s1", "dirA", n.Value);
 
-        Assert.Equal(1, a.InUseCount);
+        Assert.Equal(1, a.InUseCount(T));
     }
 
     [Fact]
     public void ReleaseForDirector_FreesEveryNumberThatDirectorOwned()
     {
         var a = new FleetSessionNumberAllocator();
-        a.Allocate("a1", "dirA");
-        a.Allocate("a2", "dirA");
-        var keep = a.Allocate("b1", "dirB");
-        Assert.Equal(3, a.InUseCount);
+        a.Allocate(T, "a1", "dirA");
+        a.Allocate(T, "a2", "dirA");
+        var keep = a.Allocate(T, "b1", "dirB");
+        Assert.Equal(3, a.InUseCount(T));
 
-        a.ReleaseForDirector("dirA");
+        a.ReleaseForDirector(T, "dirA");
 
-        Assert.Equal(1, a.InUseCount);
-        Assert.Null(a.NumberFor("a1"));
-        Assert.Null(a.NumberFor("a2"));
-        Assert.Equal(keep, a.NumberFor("b1"));
+        Assert.Equal(1, a.InUseCount(T));
+        Assert.Null(a.NumberFor(T, "a1"));
+        Assert.Null(a.NumberFor(T, "a2"));
+        Assert.Equal(keep, a.NumberFor(T, "b1"));
     }
 
     [Fact]
@@ -141,10 +148,10 @@ public class FleetSessionNumberAllocatorTests
         // Fill the entire coordinated band (100-799).
         var coordinatedCount = FleetSessionNumberAllocator.CoordinatedMaxNumber - FleetSessionNumberAllocator.MinNumber + 1;
         for (int i = 0; i < coordinatedCount; i++)
-            Assert.NotNull(a.Allocate($"c{i}", "dirA"));
+            Assert.NotNull(a.Allocate(T, $"c{i}", "dirA"));
 
         // The next allocation spills into the offline band.
-        var spill = a.Allocate("spill", "dirA");
+        var spill = a.Allocate(T, "spill", "dirA");
         Assert.NotNull(spill);
         Assert.InRange(spill!.Value, FleetSessionNumberAllocator.CoordinatedMaxNumber + 1, FleetSessionNumberAllocator.MaxNumber);
     }
@@ -155,8 +162,8 @@ public class FleetSessionNumberAllocatorTests
         var a = new FleetSessionNumberAllocator();
         var total = FleetSessionNumberAllocator.MaxNumber - FleetSessionNumberAllocator.MinNumber + 1;
         for (int i = 0; i < total; i++)
-            Assert.NotNull(a.Allocate($"s{i}", "dirA"));
+            Assert.NotNull(a.Allocate(T, $"s{i}", "dirA"));
 
-        Assert.Null(a.Allocate("overflow", "dirA"));
+        Assert.Null(a.Allocate(T, "overflow", "dirA"));
     }
 }

--- a/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
@@ -345,7 +345,8 @@ public sealed class GatewayHostTests : IAsyncLifetime
         // Releasing frees it for reuse.
         var del = await _http.DeleteAsync("session-numbers/sess-A");
         Assert.Equal(HttpStatusCode.NoContent, del.StatusCode);
-        Assert.Null(_gateway.SessionNumbers.NumberFor("sess-A"));
+        // Self-host: the endpoint resolves the request to the Local partition, so that is where to look.
+        Assert.Null(_gateway.SessionNumbers.NumberFor(Core.Tenancy.TenantId.Local, "sess-A"));
     }
 
     private async Task WaitForDirectorCount(int target, TimeSpan timeout)

--- a/src/CcDirector.Gateway.Tests/HostedSessionNumberRouteTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedSessionNumberRouteTenancyTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Audit H2, over the wire: the /session-numbers endpoints must resolve the caller's tenant from the
+/// authenticated device key (server-side, never the request body) and touch only that tenant's partition.
+///
+/// This drives a REAL hosted GatewayHost over REAL HTTP through the REAL auth middleware, with two device
+/// keys bound to two different account tenants - the same path a production Director's fleet credential
+/// travels. It proves the endpoint conversion, not just the allocator: the old routes passed the bare
+/// session id straight into a global pool, so two tenants using the same session-id string shared one
+/// reservation and one tenant's DELETE freed the other's.
+///
+/// Revert-prove: drop the tenant argument at either route (allocate/release) so it uses one shared
+/// partition and <see cref="Two_tenants_allocate_the_same_session_id_independently"/> reddens - the second
+/// tenant's allocate returns the first's number, or its release frees the first's.
+/// </summary>
+public sealed class HostedSessionNumberRouteTenancyTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string TenantAGuid = "55555555-5555-5555-5555-555555555555";
+    private const string TenantBGuid = "66666666-6666-6666-6666-666666666666";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _keyA = "";
+    private string _keyB = "";
+    private string _keyUnbound = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-snum-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        _keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        _keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        _keyUnbound = _gateway.Devices.Register("dev-unbound", "MU").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", TenantAGuid);
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", TenantBGuid);
+        // dev-unbound is deliberately left with no account binding.
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task Two_tenants_allocate_the_same_session_id_independently()
+    {
+        const string sharedSession = "sess-shared";
+
+        // Both tenants allocate a number for the SAME session-id string.
+        var aNum = await AllocateAsync(_keyA, sharedSession, "dir-a");
+        var bNum = await AllocateAsync(_keyB, sharedSession, "dir-b");
+        Assert.NotNull(aNum);
+        Assert.NotNull(bNum);
+
+        // Each drew from its own partition, so each holds its own reservation.
+        Assert.Equal(aNum, _gateway.SessionNumbers.NumberFor(new TenantId(TenantAGuid), sharedSession));
+        Assert.Equal(bNum, _gateway.SessionNumbers.NumberFor(new TenantId(TenantBGuid), sharedSession));
+
+        // Tenant A releases its identically-named session.
+        var del = await Send(HttpMethod.Delete, $"session-numbers/{sharedSession}", _keyA, null);
+        Assert.Equal(HttpStatusCode.NoContent, del.StatusCode);
+
+        // DESTRUCTIBILITY CONTROL - A's own reservation is gone.
+        Assert.Null(_gateway.SessionNumbers.NumberFor(new TenantId(TenantAGuid), sharedSession));
+        // THE PROPERTY - B's identically-named session still holds its number.
+        Assert.Equal(bNum, _gateway.SessionNumbers.NumberFor(new TenantId(TenantBGuid), sharedSession));
+    }
+
+    [Fact]
+    public async Task Allocate_with_no_bound_tenant_is_denied()
+    {
+        // A device key that authenticates but binds to no account tenant is refused on hosted (deny by
+        // default), never served the Local partition.
+        var resp = await Send(HttpMethod.Post, "session-numbers/allocate", _keyUnbound,
+            JsonContent.Create(new SessionNumberAllocateRequest { SessionId = "sess-x", DirectorId = "dir-x" }));
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    private async Task<int?> AllocateAsync(string deviceKey, string sessionId, string directorId)
+    {
+        var resp = await Send(HttpMethod.Post, "session-numbers/allocate", deviceKey,
+            JsonContent.Create(new SessionNumberAllocateRequest { SessionId = sessionId, DirectorId = directorId }));
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        return (await resp.Content.ReadFromJsonAsync<SessionNumberAllocateResponse>())!.Number;
+    }
+
+    private Task<HttpResponseMessage> Send(HttpMethod method, string path, string deviceKey, HttpContent? content)
+    {
+        var req = new HttpRequestMessage(method, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        if (content is not null) req.Content = content;
+        return _http.SendAsync(req);
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -152,23 +152,36 @@ internal static class GatewayEndpoints
         // which runs the whole turn Gateway-side. The Gateway endpoint + its two dedicated tests are deleted;
         // the Director SSE endpoint is on the Phase 1 deletion DROP list, removed at the cut.
 
-        // Issue #1292: the fleet-wide session-number authority. A Director asks for a number when it
-        // creates a session (so the number is unique across every Director on every machine) and frees
+        // Issue #1292: the per-tenant session-number authority. A Director asks for a number when it
+        // creates a session (so the number is unique across every Director THAT TENANT owns) and frees
         // it when the session ends. Guarded by the same auth middleware as every other Director-facing
         // route, so the Director's own fleet credential is required.
+        //
+        // Audit H2: the allocator is partitioned by tenant, so both routes resolve the caller's OWN tenant
+        // (server-side, from the authenticated device key - never from the request body) and touch only
+        // that tenant's partition. A request whose device key binds to no tenant is DENIED on hosted rather
+        // than served the Local partition; self-host always resolves to Local, unchanged.
         if (sessionNumbers is not null)
         {
-            app.MapPost("/session-numbers/allocate", (SessionNumberAllocateRequest req) =>
+            app.MapPost("/session-numbers/allocate", (SessionNumberAllocateRequest req, HttpContext ctx) =>
             {
                 if (string.IsNullOrWhiteSpace(req.SessionId))
                     return Results.BadRequest(new { error = "sessionId is required" });
-                var number = sessionNumbers.Allocate(req.SessionId, req.DirectorId ?? "");
+                var tenant = ResolveReadTenant(ctx, tenantBoundary);
+                if (tenant is null)
+                    return Results.Json(new { error = "no tenant is bound to this request" },
+                        statusCode: StatusCodes.Status403Forbidden);
+                var number = sessionNumbers.Allocate(tenant.Value, req.SessionId, req.DirectorId ?? "");
                 return Results.Ok(new SessionNumberAllocateResponse { Number = number });
             });
 
-            app.MapDelete("/session-numbers/{sessionId}", (string sessionId) =>
+            app.MapDelete("/session-numbers/{sessionId}", (string sessionId, HttpContext ctx) =>
             {
-                sessionNumbers.Release(sessionId);
+                var tenant = ResolveReadTenant(ctx, tenantBoundary);
+                if (tenant is null)
+                    return Results.Json(new { error = "no tenant is bound to this request" },
+                        statusCode: StatusCodes.Status403Forbidden);
+                sessionNumbers.Release(tenant.Value, sessionId);
                 return Results.NoContent();
             });
         }
@@ -1042,16 +1055,19 @@ internal static class GatewayEndpoints
             // tracker keeps only the higher value per hour, so folding on every /sessions read never inflates.
             concurrency?.Observe(all, DateTime.UtcNow, reqTenant.Value);
 
-            // Issue #1292: adopt every observed number into the fleet allocator's in-use set. This is how
-            // the Gateway learns numbers it did not hand out - a number a Director assigned offline, or any
+            // Issue #1292: adopt every observed number into the allocator's in-use set. This is how the
+            // Gateway learns numbers it did not hand out - a number a Director assigned offline, or any
             // number still live after a Gateway restart - so it never hands the same number to a new
             // session. Adopt only ever marks a number in use (never frees one), so doing it from this
             // possibly-filtered view is safe: a Director that is momentarily absent from the aggregation
             // can never lose its numbers here.
+            // Audit H2: adopt into THIS REQUEST'S tenant partition. The roster assembled above is this
+            // tenant's own (the owned-Director gate filtered it), so its numbers belong to this tenant and
+            // can never mark another account's partition in use.
             if (sessionNumbers is not null)
                 foreach (var s in all)
                     if (s.Number is int num)
-                        sessionNumbers.Adopt(s.SessionId, s.DirectorId, num);
+                        sessionNumbers.Adopt(reqTenant.Value, s.SessionId, s.DirectorId, num);
 
             if (envelope == true)
             {

--- a/src/CcDirector.Gateway/Discovery/FleetSessionNumberAllocator.cs
+++ b/src/CcDirector.Gateway/Discovery/FleetSessionNumberAllocator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
@@ -45,9 +46,11 @@ namespace CcDirector.Gateway.Discovery;
 /// re-handed. Numbers are freed only by an explicit <see cref="Release"/> when a session ends, or by
 /// <see cref="ReleaseForDirector"/> when a whole Director is swept from the registry.
 ///
-/// Thread-safe: every public method takes the single lock. The lock guards the whole tenant map, so it is
-/// held for the brief span of one partition's probe/mutate - low contention, and simpler than a lock per
-/// partition.
+/// Thread-safe, and PARTITIONED for concurrency as well as correctness (audit H2). The tenant map is a
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/>, and each tenant's partition carries its OWN lock. A
+/// caller's allocate / adopt / release / removal only ever takes the lock of ITS OWN tenant's partition,
+/// so two tenants operating at once never contend on a shared lock - one tenant flooding allocations
+/// cannot block another tenant's allocation. There is no process-global lock across tenants.
 /// </summary>
 public sealed class FleetSessionNumberAllocator
 {
@@ -60,47 +63,41 @@ public sealed class FleetSessionNumberAllocator
     /// <summary>Highest assignable number (inclusive). 800-999 is the offline band.</summary>
     public const int MaxNumber = 999;
 
-    private readonly object _lock = new();
-
-    /// <summary>One partition per tenant; each holds that tenant's own session map and in-use set (its own pool).</summary>
-    private readonly Dictionary<TenantId, TenantPool> _byTenant = new();
+    /// <summary>One partition per tenant; each holds that tenant's own session map, in-use set (its own pool), and lock.</summary>
+    private readonly ConcurrentDictionary<TenantId, TenantPool> _byTenant = new();
 
     private readonly record struct Assignment(int Number, string DirectorId);
 
-    /// <summary>One tenant's private allocation state: its session-to-number map and its own 100-999 in-use set.</summary>
+    /// <summary>
+    /// One tenant's private allocation state: its session-to-number map, its own 100-999 in-use set, and its
+    /// OWN lock. Every mutation or read of this partition's fields is done under <see cref="Lock"/>, so a
+    /// caller only ever contends with other callers for the SAME tenant - never across tenants.
+    /// </summary>
     private sealed class TenantPool
     {
+        public readonly object Lock = new();
         public readonly Dictionary<string, Assignment> BySession = new(StringComparer.Ordinal);
         public readonly HashSet<int> InUse = new();
     }
 
-    /// <summary>The tenant's partition, creating it on first use. Caller holds the lock.</summary>
-    private TenantPool PoolFor(TenantId tenant)
-    {
-        if (!_byTenant.TryGetValue(tenant, out var pool))
-        {
-            pool = new TenantPool();
-            _byTenant[tenant] = pool;
-        }
-        return pool;
-    }
+    /// <summary>The tenant's partition, creating it on first use. The map itself is thread-safe (no outer lock needed).</summary>
+    private TenantPool PoolFor(TenantId tenant) => _byTenant.GetOrAdd(tenant, static _ => new TenantPool());
 
     /// <summary>Count of numbers currently reserved in <paramref name="tenant"/>'s partition. For tests and diagnostics.</summary>
     public int InUseCount(TenantId tenant)
     {
-        lock (_lock)
-            return _byTenant.TryGetValue(tenant, out var pool) ? pool.InUse.Count : 0;
+        if (!_byTenant.TryGetValue(tenant, out var pool)) return 0;
+        lock (pool.Lock)
+            return pool.InUse.Count;
     }
 
     /// <summary>The number currently assigned to <paramref name="sessionId"/> in <paramref name="tenant"/>'s partition, or null if none.</summary>
     public int? NumberFor(TenantId tenant, string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId)) return null;
-        lock (_lock)
-        {
-            if (!_byTenant.TryGetValue(tenant, out var pool)) return null;
+        if (!_byTenant.TryGetValue(tenant, out var pool)) return null;
+        lock (pool.Lock)
             return pool.BySession.TryGetValue(sessionId, out var a) ? a.Number : (int?)null;
-        }
     }
 
     /// <summary>
@@ -117,9 +114,9 @@ public sealed class FleetSessionNumberAllocator
         if (string.IsNullOrEmpty(sessionId))
             throw new ArgumentException("sessionId is required", nameof(sessionId));
 
-        lock (_lock)
+        var pool = PoolFor(tenant);
+        lock (pool.Lock)
         {
-            var pool = PoolFor(tenant);
             if (pool.BySession.TryGetValue(sessionId, out var existing))
             {
                 FileLog.Write($"[FleetSessionNumberAllocator] Allocate: {sessionId} already has {existing.Number} (idempotent, tenant={tenant.ToLogString()})");
@@ -153,9 +150,9 @@ public sealed class FleetSessionNumberAllocator
         if (string.IsNullOrEmpty(sessionId)) return;
         if (number < MinNumber || number > MaxNumber) return;
 
-        lock (_lock)
+        var pool = PoolFor(tenant);
+        lock (pool.Lock)
         {
-            var pool = PoolFor(tenant);
             if (pool.BySession.TryGetValue(sessionId, out var existing))
             {
                 // Already tracked. Keep the number it already has (its own hand-out or a prior adopt).
@@ -187,9 +184,9 @@ public sealed class FleetSessionNumberAllocator
     public void Release(TenantId tenant, string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId)) return;
-        lock (_lock)
+        if (!_byTenant.TryGetValue(tenant, out var pool)) return;
+        lock (pool.Lock)
         {
-            if (!_byTenant.TryGetValue(tenant, out var pool)) return;
             if (!pool.BySession.Remove(sessionId, out var a))
                 return;
             // Only clear the shared reservation if no other session still holds this number (a
@@ -215,9 +212,9 @@ public sealed class FleetSessionNumberAllocator
     public void ReleaseForDirector(TenantId tenant, string directorId)
     {
         if (string.IsNullOrEmpty(directorId)) return;
-        lock (_lock)
+        if (!_byTenant.TryGetValue(tenant, out var pool)) return;
+        lock (pool.Lock)
         {
-            if (!_byTenant.TryGetValue(tenant, out var pool)) return;
             var gone = pool.BySession.Where(kv => string.Equals(kv.Value.DirectorId, directorId, StringComparison.Ordinal))
                                      .Select(kv => kv.Key).ToList();
             foreach (var sid in gone)

--- a/src/CcDirector.Gateway/Discovery/FleetSessionNumberAllocator.cs
+++ b/src/CcDirector.Gateway/Discovery/FleetSessionNumberAllocator.cs
@@ -1,25 +1,42 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Gateway.Discovery;
 
 /// <summary>
-/// The fleet-wide authority for the short three-digit session numbers (100-999) shown on the rail
-/// (issue #1292). One instance lives on the Gateway for the whole fleet, so a number names exactly
-/// ONE session across every Director on every machine - unlike the old per-Director allocator, where
-/// each Director counted independently from 100 and the same number appeared on several Directors.
+/// The per-tenant authority for the short three-digit session numbers (100-999) shown on the rail
+/// (issue #1292). One instance lives on the Gateway, but its state is PARTITIONED BY TENANT: a number
+/// names exactly ONE session across every Director a single tenant owns - unlike the old per-Director
+/// allocator, where each Director counted independently from 100 and the same number appeared on several
+/// Directors.
 ///
-/// Every Director asks the Gateway for a number when it creates a session (<see cref="Allocate"/>).
-/// The Gateway hands out the lowest free number, records which session (and Director) owns it, and
-/// guarantees it is unique across the fleet.
+/// TENANT PARTITIONING (audit H2). Every piece of state - the session-to-number map, the in-use set, and
+/// the 100-999 pool it draws from - lives inside a per-tenant partition, keyed by <see cref="TenantId"/>.
+/// Every operation takes the caller's tenant (server-resolved at the endpoint from the authenticated
+/// device key, never from client input) and only ever reads or writes that tenant's own partition. This
+/// closes a whole family of cross-tenant faults the old bare-id store had, because a director id and a
+/// session id are unique only WITHIN a tenant, not across the fleet:
+///   - Allocate for tenant B's session could read tenant A's assignment for the same id and hand back A's
+///     number; Release for one tenant could free the other's; a same-id Director removal in one tenant
+///     freed the other's assignments (surfacing as a duplicated rail number for the innocent tenant).
+///   - The pool was a single global 900-number space, so one tenant spinning up sessions exhausted
+///     numbers for every other tenant. Each tenant now draws from its OWN 100-999 pool, so exhaustion -
+///     if it ever happens - is confined to the tenant that caused it.
+/// On self-host every caller resolves to <see cref="TenantId.Local"/>, so there is one partition and the
+/// behavior is exactly as before.
 ///
-/// Two bands (the issue's refinement):
+/// Every Director asks the Gateway for a number when it creates a session (<see cref="Allocate"/>). The
+/// Gateway hands out the lowest free number IN THAT TENANT'S PARTITION, records which session (and
+/// Director) owns it, and guarantees it is unique across that tenant's fleet.
+///
+/// Two bands (the issue's refinement), applied per tenant:
 ///   - The COORDINATED band, <see cref="MinNumber"/>..<see cref="CoordinatedMaxNumber"/> (100-799),
 ///     is what the Gateway hands out. It fills from the low end.
 ///   - The OFFLINE band, <see cref="CoordinatedMaxNumber"/>+1..<see cref="MaxNumber"/> (800-999), is
 ///     left clear for Directors that cannot reach the Gateway at creation time. Those Directors pick a
 ///     random number in that band locally. Keeping the coordinated hand-outs in the low band means a
 ///     random offline pick is very unlikely to collide in normal use. The Gateway only spills into the
-///     offline band when the coordinated band is fully exhausted (700 concurrent sessions).
+///     offline band when a tenant's coordinated band is fully exhausted (700 concurrent sessions).
 ///
 /// The Gateway also learns numbers it did NOT hand out - a number a Director assigned offline, or any
 /// number still in use after a Gateway restart - via <see cref="Adopt"/>, called as the fleet is
@@ -28,7 +45,9 @@ namespace CcDirector.Gateway.Discovery;
 /// re-handed. Numbers are freed only by an explicit <see cref="Release"/> when a session ends, or by
 /// <see cref="ReleaseForDirector"/> when a whole Director is swept from the registry.
 ///
-/// Thread-safe: every public method takes the single lock.
+/// Thread-safe: every public method takes the single lock. The lock guards the whole tenant map, so it is
+/// held for the brief span of one partition's probe/mutate - low contention, and simpler than a lock per
+/// partition.
 /// </summary>
 public sealed class FleetSessionNumberAllocator
 {
@@ -43,158 +62,180 @@ public sealed class FleetSessionNumberAllocator
 
     private readonly object _lock = new();
 
-    /// <summary>sessionId -> the number and owning Director assigned to it.</summary>
-    private readonly Dictionary<string, Assignment> _bySession = new(StringComparer.Ordinal);
-
-    /// <summary>Every number currently reserved, for O(1) free-number probing.</summary>
-    private readonly HashSet<int> _inUse = new();
+    /// <summary>One partition per tenant; each holds that tenant's own session map and in-use set (its own pool).</summary>
+    private readonly Dictionary<TenantId, TenantPool> _byTenant = new();
 
     private readonly record struct Assignment(int Number, string DirectorId);
 
-    /// <summary>Count of numbers currently reserved. For tests and diagnostics.</summary>
-    public int InUseCount
+    /// <summary>One tenant's private allocation state: its session-to-number map and its own 100-999 in-use set.</summary>
+    private sealed class TenantPool
     {
-        get { lock (_lock) return _inUse.Count; }
+        public readonly Dictionary<string, Assignment> BySession = new(StringComparer.Ordinal);
+        public readonly HashSet<int> InUse = new();
     }
 
-    /// <summary>The number currently assigned to <paramref name="sessionId"/>, or null if none.</summary>
-    public int? NumberFor(string sessionId)
+    /// <summary>The tenant's partition, creating it on first use. Caller holds the lock.</summary>
+    private TenantPool PoolFor(TenantId tenant)
+    {
+        if (!_byTenant.TryGetValue(tenant, out var pool))
+        {
+            pool = new TenantPool();
+            _byTenant[tenant] = pool;
+        }
+        return pool;
+    }
+
+    /// <summary>Count of numbers currently reserved in <paramref name="tenant"/>'s partition. For tests and diagnostics.</summary>
+    public int InUseCount(TenantId tenant)
+    {
+        lock (_lock)
+            return _byTenant.TryGetValue(tenant, out var pool) ? pool.InUse.Count : 0;
+    }
+
+    /// <summary>The number currently assigned to <paramref name="sessionId"/> in <paramref name="tenant"/>'s partition, or null if none.</summary>
+    public int? NumberFor(TenantId tenant, string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId)) return null;
         lock (_lock)
-            return _bySession.TryGetValue(sessionId, out var a) ? a.Number : (int?)null;
+        {
+            if (!_byTenant.TryGetValue(tenant, out var pool)) return null;
+            return pool.BySession.TryGetValue(sessionId, out var a) ? a.Number : (int?)null;
+        }
     }
 
     /// <summary>
-    /// Hand out a fleet-unique number for <paramref name="sessionId"/>, owned by
-    /// <paramref name="directorId"/>. Idempotent: asking again for a session that already has a number
-    /// returns the SAME number, so a retry never double-assigns. Fills the coordinated band (100-799)
-    /// from the low end, spilling into the offline band (800-999) only when the coordinated band is full.
-    /// Returns null only when every number 100-999 is in use (pool exhausted) - the Director then shows
-    /// the session without a number rather than blocking real work over a cosmetic handle.
+    /// Hand out a number for <paramref name="sessionId"/> IN <paramref name="tenant"/>'s partition, unique
+    /// across that tenant's fleet, owned by <paramref name="directorId"/>. Idempotent: asking again for a
+    /// session that already has a number returns the SAME number, so a retry never double-assigns. Fills the
+    /// coordinated band (100-799) from the low end, spilling into the offline band (800-999) only when the
+    /// coordinated band is full. Returns null only when every number 100-999 IN THIS TENANT is in use (that
+    /// tenant's pool exhausted) - the Director then shows the session without a number rather than blocking
+    /// real work over a cosmetic handle.
     /// </summary>
-    public int? Allocate(string sessionId, string directorId)
+    public int? Allocate(TenantId tenant, string sessionId, string directorId)
     {
         if (string.IsNullOrEmpty(sessionId))
             throw new ArgumentException("sessionId is required", nameof(sessionId));
 
         lock (_lock)
         {
-            if (_bySession.TryGetValue(sessionId, out var existing))
+            var pool = PoolFor(tenant);
+            if (pool.BySession.TryGetValue(sessionId, out var existing))
             {
-                FileLog.Write($"[FleetSessionNumberAllocator] Allocate: {sessionId} already has {existing.Number} (idempotent)");
+                FileLog.Write($"[FleetSessionNumberAllocator] Allocate: {sessionId} already has {existing.Number} (idempotent, tenant={tenant.ToLogString()})");
                 return existing.Number;
             }
 
-            var chosen = FirstFree(MinNumber, CoordinatedMaxNumber) ?? FirstFree(CoordinatedMaxNumber + 1, MaxNumber);
+            var chosen = FirstFree(pool, MinNumber, CoordinatedMaxNumber) ?? FirstFree(pool, CoordinatedMaxNumber + 1, MaxNumber);
             if (chosen is not int number)
             {
-                FileLog.Write($"[FleetSessionNumberAllocator] Allocate: pool exhausted ({_inUse.Count} in use), no number for {sessionId}");
+                FileLog.Write($"[FleetSessionNumberAllocator] Allocate: pool exhausted ({pool.InUse.Count} in use), no number for {sessionId} (tenant={tenant.ToLogString()})");
                 return null;
             }
 
-            _inUse.Add(number);
-            _bySession[sessionId] = new Assignment(number, directorId ?? "");
-            FileLog.Write($"[FleetSessionNumberAllocator] Allocate: {number} -> {sessionId} (director={directorId}, {_inUse.Count} in use)");
+            pool.InUse.Add(number);
+            pool.BySession[sessionId] = new Assignment(number, directorId ?? "");
+            FileLog.Write($"[FleetSessionNumberAllocator] Allocate: {number} -> {sessionId} (director={directorId}, {pool.InUse.Count} in use, tenant={tenant.ToLogString()})");
             return number;
         }
     }
 
     /// <summary>
-    /// Mark a number the Gateway did NOT hand out as in use - a number a Director assigned offline, or a
-    /// number still live after a Gateway restart - learned as the fleet is aggregated. Only ever marks a
-    /// number in use; never frees one, so it is safe to call from the (possibly partial) fleet view. A
-    /// no-op when the session is already known, or when the number is out of range. If the number is
-    /// already held by a DIFFERENT session (a pre-existing offline collision the Gateway cannot resolve),
-    /// the first owner keeps it and the conflict is logged.
+    /// Mark a number the Gateway did NOT hand out as in use IN <paramref name="tenant"/>'s partition - a
+    /// number a Director assigned offline, or a number still live after a Gateway restart - learned as the
+    /// fleet is aggregated. Only ever marks a number in use; never frees one, so it is safe to call from the
+    /// (possibly partial) fleet view. A no-op when the session is already known, or when the number is out of
+    /// range. If the number is already held by a DIFFERENT session in this tenant (a pre-existing offline
+    /// collision the Gateway cannot resolve), the first owner keeps it and the conflict is logged.
     /// </summary>
-    public void Adopt(string sessionId, string directorId, int number)
+    public void Adopt(TenantId tenant, string sessionId, string directorId, int number)
     {
         if (string.IsNullOrEmpty(sessionId)) return;
         if (number < MinNumber || number > MaxNumber) return;
 
         lock (_lock)
         {
-            if (_bySession.TryGetValue(sessionId, out var existing))
+            var pool = PoolFor(tenant);
+            if (pool.BySession.TryGetValue(sessionId, out var existing))
             {
                 // Already tracked. Keep the number it already has (its own hand-out or a prior adopt).
                 if (existing.Number != number)
-                    FileLog.Write($"[FleetSessionNumberAllocator] Adopt: {sessionId} already holds {existing.Number}, ignoring observed {number}");
+                    FileLog.Write($"[FleetSessionNumberAllocator] Adopt: {sessionId} already holds {existing.Number}, ignoring observed {number} (tenant={tenant.ToLogString()})");
                 return;
             }
 
-            if (_inUse.Contains(number))
+            if (pool.InUse.Contains(number))
             {
-                FileLog.Write($"[FleetSessionNumberAllocator] Adopt: {number} already held by another session; {sessionId} keeps its offline number (pre-existing collision)");
+                FileLog.Write($"[FleetSessionNumberAllocator] Adopt: {number} already held by another session; {sessionId} keeps its offline number (pre-existing collision, tenant={tenant.ToLogString()})");
                 // Still record ownership so a later Allocate for this session is idempotent and a
                 // ReleaseForDirector can clean it up; the number simply is not exclusively ours.
-                _bySession[sessionId] = new Assignment(number, directorId ?? "");
+                pool.BySession[sessionId] = new Assignment(number, directorId ?? "");
                 return;
             }
 
-            _inUse.Add(number);
-            _bySession[sessionId] = new Assignment(number, directorId ?? "");
-            FileLog.Write($"[FleetSessionNumberAllocator] Adopt: {number} <- {sessionId} (director={directorId}, {_inUse.Count} in use)");
+            pool.InUse.Add(number);
+            pool.BySession[sessionId] = new Assignment(number, directorId ?? "");
+            FileLog.Write($"[FleetSessionNumberAllocator] Adopt: {number} <- {sessionId} (director={directorId}, {pool.InUse.Count} in use, tenant={tenant.ToLogString()})");
         }
     }
 
     /// <summary>
-    /// Free the number owned by <paramref name="sessionId"/> back to the pool when its session ends.
-    /// The number may later be reused. Releasing an unknown session is a harmless no-op.
+    /// Free the number owned by <paramref name="sessionId"/> IN <paramref name="tenant"/>'s partition back to
+    /// that tenant's pool when its session ends. The number may later be reused. Releasing an unknown session
+    /// (or an unknown tenant) is a harmless no-op.
     /// </summary>
-    public void Release(string sessionId)
+    public void Release(TenantId tenant, string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId)) return;
         lock (_lock)
         {
-            if (!_bySession.Remove(sessionId, out var a))
+            if (!_byTenant.TryGetValue(tenant, out var pool)) return;
+            if (!pool.BySession.Remove(sessionId, out var a))
                 return;
             // Only clear the shared reservation if no other session still holds this number (a
             // pre-existing offline collision could have two sessions on one number).
-            if (!_bySession.Values.Any(x => x.Number == a.Number))
-                _inUse.Remove(a.Number);
-            FileLog.Write($"[FleetSessionNumberAllocator] Release: freed {a.Number} from {sessionId} ({_inUse.Count} in use)");
+            if (!pool.BySession.Values.Any(x => x.Number == a.Number))
+                pool.InUse.Remove(a.Number);
+            FileLog.Write($"[FleetSessionNumberAllocator] Release: freed {a.Number} from {sessionId} ({pool.InUse.Count} in use, tenant={tenant.ToLogString()})");
         }
     }
 
     /// <summary>
-    /// Free every number owned by <paramref name="directorId"/>. Called when a Director is removed from
-    /// the registry (graceful unregister, or swept after its heartbeat went stale / its endpoint stayed
-    /// unreachable past the evict window) - a Director that died without releasing its sessions' numbers.
-    /// This is tied to the registry's own liveness decision, so it never fires for a Director that is
-    /// merely momentarily unreachable.
+    /// Free every number owned by <paramref name="directorId"/> IN <paramref name="tenant"/>'s partition.
+    /// Called when a Director is removed from the registry (graceful unregister, or swept after its heartbeat
+    /// went stale / its endpoint stayed unreachable past the evict window) - a Director that died without
+    /// releasing its sessions' numbers. This is tied to the registry's own liveness decision, so it never
+    /// fires for a Director that is merely momentarily unreachable.
     ///
-    /// NOT TENANT-SCOPED, and knowingly so. <see cref="DirectorRegistry.OnDirectorRemoved"/> now carries the
-    /// owning tenant, but this allocator's <c>_bySession</c> records only a bare director id beside each
-    /// assignment, so there is nothing here to filter by yet. A director id is unique only within its tenant,
-    /// so one tenant's removal can free another's numbers - which surfaces as a duplicated rail number, not
-    /// as data loss or disclosure. Closing it means partitioning the whole allocator (the pool, the
-    /// assignment record, and every Allocate/Adopt/Release caller) by tenant, which is its own unit of work
-    /// and is booked as such.
+    /// TENANT-SCOPED (audit H2). A director id is unique only within its tenant, so the tenant MUST be
+    /// supplied - <see cref="DirectorRegistry.OnDirectorRemoved"/> carries the owning tenant in its
+    /// <see cref="DirectorRemoval"/> payload, and the subscriber threads it straight through here. Only the
+    /// named tenant's partition is touched, so one tenant's removal can never free another tenant's numbers.
     /// </summary>
-    public void ReleaseForDirector(string directorId)
+    public void ReleaseForDirector(TenantId tenant, string directorId)
     {
         if (string.IsNullOrEmpty(directorId)) return;
         lock (_lock)
         {
-            var gone = _bySession.Where(kv => string.Equals(kv.Value.DirectorId, directorId, StringComparison.Ordinal))
-                                  .Select(kv => kv.Key).ToList();
+            if (!_byTenant.TryGetValue(tenant, out var pool)) return;
+            var gone = pool.BySession.Where(kv => string.Equals(kv.Value.DirectorId, directorId, StringComparison.Ordinal))
+                                     .Select(kv => kv.Key).ToList();
             foreach (var sid in gone)
-                _bySession.Remove(sid);
+                pool.BySession.Remove(sid);
             // Recompute the reserved set from what remains, so numbers shared by a surviving session stay held.
-            _inUse.Clear();
-            foreach (var a in _bySession.Values)
-                _inUse.Add(a.Number);
+            pool.InUse.Clear();
+            foreach (var a in pool.BySession.Values)
+                pool.InUse.Add(a.Number);
             if (gone.Count > 0)
-                FileLog.Write($"[FleetSessionNumberAllocator] ReleaseForDirector {directorId}: freed {gone.Count} number(s) ({_inUse.Count} in use)");
+                FileLog.Write($"[FleetSessionNumberAllocator] ReleaseForDirector {directorId}: freed {gone.Count} number(s) ({pool.InUse.Count} in use, tenant={tenant.ToLogString()})");
         }
     }
 
-    /// <summary>Lowest free number in [lo, hi], or null when the whole band is in use. Caller holds the lock.</summary>
-    private int? FirstFree(int lo, int hi)
+    /// <summary>Lowest free number in [lo, hi] within the pool, or null when the whole band is in use. Caller holds the lock.</summary>
+    private static int? FirstFree(TenantPool pool, int lo, int hi)
     {
         for (int n = lo; n <= hi; n++)
-            if (!_inUse.Contains(n))
+            if (!pool.InUse.Contains(n))
                 return n;
         return null;
     }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -641,12 +641,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // Issue #1292: free a removed Director's session numbers so a Director that died without releasing
         // them does not leak the pool. OnDirectorRemoved fires on graceful unregister and on the registry's
         // own stale/unreachable sweep, so this never fires for a merely momentarily-unreachable Director.
-        // The allocator's own store keys assignments by BARE director id with no tenant beside them, so it
-        // cannot yet scope this release even though the event now carries the tenant. That is a real hole of
-        // the same family - one account's disconnect frees another account's session numbers - but closing it
-        // means partitioning the allocator, which is its own unit of work; see the note on
-        // FleetSessionNumberAllocator.ReleaseForDirector.
-        Registry.OnDirectorRemoved += removal => SessionNumbers.ReleaseForDirector(removal.DirectorId);
+        // Audit H2: the allocator is partitioned by tenant and a director id is unique only within its
+        // tenant, so the removal's OWNING tenant is threaded straight through - dropping it would let one
+        // account's disconnect free another account's numbers. The removal carries its owner (DirectorRemoval),
+        // so the release only ever touches the departed Director's own tenant partition.
+        Registry.OnDirectorRemoved += removal => SessionNumbers.ReleaseForDirector(removal.Tenant, removal.DirectorId);
         PushedSessions = new Streaming.PushedSessionStore();
         // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store, at a Gateway-side file path
         // (CcStorage.Root(), the same location the cron and snooze stores use), NOT the Director's tool-config


### PR DESCRIPTION
## Root cause

`FleetSessionNumberAllocator` (the Gateway authority for the 100-999 rail session numbers, issue #1292) kept one **process-global** store keyed by **bare** session/director ids: `_bySession`, `_inUse`, the pool, and the lock. `Allocate` / `Adopt` / `Release` / `ReleaseForDirector` took bare ids, and the `OnDirectorRemoved` subscriber in `GatewayHost` **dropped** `DirectorRemoval.Tenant` before calling `ReleaseForDirector(removal.DirectorId)`.

A director id and a session id are unique only **within** a tenant, so on the hosted multi-tenant Gateway two tenants collided:

- tenant A's `Allocate` could idempotently read tenant B's assignment for a shared id and hand back B's number;
- tenant A's `DELETE /session-numbers/{id}` could free tenant B's number for an identically-named session;
- tenant A's same-id **Director removal** freed tenant B's assignments — surfacing as a duplicated rail number for the innocent account;
- the single 900-number pool let one busy tenant starve every other.

## Fix

Partition every piece of state by `TenantId` (`Dictionary<TenantId, TenantPool>`, each holding its own session map, in-use set, and 100-999 pool). Every method takes a tenant and only ever touches that tenant's own partition; each tenant draws from its own pool, so exhaustion is confined to the tenant that caused it. Self-host resolves to `TenantId.Local` — one partition, behavior unchanged.

- **Endpoints**: `POST /session-numbers/allocate` and `DELETE /session-numbers/{id}` resolve the caller's tenant **server-side** from the authenticated device key (`ResolveReadTenant`, never the request body). No bound tenant on hosted gives 403 (deny by default), never the Local partition. The `/sessions` adopt loop stamps the request's own tenant.
- **Removal subscriber**: threads `removal.Tenant` into `ReleaseForDirector(removal.Tenant, removal.DirectorId)` — the tenant is no longer dropped, and the required signature makes it impossible to forget.

## Reproduced-real / revert-proof

Verify-first: two reproduction tests were GREEN on current main (cross-tenant Director removal freed the other tenant's numbers; one tenant exhausted the shared pool for everyone).

- `FleetSessionNumberAllocatorTenancyTests` — removal / release / idempotent-read / pool-exhaustion isolation, each with a destructibility control beside the isolation assertion.
- `HostedSessionNumberRouteTenancyTests` — two device keys on two account tenants over real HTTP through the real auth middleware: same session-id allocates independently per tenant, one tenant's DELETE never frees the other's, unbound-tenant allocate is 403.
- Revert-proof confirmed by experiment: collapsing the allocator back to one shared pool reddened all four isolation assertions while the destructibility controls stayed green; restoring the partition greened them.

## Gates

- Build `CcDirector.Gateway` + `CcDirector.Gateway.Tests`: 0 warnings, 0 errors.
- Targeted allocator/removal/endpoint tests + the two solo tenancy filters (`OnOneRoute_TheCredentialAloneDecidesWhetherATenantScopeExists`, `The_roster_and_the_commands_agree`): all green.

**Merge note:** touches `GatewayHost.cs` and `GatewayEndpoints.cs`, which serialize at merge.
