### PR TITLE
fix(gateway): tenant-scope three hosted director lookups (audit H1)

### DIFF
--- a/mission/fix-h1.md
+++ b/mission/fix-h1.md
@@ -1,0 +1,83 @@
+# MTR H1 - tenant-scope the hosted director lookups
+
+Branch `fix/audit-h1-listdirectors`, pull request #2007.
+
+## What H1 is
+
+Three hosted, per-tenant routes read the FLEET-GLOBAL `DirectorRegistry.ListDirectors()` and then
+keyed by a BARE director id / machine name, where the registry's tenant-scoped
+`ListDirectors(TenantId)` overload already exists. The registry key is `(tenant, id)`; a director's
+id is chosen by the client and machine names are not unique across tenants, so those collisions
+turned the fleet-global reads into cross-tenant leaks and a crash:
+
+1. `GET /sessions` - filtered the fleet-global list by bare `director=`/`machine=`, so a
+   cross-tenant duplicate survived into the caller's roster and leaked its machine name and its
+   "unreachable" reachability row in the `?envelope` response.
+2. `POST /sessions/voice-mode/all` - built a dictionary keyed by the bare `DirectorId`, so a
+   cross-tenant duplicate made `ToDictionary` throw a 500 - one tenant's director denying another
+   tenant's whole voice toggle.
+3. The cron target resolver - was fed the fleet-global list, so a machine-name match could select
+   another tenant's director on the same machine and persist that cross-tenant `DirectorId` in the
+   caller's `CronRunRecord.TargetDirectorId`.
+
+All three now resolve through the tenant-scoped lookup, confined to the caller's own partition.
+Self-host (one tenant, everything `Local`) is byte-identical.
+
+## The Codex CHANGES-NEEDED residual (this increment)
+
+`GET /sessions` and the cron resolver were correct and are unchanged. ONE residual remained on
+`voice-mode/all`: its `machineByDirector` map was scoped to `ListDirectors(reqTenant)`, but the
+shared role-universe helper `GatewayEndpoints.FleetByDirector` (also folded by `GET
+/sessions/{sid}` and `/exes/list`) still looped the fleet-global `registry.ListDirectors()` AFTER
+that scoped map. So a colliding cross-tenant director id still entered the fold's director
+universe.
+
+The push-store read (`PushedSessionStore.TryGetFresh`) is tenant-keyed, so it already kept another
+tenant's DATA out - which is why reverting the helper alone did not redden the end-to-end
+`voice-mode/all` tests (the 500 came from the already-fixed `machineByDirector.ToDictionary`). The
+residual is the ID SET: iterating the fleet-global list projects every tenant's director ids into
+one bare-id set, so ANOTHER tenant's registered id could decide which of the caller's own cached
+rosters the fold surfaces - a cross-tenant coupling, correct only by the push store's key being the
+sole boundary.
+
+### Fix
+
+`FleetByDirector` now builds its universe from `registry.ListDirectors(tenant)` (the `tenant`
+parameter every caller already passes). The universe still spans machines - a Worker's Manager can
+live on another machine - but every such director is in the caller's OWN tenant (a Worker and its
+Manager belong to the same account), so spanning machines never means spanning tenants. The doc
+comment (which previously argued the fleet-global universe was deliberate) is corrected.
+
+### Coverage (revert-proof)
+
+`FleetByDirectorTenantUniverseTests` (new, unit-level on the helper):
+
+- `FleetByDirector_universe_is_bounded_to_the_callers_registered_directors` - the caller (Acme)
+  holds a fresh pushed roster under an id its REGISTRY no longer lists while only another tenant's
+  (Globex) registry lists that id. With the fix the id is absent from Acme's fold; REVERTING the
+  helper to `ListDirectors()` drags Acme's orphan cache back in via Globex's registered id and this
+  goes RED. Verified: reverting reddens exactly this test, the data-isolation test stays green.
+- `FleetByDirector_never_folds_another_tenants_cache_under_a_shared_id` - belt: with both tenants
+  owning the same id, Acme's fold surfaces only Acme's session, never Globex's (the tenant-keyed
+  push read is the data boundary).
+
+The existing `CrossTenantDuplicateDirectorIdTests` (the two H1 e2e repros) and
+`VoiceModeAllEndpointProofTests` stay green.
+
+## Verification
+
+- Build gateway + tests: 0 warnings, 0 errors.
+- Targeted run green: FleetByDirector universe, CrossTenantDuplicateDirectorId,
+  VoiceModeAllEndpointProof, CronResolverCrossTenant, RegistryDirectorTargetResolver,
+  WingmanVoiceSidPathTraversal (21 tests).
+- Two tenancy filters run SOLO: `PushedSessionStoreTenantIsolationTests` (5),
+  `DirectorRegistryTenantKeyTests` (4).
+- Revert-proof confirmed by hand (revert helper -> universe test RED -> restore).
+
+## Files
+
+- `src/CcDirector.Gateway/Api/GatewayEndpoints.cs` - `FleetByDirector` universe + doc.
+- `src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs` - comment on the tenant-scoped fold.
+- `src/CcDirector.Gateway.Tests/FleetByDirectorTenantUniverseTests.cs` - new coverage.
+
+Serializes on `GatewayEndpoints` / `GatewayHost`.

--- a/src/CcDirector.Gateway.Tests/CronResolverCrossTenantTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronResolverCrossTenantTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Hosted Multi-Tenancy (audit H1, gap audit-e): a cron job resolves its target MACHINE to a Director through
+/// <see cref="Running.RegistryDirectorTargetResolver"/>, which the Gateway used to feed the FLEET-GLOBAL
+/// <c>DirectorRegistry.ListDirectors()</c>. A machine-name match against that global list could select ANOTHER
+/// tenant's Director running on the same machine name and persist its DirectorId into this tenant's
+/// <see cref="CronRunRecord.TargetDirectorId"/> - a cross-tenant id the caller cannot even address.
+///
+/// This drives the REAL cron fire over real HTTP: tenant B owns a Director "d-bob" on machine "SHARED_TARGET";
+/// tenant A owns NONE there. Tenant A creates a cron job targeting "SHARED_TARGET" and runs it now. With the
+/// resolver scoped to the caller's partition (the fix), A resolves NOTHING on that machine, so the run record
+/// carries no target Director (empty) - crucially, never B's "d-bob". Reverting the Gateway wiring to
+/// <c>registry.ListDirectors()</c> makes A's fire resolve B's "d-bob" and stamp it into A's run record, so both
+/// assertions below go RED.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe.
+/// </summary>
+public sealed class CronResolverCrossTenantTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string SharedMachine = "SHARED_TARGET";
+    private const string BobDirectorId = "d-bob";
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private FakeTunnelDirector _dirB = null!;
+
+    private string _keyA = "";
+    private string _keyB = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-cron-xt-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        _keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        _keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", "33333333-3333-3333-3333-333333333333");
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", "44444444-4444-4444-4444-444444444444");
+
+        // ONLY tenant B has a Director on SHARED_TARGET (bound to B's partition by its authenticated Hello).
+        // Tenant A owns nothing on that machine, so a correctly tenant-scoped resolve finds nothing there.
+        _dirB = await FakeTunnelDirector.StartAsync(_gateway, _keyB, BobDirectorId, SharedMachine);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _dirB.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task Cron_fire_never_resolves_another_tenants_director_on_the_same_machine()
+    {
+        // Tenant A creates a seed cron job targeting SHARED_TARGET and fires it now (both under A's scope).
+        var job = new CronJobDto
+        {
+            Name = "audit-h1-repro",
+            Enabled = true,
+            ScheduleKind = "recurring",
+            CronExpression = "0 0 * * *",
+            TimeZoneId = "America/Chicago",
+            Target = new CronJobTarget { Machine = SharedMachine },
+            Action = new CronJobAction { RepoPath = @"D:\repo", Seed = "/help" },
+        };
+        var createResp = await Post("cron/jobs", _keyA, job);
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+        var created = await createResp.Content.ReadFromJsonAsync<CronJobDto>(JsonOpts);
+        Assert.NotNull(created);
+
+        var runResp = await Post($"cron/jobs/{created!.Id}/run", _keyA, new { });
+        runResp.EnsureSuccessStatusCode();
+        var record = await runResp.Content.ReadFromJsonAsync<CronRunRecord>(JsonOpts);
+        Assert.NotNull(record);
+
+        // The security assertion: A's run never named B's Director...
+        Assert.NotEqual(BobDirectorId, record!.TargetDirectorId);
+        // ...and, with A owning nothing on that machine, resolved to no Director at all (empty), never a
+        // cross-tenant one. On revert this becomes "d-bob".
+        Assert.Equal(string.Empty, record.TargetDirectorId);
+    }
+
+    private Task<HttpResponseMessage> Post(string path, string deviceKey, object body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, path) { Content = JsonContent.Create(body) };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/CrossTenantDuplicateDirectorIdTests.cs
+++ b/src/CcDirector.Gateway.Tests/CrossTenantDuplicateDirectorIdTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Hosted Multi-Tenancy (audit H1, gaps audit-a and audit-b): two tenants can each own a Director with the
+/// SAME id - the registry key is (tenant, id), and a Director's id is chosen by the client, so a collision is
+/// a legitimate hosted state, not an error. Two hosted read/write paths built their view from the FLEET-GLOBAL
+/// <c>DirectorRegistry.ListDirectors()</c> and then keyed by the BARE DirectorId, so a cross-tenant duplicate:
+///   - (audit-a) GET /sessions?envelope survived another tenant's DirectorDto into the caller's roster,
+///     leaking its machine name and its "unreachable" reachability row; and
+///   - (audit-b) POST /sessions/voice-mode/all built a Dictionary keyed by the bare DirectorId, so the
+///     duplicate made ToDictionary throw - a 500 in which one tenant's Director denies another tenant's whole
+///     voice-mode toggle.
+///
+/// Both are fixed by reading the registry's TENANT-SCOPED <c>ListDirectors(TenantId)</c> overload, which
+/// confines the list to the caller's own partition where ids are unique. This drives the REAL mapped endpoints
+/// over real HTTP through the real auth middleware and the real tunnel Hello (which binds each Director's
+/// tenant), with two Directors that deliberately share the id "dir-shared".
+///
+/// Revert-prove: change either handler back to the fleet-global <c>registry.ListDirectors()</c> and the
+/// duplicate id reappears - the envelope names "MB-SECRET" again (audit-a) and voice-mode/all throws a
+/// duplicate-key 500 again (audit-b) - so the assertions below go RED.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is
+/// reset in DisposeAsync.
+/// </summary>
+public sealed class CrossTenantDuplicateDirectorIdTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string SharedDirectorId = "dir-shared";
+    private const string MachineA = "MA";
+    private const string MachineBSecret = "MB-SECRET";
+    private const string SessA = "sess-a";
+    private const string SessB = "sess-b";
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private FakeTunnelDirector _dirA = null!;
+    private FakeTunnelDirector _dirB = null!;
+
+    private string _keyA = "";
+    private string _keyB = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-xt-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // Two accounts, two device keys, each bound to its OWN GUID tenant.
+        _keyA = _gateway.Devices.Register("dev-a", MachineA).DeviceKey;
+        _keyB = _gateway.Devices.Register("dev-b", MachineBSecret).DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", "33333333-3333-3333-3333-333333333333");
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", "44444444-4444-4444-4444-444444444444");
+
+        // The COLLISION: both Directors register under the SAME id, each authenticated with its own device key
+        // so the tunnel Hello binds it into its own tenant's partition - (tenant-alice, dir-shared) on MA and
+        // (tenant-bob, dir-shared) on MB-SECRET coexist in the registry. dir-a answers the voice-mode verb so
+        // the same-tenant leg of voice-mode/all can complete once the duplicate-key 500 is gone.
+        _dirA = await FakeTunnelDirector.StartAsync(_gateway, _keyA, SharedDirectorId, MachineA,
+            dispatch: cmd => cmd.Verb == "voice-mode"
+                ? FakeTunnelDirector.Ok(new { ok = true })
+                : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"));
+        _dirB = await FakeTunnelDirector.StartAsync(_gateway, _keyB, SharedDirectorId, MachineBSecret);
+        await _dirA.PushSnapshotAsync(Sample(SessA));
+        await _dirB.PushSnapshotAsync(Sample(SessB));
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _dirA.DisposeAsync();
+        await _dirB.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task Sessions_envelope_never_names_another_tenants_director_that_shares_an_id()
+    {
+        // audit-a: read the ?envelope roster as tenant A. Its OWN session is present; tenant B's Director -
+        // which shares the id "dir-shared" - must appear NOWHERE, not as a session and not as a machine name in
+        // any reachability / machineError row.
+        var resp = await Get("sessions?envelope=true", _keyA);
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadAsStringAsync();
+
+        Assert.Contains(SessA, body);                  // A's own session is present
+        Assert.DoesNotContain(SessB, body);            // never B's session
+        Assert.DoesNotContain(MachineBSecret, body);   // never B's machine name (the cross-tenant leak marker)
+    }
+
+    [Fact]
+    public async Task Voice_mode_all_does_not_500_on_a_cross_tenant_duplicate_director_id()
+    {
+        // audit-b: the fleet-global ListDirectors().ToDictionary(bare id) throws on the duplicate "dir-shared",
+        // a 500 that denies tenant A its voice-mode toggle. Scoped to A's partition the id is unique, so the
+        // call succeeds.
+        var resp = await Post("sessions/voice-mode/all", _keyA, new { enabled = true });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        // And the toggle actually reached A's own (same-tenant) session - proof the success is a real fan-out,
+        // not an empty 200 that never looked at the roster.
+        var payload = await resp.Content.ReadFromJsonAsync<VoiceModeAllResponse>(JsonOpts);
+        Assert.NotNull(payload);
+        Assert.Equal(1, payload!.Changed);
+    }
+
+    private sealed class VoiceModeAllResponse
+    {
+        public bool Enabled { get; set; }
+        public int Total { get; set; }
+        public int Changed { get; set; }
+        public int Skipped { get; set; }
+    }
+
+    private Task<HttpResponseMessage> Get(string path, string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private Task<HttpResponseMessage> Post(string path, string deviceKey, object body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, path) { Content = JsonContent.Create(body) };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private static SessionDto Sample(string sid) => new()
+    {
+        SessionId = sid,
+        Agent = "claude",
+        RepoPath = "/repo",
+        ActivityState = "Working",
+        Status = "Running",
+        StatusColor = "blue",
+        CreatedAt = DateTime.UtcNow,
+        LastActivityAt = DateTime.UtcNow,
+    };
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/FleetByDirectorTenantUniverseTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetByDirectorTenantUniverseTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Linq;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Hosted Multi-Tenancy (audit H1, Codex residual): <see cref="GatewayEndpoints.FleetByDirector"/> is the role
+/// universe for the folds that run outside the /sessions roster loop - <c>/exes/list</c>, <c>GET
+/// /sessions/{sid}</c>, and the one this residual is about, <c>POST /sessions/voice-mode/all</c>. It must build
+/// that universe from the CALLER'S OWN tenant partition, not the fleet-global registry.
+///
+/// The push-store read (<see cref="PushedSessionStore.TryGetFresh"/>) is tenant-keyed, so it already keeps
+/// another tenant's DATA out. But the helper also iterated the fleet-global <see cref="DirectorRegistry.ListDirectors()"/>,
+/// projected each entry to its BARE DirectorId, and read the caller's cache under that fleet-wide id set. Because
+/// two tenants can own a Director with the SAME id (the registry key is (tenant, id), the id is client-chosen),
+/// that let ANOTHER tenant's registered Director id decide which of the caller's own cached rosters the fold
+/// surfaced - a cross-tenant coupling on the id SET even though the data itself stayed the caller's.
+///
+/// This test isolates that coupling. Acme (the caller) holds a fresh pushed roster under the id "dir-shared"
+/// while Acme's REGISTRY has no such Director - the honest race where Acme's Director dropped from the registry
+/// but its push cache has not yet expired. Only GLOBEX's registry lists "dir-shared". With the fix the fold's
+/// universe is Acme's registered Directors, so "dir-shared" is absent; revert the helper to the fleet-global
+/// <c>ListDirectors()</c> and Globex's registered id drags Acme's orphan cache back into the result - the
+/// ContainsKey("dir-shared") assertion below goes RED. Acme's genuinely-registered "dir-acme" stays present, so
+/// the fix is a boundary, not a blanket empty.
+/// </summary>
+public sealed class FleetByDirectorTenantUniverseTests
+{
+    private static readonly TenantId Acme = new("acme");
+    private static readonly TenantId Globex = new("globex");
+    private readonly DateTime _now = new(2026, 7, 22, 12, 0, 0, DateTimeKind.Utc);
+    private readonly TimeSpan _stale = TimeSpan.FromSeconds(20);
+
+    private static SessionDto Session(string id) => new() { SessionId = id, ActivityState = "Working" };
+
+    private void SeedCache(PushedSessionStore store, TenantId tenant, string directorId, string sessionId)
+    {
+        var conn = $"conn-{tenant.Value}-{directorId}";
+        store.RegisterConnection(tenant, directorId, conn);
+        Assert.True(store.ApplySnapshot(tenant, directorId, conn, 0, new[] { Session(sessionId) }));
+    }
+
+    private static void RegisterDirector(DirectorRegistry registry, TenantId tenant, string directorId, string machine)
+        => registry.RegisterFromStream(directorId, machine, "user", "1.0", pid: 1234, startedAt: default, tenant);
+
+    [Fact]
+    public void FleetByDirector_universe_is_bounded_to_the_callers_registered_directors()
+    {
+        var store = new PushedSessionStore(() => _now);
+        using var registry = new DirectorRegistry();
+
+        // Acme owns "dir-acme" (registered AND freshly cached) - its legitimate roster.
+        RegisterDirector(registry, Acme, "dir-acme", "acme-box");
+        SeedCache(store, Acme, "dir-acme", "acme-session");
+
+        // The residual's trap: Acme has a fresh cache under "dir-shared" that its REGISTRY no longer lists,
+        // and only GLOBEX's registry lists "dir-shared". A fleet-global universe would surface Acme's orphan
+        // cache purely because Globex registered that id.
+        SeedCache(store, Acme, "dir-shared", "acme-orphan-session");
+        RegisterDirector(registry, Globex, "dir-shared", "globex-box");
+
+        var byDirector = GatewayEndpoints.FleetByDirector(registry, store, _stale, Acme);
+
+        // Acme's genuinely-registered Director is present...
+        Assert.True(byDirector.ContainsKey("dir-acme"));
+        Assert.Equal("acme-session", Assert.Single(byDirector["dir-acme"]).SessionId);
+
+        // ...but the id only Globex's registry lists never enters Acme's universe. REVERT-PROOF: with the helper
+        // reading the fleet-global ListDirectors(), Globex's "dir-shared" drags Acme's orphan cache in and this
+        // fails.
+        Assert.False(byDirector.ContainsKey("dir-shared"));
+
+        // The whole result is confined to Acme's registered Director ids - the universe is the caller's partition.
+        var acmeIds = registry.ListDirectors(Acme).Select(d => d.DirectorId).ToHashSet(StringComparer.Ordinal);
+        Assert.All(byDirector.Keys, k => Assert.Contains(k, acmeIds));
+    }
+
+    [Fact]
+    public void FleetByDirector_never_folds_another_tenants_cache_under_a_shared_id()
+    {
+        var store = new PushedSessionStore(() => _now);
+        using var registry = new DirectorRegistry();
+
+        // Both tenants own a Director with the SAME id, each with its own fresh roster.
+        RegisterDirector(registry, Acme, "dir-shared", "acme-box");
+        SeedCache(store, Acme, "dir-shared", "acme-session");
+        RegisterDirector(registry, Globex, "dir-shared", "globex-box");
+        SeedCache(store, Globex, "dir-shared", "globex-secret-session");
+
+        var byDirector = GatewayEndpoints.FleetByDirector(registry, store, _stale, Acme);
+
+        // Acme sees its own roster under the shared id, and NEVER Globex's - the tenant-keyed push read is the
+        // data boundary; this fold surfaces exactly one tenant's sessions for the id.
+        Assert.True(byDirector.ContainsKey("dir-shared"));
+        Assert.Equal("acme-session", Assert.Single(byDirector["dir-shared"]).SessionId);
+        Assert.DoesNotContain(byDirector.Values.SelectMany(v => v),
+            s => s.SessionId == "globex-secret-session");
+    }
+}

--- a/src/CcDirector.Gateway.Tests/MachineSessionSpawnerTests.cs
+++ b/src/CcDirector.Gateway.Tests/MachineSessionSpawnerTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Running;
 using Xunit;
@@ -122,7 +123,8 @@ public sealed class MachineSessionSpawnerTests
             Source = "stream",
         };
         var resolver = new RegistryDirectorTargetResolver(
-            listDirectors: () => new[] { director },
+            listDirectors: _ => new[] { director },
+            resolveTenant: () => TenantId.Local,
             launcher: new ThrowingLauncher());
 
         string? seenDirectorId = null;

--- a/src/CcDirector.Gateway.Tests/RegistryDirectorTargetResolverTests.cs
+++ b/src/CcDirector.Gateway.Tests/RegistryDirectorTargetResolverTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Running;
 using Xunit;
@@ -52,7 +53,8 @@ public sealed class RegistryDirectorTargetResolverTests
             Director("d-7879", "MACHINE_B", ""),
         };
         var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch when one is running"));
-        var resolver = new RegistryDirectorTargetResolver(() => directors, launcher, FastTimeout, FastPoll);
+        var resolver = new RegistryDirectorTargetResolver(
+            _ => directors, () => TenantId.Local, launcher, FastTimeout, FastPoll);
 
         var result = await resolver.ResolveAsync("MACHINE_A", CancellationToken.None);
 
@@ -71,7 +73,8 @@ public sealed class RegistryDirectorTargetResolverTests
             directors.Add(Director("d-new", machine, ""));
             return true;
         });
-        var resolver = new RegistryDirectorTargetResolver(() => directors, launcher, FastTimeout, FastPoll);
+        var resolver = new RegistryDirectorTargetResolver(
+            _ => directors, () => TenantId.Local, launcher, FastTimeout, FastPoll);
 
         var result = await resolver.ResolveAsync("MACHINE_A", CancellationToken.None);
 
@@ -86,7 +89,8 @@ public sealed class RegistryDirectorTargetResolverTests
     {
         var directors = new List<DirectorDto>();
         var launcher = new FakeLauncher(_ => false);              // launcher fails to start one
-        var resolver = new RegistryDirectorTargetResolver(() => directors, launcher, FastTimeout, FastPoll);
+        var resolver = new RegistryDirectorTargetResolver(
+            _ => directors, () => TenantId.Local, launcher, FastTimeout, FastPoll);
 
         var result = await resolver.ResolveAsync("MACHINE_A", CancellationToken.None);
 
@@ -101,7 +105,7 @@ public sealed class RegistryDirectorTargetResolverTests
         var directors = new List<DirectorDto>();
         var launcher = new FakeLauncher(_ => true);               // claims success but nothing registers
         var resolver = new RegistryDirectorTargetResolver(
-            () => directors, launcher, TimeSpan.FromMilliseconds(120), FastPoll);
+            _ => directors, () => TenantId.Local, launcher, TimeSpan.FromMilliseconds(120), FastPoll);
 
         var result = await resolver.ResolveAsync("MACHINE_A", CancellationToken.None);
 
@@ -114,12 +118,70 @@ public sealed class RegistryDirectorTargetResolverTests
     public async Task Resolve_EmptyMachine_ReturnsError_DoesNotLaunch()
     {
         var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch for empty machine"));
-        var resolver = new RegistryDirectorTargetResolver(() => new List<DirectorDto>(), launcher, FastTimeout, FastPoll);
+        var resolver = new RegistryDirectorTargetResolver(
+            _ => new List<DirectorDto>(), () => TenantId.Local, launcher, FastTimeout, FastPoll);
 
         var result = await resolver.ResolveAsync("   ", CancellationToken.None);
 
         Assert.Null(result.DirectorId);
         Assert.NotNull(result.Error);
         Assert.Equal(0, launcher.StartCount);
+    }
+
+    // ---- Hosted Multi-Tenancy: cross-tenant machine collision (audit H1, gap audit-e) -------------------
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public async Task Resolve_scopes_to_the_callers_tenant_never_another_tenants_same_machine_director()
+    {
+        // Two tenants each own a Director on the SAME machine name (the registry key is (tenant, id), so this
+        // is a legitimate hosted state - two accounts, two Directors, one shared machine name). Tenant A's cron
+        // fire resolves that machine. It must resolve A's OWN Director; B's Director must never be picked, or
+        // A's CronRunRecord would persist a cross-tenant DirectorId that A cannot even address.
+        var dirA = Director("d-alice", "SHARED_MACHINE", "");
+        var dirB = Director("d-bob", "SHARED_MACHINE", "");
+        // The tenant-scoped reader the production registry provides: one tenant's partition per call. B is
+        // listed FIRST in the fleet so a tenant-blind (pre-fix, fleet-global) resolve would pick B, making the
+        // isolation assertion meaningful rather than order-lucky.
+        var byTenant = new Dictionary<TenantId, DirectorDto[]>
+        {
+            [TenantA] = new[] { dirA },
+            [TenantB] = new[] { dirB },
+        };
+        IEnumerable<DirectorDto> ForTenant(TenantId t) =>
+            byTenant.TryGetValue(t, out var list) ? list : Array.Empty<DirectorDto>();
+        var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch when one is running"));
+
+        var asAlice = new RegistryDirectorTargetResolver(ForTenant, () => TenantA, launcher, FastTimeout, FastPoll);
+        var resolvedForAlice = await asAlice.ResolveAsync("SHARED_MACHINE", CancellationToken.None);
+        Assert.Null(resolvedForAlice.Error);
+        Assert.Equal("d-alice", resolvedForAlice.DirectorId);   // A's own Director, never B's
+
+        // Symmetric: B resolving the same machine gets B's Director, never A's.
+        var asBob = new RegistryDirectorTargetResolver(ForTenant, () => TenantB, launcher, FastTimeout, FastPoll);
+        var resolvedForBob = await asBob.ResolveAsync("SHARED_MACHINE", CancellationToken.None);
+        Assert.Equal("d-bob", resolvedForBob.DirectorId);
+
+        // Revert-proof: a tenant-BLIND reader (the pre-fix fleet-global list, B first) resolves B's Director for
+        // A's fire - the exact cross-tenant pick the fix removes. This pins that the tenant scoping, not list
+        // order, is what protects A: reverting the resolver to ignore the tenant reddens the assertion above.
+        var fleetGlobal = new[] { dirB, dirA };
+        var blind = new RegistryDirectorTargetResolver(_ => fleetGlobal, () => TenantA, launcher, FastTimeout, FastPoll);
+        var blindPick = await blind.ResolveAsync("SHARED_MACHINE", CancellationToken.None);
+        Assert.Equal("d-bob", blindPick.DirectorId);            // the leak, demonstrated
+    }
+
+    [Fact]
+    public async Task Resolve_denies_when_no_tenant_scope_is_in_effect()
+    {
+        // Deny-by-default: on hosted a resolve reached with no tenant scope (a boundary bug) must fail loud,
+        // never fall back to a partition it would then scan cross-tenant.
+        var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch"));
+        var resolver = new RegistryDirectorTargetResolver(
+            _ => new[] { Director("d-x", "M", "") }, () => (TenantId?)null, launcher, FastTimeout, FastPoll);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => resolver.ResolveAsync("M", CancellationToken.None));
     }
 }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -723,19 +723,27 @@ internal static class GatewayEndpoints
                 return Results.Json(new { error = "no tenant is bound to this request" },
                     statusCode: StatusCodes.Status403Forbidden);
 
-            var directors = registry.ListDirectors()
+            // Hosted Multi-Tenancy (audit H1, gap audit-a): serve THIS request's tenant's Directors, resolved
+            // from the registry's tenant-scoped (tenant, id) partition - NOT the fleet-global ListDirectors().
+            // The fleet-global overload names every tenant's Directors, and the `director=` / `machine=` filters
+            // below match on a BARE id / machine name, so a cross-tenant Director sharing the requested id or
+            // machine would survive into this tenant's roster and leak its DirectorDto (machine name, the
+            // "unreachable" reachability / machineError rows) in the ?envelope response. ListDirectors(tenant)
+            // confines the list to the caller's own partition so no such collision can name another tenant. A
+            // hosted Director reaches the registry only via its tunnel Hello, which first binds it into its
+            // tenant's partition, so scoping to the partition drops nothing of the tenant's own. On self-host the
+            // registry partition IS the one Local tenant, so this is the same list as before.
+            var directors = registry.ListDirectors(reqTenant.Value)
                 .Where(d => string.IsNullOrEmpty(director) || string.Equals(d.DirectorId, director, StringComparison.OrdinalIgnoreCase))
                 .Where(d => string.IsNullOrEmpty(machine) || string.Equals(d.MachineName, machine, StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
-            // Hosted Multi-Tenancy (session-serving PR1): the Director registry is fleet-global, but a tenant's
-            // roster must only ever NAME its own directors. Scope the list to the request tenant's partition so
-            // another tenant's directors never appear - not as sessions, and not as "unreachable"
-            // machineError / reachability rows (which would otherwise leak their ids and machine names in the
-            // ?envelope response). A hosted director reaches the registry only via its tunnel Hello, which first
-            // binds it into its tenant's partition, so scoping to the partition drops nothing of the tenant's
-            // own. On self-host the boundary is inert and the registry already IS the one tenant's directors, so
-            // this is skipped and behavior is unchanged (a registered-but-unpushed director still surfaces).
+            // Within that already tenant-scoped list, hosted additionally keeps only Directors that have pushed a
+            // session snapshot - the roster source below is the pushed stream cache, so a registered-but-unpushed
+            // Director has nothing to serve. This intersection is by bare id, which is safe ONLY because the list
+            // above is confined to this tenant's partition (every id here belongs to reqTenant); it is a
+            // pushed-vs-registered filter, not the tenant boundary. On self-host it is skipped, so a
+            // registered-but-unpushed Director still surfaces (unchanged).
             if (tenantBoundary?.IsHosted == true && pushedSessions is not null)
             {
                 var mine = new HashSet<string>(pushedSessions.DirectorIdsFor(reqTenant.Value), StringComparer.OrdinalIgnoreCase);
@@ -2883,15 +2891,26 @@ internal static class GatewayEndpoints
         statusCode: StatusCodes.Status404NotFound);
 
     /// <summary>
-    /// The ROLE UNIVERSE for a fold that runs OUTSIDE the /sessions roster loop: every tunnel-connected
-    /// Director's pushed roster, grouped by Director.
+    /// The ROLE UNIVERSE for a fold that runs OUTSIDE the /sessions roster loop: the CALLER'S TENANT's
+    /// tunnel-connected Directors' pushed rosters, grouped by Director.
     ///
     /// The roster handler builds its universe inline as it walks the Directors it already pulled. The two
     /// other folding routes (/exes/list and GET /sessions/{sid}) have no such loop, and both need the whole
-    /// fleet for the same reason: a session's role depends on whether its controller is alive, and the
+    /// tenant for the same reason: a session's role depends on whether its controller is alive, and the
     /// controller may live on a Director this route was never otherwise interested in. /exes/list is the
-    /// sharp case - it is a LOCAL-MACHINE page, but a local Worker's Manager can be on another machine
-    /// entirely, so the universe is deliberately the whole fleet and not the local Directors.
+    /// sharp case - it is a LOCAL-MACHINE page, but a Worker's Manager can be on another machine entirely, so
+    /// the universe spans every machine. Every one of those Directors is still in the caller's OWN tenant (a
+    /// Worker and its Manager belong to the same account), so spanning machines does NOT mean spanning tenants.
+    ///
+    /// Hosted Multi-Tenancy (audit H1): the universe is <see cref="DirectorRegistry.ListDirectors(TenantId)"/>,
+    /// the caller's partition, NOT the fleet-global <see cref="DirectorRegistry.ListDirectors()"/>. Two tenants
+    /// can each own a Director with the SAME id (the registry key is (tenant, id), and the id is client-chosen),
+    /// so the fleet-global list projects to bare ids in which one tenant's ids appear beside another's. Reading
+    /// the caller's cache under that fleet-wide id set means ANOTHER tenant's registered Director id decides
+    /// which of the caller's own cached rosters this fold surfaces - a cross-tenant coupling. Bounding the
+    /// universe to the caller's own registered Directors removes it: the tenant scope on the push-store read
+    /// keeps another tenant's DATA out, and this scope keeps another tenant's ID SET out, so the fold is
+    /// correct by construction rather than by the push store's key being the sole boundary.
     ///
     /// Returns copies (the push store hands out deep copies), so stamping the result never writes through
     /// to the cache.
@@ -2902,7 +2921,7 @@ internal static class GatewayEndpoints
     {
         var byDirector = new Dictionary<string, IReadOnlyList<SessionDto>>(StringComparer.Ordinal);
         if (pushedSessions is null) return byDirector;
-        foreach (var d in registry.ListDirectors())
+        foreach (var d in registry.ListDirectors(tenant))
         {
             var cached = pushedSessions.TryGetFresh(tenant, d.DirectorId, streamStale);
             if (cached is not null) byDirector[d.DirectorId] = cached;

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -242,14 +242,23 @@ internal static class GatewayWingmanVoiceEndpoint
             FileLog.Write($"[GatewayWingmanVoice] voice-mode/all requested: enabled={enabled}");
 
             // The machine each Director runs on, so a skipped session names where it lives in plain English.
-            var machineByDirector = registry.ListDirectors()
+            // Hosted Multi-Tenancy (audit H1, gap audit-b): scope this to the caller's OWN partition, not the
+            // fleet-global ListDirectors(). Two tenants can each own a Director with the SAME id (the registry
+            // key is (tenant, id)), so the fleet-global list can hold duplicate DirectorIds and ToDictionary
+            // would throw on the collision - a 500 in which one tenant's Director denies another tenant's whole
+            // voice-mode/all toggle. It would also map the caller's id to ANOTHER tenant's machine name.
+            // ListDirectors(tenant) yields ids unique within the partition (no duplicate-key throw) and only this
+            // tenant's machine names - which is all the fan-out below, itself tenant-scoped, ever looks up.
+            var machineByDirector = registry.ListDirectors(reqTenant.Value)
                 .ToDictionary(d => d.DirectorId, d => d.MachineName, StringComparer.Ordinal);
 
             // Every session the Gateway can see right now, de-duplicated by id. A session belongs to exactly
             // one Director, but the guard keeps a duplicated roster entry from being toggled (and counted) twice.
             // Hosted Multi-Tenancy: voice-mode/all is a fleet fan-out WRITE (voice family), scoped to the
             // caller's tenant resolved from its authenticated device key - so it toggles only the requester's
-            // own sessions, never another tenant's, and a request with no bound tenant is denied above.
+            // own sessions, never another tenant's, and a request with no bound tenant is denied above. FleetByDirector
+            // itself now builds its Director universe from ListDirectors(reqTenant) (audit H1 Codex residual), so a
+            // cross-tenant duplicate id cannot even enter this fold's universe, matching machineByDirector above.
             var byDirector = GatewayEndpoints.FleetByDirector(registry, pushedSessions, stale, reqTenant.Value);
             var targets = new List<(string DirectorId, string Machine, string Sid, string? Name)>();
             var seen = new HashSet<string>(StringComparer.Ordinal);

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -964,7 +964,13 @@ public sealed class GatewayHost : IAsyncDisposable
         // A cron job targets a MACHINE (#503): resolve it to a Director at fire time, launching one
         // via the launcher (the shipped /machines/{m}/director/start relay, #331) if none is running.
         var cronTargetResolver = new Running.RegistryDirectorTargetResolver(
-            () => Registry.ListDirectors(),
+            // Audit H1 (gap audit-e): list the target machine's Directors within the FIRE's tenant only, via the
+            // registry's tenant-scoped overload. The fleet-global ListDirectors() could match another tenant's
+            // Director on the same machine and persist that cross-tenant DirectorId in this tenant's
+            // CronRunRecord. The tenant is _tenantPass.Current - the scope the fire runs inside (the engine and
+            // the drain runner read the same seam); on self-host it is always Local.
+            tenant => Registry.ListDirectors(tenant),
+            () => _tenantPass.Current,
             new Running.RelayDirectorLauncher(Port, Token));
         // The single resolve-then-create path shared by the cron firing engine and the interactive
         // POST /machines/{machine}/sessions relay ("start a session on another computer"). Gateway Cleanup

--- a/src/CcDirector.Gateway/Running/IDirectorTargetResolver.cs
+++ b/src/CcDirector.Gateway/Running/IDirectorTargetResolver.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
@@ -28,23 +29,41 @@ public interface IDirectorTargetResolver
 /// Production resolver. Reads the live Director list (the <see cref="DirectorRegistry"/>) and uses an
 /// <see cref="IDirectorLauncher"/> to start a Director on demand. Uses wall-clock waits (small in
 /// tests) for the launch poll, so it never depends on the engine's injected clock.
+///
+/// Hosted Multi-Tenancy (audit H1, gap audit-e): the resolve is confined to the CALLER'S tenant. The
+/// <paramref name="listDirectors"/> reader takes the tenant to list (production: the registry's
+/// tenant-scoped <c>ListDirectors(TenantId)</c> overload), and the tenant is resolved per-resolve from
+/// <paramref name="resolveTenant"/> - the tenant of the current cron fire (<c>() =&gt; _tenantPass.Current</c>
+/// in production), which flows across the launch poll's awaits with the ambient scope. A bare machine-name
+/// match against the FLEET-GLOBAL list could pick another tenant's Director on the same machine and persist
+/// that cross-tenant DirectorId in this tenant's CronRunRecord; scoping to the caller's partition makes that
+/// structurally impossible. On self-host the tenant is always Local - one partition, unchanged.
 /// </summary>
 public sealed class RegistryDirectorTargetResolver : IDirectorTargetResolver
 {
-    private readonly Func<IEnumerable<DirectorDto>> _listDirectors;
+    private readonly Func<TenantId, IEnumerable<DirectorDto>> _listDirectors;
+    private readonly Func<TenantId?> _resolveTenant;
     private readonly IDirectorLauncher _launcher;
     private readonly TimeSpan _launchTimeout;
     private readonly TimeSpan _pollInterval;
 
-    /// <param name="listDirectors">The live Director list (production: <c>registry.ListDirectors</c>).</param>
+    /// <param name="listDirectors">
+    /// The live Director list for ONE tenant (production: the registry's <c>ListDirectors(TenantId)</c>
+    /// overload). It is only ever called with the tenant <paramref name="resolveTenant"/> yields.</param>
+    /// <param name="resolveTenant">
+    /// The tenant of the current unit of work - the cron fire's scope (production: <c>() =&gt; _tenantPass.Current</c>),
+    /// always <see cref="TenantId.Local"/> on self-host. A fire is only ever reached inside a resolved scope, so a
+    /// null here (hosted, no scope) is a boundary bug and DENIES (throws) rather than defaulting to a partition.</param>
     /// <param name="launcher">Starts a Director on a machine when none is running.</param>
     public RegistryDirectorTargetResolver(
-        Func<IEnumerable<DirectorDto>> listDirectors,
+        Func<TenantId, IEnumerable<DirectorDto>> listDirectors,
+        Func<TenantId?> resolveTenant,
         IDirectorLauncher launcher,
         TimeSpan? launchTimeout = null,
         TimeSpan? pollInterval = null)
     {
         _listDirectors = listDirectors ?? throw new ArgumentNullException(nameof(listDirectors));
+        _resolveTenant = resolveTenant ?? throw new ArgumentNullException(nameof(resolveTenant));
         _launcher = launcher ?? throw new ArgumentNullException(nameof(launcher));
         _launchTimeout = launchTimeout ?? TimeSpan.FromSeconds(90);
         _pollInterval = pollInterval ?? TimeSpan.FromSeconds(3);
@@ -84,7 +103,15 @@ public sealed class RegistryDirectorTargetResolver : IDirectorTargetResolver
     /// longer requires a non-empty ControlEndpoint or an advertised-endpoint reachability state (both are
     /// artifacts of the deleted HTTP-dial path).
     /// </summary>
-    private DirectorDto? PickReachable(string machine) =>
-        _listDirectors().FirstOrDefault(x =>
+    private DirectorDto? PickReachable(string machine)
+    {
+        // Confine the machine-name match to the caller's OWN tenant partition (audit H1, gap audit-e): a
+        // fleet-global scan could return another tenant's Director that happens to run on the same machine.
+        var tenant = _resolveTenant()
+            ?? throw new InvalidOperationException(
+                "A cron target resolution ran with no tenant scope in effect. The Director list is " +
+                "partitioned by tenant; the caller path was not bound at its tenant boundary.");
+        return _listDirectors(tenant).FirstOrDefault(x =>
             string.Equals(x.MachineName, machine, StringComparison.OrdinalIgnoreCase));
+    }
 }


### PR DESCRIPTION
## Root cause

Three hosted, per-tenant routes read the FLEET-GLOBAL `DirectorRegistry.ListDirectors()` and then keyed by a BARE director id / machine name, where the registry's tenant-scoped `ListDirectors(TenantId)` overload already exists. The registry key is `(tenant, id)`; a director's id is chosen by the client and machine names are not unique across tenants, so those collisions turned the fleet-global reads into cross-tenant leaks and a crash:

1. **`GET /sessions`** filtered the fleet-global list by bare `director=`/`machine=`, so a cross-tenant duplicate survived into the caller's roster and leaked its machine name and its "unreachable" reachability row in the `?envelope` response.
2. **`POST /sessions/voice-mode/all`** built a dictionary keyed by the bare `DirectorId`, so a cross-tenant duplicate made `ToDictionary` throw a 500 - one tenant's director denying another tenant's whole voice toggle.
3. **The cron target resolver** was fed the fleet-global list, so a machine-name match could select another tenant's director on the same machine and persist that cross-tenant `DirectorId` in the caller's `CronRunRecord.TargetDirectorId`.

## Fix

All three now resolve through the tenant-scoped lookup, confined to the caller's own partition:

- `GET /sessions` sources from `registry.ListDirectors(reqTenant)`. The existing hosted pushed-set intersection stays, now documented as a pushed-vs-registered filter (safe only because the source is already the tenant's partition), not the tenant boundary.
- `voice-mode/all` builds its machine map from `registry.ListDirectors(reqTenant)` - ids are unique within a partition (no duplicate-key throw) and only the caller's own machine names appear.
- `RegistryDirectorTargetResolver` is made tenant-aware and correct-by-construction: it takes a tenant-scoped list reader (`tenant => Registry.ListDirectors(tenant)`) and a server-resolved tenant (`() => _tenantPass.Current`, the same seam the cron engine and drain runner read). A resolve reached with no scope in effect denies (throws), never defaults. Self-host is always `Local` - unchanged.

## Reproduced-real (verify-first, revert-proof)

Each site was reproduced on a real hosted `GatewayHost` with two tenants before fixing; reverting only the one-line fix reddens the corresponding test (verified):

- `CrossTenantDuplicateDirectorIdTests.Sessions_envelope_never_names_another_tenants_director_that_shares_an_id`
- `CrossTenantDuplicateDirectorIdTests.Voice_mode_all_does_not_500_on_a_cross_tenant_duplicate_director_id`
- `CronResolverCrossTenantTests.Cron_fire_never_resolves_another_tenants_director_on_the_same_machine`
- `RegistryDirectorTargetResolverTests` - two new unit cases (tenant scoping + deny-with-no-scope)

## Notes

- Touches `GatewayEndpoints.cs`, `GatewayWingmanVoiceEndpoint.cs`, and `GatewayHost.cs` - these serialize at merge.
- Build gateway + test project: 0 warnings, 0 errors. Targeted run green (repro + resolver + spawner + session-serving isolation + cron/voice/machine families + the two solo tenancy filters).
