### PR TITLE
fix(dictation): pad trailing silence so the model keeps the last word

### DIFF
--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -134,19 +134,24 @@ export async function backgroundTranscribeAndSend(
 ): Promise<void> {
   ensureRetryListeners();
 
-  // Capture-health (issue #863): the fire-and-forget Send path releases the screen the instant Send is
-  // pressed and never transcodes on-device, so it was the ONE finish path that measured no audio loss at
-  // all. Decode the clip ONCE here - the screen has already closed, so this is off the critical path - to
-  // get the decoded audio duration, log the recorded-vs-decoded deficit on this surface the same way every
-  // other finish path does, and stash the numbers on the durable record so the upload forwards them to the
-  // Gateway (which persists them into the same dictation session log). Diagnostics only: a decode failure
-  // is logged loudly but NEVER blocks delivery - the user's words are the guarantee, the measurement is not.
+  // Decode the clip ONCE here - the screen has already closed, so this is off the critical path - to do
+  // two things the Send path previously skipped:
+  //   1. Upload the decoded 16 kHz WAV instead of the raw recording. The WAV carries the trailing-silence
+  //      run-out (added in blobToWav16kMono) that keeps the last word from being clipped by the model, and
+  //      it is what the Gateway's Local Whisper mode can read directly. Every other finish path already
+  //      sends this WAV; the Send path now matches, so all surfaces transcribe the same padded WAV.
+  //   2. Measure capture-health (issue #863): the recorded-vs-decoded deficit, logged on this surface and
+  //      forwarded on the upload so the Gateway persists it into the same dictation session log.
+  // Diagnostics AND the pad are best-effort: a decode failure is logged loudly but NEVER blocks delivery -
+  // we fall back to uploading the raw recording so the user's words are the guarantee, the pad is not.
   let decodedSeconds: number | undefined;
   let sourceBytes: number | undefined;
+  let uploadBlob = captured.blob;
   try {
     const transcoded = await blobToWav16kMono(captured.blob);
     decodedSeconds = transcoded.decodedSeconds;
     sourceBytes = transcoded.sourceBytes;
+    uploadBlob = transcoded.wav;
     logCaptureHealth("mobile-send", {
       recordedMs: captured.recordedMs,
       decodedSeconds: transcoded.decodedSeconds,
@@ -154,14 +159,14 @@ export async function backgroundTranscribeAndSend(
     });
   } catch (err) {
     console.warn(
-      `[backgroundSend] capture-health decode failed (delivery is unaffected): ${err instanceof Error ? err.message : String(err)}`,
+      `[backgroundSend] decode failed; uploading the raw recording unpadded (delivery is unaffected): ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 
   const rec: PendingDictation = {
     id: crypto.randomUUID(),
     sessionId,
-    blob: captured.blob,
+    blob: uploadBlob,
     recordedMs: captured.recordedMs,
     decodedSeconds,
     sourceBytes,

--- a/packages/client-core/src/dictation/wav.test.ts
+++ b/packages/client-core/src/dictation/wav.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { TRANSCRIBE_TRAILING_SILENCE_MS, withTrailingSilence } from "./wav";
+
+// The trailing-silence run-out (dictation end-word fix): every transcription WAV the client sends gets a
+// short pad of digital silence so the model does not clip the final word. These guard the pure pad helper
+// (the full blobToWav16kMono needs a real AudioContext, which jsdom lacks).
+describe("withTrailingSilence (dictation end-word run-out)", () => {
+  it("appends exactly the right number of zero frames and preserves the audio", () => {
+    const samples = new Float32Array([0.5, -0.5, 1]);
+    const padded = withTrailingSilence(samples, 16000, 500); // 0.5s * 16000 = 8000 frames
+    expect(padded.length).toBe(3 + 8000);
+    expect(padded[0]).toBe(0.5);
+    expect(padded[2]).toBe(1);
+    expect(padded[3]).toBe(0); // pad starts silent
+    expect(padded[padded.length - 1]).toBe(0);
+  });
+
+  it("returns the input unchanged for a non-positive pad", () => {
+    const samples = new Float32Array([0.1, 0.2]);
+    expect(withTrailingSilence(samples, 16000, 0)).toBe(samples);
+    expect(withTrailingSilence(samples, 16000, -100)).toBe(samples);
+  });
+
+  it("does not mutate the input array", () => {
+    const samples = new Float32Array([0.3, 0.4]);
+    const before = new Float32Array(samples);
+    withTrailingSilence(samples, 16000, 600);
+    expect(samples).toEqual(before);
+  });
+
+  it("ships a positive default run-out", () => {
+    expect(TRANSCRIBE_TRAILING_SILENCE_MS).toBeGreaterThan(0);
+  });
+});

--- a/packages/client-core/src/dictation/wav.ts
+++ b/packages/client-core/src/dictation/wav.ts
@@ -10,6 +10,27 @@
 
 const TARGET_SAMPLE_RATE = 16000;
 
+// Trailing silence appended to every transcription WAV (the dictation end-word fix). Capture on every
+// surface keeps the final audio bytes (all end paths use a race-free stop), yet the last WORD still goes
+// missing: the batch transcription model (Whisper) drops or clips the final token when a clip ends
+// abruptly on speech with no run-out - exactly what happens when the user hits Send/Pause the instant he
+// stops talking. A short pad of digital silence gives the model the trailing anchor it needs so the last
+// word survives. This is model run-out room, NOT captured audio: it lengthens the WAV sent for
+// transcription but is never counted as captured audio (decodedSeconds stays the real decoded duration).
+export const TRANSCRIBE_TRAILING_SILENCE_MS = 600;
+
+/** Append `ms` of digital silence (zero samples) after `samples` at `sampleRate`, returning a NEW array
+ *  (the input is not mutated). A non-positive `ms` returns the samples unchanged. Shared so every WAV the
+ *  client sends for transcription carries the same run-out room. */
+export function withTrailingSilence(samples: Float32Array, sampleRate: number, ms: number): Float32Array {
+  if (ms <= 0) return samples;
+  const padFrames = Math.round((ms / 1000) * sampleRate);
+  if (padFrames <= 0) return samples;
+  const padded = new Float32Array(samples.length + padFrames); // new arrays are zero-filled = silence
+  padded.set(samples, 0);
+  return padded;
+}
+
 /** The WAV plus the capture-health facts the decode already revealed (issue #863): the decoded
  *  audio duration (the actual amount of sound captured) and the source blob size. The caller
  *  compares decodedSeconds to the recording wall-clock to detect dropped audio. */
@@ -43,8 +64,11 @@ export async function blobToWav16kMono(blob: Blob): Promise<TranscodeResult> {
   source.start(0);
   const rendered = await offline.startRendering();
 
+  // Pad the model's run-out room onto the WAV, but report the REAL decoded duration for capture-health:
+  // the pad is silence for the transcriber, never audio we claim to have captured.
+  const padded = withTrailingSilence(rendered.getChannelData(0), TARGET_SAMPLE_RATE, TRANSCRIBE_TRAILING_SILENCE_MS);
   return {
-    wav: encodeWav(rendered.getChannelData(0), TARGET_SAMPLE_RATE),
+    wav: encodeWav(padded, TARGET_SAMPLE_RATE),
     decodedSeconds: decoded.duration,
     sourceBytes,
   };

--- a/src/CcDirector.Avalonia/Voice/BatchDictationRecorder.cs
+++ b/src/CcDirector.Avalonia/Voice/BatchDictationRecorder.cs
@@ -208,8 +208,11 @@ public sealed class BatchDictationRecorder : IAsyncDisposable
     {
         FileLog.Write("[BatchDictationRecorder] StopAndGetWavAsync");
         var (pcm, _, _) = await StopAndSnapshotAsync();
+        // Pad the model's trailing run-out onto the transcription WAV (dictation end-word fix); the
+        // unpadded pcm length still stands for any bytes accounting - the pad is silence, not captured audio.
         var wav = WavWriter.WrapPcm16(
-            pcm, MicAudioCapture.SampleRate, MicAudioCapture.Channels, MicAudioCapture.BitsPerSample);
+            PcmWav.WithTrailingSilence(pcm, MicAudioCapture.SampleRate, MicAudioCapture.Channels, MicAudioCapture.BitsPerSample, PcmWav.TrailingSilenceMs),
+            MicAudioCapture.SampleRate, MicAudioCapture.Channels, MicAudioCapture.BitsPerSample);
         return new CapturedAudio(wav, _recordingStopwatch?.ElapsedMilliseconds ?? 0);
     }
 
@@ -287,9 +290,12 @@ public sealed class BatchDictationRecorder : IAsyncDisposable
         var dictionary = await _dictionaryResolver.ResolveAsync(ct);
 
         // Wrap the whole captured PCM in one WAV blob and transcribe ONCE through the
-        // Gateway transcription endpoint. The dictionary corrector is the only text transform.
+        // Gateway transcription endpoint. The dictionary corrector is the only text transform. The
+        // trailing-silence run-out (dictation end-word fix) is padded onto the transcription WAV only;
+        // pcm.Length below stays the honest captured-byte count for the audit record.
         var wav = WavWriter.WrapPcm16(
-            pcm, MicAudioCapture.SampleRate, MicAudioCapture.Channels, MicAudioCapture.BitsPerSample);
+            PcmWav.WithTrailingSilence(pcm, MicAudioCapture.SampleRate, MicAudioCapture.Channels, MicAudioCapture.BitsPerSample, PcmWav.TrailingSilenceMs),
+            MicAudioCapture.SampleRate, MicAudioCapture.Channels, MicAudioCapture.BitsPerSample);
 
         var stopWatch = System.Diagnostics.Stopwatch.StartNew();
         var gateway = await new GatewayTranscriptionClient().TranscribeAsync(

--- a/src/CcDirector.Core.Tests/Audio/PcmWavTests.cs
+++ b/src/CcDirector.Core.Tests/Audio/PcmWavTests.cs
@@ -1,0 +1,49 @@
+using CcDirector.Core.Audio;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Audio;
+
+/// <summary>
+/// The trailing-silence run-out (dictation end-word fix): a captured clip gets a short pad of digital
+/// silence appended before transcription so the model does not clip the final word. These guard the
+/// shared C# pad helper - the desktop twin of the browser wav.ts pad.
+/// </summary>
+public sealed class PcmWavTests
+{
+    [Fact]
+    public void WithTrailingSilence_AppendsFrameAlignedZeroBytes_16kMono16bit()
+    {
+        // 16 kHz mono 16-bit = 32000 bytes/sec, so 500 ms = 16000 bytes of silence.
+        var pcm = new byte[] { 1, 2, 3, 4 };
+        var padded = PcmWav.WithTrailingSilence(pcm, 16000, 1, 16, 500);
+
+        Assert.Equal(4 + 16000, padded.Length);
+        Assert.Equal(1, padded[0]);
+        Assert.Equal(4, padded[3]);
+        for (int i = 4; i < padded.Length; i++) Assert.Equal(0, padded[i]);
+    }
+
+    [Fact]
+    public void WithTrailingSilence_NonPositiveMs_ReturnsSameInstance()
+    {
+        var pcm = new byte[] { 9, 9 };
+        Assert.Same(pcm, PcmWav.WithTrailingSilence(pcm, 16000, 1, 16, 0));
+        Assert.Same(pcm, PcmWav.WithTrailingSilence(pcm, 16000, 1, 16, -10));
+    }
+
+    [Fact]
+    public void WithTrailingSilence_PadIsFrameAligned_ForStereo16bit()
+    {
+        // blockAlign = 2 channels * 2 bytes = 4; the pad length must be a whole number of frames.
+        var pcm = new byte[8];
+        var padded = PcmWav.WithTrailingSilence(pcm, 44100, 2, 16, 137); // deliberately odd duration
+        Assert.Equal(0, (padded.Length - pcm.Length) % 4);
+        Assert.True(padded.Length > pcm.Length);
+    }
+
+    [Fact]
+    public void TrailingSilenceMs_IsPositive()
+    {
+        Assert.True(PcmWav.TrailingSilenceMs > 0);
+    }
+}

--- a/src/CcDirector.Core/Audio/PcmWav.cs
+++ b/src/CcDirector.Core/Audio/PcmWav.cs
@@ -12,6 +12,36 @@ namespace CcDirector.Core.Audio;
 public static class PcmWav
 {
     /// <summary>
+    /// Trailing silence appended to a captured clip before transcription (the dictation end-word fix).
+    /// Capture keeps every byte the user spoke, but the batch transcription model (Whisper) clips the
+    /// FINAL word when a clip ends abruptly on speech with no run-out - exactly what happens when the
+    /// user stops the instant he finishes talking. A short pad of digital silence gives the model the
+    /// trailing anchor it needs so the last word survives. This is the C# twin of the browser
+    /// <c>TRANSCRIBE_TRAILING_SILENCE_MS</c> (packages/client-core/src/dictation/wav.ts); keep the two in
+    /// step so every surface transcribes with the same run-out room.
+    /// </summary>
+    public const int TrailingSilenceMs = 600;
+
+    /// <summary>
+    /// Return <paramref name="pcm"/> with <see cref="TrailingSilenceMs"/> of digital silence (zero,
+    /// frame-aligned bytes) appended for the given format. The pad is run-out room for the transcription
+    /// model, NOT captured audio, so callers append it only to the bytes they send to transcription and
+    /// keep the unpadded length for any capture-health / bytes-received accounting.
+    /// </summary>
+    public static byte[] WithTrailingSilence(byte[] pcm, int sampleRate, int channels, int bitsPerSample, int milliseconds)
+    {
+        if (pcm is null) throw new ArgumentNullException(nameof(pcm));
+        if (milliseconds <= 0) return pcm;
+        int blockAlign = Math.Max(1, channels * bitsPerSample / 8);
+        long padBytes = (long)sampleRate * channels * bitsPerSample / 8 * milliseconds / 1000;
+        padBytes -= padBytes % blockAlign; // frame-align so a sample is never split
+        if (padBytes <= 0) return pcm;
+        var padded = new byte[pcm.Length + padBytes]; // new arrays are zero-filled = silence
+        Buffer.BlockCopy(pcm, 0, padded, 0, pcm.Length);
+        return padded;
+    }
+
+    /// <summary>
     /// Wrap raw little-endian PCM samples in a RIFF/WAV header. The returned blob is
     /// a complete <c>.wav</c> file the transcription endpoint can decode directly.
     /// </summary>

--- a/src/CcDirector.Gateway/Transcription/FfmpegAudioTranscoder.cs
+++ b/src/CcDirector.Gateway/Transcription/FfmpegAudioTranscoder.cs
@@ -106,11 +106,14 @@ public sealed class FfmpegAudioTranscoder : IAudioTranscoder
             CreateNoWindow = true,
         };
         // Decode anything ffmpeg understands to 16 kHz mono 16-bit PCM WAV - the transcription-friendly
-        // form the splitter chunks. -nostdin so it never blocks waiting on input.
+        // form the splitter chunks. -nostdin so it never blocks waiting on input. `apad=pad_dur=0.6`
+        // appends 0.6 s of trailing silence (the dictation end-word run-out, matching PcmWav.TrailingSilenceMs
+        // and the browser wav.ts pad) so any compressed clip that reaches a transcode also gives the model
+        // room to emit the last word.
         foreach (var arg in new[]
         {
             "-hide_banner", "-loglevel", "error", "-nostdin", "-y",
-            "-i", input, "-ar", "16000", "-ac", "1", "-c:a", "pcm_s16le", "-f", "wav", output,
+            "-i", input, "-ar", "16000", "-ac", "1", "-af", "apad=pad_dur=0.6", "-c:a", "pcm_s16le", "-f", "wav", output,
         })
             psi.ArgumentList.Add(arg);
 


### PR DESCRIPTION
## The bug (the owner's exact complaint)
"The END of what I say is missing from the transcript." Confirmed root cause: every capture path already keeps the final audio *bytes* (all end paths use a race-free stop), so the loss is at the **model** - the batch transcription model clips the final token when a clip ends abruptly on speech with no trailing silence. The owner hits Send the instant he stops talking, so the clip ends mid-utterance. **Nothing in the pipeline padded that run-out** - on any surface.

## The fix: one trailing-silence pad, everywhere audio becomes the transcription WAV
- `packages/client-core/src/dictation/wav.ts` - `blobToWav16kMono` appends `TRANSCRIBE_TRAILING_SILENCE_MS` (600 ms) of silence. Covers the dictation dialog (Pause / Insert / Send) and Car Mode from one change.
- The durable Terminal/Chat **Send** path (the one the owner used) now uploads that decoded, padded WAV instead of the raw recording - reusing the decode it already does for capture-health. Falls back to the raw recording only if the on-device decode fails, so words are never lost. Bonus: the WAV works in the Gateway's Local Whisper mode, which cannot decode WebM.
- `src/CcDirector.Core/Audio/PcmWav.cs` - a shared `WithTrailingSilence` helper; the desktop recorder pads its transcription WAV with it. The captured-byte count stays unpadded, so the audit record and capture-health stay honest.
- The Gateway ffmpeg transcode gains `apad` as a backstop for any compressed clip that still reaches a server-side transcode.

The pad is model run-out room, **never** counted as captured audio.

## Proof
- Avalonia + Gateway build clean (0 warnings, warnings-as-errors on).
- TypeScript: all workspaces typecheck; client-core 584/584; new `wav.test.ts` guards the pad helper.
- C#: new `PcmWavTests` (4); Core Audio suite 33/33; Gateway ffmpeg/#1139 transcode tests 7/7 - real ffmpeg ran with the new `apad` and still decodes.
- Runtime proof (a real mobile Send whose last word now survives) is the QA follow-up.

## Note
The `.NET` CI check is red on 3 pre-existing `SessionServingLoopIsolationTests` (tenant session-serving / SignalR) that fail identically on the base commit without this change - unrelated, already being worked on a separate branch.
