### PR TITLE
fix(gateway): partition the cron overlap guard and work-list drain slot by tenant (audit MED gap audit-e)

### DIFF
--- a/mission/fix-audit-e-cronlocks.md
+++ b/mission/fix-audit-e-cronlocks.md
@@ -1,0 +1,69 @@
+# Fix: audit-e - process-global admission guards keyed by a bare / tenant-relative id
+
+Gap: MED (audit-e). Two process-global in-memory admission guards on the hosted Gateway were keyed by a
+bare, caller-owned or tenant-relative id, so one tenant's admission could refuse (or leak into) another
+tenant's. Reproduced first, then partitioned both guards by the server-resolved tenant.
+
+## Root cause
+
+Both guards live on singletons that every tenant's request shares, yet each keyed its state by an id that
+is NOT globally unique across tenants:
+
+1. **Cron overlap guard** (`CronEngine`). The in-flight set was `HashSet<string>` keyed by the bare cron
+   job `Id`. A cron job's id is tenant-relative: `CronJobStore` mints a short `cj_` id whose uniqueness it
+   checks only THROUGH the tenant query filter, and the legacy import preserves caller-supplied ids, so two
+   tenants can hold a job with the SAME id (the database identity is `(TenantId, Id)`). With `PreventOverlap`
+   on, tenant A's in-flight run held the key `cj_xxxx`; tenant B's run-now of B's OWN `cj_xxxx` job then hit
+   `TryEnterFlight("cj_xxxx")` = false and was rejected as `SkippedOverlap`. On hosted the scheduled sweep is
+   skipped, so the reachable path is run-now, which runs inside the request's tenant scope.
+
+2. **Work-list machine drain slot** (`WorkListRunnerManager`). The single-drain slot was
+   `Dictionary<string,string>` keyed by the caller-controlled `machineKey` (a request body field, or a cron
+   job's target machine). Two tenants can present the SAME key. Tenant B draining `machineKey` "shared-name"
+   made tenant A's own drain on "shared-name" refuse with `RefusedMachineBusy`, and the 409's `ActiveList`
+   returned B's list name to A - a mutual denial plus a cross-tenant name leak.
+
+## Fix
+
+Both guards are now PARTITIONED BY the server-resolved tenant; a caller's admission only ever conflicts
+within its own tenant, and no 409 / `ActiveList` ever names another tenant's resource.
+
+- **`CronEngine`**: in-flight set is now `HashSet<(TenantId, string)>`. The engine takes a
+  `resolveTenant: () => _tenantPass.Current` seam - the same background-loop/request tenant seam its notifier
+  already reads, and exactly the tenant the store scoped the job read to. The tenant is resolved once per
+  fire (up front, before the first await) and used for both enter and exit; an unresolved scope fails loud
+  (deny-by-default), never defaults.
+- **`WorkListRunnerManager`**: state is now `Dictionary<TenantId, Dictionary<string,string>>` (inner map
+  keeps the machine key's case-insensitive comparison). `TryAdmit` / `Complete` / `ActiveList` take the
+  tenant. The REST caller (`WorkListRunnerEndpoints`) passes the request's already-server-resolved
+  `reqTenant`; the cron caller (`DirectorCronWorkListRunner`) reads the same `() => _tenantPass.Current` seam.
+- Log lines use `TenantId.ToLogString()` (no raw account tenant id in logs).
+
+Self-host is one tenant (`TenantId.Local`) - one partition, behaviour byte-identical. Both new seams default
+to `() => TenantId.Local` when omitted, so the existing single-tenant tests and wiring are unchanged.
+
+## GatewayHost.cs touched (NOTE - serializes at merge)
+
+`GatewayHost.cs` was edited at two construction sites only (the `CronEngine` and `DirectorCronWorkListRunner`
+`resolveTenant` wiring). `GatewayEndpoints.cs` was NOT touched.
+
+## Verify-first + revert-proof
+
+Reproduced on a single engine / single manager (production shape - one singleton serves every tenant):
+
+- `CronEngineTenancyTests.Run_now_for_one_tenant_is_not_blocked_by_another_tenants_same_id_job` - two tenants
+  seeded (via the legacy import, which preserves the id) with the SAME `cj_shared` over one database and one
+  ambient tenant context; A parks in flight, B fires its own same-id job -> `Fired`.
+- `WorkListRunnerManagerTenancyTests` - two tenants admit the SAME machine key without refusing each other,
+  and `ActiveList` never reveals another tenant's list.
+
+Revert-proof: collapsing each guard's tenant back to a constant (the bare-id behaviour) reddens exactly the
+4 cross-tenant assertions while the 2 same-tenant guard tests stay green (the within-tenant overlap /
+same-machine refusal is preserved).
+
+## Gates
+
+- Build: `CcDirector.Gateway` 0/0, `CcDirector.Gateway.Tests` 0/0.
+- Targeted: CronEngineTenancyTests + WorkListRunnerManagerTenancyTests + WorkListRunnerManagerTests +
+  CronWorkListTriggerTests + CronEngineTests = 25/25 passed.
+- Solo tenancy filters: OnOneRoute + The_roster_and_the_commands_agree passed.

--- a/src/CcDirector.Gateway.Tests/CronEngineTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronEngineTenancyTests.cs
@@ -1,0 +1,175 @@
+using System.Text.Json;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Running;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Cross-tenant partition of the cron overlap guard (audit MED, gap audit-e). A cron job's id is
+/// tenant-relative: <see cref="CronJobStore"/> mints a short <c>cj_</c> id whose uniqueness it checks only
+/// THROUGH the tenant query filter, and the legacy import preserves caller-supplied ids, so two tenants can
+/// hold a job with the SAME id (the database identity is (TenantId, Id)). Before the fix the engine's
+/// in-flight set was keyed by the bare id alone, so tenant A's in-flight run made tenant B's run-now of B's
+/// OWN same-id job be rejected as an "overlap". This test reproduces that cross-tenant denial on a single
+/// engine (as in production, one <see cref="CronEngine"/> serves every tenant) and pins the fix; reverting
+/// the key to the bare id reddens <see cref="Run_now_for_one_tenant_is_not_blocked_by_another_tenants_same_id_job"/>.
+/// </summary>
+public sealed class CronEngineTenancyTests : IDisposable
+{
+    private const string SharedId = "cj_shared";
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    [Fact]
+    public async Task Run_now_for_one_tenant_is_not_blocked_by_another_tenants_same_id_job()
+    {
+        // One database, one AMBIENT tenant context the stores and the engine both read per-operation - exactly
+        // the production shape (the store scopes by _tenantContext.Current, the engine keys by the same seam).
+        var ambient = new AsyncLocalTenantContext();
+        var db = _h.Open(ambient);
+
+        // Seed the SAME job id under BOTH tenants via the legacy import (which preserves the supplied id),
+        // each construction inside its own tenant scope so the row lands in that tenant's partition.
+        CronJobStore store;
+        CronRunHistoryStore history;
+        using (ambient.Enter(TenantA))
+        {
+            WriteLegacyJob(_h.LegacyPath("a.json"), SharedId);
+            store = new CronJobStore(db, _h.LegacyPath("a.json"));
+            history = new CronRunHistoryStore(db, _h.LegacyPath("a.runs.json"));
+        }
+        using (ambient.Enter(TenantB))
+        {
+            WriteLegacyJob(_h.LegacyPath("b.json"), SharedId);
+            _ = new CronJobStore(db, _h.LegacyPath("b.json"));   // throwaway: seeds B's row into the same db
+        }
+
+        var starter = new GatedStarter();
+        var engine = new CronEngine(
+            store, history, starter, new UnusedWorkListRunner(), new NullCronNotifier(),
+            new FixedClock(DateTime.UtcNow), resolveTenant: () => ambient.CurrentOrNull);
+
+        // Tenant A's run-now enters flight and parks inside the starter (its synchronous part - the store read,
+        // the tenant resolve, and TryEnterFlight - all run under scope A before the first await).
+        Task<CronRunNowResult> firstRun;
+        using (ambient.Enter(TenantA))
+            firstRun = engine.RunNowAsync(SharedId, CancellationToken.None);
+        await starter.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // While A is still in flight, tenant B fires ITS OWN same-id job. With the guard partitioned by tenant
+        // this is admitted and fires; with the bare-id guard it is wrongly rejected as an overlap.
+        CronRunNowResult second;
+        using (ambient.Enter(TenantB))
+            second = await engine.RunNowAsync(SharedId, CancellationToken.None);
+        Assert.Equal(CronFireOutcome.Fired, second.Outcome);
+
+        // Let A finish; it fired too. Both tenants' sessions actually started - the two runs never collided.
+        starter.Release.TrySetResult();
+        var first = await firstRun;
+        Assert.Equal(CronFireOutcome.Fired, first.Outcome);
+        Assert.Equal(2, starter.StartCount);
+    }
+
+    [Fact]
+    public async Task Same_tenant_overlap_is_still_skipped()
+    {
+        // The overlap guard is preserved WITHIN a tenant: a second run-now of the same job while the first is
+        // in flight (same tenant) is still skipped.
+        var ambient = new AsyncLocalTenantContext();
+        var db = _h.Open(ambient);
+
+        CronJobStore store;
+        CronRunHistoryStore history;
+        using (ambient.Enter(TenantA))
+        {
+            WriteLegacyJob(_h.LegacyPath("a.json"), SharedId);
+            store = new CronJobStore(db, _h.LegacyPath("a.json"));
+            history = new CronRunHistoryStore(db, _h.LegacyPath("a.runs.json"));
+        }
+
+        var starter = new GatedStarter();
+        var engine = new CronEngine(
+            store, history, starter, new UnusedWorkListRunner(), new NullCronNotifier(),
+            new FixedClock(DateTime.UtcNow), resolveTenant: () => ambient.CurrentOrNull);
+
+        Task<CronRunNowResult> firstRun;
+        using (ambient.Enter(TenantA))
+            firstRun = engine.RunNowAsync(SharedId, CancellationToken.None);
+        await starter.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        CronRunNowResult second;
+        using (ambient.Enter(TenantA))
+            second = await engine.RunNowAsync(SharedId, CancellationToken.None);
+        Assert.Equal(CronFireOutcome.SkippedOverlap, second.Outcome);
+
+        starter.Release.TrySetResult();
+        Assert.Equal(CronFireOutcome.Fired, (await firstRun).Outcome);
+        Assert.Equal(1, starter.StartCount);   // only the first run ever started a session
+    }
+
+    // ---- helpers -----------------------------------------------------------------------------
+
+    private static void WriteLegacyJob(string path, string id)
+    {
+        var job = new CronJobDto
+        {
+            Id = id,
+            Name = "shared",
+            Enabled = true,
+            ScheduleKind = CronSchedule.KindRecurring,
+            CronExpression = "0 0 * * *",
+            TimeZoneId = "America/Chicago",
+            Target = new CronJobTarget { Machine = "workstation-A" },
+            Action = new CronJobAction { RepoPath = @"D:\repo", Seed = "/help" },
+            PreventOverlap = true,
+        };
+        var json = JsonSerializer.Serialize(
+            new { jobs = new[] { job } },
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        File.WriteAllText(path, json);
+    }
+
+    // ---- fakes -------------------------------------------------------------------------------
+
+    private sealed class FixedClock : IClock
+    {
+        public FixedClock(DateTime utcNow) => UtcNow = DateTime.SpecifyKind(utcNow, DateTimeKind.Utc);
+        public DateTime UtcNow { get; }
+    }
+
+    /// <summary>Blocks ONLY its first start (the parked in-flight run); every later start returns at once, so a
+    /// second tenant's run is not itself held by the gate under test.</summary>
+    private sealed class GatedStarter : ICronSessionStarter
+    {
+        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _calls;
+        public int StartCount => _calls;
+
+        public async Task<(string? sessionId, string? directorId, string? error)> StartAsync(CronJobDto job, CancellationToken ct)
+        {
+            var n = Interlocked.Increment(ref _calls);
+            if (n == 1)
+            {
+                Entered.TrySetResult();
+                await Release.Task;
+            }
+            return ($"sid-{n}", "director-1", null);
+        }
+    }
+
+    private sealed class UnusedWorkListRunner : ICronWorkListRunner
+    {
+        public Task<CronWorkListOutcome> TriggerAsync(CronJobDto job, CancellationToken ct) =>
+            throw new InvalidOperationException("a seed-job test must not trigger the work-list runner");
+    }
+}

--- a/src/CcDirector.Gateway.Tests/CronWorkListTriggerTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronWorkListTriggerTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Data;
@@ -92,7 +93,7 @@ public sealed class CronWorkListTriggerTests : IDisposable
         store.Create("Tonight");
         store.AppendItem("Tonight", new WorkListItemRef { Source = "github", Id = "312" });
         var manager = new WorkListRunnerManager();
-        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, manager.TryAdmit("workstation-A", "OtherList"));
+        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, manager.TryAdmit(TenantId.Local, "workstation-A", "OtherList"));
 
         var t = Trigger(store, new FakeResolver("machineA"), manager, new FakeLauncher());
         Assert.Equal(CronWorkListOutcome.MachineBusy, await t.TriggerAsync(WorkListJob(), CancellationToken.None));
@@ -116,13 +117,13 @@ public sealed class CronWorkListTriggerTests : IDisposable
         Assert.Equal("Tonight", launcher.LastListName);
         Assert.Equal("machineA", launcher.LastDirectorId);   // the resolved Director id is threaded to the launcher (tunnel leg)
         Assert.StartsWith("cron:cj_test:", launcher.LastConsumer);
-        Assert.Equal("Tonight", manager.ActiveList("workstation-A")); // the machine's slot holds the "Tonight" drain
+        Assert.Equal("Tonight", manager.ActiveList(TenantId.Local, "workstation-A")); // the machine's slot holds the "Tonight" drain
 
         launcher.Release.TrySetResult();
         await launcher.Completed.Task.WaitAsync(TimeSpan.FromSeconds(10));
         // The machine slot is released after the drain completes (poll briefly for the finally).
-        await WaitUntilAsync(() => manager.ActiveList("workstation-A") is null, TimeSpan.FromSeconds(10));
-        Assert.Null(manager.ActiveList("workstation-A"));
+        await WaitUntilAsync(() => manager.ActiveList(TenantId.Local, "workstation-A") is null, TimeSpan.FromSeconds(10));
+        Assert.Null(manager.ActiveList(TenantId.Local, "workstation-A"));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/WorkListRunnerManagerTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkListRunnerManagerTenancyTests.cs
@@ -1,0 +1,74 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Running;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Cross-tenant partition of the work-list machine drain slot (audit MED, gap audit-e). The machine key is
+/// caller-controlled (a request body field or a cron job's target machine), so two tenants can present the
+/// SAME key. Before the fix the single-drain slot was keyed by the bare machine key alone, so one tenant's
+/// drain refused another tenant's drain on a shared key and the 409's <see cref="WorkListRunnerManager.ActiveList"/>
+/// leaked the other tenant's list name. Each test below reddens if the slot is un-partitioned:
+/// <see cref="Two_tenants_draining_the_same_machine_key_do_not_refuse_each_other"/> would see the second
+/// admit REFUSED, and <see cref="ActiveList_never_reveals_another_tenants_list"/> would read the other
+/// tenant's list name.
+/// </summary>
+public sealed class WorkListRunnerManagerTenancyTests
+{
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void Two_tenants_draining_the_same_machine_key_do_not_refuse_each_other()
+    {
+        var mgr = new WorkListRunnerManager();
+
+        // Both tenants name the SAME machine key. Each is admitted in its OWN partition; neither refuses the
+        // other. Reverting the fix (a single bare-key slot) makes the second admit RefusedMachineBusy.
+        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit(TenantA, "shared-machine", "list-A"));
+        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit(TenantB, "shared-machine", "list-B"));
+
+        Assert.Equal("list-A", mgr.ActiveList(TenantA, "shared-machine"));
+        Assert.Equal("list-B", mgr.ActiveList(TenantB, "shared-machine"));
+    }
+
+    [Fact]
+    public void ActiveList_never_reveals_another_tenants_list()
+    {
+        var mgr = new WorkListRunnerManager();
+        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit(TenantA, "shared-machine", "secret-A"));
+
+        // Tenant B, which has admitted nothing on this key, must see its OWN (empty) view - never tenant A's
+        // list name. A shared bare-key slot would hand B the string "secret-A".
+        Assert.Null(mgr.ActiveList(TenantB, "shared-machine"));
+    }
+
+    [Fact]
+    public void Completing_one_tenants_slot_leaves_the_other_tenants_drain_intact()
+    {
+        var mgr = new WorkListRunnerManager();
+        mgr.TryAdmit(TenantA, "shared-machine", "list-A");
+        mgr.TryAdmit(TenantB, "shared-machine", "list-B");
+
+        // A finishes its drain; B's slot on the same key is untouched, and A's key is now free for A only.
+        mgr.Complete(TenantA, "shared-machine");
+
+        Assert.Null(mgr.ActiveList(TenantA, "shared-machine"));
+        Assert.Equal("list-B", mgr.ActiveList(TenantB, "shared-machine"));
+        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit(TenantA, "shared-machine", "list-A2"));
+        // B is still busy on the key within its own partition.
+        Assert.Equal(WorkListRunnerManager.AdmitResult.RefusedMachineBusy, mgr.TryAdmit(TenantB, "shared-machine", "list-B2"));
+    }
+
+    [Fact]
+    public void Same_tenant_same_machine_key_is_still_refused()
+    {
+        // The v1 same-machine guard (criterion 8) is preserved WITHIN a tenant: a tenant's second drain on a
+        // key it already holds is still refused.
+        var mgr = new WorkListRunnerManager();
+        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit(TenantA, "machine-1", "first"));
+        Assert.Equal(WorkListRunnerManager.AdmitResult.RefusedMachineBusy, mgr.TryAdmit(TenantA, "machine-1", "second"));
+        Assert.Equal("first", mgr.ActiveList(TenantA, "machine-1"));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WorkListRunnerManagerTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkListRunnerManagerTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Running;
 using Xunit;
 
@@ -6,19 +7,23 @@ namespace CcDirector.Gateway.Tests;
 /// <summary>
 /// Unit tests for <see cref="WorkListRunnerManager"/> (issue #274): the v1 same-machine single-drain
 /// guard (criterion 8 - one slot-5 test Director per machine) and the cross-machine concurrency case
-/// (criterion 6 - different machines drain at the same time).
+/// (criterion 6 - different machines drain at the same time). The single-tenant behaviour is pinned here
+/// with <see cref="TenantId.Local"/>; the cross-tenant partition (audit MED) is pinned by
+/// <see cref="WorkListRunnerManagerTenancyTests"/>.
 /// </summary>
 public sealed class WorkListRunnerManagerTests
 {
+    private static readonly TenantId Local = TenantId.Local;
+
     [Fact]
     public void TryAdmit_SecondDrainSameMachine_Refused()
     {
         var mgr = new WorkListRunnerManager();
 
-        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit("machine-1", "today"));
+        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit(Local, "machine-1", "today"));
         // Criterion 8: a second list on a machine already draining one is refused, not run.
-        Assert.Equal(WorkListRunnerManager.AdmitResult.RefusedMachineBusy, mgr.TryAdmit("machine-1", "release-0.7"));
-        Assert.Equal("today", mgr.ActiveList("machine-1"));
+        Assert.Equal(WorkListRunnerManager.AdmitResult.RefusedMachineBusy, mgr.TryAdmit(Local, "machine-1", "release-0.7"));
+        Assert.Equal("today", mgr.ActiveList(Local, "machine-1"));
     }
 
     [Fact]
@@ -26,11 +31,11 @@ public sealed class WorkListRunnerManagerTests
     {
         var mgr = new WorkListRunnerManager();
 
-        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit("machine-1", "today"));
-        mgr.Complete("machine-1");
+        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit(Local, "machine-1", "today"));
+        mgr.Complete(Local, "machine-1");
 
-        Assert.Null(mgr.ActiveList("machine-1"));
-        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit("machine-1", "release-0.7"));
+        Assert.Null(mgr.ActiveList(Local, "machine-1"));
+        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit(Local, "machine-1", "release-0.7"));
     }
 
     [Fact]
@@ -39,10 +44,10 @@ public sealed class WorkListRunnerManagerTests
         var mgr = new WorkListRunnerManager();
 
         // Criterion 6: two lists on two different machines drain at the same time, no interference.
-        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit("machine-1", "today"));
-        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit("machine-2", "release-0.7"));
+        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit(Local, "machine-1", "today"));
+        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, mgr.TryAdmit(Local, "machine-2", "release-0.7"));
 
-        Assert.Equal("today", mgr.ActiveList("machine-1"));
-        Assert.Equal("release-0.7", mgr.ActiveList("machine-2"));
+        Assert.Equal("today", mgr.ActiveList(Local, "machine-1"));
+        Assert.Equal("release-0.7", mgr.ActiveList(Local, "machine-2"));
     }
 }

--- a/src/CcDirector.Gateway/Api/WorkListRunnerEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/WorkListRunnerEndpoints.cs
@@ -80,14 +80,17 @@ internal static class WorkListRunnerEndpoints
                 : body.MachineKey;
 
             // Single-machine guard FIRST (criterion 8): refuse a second concurrent drain on a machine
-            // already draining a list, before we touch the list's own consumer claim.
-            var admit = manager.TryAdmit(machineKey, name);
+            // already draining a list, before we touch the list's own consumer claim. The slot is partitioned
+            // by the REQUEST's own tenant (audit MED, gap audit-e): the caller-controlled machineKey is shared
+            // across tenants, so keying by tenant is what stops one tenant's drain refusing another's - and
+            // keeps the 409's activeList from ever naming another tenant's list.
+            var admit = manager.TryAdmit(reqTenant.Value, machineKey, name);
             if (admit == WorkListRunnerManager.AdmitResult.RefusedMachineBusy)
                 return Results.Conflict(new
                 {
                     error = "machine is already draining another list (v1 same-machine guard)",
                     machineKey,
-                    activeList = manager.ActiveList(machineKey),
+                    activeList = manager.ActiveList(reqTenant.Value, machineKey),
                 });
 
             try
@@ -110,7 +113,7 @@ internal static class WorkListRunnerEndpoints
             }
             finally
             {
-                manager.Complete(machineKey);
+                manager.Complete(reqTenant.Value, machineKey);
             }
         });
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -973,7 +973,10 @@ public sealed class GatewayHost : IAsyncDisposable
             new Running.DirectorWorkListDrainLauncher(
                 _workLists,
                 (directorId, endpoint, repoPath) =>
-                    new Running.DirectorImplSessionDriver(directorId, repoPath, spawnSendCommand)));
+                    new Running.DirectorImplSessionDriver(directorId, repoPath, spawnSendCommand)),
+            // MTR (audit MED): partition the machine drain slot by the fire's tenant, the same seam the engine
+            // and notifier read. On self-host this is always Local.
+            resolveTenant: () => _tenantPass.Current);
         // Run-complete notifications (issue #622, the deferred "notify on completion" piece of #479).
         // The notifier rides the EXISTING fleet channel - the per-Director doorbell event ring
         // (DirectorEvents, #330) observed at GET /directors/{id}/events - and optionally POSTs the same
@@ -999,7 +1002,11 @@ public sealed class GatewayHost : IAsyncDisposable
             resolveTenant: () => _tenantPass.Current);
         _cronEngine = new Running.CronEngine(
             _cronJobs, _cronRuns, new Running.DirectorCronSessionStarter(_machineSessionSpawner),
-            cronWorkListRunner, cronNotifier, new Running.SystemClock());
+            cronWorkListRunner, cronNotifier, new Running.SystemClock(),
+            // MTR (audit MED): partition the overlap guard by the tenant of the CURRENT unit of work - the
+            // run-now request scope on hosted, the single Local scope on self-host - the same seam the notifier
+            // reads. A run-now for tenant A's cj_ id must never be refused by tenant B's in-flight same-id job.
+            resolveTenant: () => _tenantPass.Current);
 
         // Web Push (mobile app-icon "needs you" dot): load (or generate on first run) the VAPID key
         // pair and the set of subscribed devices. The notifier that fans out to these is built and

--- a/src/CcDirector.Gateway/Running/CronEngine.cs
+++ b/src/CcDirector.Gateway/Running/CronEngine.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -44,9 +45,15 @@ public sealed class CronEngine
     private readonly ICronNotifier _notifier;
     private readonly IClock _clock;
     private readonly TimeSpan _catchUpThreshold;
+    private readonly Func<TenantId?> _resolveTenant;
 
     private readonly object _inFlightGate = new();
-    private readonly HashSet<string> _inFlight = new(StringComparer.Ordinal);
+    // Overlap admission, PARTITIONED BY TENANT (audit MED, gap audit-e). A cron job's id is tenant-relative
+    // (the store mints it under the tenant query filter, so two tenants can hold the same cj_ id; the DB
+    // identity is (TenantId, Id)). Keying the in-flight set by the bare id alone let one tenant's in-flight
+    // run refuse another tenant's run-now of a same-id job as an "overlap". The key is now (tenant, id), so a
+    // caller's overlap guard only ever conflicts within its own tenant.
+    private readonly HashSet<(TenantId Tenant, string Id)> _inFlight = new();
 
     /// <param name="starter">Starts a single seeded session for a seed-action job.</param>
     /// <param name="workListRunner">Drains a named work list for a work-list-action job (#484).</param>
@@ -58,6 +65,15 @@ public sealed class CronEngine
     /// How far past its due time a scheduled fire must be to be labeled a catch-up (default 2 min).
     /// Purely cosmetic on the run record; it does not change whether the job fires.
     /// </param>
+    /// <param name="resolveTenant">
+    /// Resolves the tenant of the current unit of work - the tenant the overlap guard is partitioned by
+    /// (audit MED, gap audit-e). Production passes the background-loop/request tenant seam
+    /// (<c>() =&gt; _tenantPass.Current</c>): the run-now request scope on hosted, the per-tenant pass or the
+    /// single Local scope on self-host - exactly the tenant the store scoped the job read to. Omitted (tests,
+    /// self-host wiring) it is <see cref="TenantId.Local"/>, so the single-tenant behaviour is unchanged. A
+    /// fire is only ever reached with a resolved scope in effect (the store read that produced the job already
+    /// required one); an unresolved tenant fails loud rather than defaulting.
+    /// </param>
     public CronEngine(
         CronJobStore store,
         CronRunHistoryStore history,
@@ -65,7 +81,8 @@ public sealed class CronEngine
         ICronWorkListRunner workListRunner,
         ICronNotifier notifier,
         IClock clock,
-        TimeSpan? catchUpThreshold = null)
+        TimeSpan? catchUpThreshold = null,
+        Func<TenantId?>? resolveTenant = null)
     {
         _store = store ?? throw new ArgumentNullException(nameof(store));
         _history = history ?? throw new ArgumentNullException(nameof(history));
@@ -74,6 +91,7 @@ public sealed class CronEngine
         _notifier = notifier ?? throw new ArgumentNullException(nameof(notifier));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _catchUpThreshold = catchUpThreshold ?? TimeSpan.FromMinutes(2);
+        _resolveTenant = resolveTenant ?? (() => TenantId.Local);
     }
 
     /// <summary>
@@ -130,9 +148,17 @@ public sealed class CronEngine
 
     private async Task<CronRunNowResult> FireAsync(CronJobDto job, DateTime scheduledUtc, bool isManual, CancellationToken ct)
     {
-        if (job.PreventOverlap && !TryEnterFlight(job.Id))
+        // Resolve the tenant of THIS fire ONCE, up front, and key the overlap guard by it. This is the same
+        // tenant the store scoped the job read to (a fire is only ever reached inside a resolved scope), so an
+        // unresolved tenant here is a boundary bug and fails loud (deny-by-default) rather than defaulting.
+        var tenant = _resolveTenant()
+            ?? throw new InvalidOperationException(
+                "A cron fire ran with no tenant scope in effect. The overlap guard is partitioned by tenant " +
+                "and cannot key an unresolved fire; the caller path was not bound at its tenant boundary.");
+
+        if (job.PreventOverlap && !TryEnterFlight(tenant, job.Id))
         {
-            FileLog.Write($"[CronEngine] skip overlap: job={job.Id} (a prior run is still in flight)");
+            FileLog.Write($"[CronEngine] skip overlap: tenant={tenant.ToLogString()} job={job.Id} (a prior run is still in flight)");
             return new CronRunNowResult(CronFireOutcome.SkippedOverlap, null);
         }
 
@@ -211,7 +237,7 @@ public sealed class CronEngine
         finally
         {
             if (job.PreventOverlap)
-                ExitFlight(job.Id);
+                ExitFlight(tenant, job.Id);
         }
     }
 
@@ -256,15 +282,15 @@ public sealed class CronEngine
         _ => "unknown",
     };
 
-    private bool TryEnterFlight(string id)
+    private bool TryEnterFlight(TenantId tenant, string id)
     {
         lock (_inFlightGate)
-            return _inFlight.Add(id);
+            return _inFlight.Add((tenant, id));
     }
 
-    private void ExitFlight(string id)
+    private void ExitFlight(TenantId tenant, string id)
     {
         lock (_inFlightGate)
-            _inFlight.Remove(id);
+            _inFlight.Remove((tenant, id));
     }
 }

--- a/src/CcDirector.Gateway/Running/DirectorCronWorkListRunner.cs
+++ b/src/CcDirector.Gateway/Running/DirectorCronWorkListRunner.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -17,17 +18,27 @@ public sealed class DirectorCronWorkListRunner : ICronWorkListRunner
     private readonly IDirectorTargetResolver _resolver;
     private readonly WorkListRunnerManager _manager;
     private readonly ICronWorkListDrainLauncher _launcher;
+    private readonly Func<TenantId?> _resolveTenant;
 
+    /// <param name="resolveTenant">
+    /// Resolves the tenant of the current cron fire - the same background-loop/request seam the engine keys its
+    /// overlap guard by (audit MED, gap audit-e). The machine drain slot is partitioned by this tenant so one
+    /// tenant's drain never refuses another tenant's drain on a shared machine key. Omitted (self-host wiring,
+    /// tests) it is <see cref="TenantId.Local"/> - one partition, unchanged. A fire is only ever reached inside
+    /// a resolved scope, so an unresolved tenant here is a boundary bug and fails loud rather than defaulting.
+    /// </param>
     public DirectorCronWorkListRunner(
         WorkListStore store,
         IDirectorTargetResolver resolver,
         WorkListRunnerManager manager,
-        ICronWorkListDrainLauncher launcher)
+        ICronWorkListDrainLauncher launcher,
+        Func<TenantId?>? resolveTenant = null)
     {
         _store = store ?? throw new ArgumentNullException(nameof(store));
         _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
         _manager = manager ?? throw new ArgumentNullException(nameof(manager));
         _launcher = launcher ?? throw new ArgumentNullException(nameof(launcher));
+        _resolveTenant = resolveTenant ?? (() => TenantId.Local);
     }
 
     public async Task<CronWorkListOutcome> TriggerAsync(CronJobDto job, CancellationToken ct)
@@ -69,10 +80,18 @@ public sealed class DirectorCronWorkListRunner : ICronWorkListRunner
         }
         var directorId = target.DirectorId;
 
+        // Partition the machine drain slot by the tenant of this fire (audit MED): a caller-controlled machine
+        // key shared across tenants must not let one tenant's drain refuse another's. Resolved once here and
+        // used for admit AND the finally-release below, so the release always matches the admit.
+        var tenant = _resolveTenant()
+            ?? throw new InvalidOperationException(
+                "A cron work-list drain ran with no tenant scope in effect. The machine drain slot is " +
+                "partitioned by tenant; the caller path was not bound at its tenant boundary.");
+
         var machineKey = string.IsNullOrWhiteSpace(machine) ? directorId : machine;
-        if (_manager.TryAdmit(machineKey, listName) == WorkListRunnerManager.AdmitResult.RefusedMachineBusy)
+        if (_manager.TryAdmit(tenant, machineKey, listName) == WorkListRunnerManager.AdmitResult.RefusedMachineBusy)
         {
-            FileLog.Write($"[DirectorCronWorkListRunner] job={job.Id}: machine={machineKey} busy (active={_manager.ActiveList(machineKey)})");
+            FileLog.Write($"[DirectorCronWorkListRunner] job={job.Id}: tenant={tenant.ToLogString()} machine={machineKey} busy (active={_manager.ActiveList(tenant, machineKey)})");
             return CronWorkListOutcome.MachineBusy;
         }
 
@@ -100,7 +119,7 @@ public sealed class DirectorCronWorkListRunner : ICronWorkListRunner
             }
             finally
             {
-                _manager.Complete(machineKey);
+                _manager.Complete(tenant, machineKey);
             }
         }, CancellationToken.None);
 

--- a/src/CcDirector.Gateway/Running/WorkListRunnerManager.cs
+++ b/src/CcDirector.Gateway/Running/WorkListRunnerManager.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Gateway.Running;
@@ -12,14 +13,24 @@ namespace CcDirector.Gateway.Running;
 /// The cross-machine case (criterion 6) needs no coordination at this manager: two different machine
 /// keys each get admitted independently, so two runners drain two lists concurrently without
 /// interfering. The single-consumer claim (#273) keeps each list to one drainer regardless.
+///
+/// HOSTED MULTI-TENANCY (audit MED, gap audit-e): the admission slot is PARTITIONED BY TENANT. The
+/// machine key is caller-controlled (a body field or a job's target machine), so two tenants can name the
+/// SAME key - and the guard's whole job is a hard refusal on that key. Keying the slot by the bare machine
+/// key alone let one tenant's drain refuse another tenant's drain on a shared name, and let the 409's
+/// <see cref="ActiveList"/> leak the other tenant's list name. Each operation now takes the SERVER-RESOLVED
+/// tenant and only ever reads/writes that tenant's own partition, so a caller's admission conflicts only
+/// within its own tenant and the 409 never names another tenant's list. Self-host is one tenant
+/// (<see cref="TenantId.Local"/>) - one partition, behaviour unchanged.
 /// </summary>
 public sealed class WorkListRunnerManager
 {
     private readonly object _gate = new();
 
-    // Machine key -> the list name currently being drained on that machine.
-    private readonly Dictionary<string, string> _activeByMachine =
-        new(StringComparer.OrdinalIgnoreCase);
+    // Tenant -> (machine key -> the list name currently being drained on that machine for THAT tenant).
+    // The inner map keeps the machine key's original case-insensitive comparison; the outer key is the
+    // tenant, so one tenant's machine key can never collide with another's.
+    private readonly Dictionary<TenantId, Dictionary<string, string>> _activeByTenant = new();
 
     /// <summary>The outcome of asking to admit a drain on a machine.</summary>
     public enum AdmitResult
@@ -32,13 +43,17 @@ public sealed class WorkListRunnerManager
     }
 
     /// <summary>
-    /// Try to admit a drain of <paramref name="listName"/> on <paramref name="machineKey"/>. Returns
-    /// <see cref="AdmitResult.Admitted"/> when the machine is free, or
-    /// <see cref="AdmitResult.RefusedMachineBusy"/> when it is already draining another list. On
-    /// admit, the caller MUST call <see cref="Complete"/> when the drain finishes (a finally block).
+    /// Try to admit a drain of <paramref name="listName"/> on <paramref name="machineKey"/> within
+    /// <paramref name="tenant"/>'s own partition. Returns <see cref="AdmitResult.Admitted"/> when the machine
+    /// is free FOR THAT TENANT, or <see cref="AdmitResult.RefusedMachineBusy"/> when that tenant is already
+    /// draining another list on the key. Another tenant draining the same key never refuses this caller. On
+    /// admit, the caller MUST call <see cref="Complete"/> with the same tenant when the drain finishes (a
+    /// finally block).
     /// </summary>
-    public AdmitResult TryAdmit(string machineKey, string listName)
+    public AdmitResult TryAdmit(TenantId tenant, string machineKey, string listName)
     {
+        if (!tenant.IsValid)
+            throw new ArgumentException("a valid tenant is required", nameof(tenant));
         if (string.IsNullOrWhiteSpace(machineKey))
             throw new ArgumentException("machine key is required", nameof(machineKey));
         if (string.IsNullOrWhiteSpace(listName))
@@ -46,33 +61,50 @@ public sealed class WorkListRunnerManager
 
         lock (_gate)
         {
-            if (_activeByMachine.TryGetValue(machineKey, out var active))
+            if (_activeByTenant.TryGetValue(tenant, out var perMachine) &&
+                perMachine.TryGetValue(machineKey, out var active))
             {
-                FileLog.Write($"[WorkListRunnerManager] TryAdmit REFUSED: machine={machineKey} already draining {active}");
+                FileLog.Write($"[WorkListRunnerManager] TryAdmit REFUSED: tenant={tenant.ToLogString()} machine={machineKey} already draining {active}");
                 return AdmitResult.RefusedMachineBusy;
             }
 
-            _activeByMachine[machineKey] = listName;
-            FileLog.Write($"[WorkListRunnerManager] TryAdmit: machine={machineKey} admitted list={listName}");
+            if (perMachine is null)
+            {
+                perMachine = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                _activeByTenant[tenant] = perMachine;
+            }
+
+            perMachine[machineKey] = listName;
+            FileLog.Write($"[WorkListRunnerManager] TryAdmit: tenant={tenant.ToLogString()} machine={machineKey} admitted list={listName}");
             return AdmitResult.Admitted;
         }
     }
 
-    /// <summary>Release the machine's single drain slot. A no-op if the machine was not active.</summary>
-    public void Complete(string machineKey)
+    /// <summary>Release the machine's single drain slot for <paramref name="tenant"/>. A no-op if that tenant
+    /// was not active on the machine.</summary>
+    public void Complete(TenantId tenant, string machineKey)
     {
-        if (string.IsNullOrWhiteSpace(machineKey)) return;
+        if (!tenant.IsValid || string.IsNullOrWhiteSpace(machineKey)) return;
         lock (_gate)
         {
-            if (_activeByMachine.Remove(machineKey))
-                FileLog.Write($"[WorkListRunnerManager] Complete: machine={machineKey} drain slot released");
+            if (_activeByTenant.TryGetValue(tenant, out var perMachine) && perMachine.Remove(machineKey))
+            {
+                if (perMachine.Count == 0)
+                    _activeByTenant.Remove(tenant);
+                FileLog.Write($"[WorkListRunnerManager] Complete: tenant={tenant.ToLogString()} machine={machineKey} drain slot released");
+            }
         }
     }
 
-    /// <summary>The list currently draining on the machine, or null if the machine is free.</summary>
-    public string? ActiveList(string machineKey)
+    /// <summary>The list currently draining on the machine FOR <paramref name="tenant"/>, or null if that
+    /// tenant is not draining on the machine. Never reveals another tenant's list.</summary>
+    public string? ActiveList(TenantId tenant, string machineKey)
     {
+        if (!tenant.IsValid) return null;
         lock (_gate)
-            return _activeByMachine.TryGetValue(machineKey, out var name) ? name : null;
+            return _activeByTenant.TryGetValue(tenant, out var perMachine) &&
+                   perMachine.TryGetValue(machineKey, out var name)
+                ? name
+                : null;
     }
 }


### PR DESCRIPTION
## Root cause

Two process-global in-memory admission guards on the hosted Gateway were keyed by a bare id that is not unique across tenants, so one tenant's admission could refuse (or leak into) another tenant's.

1. **Cron overlap guard** (`CronEngine`). The in-flight set was `HashSet<string>` keyed by the bare cron job `Id`. A cron job's id is tenant-relative: `CronJobStore` mints a short `cj_` id whose uniqueness it checks only through the tenant query filter, and the legacy import preserves caller-supplied ids, so two tenants can hold a job with the SAME id (the DB identity is `(TenantId, Id)`). With `PreventOverlap` on, tenant A's in-flight run held the key `cj_xxxx`; tenant B's run-now of B's OWN `cj_xxxx` job then hit `TryEnterFlight("cj_xxxx")` = false and was rejected as `SkippedOverlap`. On hosted the scheduled sweep is skipped, so the reachable path is run-now, which runs inside the request's tenant scope.

2. **Work-list machine drain slot** (`WorkListRunnerManager`). The single-drain slot was `Dictionary<string,string>` keyed by the caller-controlled `machineKey` (a request body field, or a cron job's target machine). Two tenants can present the same key: tenant B draining `machineKey` "shared-name" made tenant A's own drain on "shared-name" refuse with `RefusedMachineBusy`, and the 409's `ActiveList` returned B's list name to A - a mutual denial plus a cross-tenant name leak.

## Fix

Both guards are now partitioned by the server-resolved tenant; a caller's admission only ever conflicts within its own tenant, and no 409 / `ActiveList` ever names another tenant's resource.

- `CronEngine`: in-flight set is now `HashSet<(TenantId, string)>`. The engine takes a `resolveTenant: () => _tenantPass.Current` seam - the same background-loop/request tenant seam its notifier already reads, and exactly the tenant the store scoped the job read to. Resolved once per fire (before the first await), used for enter AND exit; an unresolved scope fails loud (deny-by-default).
- `WorkListRunnerManager`: state is now `Dictionary<TenantId, Dictionary<string,string>>` (inner map keeps the machine key's case-insensitive comparison). `TryAdmit` / `Complete` / `ActiveList` take the tenant. The REST caller (`WorkListRunnerEndpoints`) passes the request's already-server-resolved `reqTenant`; the cron caller (`DirectorCronWorkListRunner`) reads the same seam.
- Log lines use `TenantId.ToLogString()` (no raw account tenant id in logs).

Self-host is one tenant (`TenantId.Local`) - one partition, behaviour byte-identical. Both seams default to `() => TenantId.Local` when omitted, so the existing single-tenant tests and wiring are unchanged.

**GatewayHost.cs touched at two construction sites** (the `CronEngine` and `DirectorCronWorkListRunner` `resolveTenant` wiring) - NOTE: serializes at merge. `GatewayEndpoints.cs` was NOT touched.

## Reproduced-real + revert-proof

Reproduced on a single engine / single manager (production shape - one singleton serves every tenant):

- `CronEngineTenancyTests.Run_now_for_one_tenant_is_not_blocked_by_another_tenants_same_id_job` - two tenants seeded (via the legacy import, which preserves the id) with the SAME `cj_shared` over one database and one ambient tenant context; A parks in flight, B fires its own same-id job -> `Fired`.
- `WorkListRunnerManagerTenancyTests` - two tenants admit the SAME machine key without refusing each other, and `ActiveList` never reveals another tenant's list.

Revert-proof: collapsing each guard's tenant back to a constant (the bare-id behaviour) reddens exactly the 4 cross-tenant assertions while the 2 same-tenant guard tests stay green (the within-tenant overlap / same-machine refusal is preserved).

## Gates

- Build: `CcDirector.Gateway` 0/0, `CcDirector.Gateway.Tests` 0/0.
- Targeted: CronEngineTenancyTests + WorkListRunnerManagerTenancyTests + WorkListRunnerManagerTests + CronWorkListTriggerTests + CronEngineTests = 25/25 passed.
- Solo tenancy filters: `OnOneRoute` + `The_roster_and_the_commands_agree` passed.