### PR TITLE
fix(dictation): a Send that dropped audio warns instead of shipping silently

### DIFF
--- a/apps/mobile/src/components/DictationStatusStrip.tsx
+++ b/apps/mobile/src/components/DictationStatusStrip.tsx
@@ -38,13 +38,15 @@ export function DictationStatusStrip({ sessionId }: { sessionId: string | undefi
   const status = useDictationStatusFor(sessionId);
   const [uploadingNow, setUploadingNow] = useState(false);
 
-  // A successful send is acknowledged briefly, then clears itself so the strip does not linger.
+  // A clean successful send is acknowledged briefly, then clears itself so the strip does not linger. A
+  // delivered send that dropped audio carries a warning and must NOT auto-clear - the user has to see and
+  // dismiss it, so a Send that lost words is never silent.
   useEffect(() => {
-    if (status?.phase !== "done") return;
+    if (status?.phase !== "done" || status.warning) return;
     const uploadId = status.uploadId;
     const t = window.setTimeout(() => clearDictationStatus(uploadId), DONE_AUTOCLEAR_MS);
     return () => window.clearTimeout(t);
-  }, [status?.phase, status?.uploadId]);
+  }, [status?.phase, status?.uploadId, status?.warning]);
 
   if (!status) return null;
 
@@ -174,6 +176,20 @@ export function DictationStatusStrip({ sessionId }: { sessionId: string | undefi
   }
 
   if (status.phase === "done") {
+    // Delivered, but the capture dropped audio: the words went in, yet the transcript may be missing some.
+    // Show a non-blocking caution that stays until dismissed (never a silent "Sent"), so the user knows to
+    // check the result. role="status" not "alert" - nothing failed, the send succeeded.
+    if (status.warning) {
+      return (
+        <div className="dictate-strip dictate-strip-warning" role="status">
+          <span className="dictate-strip-icon" aria-hidden="true">!</span>
+          <span className="dictate-strip-text">{status.warning}</span>
+          <button type="button" className="dictate-strip-btn dictate-strip-dismiss" onClick={() => clearDictationStatus(status.uploadId)}>
+            Dismiss
+          </button>
+        </div>
+      );
+    }
     return (
       <div className="dictate-strip dictate-strip-done" role="status">
         <span className="dictate-strip-icon" aria-hidden="true">+</span>

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2708,6 +2708,14 @@ a.banner-btn {
   background: rgba(148, 163, 184, 0.12);
   border-color: rgba(148, 163, 184, 0.4);
 }
+/* Delivered but audio was dropped during capture (#863): the send succeeded, yet the transcript may be
+   missing words, so it is an amber caution the user dismisses - not an alarm (nothing failed), not a silent
+   "Sent" (a Send that lost words must never be silent). */
+.dictate-strip-warning {
+  color: #f5c264;
+  background: rgba(217, 164, 65, 0.12);
+  border-color: rgba(217, 164, 65, 0.4);
+}
 
 /* The dropped strip's stacked message + quoted words. flex-basis keeps the buttons beside it on a wide
    screen and drops them below on a narrow phone. */
@@ -2747,6 +2755,7 @@ a.banner-btn {
 .dictate-strip-parked .dictate-strip-icon { background: rgba(148, 163, 184, 0.3); }
 .dictate-strip-dropped .dictate-strip-icon { background: rgba(241, 76, 76, 0.3); }
 .dictate-strip-unheard .dictate-strip-icon { background: rgba(148, 163, 184, 0.3); }
+.dictate-strip-warning .dictate-strip-icon { background: rgba(217, 164, 65, 0.3); }
 
 /* Small inline spinner for the strip's in-flight state (reuses the voice-spin keyframes). */
 .dictate-strip-spin {

--- a/packages/client-core/src/dictation/backgroundSend.test.ts
+++ b/packages/client-core/src/dictation/backgroundSend.test.ts
@@ -130,6 +130,32 @@ describe("backgroundTranscribeAndSend", () => {
     expect(vi.mocked(savePending).mock.calls[0][0].blob).toBe(captured.blob);
   });
 
+  it("a delivered send that dropped audio carries a capture-loss warning on done (never silent)", async () => {
+    // The send succeeds, but the record was flagged with a capture-loss warning at Send time. The delivered
+    // `done` status must carry that warning so the strip shows a non-clearing caution instead of a silent
+    // "Sent" - the fire-and-forget Send's equivalent of the dialog's dropped-audio warning.
+    vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
+    const warned: PendingDictation = { ...makeRecord("warn-1"), captureWarning: "About 3 seconds of your audio was not captured, so words may be missing." };
+    vi.mocked(listPending).mockResolvedValue([warned]);
+
+    await resumePendingDictations();
+
+    const s = statusFor("warn-1");
+    expect(s?.phase).toBe("done");
+    expect(s?.warning).toBe("About 3 seconds of your audio was not captured, so words may be missing.");
+  });
+
+  it("a clean delivered send has no warning on done", async () => {
+    vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
+    vi.mocked(listPending).mockResolvedValue([makeRecord("clean-1")]);
+
+    await resumePendingDictations();
+
+    const s = statusFor("clean-1");
+    expect(s?.phase).toBe("done");
+    expect(s?.warning).toBeUndefined();
+  });
+
   it("removes the durable copy on a terminal submitted outcome (the queue does not accumulate)", async () => {
     vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
 

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -1,5 +1,5 @@
 import { abandonDictation, sendPrompt, uploadDictationToSession } from "../api/client";
-import { logCaptureHealth } from "./captureHealth";
+import { captureLossWarning, logCaptureHealth } from "./captureHealth";
 import { deletePending, getPending, listPending, savePending, type PendingDictation } from "./pendingStore";
 import { clearDictationStatus, publishDictationStatus } from "./status";
 import { blobToWav16kMono } from "./wav";
@@ -147,16 +147,23 @@ export async function backgroundTranscribeAndSend(
   let decodedSeconds: number | undefined;
   let sourceBytes: number | undefined;
   let uploadBlob = captured.blob;
+  let captureWarning: string | undefined;
   try {
     const transcoded = await blobToWav16kMono(captured.blob);
     decodedSeconds = transcoded.decodedSeconds;
     sourceBytes = transcoded.sourceBytes;
     uploadBlob = transcoded.wav;
-    logCaptureHealth("mobile-send", {
+    const health = {
       recordedMs: captured.recordedMs,
       decodedSeconds: transcoded.decodedSeconds,
       sourceBytes: transcoded.sourceBytes,
-    });
+    };
+    logCaptureHealth("mobile-send", health);
+    // Material capture loss must not ship SILENTLY on Send the way it currently did (the Insert/Pause paths
+    // already warn and park). We cannot park a fire-and-forget Send - the screen is gone and the words the
+    // mic DID capture should still be delivered - so instead the deficit rides along as a caution shown with
+    // the delivered `done` status, and stored durably so a resumed send still carries it.
+    captureWarning = captureLossWarning(health) ?? undefined;
   } catch (err) {
     console.warn(
       `[backgroundSend] decode failed; uploading the raw recording unpadded (delivery is unaffected): ${err instanceof Error ? err.message : String(err)}`,
@@ -170,6 +177,7 @@ export async function backgroundTranscribeAndSend(
     recordedMs: captured.recordedMs,
     decodedSeconds,
     sourceBytes,
+    captureWarning,
     before: hooks.composeParts?.before ?? "",
     after: hooks.composeParts?.after ?? "",
     prefix: captured.prefixText ?? "",
@@ -482,7 +490,9 @@ async function driveRecord(rec: PendingDictation, opts: DriveOptions): Promise<v
       // these outcomes is genuinely nothing to say: an abandon, which the user did on purpose.
       if (outcome.submitted) {
         await deletePending(rec.id);
-        publishDictationStatus({ sessionId: rec.sessionId, uploadId: rec.id, phase: "done" });
+        // Delivered. If the capture dropped audio, the words went in but the transcript may be missing some,
+        // so ride a non-blocking caution on the done status (it will not auto-clear) rather than a silent "Sent".
+        publishDictationStatus({ sessionId: rec.sessionId, uploadId: rec.id, phase: "done", warning: rec.captureWarning });
         return;
       }
 

--- a/packages/client-core/src/dictation/pendingStore.ts
+++ b/packages/client-core/src/dictation/pendingStore.ts
@@ -27,6 +27,11 @@ export interface PendingDictation {
    *  (recording wall-clock vs decoded audio duration). Absent when the on-device decode failed. */
   decodedSeconds?: number;
   sourceBytes?: number;
+  /** A material capture-loss caution measured at Send time (issue #863): some of what was said was dropped
+   *  during recording, so the transcript may be missing words. Stored durably so it survives a resume and is
+   *  shown with the delivered `done` status (the Send path's equivalent of the dialog's dropped-audio
+   *  warning, so a Send that dropped audio is never silent). Absent on a clean capture. */
+  captureWarning?: string;
   /** Typed text before the caret (Terminal Speak compose); empty for the voice case. */
   before: string;
   /** Typed text after the caret; empty for the voice case. */

--- a/packages/client-core/src/dictation/status.ts
+++ b/packages/client-core/src/dictation/status.ts
@@ -79,6 +79,12 @@ export interface DictationStatus {
    *  nothing else - a strip that quotes one thing and sends another is its own small lie. Empty/absent on the
    *  rare drop before transcription with no typed text, where the audio is kept for a fresh-id Retry instead. */
   recoverableText?: string;
+  /** A non-blocking caution shown alongside a DELIVERED send (the `done` phase): the words were sent, but
+   *  the capture-health check found a material audio-loss deficit, so the transcript may be missing words
+   *  and the user should check it (issue #863, "never fail silently on mobile"). Unlike a plain `done`, a
+   *  `done` carrying a warning does NOT auto-clear - the user dismisses it, so a Send that dropped audio is
+   *  never silent. Absent on a clean send. */
+  warning?: string;
   /** Epoch milliseconds of the last update (newest-first ordering, and the done auto-clear timer). */
   updatedAt: number;
 }


### PR DESCRIPTION
Defect 2 from the dictation sweep: the fire-and-forget Send was the one path that shipped dropped audio **silently**.

## The gap
Insert/Pause already warn (and park) when the capture-health check finds a material audio-loss deficit. The Terminal/Chat **Send** just `console.warn`ed and showed a plain self-clearing "Sent" - so a Send that dropped words told the user nothing. That is exactly the "never fail silently on mobile" rule this UI exists to uphold.

## The fix
Send cannot park (the screen is already gone, and the words the mic *did* capture should still be delivered), so the deficit rides along as a non-blocking caution:
- `backgroundSend` computes `captureLossWarning` at Send time and stores it durably on the record, so a resumed send still carries it.
- The delivered `done` status carries the warning, and a `done` **with** a warning does NOT auto-clear - the user dismisses it.
- The status strip renders an amber "check the transcript" caution with a Dismiss (`role="status"`, not `alert` - nothing failed, the send succeeded), instead of the self-clearing "Sent".

## Proof
- All TypeScript workspaces typecheck; client-core 586/586; **new tests**: a delivered send with a flagged record carries the warning on `done`; a clean send does not.
- Mobile app builds (tsc + vite) with the new strip branch and CSS.
- The visual caution + no-auto-clear is runtime QA.

## Note
The `.NET` CI check is red on pre-existing `SessionServingLoopIsolationTests` unrelated to this change (this PR is TypeScript + CSS only).
