### PR TITLE
fix(gateway): partition the session-owner cache by tenant (MTR audit-a/f)

### DIFF
--- a/src/CcDirector.Gateway.Tests/SessionOwnerCacheTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionOwnerCacheTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Discovery;
 using Xunit;
 
@@ -9,59 +10,66 @@ namespace CcDirector.Gateway.Tests;
 /// unit tests pin <see cref="SessionOwnerCache.Forget"/> and
 /// <see cref="SessionOwnerCache.RetainForDirector"/>, and that an offline owner's entry survives a
 /// reconcile of a DIFFERENT Director (the #288 503 path must not regress).
+///
+/// Hosted Multi-Tenancy (audit gap audit-a/f): the last two tests pin that the cache is partitioned by
+/// (tenant, sessionId), so one tenant's write or reconcile can never touch another tenant's retained
+/// state even when the two share a Director id or a session id. Reverting the partitioning reddens them.
 /// </summary>
 public sealed class SessionOwnerCacheTests
 {
+    private static readonly TenantId TenantA = new("tenant-a");
+    private static readonly TenantId TenantB = new("tenant-b");
+
     [Fact]
     public void Forget_removes_only_the_named_session()
     {
         var cache = new SessionOwnerCache();
-        cache.Remember("s1", "dir-a");
-        cache.Remember("s2", "dir-a");
+        cache.Remember(TenantId.Local, "s1", "dir-a");
+        cache.Remember(TenantId.Local, "s2", "dir-a");
 
-        cache.Forget("s1");
+        cache.Forget(TenantId.Local, "s1");
 
-        Assert.Null(cache.OwnerOf("s1"));
-        Assert.Equal("dir-a", cache.OwnerOf("s2"));
+        Assert.Null(cache.OwnerOf(TenantId.Local, "s1"));
+        Assert.Equal("dir-a", cache.OwnerOf(TenantId.Local, "s2"));
     }
 
     [Fact]
     public void Forget_is_a_noop_for_unknown_or_empty_id()
     {
         var cache = new SessionOwnerCache();
-        cache.Remember("s1", "dir-a");
+        cache.Remember(TenantId.Local, "s1", "dir-a");
 
-        cache.Forget("nope");
-        cache.Forget("");
+        cache.Forget(TenantId.Local, "nope");
+        cache.Forget(TenantId.Local, "");
 
-        Assert.Equal("dir-a", cache.OwnerOf("s1"));
+        Assert.Equal("dir-a", cache.OwnerOf(TenantId.Local, "s1"));
     }
 
     [Fact]
     public void RetainForDirector_drops_sessions_no_longer_live_on_that_director()
     {
         var cache = new SessionOwnerCache();
-        cache.Remember("live", "dir-a");
-        cache.Remember("exited", "dir-a");
+        cache.Remember(TenantId.Local, "live", "dir-a");
+        cache.Remember(TenantId.Local, "exited", "dir-a");
 
         // dir-a just answered and only reports "live" -> "exited" is gone.
-        cache.RetainForDirector("dir-a", new[] { "live" });
+        cache.RetainForDirector(TenantId.Local, "dir-a", new[] { "live" });
 
-        Assert.Equal("dir-a", cache.OwnerOf("live"));
-        Assert.Null(cache.OwnerOf("exited"));
+        Assert.Equal("dir-a", cache.OwnerOf(TenantId.Local, "live"));
+        Assert.Null(cache.OwnerOf(TenantId.Local, "exited"));
     }
 
     [Fact]
     public void RetainForDirector_drops_all_when_director_reports_no_live_sessions()
     {
         var cache = new SessionOwnerCache();
-        cache.Remember("s1", "dir-a");
-        cache.Remember("s2", "dir-a");
+        cache.Remember(TenantId.Local, "s1", "dir-a");
+        cache.Remember(TenantId.Local, "s2", "dir-a");
 
-        cache.RetainForDirector("dir-a", Array.Empty<string>());
+        cache.RetainForDirector(TenantId.Local, "dir-a", Array.Empty<string>());
 
-        Assert.Null(cache.OwnerOf("s1"));
-        Assert.Null(cache.OwnerOf("s2"));
+        Assert.Null(cache.OwnerOf(TenantId.Local, "s1"));
+        Assert.Null(cache.OwnerOf(TenantId.Local, "s2"));
     }
 
     [Fact]
@@ -70,23 +78,55 @@ public sealed class SessionOwnerCacheTests
         // The #288 503 case: dir-b is OFFLINE (we never reconcile it). Reconciling the reachable
         // dir-a must leave dir-b's cached session intact so the WS proxy still answers 503 for it.
         var cache = new SessionOwnerCache();
-        cache.Remember("offline-owned", "dir-b");
-        cache.Remember("a1", "dir-a");
+        cache.Remember(TenantId.Local, "offline-owned", "dir-b");
+        cache.Remember(TenantId.Local, "a1", "dir-a");
 
-        cache.RetainForDirector("dir-a", Array.Empty<string>());
+        cache.RetainForDirector(TenantId.Local, "dir-a", Array.Empty<string>());
 
-        Assert.Null(cache.OwnerOf("a1"));
-        Assert.Equal("dir-b", cache.OwnerOf("offline-owned"));
+        Assert.Null(cache.OwnerOf(TenantId.Local, "a1"));
+        Assert.Equal("dir-b", cache.OwnerOf(TenantId.Local, "offline-owned"));
     }
 
     [Fact]
     public void RetainForDirector_is_a_noop_for_empty_director_id()
     {
         var cache = new SessionOwnerCache();
-        cache.Remember("s1", "dir-a");
+        cache.Remember(TenantId.Local, "s1", "dir-a");
 
-        cache.RetainForDirector("", Array.Empty<string>());
+        cache.RetainForDirector(TenantId.Local, "", Array.Empty<string>());
 
-        Assert.Equal("dir-a", cache.OwnerOf("s1"));
+        Assert.Equal("dir-a", cache.OwnerOf(TenantId.Local, "s1"));
+    }
+
+    // ---------- audit gap audit-a/f: cross-tenant isolation ----------
+
+    [Fact]
+    public void RetainForDirector_in_one_tenant_never_evicts_another_tenant_retained_entry_for_a_shared_director_id()
+    {
+        // Both tenants happen to route through a Director with the SAME id "D" (e.g. a shared machine or
+        // an id collision). Tenant B has recorded that D owns session "SB". Tenant A then reconciles its
+        // OWN reachable roster for D, which reports only "SA" live. Tenant A's reconcile must NOT reach
+        // into tenant B's partition and evict B's "SB" -> D entry.
+        var cache = new SessionOwnerCache();
+        cache.Remember(TenantB, "SB", "D");
+        cache.Remember(TenantA, "SA", "D");
+
+        cache.RetainForDirector(TenantA, "D", new[] { "SA" });
+
+        Assert.Equal("D", cache.OwnerOf(TenantA, "SA")); // still live for A
+        Assert.Equal("D", cache.OwnerOf(TenantB, "SB")); // survives - not A's to prune
+    }
+
+    [Fact]
+    public void Remember_in_one_tenant_never_overwrites_another_tenant_owner_for_a_colliding_session_id()
+    {
+        // Two tenants observe a session with the SAME id "S" owned by different Directors. Neither
+        // Remember may clobber the other's cached owner - each tenant reads back its own.
+        var cache = new SessionOwnerCache();
+        cache.Remember(TenantB, "S", "DB");
+        cache.Remember(TenantA, "S", "DA");
+
+        Assert.Equal("DB", cache.OwnerOf(TenantB, "S"));
+        Assert.Equal("DA", cache.OwnerOf(TenantA, "S"));
     }
 }

--- a/src/CcDirector.Gateway.Tests/SessionsAggregationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionsAggregationTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Net.Sockets;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway;
 using CcDirector.Gateway.Contracts;
 using Xunit;
@@ -673,11 +674,11 @@ public sealed class SessionsAggregationTests : IAsyncLifetime
         // WS proxy must still answer 503 for it.
         var reachable = await StartFake("M", "u", new[] { Sample("live", "ClaudeCode", "r", "Idle", "green") });
         await Register(reachable);
-        _gateway.SessionOwners.Remember("offline-owned", "dead-director-id");
+        _gateway.SessionOwners.Remember(TenantId.Local, "offline-owned", "dead-director-id");
 
         await GetSessions();
 
-        Assert.Equal("dead-director-id", _gateway.SessionOwners.OwnerOf("offline-owned"));
+        Assert.Equal("dead-director-id", _gateway.SessionOwners.OwnerOf(TenantId.Local, "offline-owned"));
         var resp = await _http.GetAsync("sessions/offline-owned/stream");
         Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
     }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -861,7 +861,7 @@ internal static class GatewayEndpoints
                                      && !string.Equals(x.ActivityState, "Exited", StringComparison.OrdinalIgnoreCase))
                             .Select(x => x.SessionId),
                         StringComparer.Ordinal);
-                    owners?.RetainForDirector(d.DirectorId, liveIds);
+                    owners?.RetainForDirector(reqTenant.Value, d.DirectorId, liveIds);
                     // Snooze Length mission: a reachable Director's returned list is authoritative, so a
                     // snoozed session that has permanently exited is no longer live here - drop its
                     // snooze entry so the registry does not accumulate stale entries on disk. Runs only
@@ -915,7 +915,7 @@ internal static class GatewayEndpoints
                         s.TailnetEndpoint = baseUrl;
                     // Issue #288: remember who owns this session so the WS proxy answers 503 (owner
                     // offline) instead of 404 once this Director goes dark.
-                    owners?.Remember(s.SessionId, d.DirectorId);
+                    owners?.Remember(reqTenant.Value, s.SessionId, d.DirectorId);
                     // Issue #549: the always-on turn-brief pipeline is retired. The Gateway no
                     // longer stamps the assessed-state refutation (issue #186, Option A) nor the
                     // brief stamping (issue #187 BriefingState/RailLine) - the brief agent that
@@ -3210,7 +3210,7 @@ internal static class GatewayEndpoints
                 if (owner is not null)
                 {
                     FileLog.Write($"[GatewayEndpoints] LocateSessionAsync: sid={sid} located=pushed-cache, director={directorId}");
-                    owners?.Remember(sid, directorId);
+                    owners?.Remember(tenant, sid, directorId);
                     return Task.FromResult<(DirectorDto?, SessionDto?)>((owner, pushedSession));
                 }
             }

--- a/src/CcDirector.Gateway/Discovery/SessionOwnerCache.cs
+++ b/src/CcDirector.Gateway/Discovery/SessionOwnerCache.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
 
 namespace CcDirector.Gateway.Discovery;
 
@@ -15,56 +16,82 @@ namespace CcDirector.Gateway.Discovery;
 /// proxy records every session it successfully forwards, so any session the Cockpit has seen
 /// resolves to a 503 - not a 404 - once its Director goes dark.
 ///
+/// Hosted Multi-Tenancy (audit gap audit-a/f): the cache is partitioned by
+/// <c>(tenant, sessionId)</c>. Every write, read, and prune only ever touches the caller's OWN tenant
+/// partition, so tenant A can never overwrite tenant B's cached owner (colliding session id) and
+/// tenant A's <see cref="RetainForDirector"/> can never evict tenant B's retained entry for a Director
+/// id the two tenants happen to share. On self-host every caller passes <see cref="TenantId.Local"/>,
+/// so this is a single partition and behavior is identical to before. The tenant always comes from the
+/// server-resolved request context, never from client input.
+///
 /// In-memory only; it rebuilds from the next aggregation after a Gateway restart. Session ids are
 /// GUIDs and never reused, so a stale entry can only point at a Director that is itself gone, which
 /// is exactly the 503 case. Bounded in practice by the number of sessions the fleet has run.
 /// </summary>
 public sealed class SessionOwnerCache
 {
-    private readonly ConcurrentDictionary<string, string> _ownerBySession = new();
+    private readonly ConcurrentDictionary<(TenantId Tenant, string SessionId), string> _ownerBySession =
+        new(new KeyComparer());
 
-    /// <summary>Record (or refresh) the Director that owns <paramref name="sessionId"/>. No-op on empty input.</summary>
-    public void Remember(string sessionId, string directorId)
+    /// <summary>Record (or refresh) the Director that owns <paramref name="sessionId"/> within
+    /// <paramref name="tenant"/>. No-op on an invalid tenant or empty input.</summary>
+    public void Remember(TenantId tenant, string sessionId, string directorId)
     {
-        if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(directorId)) return;
-        _ownerBySession[sessionId] = directorId;
+        if (!tenant.IsValid || string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(directorId)) return;
+        _ownerBySession[(tenant, sessionId)] = directorId;
     }
 
-    /// <summary>The Director id last seen owning <paramref name="sessionId"/>, or null if never observed.</summary>
-    public string? OwnerOf(string sessionId)
-        => !string.IsNullOrEmpty(sessionId) && _ownerBySession.TryGetValue(sessionId, out var id) ? id : null;
+    /// <summary>The Director id last seen owning <paramref name="sessionId"/> within
+    /// <paramref name="tenant"/>, or null if never observed for that tenant.</summary>
+    public string? OwnerOf(TenantId tenant, string sessionId)
+        => tenant.IsValid && !string.IsNullOrEmpty(sessionId) && _ownerBySession.TryGetValue((tenant, sessionId), out var id) ? id : null;
 
     /// <summary>
-    /// Drop the cached owner for <paramref name="sessionId"/> (e.g. the session has exited).
-    /// No-op when the id is empty or not cached.
+    /// Drop the cached owner for <paramref name="sessionId"/> within <paramref name="tenant"/> (e.g. the
+    /// session has exited). No-op when the tenant is invalid or the id is empty or not cached.
     /// </summary>
-    public void Forget(string sessionId)
+    public void Forget(TenantId tenant, string sessionId)
     {
-        if (string.IsNullOrEmpty(sessionId)) return;
-        _ownerBySession.TryRemove(sessionId, out _);
+        if (!tenant.IsValid || string.IsNullOrEmpty(sessionId)) return;
+        _ownerBySession.TryRemove((tenant, sessionId), out _);
     }
 
     /// <summary>
     /// Reconcile the cache against a REACHABLE Director's live session set (issue #291): drop every
-    /// cached entry that points at <paramref name="directorId"/> but whose session id is no longer in
-    /// <paramref name="liveSessionIds"/>. A session is considered gone when the Director (which we just
-    /// reached) no longer reports it as live - it exited or disappeared - so the per-session WS proxy
-    /// reverts to 404 instead of the 503 "owner offline" verdict from #288.
+    /// cached entry IN <paramref name="tenant"/>'s partition that points at <paramref name="directorId"/>
+    /// but whose session id is no longer in <paramref name="liveSessionIds"/>. A session is considered
+    /// gone when the Director (which we just reached) no longer reports it as live - it exited or
+    /// disappeared - so the per-session WS proxy reverts to 404 instead of the 503 "owner offline"
+    /// verdict from #288.
     ///
-    /// Caller contract: only invoke this for a Director that just answered (reachable). Entries owned
-    /// by a DIFFERENT Director are never touched, so an offline owner's sessions stay cached -> still
-    /// 503 (#288 must not regress).
+    /// Caller contract: only invoke this for a Director that just answered (reachable) UNDER
+    /// <paramref name="tenant"/>. Entries owned by a DIFFERENT Director are never touched, so an offline
+    /// owner's sessions stay cached -> still 503 (#288 must not regress). Entries in a DIFFERENT tenant's
+    /// partition are never touched even when that tenant shares the same Director id, so a reconcile in
+    /// one tenant can never evict another tenant's retained state (audit gap audit-a/f).
     /// </summary>
-    public void RetainForDirector(string directorId, IReadOnlyCollection<string> liveSessionIds)
+    public void RetainForDirector(TenantId tenant, string directorId, IReadOnlyCollection<string> liveSessionIds)
     {
-        if (string.IsNullOrEmpty(directorId)) return;
+        if (!tenant.IsValid || string.IsNullOrEmpty(directorId)) return;
 
         var live = liveSessionIds as HashSet<string> ?? new HashSet<string>(liveSessionIds, StringComparer.Ordinal);
         foreach (var kvp in _ownerBySession)
         {
+            if (!kvp.Key.Tenant.Equals(tenant)) continue;
             if (!string.Equals(kvp.Value, directorId, StringComparison.Ordinal)) continue;
-            if (live.Contains(kvp.Key)) continue;
-            _ownerBySession.TryRemove(new KeyValuePair<string, string>(kvp.Key, kvp.Value));
+            if (live.Contains(kvp.Key.SessionId)) continue;
+            _ownerBySession.TryRemove(new KeyValuePair<(TenantId, string), string>(kvp.Key, kvp.Value));
         }
+    }
+
+    // Session ids are compared case-sensitively (they are GUIDs); the tenant half uses TenantId's own
+    // value equality. Matches the pre-partition Ordinal comparison so behavior is unchanged per tenant.
+    private sealed class KeyComparer : IEqualityComparer<(TenantId Tenant, string SessionId)>
+    {
+        public bool Equals((TenantId Tenant, string SessionId) x, (TenantId Tenant, string SessionId) y)
+            => x.Tenant.Equals(y.Tenant) && string.Equals(x.SessionId, y.SessionId, StringComparison.Ordinal);
+
+        public int GetHashCode((TenantId Tenant, string SessionId) obj)
+            => HashCode.Combine(obj.Tenant, StringComparer.Ordinal.GetHashCode(obj.SessionId));
     }
 }


### PR DESCRIPTION
## Root cause
`SessionOwnerCache` (`src/CcDirector.Gateway/Discovery/SessionOwnerCache.cs`) kept one process-global `ConcurrentDictionary<string,string>` mapping a bare session id to a bare director id. On the hosted Gateway:

- every roster serve (`GatewayEndpoints.cs:918`) and every locate (`:3213`) wrote into it with no tenant, and
- `RetainForDirector` (`:864`) scanned the entire cache and evicted entries by bare director id plus the caller's live-session set.

So one tenant's write or reconcile could touch another tenant's retained state:
- a **colliding session id** let tenant A's `Remember` overwrite tenant B's cached owner;
- a **director id shared by two tenants** let tenant A's `RetainForDirector` delete tenant B's retained entry.

`OwnerOf` has no production consumer today, so the practical impact is latent - but the retained state itself was cross-tenant, and any re-enabled consumer would immediately misroute or misclassify another tenant's session.

## Fix
Key the cache by `(tenant, sessionId)`. `Remember`, `OwnerOf`, `Forget` and `RetainForDirector` all take the server-resolved tenant (`reqTenant.Value` on the roster path, the already-resolved `tenant` on the locate path) and only ever touch that tenant's partition. `RetainForDirector` additionally skips any entry outside the caller's tenant. The tenant always comes from the request context, never from client input. On self-host every caller passes `TenantId.Local`, so it is a single partition and per-tenant behavior is unchanged. Follows the same `(TenantId, id)` + `KeyComparer` pattern already used by `FleetRosterCache`.

## Reproduced-real
Two two-tenant unit tests reproduce the collision and pin the isolation:
- `RetainForDirector_in_one_tenant_never_evicts_another_tenant_retained_entry_for_a_shared_director_id`
- `Remember_in_one_tenant_never_overwrites_another_tenant_owner_for_a_colliding_session_id`

Both **redden** when the partitioning is reverted (verified: tenant dropped from the key comparer + the tenant guard removed from `RetainForDirector` -> both fail; the six pre-existing owner-cache tests stay green). With the fix in place all pass.

## Gates
- `CcDirector.Gateway` build: 0 warnings, 0 errors.
- `CcDirector.Gateway.Tests` build: 0 warnings, 0 errors.
- Targeted run (11 tests, all pass): `SessionOwnerCacheTests` (8), `Aggregator_prune_does_not_touch_a_session_owned_by_a_different_offline_director`, plus the two solo tenancy filters `OnOneRoute` and `The_roster_and_the_commands_agree`.

## Merge note
Touches `GatewayEndpoints.cs` (three one-line call-site edits) - that file serializes at merge.