### PR TITLE
chore(gateway): default the hosted Gateway to gateway.devthrottle.com

### DIFF
--- a/src/CcDirector.Avalonia.Tests/GatewayChoicePanelIntegrationTests.cs
+++ b/src/CcDirector.Avalonia.Tests/GatewayChoicePanelIntegrationTests.cs
@@ -236,7 +236,7 @@ public class GatewayChoicePanelIntegrationTests
     {
         await WithTempRootAsync(async () =>
         {
-            const string hostedUrl = "https://devthrottle-gw.azurewebsites.net";
+            const string hostedUrl = "https://gateway.devthrottle.com";
             var panel = GatewayConnectionPanel.CreateForCurrentState(GatewayChoiceConsumer.Settings);
             var reapplied = false;
             panel.DirectorIdOverride = "test-director-id";

--- a/src/CcDirector.Core/Configuration/HostedGateway.cs
+++ b/src/CcDirector.Core/Configuration/HostedGateway.cs
@@ -22,7 +22,7 @@ public static class HostedGateway
     public const string UrlEnvironmentVariable = "DEVTHROTTLE_HOSTED_GATEWAY_URL";
 
     /// <summary>The shipped address of DevThrottle's hosted, multi-tenant Gateway.</summary>
-    public const string DefaultUrl = "https://devthrottle-gw.azurewebsites.net";
+    public const string DefaultUrl = "https://gateway.devthrottle.com";
 
     /// <summary>
     /// The hosted Gateway URL this machine should enroll against: the operator override when


### PR DESCRIPTION
Switch the shipped hosted Gateway default from the raw Azure app address `https://devthrottle-gw.azurewebsites.net` to our own custom domain `https://gateway.devthrottle.com`.

Both addresses front the same multi-tenant Gateway (verified: the custom domain reports gateway v1.7.3 and re-registration against it succeeds live). The custom domain is the address we want machines to enroll against by default. The `DEVTHROTTLE_HOSTED_GATEWAY_URL` operator override path is unchanged.

Left the CI deploy workflow's `GATEWAY_URL` on the direct Azure address, since that is the post-deploy health-check target for the Azure app itself, not the app default.

Tests: `GatewayHostedEnrollRunnerTests` (8/8, includes the two `DefaultUrl` assertions) and the touched `GatewayChoicePanelIntegrationTests.HostedChoice_SuccessfulEnroll_ReAppliesTheVerifiedCredential` all pass.