### PR TITLE
Draw scrollbar thumbs at full thickness, never a hover-only sliver

### DIFF
--- a/src/CcDirector.AgentBrain.Panel/App.axaml
+++ b/src/CcDirector.AgentBrain.Panel/App.axaml
@@ -27,5 +27,19 @@
       <Setter Property="Background" Value="#7A2D2D" />
       <Setter Property="Foreground" Value="#FFFFFF" />
     </Style>
+
+    <!-- Scrollbars are controls, not hover-revealed decoration: don't fade out. -->
+    <Style Selector="ScrollViewer">
+      <Setter Property="AllowAutoHide" Value="False" />
+    </Style>
   </Application.Styles>
+
+  <Application.Resources>
+    <!-- Draw the scrollbar thumb at full thickness always, never a thin hover-only
+         sliver. The Fluent theme collapses the thumb with a scaleX/scaleY(0.125)
+         RenderTransform set as a local value on the thumb (which a style setter
+         cannot beat), so override the resource that transform resolves to. -->
+    <TransformOperations x:Key="VerticalSmallScrollThumbScaleTransform">none</TransformOperations>
+    <TransformOperations x:Key="HorizontalSmallScrollThumbScaleTransform">none</TransformOperations>
+  </Application.Resources>
 </Application>

--- a/src/CcDirector.Avalonia/App.axaml
+++ b/src/CcDirector.Avalonia/App.axaml
@@ -4,21 +4,26 @@
              RequestedThemeVariant="Dark">
     <Application.Styles>
         <FluentTheme />
-        <!-- App-wide policy: scrollbars are controls, not hover-revealed decoration. -->
+        <!-- App-wide policy: scrollbars are controls, not hover-revealed decoration.
+             Keep the bar from fading out when the pointer leaves. -->
         <Style Selector="ScrollViewer">
             <Setter Property="AllowAutoHide" Value="False" />
-        </Style>
-        <!-- AllowAutoHide keeps the bar from fading out, but the Fluent theme still
-             draws it as a thin sliver until the pointer is over it: the thumb carries
-             a scale transform that only the IsExpanded (hover) state removes. Strip
-             that transform unconditionally so a scrollbar that is present is drawn at
-             full thickness and is unmistakably there, not a hard-to-see hairline. -->
-        <Style Selector="ScrollBar /template/ Thumb">
-            <Setter Property="RenderTransform" Value="none" />
         </Style>
     </Application.Styles>
 
     <Application.Resources>
+        <!-- Draw the scrollbar thumb at full thickness always, never a thin
+             hover-only sliver. The Fluent theme collapses the thumb to a hairline
+             by putting a scaleX(0.125)/scaleY(0.125) RenderTransform DIRECTLY on the
+             thumb in its template (a local value the IsExpanded hover state clears).
+             A style setter cannot beat a local value, so a "RenderTransform=none"
+             style on the thumb does nothing - override the resource that local value
+             resolves to instead. This is what actually fixes the collapsed bar; the
+             earlier style-based attempt (#1422) silently stopped working when Avalonia
+             moved the transform onto the thumb as a local value (11.3). -->
+        <TransformOperations x:Key="VerticalSmallScrollThumbScaleTransform">none</TransformOperations>
+        <TransformOperations x:Key="HorizontalSmallScrollThumbScaleTransform">none</TransformOperations>
+
         <SolidColorBrush x:Key="PanelBackground" Color="#1E1E1E" />
         <SolidColorBrush x:Key="SidebarBackground" Color="#252526" />
         <SolidColorBrush x:Key="ButtonBackground" Color="#3C3C3C" />

--- a/src/CcDirector.GatewayApp/App.axaml
+++ b/src/CcDirector.GatewayApp/App.axaml
@@ -3,5 +3,18 @@
              x:Class="CcDirector.GatewayApp.App">
     <Application.Styles>
         <FluentTheme />
+        <!-- Scrollbars are controls, not hover-revealed decoration: don't fade out. -->
+        <Style Selector="ScrollViewer">
+            <Setter Property="AllowAutoHide" Value="False" />
+        </Style>
     </Application.Styles>
+
+    <Application.Resources>
+        <!-- Draw the scrollbar thumb at full thickness always, never a thin hover-only
+             sliver. The Fluent theme collapses the thumb with a scaleX/scaleY(0.125)
+             RenderTransform set as a local value on the thumb (which a style setter
+             cannot beat), so override the resource that transform resolves to. -->
+        <TransformOperations x:Key="VerticalSmallScrollThumbScaleTransform">none</TransformOperations>
+        <TransformOperations x:Key="HorizontalSmallScrollThumbScaleTransform">none</TransformOperations>
+    </Application.Resources>
 </Application>

--- a/src/CcDirector.Launcher/App.axaml
+++ b/src/CcDirector.Launcher/App.axaml
@@ -3,5 +3,18 @@
              x:Class="CcDirector.Launcher.App">
     <Application.Styles>
         <FluentTheme />
+        <!-- Scrollbars are controls, not hover-revealed decoration: don't fade out. -->
+        <Style Selector="ScrollViewer">
+            <Setter Property="AllowAutoHide" Value="False" />
+        </Style>
     </Application.Styles>
+
+    <Application.Resources>
+        <!-- Draw the scrollbar thumb at full thickness always, never a thin hover-only
+             sliver. The Fluent theme collapses the thumb with a scaleX/scaleY(0.125)
+             RenderTransform set as a local value on the thumb (which a style setter
+             cannot beat), so override the resource that transform resolves to. -->
+        <TransformOperations x:Key="VerticalSmallScrollThumbScaleTransform">none</TransformOperations>
+        <TransformOperations x:Key="HorizontalSmallScrollThumbScaleTransform">none</TransformOperations>
+    </Application.Resources>
 </Application>

--- a/tools/cc-director-setup-avalonia/App.axaml
+++ b/tools/cc-director-setup-avalonia/App.axaml
@@ -4,5 +4,18 @@
     <Application.Styles>
         <FluentTheme />
         <StyleInclude Source="avares://cc-director-setup/Styles.axaml" />
+        <!-- Scrollbars are controls, not hover-revealed decoration: don't fade out. -->
+        <Style Selector="ScrollViewer">
+            <Setter Property="AllowAutoHide" Value="False" />
+        </Style>
     </Application.Styles>
+
+    <Application.Resources>
+        <!-- Draw the scrollbar thumb at full thickness always, never a thin hover-only
+             sliver. The Fluent theme collapses the thumb with a scaleX/scaleY(0.125)
+             RenderTransform set as a local value on the thumb (which a style setter
+             cannot beat), so override the resource that transform resolves to. -->
+        <TransformOperations x:Key="VerticalSmallScrollThumbScaleTransform">none</TransformOperations>
+        <TransformOperations x:Key="HorizontalSmallScrollThumbScaleTransform">none</TransformOperations>
+    </Application.Resources>
 </Application>


### PR DESCRIPTION
The collapsed terminal scrollbar in the Director is back.

The earlier fix (#1422) stripped the thumb RenderTransform with a style setter. In Avalonia 11.3 the Fluent theme moved the collapse transform onto the thumb as a **local value** in the template (`scaleX/scaleY(0.125)`). A style setter cannot beat a local value, so that fix silently stopped working once the app floated to 11.3 and the thumb collapsed back to a hairline that only appears at full width on hover.

Fix: override the resource the local value resolves to (`VerticalSmallScrollThumbScaleTransform` / `HorizontalSmallScrollThumbScaleTransform` -> `none`) at application scope. DynamicResource lookup finds the app-level override, so the thumb renders unscaled (full thickness) in every state.

Applied to all five Avalonia apps (Director, GatewayApp, Launcher, AgentBrain panel, setup wizard) so there are no collapsible scrollbars anywhere. Also kept `AllowAutoHide=False` app-wide.

Verified in a running Director build: the terminal scrollbar thumb now renders as a solid full-width block, not a thin pill. All five projects build clean.