### PR TITLE
fix(dictation): close Cockpit voice-reply warning gap + Car Mode short-command & hands-free edge cases

### DIFF
--- a/apps/cockpit/src/sessions/VoiceTab.tsx
+++ b/apps/cockpit/src/sessions/VoiceTab.tsx
@@ -175,12 +175,19 @@ export function VoiceTab({ sessionId }: { sessionId: string | undefined }) {
         )}
       </div>
 
-      {/* Reply: the shared dictation interface with NO Insert - Send goes straight into the session. */}
+      {/* Reply: the shared dictation interface with NO Insert - Send goes straight into the session.
+          Deliberately NOT wired to the fire-and-forget onSendAudio path, matching SessionComposer: that
+          path is the durable /dictation/* background pipeline, which is not tenant-aware on the hosted
+          Gateway (blocker #1884) - so a hosted-Cockpit send-direct through it resolves an empty partition
+          and holds forever with no feedback (the Cockpit mounts no DictationStatusStrip). Omitting
+          onSendAudio makes the dialog use the blocking commit path (transcribeUtterance -> the tenant-safe
+          /wingman/utterance/* route), which ALSO surfaces a dropped-audio capture-loss warning in the
+          dialog itself (it parks instead of committing), so a Cockpit voice reply that lost audio is never
+          silent - closing the one gap where the warning was published but had no strip to show it. */}
       {v.responding && (
         <DictationDialog
           showInsert={false}
           onSend={(text) => void v.onRespondSend(text)}
-          onSendAudio={v.onRespondSendAudio}
           onClose={() => v.setResponding(false)}
         />
       )}

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -208,6 +208,13 @@ export interface UseCarModeOptions {
 const KEEP_WARM_MS = 3 * 60 * 1000;
 // A snapshot smaller than this is just the container header with no real audio - skip transcribing it.
 const MIN_CLIP_BYTES = 2000;
+
+// The shortest decoded audio the button ("Over and out") path treats as a real command (defect 4). The old
+// gate rejected any clip under ~2000 compressed bytes (~0.67 s of Opus), which silently dropped short spoken
+// commands like "stop" or "yes". Gating on DECODED duration instead lets a real word through while still
+// rejecting an empty tap or stray click - below roughly one syllable there is no command, only noise the
+// transcription model would hallucinate a word from.
+const MIN_COMMAND_SECONDS = 0.2;
 // The default hands-free sign-off phrase; the page can override it with the owner's configured phrase.
 const DEFAULT_END_PHRASE = "over and out";
 // How often, while Listening, the captured audio is re-transcribed to check whether it now ends with the
@@ -969,9 +976,26 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     // resolve on an already-queued earlier chunk under load. Stopping here is safe: this turn is over
     // and takeTurn releases the microphone before Thinking anyway (its own stop then no-ops).
     const clip = prefetched ? prefetched.clip : rec.isRecording ? await rec.stop() : rec.snapshot();
-    if (!prefetched && clip.size < MIN_CLIP_BYTES) {
-      void takeTurn("", null); // nothing captured: a canned nudge, no server turn, no durable record
-      return;
+
+    // Button path: decode up-front and gate on ACTUAL decoded audio duration, not compressed bytes (defect
+    // 4). A short spoken command is well under the old byte floor yet is real speech, so the old check
+    // dropped it as "nothing captured". Gate on decoded duration instead: an empty tap / stray noise nudges,
+    // a real command passes. The decode is REUSED for the transcribe below, so it is never paid twice.
+    let buttonDecoded: Awaited<ReturnType<typeof blobToWav16kMono>> | null = null;
+    let buttonTranscodeMs = 0;
+    if (!prefetched) {
+      const decodeStart = performance.now();
+      try {
+        buttonDecoded = await blobToWav16kMono(clip);
+      } catch {
+        void takeTurn("", null); // empty / undecodable tap: a canned nudge, never a held error
+        return;
+      }
+      buttonTranscodeMs = performance.now() - decodeStart;
+      if (buttonDecoded.decodedSeconds < MIN_COMMAND_SECONDS) {
+        void takeTurn("", null); // essentially no speech captured: a canned nudge, no server turn
+        return;
+      }
     }
 
     // Persist the command audio to the durable store BEFORE any transcribe, so a connection drop mid-turn
@@ -1007,11 +1031,10 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       } else {
         setCaptureState("transcribing");
         transcribeAttemptsRef.current += 1;
-        // Measure the client-side transcode (phone CPU) separately from the transcribe round trip (network +
-        // server), so a real phone turn shows where the time actually goes.
-        const transcodeStart = performance.now();
-        const decoded = await blobToWav16kMono(clip);
-        transcodeMs = performance.now() - transcodeStart;
+        // Reuse the up-front decode from the duration gate above (the phone-CPU transcode cost is already
+        // paid and measured), so the button path decodes the clip exactly once.
+        const decoded = buttonDecoded!;
+        transcodeMs = buttonTranscodeMs;
         decodedSeconds = decoded.decodedSeconds;
         transcript = (await transcribeCarModeAudio(decoded.wav)).trim();
       }
@@ -1142,7 +1165,13 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       stopThinkingCue();
       thinkingCueStopRef.current = startThinkingCue();
       stopEndPhraseWatch();
-      void transcribeAndTake({ transcript, transcodeMs, pauseDetectedAt: startedAt, clip, decodedSeconds: decoded.decodedSeconds });
+      // Defect 3: the flushed snapshot used to DETECT the sign-off can, under load, resolve on an
+      // already-queued earlier chunk (its documented residual race) - fine for detection, but the PERSISTED
+      // command audio must be complete. Re-capture race-free via stop(), which resolves only after
+      // MediaRecorder's final buffered chunk, and commit THAT; fall back to the detection snapshot if the
+      // recorder already stopped. The transcript is unchanged - the snapshot provably contained the sign-off.
+      const committedClip = rec.isRecording ? await rec.stop() : clip;
+      void transcribeAndTake({ transcript, transcodeMs, pauseDetectedAt: startedAt, clip: committedClip, decodedSeconds: decoded.decodedSeconds });
     } catch (err) {
       // A failed rolling transcribe must not kill the turn - skip this tick and try again next second. But
       // a dead zone must not silently swallow "over and out" forever: after several consecutive failures,


### PR DESCRIPTION
Finishes the dictation coverage from the sweep: the Cockpit voice-reply gap and the two deferred Car Mode items.

## Cockpit voice-reply gap
Cockpit's voice reply wired the fire-and-forget `onSendAudio` path (the durable `/dictation/*` pipeline), which is not tenant-aware on the hosted Gateway (blocker thefrederiksen/devthrottle_internal#889) and holds forever with no feedback - and Cockpit mounts no status strip, so a dropped-audio Send there was **silent**. Removing `onSendAudio` makes the dialog fall back to the blocking commit path (the tenant-safe `/wingman/utterance` route the main composer already uses), which surfaces the capture-loss warning **in the dialog** (it parks instead of committing). So a Cockpit voice reply that lost audio is never silent - and this also removes the latent thefrederiksen/devthrottle_internal#889 exposure, matching SessionComposer.

## Car Mode short-command drop (defect 4)
"Over and out" (button path) rejected any clip under ~2000 compressed bytes (~0.67s of Opus), silently dropping short commands like "stop"/"yes". Now it gates on **decoded audio duration** (~0.2s, roughly one syllable) instead - a real word passes, an empty tap or stray click still nudges - and the decode is reused for the transcribe, so it is paid once (no magic byte number, no device measurement needed).

## Car Mode hands-free race (defect 3)
The hands-free sign-off persisted the flushed detection snapshot, which under load can resolve on an earlier chunk. It now re-captures the committed clip race-free via `stop()` (resolves only after the final buffered chunk); the transcript is unchanged - the snapshot provably held the sign-off.

## Proof
- All three TypeScript workspaces typecheck; client-core 586/586; cockpit and mobile both build.
- Behavior (in-dialog warning on Cockpit voice reply, a short Car Mode command surviving, the race-free hands-free clip) is runtime QA - these live in a React hook / component with no unit harness.

## Note
`.NET` CI is red on pre-existing `SessionServingLoopIsolationTests`, unrelated (this PR is TypeScript only).
