### PR TITLE
Seal the fleet-wide DirectorRegistry list behind a SystemScope capability

### DIFF
--- a/src/CcDirector.Gateway.Tests/DirectorRegistryTenantKeyTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorRegistryTenantKeyTests.cs
@@ -132,7 +132,7 @@ public sealed class DirectorRegistryTenantKeyTests : IDisposable
 
         // Control: the no-tenant overload is the internal aggregation view and DOES see both. Without this,
         // a registry that had simply lost Bob's entry would satisfy the two assertions above.
-        var everything = _registry.ListDirectors().Select(d => d.DirectorId).ToArray();
+        var everything = _registry.ListDirectors(CcDirector.Gateway.Tenancy.SystemScope.Grant()).Select(d => d.DirectorId).ToArray();
         Assert.Contains("dir-a", everything);
         Assert.Contains("dir-b", everything);
 

--- a/src/CcDirector.Gateway.Tests/FanoutAndEventsTests.cs
+++ b/src/CcDirector.Gateway.Tests/FanoutAndEventsTests.cs
@@ -38,7 +38,7 @@ public sealed class FanoutAndEventsTests : IAsyncLifetime
         var deadline = DateTime.UtcNow.AddSeconds(5);
         while (DateTime.UtcNow < deadline)
         {
-            if (_gateway.Registry.ListDirectors().Count >= 1) break;
+            if (_gateway.Registry.ListDirectors(CcDirector.Gateway.Tenancy.SystemScope.Grant()).Count >= 1) break;
             await Task.Delay(100);
         }
     }

--- a/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
@@ -352,7 +352,7 @@ public sealed class GatewayHostTests : IAsyncLifetime
         var deadline = DateTime.UtcNow + timeout;
         while (DateTime.UtcNow < deadline)
         {
-            if (_gateway.Registry.ListDirectors().Count >= target) return;
+            if (_gateway.Registry.ListDirectors(CcDirector.Gateway.Tenancy.SystemScope.Grant()).Count >= target) return;
             await Task.Delay(100);
         }
         // Don't fail here - tests will fail with clearer assertions if discovery didn't work

--- a/src/CcDirector.Gateway.Tests/SystemScopeGuardTests.cs
+++ b/src/CcDirector.Gateway.Tests/SystemScopeGuardTests.cs
@@ -1,0 +1,77 @@
+using System.Reflection;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Tenancy;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Guards the fleet-wide access boundary - the "system administrator" access mode. A cross-tenant read of
+/// live in-memory state must be a single, auditable decision, never something a request handler can reach
+/// for by accident. Two invariants that fail the BUILD if broken:
+///
+///   1. <c>SystemScope.Grant()</c> - which mints the fleet-wide capability - is called ONLY in the
+///      composition root (<c>GatewayHost.cs</c>). Every other component receives the token by injection.
+///   2. The fleet-wide <c>DirectorRegistry</c> listing requires a <see cref="SystemScope"/>. There is no
+///      ungated no-argument overload - that shape was where cross-tenant leaks kept appearing.
+///
+/// As more fleet-wide accessors are sealed behind <see cref="SystemScope"/>, add their no-arg-absence
+/// checks here so the guard grows with the boundary.
+/// </summary>
+public sealed class SystemScopeGuardTests
+{
+    [Fact]
+    public void SystemScope_Grant_is_called_only_in_the_composition_root()
+    {
+        var gatewaySrc = LocateGatewaySource();
+        var offenders = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(gatewaySrc, "*.cs", SearchOption.AllDirectories))
+        {
+            var name = Path.GetFileName(file);
+            if (name == "SystemScope.cs") continue; // the declaration of Grant() itself
+            if (name == "GatewayHost.cs") continue; // the one sanctioned composition-root call site
+            var text = File.ReadAllText(file);
+            if (text.Contains("SystemScope.Grant("))
+                offenders.Add(Path.GetRelativePath(gatewaySrc, file));
+        }
+
+        Assert.True(offenders.Count == 0,
+            "SystemScope.Grant() mints fleet-wide, cross-tenant access and may be called ONLY in the composition " +
+            "root (GatewayHost.cs). A system pass that needs it must receive the token by injection, not mint its " +
+            "own. Found calls in: " + string.Join(", ", offenders));
+    }
+
+    [Fact]
+    public void DirectorRegistry_has_no_ungated_fleet_wide_list()
+    {
+        // A public no-argument ListDirectors() would be an ungated cross-tenant reach that any code could call.
+        var noArg = typeof(DirectorRegistry).GetMethod(
+            "ListDirectors", BindingFlags.Public | BindingFlags.Instance, binder: null, types: Type.EmptyTypes, modifiers: null);
+        Assert.True(noArg is null,
+            "DirectorRegistry.ListDirectors() (no arguments) is an ungated fleet-wide accessor. The fleet-wide " +
+            "overload must require a SystemScope; serving a client is ListDirectors(TenantId).");
+
+        // The sanctioned fleet-wide overload exists and is gated by the capability token.
+        var gated = typeof(DirectorRegistry).GetMethod(
+            "ListDirectors", BindingFlags.Public | BindingFlags.Instance, binder: null, types: new[] { typeof(SystemScope) }, modifiers: null);
+        Assert.True(gated is not null, "The fleet-wide ListDirectors(SystemScope) overload should exist.");
+
+        // The tenant-scoped overload a handler actually uses stays available.
+        var scoped = typeof(DirectorRegistry).GetMethod(
+            "ListDirectors", BindingFlags.Public | BindingFlags.Instance, binder: null,
+            types: new[] { typeof(CcDirector.Core.Tenancy.TenantId) }, modifiers: null);
+        Assert.True(scoped is not null, "The tenant-scoped ListDirectors(TenantId) overload should exist.");
+    }
+
+    private static string LocateGatewaySource()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "CcDirector.Gateway");
+            if (Directory.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate src/CcDirector.Gateway from " + AppContext.BaseDirectory);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WingmanAskForwardingTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanAskForwardingTests.cs
@@ -46,7 +46,7 @@ public sealed class WingmanAskForwardingTests : IAsyncLifetime
         var deadline = DateTime.UtcNow.AddSeconds(5);
         while (DateTime.UtcNow < deadline)
         {
-            if (_gateway.Registry.ListDirectors().Any(d => d.DirectorId == _director.DirectorId)) break;
+            if (_gateway.Registry.ListDirectors(CcDirector.Gateway.Tenancy.SystemScope.Grant()).Any(d => d.DirectorId == _director.DirectorId)) break;
             await Task.Delay(100);
         }
     }

--- a/src/CcDirector.Gateway/Api/ExesEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/ExesEndpoints.cs
@@ -156,7 +156,7 @@ internal static class ExesEndpoints
                 // read. A dev page must not drive it.
                 GatewayEndpoints.StampFleetRolesAndFold(fleet, fleet, needsYouStampFor: null, snoozeRegistry: snoozeRegistry);
 
-                var local = registry.ListDirectors()
+                var local = registry.ListDirectors(TenantId.Local)
                     .Where(d => string.Equals(d.MachineName, machine, StringComparison.OrdinalIgnoreCase))
                     .OrderBy(d => d.StartedAt)
                     .ToList();
@@ -430,7 +430,7 @@ internal static class ExesEndpoints
     {
         var target = Path.GetFullPath(exePath);
         var machine = Environment.MachineName;
-        foreach (var d in registry.ListDirectors())
+        foreach (var d in registry.ListDirectors(TenantId.Local))
         {
             if (!string.Equals(d.MachineName, machine, StringComparison.OrdinalIgnoreCase)) continue;
             var p = TryGetExePath(d.Pid);

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -372,7 +372,8 @@ internal static class GatewayEndpoints
                 });
             }
 
-            var directors = registry.ListDirectors();
+            // Self-host status only (this branch is not reached on hosted): the single tenant is Local.
+            var directors = registry.ListDirectors(TenantId.Local);
             // Post-cut: the roster lives ONLY in the push store, so count from there. A Director with no
             // fresh pushed snapshot is not connected to the tunnel and contributes zero.
             int totalSessions = directors.Sum(d =>
@@ -2819,7 +2820,9 @@ internal static class GatewayEndpoints
             if (exePath is null)
                 return Results.Problem("cc-director.exe not found on PATH or in standard install location", statusCode: 500);
 
-            var beforeIds = registry.ListDirectors().Select(d => d.DirectorId).ToHashSet();
+            // The spawned cc-director.exe runs on the Gateway's OWN machine, so it registers as a Local-tenant
+            // entry; scope the before/after diff to Local (this route is refused on hosted).
+            var beforeIds = registry.ListDirectors(TenantId.Local).Select(d => d.DirectorId).ToHashSet();
 
             try
             {
@@ -2844,7 +2847,7 @@ internal static class GatewayEndpoints
             while (DateTime.UtcNow < deadline)
             {
                 await Task.Delay(500);
-                var newId = registry.ListDirectors().Select(d => d.DirectorId).FirstOrDefault(id => !beforeIds.Contains(id));
+                var newId = registry.ListDirectors(TenantId.Local).Select(d => d.DirectorId).FirstOrDefault(id => !beforeIds.Contains(id));
                 if (newId is not null)
                 {
                     // MTR-01: this route ShellExecutes a cc-director.exe on the GATEWAY's own machine, so the

--- a/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
@@ -147,7 +147,7 @@ internal static class SettingsEndpoints
                 state = "Running",
                 port = host.Port,
                 uptimeSeconds = (long)up.TotalSeconds,
-                directors = host.Registry.ListDirectors().Count,
+                directors = host.Registry.ListDirectors(CcDirector.Core.Tenancy.TenantId.Local).Count,
                 mode = host.SettingsHooks?.Mode?.Invoke() ?? "unknown",
                 // Issue #457: the fleet network addressing mode ("tailscale" | "lan").
                 addressingMode = Core.Configuration.AddressingModeConfig.Get().ToConfigString(),

--- a/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
@@ -350,12 +350,19 @@ public sealed class DirectorRegistry : IDisposable
     }
 
     /// <summary>
-    /// Snapshot of all currently-known Directors, FLEET-GLOBAL - every tenant's. This is the internal
-    /// aggregation view (the roster fan-out, the reconcile poll); it must NEVER be the answer to a client
-    /// request. Serving a client is <see cref="ListDirectors(TenantId)"/>.
+    /// Snapshot of all currently-known Directors, FLEET-GLOBAL - every tenant's. This is the system
+    /// aggregation view (the "is there any fleet at all" guard, reconcile, a future operator surface); it
+    /// is NEVER the answer to a client request. Serving a client is <see cref="ListDirectors(TenantId)"/>.
+    ///
+    /// It takes a <see cref="Tenancy.SystemScope"/> so that a request handler - which never holds one -
+    /// physically cannot call it. The fleet-global reach is a capability, not a convention: the old
+    /// no-argument overload was reachable by any code and was where cross-tenant leaks kept appearing.
     /// </summary>
-    public IReadOnlyCollection<DirectorDto> ListDirectors()
-        => _directors.Values.ToList().AsReadOnly();
+    public IReadOnlyCollection<DirectorDto> ListDirectors(Tenancy.SystemScope scope)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        return _directors.Values.ToList().AsReadOnly();
+    }
 
     /// <summary>
     /// Issue #1847: the Directors ONE tenant owns - what a client request is served. Before this, the

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -39,6 +39,11 @@ public sealed class GatewayHost : IAsyncDisposable
     public string Token { get; }
     public DirectorRegistry Registry { get; }
 
+    // The process's ONE system capability, minted here in the composition root. Passed to the internal
+    // system passes that legitimately read across tenants; never handed to a request handler. The guard
+    // test (SystemScopeGuardTests) enforces that SystemScope.Grant() is called nowhere else.
+    private readonly Tenancy.SystemScope _system = Tenancy.SystemScope.Grant();
+
     /// <summary>
     /// Issue #1292: the fleet-wide authority for the short three-digit session numbers. One instance for
     /// the whole Gateway, so a number names exactly one session across every Director on every machine.
@@ -1299,7 +1304,7 @@ public sealed class GatewayHost : IAsyncDisposable
         if (vs is null) return Task.CompletedTask;
         try
         {
-            if (Registry.ListDirectors().Count == 0) return Task.CompletedTask;
+            if (Registry.ListDirectors(_system).Count == 0) return Task.CompletedTask;
             // Hosted Multi-Tenancy voice-serving: run ONE pass per tenant, each inside that tenant's own scope
             // (_tenantPass.ForEachTenant). Within a pass, locate each of THAT tenant's voice sessions in ITS
             // OWN partition (push-store TryLocate - no HTTP dial) and generate into that tenant's voice state,

--- a/src/CcDirector.Gateway/Tenancy/SystemScope.cs
+++ b/src/CcDirector.Gateway/Tenancy/SystemScope.cs
@@ -1,0 +1,29 @@
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// A capability token that authorizes a FLEET-WIDE, cross-tenant read of live in-memory state - the
+/// "system administrator" access mode. This is the deliberate counterpart to the normal-user path: a
+/// request handler must NEVER hold one. A handler can only ever reach its own tenant's partition through
+/// the tenant-scoped (tenant, id) accessors; a fleet-wide accessor takes a <see cref="SystemScope"/>, so
+/// a handler physically cannot call it - there is no token to pass.
+///
+/// Fleet-wide access exists for the internal system passes (the "is there any fleet at all" guard,
+/// aggregation, reconcile) and, later, an explicit operator/admin surface. The token is GRANTED ONCE, in
+/// the composition root (<c>GatewayHost</c>), and injected only where a system pass legitimately needs it.
+///
+/// This is enforced two ways: the token cannot be constructed except through <see cref="Grant"/>, and a
+/// guard test (<c>SystemScopeGuardTests</c>) fails the build if <see cref="Grant"/> is called anywhere
+/// other than the composition root. So "who may read across tenants" is a single, auditable decision -
+/// not something any handler can reach for by accident.
+/// </summary>
+public sealed class SystemScope
+{
+    private SystemScope() { }
+
+    /// <summary>
+    /// Mint the process's system capability. ONLY the composition root may call this; the guard test
+    /// enforces the single call site. Every other component receives the token by injection, never by
+    /// minting its own.
+    /// </summary>
+    public static SystemScope Grant() => new();
+}


### PR DESCRIPTION
Multi-tenancy, area two (in-memory control plane), step 1.

Fleet-wide cross-tenant reads of live in-memory state are the system-administrator access mode, not something a request handler can reach for. This introduces `SystemScope` - a capability minted only via `Grant()`, called once in the composition root - and replaces the ungated `DirectorRegistry.ListDirectors()` no-arg overload with `ListDirectors(SystemScope)`. A handler holds no token, so it cannot call the fleet-wide accessor; it uses the tenant-scoped `ListDirectors(TenantId)`. The four handler callers move to `ListDirectors(TenantId.Local)` (self-host machine operations).

A build-time guard (`SystemScopeGuardTests`) fails the build if `Grant()` is called outside the composition root or an ungated no-arg overload reappears. Revert-proved: an illicit `Grant()` reddens the guard. 55 tests green including the director isolation suites.

Next in this area: tenant-key the still-blind stores (turn briefs, launcher registries) to the same standard.