### PR TITLE
fix(gateway): tenant-scope the session-state event emitter (audit)

### DIFF
--- a/src/CcDirector.Gateway.Tests/SessionStateEventEmitterTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionStateEventEmitterTests.cs
@@ -1,5 +1,8 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Governance;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.Tests.Data;
 using Xunit;
 
@@ -9,7 +12,9 @@ namespace CcDirector.Gateway.Tests;
 /// Tests for the session state-transition emitter (issue #1771, spine item 2). The claims that matter: the
 /// four activity states map to ledger states and Starting/Exited do not; an event lands only on a real change
 /// (a heartbeat repeat is skipped); a session that exits mid-wait gets one closing event so its wait is not
-/// overcounted; a session that exits while active needs no closer; and a restarted session re-emits.
+/// overcounted; a session that exits while active needs no closer; a restarted session re-emits; and - the
+/// Hosted Multi-Tenancy claim - two tenants sharing a raw session id keep independent dedup memory and
+/// independent ledger rows (a bare session key let one tenant suppress or steal another's transitions).
 /// </summary>
 public sealed class SessionStateEventEmitterTests : IDisposable
 {
@@ -17,10 +22,12 @@ public sealed class SessionStateEventEmitterTests : IDisposable
 
     public void Dispose() => _h.Dispose();
 
+    // Self-host shape: one Local tenant, an inert boundary (EnterScope is a no-op off the async-local path).
     private (SessionStateEventEmitter Emitter, GovernanceEventLedger Ledger) New()
     {
         var ledger = new GovernanceEventLedger(_h.Open());
-        return (new SessionStateEventEmitter(ledger), ledger);
+        var boundary = new HostedTenantBoundary(new SingleTenantContext(), new DeviceRegistry());
+        return (new SessionStateEventEmitter(ledger, boundary), ledger);
     }
 
     private List<string> StatesFor(GovernanceEventLedger ledger, string sessionId) =>
@@ -52,10 +59,10 @@ public sealed class SessionStateEventEmitterTests : IDisposable
     public void Observe_emits_only_on_a_real_transition()
     {
         var (emitter, ledger) = New();
-        emitter.Observe("s1", "Working");
-        emitter.Observe("s1", "Working");          // heartbeat repeat - no new event
-        emitter.Observe("s1", "WaitingForInput");
-        emitter.Observe("s1", "WaitingForInput");  // repeat - no new event
+        emitter.Observe(TenantId.Local, "s1", "Working");
+        emitter.Observe(TenantId.Local, "s1", "Working");          // heartbeat repeat - no new event
+        emitter.Observe(TenantId.Local, "s1", "WaitingForInput");
+        emitter.Observe(TenantId.Local, "s1", "WaitingForInput");  // repeat - no new event
 
         var states = StatesFor(ledger, "s1");
         Assert.Equal(2, states.Count);
@@ -67,7 +74,7 @@ public sealed class SessionStateEventEmitterTests : IDisposable
     public void Observe_skips_starting_and_emits_nothing()
     {
         var (emitter, ledger) = New();
-        emitter.Observe("s1", "Starting");
+        emitter.Observe(TenantId.Local, "s1", "Starting");
         Assert.Empty(ledger.List(sessionId: "s1"));
     }
 
@@ -75,8 +82,8 @@ public sealed class SessionStateEventEmitterTests : IDisposable
     public void Exit_while_waiting_emits_one_closing_event()
     {
         var (emitter, ledger) = New();
-        emitter.Observe("s1", "WaitingForInput"); // open wait
-        emitter.Observe("s1", "Exited");          // exits mid-wait -> close the interval honestly
+        emitter.Observe(TenantId.Local, "s1", "WaitingForInput"); // open wait
+        emitter.Observe(TenantId.Local, "s1", "Exited");          // exits mid-wait -> close the interval honestly
 
         var states = StatesFor(ledger, "s1");
         Assert.Equal(2, states.Count);
@@ -88,8 +95,8 @@ public sealed class SessionStateEventEmitterTests : IDisposable
     public void Exit_while_active_emits_no_closing_event()
     {
         var (emitter, ledger) = New();
-        emitter.Observe("s1", "Working"); // active, no open wait
-        emitter.Observe("s1", "Exited");  // no closer needed
+        emitter.Observe(TenantId.Local, "s1", "Working"); // active, no open wait
+        emitter.Observe(TenantId.Local, "s1", "Exited");  // no closer needed
 
         var states = StatesFor(ledger, "s1");
         Assert.Single(states);
@@ -100,11 +107,65 @@ public sealed class SessionStateEventEmitterTests : IDisposable
     public void A_restarted_session_after_exit_re_emits_its_first_state()
     {
         var (emitter, ledger) = New();
-        emitter.Observe("s1", "Working");
-        emitter.Observe("s1", "Exited");  // forgets s1 (no open wait, no closer)
-        emitter.Observe("s1", "Working"); // a fresh transition after the guard was cleared
+        emitter.Observe(TenantId.Local, "s1", "Working");
+        emitter.Observe(TenantId.Local, "s1", "Exited");  // forgets s1 (no open wait, no closer)
+        emitter.Observe(TenantId.Local, "s1", "Working"); // a fresh transition after the guard was cleared
 
         var active = ledger.List(sessionId: "s1", state: GovernanceEventState.Active);
         Assert.Equal(2, active.Count);
+    }
+
+    [Fact]
+    public void Two_tenants_sharing_a_session_id_keep_independent_transitions()
+    {
+        // Hosted shape: an async-local context, so the emitter's per-observation EnterScope actually scopes
+        // each ledger write to its owning tenant. One database file, two tenants, one shared raw session id.
+        var ctx = new AsyncLocalTenantContext();
+        var writeLedger = new GovernanceEventLedger(_h.Open(ctx));
+        var boundary = new HostedTenantBoundary(ctx, new DeviceRegistry());
+        var emitter = new SessionStateEventEmitter(writeLedger, boundary);
+
+        var alpha = new TenantId("alpha");
+        var beta = new TenantId("beta");
+
+        // Both accounts run a session that happens to share the raw id "s1".
+        emitter.Observe(alpha, "s1", "Working");
+        emitter.Observe(beta, "s1", "Working");           // must NOT be suppressed by alpha's dedup slot
+        emitter.Observe(alpha, "s1", "WaitingForInput");
+        emitter.Observe(beta, "s1", "WaitingForInput");
+
+        // Read each tenant's ledger in isolation via the global query filter (fresh contexts, same file).
+        var alphaStates = StatesFor(new GovernanceEventLedger(_h.Open(new FixedTenantContext(alpha))), "s1");
+        var betaStates = StatesFor(new GovernanceEventLedger(_h.Open(new FixedTenantContext(beta))), "s1");
+
+        // Neither tenant suppressed the other, and no row crossed over: each sees exactly its own two states.
+        Assert.Equal(2, alphaStates.Count);
+        Assert.Contains(GovernanceEventState.Active, alphaStates);
+        Assert.Contains(GovernanceEventState.WaitingOnHuman, alphaStates);
+
+        Assert.Equal(2, betaStates.Count);
+        Assert.Contains(GovernanceEventState.Active, betaStates);
+        Assert.Contains(GovernanceEventState.WaitingOnHuman, betaStates);
+    }
+
+    [Fact]
+    public void One_tenants_exit_does_not_clear_anothers_dedup_memory()
+    {
+        var ctx = new AsyncLocalTenantContext();
+        var writeLedger = new GovernanceEventLedger(_h.Open(ctx));
+        var boundary = new HostedTenantBoundary(ctx, new DeviceRegistry());
+        var emitter = new SessionStateEventEmitter(writeLedger, boundary);
+
+        var alpha = new TenantId("alpha");
+        var beta = new TenantId("beta");
+
+        emitter.Observe(alpha, "s1", "Working");
+        emitter.Observe(beta, "s1", "Working");
+        emitter.Observe(alpha, "s1", "Exited");   // forgets ONLY alpha's s1
+        emitter.Observe(beta, "s1", "Working");   // a repeat for beta - still deduped, must NOT re-emit
+
+        var betaActive = new GovernanceEventLedger(_h.Open(new FixedTenantContext(beta)))
+            .List(sessionId: "s1", state: GovernanceEventState.Active);
+        Assert.Single(betaActive); // beta emitted Active once; alpha's exit did not reset beta's dedup guard
     }
 }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -786,7 +786,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // sandbox decisions on the EF data layer, so a Gateway restart never loses a recorded audit fact.
         _governanceAudit = new Governance.GovernanceAuditLog(_gatewayDb);
         _sessionSpendEmitter = new Governance.SessionSpendEmitter(_sessionSpend);
-        _sessionStateEmitter = new Governance.SessionStateEventEmitter(_governanceEvents);
+        _sessionStateEmitter = new Governance.SessionStateEventEmitter(_governanceEvents, _tenantBoundary);
         // The weekly Outcome Ledger reporter (issue #1771, spine item 4): read-only over the run tables +
         // event ledger + spend + audit trail. No store of its own.
         _outcomeLedger = new Governance.OutcomeLedgerReporter(_gatewayDb);
@@ -1833,7 +1833,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 // breaks the turn tracking above).
                 try
                 {
-                    _sessionStateEmitter.Observe(sessionId, newState);
+                    _sessionStateEmitter.Observe(owningTenant, sessionId, newState);
                 }
                 catch (Exception ex)
                 {

--- a/src/CcDirector.Gateway/Governance/SessionStateEventEmitter.cs
+++ b/src/CcDirector.Gateway/Governance/SessionStateEventEmitter.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Tenancy;
 
 namespace CcDirector.Gateway.Governance;
 
@@ -16,64 +18,80 @@ namespace CcDirector.Gateway.Governance;
 /// waiting-on-human / waiting-on-permission / blocked this emits one closing event at the true exit time.
 /// <see cref="ActivityState"/>'s Starting and Exited are lifecycle, not activity states, so they are not
 /// emitted as-is (and the ledger would reject them anyway).
+///
+/// Hosted Multi-Tenancy: every observation carries its OWNING tenant. The tenant is half of the dedup key and
+/// scopes the ledger append, so two accounts that happen to share a raw session id never collide - a bare
+/// session key let one tenant suppress another's real transition (or clear it on exit) and let the ledger row
+/// land under the wrong tenant. A name is a label, not an authority; the address is (tenant, session id).
 /// </summary>
 public sealed class SessionStateEventEmitter
 {
     private readonly GovernanceEventLedger _ledger;
+    private readonly HostedTenantBoundary _tenants;
 
-    // The last ledger state emitted per session, so an event lands only on a real change. Cleared on exit so
-    // the map does not grow without bound. Per-session observations are ordered by the funnel, so the
-    // read-then-write is effectively serial per session; a rare race would at worst emit a duplicate the
-    // reader tolerates.
-    private readonly ConcurrentDictionary<string, string> _lastState = new(StringComparer.Ordinal);
+    // The last ledger state emitted per (tenant, session), so an event lands only on a real change. Cleared on
+    // exit so the map does not grow without bound. Keyed by the OWNING tenant AND the session id - never the
+    // bare session id - so two tenants sharing a raw session identifier keep independent dedup memory.
+    // Per-session observations are ordered by the funnel, so the read-then-write is effectively serial per
+    // key; a rare race would at worst emit a duplicate the reader tolerates. Self-host uses TenantId.Local.
+    private readonly ConcurrentDictionary<(TenantId Tenant, string SessionId), string> _lastState = new();
 
-    public SessionStateEventEmitter(GovernanceEventLedger ledger)
+    public SessionStateEventEmitter(GovernanceEventLedger ledger, HostedTenantBoundary tenants)
     {
         _ledger = ledger ?? throw new ArgumentNullException(nameof(ledger));
+        _tenants = tenants ?? throw new ArgumentNullException(nameof(tenants));
     }
 
     /// <summary>
-    /// Observe a session's reported activity state. Appends a ledger event on a real transition; on exit,
-    /// closes an open wait/block interval at the true exit time and forgets the session.
+    /// Observe a session's reported activity state under its OWNING tenant. Appends a ledger event on a real
+    /// transition; on exit, closes an open wait/block interval at the true exit time and forgets the session.
+    /// The tenant scopes both the dedup memory and the ledger write, so a shared session id never collides.
     /// </summary>
-    public void Observe(string sessionId, string? activityState)
+    public void Observe(TenantId tenant, string sessionId, string? activityState)
     {
         if (string.IsNullOrEmpty(sessionId))
             return;
 
+        var key = (tenant, sessionId);
         var mapped = MapState(activityState);
         if (mapped is null)
         {
             // Not one of the six ledger states. On exit, close any open wait/block interval at the true exit
             // (so a mid-wait exit is not overcounted to the window end), then forget the session.
             if (IsExit(activityState) &&
-                _lastState.TryRemove(sessionId, out var lastOnExit) &&
+                _lastState.TryRemove(key, out var lastOnExit) &&
                 IsOpenInterval(lastOnExit))
             {
-                Append(sessionId, GovernanceEventState.Recovered);
+                Append(tenant, sessionId, GovernanceEventState.Recovered);
             }
             return;
         }
 
         // A real transition only - a heartbeat re-reporting the current state must not append a duplicate.
-        var previous = _lastState.GetValueOrDefault(sessionId);
+        var previous = _lastState.GetValueOrDefault(key);
         if (string.Equals(previous, mapped, StringComparison.Ordinal))
             return;
 
-        _lastState[sessionId] = mapped;
-        Append(sessionId, mapped);
+        _lastState[key] = mapped;
+        Append(tenant, sessionId, mapped);
     }
 
-    private void Append(string sessionId, string state)
+    private void Append(TenantId tenant, string sessionId, string state)
     {
-        _ledger.Append(new AppendGovernanceEventRequest
+        // The ledger is a tenant-scoped store: its append stamps the AMBIENT tenant. This funnel runs off the
+        // doorbell/heartbeat with no request scope, so enter the owning tenant's scope for the write - the
+        // sibling turn-end watcher is handed the same tenant explicitly. Inert on self-host (Local).
+        using (_tenants.EnterScope(tenant))
         {
-            SubjectKind = GovernanceEventSubject.Session,
-            SessionId = sessionId,
-            State = state,
-            OccurredUtc = null, // the Gateway stamps the append time
-        });
-        FileLog.Write($"[SessionStateEventEmitter] Append: session={sessionId}, state={state}");
+            _ledger.Append(new AppendGovernanceEventRequest
+            {
+                SubjectKind = GovernanceEventSubject.Session,
+                SessionId = sessionId,
+                State = state,
+                OccurredUtc = null, // the Gateway stamps the append time
+            });
+        }
+        FileLog.Write($"[SessionStateEventEmitter] Append: tenant={tenant.ToLogString()}, session={sessionId}, state={state}");
     }
 
     /// <summary>


### PR DESCRIPTION
## What
The governance `SessionStateEventEmitter` keyed its per-session dedup map by the **bare session id** and appended to the tenant-scoped ledger under the **ambient** tenant. On the hosted Gateway, two accounts sharing a raw session id collide: one tenant can suppress or clear another's real state transition, and the ledger row can land under the wrong tenant (or throw off the doorbell/heartbeat funnel, which runs with no request scope).

## Fix
Thread the owning tenant - the same value already handed to the sibling turn-end watcher one line above in `GatewayHost` - into `Observe`. Key the dedup map by `(tenant, session id)` and enter the owning tenant's scope for the ledger append. Inert on self-host (`EnterScope(Local)` is a no-op; the map keys on `(Local, sid)`), so single-tenant behaviour is byte-identical.

## Tests
- Five existing tests updated to the new signature (Local, unchanged behaviour).
- Two new two-tenant isolation tests over one database file: transitions do not cross-suppress, and one tenant's exit does not clear another's dedup memory.
- **Revert-proven**: reintroducing the collision (`key = (Local, sid)`) makes the two-tenant test go red (Expected 2, Actual 0), so the test catches the bug rather than passing vacuously.

Closes the `SessionStateEventEmitter` row from the hosted-gateway control/retained-state audit.