### PR TITLE
fix(mac): identity-gated install purge, and dev slots out of the installer's reach

### DIFF
--- a/scripts/local-build/mac/README.md
+++ b/scripts/local-build/mac/README.md
@@ -10,7 +10,7 @@ slots** you build on demand while developing (run several at once to compare ver
 ## TL;DR
 
 ```bash
-# One-time: install the apps + pin "CC Director" to the Dock
+# One-time: install the apps + pin "Director Dev" to the Dock
 scripts/mac-setup.sh
 
 # Day to day, from the repo root:
@@ -20,7 +20,7 @@ scripts/mac-rebuild.sh all      # rebuild main + all 4 slots
 ```
 
 After setup, launch from the **Dock** (the bar at the bottom), **Spotlight**
-(`Cmd+Space`, type "CC Director 2"), or **Launchpad** — never the terminal.
+(`Cmd+Space`, type "Director Dev 2"), or **Launchpad** — never the terminal.
 
 ---
 
@@ -42,23 +42,31 @@ Then run the one-time setup:
 scripts/mac-setup.sh
 ```
 
-This creates five apps in `/Applications`, builds the **main** binary, and pins
-**"CC Director"** to your Dock. Re-running it is safe.
+This creates the apps in `~/Applications/DevThrottle Dev`, builds the **main**
+binary, and pins **"Director Dev"** to your Dock. Re-running it is safe — and it
+migrates: old `CC Director*` wrappers this setup used to place in `/Applications`
+are removed (wrappers only; a real installed `Director.app` is never touched).
+
+Dev bundles deliberately live **outside** `/Applications` and `~/Applications`
+top level, under names the real installer's stale-bundle purge can never match:
+the installer removes stale `Director*`/`CC Director*` product bundles from
+those two directories on every fresh install (see `MacBundlePurger` in the
+setup engine), and the dev slots must be out of its reach.
 
 ---
 
 ## The apps
 
-| App (in `/Applications`) | Binary | Purpose |
-|--------------------------|--------|---------|
-| **CC Director**          | `cc-director-mac-main` | Your stable everyday copy. Pinned to the Dock. |
-| **CC Director 1–4**      | `cc-director-mac1`…`4` | Independent dev test slots. Build on demand; run several at once. |
+| App (in `~/Applications/DevThrottle Dev`) | Binary | Purpose |
+|-------------------------------------------|--------|---------|
+| **Director Dev**          | `cc-director-mac-main` | Your stable everyday copy. Pinned to the Dock. |
+| **Director Dev 1–4**      | `cc-director-mac1`…`4` | Independent dev test slots. Build on demand; run several at once. |
 
 Each app is a distinct macOS bundle (own Dock tile, own Spotlight/Launchpad entry,
 own bundle id), so they don't interfere with each other.
 
-A slot you haven't built yet still has an icon in `/Applications`; clicking it just
-pops a dialog telling you the build command.
+A slot you haven't built yet still has an icon in `~/Applications/DevThrottle Dev`;
+clicking it just pops a dialog telling you the build command.
 
 ---
 
@@ -69,11 +77,11 @@ pops a dialog telling you the build command.
 | `scripts/mac-setup.sh` | One-time bootstrap: create all 5 app icons, build main, pin main to the Dock. |
 | `scripts/mac-rebuild.sh <main\|1\|2\|3\|4\|all\|apps>` | The everyday command. Builds a target and refreshes its `.app`. `main` also re-pins the Dock; `apps` (re)creates the bundles without building. |
 | `scripts/local-build-mac.sh` | The underlying build (clean → build Core → single-file publish → copy here). Called by the above; use directly for flags like `--self-contained`, `--rid osx-x64`, `--configuration Debug`. |
-| `scripts/local-build/mac/make-app-bundle.sh --target <main\|1\|2\|3\|4>` | Wraps a built binary in a `.app` bundle installed to `/Applications`. Called by `mac-rebuild.sh`. |
+| `scripts/local-build/mac/make-app-bundle.sh --target <main\|1\|2\|3\|4>` | Wraps a built binary in a `.app` bundle installed to `~/Applications/DevThrottle Dev`. Called by `mac-rebuild.sh`. |
 | `scripts/local-build/mac/run.sh [--slot N]` | Launch a built binary straight from the terminal (sets `DOTNET_ROOT`). For quick checks; prefer the Dock/`.app` for real use (see below). |
 
-`APPS_DIR` env var overrides the install location (default `/Applications`), e.g.
-`APPS_DIR=~/Applications scripts/mac-rebuild.sh main`.
+`APPS_DIR` env var overrides the install location (default
+`~/Applications/DevThrottle Dev`), e.g. `APPS_DIR=/tmp/dev-apps scripts/mac-rebuild.sh main`.
 
 ---
 
@@ -85,7 +93,7 @@ pops a dialog telling you the build command.
 | `AppIcon.svg` | yes | Editable vector **source** for the app icon. Edit this to change the icon. |
 | `README.md` | yes | This file. |
 | `cc-director-mac-main`, `cc-director-mac1`…`4` | no | Built binaries (gitignored). |
-| `CC Director*.app` | no | Built bundles live in `/Applications`, not here. |
+| `Director Dev*.app` | no | Built bundles live in `~/Applications/DevThrottle Dev`, not here. |
 | `AppIcon.icns` | no | Generated from `AppIcon.svg` (gitignored). |
 
 ---
@@ -114,7 +122,7 @@ ad-hoc-signed, **arm64-only** `CC Director.app` (no .NET runtime needed).
 **First install (one time):**
 
 1. Download `cc-director-mac-arm64.zip` from the release, unzip it, and drag
-   **`CC Director.app`** into `/Applications`.
+   **`Director.app`** into `/Applications`.
 2. Because the app is **not notarized** (we use no paid Apple Developer
    certificate), macOS quarantines a freshly downloaded app. **Right-click the
    app → Open** once, then confirm. This is needed only for the very first launch.

--- a/scripts/local-build/mac/make-app-bundle.sh
+++ b/scripts/local-build/mac/make-app-bundle.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # make-app-bundle.sh — Wraps a built cc-director binary in a double-clickable
-# macOS .app bundle and installs it into /Applications.
+# macOS .app bundle and installs it into the developer apps folder
+# "~/Applications/DevThrottle Dev".
 #
 # Why a bundle: a bare Mach-O binary isn't launchable from Finder/Dock/Spotlight,
 # and — more importantly — launching from a .app runs cc-director under launchd,
@@ -11,19 +12,33 @@
 # the Terminal/Wingman tabs die with the "--print" error.
 #
 # Targets:
-#   main         -> "CC Director.app"   <- cc-director-mac-main   (your stable copy)
-#   1|2|3|4      -> "CC Director N.app" <- cc-director-macN       (normal-work slots)
-#   5            -> "CC Director 5.app" <- cc-director-mac5       (testing slot)
+#   main         -> "Director Dev.app"   <- cc-director-mac-main   (your stable copy)
+#   1|2|3|4      -> "Director Dev N.app" <- cc-director-macN       (normal-work slots)
+#   5            -> "Director Dev 5.app" <- cc-director-mac5       (testing slot)
+#
+# Why NOT /Applications, and why not the "Director" name: the real installed app
+# is "Director.app", and its installer PURGES stale product bundles (the legacy
+# "CC Director.app" and Finder-numbered duplicates like "Director 2.app") from
+# both ~/Applications and /Applications. Developer bundles therefore live in
+# their own folder under a name the purge patterns can never match, so a real
+# install on a development machine can never sweep the dev slots away.
 #
 # Each target gets a distinct CFBundleIdentifier so macOS treats them as separate
-# apps (own Dock tile, own Spotlight entry, can run side by side). The bundle's
-# launcher references the binary by absolute path, so rebuilding the binary in
-# place is picked up automatically — no need to re-make the bundle after a build.
+# apps (own Dock tile, own Spotlight entry, can run side by side) - and none of
+# them uses the REAL app's id (com.devthrottle.ccdirector), so the dev main copy
+# never fights the installed Director over LaunchServices registration. The
+# bundle's launcher references the binary by absolute path, so rebuilding the
+# binary in place is picked up automatically — no need to re-make the bundle
+# after a build.
+#
+# Re-running migrates: any old wrapper this script previously placed in
+# /Applications under the old "CC Director*" names is removed (wrappers only,
+# identified by their script launcher - a real installed app is never touched).
 #
 # Usage:
 #   scripts/local-build/mac/make-app-bundle.sh --target main
 #   scripts/local-build/mac/make-app-bundle.sh --target 2
-#   APPS_DIR=~/Applications scripts/local-build/mac/make-app-bundle.sh --target main
+#   APPS_DIR=/tmp/somewhere scripts/local-build/mac/make-app-bundle.sh --target main
 #
 set -euo pipefail
 
@@ -66,24 +81,39 @@ done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-BIN_DIR="$REPO_ROOT/local_builds/mac"                  # where the binaries live
-APPS_DIR="${APPS_DIR:-/Applications}"                  # override for testing
+BIN_DIR="${BIN_DIR:-$REPO_ROOT/local_builds/mac}"      # where the binaries live (override when
+                                                       # bundling from a worktree whose binaries
+                                                       # live in the main checkout)
+APPS_DIR="${APPS_DIR:-$HOME/Applications/DevThrottle Dev}"   # override for testing
 
-# Map target -> app display name, binary name, bundle id, and rebuild hint.
+# Map target -> app display name, binary name, bundle id, old wrapper name (for
+# migration off /Applications), and rebuild hint.
 case "$TARGET" in
     main)
-        APP_NAME="CC Director"
+        APP_NAME="Director Dev"
         BIN="cc-director-mac-main"
-        BID="com.devthrottle.ccdirector"
+        BID="com.devthrottle.ccdirector.dev"
+        OLD_NAME="CC Director"
         REBUILD="scripts/mac-rebuild.sh main" ;;
     1|2|3|4|5)
-        APP_NAME="CC Director $TARGET"
+        APP_NAME="Director Dev $TARGET"
         BIN="cc-director-mac$TARGET"
         BID="com.devthrottle.ccdirector.slot$TARGET"
+        OLD_NAME="CC Director $TARGET"
         REBUILD="scripts/mac-rebuild.sh $TARGET" ;;
     *)
         echo "ERROR: invalid --target '$TARGET' (use: main|1|2|3|4|5)" >&2; exit 1 ;;
 esac
+
+# Migration: this script used to place the wrappers in /Applications under the
+# "CC Director*" names. Remove that old copy IF it is one of our wrappers - the
+# tell is the generated script launcher at Contents/MacOS/launch. A real
+# installed application never has that, so it can never be removed here.
+OLD_APP="/Applications/$OLD_NAME.app"
+if [[ -f "$OLD_APP/Contents/MacOS/launch" ]]; then
+    echo "Migrating: removing old dev wrapper \"$OLD_APP\""
+    rm -rf "$OLD_APP"
+fi
 
 BIN_PATH="$BIN_DIR/$BIN"
 

--- a/scripts/mac-rebuild.sh
+++ b/scripts/mac-rebuild.sh
@@ -4,12 +4,15 @@
 #
 # This is the one command you run while developing. It builds the requested
 # binary (via local-build-mac.sh), then (re)creates the matching .app bundle in
-# /Applications. For the main target it also pins the app to the Dock.
+# "~/Applications/DevThrottle Dev" (NEVER /Applications - the real installer
+# purges stale product bundles there, and dev wrappers must be out of its
+# reach; see make-app-bundle.sh). For the main target it also pins the app to
+# the Dock.
 #
 # Targets:
-#   main        Build the stable copy -> "CC Director.app", pinned to the Dock.
-#   1|2|3|4     Build a normal-work slot -> "CC Director N.app" (run several at once).
-#   5           Build the testing slot -> "CC Director 5.app" (started and stopped freely).
+#   main        Build the stable copy -> "Director Dev.app", pinned to the Dock.
+#   1|2|3|4     Build a normal-work slot -> "Director Dev N.app" (run several at once).
+#   5           Build the testing slot -> "Director Dev 5.app" (started and stopped freely).
 #   all         Build main + slots 1 through 5.
 #   apps        (Re)create all six .app bundles WITHOUT building — fast, used by
 #               mac-setup.sh to lay down the icons before anything is built.
@@ -20,7 +23,7 @@
 #   scripts/mac-rebuild.sh all
 #
 # Env:
-#   APPS_DIR    Where to install the apps (default /Applications).
+#   APPS_DIR    Where to install the apps (default "~/Applications/DevThrottle Dev").
 #
 set -euo pipefail
 
@@ -34,7 +37,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 MAC_DIR="$REPO_ROOT/local_builds/mac"
 MAC_HELPERS="$REPO_ROOT/scripts/local-build/mac"
-APPS_DIR="${APPS_DIR:-/Applications}"
+APPS_DIR="${APPS_DIR:-$HOME/Applications/DevThrottle Dev}"
 export APPS_DIR
 
 # Build one target's binary, then (re)make its app bundle.
@@ -46,25 +49,28 @@ build_one() {
     "$MAC_HELPERS/make-app-bundle.sh" --target "$t"
 }
 
-# Pin the main app to the Dock. Always unpins any existing 'CC Director' tile
-# first, rebuilds the icon cache, then re-pins — so the tile reliably shows the
-# current icon even if an earlier (icon-less) bundle was cached by the Dock.
+# Pin the main app to the Dock. Always unpins any existing 'Director Dev' tile
+# (and any old 'CC Director' tile from the pre-migration layout) first, rebuilds
+# the icon cache, then re-pins — so the tile reliably shows the current icon
+# even if an earlier (icon-less) bundle was cached by the Dock.
 pin_dock() {
-    local app="$APPS_DIR/CC Director.app"
+    local app="$APPS_DIR/Director Dev.app"
     touch "$app"
     /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
         -f "$app" 2>/dev/null || true
 
-    # Remove any existing 'CC Director' (main, not the numbered slots) tile.
+    # Remove any existing 'Director Dev' tile, and any old 'CC Director' tile
+    # left from the pre-migration /Applications layout (its app is gone).
     python3 - <<PY 2>/dev/null || true
 import subprocess, plistlib
 data = subprocess.run(["defaults","export","com.apple.dock","-"],capture_output=True).stdout
 pl = plistlib.loads(data)
-def is_main(e):
+def is_stale(e):
     try: s = e["tile-data"]["file-data"]["_CFURLString"].replace("%20"," ")
     except Exception: return False
-    return s.rstrip("/").endswith("/CC Director.app")
-pl["persistent-apps"] = [e for e in pl.get("persistent-apps",[]) if not is_main(e)]
+    s = s.rstrip("/")
+    return s.endswith("/Director Dev.app") or s.endswith("/CC Director.app")
+pl["persistent-apps"] = [e for e in pl.get("persistent-apps",[]) if not is_stale(e)]
 subprocess.run(["defaults","import","com.apple.dock","-"],input=plistlib.dumps(pl))
 PY
 
@@ -73,7 +79,7 @@ PY
     defaults write com.apple.dock persistent-apps -array-add \
         "<dict><key>tile-data</key><dict><key>file-data</key><dict><key>_CFURLString</key><string>file://$app/</string><key>_CFURLStringType</key><integer>15</integer></dict></dict></dict>"
     killall Dock
-    echo "Dock: pinned 'CC Director' (the Dock restarted briefly — that's normal)."
+    echo "Dock: pinned 'Director Dev' (the Dock restarted briefly — that's normal)."
 }
 
 case "$TARGET" in
@@ -82,7 +88,7 @@ case "$TARGET" in
         pin_dock ;;
     1|2|3|4|5)
         build_one "$TARGET"
-        echo "Open it from Launchpad/Spotlight, or: open \"$APPS_DIR/CC Director $TARGET.app\"" ;;
+        echo "Open it from Launchpad/Spotlight, or: open \"$APPS_DIR/Director Dev $TARGET.app\"" ;;
     all)
         build_one main
         for n in 1 2 3 4 5; do build_one "$n"; done

--- a/scripts/mac-setup.sh
+++ b/scripts/mac-setup.sh
@@ -2,11 +2,16 @@
 #
 # mac-setup.sh — One-time setup for CC Director on macOS.
 #
-# After this runs you'll have:
-#   • "CC Director" — your stable copy, in /Applications AND pinned to the Dock.
-#   • "CC Director 1".."CC Director 4" — normal-work slots, in /Applications
+# After this runs you'll have, in "~/Applications/DevThrottle Dev" (never
+# /Applications - the real installer purges stale product bundles there):
+#   • "Director Dev" — your stable copy, pinned to the Dock.
+#   • "Director Dev 1".."Director Dev 4" — normal-work slots
 #     (find them in Launchpad or Spotlight).
-#   • "CC Director 5" — the testing slot, started and stopped freely.
+#   • "Director Dev 5" — the testing slot, started and stopped freely.
+#
+# Re-running is also the MIGRATION path: old "CC Director*" wrappers this setup
+# used to place in /Applications are removed (wrappers only - a real installed
+# Director.app is never touched).
 #
 # Re-running is safe (idempotent). Requires the .NET 10 SDK (see scripts/local-build/mac/README.md).
 #
@@ -19,7 +24,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # bundle id and would confuse LaunchServices/Dock about which app to open.
 rm -rf "$REPO_ROOT/local_builds/mac/CC Director.app"
 
-echo "Setting up CC Director apps (1 main + 5 slots)..."
+echo "Setting up Director Dev apps (1 main + 5 slots)..."
 
 # 0) Create and trust the stable local code-signing certificate (idempotent;
 #    may ask for your administrator password). Without it every rebuild
@@ -38,13 +43,14 @@ cat <<'EOF'
 
 ✅ Done.
 
-  • "CC Director" is now in your Dock (bottom toolbar) and in /Applications.
-    Click the Dock icon any time — this is your everyday copy.
+  • "Director Dev" is now in your Dock (bottom toolbar) and in
+    "~/Applications/DevThrottle Dev". Click the Dock icon any time — this is
+    your everyday copy.
 
-  • Slots "CC Director 1" … "CC Director 4" (normal work) and "CC Director 5"
-    (testing) are in /Applications. Find them with Spotlight (press Cmd+Space,
-    type "CC Director 2") or in Launchpad. A slot that isn't built yet tells
-    you how to build it when you click it.
+  • Slots "Director Dev 1" … "Director Dev 4" (normal work) and "Director Dev 5"
+    (testing) are in "~/Applications/DevThrottle Dev". Find them with Spotlight
+    (press Cmd+Space, type "Director Dev 2") or in Launchpad. A slot that isn't
+    built yet tells you how to build it when you click it.
 
 Everyday commands (run from the repo root):
 

--- a/tools/cc-director-setup-engine.Tests/MacBundlePurgerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/MacBundlePurgerTests.cs
@@ -1,0 +1,150 @@
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// The purge must converge a host on ONE canonical Director bundle without ever deleting
+/// something that is not provably the product's own: developer slot wrappers share the
+/// "CC Director N" names but carry suffixed bundle ids, and "Director" is generic enough
+/// that an unrelated vendor's app could share the name outright (issue #1821).
+/// </summary>
+public class MacBundlePurgerTests : IDisposable
+{
+    private readonly string _root;
+    private readonly List<string> _log = [];
+
+    public MacBundlePurgerTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"purger-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private string MakeBundle(string name, string? bundleId)
+    {
+        var contents = Path.Combine(_root, name, "Contents");
+        Directory.CreateDirectory(contents);
+        if (bundleId is not null)
+        {
+            File.WriteAllText(Path.Combine(contents, "Info.plist"),
+                $"""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <plist version="1.0">
+                <dict>
+                    <key>CFBundleIdentifier</key>      <string>{bundleId}</string>
+                    <key>CFBundleExecutable</key>      <string>launch</string>
+                </dict>
+                </plist>
+                """);
+        }
+        return Path.Combine(_root, name);
+    }
+
+    private void Purge(string keepName = "Director.app") =>
+        MacBundlePurger.Purge([_root], Path.Combine(_root, keepName), _log.Add,
+            MacBundlePurger.ReadBundleIdentifier);
+
+    [Fact]
+    public void Purge_LegacyProductBundle_Deleted()
+    {
+        var legacy = MakeBundle("CC Director.app", MacBundlePurger.ProductBundleIdentifier);
+        Purge();
+        Assert.False(Directory.Exists(legacy));
+        Assert.Contains(_log, l => l.Contains("removed stale bundle"));
+    }
+
+    [Fact]
+    public void Purge_FinderNumberedDuplicates_Deleted()
+    {
+        var dup1 = MakeBundle("Director 2.app", MacBundlePurger.ProductBundleIdentifier);
+        var dup2 = MakeBundle("CC Director 10.app", MacBundlePurger.ProductBundleIdentifier);
+        Purge();
+        Assert.False(Directory.Exists(dup1));
+        Assert.False(Directory.Exists(dup2));
+    }
+
+    [Fact]
+    public void Purge_KeepPath_Survives()
+    {
+        var keep = MakeBundle("Director.app", MacBundlePurger.ProductBundleIdentifier);
+        Purge();
+        Assert.True(Directory.Exists(keep));
+    }
+
+    [Fact]
+    public void Purge_DeveloperSlotWrapper_SurvivesAndIsLogged()
+    {
+        // The developer slot wrappers live beside the real install on a development machine.
+        // Their suffixed bundle id is the proof they are not the shipped Director.
+        var slot = MakeBundle("CC Director 2.app", "com.devthrottle.ccdirector.slot2");
+        Purge();
+        Assert.True(Directory.Exists(slot));
+        Assert.Contains(_log, l => l.Contains("not ours to delete"));
+    }
+
+    [Fact]
+    public void Purge_UnrelatedAppSharingTheName_Survives()
+    {
+        var foreign = MakeBundle("Director.app", "com.adobe.director");
+        Purge(keepName: "elsewhere/Director.app");
+        Assert.True(Directory.Exists(foreign));
+    }
+
+    [Fact]
+    public void Purge_BundleWithoutInfoPlist_SurvivesAndIsLogged()
+    {
+        // No Info.plist means identity cannot be confirmed - the safe default is to leave it.
+        var broken = MakeBundle("CC Director 3.app", bundleId: null);
+        Purge();
+        Assert.True(Directory.Exists(broken));
+        Assert.Contains(_log, l => l.Contains("unreadable"));
+    }
+
+    [Fact]
+    public void Purge_NameNotMatchingBundlePattern_NotTouched()
+    {
+        // "Directory.app" and non-numeric suffixes must never be considered, whatever their id.
+        var directory = MakeBundle("Directory.app", MacBundlePurger.ProductBundleIdentifier);
+        var devNamed = MakeBundle("Director Dev 2.app", MacBundlePurger.ProductBundleIdentifier);
+        Purge();
+        Assert.True(Directory.Exists(directory));
+        Assert.True(Directory.Exists(devNamed));
+    }
+
+    [Fact]
+    public void Purge_NonExistentDirectory_NoThrow()
+    {
+        MacBundlePurger.Purge([Path.Combine(_root, "missing")], Path.Combine(_root, "Director.app"), _log.Add);
+        Assert.Empty(_log);
+    }
+
+    [Theory]
+    [InlineData("Director.app", "Director", true)]
+    [InlineData("Director 2.app", "Director", true)]
+    [InlineData("CC Director 10.app", "CC Director", true)]
+    [InlineData("Directory.app", "Director", false)]
+    [InlineData("Director Dev.app", "Director", false)]
+    [InlineData("Director 2b.app", "Director", false)]
+    [InlineData("Director .app", "Director", false)]
+    public void IsBundleName_MatchesOnlyExactAndNumberedForms(string name, string baseName, bool expected) =>
+        Assert.Equal(expected, MacBundlePurger.IsBundleName(name, baseName));
+
+    [Fact]
+    public void ReadBundleIdentifier_ReadsXmlPlist()
+    {
+        var bundle = MakeBundle("Director.app", "com.devthrottle.ccdirector");
+        Assert.Equal("com.devthrottle.ccdirector", MacBundlePurger.ReadBundleIdentifier(bundle));
+    }
+
+    [Fact]
+    public void ReadBundleIdentifier_MissingPlist_ReturnsNull()
+    {
+        var bundle = MakeBundle("Director.app", bundleId: null);
+        Assert.Null(MacBundlePurger.ReadBundleIdentifier(bundle));
+    }
+}

--- a/tools/cc-director-setup-engine/MacAppPlacer.cs
+++ b/tools/cc-director-setup-engine/MacAppPlacer.cs
@@ -61,7 +61,10 @@ public static class MacAppPlacer
             // "CC Director.app", Finder's auto-suffixed duplicates ("CC Director 2.app", "Director 2.app"),
             // and any copy dragged into the system /Applications instead of ~/Applications. This is what
             // makes reinstalling upgrade-in-place instead of stacking a new icon beside the old ones.
-            PurgeStaleBundles(layout, keep: target, Log);
+            // Deletion is identity-gated (MacBundlePurger): only bundles carrying the Director's own
+            // CFBundleIdentifier are removed, so developer slot wrappers and unrelated apps that happen
+            // to share the name survive.
+            MacBundlePurger.Purge([layout.MacAppsDir, "/Applications"], keep: target, Log);
 
             Log($"installing {AppName} to {layout.MacAppsDir}");
             // Build beside, then this is a fresh place: remove any existing app, then ditto in.
@@ -86,52 +89,6 @@ public static class MacAppPlacer
             try { if (zip is not null && File.Exists(zip)) File.Delete(zip); } catch { /* best-effort */ }
             try { if (stage is not null && Directory.Exists(stage)) Directory.Delete(stage, recursive: true); } catch { /* best-effort */ }
         }
-    }
-
-    /// <summary>
-    /// Remove stale Director bundles the old loose-zip distribution could have left, so a reinstall
-    /// converges on the single <paramref name="keep"/> bundle instead of stacking icons. Scans both the
-    /// per-user ~/Applications and the system /Applications for the current and legacy bundle names plus
-    /// Finder's numbered duplicates ("Director 2.app", "CC Director 3.app"). The <paramref name="keep"/>
-    /// path is never removed here - the caller replaces it in place immediately after. Best-effort:
-    /// a copy under /Applications the user cannot delete without admin is logged and skipped, not fatal.
-    /// </summary>
-    private static void PurgeStaleBundles(InstallLayout layout, string keep, Action<string> log)
-    {
-        var dirs = new[] { layout.MacAppsDir, "/Applications" };
-        var baseNames = new[] { "Director", "CC Director" };
-
-        foreach (var dir in dirs)
-        {
-            if (!Directory.Exists(dir)) continue;
-            foreach (var baseName in baseNames)
-            {
-                // The exact bundle plus Finder's " N" suffixed duplicates (space + digits), e.g.
-                // "Director.app", "Director 2.app", "CC Director 10.app".
-                foreach (var bundle in Directory.EnumerateDirectories(dir, $"{baseName}*.app"))
-                {
-                    var name = Path.GetFileName(bundle);
-                    if (!IsBundleName(name, baseName)) continue;
-                    if (string.Equals(Path.GetFullPath(bundle), Path.GetFullPath(keep), StringComparison.Ordinal))
-                        continue; // the caller replaces this one in place.
-
-                    var (exit, out_) = ProcessRunner.Run("/bin/rm", $"-rf \"{bundle}\"");
-                    if (exit == 0) log($"removed stale bundle {bundle}");
-                    else log($"could not remove {bundle} (needs admin?); skipping: {Trim(out_)}");
-                }
-            }
-        }
-    }
-
-    /// <summary>True for "&lt;base&gt;.app" or Finder's "&lt;base&gt; N.app" duplicate form, and nothing else -
-    /// so "Director.app"/"Director 2.app" match "Director" but an unrelated "Directory.app" does not.</summary>
-    private static bool IsBundleName(string name, string baseName)
-    {
-        if (string.Equals(name, $"{baseName}.app", StringComparison.Ordinal)) return true;
-        if (!name.StartsWith($"{baseName} ", StringComparison.Ordinal) ||
-            !name.EndsWith(".app", StringComparison.Ordinal)) return false;
-        var middle = name.Substring(baseName.Length + 1, name.Length - baseName.Length - 1 - ".app".Length);
-        return middle.Length > 0 && middle.All(char.IsDigit);
     }
 
     private static string Trim(string s) => s.Length > 400 ? s[..400] : s;

--- a/tools/cc-director-setup-engine/MacBundlePurger.cs
+++ b/tools/cc-director-setup-engine/MacBundlePurger.cs
@@ -1,0 +1,112 @@
+using System.Text.RegularExpressions;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// Removes stale Director .app bundles so a reinstall converges on one canonical bundle
+/// (issue #1821). Deletion is gated on PROOF OF IDENTITY: a bundle is only removed when its
+/// Info.plist carries the product's own CFBundleIdentifier. Name alone is not enough - the
+/// developer slot wrappers ("CC Director 2.app", bundle id com.devthrottle.ccdirector.slot2)
+/// live in /Applications on a development machine, and "Director" is a generic enough app
+/// name that an unrelated vendor's "Director.app" could exist. Deleting either would destroy
+/// something we do not own, so anything whose identity cannot be confirmed is skipped and
+/// logged, never deleted.
+/// </summary>
+public static class MacBundlePurger
+{
+    /// <summary>The shipped Director bundle's CFBundleIdentifier - the ONLY identity we ever delete.
+    /// Developer slot wrappers use suffixed ids ("com.devthrottle.ccdirector.slot2") which do NOT
+    /// match, by design.</summary>
+    public const string ProductBundleIdentifier = "com.devthrottle.ccdirector";
+
+    /// <summary>Bundle base names the product has shipped under: the current "Director" and the
+    /// pre-rename "CC Director" (issue #1821).</summary>
+    public static readonly IReadOnlyList<string> BaseNames = ["Director", "CC Director"];
+
+    /// <summary>
+    /// Delete every stale product bundle in <paramref name="directories"/>: bundles named
+    /// "&lt;base&gt;.app" or Finder's "&lt;base&gt; N.app" duplicate form whose CFBundleIdentifier is
+    /// <see cref="ProductBundleIdentifier"/>. The <paramref name="keep"/> path is never deleted -
+    /// the caller replaces that one in place. Best-effort: a bundle that cannot be deleted (for
+    /// example a copy in /Applications that needs admin rights) is logged and skipped, not fatal.
+    /// </summary>
+    /// <param name="directories">The directories to scan (non-existent ones are skipped).</param>
+    /// <param name="keep">The canonical bundle path that must survive.</param>
+    /// <param name="log">Receives one line per removal or skip.</param>
+    /// <param name="readBundleIdentifier">
+    /// Reads a bundle's CFBundleIdentifier, or null when it has none / cannot be read. Null uses
+    /// the real Info.plist reader; tests inject a fake.
+    /// </param>
+    public static void Purge(IReadOnlyList<string> directories, string keep, Action<string> log,
+        Func<string, string?>? readBundleIdentifier = null)
+    {
+        ArgumentNullException.ThrowIfNull(directories);
+        ArgumentNullException.ThrowIfNull(keep);
+        ArgumentNullException.ThrowIfNull(log);
+        var readId = readBundleIdentifier ?? ReadBundleIdentifier;
+
+        foreach (var dir in directories)
+        {
+            if (!Directory.Exists(dir)) continue;
+            foreach (var baseName in BaseNames)
+            {
+                foreach (var bundle in Directory.EnumerateDirectories(dir, $"{baseName}*.app"))
+                {
+                    var name = Path.GetFileName(bundle);
+                    if (!IsBundleName(name, baseName)) continue;
+                    if (string.Equals(Path.GetFullPath(bundle), Path.GetFullPath(keep), StringComparison.Ordinal))
+                        continue; // the caller replaces this one in place.
+
+                    var id = readId(bundle);
+                    if (!string.Equals(id, ProductBundleIdentifier, StringComparison.Ordinal))
+                    {
+                        log($"leaving {bundle}: bundle id '{id ?? "unreadable"}' is not the Director's own; not ours to delete");
+                        continue;
+                    }
+
+                    try
+                    {
+                        Directory.Delete(bundle, recursive: true);
+                        log($"removed stale bundle {bundle}");
+                    }
+                    catch (Exception ex)
+                    {
+                        log($"could not remove {bundle} (needs admin?); skipping: {ex.Message}");
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>True for "&lt;base&gt;.app" or Finder's "&lt;base&gt; N.app" duplicate form, and nothing else -
+    /// so "Director.app"/"Director 2.app" match "Director" but an unrelated "Directory.app" does not.</summary>
+    public static bool IsBundleName(string name, string baseName)
+    {
+        if (string.Equals(name, $"{baseName}.app", StringComparison.Ordinal)) return true;
+        if (!name.StartsWith($"{baseName} ", StringComparison.Ordinal) ||
+            !name.EndsWith(".app", StringComparison.Ordinal)) return false;
+        var middle = name.Substring(baseName.Length + 1, name.Length - baseName.Length - 1 - ".app".Length);
+        return middle.Length > 0 && middle.All(char.IsDigit);
+    }
+
+    /// <summary>
+    /// Read CFBundleIdentifier from the bundle's Contents/Info.plist, or null when absent or
+    /// unreadable. Handles the XML plist form our packaging writes; a binary plist (which our
+    /// bundles never use) reads as null and the bundle is therefore left alone - the safe default.
+    /// </summary>
+    public static string? ReadBundleIdentifier(string bundlePath)
+    {
+        var plist = Path.Combine(bundlePath, "Contents", "Info.plist");
+        if (!File.Exists(plist)) return null;
+        try
+        {
+            var text = File.ReadAllText(plist);
+            var match = Regex.Match(text,
+                @"<key>\s*CFBundleIdentifier\s*</key>\s*<string>\s*([^<]+?)\s*</string>",
+                RegexOptions.Singleline);
+            return match.Success ? match.Groups[1].Value : null;
+        }
+        catch (IOException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+    }
+}


### PR DESCRIPTION
Two safety fixes for the macOS installer's stale-bundle cleanup, verified live on Sorens-Mac-mini.

## The problem

The stale-bundle purge that ships in the v1.7.3 installer (pull request 2024) deletes by NAME alone: any \`Director*.app\` or \`CC Director*.app\` in \`~/Applications\` or \`/Applications\`. On a development machine the dev slot wrappers ("CC Director 1.app" through "CC Director 5.app") sat exactly inside those patterns in \`/Applications\` - a single fresh install would have deleted all of the owner's dev slots. "Director" is also a generic app name, so an unrelated vendor's \`Director.app\` would have been deleted too.

## The fixes

1. **The purge now demands proof of identity** (\`MacBundlePurger\`): a bundle is deleted only when its Info.plist carries the Director's own bundle identifier (\`com.devthrottle.ccdirector\`). Dev slot wrappers use suffixed identifiers and survive; a bundle whose identity cannot be read is left in place and logged.
2. **The dev slot scripts move off \`/Applications\` entirely**: wrappers now build into \`~/Applications/DevThrottle Dev\` as "Director Dev.app" / "Director Dev N.app" - names the purge patterns can never match - and the dev main wrapper stops squatting on the real app's bundle identifier. Re-running the scripts migrates: an old \`/Applications\` wrapper is removed only when it carries the generated script launcher, so a real installed Director.app is never touched.

## Verified on real hardware (Sorens-Mac-mini)

Live install from a local v1.7.3 release directory, with the machine's real state plus seeded bundles:

- The real pre-rename \`~/Applications/CC Director.app\` (v1.7.1 install): **removed and replaced** by one canonical \`Director.app\` - the upgrade path works.
- Seeded Finder duplicate \`CC Director 2.app\` (product identifier) in \`~/Applications\`: **removed**.
- Seeded stale \`CC Director 3.app\` (product identifier) in \`/Applications\`: **removed**.
- Seeded foreign \`Director 2.app\` (identifier \`com.example.othervendor.director\`) in \`/Applications\`: **left alone**, with the log line "bundle id ... is not the Director's own; not ours to delete".
- Reinstalling replaces in place; exactly one \`Director.app\` remains.
- All six dev wrappers migrated off \`/Applications\` into \`~/Applications/DevThrottle Dev\`, pointing at the main checkout's binaries, with icons.

## Tests

17 new tests in \`MacBundlePurgerTests\`. Revert-proof: with the identity gate disabled, the three protection tests fail (slot wrapper deleted, foreign app deleted, plist-less bundle deleted) and the fourteen control tests stay green. Full engine suite: 357 passed, 29 failures all pre-existing macOS environment failures present without this change (Windows shim and Python tools tests).