### PR TITLE
fix(gateway): partition the telemetry retry queue by tenant (audit MTR gap C)

### DIFF
--- a/mission/fix-med-telemetry.md
+++ b/mission/fix-med-telemetry.md
@@ -1,0 +1,70 @@
+# MTR - telemetry retry queue tenant partition (PR #2002)
+
+Branch `fix/audit-med-telemetry`. Fixes audit MTR gap C: the two hosted `/telemetry`
+writers shared one process-global durable FIFO with no tenant, so one tenant's volume
+evicted another's oldest event and one tenant's poison event head-of-line-blocked every
+other tenant's delivery; the startup route also accepted an arbitrary `director_id`.
+
+## r1 (accepted by Codex, 12/12) - kept
+
+- Every queued event is tagged with the SERVER-RESOLVED tenant of the authenticated
+  request (`HostedTenantBoundary`; `TenantId.Local` on self-host, 403 deny when
+  unresolved on hosted).
+- The bound is PER TENANT (a caller only evicts its own oldest) and the flush skips a
+  tenant whose head fails and keeps flushing every other tenant (a poison blocks only its
+  own line).
+- Revert-proof: neutering the per-tenant keying reddens the isolation tests.
+
+## r2 - Codex CHANGES-NEEDED residuals, now fixed
+
+Codex flagged two residuals; both addressed on top of r1.
+
+### Residual 1 - startup route accepted an unowned director_id
+
+The route rejected only a director_id positively owned by ANOTHER tenant, and ALLOWED an
+unknown/blank/malformed id (to avoid over-refusing a startup report that races the tunnel
+Hello). A caller could therefore mint a startup observation for any id it did not own.
+
+Fix: on hosted the route now REQUIRES positive ownership -
+`DirectorRegistry.IsDirectorOwnedByTenant(caller, id)` returns true only for an id keyed
+to the caller's own tenant; a blank/malformed, another-tenant, or as-yet-unknown id all
+fail and are rejected (403, never recorded, never enqueued). The accepted cost: a startup
+report that arrives before its own id is registered is dropped - a best-effort, swallowed
+ping is the lesser loss than accepting a forgeable cross-tenant observation. Self-host
+(single tenant) never fires the gate.
+
+- `DirectorRegistry.IsDirectorOwnedByOtherTenant` -> `IsDirectorOwnedByTenant` (positive).
+- Endpoint gate flipped from "reject if owned-by-other" to "reject unless provably owned".
+- Tests: unknown id -> 403 (was 202), blank id -> 403 (new), own id -> 202, other tenant
+  -> 403, unbound key -> 403. Revert-proof: forcing the ownership check to `true` reddens
+  the unknown/blank reject tests.
+
+### Residual 2 - legacy pre-tag persisted events collapsed to Local
+
+A queue file written before the tenant tag existed has untagged events; r1 defaulted them
+to `TenantId.Local`. On a hosted Gateway those came from many real accounts but landed in
+ONE shared Local partition, where a legacy poison event could head-of-line-block a real
+Local-tenant event (and legacy events from different accounts blocked each other).
+
+Fix: legacy untagged events are quarantined into an ISOLATED partition
+(`TelemetryRetryQueue.LegacyUntaggedPartition`, a reserved key that is deliberately not a
+valid `TenantId`). The bound and flush are keyed by that string, so the quarantine lane is
+fully isolated: it still drains (at-least-once preserved - legacy events delivered, not
+dropped) and a legacy poison blocks ONLY the quarantine lane, never any real tenant's
+flush.
+
+- Tests: legacy untagged file loads + delivers from the isolated lane; a legacy poison
+  does NOT HOL-block a real Local-tenant event enqueued after it. Revert-proof: reverting
+  the Load default back to Local reddens the HOL-block test (uses `TenantId.Local` as the
+  real tenant on purpose - a GUID tenant would not catch the revert).
+
+## Verification
+
+- `dotnet build` gateway + tests: 0 warnings, 0 errors.
+- Telemetry + startup tests: 101 passed.
+- `DirectorStartupTelemetryTenantTests` solo: 7 passed.
+- `TelemetryRetryQueueTenantTests` solo: 7 passed.
+- Both r2 fixes independently proven revert-proof (revert -> the matching new test reddens).
+
+Touches `GatewayHost.cs` (the 4-arg `DirectorStartupTelemetryEndpoint.Map` wiring) - so this
+serializes at merge.

--- a/mission/fix-med-telemetry.md
+++ b/mission/fix-med-telemetry.md
@@ -58,13 +58,53 @@ flush.
   the Load default back to Local reddens the HOL-block test (uses `TenantId.Local` as the
   real tenant on purpose - a GUID tenant would not catch the revert).
 
-## Verification
+## r3 - Codex CHANGES-NEEDED round 2 residuals, now fixed
+
+Codex round 2 flagged two precise residuals in the hosted STARTUP telemetry parser/ownership
+path; both fixed on top of r2. The legacy-quarantine and per-tenant partitioning from r1/r2 are
+correct and untouched.
+
+### Residual 1 - a non-object / malformed JSON root threw a 500 before the ownership gate
+
+`ReadRecordFields` only caught `JsonException`. A body that is VALID JSON but whose root is not an
+object (an array, number, string, bool, or `null` literal) parses fine, then `TryGetProperty`
+throws `InvalidOperationException` on the non-object element - which escaped as an unhandled 500
+BEFORE the ownership gate ran. So an arbitrary caller's junk body was a server error.
+
+Fix: the body is parsed DEFENSIVELY (`TryReadRecordFields`). A malformed body OR a non-object root
+is rejected CLEANLY - 400 Bad Request, never recorded, never enqueued, never a throw. Only a JSON
+object proceeds.
+
+### Residual 2 - a missing/wrong-typed director_id collapsed to the literal string "(none)"
+
+`ReadRecordFields` returned the literal `"(none)"` for a missing/blank/wrong-typed `director_id`,
+and that string was handed to the ownership check. If any tenant registered a Director LITERALLY
+named `(none)`, an id-less request satisfied its own ownership gate - a real-looking placeholder
+that could pass.
+
+Fix: a missing/blank/wrong-typed `director_id` now resolves to `null` - an ownership-INCAPABLE
+sentinel, never a real-looking string. `IsDirectorOwnedByTenant` takes `string?` and returns false
+for null, so a null id can NEVER satisfy the gate no matter what any tenant registers. The gate then
+requires positive ownership of a real `director_id` by the caller's server-resolved tenant.
+
+### Tests (HOSTED WIRE - POST the real startup route over HTTP, behind the real auth gate)
+
+Added to `DirectorStartupTelemetryTenantTests`:
+- Non-object roots (`[1,2,3]`, `123`, `"str"`, `true`, `null`), malformed JSON, and an empty body
+  -> 400, asserted NOT 500.
+- Missing, wrong-typed (number), and blank `director_id` -> 403, WITH a Director literally named
+  `(none)` registered to the caller's tenant (proves the null sentinel never matches it).
+- A real owned `director_id` over the wire -> 202.
+
+## Verification (r3)
 
 - `dotnet build` gateway + tests: 0 warnings, 0 errors.
-- Telemetry + startup tests: 101 passed.
-- `DirectorStartupTelemetryTenantTests` solo: 7 passed.
+- Telemetry + startup tests: 112 passed (was 101; +11 new wire tests).
+- `DirectorStartupTelemetryTenantTests` solo: 18 passed (was 7).
 - `TelemetryRetryQueueTenantTests` solo: 7 passed.
-- Both r2 fixes independently proven revert-proof (revert -> the matching new test reddens).
+- Both r3 fixes independently proven revert-proof: collapsing a missing id back to `"(none)"`
+  reddens the missing/wrong-typed/blank reject tests (false 202); removing the non-object guard
+  reddens the non-object body tests (500 instead of 400).
 
 Touches `GatewayHost.cs` (the 4-arg `DirectorStartupTelemetryEndpoint.Map` wiring) - so this
 serializes at merge.

--- a/src/CcDirector.Gateway.Tests/DirectorStartupTelemetryEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorStartupTelemetryEndpointTests.cs
@@ -92,7 +92,16 @@ public sealed class DirectorStartupTelemetryEndpointTests
             queuePath,
             new HttpClient { Timeout = TimeSpan.FromSeconds(3) },
             retryInterval: TimeSpan.FromMilliseconds(100));
-        DirectorStartupTelemetryEndpoint.Map(app, queue);
+        // Self-host tenant boundary (no ambient AsyncLocalTenantContext -> every request resolves to
+        // TenantId.Local, IsHosted=false) and an empty Director registry, so this record/forward suite is
+        // unaffected by the tenant tag and the hosted ownership gate never fires (self-host accepts an
+        // unregistered id). The multi-tenant behaviour is proven in DirectorStartupTelemetryTenantTests and
+        // TelemetryRetryQueueTenantTests.
+        var tenants = new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+            new CcDirector.Core.Tenancy.SingleTenantContext(),
+            new CcDirector.Gateway.Pairing.DeviceRegistry(Path.Combine(Path.GetTempPath(), $"startup-devices-{Guid.NewGuid():N}.json")));
+        var directors = new CcDirector.Gateway.Discovery.DirectorRegistry(Path.Combine(Path.GetTempPath(), $"startup-registry-{Guid.NewGuid():N}"));
+        DirectorStartupTelemetryEndpoint.Map(app, queue, tenants, directors);
         queue.StartFlushing();
         await app.StartAsync();
 

--- a/src/CcDirector.Gateway.Tests/DirectorStartupTelemetryTenantTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorStartupTelemetryTenantTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The Director-startup telemetry route over the WIRE, behind the REAL authentication gate, on a HOSTED
+/// Gateway (an <see cref="AsyncLocalTenantContext"/> so <see cref="HostedTenantBoundary.IsHosted"/> is true),
+/// with two callers whose enrolled device keys bind to different tenants (audit MTR gap C).
+///
+/// Two endpoint-specific properties the queue tests cannot see:
+/// <list type="bullet">
+///   <item>The tenant is the SERVER-RESOLVED one, deny-by-default: a caller whose key binds to NO tenant is
+///     refused 403 on hosted, never queued under a guessed tenant.</item>
+///   <item>Director-id ownership: a caller may create a startup observation ONLY for a director id its own
+///     tenant PROVABLY owns. Its own id is 202; ANOTHER tenant's known id (the "false startup observation
+///     for B" the audit describes), an as-yet-UNKNOWN id, and a blank id are all 403 - a caller may not post
+///     an observation for a director id it does not own.</item>
+/// </list>
+/// The gate is in the pipeline on purpose (<see cref="NoCredential_IsRejected_SoTheseTestsRunBehindTheGate"/>
+/// keeps that honest); status codes are asserted directly, never inferred from a body.
+/// </summary>
+public sealed class DirectorStartupTelemetryTenantTests : IAsyncLifetime
+{
+    private const string SharedMachineToken = "shared-machine-token-startup-tenant";
+    private const string TenantA = "tenant-a-guid-aaaaaaaaaaaaaaaa";
+    private const string TenantB = "tenant-b-guid-bbbbbbbbbbbbbbbb";
+
+    private readonly string _registryPath = Path.Combine(Path.GetTempPath(), $"startup-tenant-devices-{Guid.NewGuid():N}.json");
+    private readonly string _queuePath = Path.Combine(Path.GetTempPath(), $"startup-tenant-queue-{Guid.NewGuid():N}.json");
+    private readonly string _directorsDir = Path.Combine(Path.GetTempPath(), $"startup-tenant-directors-{Guid.NewGuid():N}");
+
+    private WebApplication _app = null!;
+    private TelemetryRetryQueue _queue = null!;
+    private string _baseAddress = "";
+
+    private string _keyA = "";       // binds to tenant A
+    private string _keyB = "";       // binds to tenant B
+    private string _keyUnbound = ""; // enrolled but never bound to a tenant
+
+    public async Task InitializeAsync()
+    {
+        var devices = new DeviceRegistry(_registryPath);
+        _keyA = devices.Register("device-a", "PHONE-A", "android", "phone").DeviceKey;
+        _keyB = devices.Register("device-b", "PHONE-B", "android", "phone").DeviceKey;
+        _keyUnbound = devices.Register("device-u", "PHONE-U", "android", "phone").DeviceKey;
+        devices.SetAccountBinding("device-a", "subject-a", TenantA);
+        devices.SetAccountBinding("device-b", "subject-b", TenantB);
+        // device-u is left unbound on purpose - on hosted it resolves to NO tenant (a deny).
+
+        // Tenant B owns Director "dir-b". Tenant A owns "dir-a". Registered via the tunnel Hello path, which
+        // is the only path that keys a Director to a real account tenant.
+        var directors = new DirectorRegistry(_directorsDir);
+        directors.RegisterFromStream("dir-b", "MACHINE-B", "userb", "1.0", 4321, DateTime.UtcNow, new TenantId(TenantB));
+        directors.RegisterFromStream("dir-a", "MACHINE-A", "usera", "1.0", 1234, DateTime.UtcNow, new TenantId(TenantA));
+
+        // Hosted boundary: a real AsyncLocalTenantContext makes IsHosted true and the tenant resolve from the
+        // authenticated device key's binding.
+        var boundary = new HostedTenantBoundary(new AsyncLocalTenantContext(), devices);
+        Assert.True(boundary.IsHosted); // this suite really is exercising the hosted path
+
+        // No cloud startup URL configured -> the endpoint records only (202) and never forwards; the
+        // deny/forgery decisions all happen before the queue, so this keeps the test to status-code checks.
+        Environment.SetEnvironmentVariable(DirectorStartupTelemetryEndpoint.TargetUrlEnvVar, null);
+
+        _queue = new TelemetryRetryQueue(_queuePath, new HttpClient { Timeout = TimeSpan.FromSeconds(3) },
+            retryInterval: TimeSpan.FromMilliseconds(100));
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        _app = builder.Build();
+        var port = AllocateFreePort();
+        _app.Urls.Add($"http://127.0.0.1:{port}");
+
+        // The real host-wide gate, exactly as GatewayHost installs it - so the device key that the boundary
+        // reads is the one the gate accepted, never a second re-parse of the request.
+        var requireToken = new AuthMiddleware.RequireToken { Token = SharedMachineToken, Devices = devices };
+        _app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, requireToken, next));
+
+        DirectorStartupTelemetryEndpoint.Map(_app, _queue, boundary, directors);
+        _queue.StartFlushing();
+        await _app.StartAsync();
+        _baseAddress = $"http://127.0.0.1:{port}";
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+        await _queue.DisposeAsync();
+        try { if (File.Exists(_registryPath)) File.Delete(_registryPath); } catch { }
+        try { if (File.Exists(_queuePath)) File.Delete(_queuePath); } catch { }
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private HttpClient Client() => new() { BaseAddress = new Uri(_baseAddress) };
+
+    private async Task<HttpStatusCode> PostStartupAsync(string? bearerKey, string directorId)
+    {
+        using var client = Client();
+        var request = new HttpRequestMessage(HttpMethod.Post, "/telemetry/director-startup")
+        {
+            Content = JsonContent.Create(new { director_id = directorId, machine_name = "M", app_version = "1.0" }),
+        };
+        if (bearerKey is not null)
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerKey);
+        var response = await client.SendAsync(request);
+        return response.StatusCode;
+    }
+
+    [Fact]
+    public async Task NoCredential_IsRejected_SoTheseTestsRunBehindTheGate()
+        => Assert.Equal(HttpStatusCode.Unauthorized, await PostStartupAsync(bearerKey: null, "dir-a"));
+
+    [Fact]
+    public async Task UnboundKey_ResolvesNoTenantOnHosted_IsDenied()
+        => Assert.Equal(HttpStatusCode.Forbidden, await PostStartupAsync(_keyUnbound, "dir-a"));
+
+    [Fact]
+    public async Task CallerPostingAnotherTenantsKnownDirectorId_IsRejected()
+        // Tenant A forging tenant B's known director id - the exact "false startup observation for B".
+        => Assert.Equal(HttpStatusCode.Forbidden, await PostStartupAsync(_keyA, "dir-b"));
+
+    [Fact]
+    public async Task CallerPostingItsOwnDirectorId_IsAccepted()
+        => Assert.Equal(HttpStatusCode.Accepted, await PostStartupAsync(_keyA, "dir-a"));
+
+    [Fact]
+    public async Task CallerPostingAnUnknownDirectorId_IsRejected_NotProvablyOwned()
+        // An id registered to nobody yet is not PROVABLY the caller's, so it is refused rather than accepted:
+        // the caller may not create a startup observation for a director id it cannot prove it owns. This is
+        // the audit fix - the previous behaviour accepted an unknown id, which let a caller mint an
+        // observation for any id at all.
+        => Assert.Equal(HttpStatusCode.Forbidden, await PostStartupAsync(_keyA, "dir-not-registered-yet"));
+
+    [Fact]
+    public async Task CallerPostingABlankDirectorId_IsRejected()
+        // A blank director id can never be provably owned, so it is refused (not recorded, not enqueued).
+        => Assert.Equal(HttpStatusCode.Forbidden, await PostStartupAsync(_keyA, ""));
+
+    [Fact]
+    public async Task TheOtherDirection_TenantBMayNotForgeTenantAsId()
+        => Assert.Equal(HttpStatusCode.Forbidden, await PostStartupAsync(_keyB, "dir-a"));
+}

--- a/src/CcDirector.Gateway.Tests/DirectorStartupTelemetryTenantTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorStartupTelemetryTenantTests.cs
@@ -64,6 +64,11 @@ public sealed class DirectorStartupTelemetryTenantTests : IAsyncLifetime
         var directors = new DirectorRegistry(_directorsDir);
         directors.RegisterFromStream("dir-b", "MACHINE-B", "userb", "1.0", 4321, DateTime.UtcNow, new TenantId(TenantB));
         directors.RegisterFromStream("dir-a", "MACHINE-A", "usera", "1.0", 1234, DateTime.UtcNow, new TenantId(TenantA));
+        // A director LITERALLY named "(none)" owned by tenant A. This is the adversary for residual 2: if a
+        // missing/wrong-typed director_id collapsed to the literal string "(none)", tenant A could satisfy its
+        // own ownership gate by simply omitting the field. It must NOT - a missing id resolves to a null,
+        // ownership-incapable sentinel that never matches this (or any) registered director.
+        directors.RegisterFromStream("(none)", "MACHINE-A2", "usera", "1.0", 1235, DateTime.UtcNow, new TenantId(TenantA));
 
         // Hosted boundary: a real AsyncLocalTenantContext makes IsHosted true and the tenant resolve from the
         // authenticated device key's binding.
@@ -127,6 +132,24 @@ public sealed class DirectorStartupTelemetryTenantTests : IAsyncLifetime
         return response.StatusCode;
     }
 
+    /// <summary>
+    /// POSTs a RAW body string (not a serialized object) so a test can send a malformed body, a non-object
+    /// JSON root, or an object with a missing/wrong-typed director_id - the shapes the typed
+    /// <see cref="PostStartupAsync"/> helper cannot express.
+    /// </summary>
+    private async Task<HttpStatusCode> PostRawAsync(string? bearerKey, string rawBody)
+    {
+        using var client = Client();
+        var request = new HttpRequestMessage(HttpMethod.Post, "/telemetry/director-startup")
+        {
+            Content = new StringContent(rawBody, System.Text.Encoding.UTF8, "application/json"),
+        };
+        if (bearerKey is not null)
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerKey);
+        var response = await client.SendAsync(request);
+        return response.StatusCode;
+    }
+
     [Fact]
     public async Task NoCredential_IsRejected_SoTheseTestsRunBehindTheGate()
         => Assert.Equal(HttpStatusCode.Unauthorized, await PostStartupAsync(bearerKey: null, "dir-a"));
@@ -160,4 +183,60 @@ public sealed class DirectorStartupTelemetryTenantTests : IAsyncLifetime
     [Fact]
     public async Task TheOtherDirection_TenantBMayNotForgeTenantAsId()
         => Assert.Equal(HttpStatusCode.Forbidden, await PostStartupAsync(_keyB, "dir-a"));
+
+    // ----- Residual 1: a non-object / malformed body is rejected CLEANLY, never a 500 -----
+
+    [Theory]
+    [InlineData("[1,2,3]")]              // valid JSON, array root
+    [InlineData("123")]                   // valid JSON, number root
+    [InlineData("\"just-a-string\"")]   // valid JSON, string root
+    [InlineData("true")]                  // valid JSON, bool root
+    [InlineData("null")]                  // valid JSON, null literal root
+    [InlineData("{ not json ")]          // malformed JSON
+    [InlineData("")]                      // empty body
+    public async Task NonObjectOrMalformedBody_IsRejectedCleanly_Never500(string rawBody)
+    {
+        // These roots make property access throw InvalidOperationException; the old parser only caught
+        // JsonException, so a non-object root escaped as an unhandled 500 BEFORE the ownership gate. The
+        // defensive parse rejects them as 400 - and, critically, NOT a 500.
+        var status = await PostRawAsync(_keyA, rawBody);
+        Assert.Equal(HttpStatusCode.BadRequest, status);
+        Assert.NotEqual(HttpStatusCode.InternalServerError, status);
+    }
+
+    // ----- Residual 2: a missing / wrong-typed director_id is a null sentinel, never the literal "(none)" -----
+
+    [Fact]
+    public async Task MissingDirectorId_ResolvesToNullSentinel_NotTheRegisteredNoneDirector_IsRejected()
+    {
+        // Tenant A has a Director LITERALLY named "(none)" registered. A well-formed object with NO
+        // director_id field must resolve to a null, ownership-INCAPABLE sentinel - NOT the literal string
+        // "(none)" - so it can never satisfy the gate by matching that director. Revert-proof: if a missing id
+        // collapsed to "(none)", this would falsely return 202.
+        var status = await PostRawAsync(_keyA, "{ \"machine_name\": \"M\", \"app_version\": \"1.0\" }");
+        Assert.Equal(HttpStatusCode.Forbidden, status);
+    }
+
+    [Fact]
+    public async Task WrongTypedDirectorId_ResolvesToNullSentinel_IsRejected()
+    {
+        // director_id present but NOT a string (a number) -> null sentinel -> rejected, even with the
+        // "(none)" director registered to tenant A.
+        var status = await PostRawAsync(_keyA, "{ \"director_id\": 12345, \"machine_name\": \"M\", \"app_version\": \"1.0\" }");
+        Assert.Equal(HttpStatusCode.Forbidden, status);
+    }
+
+    [Fact]
+    public async Task BlankStringDirectorId_ResolvesToNullSentinel_IsRejected()
+    {
+        // A whitespace-only director_id string is treated as absent -> null sentinel -> rejected.
+        var status = await PostRawAsync(_keyA, "{ \"director_id\": \"   \", \"machine_name\": \"M\", \"app_version\": \"1.0\" }");
+        Assert.Equal(HttpStatusCode.Forbidden, status);
+    }
+
+    [Fact]
+    public async Task RealOwnedDirectorId_OverTheWire_IsAccepted()
+        // The positive case of the three residual wire checks: a real, owned director_id from its owning
+        // tenant is accepted (202) - the gate rejects only what is not provably owned.
+        => Assert.Equal(HttpStatusCode.Accepted, await PostRawAsync(_keyA, "{ \"director_id\": \"dir-a\", \"machine_name\": \"M\", \"app_version\": \"1.0\" }"));
 }

--- a/src/CcDirector.Gateway.Tests/Issue639GatewayTelemetryTokenTests.cs
+++ b/src/CcDirector.Gateway.Tests/Issue639GatewayTelemetryTokenTests.cs
@@ -115,7 +115,7 @@ public sealed class Issue639GatewayTelemetryTokenTests
         {
             source.SignedIn = true;
             // Enqueued with NO per-event bearer (the relay path): the Gateway token must still be attached.
-            queue.Enqueue(TargetUrl, BodyFor(0), bearer: null);
+            queue.Enqueue(TargetUrl, BodyFor(0), bearer: null, CcDirector.Core.Tenancy.TenantId.Local);
 
             var delivered = await queue.FlushOnceAsync();
 
@@ -137,7 +137,7 @@ public sealed class Issue639GatewayTelemetryTokenTests
         {
             source.SignedIn = false; // Gateway not signed in yet
             for (var i = 0; i < 4; i++)
-                queue.Enqueue(TargetUrl, BodyFor(i), bearer: null);
+                queue.Enqueue(TargetUrl, BodyFor(i), bearer: null, CcDirector.Core.Tenancy.TenantId.Local);
 
             // Not forwarded while not signed in - the events stay queued.
             Assert.Equal(4, queue.Depth);
@@ -174,7 +174,7 @@ public sealed class Issue639GatewayTelemetryTokenTests
         {
             source.SignedIn = true;
             // Simulate a leftover Director Bearer that somehow reached the queue: it must NOT be forwarded.
-            queue.Enqueue(TargetUrl, BodyFor(0), bearer: DirectorToken);
+            queue.Enqueue(TargetUrl, BodyFor(0), bearer: DirectorToken, CcDirector.Core.Tenancy.TenantId.Local);
 
             var delivered = await queue.FlushOnceAsync();
 
@@ -201,7 +201,7 @@ public sealed class Issue639GatewayTelemetryTokenTests
         try
         {
             source.SignedIn = false;
-            queue.Enqueue(TargetUrl, BodyFor(0), bearer: DirectorToken);
+            queue.Enqueue(TargetUrl, BodyFor(0), bearer: DirectorToken, CcDirector.Core.Tenancy.TenantId.Local);
             // A deferred (not-signed-in) pass logs, then a signed-in pass forwards and logs - both paths
             // touch the token-bearing code; neither may write a token value.
             Assert.Equal(0, await queue.FlushOnceAsync());
@@ -235,7 +235,7 @@ public sealed class Issue639GatewayTelemetryTokenTests
         var queue = new TelemetryRetryQueue(path, new HttpClient(handler), TimeSpan.FromMilliseconds(50));
         try
         {
-            queue.Enqueue(TargetUrl, BodyFor(0), bearer: DirectorToken);
+            queue.Enqueue(TargetUrl, BodyFor(0), bearer: DirectorToken, CcDirector.Core.Tenancy.TenantId.Local);
             var delivered = await queue.FlushOnceAsync();
 
             Assert.Equal(1, delivered);
@@ -394,7 +394,12 @@ public sealed class Issue639GatewayTelemetryTokenTests
             retryInterval: TimeSpan.FromMilliseconds(100),
             maxSize: TelemetryRetryQueue.DefaultMaxSize,
             gatewayTokenSource: source);
-        TelemetryRelayEndpoint.Map(relayApp, queue);
+        // Self-host tenant boundary (no ambient AsyncLocalTenantContext -> TenantId.Local for every request),
+        // so this issue-639 token suite is unaffected by the tenant tag.
+        var tenants = new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+            new CcDirector.Core.Tenancy.SingleTenantContext(),
+            new CcDirector.Gateway.Pairing.DeviceRegistry(Path.Combine(Path.GetTempPath(), $"relay639-devices-{Guid.NewGuid():N}.json")));
+        TelemetryRelayEndpoint.Map(relayApp, queue, tenants);
         queue.StartFlushing();
         await relayApp.StartAsync();
 

--- a/src/CcDirector.Gateway.Tests/TelemetryRelayEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/TelemetryRelayEndpointTests.cs
@@ -104,7 +104,14 @@ public sealed class TelemetryRelayEndpointTests
             queuePath,
             new HttpClient { Timeout = TimeSpan.FromSeconds(3) },
             retryInterval: TimeSpan.FromMilliseconds(100));
-        TelemetryRelayEndpoint.Map(relay, queue);
+        // Self-host tenant boundary: no ambient AsyncLocalTenantContext, so every request resolves to
+        // TenantId.Local - the endpoint behaves exactly as it did before the tenant tag (this suite is not
+        // the multi-tenant one; the per-tenant isolation is proven in TelemetryRetryQueueTenantTests and
+        // the endpoint tenant/forgery behaviour in DirectorStartupTelemetryTenantTests).
+        var tenants = new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+            new CcDirector.Core.Tenancy.SingleTenantContext(),
+            new CcDirector.Gateway.Pairing.DeviceRegistry(Path.Combine(Path.GetTempPath(), $"relay-devices-{Guid.NewGuid():N}.json")));
+        TelemetryRelayEndpoint.Map(relay, queue, tenants);
         queue.StartFlushing();
         await relay.StartAsync();
 

--- a/src/CcDirector.Gateway.Tests/TelemetryRetryQueueTenantTests.cs
+++ b/src/CcDirector.Gateway.Tests/TelemetryRetryQueueTenantTests.cs
@@ -1,0 +1,287 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Multi-tenancy regression for the durable telemetry retry queue (audit MTR gap C). The queue is ONE
+/// process-global durable FIFO shared by every tenant's <c>/telemetry/*</c> writes. Before the fix its
+/// bound evicted the globally-oldest event and its flush stopped the whole FIFO on the first non-2xx, so
+/// one tenant's volume could evict another tenant's queued event and one tenant's poison event could
+/// head-of-line-block every other tenant's delivery.
+///
+/// Each test is written so that REVERTING the fix reddens it:
+/// <list type="bullet">
+///   <item><see cref="PerTenantCap_OneTenantsOverflow_DoesNotEvictAnotherTenantsEvent"/> - reverting the
+///     per-tenant eviction to a global <c>_events.First</c> drop evicts tenant B's event, failing the
+///     positive control that B is still delivered.</item>
+///   <item><see cref="PerTenantFlush_OneTenantsPoison_DoesNotBlockAnotherTenant"/> - reverting the
+///     per-tenant skip to the single-line "stop on first failure" leaves tenant B's event undelivered
+///     behind tenant A's poison.</item>
+///   <item><see cref="LegacyUntaggedPoison_DoesNotHeadOfLineBlock_ARealTenant"/> - reverting the legacy
+///     quarantine lane to a shared Local default lets a pre-tag poison event block a real tenant.</item>
+/// </list>
+/// Delivery is driven deterministically through a fake handler + the public
+/// <see cref="TelemetryRetryQueue.FlushOnceAsync"/> - no timers, no network.
+/// </summary>
+public sealed class TelemetryRetryQueueTenantTests
+{
+    private const string Url = "http://backend.test/api/v1/telemetry/login";
+    private static readonly TenantId TenantA = new("tenant-a-guid-0000000000000000");
+    private static readonly TenantId TenantB = new("tenant-b-guid-1111111111111111");
+
+    /// <summary>
+    /// A fake backend that DELIVERS any body not marked POISON (recording it) and PERMANENTLY rejects a
+    /// POISON body with a non-2xx - the shape of an event the backend will never accept.
+    /// </summary>
+    private sealed class PoisonAwareHandler : HttpMessageHandler
+    {
+        public readonly List<string> Delivered = new();
+        private readonly object _lock = new();
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var body = request.Content is null ? "" : await request.Content.ReadAsStringAsync(ct);
+            if (body.Contains("POISON"))
+                return new HttpResponseMessage(HttpStatusCode.BadRequest);
+            lock (_lock) Delivered.Add(body);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    private static (TelemetryRetryQueue queue, PoisonAwareHandler handler, string path) NewQueue(int maxSize = 1000)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"telemetry-queue-tenant-{Guid.NewGuid():N}.json");
+        var handler = new PoisonAwareHandler();
+        var queue = new TelemetryRetryQueue(path, new HttpClient(handler), TimeSpan.FromMilliseconds(50), maxSize);
+        return (queue, handler, path);
+    }
+
+    // The body carries a short label ("A"/"B") that mirrors which TenantId the event was enqueued under, so
+    // a delivered body can be attributed back to its tenant. The queue partitions by the TenantId passed to
+    // Enqueue (never by the body), so the label is only the test's read-back handle.
+    private static string Body(string label, int n) => JsonSerializer.Serialize(new { tenant = label, n });
+    private static bool IsFrom(string body, string label)
+        => JsonDocument.Parse(body).RootElement.GetProperty("tenant").GetString() == label;
+
+    private static void Cleanup(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* temp cleanup */ }
+    }
+
+    // ----- per-tenant bound: one tenant's flood never evicts another tenant's event -----
+
+    [Fact]
+    public async Task PerTenantCap_OneTenantsOverflow_DoesNotEvictAnotherTenantsEvent()
+    {
+        var (queue, handler, path) = NewQueue(maxSize: 3);
+        try
+        {
+            // Tenant B queues one legitimate event (the oldest event in the shared list).
+            queue.Enqueue(Url, Body("B", 0), bearer: null, TenantB);
+            // Tenant A floods past the bound of 3. A global cap would evict the list head - B's event.
+            for (var i = 0; i < 5; i++)
+                queue.Enqueue(Url, Body("A", i), bearer: null, TenantA);
+
+            // A is bounded to its OWN 3 newest (2,3,4); B keeps its one. Nothing global was dropped.
+            Assert.Equal(4, queue.Depth);
+
+            var delivered = await queue.FlushOnceAsync();
+            Assert.Equal(4, delivered);
+
+            // Positive control + the isolation fact: B's event survived A's flood and was delivered.
+            Assert.Contains(handler.Delivered, b => IsFrom(b, "B"));
+            // A kept exactly its newest three (2,3,4), evicting only its OWN oldest (0,1).
+            var aNs = handler.Delivered.Where(b => IsFrom(b, "A"))
+                .Select(b => JsonDocument.Parse(b).RootElement.GetProperty("n").GetInt32())
+                .OrderBy(n => n).ToArray();
+            Assert.Equal(new[] { 2, 3, 4 }, aNs);
+        }
+        finally { await queue.DisposeAsync(); Cleanup(path); }
+    }
+
+    // ----- per-tenant flush: one tenant's poison never blocks another tenant -----
+
+    [Fact]
+    public async Task PerTenantFlush_OneTenantsPoison_DoesNotBlockAnotherTenant()
+    {
+        var (queue, handler, path) = NewQueue();
+        try
+        {
+            // Tenant A's poison event is at the HEAD of the shared FIFO - the backend rejects it forever.
+            queue.Enqueue(Url, Body("A", 0) + "POISON", bearer: null, TenantA);
+            // Tenant B's legitimate event is queued behind it.
+            queue.Enqueue(Url, Body("B", 0), bearer: null, TenantB);
+
+            var delivered = await queue.FlushOnceAsync();
+
+            // B flushed PAST A's poison - a single-line "stop on first failure" would leave B undelivered.
+            Assert.Equal(1, delivered);
+            Assert.Contains(handler.Delivered, b => IsFrom(b, "B"));
+            // A's poison stays queued (at-least-once, its own FIFO preserved) - not dropped, not delivered.
+            Assert.DoesNotContain(handler.Delivered, b => IsFrom(b, "A"));
+            Assert.Equal(1, queue.Depth);
+        }
+        finally { await queue.DisposeAsync(); Cleanup(path); }
+    }
+
+    // ----- per-tenant FIFO within a tenant is preserved while other tenants flush past a block -----
+
+    [Fact]
+    public async Task PerTenantFlush_BlockedTenantKeepsItsOrder_WhileOthersDrain()
+    {
+        var (queue, handler, path) = NewQueue();
+        try
+        {
+            queue.Enqueue(Url, Body("A", 0) + "POISON", bearer: null, TenantA); // A head: poison
+            queue.Enqueue(Url, Body("A", 1), bearer: null, TenantA);            // A second: must NOT jump ahead
+            queue.Enqueue(Url, Body("B", 0), bearer: null, TenantB);            // B: drains
+            queue.Enqueue(Url, Body("B", 1), bearer: null, TenantB);            // B: drains
+
+            var delivered = await queue.FlushOnceAsync();
+
+            // Both of B's events delivered, in order; NONE of A's (its head is stuck, so its later event
+            // waits behind it - A's FIFO is not violated by delivering A(1) ahead of the stuck A(0)).
+            Assert.Equal(2, delivered);
+            var bNs = handler.Delivered.Where(b => IsFrom(b, "B"))
+                .Select(b => JsonDocument.Parse(b).RootElement.GetProperty("n").GetInt32()).ToArray();
+            Assert.Equal(new[] { 0, 1 }, bNs);
+            Assert.DoesNotContain(handler.Delivered, b => IsFrom(b, "A"));
+            Assert.Equal(2, queue.Depth); // both A events remain queued
+        }
+        finally { await queue.DisposeAsync(); Cleanup(path); }
+    }
+
+    // ----- legacy (pre-tag) events are quarantined into an isolated lane, not a shared Local partition -----
+
+    [Fact]
+    public async Task Load_UntaggedFile_QuarantinesLegacyEvents_StillDelivers()
+    {
+        // A queue file written before the tenant tag existed: events with no "tenant" field.
+        var path = Path.Combine(Path.GetTempPath(), $"telemetry-queue-tenant-{Guid.NewGuid():N}.json");
+        var legacy = JsonSerializer.Serialize(new
+        {
+            events = new[]
+            {
+                new { id = "abc123", enqueuedAtUtc = DateTime.UtcNow, targetUrl = Url, body = "{}", bearer = (string?)null }
+            }
+        });
+        await File.WriteAllTextAsync(path, legacy);
+        try
+        {
+            var handler = new PoisonAwareHandler();
+            var queue = new TelemetryRetryQueue(path, new HttpClient(handler), TimeSpan.FromMilliseconds(50));
+            Assert.Equal(1, queue.Depth); // loaded (quarantined into the isolated lane), not dropped, not quarantined-as-corrupt
+            // It still flushes (at-least-once preserved) - the legacy event is delivered from its own lane.
+            var delivered = await queue.FlushOnceAsync();
+            Assert.Equal(1, delivered);
+            await queue.DisposeAsync();
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public async Task LegacyUntaggedPoison_DoesNotHeadOfLineBlock_ARealTenant()
+    {
+        // The residual the audit flags: pre-tag persisted events carry no tenant. The OLD behaviour defaulted
+        // them to TenantId.Local - the SAME partition a real Local-tenant event lands in - so a single legacy
+        // POISON event head-of-line-blocked the real Local tenant's delivery. The fix quarantines legacy events
+        // into an ISOLATED lane, so a real tenant flushes past a stuck legacy poison.
+        //
+        // Revert-proof: this uses TenantId.Local as the real tenant on purpose. Reverting the Load default back
+        // to Local puts the legacy poison in Local's partition, HOL-blocking the real Local event below, and
+        // this test reddens. (A GUID tenant would NOT catch the revert - it never shared Local's partition.)
+        var path = Path.Combine(Path.GetTempPath(), $"telemetry-queue-tenant-{Guid.NewGuid():N}.json");
+        var legacy = JsonSerializer.Serialize(new
+        {
+            events = new[]
+            {
+                // A legacy untagged event the backend rejects forever, sitting at the HEAD of the file.
+                new { id = "legacy-poison", enqueuedAtUtc = DateTime.UtcNow, targetUrl = Url, body = Body("legacy", 0) + "POISON", bearer = (string?)null }
+            }
+        });
+        await File.WriteAllTextAsync(path, legacy);
+        try
+        {
+            var handler = new PoisonAwareHandler();
+            var queue = new TelemetryRetryQueue(path, new HttpClient(handler), TimeSpan.FromMilliseconds(50));
+            Assert.Equal(1, queue.Depth); // the legacy poison loaded into the quarantine lane
+
+            // A real Local-tenant event enqueued AFTER the legacy poison (which is ahead of it in the list).
+            queue.Enqueue(Url, Body("local", 0), bearer: null, TenantId.Local);
+
+            var delivered = await queue.FlushOnceAsync();
+
+            // The real Local event flushed PAST the stuck legacy poison. Under the reverted default-to-Local
+            // behaviour the poison would share Local's partition and block it - nothing would deliver.
+            Assert.Equal(1, delivered);
+            Assert.Contains(handler.Delivered, b => IsFrom(b, "local"));
+            Assert.DoesNotContain(handler.Delivered, b => IsFrom(b, "legacy"));
+            // The legacy poison remains queued in its isolated lane (at-least-once), blocking only itself.
+            Assert.Equal(1, queue.Depth);
+
+            // And it really is in the isolated quarantine partition, NOT collapsed into the real Local one.
+            await queue.DisposeAsync();
+            var onDisk = await File.ReadAllTextAsync(path);
+            using var doc = JsonDocument.Parse(onDisk);
+            var tenants = doc.RootElement.GetProperty("events").EnumerateArray()
+                .Select(e => e.GetProperty("tenant").GetString()).ToList();
+            Assert.Contains(TelemetryRetryQueue.LegacyUntaggedPartition, tenants);
+            Assert.DoesNotContain(TenantId.Local.Value, tenants); // the legacy event did NOT become Local
+        }
+        finally { Cleanup(path); }
+    }
+
+    // ----- the tenant tag survives a restart -----
+
+    [Fact]
+    public async Task PersistenceRoundTrip_PreservesTheTenantTag()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"telemetry-queue-tenant-{Guid.NewGuid():N}.json");
+        try
+        {
+            var h1 = new PoisonAwareHandler();
+            var q1 = new TelemetryRetryQueue(path, new HttpClient(h1), TimeSpan.FromMilliseconds(50), maxSize: 2);
+            // Cannot deliver yet - point at a URL the handler treats as poison so both stay queued.
+            q1.Enqueue(Url, Body("A", 0) + "POISON", bearer: null, TenantA);
+            q1.Enqueue(Url, Body("B", 0) + "POISON", bearer: null, TenantB);
+            await q1.DisposeAsync();
+
+            // Reconstruct over the same file. The per-tenant bound must still see A as A and B as B: enqueue
+            // TWO more A events; A is bounded to 2, so A holds its newest 2 while B's one is untouched.
+            var h2 = new PoisonAwareHandler();
+            var q2 = new TelemetryRetryQueue(path, new HttpClient(h2), TimeSpan.FromMilliseconds(50), maxSize: 2);
+            Assert.Equal(2, q2.Depth); // both survived the restart
+            q2.Enqueue(Url, Body("A", 1), bearer: null, TenantA);
+            q2.Enqueue(Url, Body("A", 2), bearer: null, TenantA);
+
+            // If the tag had been lost, A's overflow would have evicted B. It did not: B's event remains.
+            var onDisk = await File.ReadAllTextAsync(path);
+            using var doc = JsonDocument.Parse(onDisk);
+            var tenants = doc.RootElement.GetProperty("events").EnumerateArray()
+                .Select(e => e.GetProperty("tenant").GetString()).ToList();
+            Assert.Contains(TenantB.Value, tenants);
+            Assert.Equal(2, tenants.Count(t => t == TenantA.Value)); // A bounded to its own 2
+            await q2.DisposeAsync();
+        }
+        finally { Cleanup(path); }
+    }
+
+    // ----- validation: an invalid tenant is a loud reject, never a queued event under a guess -----
+
+    [Fact]
+    public async Task Enqueue_InvalidTenant_Throws()
+    {
+        var (queue, _, path) = NewQueue();
+        try
+        {
+            Assert.Throws<ArgumentException>(() => queue.Enqueue(Url, Body("x", 0), bearer: null, default));
+        }
+        finally { await queue.DisposeAsync(); Cleanup(path); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TelemetryRetryQueueTests.cs
+++ b/src/CcDirector.Gateway.Tests/TelemetryRetryQueueTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Api;
 using Xunit;
 
@@ -74,7 +75,7 @@ public sealed class TelemetryRetryQueueTests
             handler.Reachable = false; // backend down
 
             for (var i = 0; i < 5; i++)
-                queue.Enqueue(TargetUrl, BodyFor(i), AccessToken);
+                queue.Enqueue(TargetUrl, BodyFor(i), AccessToken, TenantId.Local);
 
             // Nothing delivered while the backend is down...
             Assert.Equal(5, queue.Depth);
@@ -97,7 +98,7 @@ public sealed class TelemetryRetryQueueTests
         {
             handler.Reachable = false;
             for (var i = 0; i < 5; i++)
-                queue.Enqueue(TargetUrl, BodyFor(i), AccessToken);
+                queue.Enqueue(TargetUrl, BodyFor(i), AccessToken, TenantId.Local);
             Assert.Equal(5, queue.Depth);
 
             // Backend comes back; one flush pass should drain everything.
@@ -129,7 +130,7 @@ public sealed class TelemetryRetryQueueTests
         {
             handler.Reachable = true;
             for (var i = 0; i < 3; i++)
-                queue.Enqueue(TargetUrl, BodyFor(i), AccessToken);
+                queue.Enqueue(TargetUrl, BodyFor(i), AccessToken, TenantId.Local);
 
             // First two deliver, then the backend drops before the third.
             // Deliver one at a time by toggling: deliver all reachable first.
@@ -163,7 +164,7 @@ public sealed class TelemetryRetryQueueTests
             var handler1 = new ControllableHandler { Reachable = false };
             var q1 = new TelemetryRetryQueue(path, new HttpClient(handler1), TimeSpan.FromMilliseconds(50));
             for (var i = 0; i < 4; i++)
-                q1.Enqueue(TargetUrl, BodyFor(i), AccessToken);
+                q1.Enqueue(TargetUrl, BodyFor(i), AccessToken, TenantId.Local);
             Assert.Equal(4, q1.Depth);
             await q1.DisposeAsync(); // simulate Gateway stop
 
@@ -199,7 +200,7 @@ public sealed class TelemetryRetryQueueTests
             handler.Reachable = false;
             // Enqueue 5 into a bound-3 queue: events 0 and 1 are evicted (oldest first); 2,3,4 remain.
             for (var i = 0; i < 5; i++)
-                queue.Enqueue(TargetUrl, BodyFor(i), AccessToken);
+                queue.Enqueue(TargetUrl, BodyFor(i), AccessToken, TenantId.Local);
 
             Assert.Equal(3, queue.Depth); // never grows past the bound
 
@@ -228,7 +229,7 @@ public sealed class TelemetryRetryQueueTests
         try
         {
             handler.Reachable = false;
-            queue.Enqueue(TargetUrl, BodyFor(0), AccessToken);
+            queue.Enqueue(TargetUrl, BodyFor(0), AccessToken, TenantId.Local);
             var onDisk = await File.ReadAllTextAsync(path);
             Assert.Contains(AccessToken, onDisk); // present for replay
         }
@@ -258,7 +259,7 @@ public sealed class TelemetryRetryQueueTests
         var (queue, _, path) = NewQueue();
         try
         {
-            Assert.Throws<ArgumentException>(() => queue.Enqueue("", BodyFor(0), AccessToken));
+            Assert.Throws<ArgumentException>(() => queue.Enqueue("", BodyFor(0), AccessToken, TenantId.Local));
         }
         finally { await queue.DisposeAsync(); Cleanup(path); }
     }

--- a/src/CcDirector.Gateway/Api/DirectorStartupTelemetryEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/DirectorStartupTelemetryEndpoint.cs
@@ -96,27 +96,36 @@ internal static class DirectorStartupTelemetryEndpoint
             using (var reader = new StreamReader(ctx.Request.Body))
                 body = await reader.ReadToEndAsync(ctx.RequestAborted);
 
-            // Record the event Gateway-side so the startup is observable here regardless of whether a
-            // cloud endpoint exists. director_id + app_version are pulled out for the record line; the
-            // rest of the body is carried verbatim into the queue (when forwarding is configured).
-            var (directorId, appVersion) = ReadRecordFields(body);
+            // Parse the body DEFENSIVELY. A malformed body, or a JSON root that is NOT an object (an
+            // array/number/string/bool/null), is REJECTED cleanly - 400, never recorded, never enqueued.
+            // This is deliberate: property access on a non-object JsonElement throws
+            // InvalidOperationException, and letting that escape here turned an arbitrary caller's junk body
+            // into a 500 server error BEFORE the ownership gate even ran. director_id resolves to null (an
+            // ownership-INCAPABLE sentinel) when it is missing/blank/non-string; app_version is a display
+            // string.
+            if (!TryReadRecordFields(body, out var directorId, out var appVersion))
+            {
+                FileLog.Write("[DirectorStartupTelemetryEndpoint] director-startup REJECTED: body is not a JSON object (malformed or non-object root); not recorded, not enqueued");
+                return Results.StatusCode(StatusCodes.Status400BadRequest);
+            }
 
             // Ownership gate (audit MTR gap C): on hosted, a caller may only create a startup observation for
             // a director_id its OWN tenant PROVABLY owns. Anything the caller cannot prove it owns - a
-            // blank/malformed id, an id owned by ANOTHER tenant (the "submit B's director id to create a false
-            // startup observation for B" the audit describes), or an as-yet-UNKNOWN id registered to nobody -
-            // is rejected, never recorded and never enqueued. A startup report that races the tunnel Hello and
-            // arrives before its own id is registered is therefore dropped; that is the accepted cost of not
-            // accepting a forgeable cross-tenant observation, for a best-effort, swallowed startup ping. On
-            // self-host (single tenant, no forgery surface, and the id may legitimately be unregistered) this
-            // gate never fires.
+            // missing/blank/wrong-typed id (which is now a NULL, ownership-incapable sentinel that no
+            // registered director can ever match, not the literal string "(none)"), an id owned by ANOTHER
+            // tenant (the "submit B's director id to create a false startup observation for B" the audit
+            // describes), or an as-yet-UNKNOWN id registered to nobody - is rejected, never recorded and never
+            // enqueued. A startup report that races the tunnel Hello and arrives before its own id is
+            // registered is therefore dropped; that is the accepted cost of not accepting a forgeable
+            // cross-tenant observation, for a best-effort, swallowed startup ping. On self-host (single
+            // tenant, no forgery surface, and the id may legitimately be unregistered) this gate never fires.
             if (tenants.IsHosted && !directors.IsDirectorOwnedByTenant(tenant.Value, directorId))
             {
-                FileLog.Write($"[DirectorStartupTelemetryEndpoint] director-startup DENIED: director_id={directorId} is not provably owned by the caller (tenant={tenant.Value.ToLogString()}); refusing a startup observation for an unowned director id");
+                FileLog.Write($"[DirectorStartupTelemetryEndpoint] director-startup DENIED: director_id={directorId ?? "(none)"} is not provably owned by the caller (tenant={tenant.Value.ToLogString()}); refusing a startup observation for an unowned director id");
                 return Results.StatusCode(StatusCodes.Status403Forbidden);
             }
 
-            FileLog.Write($"[DirectorStartupTelemetryEndpoint] director-startup recorded: director_id={directorId}, app_version={appVersion}, tenant={tenant.Value.ToLogString()}");
+            FileLog.Write($"[DirectorStartupTelemetryEndpoint] director-startup recorded: director_id={directorId ?? "(none)"}, app_version={appVersion}, tenant={tenant.Value.ToLogString()}");
 
             var targetUrl = ResolveTargetUrl();
             if (targetUrl is null)
@@ -141,32 +150,61 @@ internal static class DirectorStartupTelemetryEndpoint
     }
 
     /// <summary>
-    /// Pulls <c>director_id</c> and <c>app_version</c> out of the inbound body for the record line.
-    /// A missing or unparseable field is recorded as the literal "(none)" so the record line is always
-    /// written - the record is best-effort observability, never a validation gate on the 202.
+    /// Parses the inbound body DEFENSIVELY and pulls out <c>director_id</c> and <c>app_version</c>.
+    /// Returns <c>false</c> when the body is not a JSON OBJECT - a malformed body, or a valid JSON whose
+    /// root is an array/number/string/bool/null - so the caller can reject it cleanly (400) instead of
+    /// letting a non-object property access throw <see cref="System.InvalidOperationException"/> and become
+    /// a 500. On <c>true</c>:
+    /// <list type="bullet">
+    ///   <item><paramref name="directorId"/> is the <c>director_id</c> value ONLY when it is a present,
+    ///     non-blank STRING; otherwise it is <c>null</c> - an ownership-INCAPABLE sentinel (never a
+    ///     real-looking placeholder like "(none)") that can never satisfy the ownership gate no matter what
+    ///     any tenant registers.</item>
+    ///   <item><paramref name="appVersion"/> is the <c>app_version</c> string for the record line, or
+    ///     "(none)" when it is missing/blank/non-string - the record line is best-effort observability.</item>
+    /// </list>
     /// </summary>
-    private static (string DirectorId, string AppVersion) ReadRecordFields(string body)
+    private static bool TryReadRecordFields(string body, out string? directorId, out string appVersion)
     {
-        if (string.IsNullOrWhiteSpace(body))
-            return ("(none)", "(none)");
+        directorId = null;
+        appVersion = "(none)";
 
+        if (string.IsNullOrWhiteSpace(body))
+            return false;
+
+        System.Text.Json.JsonDocument doc;
         try
         {
-            using var doc = System.Text.Json.JsonDocument.Parse(body);
-            var root = doc.RootElement;
-            var directorId = root.TryGetProperty("director_id", out var d) && d.ValueKind == System.Text.Json.JsonValueKind.String
-                ? d.GetString() ?? "(none)"
-                : "(none)";
-            var appVersion = root.TryGetProperty("app_version", out var v) && v.ValueKind == System.Text.Json.JsonValueKind.String
-                ? v.GetString() ?? "(none)"
-                : "(none)";
-            return (directorId, appVersion);
+            doc = System.Text.Json.JsonDocument.Parse(body);
         }
         catch (System.Text.Json.JsonException)
         {
-            // A malformed body still records (with placeholders) and still returns 202 - the inbound
-            // event is best-effort, and the verbatim body is what would be forwarded if configured.
-            return ("(none)", "(none)");
+            return false;
+        }
+
+        using (doc)
+        {
+            var root = doc.RootElement;
+            if (root.ValueKind != System.Text.Json.JsonValueKind.Object)
+                return false;
+
+            if (root.TryGetProperty("director_id", out var d)
+                && d.ValueKind == System.Text.Json.JsonValueKind.String)
+            {
+                var s = d.GetString();
+                if (!string.IsNullOrWhiteSpace(s))
+                    directorId = s;
+            }
+
+            if (root.TryGetProperty("app_version", out var v)
+                && v.ValueKind == System.Text.Json.JsonValueKind.String)
+            {
+                var s = v.GetString();
+                if (!string.IsNullOrWhiteSpace(s))
+                    appVersion = s!;
+            }
+
+            return true;
         }
     }
 }

--- a/src/CcDirector.Gateway/Api/DirectorStartupTelemetryEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/DirectorStartupTelemetryEndpoint.cs
@@ -1,4 +1,6 @@
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -56,13 +58,38 @@ internal static class DirectorStartupTelemetryEndpoint
     /// </summary>
     /// <param name="app">The route builder.</param>
     /// <param name="queue">The durable retry queue that owns cloud delivery (issues #628 / #629).</param>
-    public static void Map(IEndpointRouteBuilder app, TelemetryRetryQueue queue)
+    /// <param name="tenants">
+    /// The auth-boundary tenant binder (audit MTR gap C). Resolves the SERVER-BOUND tenant of the
+    /// authenticated request so the queued event is partitioned by tenant; on hosted an unresolved tenant is
+    /// a 403 DENY, on self-host it is always <see cref="Core.Tenancy.TenantId.Local"/>.
+    /// </param>
+    /// <param name="directors">
+    /// The Director registry (audit MTR gap C). On hosted it is asked whether the posted <c>director_id</c>
+    /// is PROVABLY OWNED by the caller's server-resolved tenant; a request that cannot prove ownership
+    /// (blank/malformed, unknown, or owned by another tenant) is rejected - a caller may not create a startup
+    /// observation for a director_id it does not own.
+    /// </param>
+    public static void Map(IEndpointRouteBuilder app, TelemetryRetryQueue queue, HostedTenantBoundary tenants, DirectorRegistry directors)
     {
         if (queue is null)
             throw new ArgumentNullException(nameof(queue));
+        if (tenants is null)
+            throw new ArgumentNullException(nameof(tenants));
+        if (directors is null)
+            throw new ArgumentNullException(nameof(directors));
 
         app.MapPost("/telemetry/director-startup", async (HttpContext ctx) =>
         {
+            // Resolve the tenant from the AUTHENTICATED request (never from the body). On hosted a key with
+            // no bound tenant is a DENY; on self-host this is always Local. It is the partition the queue
+            // bounds and flushes by.
+            var tenant = tenants.ResolveRequestTenant(ctx);
+            if (tenant is null)
+            {
+                FileLog.Write("[DirectorStartupTelemetryEndpoint] director-startup DENIED: no tenant resolved for the authenticated caller (hosted deny-by-default)");
+                return Results.StatusCode(StatusCodes.Status403Forbidden);
+            }
+
             // Read the inbound body (the event JSON) verbatim so it is forwarded UNCHANGED. The body
             // shape is provisional; the Gateway does not reshape it.
             string body;
@@ -73,7 +100,23 @@ internal static class DirectorStartupTelemetryEndpoint
             // cloud endpoint exists. director_id + app_version are pulled out for the record line; the
             // rest of the body is carried verbatim into the queue (when forwarding is configured).
             var (directorId, appVersion) = ReadRecordFields(body);
-            FileLog.Write($"[DirectorStartupTelemetryEndpoint] director-startup recorded: director_id={directorId}, app_version={appVersion}");
+
+            // Ownership gate (audit MTR gap C): on hosted, a caller may only create a startup observation for
+            // a director_id its OWN tenant PROVABLY owns. Anything the caller cannot prove it owns - a
+            // blank/malformed id, an id owned by ANOTHER tenant (the "submit B's director id to create a false
+            // startup observation for B" the audit describes), or an as-yet-UNKNOWN id registered to nobody -
+            // is rejected, never recorded and never enqueued. A startup report that races the tunnel Hello and
+            // arrives before its own id is registered is therefore dropped; that is the accepted cost of not
+            // accepting a forgeable cross-tenant observation, for a best-effort, swallowed startup ping. On
+            // self-host (single tenant, no forgery surface, and the id may legitimately be unregistered) this
+            // gate never fires.
+            if (tenants.IsHosted && !directors.IsDirectorOwnedByTenant(tenant.Value, directorId))
+            {
+                FileLog.Write($"[DirectorStartupTelemetryEndpoint] director-startup DENIED: director_id={directorId} is not provably owned by the caller (tenant={tenant.Value.ToLogString()}); refusing a startup observation for an unowned director id");
+                return Results.StatusCode(StatusCodes.Status403Forbidden);
+            }
+
+            FileLog.Write($"[DirectorStartupTelemetryEndpoint] director-startup recorded: director_id={directorId}, app_version={appVersion}, tenant={tenant.Value.ToLogString()}");
 
             var targetUrl = ResolveTargetUrl();
             if (targetUrl is null)
@@ -86,8 +129,9 @@ internal static class DirectorStartupTelemetryEndpoint
             {
                 // A startup URL is configured: enqueue for durable, retried delivery via the shared
                 // queue (issues #628 / #629). No Bearer - startup is unauthenticated to the cloud here.
-                FileLog.Write($"[DirectorStartupTelemetryEndpoint] forwarding configured -> enqueue for {targetUrl}");
-                queue.Enqueue(targetUrl, body, bearer: null);
+                // Partitioned by the server-resolved tenant so one tenant can never evict/block another's.
+                FileLog.Write($"[DirectorStartupTelemetryEndpoint] forwarding configured -> enqueue for {targetUrl} (tenant={tenant.Value.ToLogString()})");
+                queue.Enqueue(targetUrl, body, bearer: null, tenant.Value);
             }
 
             // 202 Accepted is the truthful answer on both paths: "received and recorded" - and, when a

--- a/src/CcDirector.Gateway/Api/TelemetryRelayEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TelemetryRelayEndpoint.cs
@@ -1,4 +1,5 @@
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -60,14 +61,31 @@ internal static class TelemetryRelayEndpoint
     /// </summary>
     /// <param name="app">The route builder.</param>
     /// <param name="queue">The durable retry queue that owns delivery to the backend (issue #629).</param>
-    public static void Map(IEndpointRouteBuilder app, TelemetryRetryQueue queue)
+    /// <param name="tenants">
+    /// The auth-boundary tenant binder (audit MTR gap C). It resolves the SERVER-BOUND tenant of the
+    /// authenticated request so the queued event is partitioned by tenant. On hosted an unresolved tenant
+    /// is a 403 DENY (never Local); on self-host every request is <see cref="TenantId.Local"/>.
+    /// </param>
+    public static void Map(IEndpointRouteBuilder app, TelemetryRetryQueue queue, HostedTenantBoundary tenants)
     {
         if (queue is null)
             throw new ArgumentNullException(nameof(queue));
+        if (tenants is null)
+            throw new ArgumentNullException(nameof(tenants));
 
         app.MapPost("/telemetry/login", async (HttpContext ctx) =>
         {
             var targetUrl = ResolveTargetUrl();
+
+            // Resolve the tenant from the AUTHENTICATED request (never from the body). On hosted a key with
+            // no bound tenant is a DENY - the event is not queued under a guessed owner; on self-host this is
+            // always Local. This is the partition the queue bounds and flushes by.
+            var tenant = tenants.ResolveRequestTenant(ctx);
+            if (tenant is null)
+            {
+                FileLog.Write("[TelemetryRelayEndpoint] POST /telemetry/login DENIED: no tenant resolved for the authenticated caller (hosted deny-by-default)");
+                return Results.StatusCode(StatusCodes.Status403Forbidden);
+            }
 
             // Read the inbound body (the event JSON) verbatim so it is forwarded UNCHANGED.
             string body;
@@ -82,9 +100,9 @@ internal static class TelemetryRelayEndpoint
 
             // Enqueue for durable delivery with NO stored Bearer - the Gateway token is attached when the
             // queue forwards. The queue logs the target + depth (never any token value) and owns the
-            // retry / persistence / bound-eviction behaviour; the relay just hands off.
-            FileLog.Write($"[TelemetryRelayEndpoint] POST /telemetry/login -> enqueue for {targetUrl} (inboundAuthPresent={inboundAuthPresent}; ignored, gateway token attached on forward)");
-            queue.Enqueue(targetUrl, body, bearer: null);
+            // retry / persistence / per-tenant bound-eviction behaviour; the relay just hands off.
+            FileLog.Write($"[TelemetryRelayEndpoint] POST /telemetry/login -> enqueue for {targetUrl} (tenant={tenant.Value.ToLogString()}, inboundAuthPresent={inboundAuthPresent}; ignored, gateway token attached on forward)");
+            queue.Enqueue(targetUrl, body, bearer: null, tenant.Value);
 
             // The relay accepts the event regardless of the backend's current reachability or whether the
             // Gateway is signed in yet (the queue delivers it once both are ready). 202 Accepted is the

--- a/src/CcDirector.Gateway/Api/TelemetryRetryQueue.cs
+++ b/src/CcDirector.Gateway/Api/TelemetryRetryQueue.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Gateway.Api;
@@ -12,16 +13,25 @@ namespace CcDirector.Gateway.Api;
 ///
 /// Behaviour:
 /// <list type="bullet">
-///   <item>FIFO: events flush in the order they were enqueued (best-effort FIFO, at-least-once).</item>
-///   <item>Retry with backoff: a failed or unreachable forward leaves the event at the HEAD of the
-///     queue and the flusher waits the retry interval before trying again, so a backend outage queues
-///     events instead of dropping them.</item>
-///   <item>Bounded: the queue never grows past <see cref="MaxSize"/>; when full, the OLDEST event is
-///     evicted (dropped) with a logged WARNING so there is no unbounded growth.</item>
+///   <item>FIFO per tenant: events flush in the order they were enqueued WITHIN a tenant (best-effort
+///     FIFO, at-least-once).</item>
+///   <item>Retry with backoff: a failed or unreachable forward leaves the event at the head of ITS
+///     TENANT's line and the flusher waits the retry interval before trying again, so a backend outage
+///     queues events instead of dropping them.</item>
+///   <item>Bounded PER TENANT: each tenant's queued events never grow past <see cref="MaxSize"/>; when a
+///     tenant is full its OWN oldest event is evicted (dropped) with a logged WARNING, so one tenant's
+///     volume can never evict another tenant's queued event.</item>
 ///   <item>Durable: the whole queue is persisted to one JSON file (the WorkListStore precedent: atomic
 ///     temp + rename write-through, reload on construction, corrupt-file quarantine) under the Gateway
 ///     config directory, so queued events survive a Gateway restart.</item>
 /// </list>
+///
+/// Multi-tenancy (audit MTR gap C: telemetry queue): every queued event is tagged with the
+/// SERVER-RESOLVED tenant of the request that enqueued it (never a client-supplied value). The bound and
+/// the flush are PER TENANT: a caller can only evict its own tenant's oldest event, and a poison event
+/// that the backend permanently rejects blocks only its own tenant's line - other tenants keep flushing
+/// past it (no cross-tenant head-of-line block). On self-host every event is <see cref="TenantId.Local"/>
+/// and the behaviour is exactly the single-line FIFO it always was.
 ///
 /// Security (issue #628 property preserved): a queued payload carries the inbound access token (the
 /// Bearer) in memory and on disk so it can be replayed, but the token value is NEVER written to the
@@ -32,6 +42,22 @@ public sealed class TelemetryRetryQueue : IAsyncDisposable
 {
     /// <summary>The default maximum number of queued events before the oldest is evicted.</summary>
     public const int DefaultMaxSize = 1000;
+
+    /// <summary>
+    /// The isolated partition legacy, pre-tag persisted events are loaded into (audit MTR gap C). A queue
+    /// file written before the tenant tag existed has events with an EMPTY tenant; on a hosted Gateway those
+    /// events came from many real accounts but carry no way to tell them apart, so they must NOT be collapsed
+    /// into any real tenant's partition - least of all the shared <see cref="TenantId.Local"/> one, where one
+    /// account's legacy poison event would head-of-line-block every other account's legacy event.
+    ///
+    /// They are instead quarantined under this reserved partition key, which is deliberately NOT a valid
+    /// <see cref="TenantId"/> (the '#' can never appear in a real tenant id, Local, or System), so it can
+    /// never collide with a real tenant's line. Because the bound and the flush are keyed by this string, the
+    /// quarantine lane is fully isolated: it still drains (at-least-once preserved - legacy events are
+    /// delivered, not dropped) and a poison event in it blocks ONLY the quarantine lane, never any real
+    /// tenant's flush. Newly-enqueued events always carry a real server-resolved tenant and never land here.
+    /// </summary>
+    public const string LegacyUntaggedPartition = "__legacy-untagged#quarantine__";
 
     private static readonly JsonSerializerOptions FileJsonOptions = new()
     {
@@ -124,17 +150,26 @@ public sealed class TelemetryRetryQueue : IAsyncDisposable
 
     /// <summary>
     /// Enqueue one accepted telemetry event for durable delivery. The body and Bearer are stored
-    /// verbatim so they replay UNCHANGED. When the queue is full the OLDEST event is evicted first
-    /// (logged WARNING). The token value is never logged.
+    /// verbatim so they replay UNCHANGED. The event is tagged with <paramref name="tenant"/> - the tenant
+    /// the CALLING endpoint resolved from the authenticated request (never a client-supplied value) - and
+    /// the bound is enforced PER TENANT: when this tenant already holds <see cref="MaxSize"/> events, THIS
+    /// tenant's own oldest is evicted first (logged WARNING), so a flood from one tenant never drops
+    /// another tenant's queued event. The token value and the raw tenant id are never logged.
     /// </summary>
     /// <param name="targetUrl">The backend URL to forward to.</param>
     /// <param name="body">The event JSON, forwarded unchanged.</param>
     /// <param name="bearer">The inbound access token, replayed unchanged; NEVER logged.</param>
-    /// <exception cref="ArgumentException">targetUrl is null/empty/whitespace.</exception>
-    public void Enqueue(string targetUrl, string body, string? bearer)
+    /// <param name="tenant">
+    /// The server-resolved owning tenant (<see cref="TenantId.Local"/> on self-host). REQUIRED and must be
+    /// valid - an unresolved tenant is a denied request at the endpoint, never a queued event under a guess.
+    /// </param>
+    /// <exception cref="ArgumentException">targetUrl is null/empty/whitespace, or tenant is invalid.</exception>
+    public void Enqueue(string targetUrl, string body, string? bearer, TenantId tenant)
     {
         if (string.IsNullOrWhiteSpace(targetUrl))
             throw new ArgumentException("targetUrl is required", nameof(targetUrl));
+        if (!tenant.IsValid)
+            throw new ArgumentException("a valid tenant is required to enqueue a telemetry event", nameof(tenant));
 
         var item = new QueuedEvent
         {
@@ -143,6 +178,7 @@ public sealed class TelemetryRetryQueue : IAsyncDisposable
             TargetUrl = targetUrl,
             Body = body ?? string.Empty,
             Bearer = bearer,
+            Tenant = tenant.Value,
         };
 
         int depth;
@@ -150,53 +186,100 @@ public sealed class TelemetryRetryQueue : IAsyncDisposable
         lock (_gate)
         {
             _events.AddLast(item);
-            while (_events.Count > MaxSize)
+            // Per-tenant bound: count and evict only THIS tenant's own events, so one tenant's volume can
+            // never push another tenant's event out of the shared list.
+            while (CountForTenant(item.Tenant) > MaxSize)
             {
-                var oldest = _events.First;
+                var oldest = FirstNodeForTenant(item.Tenant);
                 if (oldest is null)
                     break;
-                _events.RemoveFirst();
+                _events.Remove(oldest);
                 evicted = true;
-                FileLog.Write($"[TelemetryRetryQueue] WARNING bound exceeded (maxSize={MaxSize}); evicted OLDEST event id={oldest.Value.Id} enqueuedAt={oldest.Value.EnqueuedAtUtc:O} target={oldest.Value.TargetUrl} (dropped, not delivered)");
+                FileLog.Write($"[TelemetryRetryQueue] WARNING per-tenant bound exceeded (maxSize={MaxSize}, tenant={tenant.ToLogString()}); evicted OLDEST event id={oldest.Value.Id} enqueuedAt={oldest.Value.EnqueuedAtUtc:O} target={oldest.Value.TargetUrl} (dropped, not delivered)");
             }
             depth = _events.Count;
             Save();
         }
 
-        FileLog.Write($"[TelemetryRetryQueue] Enqueue: target={targetUrl} (bearerPresent={(bearer is not null)}), depth={depth}{(evicted ? " (oldest evicted)" : "")}");
+        FileLog.Write($"[TelemetryRetryQueue] Enqueue: target={targetUrl} (bearerPresent={(bearer is not null)}, tenant={tenant.ToLogString()}), depth={depth}{(evicted ? " (tenant oldest evicted)" : "")}");
+    }
+
+    /// <summary>Count the queued events belonging to one tenant. Caller holds <see cref="_gate"/>.</summary>
+    private int CountForTenant(string tenant)
+    {
+        var count = 0;
+        for (var node = _events.First; node is not null; node = node.Next)
+            if (string.Equals(node.Value.Tenant, tenant, StringComparison.Ordinal))
+                count++;
+        return count;
+    }
+
+    /// <summary>The oldest (head-most) queued node for one tenant, or null. Caller holds <see cref="_gate"/>.</summary>
+    private LinkedListNode<QueuedEvent>? FirstNodeForTenant(string tenant)
+    {
+        for (var node = _events.First; node is not null; node = node.Next)
+            if (string.Equals(node.Value.Tenant, tenant, StringComparison.Ordinal))
+                return node;
+        return null;
+    }
+
+    /// <summary>The node carrying a given event id, or null. Caller holds <see cref="_gate"/>.</summary>
+    private LinkedListNode<QueuedEvent>? FindNodeById(string id)
+    {
+        for (var node = _events.First; node is not null; node = node.Next)
+            if (string.Equals(node.Value.Id, id, StringComparison.Ordinal))
+                return node;
+        return null;
     }
 
     /// <summary>
-    /// Try to drain the queue once, head-first, in FIFO order. Each event is forwarded; on success it
-    /// is removed from the head and the next is attempted; on the FIRST failure the pass stops and the
-    /// failing event stays at the head (so order is preserved and it is retried next pass). Returns the
-    /// number of events delivered this pass. Public so a test can trigger a deterministic drain without
-    /// waiting on the timer.
+    /// Try to drain the queue once, in per-tenant FIFO order. Each pass repeatedly picks the head-most
+    /// event whose tenant is still flushing, forwards it, and on success removes it. On a failure the
+    /// event stays queued and its TENANT is marked done-for-this-pass, so that tenant's later events wait
+    /// (its FIFO + at-least-once preserved) while EVERY OTHER tenant keeps flushing past it - one tenant's
+    /// poison event can never head-of-line-block another tenant. Returns the number of events delivered
+    /// this pass. Public so a test can trigger a deterministic drain without waiting on the timer.
     /// </summary>
     public async Task<int> FlushOnceAsync(CancellationToken cancellationToken = default)
     {
         var delivered = 0;
+        // Tenants whose earliest event failed THIS pass. Skipped for the rest of the pass so their FIFO
+        // order holds; they are retried on the next pass.
+        var blocked = new HashSet<string>(StringComparer.Ordinal);
         while (!cancellationToken.IsCancellationRequested)
         {
-            QueuedEvent head;
+            QueuedEvent? next = null;
             lock (_gate)
             {
-                if (_events.First is null)
-                    break;
-                head = _events.First.Value;
+                for (var node = _events.First; node is not null; node = node.Next)
+                {
+                    if (!blocked.Contains(node.Value.Tenant))
+                    {
+                        next = node.Value;
+                        break;
+                    }
+                }
+            }
+            if (next is null)
+                break; // nothing left whose tenant is still flushing this pass
+
+            var ok = await TryForwardAsync(next, cancellationToken);
+            if (!ok)
+            {
+                // Leave it queued; stop this tenant for the pass so its order holds and other tenants
+                // are not blocked behind it.
+                blocked.Add(next.Tenant);
+                continue;
             }
 
-            var ok = await TryForwardAsync(head, cancellationToken);
-            if (!ok)
-                break; // leave it at the head; retry next pass (FIFO preserved)
-
             lock (_gate)
             {
-                // The head may only be removed if it is still the same event (it always is here:
-                // a single flusher drains, and Enqueue only appends to the tail).
-                if (_events.First is not null && _events.First.Value.Id == head.Id)
+                // Remove that specific event if still present (a single flusher drains; Enqueue only
+                // appends to the tail or evicts its own tenant's oldest).
+                var node = FindNodeById(next.Id);
+                if (node is not null)
                 {
-                    _events.RemoveFirst();
+                    _events.Remove(node);
                     Save();
                 }
             }
@@ -302,6 +385,14 @@ public sealed class TelemetryRetryQueue : IAsyncDisposable
 
         /// <summary>The inbound access token, replayed unchanged. On disk, never logged.</summary>
         public string? Bearer { get; set; }
+
+        /// <summary>
+        /// The server-resolved owning tenant (audit MTR gap C). The bound and the flush are scoped by this,
+        /// so a caller only ever evicts/blocks its own tenant. A queue file written before this field existed
+        /// has it empty; <see cref="Load"/> quarantines such legacy events into the isolated
+        /// <see cref="LegacyUntaggedPartition"/> so they can never head-of-line-block a real tenant.
+        /// </summary>
+        public string Tenant { get; set; } = string.Empty;
     }
 
     /// <summary>The on-disk shape: one document holding the ordered queue.</summary>
@@ -350,6 +441,13 @@ public sealed class TelemetryRetryQueue : IAsyncDisposable
                 _events.Clear();
                 return;
             }
+            // A queue file written before the tenant tag existed has an empty Tenant. Such legacy events
+            // cannot be attributed to a real account, so they are quarantined into an ISOLATED partition
+            // (never the shared Local one) - see <see cref="LegacyUntaggedPartition"/>. This keeps a legacy
+            // poison event from head-of-line-blocking any real tenant's flush while still delivering the
+            // legacy events (they drain in their own isolated lane).
+            if (string.IsNullOrWhiteSpace(ev.Tenant))
+                ev.Tenant = LegacyUntaggedPartition;
             _events.AddLast(ev);
         }
 

--- a/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
@@ -387,15 +387,19 @@ public sealed class DirectorRegistry : IDisposable
     /// yours".
     ///
     /// This is a POSITIVE-ownership check: it returns true ONLY for an id keyed to the caller's own tenant.
-    /// A blank/malformed id, an id owned by a DIFFERENT tenant, and an as-yet-UNKNOWN id (registered to
+    /// A null/blank/malformed id, an id owned by a DIFFERENT tenant, and an as-yet-UNKNOWN id (registered to
     /// nobody) all return false. The caller (the startup endpoint) uses that to REJECT any startup
     /// observation the caller cannot prove it owns, rather than accepting a forgeable one: the audit's threat
     /// is a caller creating a startup observation for a director_id it does not own, and an unknown id is not
     /// provably the caller's, so it is refused. The cost is that a startup report that races the tunnel Hello
     /// (arriving before the caller's own id is registered) is dropped - acceptable for a best-effort,
     /// swallowed startup ping, where a forgeable cross-tenant observation is the worse failure.
+    ///
+    /// <paramref name="directorId"/> is NULLABLE on purpose: the caller resolves a missing/blank/wrong-typed
+    /// director_id to null (an ownership-INCAPABLE sentinel, never a real-looking placeholder string), and a
+    /// null id can never be provably owned no matter what any tenant registers, so it returns false here.
     /// </summary>
-    public bool IsDirectorOwnedByTenant(TenantId caller, string directorId)
+    public bool IsDirectorOwnedByTenant(TenantId caller, string? directorId)
     {
         if (string.IsNullOrEmpty(directorId) || !caller.IsValid)
             return false;

--- a/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
@@ -379,6 +379,29 @@ public sealed class DirectorRegistry : IDisposable
             ? d
             : null;
 
+    /// <summary>
+    /// True when <paramref name="directorId"/> is registered to <paramref name="caller"/> - i.e. the caller
+    /// PROVABLY owns it (audit MTR gap C, the startup-telemetry ownership guard). It answers ONLY the yes/no
+    /// ownership question a caller-side gate needs; it never returns another tenant's identity or its Director,
+    /// so it is NOT the bare-id serving lookup MTR-01 removed - a caller learns nothing but "that id is (not)
+    /// yours".
+    ///
+    /// This is a POSITIVE-ownership check: it returns true ONLY for an id keyed to the caller's own tenant.
+    /// A blank/malformed id, an id owned by a DIFFERENT tenant, and an as-yet-UNKNOWN id (registered to
+    /// nobody) all return false. The caller (the startup endpoint) uses that to REJECT any startup
+    /// observation the caller cannot prove it owns, rather than accepting a forgeable one: the audit's threat
+    /// is a caller creating a startup observation for a director_id it does not own, and an unknown id is not
+    /// provably the caller's, so it is refused. The cost is that a startup report that races the tunnel Hello
+    /// (arriving before the caller's own id is registered) is dropped - acceptable for a best-effort,
+    /// swallowed startup ping, where a forgeable cross-tenant observation is the worse failure.
+    /// </summary>
+    public bool IsDirectorOwnedByTenant(TenantId caller, string directorId)
+    {
+        if (string.IsNullOrEmpty(directorId) || !caller.IsValid)
+            return false;
+        return _directors.ContainsKey(new DirectorKey(caller, directorId));
+    }
+
     private void LoadExisting()
     {
         try

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2128,7 +2128,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // Issue #629: the relay enqueues every accepted event into the durable retry queue (which owns
         // delivery, retry-with-backoff, FIFO flush, the bound, and restart survival) instead of
         // forwarding inline. The flush loop is started just below in StartAsync.
-        TelemetryRelayEndpoint.Map(_app, _telemetryQueue);
+        TelemetryRelayEndpoint.Map(_app, _telemetryQueue, _tenantBoundary);
 
         // Gateway Centralization Phase 1 (issue #631): the inbound Director-STARTUP telemetry endpoint.
         // A Director POSTs a startup event here on launch (Director-side firing is issue #632); the
@@ -2138,7 +2138,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // (flagged dependency), so with no URL configured the event is recorded locally and the caller
         // still gets a 202 - no error. Forwarding reuses the SAME durable retry queue as the login relay
         // (issues #628 / #629), adding no new forwarder. Inherits the host-wide token middleware above.
-        DirectorStartupTelemetryEndpoint.Map(_app, _telemetryQueue);
+        DirectorStartupTelemetryEndpoint.Map(_app, _telemetryQueue, _tenantBoundary, Registry);
 
         // Gateway Centralization Phase 2 (issue #638): GET /account/status answers "is the Gateway
         // signed in to DevThrottle, and as whom?" computed ENTIRELY LOCALLY from the Gateway-hosted


### PR DESCRIPTION
## Root cause

`TelemetryRetryQueue` is one process-global durable FIFO shared by every tenant's two hosted
`/telemetry/*` writers (`TelemetryRelayEndpoint`, `DirectorStartupTelemetryEndpoint`). Its
queued item had no tenant, so `Enqueue` applied one global cap (evicting the globally-oldest
event) and `FlushOnceAsync` stopped the whole FIFO on the first non-2xx. The startup route
also forwarded an arbitrary bare `director_id` without proving it belonged to the caller.

## Reproduced real

A two-tenant reproduction on current main passed while asserting the buggy shared behaviour:

- **Global eviction** - tenant B's queued event was evicted when tenant A overflowed the
  shared bound.
- **Head-of-line block** - tenant A's one permanently-rejected event sat at the shared head
  and blocked tenant B's legitimate telemetry from flushing.

Tenant A could also submit tenant B's known director id to forge a startup observation for B.

## Fix

- Tag each queued event with the SERVER-RESOLVED tenant of the authenticated request
  (`HostedTenantBoundary`; `TenantId.Local` on self-host, a 403 deny when unresolved on
  hosted). Never the request body.
- The bound is **per tenant**: a caller only ever evicts its own tenant's oldest event.
- The flush **skips a blocked tenant and keeps flushing every other tenant**, so a poison
  event blocks only its own tenant's line - no cross-tenant head-of-line block, per-tenant
  FIFO + at-least-once preserved.
- The startup route rejects a `director_id` positively owned by **another** tenant (the
  forgery) while allowing an unknown id - the startup report races the tunnel Hello that
  registers the Director, so rejecting an unknown id would over-refuse legitimate telemetry.
- A pre-tag queue file loads with its events defaulted to `Local`.

**Touches `GatewayHost.cs`** (two `.Map(...)` call sites gain the boundary/registry
arguments) - serializes at merge.

## Tests (revert-proof)

- `TelemetryRetryQueueTenantTests` (6) and `DirectorStartupTelemetryTenantTests` (6, behind
  the real auth gate on a hosted boundary). Existing telemetry + issue-639 suites migrated to
  the tenant-taking signatures (self-host -> Local, unchanged).
- Build gateway + gateway test project 0/0; 101 targeted tests pass including the solo
  tenancy filters `OnOneRoute` and `The_roster_and_the_commands_agree`.
- Revert-proof: neutering the eviction to the global head and the flush to break-on-first-
  failure reddens 4 of the 6 queue tenant tests; restoring greens them.
