### PR TITLE
fix(gateway): re-partition turn-end memory and display-push voice enrichment by tenant (MTR-10 Gap C+D)

### DIFF
--- a/mission/fix-gapcd-redo.md
+++ b/mission/fix-gapcd-redo.md
@@ -1,0 +1,100 @@
+# MTR-10 Gap C+D redo
+
+Re-implementation of MTR-10 Gap C+D after the first attempt (abf581ff) was reverted
+(#1995) for regressing the display-state push.
+
+## The isolation goals (unchanged from the original)
+
+- **Gap C**: `TurnEndWatcher` (and the coupled `NeedsYouClock`) keyed by
+  `(tenant, sessionId)`, never the bare session id. The owning tenant is resolved
+  BEFORE the transition decision and carried on the `TurnEndSignal`, and the push-store
+  reconcile runs one pass per tenant. Two accounts that happen to share a session GUID
+  can no longer suppress or fabricate each other's Working -> Waiting boundary (and so
+  each other's voice auto-refresh or "waiting since" clock).
+- **Gap D**: the display-state PUSH seam's voice enrichment
+  (`GatewayHost.EnrichVoiceThenFoldForPush`) reads the AMBIENT per-tenant of the display
+  pass, not `TenantId.Local`. The tenant-partitioned voice service is live on hosted
+  (#1973); a `Local` read there is an EMPTY partition, so the push-only desktop rail
+  folded `VoiceAudioReady=false` for every session and held every voice-mode session
+  permanently "Preparing voice" (yellow) while the roster served red.
+
+## Why the first attempt broke PushSnapshot
+
+The reverted change made the Gap D push closure read the ambient tenant:
+
+```csharp
+voiceGeneratingFor: sid => _tenantPass.Current is { } t && _voiceService?.IsGenerating(t, sid) == true,
+voiceAudioReadyFor: sid => _tenantPass.Current is { } t && _voiceService?.HasVoice(t, sid) == true,
+```
+
+The ambient tenant during a Director push is whatever tenant that Director is BOUND to.
+`DirectorHub.PushSnapshot` scopes the whole handler to the bound tenant
+(`EnterBoundTenantScope`) and then calls `_fleetDisplayState?.ObserveSnapshot(set)`
+SYNCHRONOUSLY, which folds through this closure.
+
+`WingmanVoiceService` REFUSES to name a voice-state partition for a tenant that is not
+`TenantId.Local` and not a minted account tenant - `IsGenerating`/`HasVoice` ->
+`StateFor` -> `CanonicalTenantKey` THROW `ArgumentException` for it. A Director bound to
+such a tenant therefore threw straight out of `PushSnapshot` as a SignalR
+`HubException`, taking the WHOLE fleet's display push down.
+
+`SessionServingLoopIsolationTests` binds its two Directors to `TenantId("tenant-alice")`
+and `TenantId("tenant-bob")` - deliberately unminted ids - so its `PushSnapshotAsync`
+calls hit exactly this throw. The original review only ran an "affected slice" (79/79)
+that did not include those tests, so the regression reached production and was caught by
+the CI backstop and rolled back (#1995).
+
+## How this fixes it
+
+The push read now degrades to "no voice" for an ambient tenant that cannot name a voice
+partition, instead of throwing:
+
+```csharp
+voiceGeneratingFor: sid => _tenantPass.Current is { } t
+    && Wingman.WingmanVoiceService.CanNameVoicePartition(t)
+    && _voiceService?.IsGenerating(t, sid) == true,
+voiceAudioReadyFor: sid => _tenantPass.Current is { } t
+    && Wingman.WingmanVoiceService.CanNameVoicePartition(t)
+    && _voiceService?.HasVoice(t, sid) == true,
+```
+
+`WingmanVoiceService.CanNameVoicePartition(TenantId)` is the SAME decision
+`CanonicalTenantKey` already makes (Local, or a minted account tenant), surfaced without
+throwing. This aligns the hot read path with the design-documented answer that a
+partition-less tenant (System, unminted, unresolved) "has no voice state at all" - a
+plain false, never an exception. The persisting/generating paths still throw for such a
+tenant, because writing into a partition that cannot be named IS a bug.
+
+Gap D's per-tenant read is unchanged where it matters: minted account tenants
+(production) and `Local` (self-host) are nameable, so the ambient read still finds their
+real voice state. The `DisplayPushTenantEnrichmentTests` canary (minted GUID tenants)
+still proves owning-tenant=red / other-tenant=yellow.
+
+Gap C did not participate in the throw: the turn-end watcher is fed by the doorbell
+(`onSessionState`) and the reconcile timer, not by `PushSnapshot`, so its per-tenant
+voice calls never ran synchronously inside the push. Gap C is re-applied exactly as the
+original, with its revert-proof wiring canaries intact.
+
+## Proof
+
+- `dotnet build` Gateway + Gateway.Tests: 0 warnings, 0 errors.
+- HARD GATE - `SessionServingLoopIsolationTests`: 4/4 PASS.
+- `TurnEndWatcherTenantIsolationTests` (solo): 1/1 PASS.
+- `VoiceServingLoopIsolationTests` (solo): 3/3 PASS.
+- `DisplayPushTenantEnrichmentTests` (solo): 1/1 PASS.
+- Turn-end / needs-you-clock / display-push units: 32/32 PASS.
+- Full Gateway test suite: PASS (see PR body for counts).
+
+## Files
+
+- `src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs` - add
+  `CanNameVoicePartition`.
+- `src/CcDirector.Gateway/GatewayHost.cs` - guard the Gap D push read; Gap C wiring.
+- `src/CcDirector.Gateway/Briefing/TurnEndWatcher.cs` - `(tenant, sessionId)` keying,
+  tenant on the signal, per-tenant reconcile.
+- `src/CcDirector.Gateway/Briefing/NeedsYouClock.cs` - `(tenant, sessionId)` keying.
+- `src/CcDirector.Gateway/Api/GatewayEndpoints.cs` - thread the owning tenant into the
+  needs-you stamp.
+- Tests: `DisplayPushTenantEnrichmentTests`, `TurnEndWatcherTenantIsolationTests` (new);
+  `NeedsYouClockTests`, `TurnEndWatcherVoiceRefreshTests`, `GatewayTurnBriefTests`,
+  `VoiceServingLoopIsolationTests`, `DisplayPushVoiceEnrichmentTests` (updated).

--- a/src/CcDirector.Gateway.Tests/DisplayPushTenantEnrichmentTests.cs
+++ b/src/CcDirector.Gateway.Tests/DisplayPushTenantEnrichmentTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Hosted Multi-Tenancy (MTR-10 Gap D): the display-state PUSH seam's voice enrichment
+/// (<c>FleetDisplayStateObserver</c> -> <c>GatewayHost.EnrichVoiceThenFoldForPush</c>) reads the AMBIENT
+/// tenant of the per-tenant display pass, NOT <c>TenantId.Local</c>. The tenant-partitioned voice service is
+/// live on hosted (#1973); a Local read there is an EMPTY partition, so the push-only desktop rail would fold
+/// <c>VoiceAudioReady=false</c> for every session and hold every voice-mode session permanently "Preparing
+/// voice" (yellow) while the roster - which resolves the request tenant - served red.
+///
+/// This drives the REAL production seam through the live DirectorHub push: two Directors on two DIFFERENT
+/// tenants share a voice-mode session id, a ready clip exists in ONLY one tenant's partition, and each
+/// Director's own snapshot push triggers the Gateway to fold and stamp the display state back down over the
+/// tunnel. The fold that reaches each Director is the production <c>EnrichVoiceThenFoldForPush</c> closure
+/// wired in <see cref="GatewayHost"/>, not a re-implementation.
+///
+/// REVERT-PROOF against the production enrichment: change the closure back to
+/// <c>IsGenerating(TenantId.Local, sid)</c> / <c>HasVoice(TenantId.Local, sid)</c> and
+/// <see cref="Voice_ready_folds_red_for_the_owning_tenant_yellow_for_the_other"/> goes RED - the owning
+/// tenant's ready clip is invisible in the Local partition, so its desktop is stamped "yellow" (Preparing
+/// voice) instead of "red".
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is
+/// reset in DisposeAsync.
+/// </summary>
+public sealed class DisplayPushTenantEnrichmentTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    // The COLLIDING id: both accounts run a voice-mode session called "s".
+    private const string SharedSid = "s";
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    private GatewayHost _gateway = null!;
+    private FakeTunnelDirector _dirA = null!;
+    private FakeTunnelDirector _dirB = null!;
+
+    private readonly ConcurrentQueue<DirectorCommand> _seenByA = new();
+    private readonly ConcurrentQueue<DirectorCommand> _seenByB = new();
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-display-tenant-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+
+        var keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", TenantA.Value);
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", TenantB.Value);
+
+        _dirA = await FakeTunnelDirector.StartAsync(_gateway, keyA, "dir-a", "MA",
+            dispatch: cmd => { _seenByA.Enqueue(cmd); return FakeTunnelDirector.Ok(new { ok = true }); });
+        _dirB = await FakeTunnelDirector.StartAsync(_gateway, keyB, "dir-b", "MB",
+            dispatch: cmd => { _seenByB.Enqueue(cmd); return FakeTunnelDirector.Ok(new { ok = true }); });
+
+        // A ready voice clip exists in tenant B's partition ONLY. Seeded BEFORE any push so the very first fold
+        // already sees it - the enrichment must find it for B and NOT for A (same session id).
+        _gateway.VoiceService!.StoreReadyAudioForTest(TenantB, SharedSid, "spoken", "reply", new byte[] { 1, 2, 3 });
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _dirA.DisposeAsync();
+        await _dirB.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task Voice_ready_folds_red_for_the_owning_tenant_yellow_for_the_other()
+    {
+        // Each Director pushes its OWN voice-mode waiting session (same id "s"). The push triggers the Gateway
+        // to fold that tenant's fleet and stamp the display state back down over the tunnel.
+        await _dirB.PushSnapshotAsync(VoiceModeWaiting(SharedSid));
+        await _dirA.PushSnapshotAsync(VoiceModeWaiting(SharedSid));
+
+        // Tenant B OWNS the ready clip: its ambient-tenant enrichment finds VoiceAudioReady=true, so the fold
+        // stamped down to dir-B is RED. Reverting the enrichment to TenantId.Local reads an empty partition and
+        // this becomes "yellow" (Preparing voice) - the exact stuck-yellow this gap describes.
+        Assert.Equal("red", await WaitForDisplayColor(_seenByB, SharedSid));
+
+        // Tenant A has NO clip for the same id: its own partition read yields VoiceAudioReady=false, so its
+        // desktop is honestly "yellow". Same id, different tenant, different fold - the per-tenant proof.
+        Assert.Equal("yellow", await WaitForDisplayColor(_seenByA, SharedSid));
+    }
+
+    /// <summary>Wait for a set-display-state command for the session and return its folded EffectiveColor.</summary>
+    private static async Task<string?> WaitForDisplayColor(ConcurrentQueue<DirectorCommand> seen, string sessionId)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            var hit = seen.LastOrDefault(c => c.Verb == "set-display-state" && c.SessionId == sessionId);
+            if (hit?.PayloadJson is { Length: > 0 } payload)
+            {
+                using var doc = JsonDocument.Parse(payload);
+                if (doc.RootElement.TryGetProperty("effectiveColor", out var color))
+                    return color.GetString();
+            }
+            await Task.Delay(50);
+        }
+        return null;
+    }
+
+    // A voice-mode session settled at a turn end (raw red, waiting) with the Gateway-only voice booleans at
+    // their default false - exactly what a Director pushes; the Gateway enriches VoiceAudioReady from its own
+    // per-tenant voice store before folding.
+    private static SessionDto VoiceModeWaiting(string sid) => new()
+    {
+        SessionId = sid,
+        Agent = "claude",
+        RepoPath = "/repo",
+        ActivityState = "WaitingForInput",
+        Status = "Running",
+        StatusColor = "red",
+        VoiceMode = true,
+        VoiceGenerating = false,
+        VoiceAudioReady = false,
+        CreatedAt = DateTime.UtcNow,
+        LastActivityAt = DateTime.UtcNow,
+    };
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DisplayPushVoiceEnrichmentTests.cs
+++ b/src/CcDirector.Gateway.Tests/DisplayPushVoiceEnrichmentTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using Xunit;
 
@@ -42,6 +43,7 @@ public sealed class DisplayPushVoiceEnrichmentTests
             new List<SessionDto> { s },
             voiceGeneratingFor: _ => false,
             voiceAudioReadyFor: _ => true,
+            tenant: TenantId.Local,
             needsYouStampFor: null,
             snoozeRegistry: null);
 
@@ -60,6 +62,7 @@ public sealed class DisplayPushVoiceEnrichmentTests
             new List<SessionDto> { s },
             voiceGeneratingFor: _ => false,
             voiceAudioReadyFor: _ => false,
+            tenant: TenantId.Local,
             needsYouStampFor: null,
             snoozeRegistry: null);
 
@@ -77,6 +80,7 @@ public sealed class DisplayPushVoiceEnrichmentTests
             new List<SessionDto> { s },
             voiceGeneratingFor: _ => true,
             voiceAudioReadyFor: _ => true,
+            tenant: TenantId.Local,
             needsYouStampFor: null,
             snoozeRegistry: null);
 

--- a/src/CcDirector.Gateway.Tests/GatewayTurnBriefTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTurnBriefTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Wingman;
 using CcDirector.Gateway.Briefing;
 using CcDirector.Gateway.Contracts;
@@ -165,7 +166,7 @@ public sealed class TurnEndWatcherTests
     {
         var turnEnds = new List<TurnEndSignal>();
         var working = new List<string>();
-        var watcher = new TurnEndWatcher(turnEnds.Add, (sid, _) => working.Add(sid));
+        var watcher = new TurnEndWatcher(turnEnds.Add, (_, sid, _) => working.Add(sid));
         return (watcher, turnEnds, working);
     }
 
@@ -175,8 +176,8 @@ public sealed class TurnEndWatcherTests
         var (watcher, turnEnds, working) = BuildObserved();
         using (watcher)
         {
-            watcher.Observe("s1", "Working", "d1");
-            watcher.Observe("s1", "WaitingForInput", "d1");
+            watcher.Observe(TenantId.Local, "s1", "Working", "d1");
+            watcher.Observe(TenantId.Local, "s1", "WaitingForInput", "d1");
 
             Assert.Single(working);
             Assert.Single(turnEnds);
@@ -193,11 +194,11 @@ public sealed class TurnEndWatcherTests
         var (watcher, turnEnds, working) = BuildObserved();
         using (watcher)
         {
-            watcher.Observe("s1", "Working", "http://d1");           // doorbell
-            watcher.Observe("s1", "WaitingForInput", "http://d1");   // doorbell -> turn end
-            watcher.Observe("s1", "WaitingForInput", "http://d1");   // heartbeat replay
-            watcher.Observe("s1", "Working", "http://d1");           // user replied
-            watcher.Observe("s1", "Working", "http://d1");           // heartbeat replay
+            watcher.Observe(TenantId.Local, "s1", "Working", "http://d1");           // doorbell
+            watcher.Observe(TenantId.Local, "s1", "WaitingForInput", "http://d1");   // doorbell -> turn end
+            watcher.Observe(TenantId.Local, "s1", "WaitingForInput", "http://d1");   // heartbeat replay
+            watcher.Observe(TenantId.Local, "s1", "Working", "http://d1");           // user replied
+            watcher.Observe(TenantId.Local, "s1", "Working", "http://d1");           // heartbeat replay
 
             Assert.Single(turnEnds);
             Assert.Equal(2, working.Count); // entered Working twice, replays ignored
@@ -225,13 +226,13 @@ public sealed class TurnEndWatcherTests
         var (watcher, turnEnds, _) = BuildObserved();
         using (watcher)
         {
-            watcher.Observe("s1", "Working", "http://d1");
-            watcher.Observe("s1", "WaitingForInput", "http://d1");
+            watcher.Observe(TenantId.Local, "s1", "Working", "http://d1");
+            watcher.Observe(TenantId.Local, "s1", "WaitingForInput", "http://d1");
             turnEnds.Clear();
 
             // Working -> (lost) -> heartbeat says Working -> doorbell says WaitingForInput
-            watcher.Observe("s1", "Working", "http://d1");
-            watcher.Observe("s1", "WaitingForInput", "http://d1");
+            watcher.Observe(TenantId.Local, "s1", "Working", "http://d1");
+            watcher.Observe(TenantId.Local, "s1", "WaitingForInput", "http://d1");
             Assert.Single(turnEnds);
         }
     }

--- a/src/CcDirector.Gateway.Tests/NeedsYouClockTests.cs
+++ b/src/CcDirector.Gateway.Tests/NeedsYouClockTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Briefing;
 using Xunit;
 
@@ -17,7 +18,7 @@ public sealed class NeedsYouClockTests
     {
         var clock = new NeedsYouClock();
 
-        var result = clock.Stamp("s1", isRed: false);
+        var result = clock.Stamp(TenantId.Local, "s1", isRed: false);
 
         Assert.Null(result);
     }
@@ -28,7 +29,7 @@ public sealed class NeedsYouClockTests
         var clock = new NeedsYouClock();
         var before = DateTime.UtcNow;
 
-        var result = clock.Stamp("s1", isRed: true);
+        var result = clock.Stamp(TenantId.Local, "s1", isRed: true);
 
         Assert.NotNull(result);
         var after = DateTime.UtcNow;
@@ -40,9 +41,9 @@ public sealed class NeedsYouClockTests
     {
         var clock = new NeedsYouClock();
 
-        var first = clock.Stamp("s1", isRed: true);
+        var first = clock.Stamp(TenantId.Local, "s1", isRed: true);
         Thread.Sleep(20); // a later poll cycle
-        var second = clock.Stamp("s1", isRed: true);
+        var second = clock.Stamp(TenantId.Local, "s1", isRed: true);
 
         Assert.NotNull(first);
         Assert.NotNull(second);
@@ -54,9 +55,9 @@ public sealed class NeedsYouClockTests
     public void Stamp_LeavesRed_ClearsToNull()
     {
         var clock = new NeedsYouClock();
-        clock.Stamp("s1", isRed: true);
+        clock.Stamp(TenantId.Local, "s1", isRed: true);
 
-        var afterLeaving = clock.Stamp("s1", isRed: false);
+        var afterLeaving = clock.Stamp(TenantId.Local, "s1", isRed: false);
 
         Assert.Null(afterLeaving);
     }
@@ -66,10 +67,10 @@ public sealed class NeedsYouClockTests
     {
         var clock = new NeedsYouClock();
 
-        var first = clock.Stamp("s1", isRed: true);
-        clock.Stamp("s1", isRed: false); // leaves red - episode ends, value goes null
+        var first = clock.Stamp(TenantId.Local, "s1", isRed: true);
+        clock.Stamp(TenantId.Local, "s1", isRed: false); // leaves red - episode ends, value goes null
         Thread.Sleep(20);
-        var second = clock.Stamp("s1", isRed: true); // returns to red - new episode
+        var second = clock.Stamp(TenantId.Local, "s1", isRed: true); // returns to red - new episode
 
         Assert.NotNull(first);
         Assert.NotNull(second);
@@ -82,11 +83,11 @@ public sealed class NeedsYouClockTests
     {
         var clock = new NeedsYouClock();
 
-        var a = clock.Stamp("a", isRed: true);
+        var a = clock.Stamp(TenantId.Local, "a", isRed: true);
         Thread.Sleep(20);
-        var b = clock.Stamp("b", isRed: true);
+        var b = clock.Stamp(TenantId.Local, "b", isRed: true);
         // re-poll a while still red: it keeps its (earlier) value, independent of b.
-        var aAgain = clock.Stamp("a", isRed: true);
+        var aAgain = clock.Stamp(TenantId.Local, "a", isRed: true);
 
         Assert.NotNull(a);
         Assert.NotNull(b);
@@ -100,6 +101,50 @@ public sealed class NeedsYouClockTests
     {
         var clock = new NeedsYouClock();
 
-        Assert.Throws<ArgumentException>(() => clock.Stamp("", isRed: true));
+        Assert.Throws<ArgumentException>(() => clock.Stamp(TenantId.Local, "", isRed: true));
+    }
+
+    // MTR-10 Gap C: two accounts can run sessions with the SAME id. The clock is keyed by
+    // (tenant, sessionId), so one account's "left red" must never clear the other account's entry,
+    // and one account's held stamp must never be reported as the other's "waiting since".
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void Stamp_SameSessionIdTwoTenants_TracksIndependently()
+    {
+        var clock = new NeedsYouClock();
+
+        // Both accounts have a red session with the SAME id.
+        var a = clock.Stamp(TenantA, "shared", isRed: true);
+        Thread.Sleep(20);
+        var b = clock.Stamp(TenantB, "shared", isRed: true);
+
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        // Distinct entries - B's later entry did not adopt or overwrite A's earlier one (a bare-sid
+        // key would return A's held value here, so these would be equal).
+        Assert.True(b!.Value > a!.Value,
+            $"tenant B's entry {b.Value:o} should be its own, strictly later than tenant A's {a.Value:o}");
+
+        // A holds its OWN value on a re-poll, unaffected by B sharing the id.
+        var aAgain = clock.Stamp(TenantA, "shared", isRed: true);
+        Assert.Equal(a.Value, aAgain);
+    }
+
+    [Fact]
+    public void Stamp_OneTenantLeavesRed_DoesNotClearTheOtherTenant()
+    {
+        var clock = new NeedsYouClock();
+
+        var a = clock.Stamp(TenantA, "shared", isRed: true);   // A enters red
+        clock.Stamp(TenantB, "shared", isRed: false);          // B leaves red on the SAME id
+
+        // A's entry survives - B clearing the shared id cleared only B's partition. A bare-sid key
+        // would have removed the one shared entry, so A's next red would re-stamp a strictly-later
+        // moment instead of holding this one.
+        var aAgain = clock.Stamp(TenantA, "shared", isRed: true);
+        Assert.NotNull(a);
+        Assert.Equal(a!.Value, aAgain);
     }
 }

--- a/src/CcDirector.Gateway.Tests/TurnEndWatcherTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/TurnEndWatcherTenantIsolationTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Hosted Multi-Tenancy (MTR-10 Gap C): the turn-end tracker's transition memory
+/// (<c>TurnEndWatcher._lastActivity</c>) is keyed by (tenant, sessionId), NEVER the bare session id. Two
+/// accounts can run sessions that happen to share an id; a bare-sid key let one tenant's last-seen state
+/// suppress - or fabricate - the OTHER tenant's Working -> Waiting boundary, and so its voice auto-refresh.
+///
+/// This drives the REAL production path: two Directors on two DIFFERENT tenants over the real tunnel, each
+/// authenticated with its own per-device key, and the live <c>TurnEndWatcher.Observe</c> transition wired
+/// exactly as <see cref="GatewayHost"/> installs it (onTurnEnd -> voice refresh, resolving from the owning
+/// tenant carried on the signal). Both tenants own a session with the SAME id, and both are marked voice
+/// sessions, so a correctly-partitioned watcher fires an independent turn-end refresh for EACH tenant's own
+/// Director.
+///
+/// REVERT-PROOF against the production keying: change <c>_lastActivity</c> back to a bare
+/// <c>ConcurrentDictionary&lt;string, string&gt;</c> keyed by session id alone and
+/// <see cref="Same_sid_two_tenants_each_turn_end_reaches_only_its_own_director"/> goes RED - tenant B writing
+/// "WaitingForInput" into the shared key first means tenant A's real Working -> Waiting transition sees no
+/// change and its refresh is suppressed, so dir-A is never asked to read session "s".
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is
+/// reset in DisposeAsync.
+/// </summary>
+public sealed class TurnEndWatcherTenantIsolationTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    // The COLLIDING id: both accounts run a session called "s".
+    private const string SharedSid = "s";
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    private GatewayHost _gateway = null!;
+    private FakeTunnelDirector _dirA = null!;
+    private FakeTunnelDirector _dirB = null!;
+
+    private readonly ConcurrentQueue<DirectorCommand> _seenByA = new();
+    private readonly ConcurrentQueue<DirectorCommand> _seenByB = new();
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-turnend-tenant-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+
+        var keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", TenantA.Value);
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", TenantB.Value);
+
+        _dirA = await FakeTunnelDirector.StartAsync(_gateway, keyA, "dir-a", "MA",
+            dispatch: cmd => { _seenByA.Enqueue(cmd); return TurnsOrOk(cmd); });
+        _dirB = await FakeTunnelDirector.StartAsync(_gateway, keyB, "dir-b", "MB",
+            dispatch: cmd => { _seenByB.Enqueue(cmd); return TurnsOrOk(cmd); });
+
+        // Each tenant owns a session with the SAME id, in its OWN partition, and both are marked voice
+        // sessions so a correctly-scoped turn-end fires a refresh for each.
+        await _dirA.PushSnapshotAsync(Sample(SharedSid));
+        await _dirB.PushSnapshotAsync(Sample(SharedSid));
+        _gateway.VoiceService!.Mark(TenantA, SharedSid);
+        _gateway.VoiceService!.Mark(TenantB, SharedSid);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _dirA.DisposeAsync();
+        await _dirB.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task Same_sid_two_tenants_each_turn_end_reaches_only_its_own_director()
+    {
+        var watcher = _gateway.TurnEndWatcherForTest!;
+
+        // The interleaving that a bare-sid key gets wrong. Tenant A starts working; tenant B (same id) also
+        // works then ENDS its turn first - writing "WaitingForInput" into the shared key. Then tenant A ends
+        // its own turn. With a per-tenant key each transition is A's or B's alone; with a bare key A's real
+        // transition sees the key already at "WaitingForInput" (from B) and fires nothing.
+        watcher.Observe(TenantA, SharedSid, "Working", "dir-a");           // A working
+        watcher.Observe(TenantB, SharedSid, "Working", "dir-b");           // B working (bare key: a no-op)
+        watcher.Observe(TenantB, SharedSid, "WaitingForInput", "dir-b");   // B turn end -> refresh dir-B
+        watcher.Observe(TenantA, SharedSid, "WaitingForInput", "dir-a");   // A turn end -> refresh dir-A
+
+        // POSITIVE CONTROL: B's turn end reached its own Director, so the watcher is live and the harness works.
+        Assert.NotNull(await WaitForVerb(_seenByB, "turns", SharedSid));
+
+        // THE PARTITION PROOF: A's turn end reached dir-A too - it was NOT suppressed by B sharing the id. A
+        // bare-sid key reddens exactly here (A's transition is swallowed, dir-A sees no "turns" read).
+        Assert.NotNull(await WaitForVerb(_seenByA, "turns", SharedSid));
+    }
+
+    /// <summary>
+    /// Poll for a verb+session rather than sleeping a fixed time: the refresh fires generation onto the thread
+    /// pool and the tunnel round-trip is asynchronous, so a fixed wait would be either flaky or slow.
+    /// </summary>
+    private static async Task<DirectorCommand?> WaitForVerb(ConcurrentQueue<DirectorCommand> seen, string verb, string sessionId)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            var hit = seen.FirstOrDefault(c => c.Verb == verb && c.SessionId == sessionId);
+            if (hit is not null) return hit;
+            await Task.Delay(50);
+        }
+        return null;
+    }
+
+    // A "turns" read answers with an empty widget set (no text reply -> generation stops before any hosted
+    // call); everything else is a harmless ok.
+    private static DirectorCommandResult TurnsOrOk(DirectorCommand cmd) =>
+        cmd.Verb == "turns"
+            ? FakeTunnelDirector.Ok(new { widgets = Array.Empty<object>() })
+            : FakeTunnelDirector.Ok(new { ok = true });
+
+    private static SessionDto Sample(string sid) => new()
+    {
+        SessionId = sid,
+        Agent = "claude",
+        RepoPath = "/repo",
+        ActivityState = "WaitingForInput",
+        Status = "Running",
+        StatusColor = "red",
+        CreatedAt = DateTime.UtcNow,
+        LastActivityAt = DateTime.UtcNow,
+    };
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TurnEndWatcherVoiceRefreshTests.cs
+++ b/src/CcDirector.Gateway.Tests/TurnEndWatcherVoiceRefreshTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Briefing;
 using Xunit;
 
@@ -47,7 +48,7 @@ public sealed class TurnEndWatcherVoiceRefreshTests
                 if (voice.IsVoiceSession(signal.SessionId))
                     voice.GenerateAsync(signal.SessionId, signal.DirectorId, signal.IsNewTurn);
             },
-            onSessionWorking: (sid, _) => voice.OnSessionWorking(sid));
+            onSessionWorking: (_, sid, _) => voice.OnSessionWorking(sid));
     }
 
     [Fact]
@@ -59,8 +60,8 @@ public sealed class TurnEndWatcherVoiceRefreshTests
         // A turn runs and then finishes on its own (Working -> WaitingForInput) - the hands-off
         // boundary. The watcher must call voice GenerateAsync for the session, with the owning
         // Director endpoint, and nothing else.
-        watcher.Observe("voice-sid", "Working", "d1");
-        watcher.Observe("voice-sid", "WaitingForInput", "d1");
+        watcher.Observe(TenantId.Local, "voice-sid", "Working", "d1");
+        watcher.Observe(TenantId.Local, "voice-sid", "WaitingForInput", "d1");
 
         var generated = Assert.Single(voice.Generated);
         Assert.Equal("voice-sid", generated.Sid);
@@ -80,7 +81,7 @@ public sealed class TurnEndWatcherVoiceRefreshTests
         using var watcher = BuildWatcher(voice);
 
         // No prior Working observation - the very first sighting is the waiting state.
-        watcher.Observe("voice-sid", "WaitingForInput", "d1");
+        watcher.Observe(TenantId.Local, "voice-sid", "WaitingForInput", "d1");
 
         var generated = Assert.Single(voice.Generated);
         Assert.Equal("voice-sid", generated.Sid);
@@ -95,8 +96,8 @@ public sealed class TurnEndWatcherVoiceRefreshTests
         var voice = new RecordingVoice(/* no voice sessions */);
         using var watcher = BuildWatcher(voice);
 
-        watcher.Observe("plain-sid", "Working", "d1");
-        watcher.Observe("plain-sid", "WaitingForInput", "d1");
+        watcher.Observe(TenantId.Local, "plain-sid", "Working", "d1");
+        watcher.Observe(TenantId.Local, "plain-sid", "WaitingForInput", "d1");
 
         Assert.Empty(voice.Generated);
     }
@@ -108,9 +109,9 @@ public sealed class TurnEndWatcherVoiceRefreshTests
         var voice = new RecordingVoice("voice-sid");
         using var watcher = BuildWatcher(voice);
 
-        watcher.Observe("voice-sid", "Working", "d1");
-        watcher.Observe("voice-sid", "WaitingForInput", "d1");  // turn end -> generate
-        watcher.Observe("voice-sid", "Working", "d1");          // user replied -> clear cache
+        watcher.Observe(TenantId.Local, "voice-sid", "Working", "d1");
+        watcher.Observe(TenantId.Local, "voice-sid", "WaitingForInput", "d1");  // turn end -> generate
+        watcher.Observe(TenantId.Local, "voice-sid", "Working", "d1");          // user replied -> clear cache
 
         Assert.Single(voice.Generated);
         Assert.Contains("voice-sid", voice.Cleared);

--- a/src/CcDirector.Gateway.Tests/VoiceServingLoopIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceServingLoopIsolationTests.cs
@@ -32,10 +32,10 @@ namespace CcDirector.Gateway.Tests;
 ///    old single <c>TenantId.Local</c> pass and <see cref="Voice_sweep_reaches_only_the_owning_tenants_director"/>
 ///    goes RED - the Local partition holds no marked voice session, so the tunnel read that must reach dir-B is
 ///    never sent.
-///  - the turn-end callback: replace its <c>ResolveOwningTenant(signal.DirectorId)</c> + tenant-passed
-///    <c>IsVoiceSession</c>/<c>GenerateAsync</c> with the old <c>TenantId.Local</c> and
-///    <see cref="Turn_end_voice_refresh_reaches_only_the_owning_tenants_director"/> goes RED - IsVoiceSession is
-///    false in the Local partition, so no refresh is issued.
+///  - the turn-end callback: replace its <c>signal.Tenant</c>-passed <c>IsVoiceSession</c>/<c>GenerateAsync</c>
+///    (the owning tenant resolved BEFORE Observe and carried on the signal, MTR-10 Gap C) with the old
+///    <c>TenantId.Local</c> and <see cref="Turn_end_voice_refresh_reaches_only_the_owning_tenants_director"/>
+///    goes RED - IsVoiceSession is false in the Local partition, so no refresh is issued.
 ///
 /// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is
 /// reset in DisposeAsync.
@@ -124,8 +124,8 @@ public sealed class VoiceServingLoopIsolationTests : IAsyncLifetime
         // Drive a REAL Working -> Waiting transition for B's session on dir-B through the live watcher, which
         // fires the production onSessionWorking (clear) then onTurnEnd (refresh) callbacks. Both resolve the
         // owning tenant from the director id the signal carries.
-        _gateway.TurnEndWatcherForTest!.Observe(SessB, "Working", "dir-b");
-        _gateway.TurnEndWatcherForTest!.Observe(SessB, "WaitingForInput", "dir-b");
+        _gateway.TurnEndWatcherForTest!.Observe(TenantB, SessB, "Working", "dir-b");
+        _gateway.TurnEndWatcherForTest!.Observe(TenantB, SessB, "WaitingForInput", "dir-b");
 
         // POSITIVE CONTROL FIRST: the turn-end refresh's tunnel read for B's session reached dir-B.
         Assert.NotNull(await WaitForVerb(_seenByB, "turns", SessB));

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -26,7 +26,8 @@ internal static class GatewayEndpoints
     /// <param name="voiceAudioReadyFor">Issue #553: whether the Gateway has fetchable, playable
     /// cached audio for a session id (<c>WingmanVoiceService.HasVoice</c>), stamped onto
     /// <see cref="SessionDto.VoiceAudioReady"/>. Null leaves the field false.</param>
-    /// <param name="needsYouStampFor">Issue #218: given (sessionId, isRed) where isRed is the
+    /// <param name="needsYouStampFor">Issue #218 (MTR-10 Gap C: tenant-partitioned): given
+    /// (tenant, sessionId, isRed) where tenant is the OWNING tenant of the row and isRed is the
     /// session's final EffectiveColor=="red" this refresh, returns the Gateway-owned UTC
     /// timestamp the session entered red (held while red, null when not red), stamped onto
     /// <see cref="SessionDto.NeedsYouSince"/>. Null (old callers) leaves
@@ -52,7 +53,7 @@ internal static class GatewayEndpoints
         Func<TenantId, string, Core.HostedAi.HostedAiState?>? voiceUnavailableFor = null,
         Func<TenantId, string, bool>? nothingToNarrateFor = null,
         Func<TenantId, string, bool>? servedViaFallbackFor = null,
-        Func<string, bool, DateTime?>? needsYouStampFor = null,
+        Func<TenantId, string, bool, DateTime?>? needsYouStampFor = null,
         Func<TenantId, string, bool>? transcribingFor = null,
         Func<TenantId, string, string?>? dictationStatusFor = null,
         Transcription.TranscribingSessions? transcribingSessions = null,
@@ -1035,7 +1036,7 @@ internal static class GatewayEndpoints
             // stamp the presentation fold (which reads the role to suppress a live Worker's red toward the
             // human). Done here, once, because the role needs the full fleet view - the UNFILTERED one
             // (`fleet`), not the response set (`all`). See defect 13 in StampFleetRolesAndFold.
-            StampFleetRolesAndFold(fleet, all, needsYouStampFor, snoozeRegistry);
+            StampFleetRolesAndFold(fleet, all, needsYouStampFor, snoozeRegistry, reqTenant.Value);
 
             // DevThrottle Stats: fold the assembled roster's per-session input tallies into the always-
             // available aggregate that backs "Your Throttle". This is the ONE path that carries
@@ -1334,7 +1335,7 @@ internal static class GatewayEndpoints
             // is driven by the roster read. Letting a by-id read stamp it would drive that clock out of band
             // and corrupt the roster's own waiting times. NeedsYouSince stays unstamped here, exactly as
             // before - this fix does not claim it.
-            StampFleetRolesAndFold(fleet, new[] { session }, needsYouStampFor: null, snoozeRegistry: snoozeRegistry);
+            StampFleetRolesAndFold(fleet, new[] { session }, needsYouStampFor: null, snoozeRegistry: snoozeRegistry, tenant: reqTenant.Value);
             return Results.Json(session);
         });
 
@@ -2939,8 +2940,9 @@ internal static class GatewayEndpoints
     internal static void StampFleetRolesAndFold(
         List<SessionDto> roleUniverse,
         IReadOnlyList<SessionDto> toStamp,
-        Func<string, bool, DateTime?>? needsYouStampFor = null,
-        Snooze.SnoozeRegistry? snoozeRegistry = null)
+        Func<TenantId, string, bool, DateTime?>? needsYouStampFor = null,
+        Snooze.SnoozeRegistry? snoozeRegistry = null,
+        TenantId? tenant = null)
     {
         if (roleUniverse is null) throw new ArgumentNullException(nameof(roleUniverse));
         if (toStamp is null) throw new ArgumentNullException(nameof(toStamp));
@@ -3036,7 +3038,11 @@ internal static class GatewayEndpoints
             if (needsYouStampFor is not null)
             {
                 var isRed = string.Equals(effectiveColor, "red", StringComparison.OrdinalIgnoreCase);
-                s.NeedsYouSince = needsYouStampFor(s.SessionId, isRed);
+                // MTR-10 Gap C: the needs-you clock is partitioned per tenant. The tenant is the OWNING tenant
+                // of the fold pass - the roster's request tenant, the display push's ambient tenant. Only the
+                // needs-you callers pass it; the dev/diagnostic callers pass no needsYouStampFor and no tenant,
+                // so the null-to-Local resolution here is never reached for them.
+                s.NeedsYouSince = needsYouStampFor(tenant ?? TenantId.Local, s.SessionId, isRed);
             }
             // The armed-snooze deadline, so a client can show "Snoozed - wakes in Xh". Read straight from the
             // registry (the sole timer owner) alongside HoldState above; null when there is no running clock

--- a/src/CcDirector.Gateway/Briefing/NeedsYouClock.cs
+++ b/src/CcDirector.Gateway/Briefing/NeedsYouClock.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Gateway.Briefing;
@@ -22,37 +23,46 @@ namespace CcDirector.Gateway.Briefing;
 /// EffectiveColor folds in OnHold / Briefing / Explaining (see <see cref="Contracts.SessionOrdering"/>),
 /// so a session the wingman is still reading is effective yellow/orange, not red, and is
 /// correctly treated as not-yet-waiting here.
+///
+/// Hosted Multi-Tenancy (MTR-10 Gap C): the clock is keyed by (tenant, sessionId), never the
+/// bare session id. Two accounts can run sessions with the SAME id; a bare-sid key let one
+/// tenant's "left red" clear the other tenant's entry, or one tenant's held stamp be reported
+/// as the other's "waiting since". The fold hands the OWNING tenant of the row it is stamping
+/// (the roster's request tenant, the display push's ambient tenant), so each tenant's clock is
+/// its own. Self-host resolves to the single <see cref="TenantId.Local"/> partition, unchanged.
 /// </summary>
 public sealed class NeedsYouClock
 {
-    private readonly ConcurrentDictionary<string, DateTime> _since = new();
+    private readonly ConcurrentDictionary<(TenantId Tenant, string SessionId), DateTime> _since = new();
 
     /// <summary>
     /// Apply the entry/hold/clear rule for one session and return the timestamp to stamp on
     /// its <see cref="Contracts.SessionDto.NeedsYouSince"/> (UTC), or null when it is not red.
     /// </summary>
+    /// <param name="tenant">The tenant that owns the session being stamped (MTR-10 Gap C).</param>
     /// <param name="sessionId">The session's stable id.</param>
     /// <param name="isRed">Whether the session's EffectiveColor is "red" this refresh.</param>
-    public DateTime? Stamp(string sessionId, bool isRed)
+    public DateTime? Stamp(TenantId tenant, string sessionId, bool isRed)
     {
         ArgumentException.ThrowIfNullOrEmpty(sessionId);
 
+        var key = (tenant, sessionId);
         if (!isRed)
         {
-            if (_since.TryRemove(sessionId, out _))
-                FileLog.Write($"[NeedsYouClock] sid={sessionId}: left red, cleared NeedsYouSince");
+            if (_since.TryRemove(key, out _))
+                FileLog.Write($"[NeedsYouClock] tenant={tenant.ToLogString()} sid={sessionId}: left red, cleared NeedsYouSince");
             return null;
         }
 
         // First red refresh stamps UtcNow; every subsequent red refresh holds that value.
         var added = false;
-        var since = _since.GetOrAdd(sessionId, _ =>
+        var since = _since.GetOrAdd(key, _ =>
         {
             added = true;
             return DateTime.UtcNow;
         });
         if (added)
-            FileLog.Write($"[NeedsYouClock] sid={sessionId}: entered red, NeedsYouSince={since:o}");
+            FileLog.Write($"[NeedsYouClock] tenant={tenant.ToLogString()} sid={sessionId}: entered red, NeedsYouSince={since:o}");
         return since;
     }
 }

--- a/src/CcDirector.Gateway/Briefing/TurnEndWatcher.cs
+++ b/src/CcDirector.Gateway/Briefing/TurnEndWatcher.cs
@@ -7,14 +7,16 @@ using CcDirector.Gateway.Streaming;
 
 namespace CcDirector.Gateway.Briefing;
 
-/// <summary>One observed turn boundary: the session and the id of the Director that owns it (Gateway
+/// <summary>One observed turn boundary: the session, the id of the Director that owns it (Gateway
 /// Cleanup mission, Phase 2: the owning Director is now carried as its DirectorId, not a dialable control
-/// URL, so the voice-refresh path reaches it through the tunnel). <paramref name="IsNewTurn"/> is true only
-/// for a live Working -> Waiting boundary (a genuinely new turn the user is now waiting on); it is false
-/// when a session is FIRST seen already waiting (a startup catch-up of a turn that ended earlier). Voice
-/// generation uses it to show the yellow "wingman reading" hold only for a new turn and stay quiet on a
-/// catch-up refresh (issue #1322).</summary>
-public sealed record TurnEndSignal(string SessionId, string DirectorId, bool IsNewTurn = false);
+/// URL, so the voice-refresh path reaches it through the tunnel), and the tenant that owns it. Hosted
+/// Multi-Tenancy (MTR-10 Gap C): the tenant is RESOLVED before the transition decision and carried here, so
+/// the voice refresh runs in the right partition with no second resolution. <paramref name="IsNewTurn"/> is
+/// true only for a live Working -> Waiting boundary (a genuinely new turn the user is now waiting on); it is
+/// false when a session is FIRST seen already waiting (a startup catch-up of a turn that ended earlier).
+/// Voice generation uses it to show the yellow "wingman reading" hold only for a new turn and stay quiet on
+/// a catch-up refresh (issue #1322).</summary>
+public sealed record TurnEndSignal(string SessionId, string DirectorId, TenantId Tenant, bool IsNewTurn = false);
 
 /// <summary>
 /// The brief agent's turn-boundary tracker (issues #185/#186). PUSH-fed since #186:
@@ -51,11 +53,16 @@ public sealed class TurnEndWatcher : IDisposable
     private readonly PushedSessionStore? _pushedSessions;
     private readonly TimeSpan _streamStale;
     private readonly Action<TurnEndSignal> _onTurnEnd;
-    // (sessionId, directorId): the director id is carried so the handler can resolve the session's OWNING
-    // tenant (Hosted Multi-Tenancy voice-serving) and clear the stale voice cache in the right partition.
-    private readonly Action<string, string> _onSessionWorking;
+    // (tenant, sessionId, directorId): the owning tenant is resolved BEFORE the transition decision and passed
+    // in (Hosted Multi-Tenancy voice-serving, MTR-10 Gap C), so the handler clears the stale voice cache in the
+    // right partition; the director id is carried for the tunnel reach.
+    private readonly Action<TenantId, string, string> _onSessionWorking;
     private readonly TimeSpan _interval;
-    private readonly ConcurrentDictionary<string, string> _lastActivity = new();
+    // MTR-10 Gap C: keyed by (tenant, sessionId), never the bare session id. Two accounts can run sessions with
+    // the SAME id; a bare key let one tenant's last-seen state suppress - or fabricate - the other tenant's
+    // Working -> Waiting transition (and so its voice refresh / stale-cache clear). The owning tenant is
+    // resolved before Observe and scopes the transition memory here. Self-host uses the one TenantId.Local key.
+    private readonly ConcurrentDictionary<(TenantId Tenant, string SessionId), string> _lastActivity = new();
     private Timer? _timer;
     private int _polling;
     private bool _disposed;
@@ -67,7 +74,7 @@ public sealed class TurnEndWatcher : IDisposable
     /// <param name="streamStale">Freshness window for the push store read; defaults to the roster's window.</param>
     public TurnEndWatcher(
         Action<TurnEndSignal> onTurnEnd,
-        Action<string, string> onSessionWorking,
+        Action<TenantId, string, string> onSessionWorking,
         TimeSpan? reconcileInterval = null,
         PushedSessionStore? pushedSessions = null,
         TimeSpan? streamStale = null)
@@ -100,19 +107,25 @@ public sealed class TurnEndWatcher : IDisposable
     /// Feed one observation (doorbell ping, heartbeat snapshot entry, or reconcile sweep
     /// row) into the tracker. Idempotent for repeated identical states - a heartbeat
     /// replaying a state the doorbell already delivered changes nothing.
+    ///
+    /// MTR-10 Gap C: the OWNING <paramref name="tenant"/> is resolved by the caller BEFORE this call and
+    /// scopes the transition memory, so a session id shared across two accounts can never suppress or
+    /// fabricate the other account's Working -> Waiting boundary. On self-host the caller passes
+    /// <see cref="TenantId.Local"/> and the behaviour is unchanged.
     /// </summary>
-    public void Observe(string sessionId, string activityState, string directorId)
+    public void Observe(TenantId tenant, string sessionId, string activityState, string directorId)
     {
         if (_disposed) return;
         if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(activityState)) return;
 
-        var hadPrev = _lastActivity.TryGetValue(sessionId, out var prev);
+        var key = (tenant, sessionId);
+        var hadPrev = _lastActivity.TryGetValue(key, out var prev);
         if (hadPrev && prev == activityState) return; // no transition, nothing to do
-        _lastActivity[sessionId] = activityState;
+        _lastActivity[key] = activityState;
 
         if (IsWorking(activityState))
         {
-            _onSessionWorking(sessionId, directorId);
+            _onSessionWorking(tenant, sessionId, directorId);
             return;
         }
 
@@ -121,7 +134,7 @@ public sealed class TurnEndWatcher : IDisposable
             // A live boundary (previous state was Working) is a genuinely new turn; a first sighting
             // of an already-waiting session (no previous state) is a catch-up of an earlier turn.
             var isNewTurn = hadPrev && prev == "Working";
-            _onTurnEnd(new TurnEndSignal(sessionId, directorId, isNewTurn));
+            _onTurnEnd(new TurnEndSignal(sessionId, directorId, tenant, isNewTurn));
         }
     }
 
@@ -146,16 +159,19 @@ public sealed class TurnEndWatcher : IDisposable
         _ = sweepAll;
         if (_pushedSessions is not null)
         {
-            // Hosted Multi-Tenancy (session-serving): this reconcile is NOT yet per-tenant.
-            // BLOCKED ON: partitioning TurnEndWatcher._lastActivity by tenant (and NeedsYouClock._stamps,
-            // which the turn-end signal feeds). Both are keyed by session id alone, so a per-tenant pass would
-            // let one tenant's last-seen state suppress - or fabricate - another tenant's turn boundary.
-            // Until then it serves Local: correct on self-host, and on hosted a Local read is empty, so the
-            // reconcile degrades to a no-op (never a wrong-tenant read).
-            foreach (var (directorId, session) in _pushedSessions.SnapshotFresh(TenantId.Local, _streamStale))
+            // Hosted Multi-Tenancy (session-serving), MTR-10 Gap C: reconcile ONE pass PER TENANT, each row fed
+            // with its OWNING tenant so the transition memory is partitioned. The push store's KnownTenants is
+            // exactly the set of tenants with a tunnel-bound Director - the only fleets a push-store reconcile
+            // could act on. Self-host has one tenant (Local) and runs the single pass unchanged; on hosted each
+            // tenant's snapshot is read in its own partition and never reaches across.
+            foreach (var tenant in _pushedSessions.KnownTenants())
             {
-                if (_disposed) return Task.CompletedTask;
-                Observe(session.SessionId, session.ActivityState, directorId);
+                if (!tenant.IsValid) continue;
+                foreach (var (directorId, session) in _pushedSessions.SnapshotFresh(tenant, _streamStale))
+                {
+                    if (_disposed) return Task.CompletedTask;
+                    Observe(tenant, session.SessionId, session.ActivityState, directorId);
+                }
             }
         }
         return Task.CompletedTask;

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -859,16 +859,36 @@ public sealed class GatewayHost : IAsyncDisposable
             () => AmbientSnapshotFresh(AutoDismissStaleAfter),
             sessions => EnrichVoiceThenFoldForPush(
                 sessions,
-                // Voice reads TenantId.Local, byte-identical to the ROSTER's own enrichment (the roster map
-                // below passes TenantId.Local too). Voice/TTS is OFF on the hosted Gateway by design and its
-                // per-tenant partitioning is deferred, so the voice-state store only knows the Local partition;
-                // reading it is correct on self-host and yields false on hosted (voice off), which is the right
-                // answer. It must NOT read the ambient account tenant here: WingmanVoiceService rejects any
-                // tenant that is not a minted voice partition, and matching the roster keeps the pushed fold
-                // byte-identical to the served one - the whole point of this seam.
-                voiceGeneratingFor: sid => _voiceService?.IsGenerating(TenantId.Local, sid) == true,
-                voiceAudioReadyFor: sid => _voiceService?.HasVoice(TenantId.Local, sid) == true,
-                needsYouStampFor: (sid, isRed) => _needsYouClock.Stamp(sid, isRed),
+                // MTR-10 Gap D: read the AMBIENT tenant of this per-tenant display pass, byte-identical to the
+                // ROSTER's own enrichment (the roster map below resolves the REQUEST tenant and passes it to
+                // IsGenerating/HasVoice). This fold runs inside a tenant scope in both drivers - the periodic
+                // sweep wraps it in _tenantPass.ForEachTenant, and the DirectorHub push runs in the bound
+                // tenant's scope - so _tenantPass.Current is the owning tenant, never null on hosted. The earlier
+                // code read TenantId.Local, which #1973 made stale: the tenant-partitioned voice service IS live
+                // on hosted, and a Local read there is an EMPTY partition, folding VoiceAudioReady=false for
+                // every session and holding every voice-mode session permanently "Preparing voice" (yellow) on
+                // the push-only desktop while the roster served red. A null Current is a DENY (false), never a
+                // Local fall back, so an unscoped pass discloses nothing.
+                //
+                // WHY THE FIRST ATTEMPT (abf581ff) REGRESSED THE PUSH: the ambient tenant is whatever tenant a
+                // Director is BOUND to, which need not be a minted voice partition. WingmanVoiceService REFUSES
+                // to name a partition for such a tenant - IsGenerating/HasVoice THROW ArgumentException for it -
+                // and this fold runs synchronously inside DirectorHub.PushSnapshot (which scopes the whole handler
+                // to the bound tenant). An unminted-tenant Director's snapshot push therefore threw straight out
+                // of PushSnapshot as a HubException and took the WHOLE fleet's display push down. The guard makes
+                // an unnameable ambient tenant answer the design-documented "no voice state at all" (false)
+                // instead of throwing - see WingmanVoiceService.CanNameVoicePartition. Minted account tenants
+                // (production) and Local (self-host) are nameable, so Gap D's per-tenant read is unchanged there.
+                voiceGeneratingFor: sid => _tenantPass.Current is { } t
+                    && Wingman.WingmanVoiceService.CanNameVoicePartition(t)
+                    && _voiceService?.IsGenerating(t, sid) == true,
+                voiceAudioReadyFor: sid => _tenantPass.Current is { } t
+                    && Wingman.WingmanVoiceService.CanNameVoicePartition(t)
+                    && _voiceService?.HasVoice(t, sid) == true,
+                // The needs-you clock is partitioned per tenant too (Gap C coupled state): pass this pass's
+                // owning tenant so a session id shared across accounts keeps a per-tenant "waiting since".
+                tenant: _tenantPass.Current ?? TenantId.Local,
+                needsYouStampFor: (tenant, sid, isRed) => _needsYouClock.Stamp(tenant, sid, isRed),
                 snoozeRegistry: _snoozeRegistry),
             SendCommandAsync,
             currentScopeKey: () => _tenantPass.Current?.Value);
@@ -1442,13 +1462,14 @@ public sealed class GatewayHost : IAsyncDisposable
         _turnEndWatcher = new TurnEndWatcher(
             onTurnEnd: signal =>
             {
-                // Hosted Multi-Tenancy voice-serving: the turn-end signal carries the owning director id but no
-                // request scope, so resolve the OWNING tenant from the push store and act only within it. Null =
-                // deny (skip): a director with no claiming tenant must never fall back to Local, which on hosted
-                // would emit spend and generate audio into the wrong partition. Self-host resolves to Local.
-                if (ResolveOwningTenant(signal.DirectorId) is not { } tenant)
+                // Hosted Multi-Tenancy voice-serving (MTR-10 Gap C): the OWNING tenant was resolved BEFORE the
+                // transition decision and is carried on the signal, so act within it directly - no second
+                // resolution. An invalid tenant never reaches here (the resolver denies before Observe, so the
+                // watcher never fires), but guard defensively rather than fall back to Local on hosted.
+                var tenant = signal.Tenant;
+                if (!tenant.IsValid)
                 {
-                    FileLog.Write($"[GatewayHost] turn-end: no owning tenant for director {signal.DirectorId} sid={signal.SessionId} - skipped");
+                    FileLog.Write($"[GatewayHost] turn-end: invalid tenant on signal for director {signal.DirectorId} sid={signal.SessionId} - skipped");
                     return;
                 }
 
@@ -1490,13 +1511,15 @@ public sealed class GatewayHost : IAsyncDisposable
                         _ = vs.GenerateAsync(tenant, signal.SessionId, route, CancellationToken.None, showReadingWindow: signal.IsNewTurn);
                 }
             },
-            onSessionWorking: (sid, directorId) =>
+            onSessionWorking: (tenant, sid, directorId) =>
             {
                 // Working again: the cached voice/text summary is now stale - clear it so the list stops
                 // showing it ready and nothing stale plays (issue #531). It regenerates on the next turn-end.
-                // Hosted Multi-Tenancy voice-serving: clear it in the OWNING tenant's partition (resolved from
-                // the director id the watcher carries); null = deny (skip), never a Local fall back on hosted.
-                if (ResolveOwningTenant(directorId) is { } tenant)
+                // Hosted Multi-Tenancy voice-serving (MTR-10 Gap C): the OWNING tenant was resolved before the
+                // transition decision and is passed in, so clear it in that partition directly; an invalid
+                // tenant never reaches here (the resolver denies before Observe) and never falls back to Local.
+                _ = directorId;
+                if (tenant.IsValid)
                     _voiceService?.OnSessionWorking(tenant, sid);
             },
             // Gateway Cleanup mission, Phase 2: under stream mode the catch-up / reconcile reads the push
@@ -1734,19 +1757,26 @@ public sealed class GatewayHost : IAsyncDisposable
             // the aggregated /sessions view carries the Gateway-owned assessedState.
             onSessionState: (directorId, sessionId, newState) =>
             {
+                // Hosted Multi-Tenancy voice-serving (MTR-10 Gap C): resolve the OWNING tenant ONCE, HERE,
+                // BEFORE the transition decision, and thread it through both the broad stale-cache clear and the
+                // watcher. Null = deny (skip everything): a director with no claiming tenant must never fall back
+                // to Local, which on hosted would clear/refresh another partition. Self-host resolves to Local.
+                if (ResolveOwningTenant(directorId) is not { } owningTenant)
+                {
+                    FileLog.Write($"[GatewayHost] session-state: no owning tenant for director {directorId} sid={sessionId} - skipped");
+                    return;
+                }
                 // Any observed Working state means a new turn is in progress, so the cached voice/text
                 // summary is stale - clear it (broad net for turns started outside the voice app, e.g.
                 // the desktop cockpit). The voice-turn endpoint also clears deterministically on send.
-                // Hosted Multi-Tenancy voice-serving: clear it in the OWNING tenant's partition (resolved from
-                // the director id this observation carries); null = deny (skip), never a Local fall back.
-                if (string.Equals(newState, "Working", StringComparison.OrdinalIgnoreCase)
-                    && ResolveOwningTenant(directorId) is { } workingTenant)
-                    _voiceService?.OnSessionWorking(workingTenant, sessionId);
+                if (string.Equals(newState, "Working", StringComparison.OrdinalIgnoreCase))
+                    _voiceService?.OnSessionWorking(owningTenant, sessionId);
                 if (_turnEndWatcher is null) return;
                 // Gateway Cleanup mission, Phase 2: the doorbell/heartbeat already carries the owning
                 // directorId, so feed THAT to the watcher (the voice-refresh path reaches the Director
-                // through the tunnel by id) instead of converting it to a dialable control URL.
-                _turnEndWatcher.Observe(sessionId, newState, directorId);
+                // through the tunnel by id) instead of converting it to a dialable control URL. MTR-10 Gap C:
+                // the owning tenant resolved above scopes the watcher's transition memory.
+                _turnEndWatcher.Observe(owningTenant, sessionId, newState, directorId);
 
                 // Governance capture (issue #1771, spine item 2): record this session's state transition on
                 // the append-only ledger (emits only on a real change; isolated so a ledger hiccup never
@@ -1784,8 +1814,10 @@ public sealed class GatewayHost : IAsyncDisposable
             // was overloaded and the cloud proxy failed over). Feeds the folded VoiceDisplay so the screen
             // shows the generic backup-voice notice. A success-with-a-note, never an outage state.
             servedViaFallbackFor: (tenant, sid) => _voiceService?.ServedViaFallbackFor(tenant, sid) == true,
-            // Issue #218: stamp the Gateway-owned NeedsYouSince entry clock onto each session.
-            needsYouStampFor: (sid, isRed) => _needsYouClock.Stamp(sid, isRed),
+            // Issue #218: stamp the Gateway-owned NeedsYouSince entry clock onto each session. MTR-10 Gap C:
+            // the clock is partitioned per tenant, so the roster's request tenant (threaded into the fold)
+            // scopes each stamp - a session id shared across accounts keeps a per-tenant "waiting since".
+            needsYouStampFor: (tenant, sid, isRed) => _needsYouClock.Stamp(tenant, sid, isRed),
             // Stamp the orange "Transcribing..." flag while a dictated utterance is being uploaded
             // and transcribed in the background for this session (mobile Speak -> Send).
             transcribingFor: (tenant, sid) => _transcribingSessions.IsTranscribing(tenant, sid),
@@ -2540,7 +2572,8 @@ public sealed class GatewayHost : IAsyncDisposable
         List<SessionDto> sessions,
         Func<string, bool> voiceGeneratingFor,
         Func<string, bool> voiceAudioReadyFor,
-        Func<string, bool, DateTime?>? needsYouStampFor,
+        TenantId tenant,
+        Func<TenantId, string, bool, DateTime?>? needsYouStampFor,
         Snooze.SnoozeRegistry? snoozeRegistry)
     {
         foreach (var s in sessions)
@@ -2548,7 +2581,7 @@ public sealed class GatewayHost : IAsyncDisposable
             s.VoiceGenerating = voiceGeneratingFor(s.SessionId);
             s.VoiceAudioReady = voiceAudioReadyFor(s.SessionId);
         }
-        Api.GatewayEndpoints.StampFleetRolesAndFold(sessions, sessions, needsYouStampFor, snoozeRegistry);
+        Api.GatewayEndpoints.StampFleetRolesAndFold(sessions, sessions, needsYouStampFor, snoozeRegistry, tenant);
     }
 
     private void SweepCron()

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -101,6 +101,26 @@ public sealed class WingmanVoiceService
            && string.Equals(value, parsed.ToString("D"), StringComparison.Ordinal);
 
     /// <summary>
+    /// Whether <paramref name="tenant"/> can name a voice-state partition at all: self-host's single
+    /// <see cref="TenantId.Local"/>, or a minted account tenant. This is the SAME decision
+    /// <see cref="CanonicalTenantKey"/> makes, surfaced WITHOUT throwing, so a hot read path can ask "does
+    /// this tenant even have a voice partition?" and get a plain false for one that has none - the reserved
+    /// <see cref="TenantId.System"/> identity, an unminted id, an unresolved id - instead of an exception.
+    ///
+    /// The persisting/generating paths keep throwing for such a tenant (writing into a partition that cannot
+    /// be named IS a bug); but a READ on the fleet-wide display-push seam must degrade to "no voice", never
+    /// take the whole snapshot push down with it. MTR-10 Gap D reads the AMBIENT per-tenant of the display
+    /// pass, and that ambient tenant is whatever tenant a Director is bound to - which need NOT be a minted
+    /// voice partition (a self-host-shaped tenant on a hosted Gateway, a test tenant). The original Gap D
+    /// change called the voice read unguarded and an unminted ambient tenant threw
+    /// <see cref="ArgumentException"/> straight out of the DirectorHub <c>PushSnapshot</c> as a
+    /// <c>HubException</c>, taking the whole fleet's display push down - the regression that reverted #1986.
+    /// Guarding the read with this predicate answers the design-documented "no voice state at all" instead.
+    /// </summary>
+    public static bool CanNameVoicePartition(TenantId tenant)
+        => tenant.IsValid && (tenant.IsLocal || IsMintedAccountTenant(tenant.Value));
+
+    /// <summary>
     /// The canonical partition key for a tenant - the single string used BOTH as the in-memory bucket key and
     /// as the on-disk directory name, so the two can never disagree about which tenant a session belongs to.
     ///


### PR DESCRIPTION
Re-implements MTR-10 Gap C+D after the first attempt (abf581ff) was reverted (#1995) for regressing the display-state push.

## The isolation goals (unchanged)

- **Gap C**: `TurnEndWatcher` (and coupled `NeedsYouClock`) keyed by `(tenant, sessionId)`; the owning tenant is resolved BEFORE the transition decision and carried on the `TurnEndSignal`; the push-store reconcile runs one pass per tenant. Two accounts sharing a session GUID can no longer suppress or fabricate each other's Working -> Waiting boundary (and so each other's voice auto-refresh or "waiting since" clock).
- **Gap D**: the display-state push seam's voice enrichment (`EnrichVoiceThenFoldForPush`) reads the AMBIENT per-tenant of the display pass, not `TenantId.Local`. The tenant-partitioned voice service is live on hosted (#1973); a `Local` read there is an EMPTY partition, so the push-only desktop rail folded `VoiceAudioReady=false` for every session and held every voice-mode session permanently "Preparing voice" (yellow) while the roster served red.

## Why the first attempt (abf581ff) broke PushSnapshot

The reverted Gap D push closure read the ambient tenant unguarded:

```csharp
voiceGeneratingFor: sid => _tenantPass.Current is { } t && _voiceService?.IsGenerating(t, sid) == true,
voiceAudioReadyFor: sid => _tenantPass.Current is { } t && _voiceService?.HasVoice(t, sid) == true,
```

The ambient tenant during a Director push is whatever tenant that Director is BOUND to. `DirectorHub.PushSnapshot` scopes the whole handler to the bound tenant (`EnterBoundTenantScope`) and then calls `_fleetDisplayState?.ObserveSnapshot(set)` **synchronously**, which folds through this closure.

`WingmanVoiceService` refuses to name a voice-state partition for a tenant that is not `TenantId.Local` and not a minted account tenant — `IsGenerating`/`HasVoice` → `StateFor` → `CanonicalTenantKey` **throw** `ArgumentException`. A Director bound to such a tenant therefore threw straight out of `PushSnapshot` as a SignalR `HubException`, taking the whole fleet's display push down.

`SessionServingLoopIsolationTests` binds its two Directors to `TenantId("tenant-alice")` / `TenantId("tenant-bob")` — deliberately unminted ids — so its `PushSnapshotAsync` calls hit exactly this throw. The original review ran only an "affected slice" (79/79) that excluded those tests, so the regression reached production and was caught by the CI backstop and rolled back (#1995).

Gap C did **not** participate in the throw: the turn-end watcher is fed by the doorbell (`onSessionState`) and the reconcile timer, not by `PushSnapshot`, so its per-tenant voice calls never ran synchronously inside the push. Gap C is re-applied exactly as the original, with its revert-proof wiring canaries intact.

## How this fixes it

The push read degrades to "no voice" for an ambient tenant that cannot name a voice partition, instead of throwing:

```csharp
voiceGeneratingFor: sid => _tenantPass.Current is { } t
    && Wingman.WingmanVoiceService.CanNameVoicePartition(t)
    && _voiceService?.IsGenerating(t, sid) == true,
voiceAudioReadyFor: sid => _tenantPass.Current is { } t
    && Wingman.WingmanVoiceService.CanNameVoicePartition(t)
    && _voiceService?.HasVoice(t, sid) == true,
```

`CanNameVoicePartition(TenantId)` is the SAME decision `CanonicalTenantKey` already makes (Local, or a minted account tenant), surfaced without throwing. It aligns the hot read path with the design-documented answer that a partition-less tenant (System, unminted, unresolved) "has no voice state at all" — a plain false, never an exception. The persisting/generating paths still throw for such a tenant, because writing into a partition that cannot be named IS a bug.

Gap D's per-tenant read is unchanged where it matters: minted account tenants (production) and `Local` (self-host) are nameable, so the ambient read still finds their real voice state. The `DisplayPushTenantEnrichmentTests` canary (minted GUID tenants) still proves owning-tenant=red / other-tenant=yellow.

## Proof

- Build Gateway + Gateway.Tests: **0 warnings, 0 errors**.
- **HARD GATE — `SessionServingLoopIsolationTests`: 4/4 PASS.**
- `TurnEndWatcherTenantIsolationTests` (solo): 1/1 PASS.
- `VoiceServingLoopIsolationTests` (solo): 3/3 PASS.
- `DisplayPushTenantEnrichmentTests` (solo): 1/1 PASS.
- Turn-end / needs-you-clock / display-push units: 32/32 PASS.
- **Full Gateway test suite: 3648 passed, 14 skipped, 0 failed** (not an affected slice — the whole suite, the exact check the first attempt skipped).

Completes MTR-10. Touches `GatewayHost.cs` — serializes at merge.
