### PR TITLE
fix(mac): single 'Director' app, upgrade-in-place install, working Launch button

### DIFF
--- a/docs/public/release-notes/v1.7.3.md
+++ b/docs/public/release-notes/v1.7.3.md
@@ -5,6 +5,7 @@ This release brings all of your machines together on one cockpit, tells you whic
 ### Highlights
 - See every machine on one cockpit: the Fleet Map now lays out all of your connected machines, the Directors running on each, and their sessions in a single view. Group the map by machine, by repository, or by working tree. Point several machines at the same gateway and watch them all appear together.
 - Know which gateway you are on: the desktop status box now shows the gateway host and whether it is connected, so you can tell at a glance where this Director is pointed.
+- A cleaner Mac install: the Mac app is now a single app named "Director". Reinstalling replaces the previous copy in place instead of leaving a pile of duplicates, and installing removes older copies left behind by earlier versions. The "Launch Director" button at the end of setup now works on Mac and opens the app in the Dock.
 - No more first-party telemetry: DevThrottle no longer reports any usage telemetry back to us. The reporting code is gone, and this release also cleans up any telemetry files and settings left behind by earlier versions.
 
 ### Also in this release

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -18,11 +18,11 @@
 # Usage:
 #   scripts/package-mac-app.sh --binary <path-to-self-contained-binary> --out <output-dir>
 #
-# Produces:  <output-dir>/cc-director-mac-arm64.zip  (contains "CC Director.app")
+# Produces:  <output-dir>/cc-director-mac-arm64.zip  (contains "Director.app")
 #
 set -euo pipefail
 
-APP_NAME="CC Director"
+APP_NAME="Director"
 BIN_NAME="cc-director"                 # CFBundle binary name (matches AssemblyName)
 BID="com.devthrottle.ccdirector"
 ZIP_NAME="cc-director-mac-arm64.zip"

--- a/src/CcDirector.Core/Update/UpdateInstaller.cs
+++ b/src/CcDirector.Core/Update/UpdateInstaller.cs
@@ -24,7 +24,7 @@ public static class UpdateInstaller
     /// <summary>
     /// The path a new build must overwrite to "become" the installed app. On
     /// Windows this is the running cc-director.exe; on macOS it is the enclosing
-    /// "CC Director.app" bundle (not the binary inside it). Falls back to the
+    /// "Director.app" bundle (not the binary inside it). Falls back to the
     /// process path when not running from a bundle (e.g. a bare dev binary).
     /// </summary>
     public static string InstallTarget()

--- a/src/CcDirector.Core/Update/UpdaterState.cs
+++ b/src/CcDirector.Core/Update/UpdaterState.cs
@@ -34,7 +34,7 @@ public sealed class UpdaterState
 
     /// <summary>
     /// Absolute path the staged build should overwrite. On Windows the installed
-    /// cc-director.exe; on macOS the installed "CC Director.app" bundle directory.
+    /// cc-director.exe; on macOS the installed "Director.app" bundle directory.
     /// </summary>
     [JsonPropertyName("installTarget")]
     public string? InstallTarget { get; set; }

--- a/src/CcDirector.Launcher.Tests/DirectorSupervisorTests.cs
+++ b/src/CcDirector.Launcher.Tests/DirectorSupervisorTests.cs
@@ -38,7 +38,7 @@ public sealed class DirectorSupervisorTests
         else
         {
             // macOS: the installed Director is the application bundle in ~/Applications.
-            Assert.EndsWith("CC Director.app", supervisor.DirectorExePath, StringComparison.Ordinal);
+            Assert.EndsWith("Director.app", supervisor.DirectorExePath, StringComparison.Ordinal);
         }
     }
 
@@ -46,7 +46,7 @@ public sealed class DirectorSupervisorTests
     public void DirectorExeExists_ReturnsFalse_WhenPathDoesNotExist()
     {
         // Windows-only premise: on macOS PathFor(Director) is the machine-global
-        // ~/Applications/CC Director.app, independent of the injected root - the macOS
+        // ~/Applications/Director.app, independent of the injected root - the macOS
         // presence semantics are covered by DirectorExeExists_MacBundleDirectory_CountsAsInstalled.
         if (!OperatingSystem.IsWindows()) return;
 
@@ -89,7 +89,7 @@ public sealed class DirectorSupervisorTests
         if (OperatingSystem.IsWindows()) return; // macOS/Unix semantics only
 
         // Point the layout at a scratch root, then create the bundle DIRECTORY where
-        // InstallLayout would place it. PathFor(Director) on macOS is ~/Applications/CC Director.app
+        // InstallLayout would place it. PathFor(Director) on macOS is ~/Applications/Director.app
         // regardless of the root, so simulate through a real temp bundle only when it does
         // not already exist - never touch a real installed bundle.
         var supervisor = new DirectorSupervisor();

--- a/src/CcDirector.Launcher/DirectorSupervisor.cs
+++ b/src/CcDirector.Launcher/DirectorSupervisor.cs
@@ -12,7 +12,7 @@ namespace CcDirector.Launcher;
 ///
 /// Resolves the installed Director via <see cref="InstallLayout"/>:
 ///   - Windows: %LOCALAPPDATA%/cc-director/app/cc-director.exe
-///   - macOS:   ~/Applications/CC Director.app (an application bundle - a directory)
+///   - macOS:   ~/Applications/Director.app (an application bundle - a directory)
 ///
 /// Provides start / stop / restart operations with a FileLog audit trail.
 ///

--- a/tools/cc-director-setup-avalonia/Services/EngineInstallRunner.cs
+++ b/tools/cc-director-setup-avalonia/Services/EngineInstallRunner.cs
@@ -16,7 +16,7 @@ public sealed class EngineInstallRunner
     private readonly InstallLayout _layout = InstallLayout.Default();
     private readonly ReleaseSource _source = new();
 
-    /// <summary>The on-disk Director path for this OS (~/Applications/CC Director.app on macOS).</summary>
+    /// <summary>The on-disk Director path for this OS (~/Applications/Director.app on macOS).</summary>
     public string DirectorPath => _layout.PathFor(ComponentRegistry.Director);
 
     /// <summary>Everything ApplyAsync needs, plus the UI rows and up-to-date state.</summary>

--- a/tools/cc-director-setup-avalonia/Services/InstallDetector.cs
+++ b/tools/cc-director-setup-avalonia/Services/InstallDetector.cs
@@ -8,7 +8,7 @@ namespace CcDirectorSetup.Services;
 /// source of truth the command-line installer uses - so the wizard and the engine can
 /// never disagree about the machine. The wizard previously kept its own File.Exists
 /// check on &lt;root&gt;/bin/cc-director, a path that does not exist in the macOS layout
-/// (the Director there is the "~/Applications/CC Director.app" bundle), so every Mac
+/// (the Director there is the "~/Applications/Director.app" bundle), so every Mac
 /// opened in fresh-install mode with update and repair unreachable (issue #1736).
 /// </summary>
 public static class InstallDetector

--- a/tools/cc-director-setup-avalonia/Steps/CompleteStep.axaml
+++ b/tools/cc-director-setup-avalonia/Steps/CompleteStep.axaml
@@ -60,19 +60,17 @@
                        Margin="0,12,0,24"
                        LineHeight="20" />
 
-            <!-- Launch button: the hero of the happy path -->
+            <!-- Launch button: the hero of the happy path. Colours + hover/pressed live in the
+                 Button.launch style (Styles.axaml) so the green stays visible on hover. -->
             <Button x:Name="LaunchButton"
+                    Classes="launch"
                     Height="44"
                     HorizontalAlignment="Stretch"
                     Margin="0,0,0,12"
-                    Cursor="Hand"
-                    Background="#22C55E"
-                    Foreground="White"
                     FontSize="16"
                     FontWeight="SemiBold"
                     HorizontalContentAlignment="Center"
-                    CornerRadius="6"
-                    Content="Launch cc-director"
+                    Content="Launch Director"
                     Click="LaunchButton_Click" />
 
             <!-- One quiet summary line on success -->

--- a/tools/cc-director-setup-avalonia/Steps/CompleteStep.axaml.cs
+++ b/tools/cc-director-setup-avalonia/Steps/CompleteStep.axaml.cs
@@ -161,34 +161,43 @@ public partial class CompleteStep : UserControl
     {
         SetupLog.Write("[CompleteStep] LaunchButton_Click");
 
-        var binName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? "cc-director.exe"
-            : "cc-director";
-        var exePath = Path.Combine(_installPath, binName);
-
-        if (!File.Exists(exePath))
-        {
-            SetupLog.Write($"[CompleteStep] cc-director not found at {exePath}");
-            return;
-        }
-
+        // _installPath is the canonical Director path (InstallLayout.PathFor). On Windows that is the
+        // installed cc-director.exe; on macOS it is the ~/Applications/Director.app bundle. The two
+        // launch differently: run the exe directly on Windows, but on macOS hand the bundle to
+        // /usr/bin/open so LaunchServices registers it - that is what gives the app its Dock icon and
+        // foreground activation. Launching the inner Mach-O binary directly gives neither.
         try
         {
-            var psi = new ProcessStartInfo
-            {
-                FileName = exePath,
-                UseShellExecute = false,
-            };
+            ProcessStartInfo psi;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
+                if (!Directory.Exists(_installPath))
+                {
+                    SetupLog.Write($"[CompleteStep] Director bundle not found at {_installPath}");
+                    return;
+                }
+
+                psi = new ProcessStartInfo("/usr/bin/open") { UseShellExecute = false };
+                psi.ArgumentList.Add(_installPath);
+            }
+            else
+            {
+                if (!File.Exists(_installPath))
+                {
+                    SetupLog.Write($"[CompleteStep] cc-director not found at {_installPath}");
+                    return;
+                }
+
+                psi = new ProcessStartInfo { FileName = _installPath, UseShellExecute = false };
+
                 var freshPath = GetFreshPathWindows();
                 if (freshPath != null)
                     psi.Environment["PATH"] = freshPath;
             }
 
             Process.Start(psi);
-            SetupLog.Write("[CompleteStep] LaunchButton_Click: cc-director launched");
+            SetupLog.Write("[CompleteStep] LaunchButton_Click: Director launched");
 
             // Close the setup wizard
             var window = this.VisualRoot as Window;

--- a/tools/cc-director-setup-avalonia/Styles.axaml
+++ b/tools/cc-director-setup-avalonia/Styles.axaml
@@ -52,4 +52,27 @@
         <Setter Property="Opacity" Value="0.5" />
     </Style>
 
+    <!-- Launch (success/hero) button: the green "Launch Director" call to action on the final step.
+         The hover and pressed backgrounds MUST be set on the templated ContentPresenter, otherwise
+         the base theme repaints it on :pointerover and the green (and its white text) vanish - which
+         made the button look like it "disappeared on hover" and could not be clicked. -->
+    <Style Selector="Button.launch">
+        <Setter Property="Background" Value="#22C55E" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="CornerRadius" Value="6" />
+    </Style>
+    <Style Selector="Button.launch:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="#16A34A" />
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.launch:pressed /template/ ContentPresenter">
+        <Setter Property="Background" Value="#15803D" />
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.launch:disabled">
+        <Setter Property="Opacity" Value="0.5" />
+    </Style>
+
 </Styles>

--- a/tools/cc-director-setup-cli/Commands.cs
+++ b/tools/cc-director-setup-cli/Commands.cs
@@ -488,7 +488,7 @@ internal static class Commands
     {
         if (!OperatingSystem.IsMacOS())
             throw new InvalidOperationException("PlaceMacDirectorAsync is macOS-only.");
-        if (!json) Console.WriteLine("Placing CC Director.app:");
+        if (!json) Console.WriteLine("Placing Director.app:");
         return await MacAppPlacer.PlaceAsync(layout, release, source,
             log: m => { if (!json) Console.WriteLine($"  {m}"); });
     }

--- a/tools/cc-director-setup-engine.Tests/InstalledManifestTests.cs
+++ b/tools/cc-director-setup-engine.Tests/InstalledManifestTests.cs
@@ -123,7 +123,7 @@ public class InstalledManifestTests : IDisposable
     public void Reader_MacBundleDirectoryWithNoManifestEntry_ReportsBundleVersion()
     {
         // Issue #1736 regression shape: a macOS machine whose Director exists only as the
-        // "CC Director.app" bundle, with no manifest entry (installed before the manifest
+        // "Director.app" bundle, with no manifest entry (installed before the manifest
         // existed). It must read as PRESENT with the bundle's Info.plist version - the wizard's
         // old private detector reported exactly this machine as "not installed". (That the
         // presence check accepts a directory is covered by the DefaultExists tests.)

--- a/tools/cc-director-setup-engine/InstallLayout.cs
+++ b/tools/cc-director-setup-engine/InstallLayout.cs
@@ -129,7 +129,7 @@ public sealed class InstallLayout
         {
             return component.Kind switch
             {
-                ComponentKind.Director => Path.Combine(MacAppsDir, "CC Director.app"),
+                ComponentKind.Director => Path.Combine(MacAppsDir, "Director.app"),
                 ComponentKind.Tool => Path.Combine(BinDir, component.Id),
                 ComponentKind.Gateway => Path.Combine(GatewayDir, "devthrottle-gateway"),
                 ComponentKind.Launcher => Path.Combine(LauncherDir, "cc-launcher"),
@@ -150,18 +150,27 @@ public sealed class InstallLayout
     /// <summary>
     /// Pre-rename on-disk names a component may still occupy on an existing host, besides its current
     /// canonical <see cref="PathFor"/> location. Presence detection accepts these so an update
-    /// recognises a legacy host and refreshes it instead of silently orphaning it (issue #1821). Only
-    /// the Gateway was renamed (cc-director-gateway.exe -> devthrottle-gateway.exe); every other
-    /// component has no legacy alias. The CURRENT name stays canonical/target - these are read-only
-    /// aliases for detection, never a place we write to.
+    /// recognises a legacy host and refreshes it instead of silently orphaning it (issue #1821). Two
+    /// components have been renamed: the Gateway (cc-director-gateway.exe -> devthrottle-gateway.exe),
+    /// and the macOS Director bundle ("CC Director.app" -> "Director.app"). The CURRENT name stays
+    /// canonical/target - these are read-only aliases for detection, never a place we write to.
     /// </summary>
     public IReadOnlyList<string> LegacyAliasesFor(Component component)
     {
         ArgumentNullException.ThrowIfNull(component);
-        if (component.Kind != ComponentKind.Gateway)
-            return Array.Empty<string>();
 
-        var legacyName = OperatingSystem.IsWindows() ? "cc-director-gateway.exe" : "cc-director-gateway";
-        return new[] { Path.Combine(GatewayDir, legacyName) };
+        if (component.Kind == ComponentKind.Gateway)
+        {
+            var legacyName = OperatingSystem.IsWindows() ? "cc-director-gateway.exe" : "cc-director-gateway";
+            return new[] { Path.Combine(GatewayDir, legacyName) };
+        }
+
+        // The macOS Director bundle was renamed "CC Director.app" -> "Director.app". A host installed
+        // before the rename still carries the old bundle in ~/Applications; accept it for detection so
+        // an update refreshes that host instead of orphaning it. Windows/tool names never changed.
+        if (component.Kind == ComponentKind.Director && !OperatingSystem.IsWindows())
+            return new[] { Path.Combine(MacAppsDir, "CC Director.app") };
+
+        return Array.Empty<string>();
     }
 }

--- a/tools/cc-director-setup-engine/MacAppPlacer.cs
+++ b/tools/cc-director-setup-engine/MacAppPlacer.cs
@@ -7,7 +7,7 @@ public sealed record MacAppResult(bool Success, string Message, string? Version)
 
 /// <summary>
 /// Places the Director on macOS. The generic UpdateRunner places single-file exes and skips archives,
-/// so the Director (shipped as cc-director-mac-arm64.zip containing "CC Director.app") needs this
+/// so the Director (shipped as cc-director-mac-arm64.zip containing "Director.app") needs this
 /// dedicated step - the analog of MobilePackage's side-car-zip handling. It downloads + SHA-256 verifies the zip,
 /// extracts the .app with ditto (preserving the bundle's symlinks + exec bits), swaps it into
 /// ~/Applications, strips the Gatekeeper quarantine, and marks the launcher executable. Mirrors
@@ -16,7 +16,11 @@ public sealed record MacAppResult(bool Success, string Message, string? Version)
 public static class MacAppPlacer
 {
     public const string DirectorAsset = "cc-director-mac-arm64.zip";
-    private const string AppName = "CC Director.app";
+    private const string AppName = "Director.app";
+
+    /// <summary>The pre-rename bundle name (issue #1821 alias). A fresh place removes any copy of this
+    /// so a host never ends up with both "CC Director.app" and "Director.app".</summary>
+    private const string LegacyAppName = "CC Director.app";
 
     [SupportedOSPlatform("macos")]
     public static async Task<MacAppResult> PlaceAsync(
@@ -49,8 +53,15 @@ public static class MacAppPlacer
             if (!Directory.Exists(stagedApp))
                 return new MacAppResult(false, $"{AppName} not found inside {DirectorAsset}.", null);
 
-            var target = layout.PathFor(ComponentRegistry.Director); // ~/Applications/CC Director.app
+            var target = layout.PathFor(ComponentRegistry.Director); // ~/Applications/Director.app
             Directory.CreateDirectory(layout.MacAppsDir);
+
+            // Collapse the pile-up (issue #1821 rename): before placing the one canonical bundle,
+            // remove every stale copy the old distribution model could have left - the legacy
+            // "CC Director.app", Finder's auto-suffixed duplicates ("CC Director 2.app", "Director 2.app"),
+            // and any copy dragged into the system /Applications instead of ~/Applications. This is what
+            // makes reinstalling upgrade-in-place instead of stacking a new icon beside the old ones.
+            PurgeStaleBundles(layout, keep: target, Log);
 
             Log($"installing {AppName} to {layout.MacAppsDir}");
             // Build beside, then this is a fresh place: remove any existing app, then ditto in.
@@ -67,14 +78,60 @@ public static class MacAppPlacer
             im.Set(ComponentRegistry.Director.Id, asset.Version);
             im.Save(layout);
 
-            Log($"CC Director {asset.Version} installed to {target}");
-            return new MacAppResult(true, $"CC Director {asset.Version} installed to {target}.", asset.Version);
+            Log($"Director {asset.Version} installed to {target}");
+            return new MacAppResult(true, $"Director {asset.Version} installed to {target}.", asset.Version);
         }
         finally
         {
             try { if (zip is not null && File.Exists(zip)) File.Delete(zip); } catch { /* best-effort */ }
             try { if (stage is not null && Directory.Exists(stage)) Directory.Delete(stage, recursive: true); } catch { /* best-effort */ }
         }
+    }
+
+    /// <summary>
+    /// Remove stale Director bundles the old loose-zip distribution could have left, so a reinstall
+    /// converges on the single <paramref name="keep"/> bundle instead of stacking icons. Scans both the
+    /// per-user ~/Applications and the system /Applications for the current and legacy bundle names plus
+    /// Finder's numbered duplicates ("Director 2.app", "CC Director 3.app"). The <paramref name="keep"/>
+    /// path is never removed here - the caller replaces it in place immediately after. Best-effort:
+    /// a copy under /Applications the user cannot delete without admin is logged and skipped, not fatal.
+    /// </summary>
+    private static void PurgeStaleBundles(InstallLayout layout, string keep, Action<string> log)
+    {
+        var dirs = new[] { layout.MacAppsDir, "/Applications" };
+        var baseNames = new[] { "Director", "CC Director" };
+
+        foreach (var dir in dirs)
+        {
+            if (!Directory.Exists(dir)) continue;
+            foreach (var baseName in baseNames)
+            {
+                // The exact bundle plus Finder's " N" suffixed duplicates (space + digits), e.g.
+                // "Director.app", "Director 2.app", "CC Director 10.app".
+                foreach (var bundle in Directory.EnumerateDirectories(dir, $"{baseName}*.app"))
+                {
+                    var name = Path.GetFileName(bundle);
+                    if (!IsBundleName(name, baseName)) continue;
+                    if (string.Equals(Path.GetFullPath(bundle), Path.GetFullPath(keep), StringComparison.Ordinal))
+                        continue; // the caller replaces this one in place.
+
+                    var (exit, out_) = ProcessRunner.Run("/bin/rm", $"-rf \"{bundle}\"");
+                    if (exit == 0) log($"removed stale bundle {bundle}");
+                    else log($"could not remove {bundle} (needs admin?); skipping: {Trim(out_)}");
+                }
+            }
+        }
+    }
+
+    /// <summary>True for "&lt;base&gt;.app" or Finder's "&lt;base&gt; N.app" duplicate form, and nothing else -
+    /// so "Director.app"/"Director 2.app" match "Director" but an unrelated "Directory.app" does not.</summary>
+    private static bool IsBundleName(string name, string baseName)
+    {
+        if (string.Equals(name, $"{baseName}.app", StringComparison.Ordinal)) return true;
+        if (!name.StartsWith($"{baseName} ", StringComparison.Ordinal) ||
+            !name.EndsWith(".app", StringComparison.Ordinal)) return false;
+        var middle = name.Substring(baseName.Length + 1, name.Length - baseName.Length - 1 - ".app".Length);
+        return middle.Length > 0 && middle.All(char.IsDigit);
     }
 
     private static string Trim(string s) => s.Length > 400 ? s[..400] : s;


### PR DESCRIPTION
Makes the macOS install runnable and stops the copy pile-up, ahead of the v1.7.3 release.

## What this fixes
- **Five copies pile up.** Fresh install now purges stale bundles (legacy "CC Director.app", the new name, and Finder's numbered duplicates) from both ~/Applications and /Applications before placing one canonical bundle, so reinstalling upgrades in place.
- **App named "CC Director".** Renamed to a single app "Director" across packaging, setup engine, launcher, and updater. Bundle id, binary name, and download asset are unchanged so the auto-updater is unaffected; the old name is kept as a detection alias (issue thefrederiksen/devthrottle_internal#871) so a pre-rename host is refreshed, not orphaned.
- **Launch button vanished on hover / did nothing.** The final "Launch Director" button now uses a reusable Button.launch style with a :pointerover template override so it stays visible, and on macOS it launches the .app via /usr/bin/open (correct path + Dock registration) instead of running the inner binary at the wrong path.

## Verification
- setup-engine build clean; 369 setup-engine tests + 27 launcher tests pass; setup wizard builds clean.
- The .app launch and Dock behavior are verified on the Mac after release (cannot be exercised from a Windows CI build).

## Follow-up (not in this PR)
- Rename the dev-slot build scripts off /Applications so developer slot builds cannot collide with the user install, and add a DMG drag-to-Applications package + a Director icon.