### PR TITLE
release: v1.7.3 - multi-machine cockpit, gateway status box, telemetry removal

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.7.1</Version>
+    <Version>1.7.3</Version>
   </PropertyGroup>
 </Project>

--- a/docs/public/release-notes/v1.7.3.md
+++ b/docs/public/release-notes/v1.7.3.md
@@ -1,0 +1,18 @@
+## v1.7.3 - July 22, 2026
+
+This release brings all of your machines together on one cockpit, tells you which gateway you are connected to, and removes first-party usage telemetry.
+
+### Highlights
+- See every machine on one cockpit: the Fleet Map now lays out all of your connected machines, the Directors running on each, and their sessions in a single view. Group the map by machine, by repository, or by working tree. Point several machines at the same gateway and watch them all appear together.
+- Know which gateway you are on: the desktop status box now shows the gateway host and whether it is connected, so you can tell at a glance where this Director is pointed.
+- No more first-party telemetry: DevThrottle no longer reports any usage telemetry back to us. The reporting code is gone, and this release also cleans up any telemetry files and settings left behind by earlier versions.
+
+### Also in this release
+- Dictation keeps your last word: recordings now pad a little trailing silence so the model no longer clips the final word.
+- A send that lost its audio now warns you instead of quietly sending silence, on both the Cockpit voice reply and in Car Mode.
+- Speaking straight into the Speak box and sending now sends the transcribed text, as expected.
+- The desktop app fails loudly if the gateway stops updating a session's status, instead of leaving the session a silent grey.
+- Scrollbar thumbs draw at full thickness, not a thin sliver that only appeared on hover.
+- Snooze on the mobile cockpit now gives instant feedback when you tap it.
+- Per-device keys are now stored hashed at rest, never in plain text.
+- Continued isolation hardening on the hosted multi-tenant gateway, so each account's sessions, devices, and data stay separated from every other account's.


### PR DESCRIPTION
Version bump to v1.7.3 and canonical release notes.

Bumps Directory.Build.props 1.7.1 -> 1.7.3 and adds docs/public/release-notes/v1.7.3.md.

Release story: all your machines on one cockpit (Fleet Map), the desktop status box shows the gateway host and connection state, and first-party telemetry reporting is removed. Every headline verified against shipped code on main.