### PR TITLE
fix(gateway): give the prompt log a per-tenant file-IO lock (audit-a)

### DIFF
--- a/docs/reviews/production-readiness/mission/fix-audit-a.md
+++ b/docs/reviews/production-readiness/mission/fix-audit-a.md
@@ -1,0 +1,69 @@
+# audit-a - Prompt-log shared lock serializes tenants (MED) - FIXED
+
+## Verdict
+
+REAL gap, reproduced on main, fixed, revert-proofed.
+
+## The gap
+
+`GatewayPromptLog` partitions each tenant's prompt TEXT correctly - the partition is the DIRECTORY, so
+two tenants never write or read the same daily file. But every tenant's `Append` and daily-file `Read`
+took ONE process-global lock (`private readonly object _gate = new()`):
+
+- `Append`: `lock (_gate) { Directory.CreateDirectory(directory); File.AppendAllLines(path, lines); }`
+- `Read`:   `lock (_gate) { lines = File.ReadAllLines(path); }`
+
+Retention is unbounded by design ("looking back across weeks and months ... Nothing prunes this"), so a
+daily file grows without limit. `File.AppendAllLines` / `File.ReadAllLines` hold the lock for the WHOLE
+file operation. One tenant appending to or reading a large file therefore stalls every OTHER tenant's
+unrelated prompt IO, even though they live in different directories. Correctness partitioning without
+concurrency partitioning: tenant A's large or slow file blocks tenant B's `GET /prompts`.
+
+## Reproduction (on main, before the fix)
+
+`PromptLogTenantConcurrencyTests.One_tenant_holding_its_gate_does_not_block_another_tenants_append`,
+mirroring the proven shape of `FleetSessionNumberAllocatorTenancyTests`:
+
+1. Reach the exact lock tenant A's own appends take (reflection over the per-tenant gate).
+2. Hold tenant A's gate on the test thread.
+3. PROPERTY: tenant B appends on another thread and must complete without waiting.
+4. DESTRUCTIBILITY CONTROL: a same-tenant A append DOES block on the held gate (proving the gate held is
+   the one A's operations take, so "B proceeded" is real independence, not a lock nobody uses).
+
+With the single shared `_gate`, the property assertion reddens: tenant B blocks on the very lock the
+test holds. (Confirmed by temporarily restoring a shared gate - the test failed as expected.)
+
+## The fix
+
+Replaced the single `_gate` with one file-IO lock PER TENANT, keyed by `TenantId`:
+
+```csharp
+private readonly ConcurrentDictionary<TenantId, object> _gates = new();
+private object GateFor(TenantId tenant) => _gates.GetOrAdd(tenant, static _ => new object());
+```
+
+`Append` and `Read` each take `GateFor(tenant)` instead of `_gate`, so a caller only ever locks its own
+partition's gate. One tenant's file IO can no longer block another's. A single tenant's concurrent
+appends/reads to its own files are still serialized - the only serialization actually required. This is
+the same shape `FleetSessionNumberAllocator` (audit H2, #1996) uses for its per-tenant pool lock.
+
+## Revert-proof
+
+Restore a single shared gate (`GateFor` returns one shared object) and rebuild: the concurrency test
+reddens on the tenant-B property (B blocks on the held lock). Restore the per-tenant `GetOrAdd` and it
+passes again. Confirmed both directions with a full-assembly build (0/0).
+
+## Test evidence
+
+- `PromptLogTenantConcurrencyTests`: 1/1 pass (the reproduction).
+- `PromptLogTenantIsolationTests` + `GatewayPromptLogTests` + `PromptEndpointsTests`: 20/20 pass.
+- Solo tenancy filters: `OnOneRoute` 1/1, `The_roster_and_the_commands_agree` 1/1.
+- Gateway + Gateway.Tests build: 0 warnings / 0 errors.
+
+Does NOT touch GatewayHost.cs or GatewayEndpoints.cs (no merge serialization).
+
+## Files
+
+- `src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs` - per-tenant gate dictionary; `Append`/`Read`
+  take `GateFor(tenant)`.
+- `src/CcDirector.Gateway.Tests/PromptLogTenantConcurrencyTests.cs` - reproduction + revert-proof.

--- a/src/CcDirector.Gateway.Tests/PromptLogTenantConcurrencyTests.cs
+++ b/src/CcDirector.Gateway.Tests/PromptLogTenantConcurrencyTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Prompts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Audit gap audit-a: the prompt log correctly partitions each tenant's daily FILES by directory, but every
+/// tenant's append and daily-file read used to share ONE process-global lock. Retention is unbounded, so an
+/// append or read of one tenant's large file (which holds the lock for the whole File.AppendAllLines /
+/// File.ReadAllLines) would stall every OTHER tenant's unrelated prompt IO - correctness partitioning without
+/// concurrency partitioning. The fix gives each tenant its OWN gate, keyed by <see cref="TenantId"/>, so a
+/// caller only ever takes the lock of its own partition.
+///
+/// This mirrors the proven shape of <c>FleetSessionNumberAllocatorTenancyTests</c>: hold tenant A's gate, prove
+/// tenant B's append completes concurrently WITHOUT waiting, and prove a same-tenant A append DOES wait (the
+/// destructibility control - it proves the gate this test holds is the very one A's own operations take, so
+/// "B proceeded" is real independence rather than a lock nobody uses). Revert to a single shared lock and the
+/// tenant-B property assertion reddens: B would then block on the exact lock this test holds.
+/// </summary>
+public sealed class PromptLogTenantConcurrencyTests
+{
+    // Two DISTINCT minted account tenants - the canonical lowercase GUID shape the prompt log requires for a
+    // non-local partition. Two tenants means two partitions means, after the fix, two gates.
+    private static readonly TenantId TenantA = new("aaaaaaaa-1111-4aaa-8aaa-aaaaaaaaaaaa");
+    private static readonly TenantId TenantB = new("bbbbbbbb-2222-4bbb-8bbb-bbbbbbbbbbbb");
+
+    [Fact]
+    public void One_tenant_holding_its_gate_does_not_block_another_tenants_append()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "cc-plog-conc-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var log = new GatewayPromptLog(root);
+
+            // Materialize both partitions' gates so each has a lock object to reach, and grab the EXACT gate
+            // tenant A's own appends take.
+            var tenantAGate = GateFor(log, TenantA);
+            _ = GateFor(log, TenantB);
+            var aBlockedAppendDone = new ManualResetEventSlim(false);
+
+            lock (tenantAGate)
+            {
+                // Tenant A's gate is HELD by this thread; any file IO on A's partition must wait on it.
+
+                // THE PROPERTY - tenant B appends on ANOTHER thread and completes without waiting on A's gate.
+                var bWritten = -1;
+                var bDone = new ManualResetEventSlim(false);
+                var bThread = new Thread(() =>
+                {
+                    bWritten = log.Append(TenantB, new[] { Record("bravo-concurrent") });
+                    bDone.Set();
+                }) { IsBackground = true };
+                bThread.Start();
+
+                Assert.True(bDone.Wait(TimeSpan.FromSeconds(5)),
+                    "Tenant B's append blocked while tenant A held ITS OWN gate - the prompt log is serializing tenants on a shared lock.");
+                Assert.Equal(1, bWritten);
+
+                // DESTRUCTIBILITY CONTROL - a same-tenant (A) append really DOES block on the held gate.
+                var aThread = new Thread(() =>
+                {
+                    log.Append(TenantA, new[] { Record("alpha-concurrent") });
+                    aBlockedAppendDone.Set();
+                }) { IsBackground = true };
+                aThread.Start();
+                Assert.False(aBlockedAppendDone.Wait(TimeSpan.FromSeconds(1)),
+                    "Tenant A's own append completed while A's gate was held - the gate held is not the one A's partition takes, so the property assertion above proves nothing.");
+            }
+
+            // Once A's gate is released, the previously-blocked A append completes - closing the control.
+            Assert.True(aBlockedAppendDone.Wait(TimeSpan.FromSeconds(5)),
+                "Tenant A's append never completed after its gate was released.");
+        }
+        finally
+        {
+            try { if (Directory.Exists(root)) Directory.Delete(root, true); } catch { /* best-effort */ }
+        }
+    }
+
+    private static PromptRecord Record(string text) => new()
+    {
+        TsUtc = DateTime.UtcNow,
+        Machine = "M",
+        SessionId = "s",
+        Agent = "ClaudeCode",
+        Role = "user",
+        TimestampFromAgent = true,
+        CharCount = text.Length,
+        WordCount = 1,
+        Text = text,
+    };
+
+    /// <summary>
+    /// Reach the per-tenant gate object a caller for that tenant takes. This is a concurrency proof, so it must
+    /// hold the EXACT lock the tenant's own append/read takes - there is no public seam for that by design.
+    /// </summary>
+    private static object GateFor(GatewayPromptLog log, TenantId tenant)
+    {
+        var method = typeof(GatewayPromptLog).GetMethod("GateFor", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        return method!.Invoke(log, new object[] { tenant })!;
+    }
+}

--- a/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
+++ b/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using CcDirector.Core.Storage;
@@ -67,8 +68,20 @@ public sealed class GatewayPromptLog
         => Guid.TryParseExact(value, "D", out var parsed)
            && string.Equals(value, parsed.ToString("D"), StringComparison.Ordinal);
 
-    private readonly object _gate = new();
+    /// <summary>
+    /// One file-IO lock PER TENANT, not one shared across the whole fleet (audit gap audit-a). The partition
+    /// is already the directory, so two tenants never touch the same daily FILE; a single process-global lock
+    /// would nonetheless serialize them, letting one tenant's append/read of an unbounded (retention is
+    /// forever) file stall every other tenant's unrelated prompt IO. Each tenant gets its OWN gate, keyed by
+    /// <see cref="TenantId"/>, so a caller only ever takes the lock of its own partition and one account's
+    /// large or slow file cannot block another's read. The gate still serializes a single tenant's own
+    /// concurrent appends/reads to its files, which is the only serialization actually required.
+    /// </summary>
+    private readonly ConcurrentDictionary<TenantId, object> _gates = new();
     private readonly string _directory;
+
+    /// <summary>This tenant's file-IO lock, created on first use. Two distinct tenants get two distinct gates.</summary>
+    private object GateFor(TenantId tenant) => _gates.GetOrAdd(tenant, static _ => new object());
 
     /// <param name="directory">Override the log directory (tests). Defaults to the per-user location.</param>
     public GatewayPromptLog(string? directory = null)
@@ -138,6 +151,7 @@ public sealed class GatewayPromptLog
     public int Append(TenantId tenant, IEnumerable<PromptRecord> records)
     {
         var directory = DirectoryFor(tenant);
+        var gate = GateFor(tenant);
         var written = 0;
         try
         {
@@ -147,7 +161,7 @@ public sealed class GatewayPromptLog
             {
                 var lines = day.Select(r => JsonSerializer.Serialize(r, JsonOpts)).ToList();
                 var path = FileFor(tenant, day.Key);
-                lock (_gate)
+                lock (gate)
                 {
                     Directory.CreateDirectory(directory);
                     File.AppendAllLines(path, lines);
@@ -173,6 +187,7 @@ public sealed class GatewayPromptLog
     public IReadOnlyList<PromptRecord> Read(TenantId tenant, DateTime fromUtc, DateTime toUtc)
     {
         var results = new List<PromptRecord>();
+        var gate = GateFor(tenant);
         for (var day = fromUtc.Date; day <= toUtc.Date; day = day.AddDays(1))
         {
             var path = FileFor(tenant, day);
@@ -180,7 +195,7 @@ public sealed class GatewayPromptLog
             string[] lines;
             try
             {
-                lock (_gate) { lines = File.ReadAllLines(path); }
+                lock (gate) { lines = File.ReadAllLines(path); }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Root cause

`GatewayPromptLog` partitions each tenant's prompt TEXT correctly - the partition is the directory, so two tenants never touch the same daily file. But every tenant's `Append` and daily-file `Read` took ONE process-global lock (`_gate`). Retention is unbounded by design, so `File.AppendAllLines`/`File.ReadAllLines` can hold that lock for the whole (potentially large) file operation. One tenant appending to or reading a big file therefore stalls every OTHER tenant's unrelated prompt IO, despite the separate directories - correctness partitioning without concurrency partitioning.

## Fix

Replace the single `_gate` with one file-IO lock per tenant, keyed by `TenantId`:

```csharp
private readonly ConcurrentDictionary<TenantId, object> _gates = new();
private object GateFor(TenantId tenant) => _gates.GetOrAdd(tenant, static _ => new object());
```

`Append` and `Read` take `GateFor(tenant)`, so a caller only ever locks its own partition. A single tenant's concurrent file operations are still serialized (the only serialization required); two different tenants never contend. Same shape as the per-tenant pool lock in `FleetSessionNumberAllocator` (#1996).

## Reproduced real

`PromptLogTenantConcurrencyTests` holds tenant A's own gate, proves tenant B appends concurrently without waiting (the property), and proves a same-tenant A append DOES block on the held gate (destructibility control). Revert-proof: restore a single shared gate and the tenant-B property reddens (B blocks on the held lock); confirmed both directions with a 0/0 build.

## Tests

- `PromptLogTenantConcurrencyTests` 1/1; `PromptLogTenantIsolationTests` + `GatewayPromptLogTests` + `PromptEndpointsTests` 20/20.
- Solo tenancy filters `OnOneRoute` 1/1, `The_roster_and_the_commands_agree` 1/1.
- Gateway + Gateway.Tests build 0/0.

Does not touch GatewayHost.cs or GatewayEndpoints.cs.