### PR TITLE
fix(gateway): deny the /launcher-stream hub on hosted (tenant-blind machine collision)

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedLauncherHubDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherHubDenyTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Audit gap (audit-a/e): the <c>/launcher-stream</c> SignalR hub was the ONE launcher/machine writer #1917's
+/// HTTP deny did not cover. The HTTP family (<c>/launchers</c> + <c>/machines</c>) is denied on hosted through
+/// <see cref="HostedRouteDeny.ExclusiveGroup"/>, but the hub was mapped unconditionally in
+/// <c>GatewayHost.ConfigurePipeline</c>. <c>LauncherHub.Hello</c> resolves NO tenant (unlike
+/// <c>DirectorHub.Hello</c>, which aborts when the device key resolves to no tenant), and
+/// <c>LauncherConnectionRegistry</c> keys one active connection per BARE machine name. So on hosted:
+///
+///   1. Tenant B connects a launcher for machine X -> <c>_byMachine[X] = connB</c>.
+///   2. Tenant A connects a launcher and Hellos as the same machine name X -> <c>RegisterConnection</c>
+///      overwrites <c>_byMachine[X] = connA</c>, SUPERSEDING tenant B's active connection across tenants.
+///
+/// There is no per-tenant ownership of a physical machine on shared hosted infrastructure - the same reason
+/// #1917 chose a DENY over a partition. So the consistent close is to DENY the hub on hosted: on hosted the
+/// hub is never mapped, so no launcher can join and no bare-machine-keyed connection row is ever written.
+/// Self-host keeps the hub exactly as before.
+///
+/// <see cref="Cross_tenant_replacement_is_impossible_because_the_hub_is_denied_on_hosted"/> is the
+/// reproduction turned revert-proof: on CURRENT main the two connections both join and the second replaces the
+/// first (the collision); with the deny in place the connect itself fails, so the collision cannot occur.
+/// Re-map the hub on hosted and this reddens. <see cref="The_hub_still_serves_on_self_host"/> is the control -
+/// it stays green through that revert, because a hub that is denied EVERYWHERE would pass the deny test while
+/// breaking self-host.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class HostedLauncherHubDenyTests : IAsyncLifetime
+{
+    private const string Token = "test-token-launcher-hub-deny";
+    private const string Machine = "SHARED-MACHINE-X";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string? _priorHosted;
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-launcher-hub-deny-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+
+    public HostedLauncherHubDenyTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-launcher-hub-deny-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        if (_gateway is not null)
+            await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch (Exception) { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch (Exception) { /* best effort */ }
+    }
+
+    private async Task StartGatewayAsync(bool hosted)
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : "0");
+        Assert.Equal(hosted, GatewayHostedMode.IsHosted);
+
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+    }
+
+    /// <summary>
+    /// THE REPRODUCTION, REVERT-PROOF. Two enrolled tenants each bind a device key, then each dials the
+    /// launcher hub claiming the SAME machine name. On CURRENT main both would join and tenant A's Hello would
+    /// replace tenant B's active connection in the bare-machine-keyed registry (cross-tenant supersession).
+    /// With the hub denied on hosted, the connect fails at negotiate (the route is not mapped), so neither
+    /// launcher ever joins and the registry stays empty - there is no shared row to collide on.
+    ///
+    /// Re-map <c>LauncherHub</c> on hosted (the revert) and the first connect succeeds instead of throwing,
+    /// reddening this test.
+    /// </summary>
+    [Fact]
+    public async Task Cross_tenant_replacement_is_impossible_because_the_hub_is_denied_on_hosted()
+    {
+        await StartGatewayAsync(hosted: true);
+
+        // Two fully enrolled, tenant-bound device keys - the strongest callers hosted has. Neither may reach
+        // the hub: a physical machine is not owned by a tenant on shared hardware.
+        var keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        var tenantB = _gateway.TenantRegistry.MintOrLookupBySubject("sub-bob", "bob@example.com");
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", tenantB.Value);
+
+        var keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        var tenantA = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", tenantA.Value);
+
+        // Tenant B's launcher cannot even establish the connection: /launcher-stream is not mapped on hosted,
+        // so negotiate 404s and StartAsync throws. That is the whole collision closed at the transport.
+        await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await using var connB = await ConnectLauncherAsync(keyB);
+        });
+
+        await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await using var connA = await ConnectLauncherAsync(keyA);
+        });
+
+        // The registry was never written by either tenant - there is no bare-machine-keyed row to supersede.
+        Assert.False(_gateway.LauncherConnections.IsStreamConnected(Machine));
+        Assert.Null(_gateway.LauncherConnections.GetActiveConnectionId(Machine));
+    }
+
+    /// <summary>
+    /// THE CONTROL. Off hosted the hub is mapped exactly as before: a launcher joins, Hello binds the machine,
+    /// and the connection is registered. This stays green through the revert on
+    /// <see cref="Cross_tenant_replacement_is_impossible_because_the_hub_is_denied_on_hosted"/> - a hub denied
+    /// everywhere would pass the deny test while silently breaking self-host, so the deny must be proved to be
+    /// scoped to hosted, not universal.
+    /// </summary>
+    [Fact]
+    public async Task The_hub_still_serves_on_self_host()
+    {
+        await StartGatewayAsync(hosted: false);
+
+        await using var conn = await ConnectLauncherAsync(Token);
+        conn.On<LauncherCommand, LauncherCommandResult>("Command", _ => Task.FromResult(LauncherCommandResult.Ok()));
+
+        await conn.InvokeAsync("Hello", new LauncherStreamHello { MachineName = Machine, Port = 7878, Version = "test" });
+
+        Assert.True(_gateway.LauncherConnections.IsStreamConnected(Machine));
+    }
+
+    private async Task<HubConnection> ConnectLauncherAsync(string token)
+    {
+        var conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/launcher-stream", options =>
+            {
+                options.AccessTokenProvider = () => Task.FromResult<string?>(token);
+            })
+            .Build();
+        await conn.StartAsync();
+        return conn;
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1745,11 +1745,28 @@ public sealed class GatewayHost : IAsyncDisposable
         _app.MapHub<Streaming.DirectorHub>("/director-stream");
         FileLog.Write("[GatewayHost] DirectorHub mapped at /director-stream; /sessions serves from the push cache when fresh");
 
-        // launcher-persistent-join: the launcher-push stream endpoint, also mandatory. When a launcher
-        // joins, the machine lifecycle relay pushes commands DOWN this stream instead of dialing the
-        // launcher's REST API.
-        _app.MapHub<Streaming.LauncherHub>("/launcher-stream");
-        FileLog.Write("[GatewayHost] LauncherHub mapped at /launcher-stream; machine lifecycle relay prefers the stream when a launcher is joined");
+        // launcher-persistent-join: the launcher-push stream endpoint. When a launcher joins, the machine
+        // lifecycle relay pushes commands DOWN this stream instead of dialing the launcher's REST API.
+        //
+        // DENIED ON HOSTED, consistent with #1917's deny of the /launchers + /machines HTTP family. The hub is
+        // the ONE launcher/machine writer that HTTP deny did not cover: LauncherHub.Hello resolves NO tenant
+        // (unlike DirectorHub.Hello, which aborts when the device key resolves to no tenant), and
+        // LauncherConnectionRegistry keys one active connection per BARE machine name. So on hosted a launcher
+        // Hello for machine X supersedes ANY other tenant's active connection for the same name - a cross-tenant
+        // collision. A physical machine is not owned by a tenant on shared hosted infrastructure, so there is no
+        // per-tenant answer to serve here, only a leak to close: the hub is NOT MAPPED on hosted, exactly as the
+        // HTTP family's handlers are not mapped, so no launcher can join and no bare-machine-keyed row is ever
+        // written. Self-host maps the hub unchanged. Un-denying requires a launcher/machine tenant-ownership
+        // model AND a purge of the launcher + launcher-connection registries.
+        if (GatewayHostedMode.IsHosted)
+        {
+            FileLog.Write("[GatewayHost] LauncherHub DENIED on hosted (no per-tenant machine ownership) - /launcher-stream is not mapped; launcher/machine control is self-host only");
+        }
+        else
+        {
+            _app.MapHub<Streaming.LauncherHub>("/launcher-stream");
+            FileLog.Write("[GatewayHost] LauncherHub mapped at /launcher-stream; machine lifecycle relay prefers the stream when a launcher is joined");
+        }
 
         // Product version stamped by Directory.Build.props; full form carries the commit SHA.
         var version = AppVersion.Full;


### PR DESCRIPTION
## Root cause

`#1917` denied the launcher/machine HTTP family (`/launchers` + `/machines`) on the hosted Gateway because a physical machine has no per-tenant ownership on shared infrastructure. The `/launcher-stream` SignalR hub was the **one launcher/machine writer that deny did not cover**:

- In `GatewayHost.ConfigurePipeline` the hub was mapped unconditionally.
- `LauncherHub.Hello` resolves **no tenant** - unlike `DirectorHub.Hello`, which aborts when the authenticated device key resolves to no tenant.
- `LauncherConnectionRegistry` keys **one active connection per bare machine name**, and a new Hello for that name supersedes the prior connection.

So on hosted, tenant B connects a launcher for machine X, then tenant A Hellos as the same machine name X and **replaces tenant B's active connection across tenants**.

## Reproduced-real (verify-first)

A temporary two-tenant reproduction booted a real hosted `GatewayHost` (`CC_GATEWAY_HOSTED=1`, stream mode), enrolled two device keys bound to two tenants, and had both dial `/launcher-stream` claiming the same machine name. On current main the second Hello superseded the first's active connection id. The reproduction **passed on main** - the collision is real - then was deleted.

## Fix

Deny the hub on hosted, consistent with `#1917` (launcher/machine control has no per-tenant hosted story). On hosted the hub is **not mapped** - exactly as the HTTP family's handlers are not mapped - so no launcher can join (`/launcher-stream` negotiate 404s) and no bare-machine-keyed row is ever written. Self-host maps the hub unchanged.

**Touches `GatewayHost.cs` (serializes at merge).**

Un-deny requires a launcher/machine tenant-ownership model **plus** a purge of the launcher + launcher-connection registries (same un-deny instruction `#1917` records for the HTTP family).

## Tests

New `HostedLauncherHubDenyTests`:
- `Cross_tenant_replacement_is_impossible_because_the_hub_is_denied_on_hosted` - reproduction turned revert-proof: on hosted both tenant connects fail at negotiate and the registry stays empty.
- `The_hub_still_serves_on_self_host` - control: off hosted the hub is mapped, Hello binds, connection registered. Stays green through the revert.

**Revert-proof verified:** re-mapping the hub on hosted reddens the deny test on its `ThrowsAny` assertion while the self-host control stays green.

## Gates

- `dotnet build` gateway 0/0, test project 0/0.
- Targeted run (29 tests, all pass): `HostedLauncherHubDenyTests`, `LauncherStreamIntegrationTests`, `HostedLauncherMachineDenyTests`, `LauncherConnectionRegistryTests`, plus the solo tenancy filters `OnOneRoute_TheCredentialAloneDecidesWhetherATenantScopeExists` and `The_roster_and_the_commands_agree`.