### PR TITLE
test(dictation): desktop capture is the WAV data PREFIX, not its suffix (fix false silent-capture red)

### DIFF
--- a/src/CcDirector.Avalonia.Tests/BatchDictationRecorderStopWavTests.cs
+++ b/src/CcDirector.Avalonia.Tests/BatchDictationRecorderStopWavTests.cs
@@ -1,4 +1,5 @@
 using CcDirector.Avalonia.Voice;
+using CcDirector.Core.Audio;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Dictation;
 using Xunit;
@@ -11,6 +12,10 @@ namespace CcDirector.Avalonia.Tests;
 /// prove <see cref="BatchDictationRecorder.StopAndGetWavAsync"/> returns the complete capture - tail
 /// included - and still enforces the completeness gate, driven through the fake-microphone seam with no
 /// real mic and no network.
+///
+/// The WAV also carries the transcription run-out pad (<see cref="PcmWav.TrailingSilenceMs"/> of trailing
+/// silence, #2003) AFTER the capture, so the captured audio is the DATA region's PREFIX (right after the
+/// header), not its suffix. Asserting on the suffix would read the pad, not the capture.
 /// </summary>
 public sealed class BatchDictationRecorderStopWavTests
 {
@@ -50,11 +55,21 @@ public sealed class BatchDictationRecorderStopWavTests
 
         var captured = await recorder.StopAndGetWavAsync();
 
-        // The clip is a WAV: a header followed by exactly the captured PCM, tail included and in order.
+        // The clip is a WAV: a 44-byte header, then EXACTLY the captured PCM (body + tail delivered during
+        // drain, in order), then the transcription run-out pad of trailing silence (#2003). The capture is
+        // therefore the DATA region's PREFIX - asserting on the suffix reads the pad, not the audio.
         Assert.NotNull(captured.Wav);
-        Assert.True(captured.Wav.Length > expectedPcm.Length, "WAV must include a header plus the PCM");
-        var pcmSuffix = captured.Wav.AsSpan(captured.Wav.Length - expectedPcm.Length).ToArray();
-        Assert.Equal(expectedPcm, pcmSuffix);
+        const int headerBytes = 44;
+        Assert.True(captured.Wav.Length > headerBytes + expectedPcm.Length, "WAV must include a header, the PCM, and the pad");
+
+        // The captured audio (tail included) sits immediately after the header - this is the real guarantee:
+        // a clipped tail would break here.
+        var pcmPrefix = captured.Wav.AsSpan(headerBytes, expectedPcm.Length).ToArray();
+        Assert.Equal(expectedPcm, pcmPrefix);
+
+        // Everything after the capture is the pad: pure trailing silence, and nothing but silence.
+        for (int i = headerBytes + expectedPcm.Length; i < captured.Wav.Length; i++)
+            Assert.True(captured.Wav[i] == 0, $"pad byte at {i} must be silence");
     }
 
     [Fact]


### PR DESCRIPTION
CI backstop red on `BatchDictationRecorderStopWavTests`, triaged as "desktop recorder produces silent WAVs." **Verified against origin/main - it does not.**

## What actually happens
#2003 appends a trailing-silence run-out pad AFTER the captured PCM in `StopAndGetWavAsync`. The old test asserted the capture was the WAV's **suffix** (`Wav[Wav.Length - 8 ..]`), which is now the pad, so it read zeros and looked like the capture was gone.

Dumped the real bytes for the exact "tail delivered during drain" scenario:
```
wavLen=28852, bytes[44..52]=[1,2,3,4,5,6,7,8], nonZeroBytesInDataRegion=8
```
The body `{1,2,3,4}` and the tail `{5,6,7,8}` delivered during drain are both present, in order, right after the 44-byte header. The 28800 trailing zeros are exactly 600 ms of run-out silence (24000 x 2 x 0.6). The capture is intact; the WAV is audio **+** run-out, not silent.

## Fix
Assert the real guarantee instead of the fragile suffix: the captured audio (tail included, in order) sits immediately after the header, and everything after it is pure silence. A clipped tail still fails the prefix check, so the no-tail-loss protection this test exists for is preserved.

## Impact
- Recorder code unchanged - it was correct. **A desktop director built from current main is safe**; desktop dictation is not broken.
- All desktop dictation-recorder + WavWriter tests green (11/11).
