### PR TITLE
fix(gateway): isolate the events feed by request tenant

### DIFF
--- a/src/CcDirector.Gateway.Tests/DirectorRouteTenantScopingTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorRouteTenantScopingTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using CcDirector.Core.Tenancy;
 using CcDirector.Gateway;
 using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
@@ -251,6 +252,61 @@ public sealed class DirectorRouteTenantScopingTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Events_feed_for_tenant_a_does_not_announce_tenant_b_director()
+    {
+        // Subscribe both accounts before B adds a new Director. B is the positive control that proves the real
+        // server-sent-events route is attached and publishing; A must see no event for the same registry change.
+        using var tenantASubscription = await SubscribeToEventsAsync(_keyA);
+        using var tenantBSubscription = await SubscribeToEventsAsync(_keyB);
+        using var tenantAReader = new StreamReader(await tenantASubscription.Content.ReadAsStreamAsync());
+        using var tenantBReader = new StreamReader(await tenantBSubscription.Content.ReadAsStreamAsync());
+
+        await using var tenantBDirector = await FakeTunnelDirector.StartAsync(
+            _gateway, _keyB, "dir-b-feed-only", "MB", dispatch: Recorder(new ConcurrentQueue<string>()));
+
+        using var positiveControlTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var tenantBEvent = await ReadNextEventDataAsync(tenantBReader, positiveControlTimeout.Token);
+        Assert.Contains("dir-b-feed-only", tenantBEvent);
+
+        using var isolationWindow = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await ReadNextEventDataAsync(tenantAReader, isolationWindow.Token));
+    }
+
+    [Fact]
+    public async Task Events_feed_with_no_bound_tenant_is_denied()
+    {
+        using var response = await SubscribeToEventsAsync(_keyUnbound);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Events_feed_for_tenant_a_does_not_announce_tenant_b_director_removal()
+    {
+        await using var tenantBDirector = await FakeTunnelDirector.StartAsync(
+            _gateway, _keyB, "dir-b-feed-remove", "MB", dispatch: Recorder(new ConcurrentQueue<string>()));
+
+        using var tenantASubscription = await SubscribeToEventsAsync(_keyA);
+        using var tenantBSubscription = await SubscribeToEventsAsync(_keyB);
+        using var tenantAReader = new StreamReader(await tenantASubscription.Content.ReadAsStreamAsync());
+        using var tenantBReader = new StreamReader(await tenantBSubscription.Content.ReadAsStreamAsync());
+
+        var registered = _gateway.Registry.Get(new TenantId("tenant-bob"), "dir-b-feed-remove");
+        Assert.NotNull(registered);
+        registered.LastSeen = DateTime.UtcNow - DirectorRegistry.HttpHeartbeatTimeout - TimeSpan.FromSeconds(1);
+        _gateway.Registry.SweepStale();
+
+        using var positiveControlTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var tenantBEvent = await ReadNextEventDataAsync(tenantBReader, positiveControlTimeout.Token);
+        Assert.Contains("dir-b-feed-remove", tenantBEvent);
+
+        using var isolationWindow = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await ReadNextEventDataAsync(tenantAReader, isolationWindow.Token));
+    }
+
+    [Fact]
     public async Task Legacy_discovery_plane_is_unavailable_on_hosted_and_leaves_no_shadow()
     {
         // The discovery legs (register / heartbeat / doorbell / unregister) are the same-machine HTTP plane and
@@ -311,6 +367,24 @@ public sealed class DirectorRouteTenantScopingTests : IAsyncLifetime
         var req = new HttpRequestMessage(HttpMethod.Get, path);
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
         return _http.SendAsync(req);
+    }
+
+    private Task<HttpResponseMessage> SubscribeToEventsAsync(string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "events");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead);
+    }
+
+    private static async Task<string> ReadNextEventDataAsync(StreamReader reader, CancellationToken cancellationToken)
+    {
+        while (await reader.ReadLineAsync(cancellationToken) is { } line)
+        {
+            if (line.StartsWith("data: ", StringComparison.Ordinal))
+                return line[6..];
+        }
+
+        throw new EndOfStreamException("The events feed closed before publishing an event.");
     }
 
     private Task<HttpResponseMessage> Post(string path, string deviceKey, object body)

--- a/src/CcDirector.Gateway.Tests/EventsFeedSelfHostedTests.cs
+++ b/src/CcDirector.Gateway.Tests/EventsFeedSelfHostedTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves the tenant-scoped events feed preserves the single Local tenant behavior of a self-hosted Gateway.
+/// The test uses the real route and the local registration seam that publishes Director arrivals.
+/// </summary>
+public sealed class EventsFeedSelfHostedTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-events-self-hosted-" + Guid.NewGuid().ToString("N"));
+    private GatewayHost _gateway = null!; // Initialized before each test by InitializeAsync.
+    private HttpClient _http = null!; // Initialized before each test by InitializeAsync.
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+
+        _gateway = new GatewayHost(
+            port: FreePort(),
+            token: Token,
+            authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task Events_feed_on_self_host_announces_local_director()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "events");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        using var subscription = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+        using var reader = new StreamReader(await subscription.Content.ReadAsStreamAsync());
+
+        _gateway.Registry.Upsert(new DirectorRegistrationRequest
+        {
+            DirectorId = "dir-local-feed",
+            TailnetEndpoint = "http://127.0.0.1:9/",
+            MachineName = "local",
+            Pid = 1,
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        });
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var eventData = await ReadNextEventDataAsync(reader, timeout.Token);
+        Assert.Contains("dir-local-feed", eventData);
+    }
+
+    private static async Task<string> ReadNextEventDataAsync(StreamReader reader, CancellationToken cancellationToken)
+    {
+        while (await reader.ReadLineAsync(cancellationToken) is { } line)
+        {
+            if (line.StartsWith("data: ", StringComparison.Ordinal))
+                return line[6..];
+        }
+
+        throw new EndOfStreamException("The events feed closed before publishing an event.");
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -2734,6 +2734,17 @@ internal static class GatewayEndpoints
 
         app.MapGet("/events", async (HttpContext ctx) =>
         {
+            var requestTenant = ResolveReadTenant(ctx, tenantBoundary);
+            if (requestTenant is null)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status403Forbidden;
+                await ctx.Response.WriteAsJsonAsync(
+                    new { error = "no tenant is bound to this request" },
+                    cancellationToken: ctx.RequestAborted);
+                return;
+            }
+            var resolvedTenant = requestTenant.Value;
+
             ctx.Response.Headers["Content-Type"] = "text/event-stream";
             ctx.Response.Headers["Cache-Control"] = "no-cache";
             ctx.Response.Headers["Connection"] = "keep-alive";
@@ -2741,11 +2752,17 @@ internal static class GatewayEndpoints
             var ct = ctx.RequestAborted;
             var queue = System.Threading.Channels.Channel.CreateUnbounded<GatewayEvent>();
 
-            void OnAdded(DirectorDto d) => queue.Writer.TryWrite(new GatewayEvent("director.added", d.DirectorId));
-            // The removal carries its tenant now, but this stream has no tenant of its own to filter against
-            // (it is the fleet-global event feed), so it still announces every removal to every listener. It
-            // is on the existing list of not-yet-tenant-aware routes and is converted with them, not here.
-            void OnRemoved(DirectorRemoval removal) => queue.Writer.TryWrite(new GatewayEvent("director.removed", removal.DirectorId));
+            void OnAdded(DirectorArrival arrival)
+            {
+                if (arrival.Tenant.Equals(resolvedTenant))
+                    queue.Writer.TryWrite(new GatewayEvent("director.added", arrival.Director.DirectorId));
+            }
+
+            void OnRemoved(DirectorRemoval removal)
+            {
+                if (removal.Tenant.Equals(resolvedTenant))
+                    queue.Writer.TryWrite(new GatewayEvent("director.removed", removal.DirectorId));
+            }
 
             registry.OnDirectorAdded += OnAdded;
             registry.OnDirectorRemoved += OnRemoved;

--- a/src/CcDirector.Gateway/Discovery/DirectorArrival.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorArrival.cs
@@ -1,0 +1,12 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Discovery;
+
+/// <summary>
+/// One Director entering the registry, together with the tenant that owns it. A Director identifier is unique only
+/// within a tenant, so registry subscribers must receive both values to make tenant-scoped decisions.
+/// </summary>
+/// <param name="Tenant">The tenant whose partition received the Director.</param>
+/// <param name="Director">The Director registered in that partition.</param>
+public readonly record struct DirectorArrival(TenantId Tenant, DirectorDto Director);

--- a/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
@@ -105,8 +105,11 @@ public sealed class DirectorRegistry : IDisposable
     private Timer? _sweeper;
     private bool _disposed;
 
-    /// <summary>Raised when a Director appears (file created or HTTP register).</summary>
-    public event Action<DirectorDto>? OnDirectorAdded;
+    /// <summary>
+    /// Raised when a Director appears (file created, local registration, or tunnel registration). The payload
+    /// carries the owning tenant because a Director identifier is unique only within a tenant.
+    /// </summary>
+    public event Action<DirectorArrival>? OnDirectorAdded;
 
     /// <summary>
     /// Raised when a Director disappears (file removed, HTTP unregister, or stale).
@@ -212,7 +215,7 @@ public sealed class DirectorRegistry : IDisposable
             ? $"[DirectorRegistry] Upsert (http): id={dto.DirectorId}, endpoint={dto.TailnetEndpoint}, existed={existed}"
             : $"[DirectorRegistry] Upsert (http, FLAGGED no reachable endpoint): id={dto.DirectorId}, existed={existed}, reason={dto.EndpointUnreachableReason}");
         if (!existed)
-            OnDirectorAdded?.Invoke(dto);
+            OnDirectorAdded?.Invoke(new DirectorArrival(key.Tenant, dto));
         return dto;
     }
 
@@ -263,7 +266,7 @@ public sealed class DirectorRegistry : IDisposable
         if (!existed)
         {
             FileLog.Write($"[DirectorRegistry] RegisterFromStream: id={directorId}, machine={machineName}, version={version}");
-            OnDirectorAdded?.Invoke(dto);
+            OnDirectorAdded?.Invoke(new DirectorArrival(key.Tenant, dto));
         }
         return dto;
     }
@@ -496,7 +499,7 @@ public sealed class DirectorRegistry : IDisposable
             dto.Source = "file";
             var wasNew = !_directors.ContainsKey(key);
             _directors[key] = dto;
-            if (wasNew) OnDirectorAdded?.Invoke(dto);
+            if (wasNew) OnDirectorAdded?.Invoke(new DirectorArrival(key.Tenant, dto));
             FileLog.Write($"[DirectorRegistry] Added (file): id={dto.DirectorId}, endpoint={dto.ControlEndpoint}");
             return true;
         }


### PR DESCRIPTION
## Summary

- resolve the authenticated request tenant before opening the `/events` stream
- deny hosted requests when no tenant is bound, instead of exposing the fleet-wide feed
- carry tenant ownership through Director arrival notifications and filter both arrivals and removals
- preserve the Local tenant behavior on self-hosted Gateways

## Reproduction

A hostile two-tenant test subscribed tenants A and B to the real `/events` route, then connected a new Director owned only by tenant B through the real tunnel. Before the fix, tenant A received tenant B's Director notification. The test failed with `Assert.ThrowsAny() Failure: No exception was thrown` because tenant A's stream returned the foreign event instead of remaining quiet.

## Verification

- 23 affected Gateway tests passed, including cross-tenant arrival and removal isolation, hosted fail-closed behavior, registry ownership, and self-hosted Local behavior
- `CcDirector.Gateway` built successfully with zero warnings
- `CcDirector.Gateway.Migrations.Postgres` built successfully with zero warnings
