### PR TITLE
Tenant-key the launcher registries and bind the tenant on the launcher hub

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedLauncherHubDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherHubDenyTests.cs
@@ -119,8 +119,8 @@ public sealed class HostedLauncherHubDenyTests : IAsyncLifetime
         });
 
         // The registry was never written by either tenant - there is no bare-machine-keyed row to supersede.
-        Assert.False(_gateway.LauncherConnections.IsStreamConnected(Machine));
-        Assert.Null(_gateway.LauncherConnections.GetActiveConnectionId(Machine));
+        Assert.False(_gateway.LauncherConnections.IsStreamConnected(CcDirector.Core.Tenancy.TenantId.Local, Machine));
+        Assert.Null(_gateway.LauncherConnections.GetActiveConnectionId(CcDirector.Core.Tenancy.TenantId.Local, Machine));
     }
 
     /// <summary>
@@ -140,7 +140,7 @@ public sealed class HostedLauncherHubDenyTests : IAsyncLifetime
 
         await conn.InvokeAsync("Hello", new LauncherStreamHello { MachineName = Machine, Port = 7878, Version = "test" });
 
-        Assert.True(_gateway.LauncherConnections.IsStreamConnected(Machine));
+        Assert.True(_gateway.LauncherConnections.IsStreamConnected(CcDirector.Core.Tenancy.TenantId.Local, Machine));
     }
 
     private async Task<HubConnection> ConnectLauncherAsync(string token)

--- a/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
@@ -331,7 +331,7 @@ public sealed class HostedLauncherMachineDenyTests : IAsyncLifetime
         // port and process id fleet-wide. Seeding a machine directly into the registry and then proving the
         // hosted response cannot possibly carry it states the disclosure in its own terms - an empty list
         // would satisfy "no leak" while being a false statement about the fleet, so the refusal is asserted too.
-        _gateway.Launchers.Upsert(new LauncherRegistrationRequest
+        _gateway.Launchers.Upsert(CcDirector.Core.Tenancy.TenantId.Local, new LauncherRegistrationRequest
         {
             MachineName = "SOMEONE-ELSES-PC",
             Port = 7999,
@@ -532,7 +532,7 @@ internal sealed class MachineGroupProbeHost : IAsyncDisposable
 
     /// <summary>Register the stub launcher under <paramref name="machine"/> so the REST relay dials it on loopback.</summary>
     public void SeedStubLauncher(string machine) =>
-        Launchers.Upsert(new LauncherRegistrationRequest
+        Launchers.Upsert(CcDirector.Core.Tenancy.TenantId.Local, new LauncherRegistrationRequest
         {
             MachineName = machine,
             Port = StubLauncherPort,
@@ -770,8 +770,8 @@ public sealed class HostedLauncherMachineExclusiveGroupTests : IDisposable
 
         // Read the write side directly. Nothing landed - so the outbound-request-forgery primitive
         // (re-pointing a machine's relay at an arbitrary host) never armed.
-        Assert.Null(probe.Launchers.Get("ATTACKER-REDIRECT"));
-        Assert.Empty(probe.Launchers.ListLaunchers());
+        Assert.Null(probe.Launchers.Get(CcDirector.Core.Tenancy.TenantId.Local, "ATTACKER-REDIRECT"));
+        Assert.Empty(probe.Launchers.ListLaunchers(CcDirector.Core.Tenancy.TenantId.Local));
     }
 
     /// <summary>
@@ -894,7 +894,7 @@ public sealed class HostedLauncherMachineSelfHostControlTests : IDisposable
         // UNREGISTER - and re-read the registry OBJECT directly, so the effect is observed at the write side
         // rather than only through the route that reports it.
         Assert.Equal(HttpStatusCode.OK, (await probe.Http.DeleteAsync($"/launchers/{Machine}")).StatusCode);
-        Assert.Null(probe.Launchers.Get(Machine));
+        Assert.Null(probe.Launchers.Get(CcDirector.Core.Tenancy.TenantId.Local, Machine));
         Assert.Empty((await probe.Http.GetFromJsonAsync<List<LauncherDto>>("/launchers"))!);
     }
 

--- a/src/CcDirector.Gateway.Tests/LauncherCommandRouterTests.cs
+++ b/src/CcDirector.Gateway.Tests/LauncherCommandRouterTests.cs
@@ -19,7 +19,7 @@ public sealed class LauncherCommandRouterTests
     public async Task TrySendAsync_NullDelegate_ReturnsNull_ForRestFallback()
     {
         // Arrange + Act - stream mode off: the host passes a null send delegate.
-        var result = await LauncherCommandRouter.TrySendAsync(null, "machine-A", StartCommand(), CancellationToken.None);
+        var result = await LauncherCommandRouter.TrySendAsync(null, CcDirector.Core.Tenancy.TenantId.Local, "machine-A", StartCommand(), CancellationToken.None);
 
         // Assert - null tells the caller to use the existing HTTP relay.
         Assert.Null(result);
@@ -30,10 +30,10 @@ public sealed class LauncherCommandRouterTests
     {
         // Arrange - the launcher is online: the delegate returns an authoritative result.
         var expected = LauncherCommandResult.Ok();
-        LauncherCommandRouter.SendLauncherCommandAsync del = (_, _, _) => Task.FromResult<LauncherCommandResult?>(expected);
+        LauncherCommandRouter.SendLauncherCommandAsync del = (_, _, _, _) => Task.FromResult<LauncherCommandResult?>(expected);
 
         // Act
-        var result = await LauncherCommandRouter.TrySendAsync(del, "machine-A", StartCommand(), CancellationToken.None);
+        var result = await LauncherCommandRouter.TrySendAsync(del, CcDirector.Core.Tenancy.TenantId.Local, "machine-A", StartCommand(), CancellationToken.None);
 
         // Assert - the stream result is returned unchanged; the caller must NOT also relay over HTTP.
         Assert.Same(expected, result);
@@ -43,10 +43,10 @@ public sealed class LauncherCommandRouterTests
     public async Task TrySendAsync_DelegateReturnsNull_ReturnsNull_ForRestFallback()
     {
         // Arrange - stream mode on but the launcher has no active connection: the delegate returns null.
-        LauncherCommandRouter.SendLauncherCommandAsync del = (_, _, _) => Task.FromResult<LauncherCommandResult?>(null);
+        LauncherCommandRouter.SendLauncherCommandAsync del = (_, _, _, _) => Task.FromResult<LauncherCommandResult?>(null);
 
         // Act
-        var result = await LauncherCommandRouter.TrySendAsync(del, "machine-A", StartCommand(), CancellationToken.None);
+        var result = await LauncherCommandRouter.TrySendAsync(del, CcDirector.Core.Tenancy.TenantId.Local, "machine-A", StartCommand(), CancellationToken.None);
 
         // Assert - still the HTTP-relay fall-back signal.
         Assert.Null(result);
@@ -58,7 +58,7 @@ public sealed class LauncherCommandRouterTests
         // Arrange
         string? seenMachine = null;
         string? seenVerb = null;
-        LauncherCommandRouter.SendLauncherCommandAsync del = (machine, cmd, _) =>
+        LauncherCommandRouter.SendLauncherCommandAsync del = (_, machine, cmd, _) =>
         {
             seenMachine = machine;
             seenVerb = cmd.Verb;
@@ -66,7 +66,7 @@ public sealed class LauncherCommandRouterTests
         };
 
         // Act
-        await LauncherCommandRouter.TrySendAsync(del, "machine-Z", new LauncherCommand { Verb = "director/restart" }, CancellationToken.None);
+        await LauncherCommandRouter.TrySendAsync(del, CcDirector.Core.Tenancy.TenantId.Local, "machine-Z", new LauncherCommand { Verb = "director/restart" }, CancellationToken.None);
 
         // Assert - the router forwards the routing key and command verbatim.
         Assert.Equal("machine-Z", seenMachine);
@@ -78,10 +78,10 @@ public sealed class LauncherCommandRouterTests
     {
         // Arrange - the launcher rejected the command; a typed failure is authoritative, not a fall-back.
         var failure = LauncherCommandResult.Fail(LauncherCommandStatus.BadRequest, "unknown verb: bogus");
-        LauncherCommandRouter.SendLauncherCommandAsync del = (_, _, _) => Task.FromResult<LauncherCommandResult?>(failure);
+        LauncherCommandRouter.SendLauncherCommandAsync del = (_, _, _, _) => Task.FromResult<LauncherCommandResult?>(failure);
 
         // Act
-        var result = await LauncherCommandRouter.TrySendAsync(del, "machine-A", new LauncherCommand { Verb = "bogus" }, CancellationToken.None);
+        var result = await LauncherCommandRouter.TrySendAsync(del, CcDirector.Core.Tenancy.TenantId.Local, "machine-A", new LauncherCommand { Verb = "bogus" }, CancellationToken.None);
 
         // Assert - a non-null failure is returned as-is (the caller must NOT relay over HTTP).
         Assert.Same(failure, result);

--- a/src/CcDirector.Gateway.Tests/LauncherConnectionRegistryTests.cs
+++ b/src/CcDirector.Gateway.Tests/LauncherConnectionRegistryTests.cs
@@ -20,11 +20,11 @@ public sealed class LauncherConnectionRegistryTests
         var registry = NewRegistry();
 
         // Act
-        registry.RegisterConnection("machine-A", "conn-1");
+        registry.RegisterConnection(CcDirector.Core.Tenancy.TenantId.Local, "machine-A", "conn-1");
 
         // Assert
-        Assert.Equal("conn-1", registry.GetActiveConnectionId("machine-A"));
-        Assert.True(registry.IsStreamConnected("machine-A"));
+        Assert.Equal("conn-1", registry.GetActiveConnectionId(CcDirector.Core.Tenancy.TenantId.Local, "machine-A"));
+        Assert.True(registry.IsStreamConnected(CcDirector.Core.Tenancy.TenantId.Local, "machine-A"));
     }
 
     [Fact]
@@ -32,11 +32,11 @@ public sealed class LauncherConnectionRegistryTests
     {
         // Arrange
         var registry = NewRegistry();
-        registry.RegisterConnection("Machine-A", "conn-1");
+        registry.RegisterConnection(CcDirector.Core.Tenancy.TenantId.Local, "Machine-A", "conn-1");
 
         // Assert - the map is keyed case-insensitively (OrdinalIgnoreCase).
-        Assert.Equal("conn-1", registry.GetActiveConnectionId("machine-a"));
-        Assert.True(registry.IsStreamConnected("MACHINE-A"));
+        Assert.Equal("conn-1", registry.GetActiveConnectionId(CcDirector.Core.Tenancy.TenantId.Local, "machine-a"));
+        Assert.True(registry.IsStreamConnected(CcDirector.Core.Tenancy.TenantId.Local, "MACHINE-A"));
     }
 
     [Fact]
@@ -44,14 +44,14 @@ public sealed class LauncherConnectionRegistryTests
     {
         // Arrange
         var registry = NewRegistry();
-        registry.RegisterConnection("machine-A", "conn-1");
+        registry.RegisterConnection(CcDirector.Core.Tenancy.TenantId.Local, "machine-A", "conn-1");
 
         // Act
         registry.Unregister("conn-1");
 
         // Assert
-        Assert.False(registry.IsStreamConnected("machine-A"));
-        Assert.Null(registry.GetActiveConnectionId("machine-A"));
+        Assert.False(registry.IsStreamConnected(CcDirector.Core.Tenancy.TenantId.Local, "machine-A"));
+        Assert.Null(registry.GetActiveConnectionId(CcDirector.Core.Tenancy.TenantId.Local, "machine-A"));
     }
 
     [Fact]
@@ -59,13 +59,13 @@ public sealed class LauncherConnectionRegistryTests
     {
         // Arrange - a launcher restart / reconnect: a new connection for the same machine wins.
         var registry = NewRegistry();
-        registry.RegisterConnection("machine-A", "conn-1");
+        registry.RegisterConnection(CcDirector.Core.Tenancy.TenantId.Local, "machine-A", "conn-1");
 
         // Act
-        registry.RegisterConnection("machine-A", "conn-2");
+        registry.RegisterConnection(CcDirector.Core.Tenancy.TenantId.Local, "machine-A", "conn-2");
 
         // Assert
-        Assert.Equal("conn-2", registry.GetActiveConnectionId("machine-A"));
+        Assert.Equal("conn-2", registry.GetActiveConnectionId(CcDirector.Core.Tenancy.TenantId.Local, "machine-A"));
     }
 
     [Fact]
@@ -75,15 +75,15 @@ public sealed class LauncherConnectionRegistryTests
         // (the superseded old connection) disconnects late. The atomic compare-remove must ignore the stale
         // disconnect so the newer connection keeps owning the machine.
         var registry = NewRegistry();
-        registry.RegisterConnection("machine-A", "conn-1");
-        registry.RegisterConnection("machine-A", "conn-2");
+        registry.RegisterConnection(CcDirector.Core.Tenancy.TenantId.Local, "machine-A", "conn-1");
+        registry.RegisterConnection(CcDirector.Core.Tenancy.TenantId.Local, "machine-A", "conn-2");
 
         // Act
         registry.Unregister("conn-1");
 
         // Assert - the newer connection still owns the machine.
-        Assert.True(registry.IsStreamConnected("machine-A"));
-        Assert.Equal("conn-2", registry.GetActiveConnectionId("machine-A"));
+        Assert.True(registry.IsStreamConnected(CcDirector.Core.Tenancy.TenantId.Local, "machine-A"));
+        Assert.Equal("conn-2", registry.GetActiveConnectionId(CcDirector.Core.Tenancy.TenantId.Local, "machine-A"));
     }
 
     [Fact]
@@ -91,22 +91,22 @@ public sealed class LauncherConnectionRegistryTests
     {
         // Arrange
         var registry = NewRegistry();
-        registry.RegisterConnection("machine-A", "conn-1");
+        registry.RegisterConnection(CcDirector.Core.Tenancy.TenantId.Local, "machine-A", "conn-1");
 
         // Act - a connection id the registry never held.
         registry.Unregister("conn-does-not-exist");
 
         // Assert - the active connection is untouched.
-        Assert.True(registry.IsStreamConnected("machine-A"));
-        Assert.Equal("conn-1", registry.GetActiveConnectionId("machine-A"));
+        Assert.True(registry.IsStreamConnected(CcDirector.Core.Tenancy.TenantId.Local, "machine-A"));
+        Assert.Equal("conn-1", registry.GetActiveConnectionId(CcDirector.Core.Tenancy.TenantId.Local, "machine-A"));
     }
 
     [Fact]
     public void GetActiveConnectionId_ForUnknownMachine_ReturnsNull()
     {
         var registry = NewRegistry();
-        Assert.Null(registry.GetActiveConnectionId("nobody"));
-        Assert.False(registry.IsStreamConnected("nobody"));
+        Assert.Null(registry.GetActiveConnectionId(CcDirector.Core.Tenancy.TenantId.Local, "nobody"));
+        Assert.False(registry.IsStreamConnected(CcDirector.Core.Tenancy.TenantId.Local, "nobody"));
     }
 
     [Fact]
@@ -114,15 +114,15 @@ public sealed class LauncherConnectionRegistryTests
     {
         // Arrange - two machines each with their own launcher connection.
         var registry = NewRegistry();
-        registry.RegisterConnection("machine-A", "conn-A");
-        registry.RegisterConnection("machine-B", "conn-B");
+        registry.RegisterConnection(CcDirector.Core.Tenancy.TenantId.Local, "machine-A", "conn-A");
+        registry.RegisterConnection(CcDirector.Core.Tenancy.TenantId.Local, "machine-B", "conn-B");
 
         // Act - one disconnects.
         registry.Unregister("conn-A");
 
         // Assert - the other is unaffected.
-        Assert.False(registry.IsStreamConnected("machine-A"));
-        Assert.True(registry.IsStreamConnected("machine-B"));
-        Assert.Equal("conn-B", registry.GetActiveConnectionId("machine-B"));
+        Assert.False(registry.IsStreamConnected(CcDirector.Core.Tenancy.TenantId.Local, "machine-A"));
+        Assert.True(registry.IsStreamConnected(CcDirector.Core.Tenancy.TenantId.Local, "machine-B"));
+        Assert.Equal("conn-B", registry.GetActiveConnectionId(CcDirector.Core.Tenancy.TenantId.Local, "machine-B"));
     }
 }

--- a/src/CcDirector.Gateway.Tests/LauncherRegistryTests.cs
+++ b/src/CcDirector.Gateway.Tests/LauncherRegistryTests.cs
@@ -20,9 +20,9 @@ public sealed class LauncherRegistryTests
         var reg = new LauncherRegistry();
         var req = MakeReq("MACHINE-A", 7900);
 
-        reg.Upsert(req);
+        reg.Upsert(CcDirector.Core.Tenancy.TenantId.Local, req);
 
-        var dto = reg.Get("MACHINE-A");
+        var dto = reg.Get(CcDirector.Core.Tenancy.TenantId.Local, "MACHINE-A");
         Assert.NotNull(dto);
         Assert.Equal("MACHINE-A", dto.MachineName);
         Assert.Equal(7900, dto.Port);
@@ -32,20 +32,20 @@ public sealed class LauncherRegistryTests
     public void Upsert_IsCaseInsensitive()
     {
         var reg = new LauncherRegistry();
-        reg.Upsert(MakeReq("machine-b", 7901));
+        reg.Upsert(CcDirector.Core.Tenancy.TenantId.Local, MakeReq("machine-b", 7901));
 
-        Assert.NotNull(reg.Get("MACHINE-B"));
-        Assert.NotNull(reg.Get("Machine-B"));
+        Assert.NotNull(reg.Get(CcDirector.Core.Tenancy.TenantId.Local, "MACHINE-B"));
+        Assert.NotNull(reg.Get(CcDirector.Core.Tenancy.TenantId.Local, "Machine-B"));
     }
 
     [Fact]
     public void Upsert_UpdatesExistingEntry()
     {
         var reg = new LauncherRegistry();
-        reg.Upsert(MakeReq("MACHINE-C", 7902, version: "1.0.0"));
-        reg.Upsert(MakeReq("MACHINE-C", 7902, version: "1.0.1"));
+        reg.Upsert(CcDirector.Core.Tenancy.TenantId.Local, MakeReq("MACHINE-C", 7902, version: "1.0.0"));
+        reg.Upsert(CcDirector.Core.Tenancy.TenantId.Local, MakeReq("MACHINE-C", 7902, version: "1.0.1"));
 
-        var dto = reg.Get("MACHINE-C");
+        var dto = reg.Get(CcDirector.Core.Tenancy.TenantId.Local, "MACHINE-C");
         Assert.NotNull(dto);
         Assert.Equal("1.0.1", dto!.Version);
     }
@@ -57,7 +57,7 @@ public sealed class LauncherRegistryTests
         var req = MakeReq("MACHINE-D", 7903);
         req.Token = "SECRET-TOKEN";
 
-        var dto = reg.Upsert(req);
+        var dto = reg.Upsert(CcDirector.Core.Tenancy.TenantId.Local, req);
 
         // Token MUST NOT be in the public DTO.
         var json = System.Text.Json.JsonSerializer.Serialize(dto);
@@ -74,16 +74,16 @@ public sealed class LauncherRegistryTests
         var reg = new LauncherRegistry();
         var req = MakeReq("MACHINE-E", 7904);
         req.Token = "my-relay-token";
-        reg.Upsert(req);
+        reg.Upsert(CcDirector.Core.Tenancy.TenantId.Local, req);
 
-        Assert.Equal("my-relay-token", reg.GetToken("MACHINE-E"));
+        Assert.Equal("my-relay-token", reg.GetToken(CcDirector.Core.Tenancy.TenantId.Local, "MACHINE-E"));
     }
 
     [Fact]
     public void GetToken_UnknownMachine_ReturnsNull()
     {
         var reg = new LauncherRegistry();
-        Assert.Null(reg.GetToken("NOBODY"));
+        Assert.Null(reg.GetToken(CcDirector.Core.Tenancy.TenantId.Local, "NOBODY"));
     }
 
     // -------------------------------------------------------------------------
@@ -94,16 +94,16 @@ public sealed class LauncherRegistryTests
     public void Heartbeat_KnownMachine_ReturnsTrue()
     {
         var reg = new LauncherRegistry();
-        reg.Upsert(MakeReq("MACHINE-F", 7905));
+        reg.Upsert(CcDirector.Core.Tenancy.TenantId.Local, MakeReq("MACHINE-F", 7905));
 
-        Assert.True(reg.Heartbeat("MACHINE-F"));
+        Assert.True(reg.Heartbeat(CcDirector.Core.Tenancy.TenantId.Local, "MACHINE-F"));
     }
 
     [Fact]
     public void Heartbeat_UnknownMachine_ReturnsFalse()
     {
         var reg = new LauncherRegistry();
-        Assert.False(reg.Heartbeat("NOBODY"));
+        Assert.False(reg.Heartbeat(CcDirector.Core.Tenancy.TenantId.Local, "NOBODY"));
     }
 
     // -------------------------------------------------------------------------
@@ -114,18 +114,18 @@ public sealed class LauncherRegistryTests
     public void Remove_ExistingEntry_IsGone()
     {
         var reg = new LauncherRegistry();
-        reg.Upsert(MakeReq("MACHINE-G", 7906));
+        reg.Upsert(CcDirector.Core.Tenancy.TenantId.Local, MakeReq("MACHINE-G", 7906));
 
-        reg.Remove("MACHINE-G");
+        reg.Remove(CcDirector.Core.Tenancy.TenantId.Local, "MACHINE-G");
 
-        Assert.Null(reg.Get("MACHINE-G"));
+        Assert.Null(reg.Get(CcDirector.Core.Tenancy.TenantId.Local, "MACHINE-G"));
     }
 
     [Fact]
     public void Remove_NonExistentEntry_DoesNotThrow()
     {
         var reg = new LauncherRegistry();
-        var ex = Record.Exception(() => reg.Remove("NOBODY"));
+        var ex = Record.Exception(() => reg.Remove(CcDirector.Core.Tenancy.TenantId.Local, "NOBODY"));
         Assert.Null(ex);
     }
 
@@ -137,10 +137,10 @@ public sealed class LauncherRegistryTests
     public void ListLaunchers_ReturnsAllEntries()
     {
         var reg = new LauncherRegistry();
-        reg.Upsert(MakeReq("MACHINE-H", 7907));
-        reg.Upsert(MakeReq("MACHINE-I", 7908));
+        reg.Upsert(CcDirector.Core.Tenancy.TenantId.Local, MakeReq("MACHINE-H", 7907));
+        reg.Upsert(CcDirector.Core.Tenancy.TenantId.Local, MakeReq("MACHINE-I", 7908));
 
-        var list = reg.ListLaunchers();
+        var list = reg.ListLaunchers(CcDirector.Core.Tenancy.TenantId.Local);
         Assert.Equal(2, list.Count);
         Assert.Contains(list, l => l.MachineName == "MACHINE-H");
         Assert.Contains(list, l => l.MachineName == "MACHINE-I");
@@ -150,7 +150,7 @@ public sealed class LauncherRegistryTests
     public void ListLaunchers_EmptyWhenNoneRegistered()
     {
         var reg = new LauncherRegistry();
-        Assert.Empty(reg.ListLaunchers());
+        Assert.Empty(reg.ListLaunchers(CcDirector.Core.Tenancy.TenantId.Local));
     }
 
     // -------------------------------------------------------------------------
@@ -163,9 +163,9 @@ public sealed class LauncherRegistryTests
         var reg = new LauncherRegistry();
         var req = MakeReq("MACHINE-NA", 7920, networkAddress: "example-pc.ts.net");
 
-        reg.Upsert(req);
+        reg.Upsert(CcDirector.Core.Tenancy.TenantId.Local, req);
 
-        var dto = reg.Get("MACHINE-NA");
+        var dto = reg.Get(CcDirector.Core.Tenancy.TenantId.Local, "MACHINE-NA");
         Assert.NotNull(dto);
         Assert.Equal("example-pc.ts.net", dto!.NetworkAddress);
     }
@@ -174,26 +174,26 @@ public sealed class LauncherRegistryTests
     public void GetNetworkAddress_ReturnsStoredAddress()
     {
         var reg = new LauncherRegistry();
-        reg.Upsert(MakeReq("MACHINE-NB", 7921, networkAddress: "example-host.tailnet.ts.net"));
+        reg.Upsert(CcDirector.Core.Tenancy.TenantId.Local, MakeReq("MACHINE-NB", 7921, networkAddress: "example-host.tailnet.ts.net"));
 
-        Assert.Equal("example-host.tailnet.ts.net", reg.GetNetworkAddress("MACHINE-NB"));
+        Assert.Equal("example-host.tailnet.ts.net", reg.GetNetworkAddress(CcDirector.Core.Tenancy.TenantId.Local, "MACHINE-NB"));
     }
 
     [Fact]
     public void GetNetworkAddress_EmptyWhenNotSet()
     {
         var reg = new LauncherRegistry();
-        reg.Upsert(MakeReq("MACHINE-NC", 7922)); // no networkAddress
+        reg.Upsert(CcDirector.Core.Tenancy.TenantId.Local, MakeReq("MACHINE-NC", 7922)); // no networkAddress
 
         // Empty string = co-located, loopback applies.
-        Assert.Equal("", reg.GetNetworkAddress("MACHINE-NC"));
+        Assert.Equal("", reg.GetNetworkAddress(CcDirector.Core.Tenancy.TenantId.Local, "MACHINE-NC"));
     }
 
     [Fact]
     public void GetNetworkAddress_NullForUnknownMachine()
     {
         var reg = new LauncherRegistry();
-        Assert.Null(reg.GetNetworkAddress("NOBODY-NA"));
+        Assert.Null(reg.GetNetworkAddress(CcDirector.Core.Tenancy.TenantId.Local, "NOBODY-NA"));
     }
 
     // -------------------------------------------------------------------------

--- a/src/CcDirector.Gateway.Tests/LauncherStreamIntegrationTests.cs
+++ b/src/CcDirector.Gateway.Tests/LauncherStreamIntegrationTests.cs
@@ -60,7 +60,7 @@ public sealed class LauncherStreamIntegrationTests : IAsyncLifetime
 
         await conn.InvokeAsync("Hello", new LauncherStreamHello { MachineName = Machine, Port = 7878, Version = "test" });
 
-        Assert.True(_gateway.LauncherConnections.IsStreamConnected(Machine));
+        Assert.True(_gateway.LauncherConnections.IsStreamConnected(CcDirector.Core.Tenancy.TenantId.Local, Machine));
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public sealed class LauncherStreamIntegrationTests : IAsyncLifetime
         });
         await conn.InvokeAsync("Hello", new LauncherStreamHello { MachineName = Machine, Port = 7878, Version = "test" });
 
-        var result = await _gateway.SendLauncherCommandAsync(Machine, new LauncherCommand { Verb = "director/restart" });
+        var result = await _gateway.SendLauncherCommandAsync(CcDirector.Core.Tenancy.TenantId.Local, Machine, new LauncherCommand { Verb = "director/restart" });
 
         Assert.NotNull(result);
         Assert.True(result!.IsOk);
@@ -91,7 +91,7 @@ public sealed class LauncherStreamIntegrationTests : IAsyncLifetime
             _ => Task.FromResult(LauncherCommandResult.Fail(LauncherCommandStatus.BadRequest, "unknown verb: bogus")));
         await conn.InvokeAsync("Hello", new LauncherStreamHello { MachineName = Machine, Port = 7878, Version = "test" });
 
-        var result = await _gateway.SendLauncherCommandAsync(Machine, new LauncherCommand { Verb = "bogus" });
+        var result = await _gateway.SendLauncherCommandAsync(CcDirector.Core.Tenancy.TenantId.Local, Machine, new LauncherCommand { Verb = "bogus" });
 
         Assert.NotNull(result);
         Assert.False(result!.IsOk);
@@ -104,7 +104,7 @@ public sealed class LauncherStreamIntegrationTests : IAsyncLifetime
     {
         // No launcher has joined for this machine => no active stream connection => null, which the caller
         // treats as "no stream" and falls back to the existing HTTP relay.
-        var result = await _gateway.SendLauncherCommandAsync("no-such-machine", new LauncherCommand { Verb = "director/start" });
+        var result = await _gateway.SendLauncherCommandAsync(CcDirector.Core.Tenancy.TenantId.Local, "no-such-machine", new LauncherCommand { Verb = "director/start" });
         Assert.Null(result);
     }
 

--- a/src/CcDirector.Gateway.Tests/LauncherTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/LauncherTenantIsolationTests.cs
@@ -1,0 +1,110 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Two hostile tenants, one COLLIDING machine name. Machine names are not unique across tenants, so the
+/// launcher registries key by (tenant, machine): a tenant naming a machine can only ever reach its OWN
+/// launcher entry / connection, never another tenant's launcher of the same bare name. This is the
+/// structural isolation the launcher subsystem lacked (it keyed on bare machine name), the same composite
+/// keying DirectorRegistry uses.
+/// </summary>
+public sealed class LauncherTenantIsolationTests
+{
+    private static readonly TenantId Alpha = new("alpha");
+    private static readonly TenantId Beta = new("beta");
+
+    private static LauncherRegistrationRequest Req(string machine, int port, string token, string net = "") =>
+        new()
+        {
+            MachineName = machine,
+            Port = port,
+            Token = token,
+            NetworkAddress = net,
+            Pid = 1,
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        };
+
+    [Fact]
+    public void Two_tenants_registering_the_same_machine_name_are_isolated()
+    {
+        var reg = new LauncherRegistry();
+        const string machine = "SHARED-BOX";
+        reg.Upsert(Alpha, Req(machine, 1111, "alpha-token", "alpha.net"));
+        reg.Upsert(Beta, Req(machine, 2222, "beta-token", "beta.net"));
+
+        // Each tenant sees ONLY its own launcher for the colliding machine name - port, token and address.
+        Assert.Equal(1111, reg.Get(Alpha, machine)!.Port);
+        Assert.Equal(2222, reg.Get(Beta, machine)!.Port);
+        Assert.Equal("alpha-token", reg.GetToken(Alpha, machine));
+        Assert.Equal("beta-token", reg.GetToken(Beta, machine));
+        Assert.Equal("alpha.net", reg.GetNetworkAddress(Alpha, machine));
+        Assert.Equal("beta.net", reg.GetNetworkAddress(Beta, machine));
+
+        // Lists are per-tenant: neither tenant's list carries the other's machine.
+        Assert.Single(reg.ListLaunchers(Alpha));
+        Assert.Single(reg.ListLaunchers(Beta));
+
+        // Removing Alpha's launcher does not touch Beta's same-named entry.
+        reg.Remove(Alpha, machine);
+        Assert.Null(reg.Get(Alpha, machine));
+        Assert.Equal(2222, reg.Get(Beta, machine)!.Port);
+        Assert.Empty(reg.ListLaunchers(Alpha));
+        Assert.Single(reg.ListLaunchers(Beta));
+    }
+
+    [Fact]
+    public void A_tenant_never_reaches_another_tenants_launcher_or_its_token()
+    {
+        var reg = new LauncherRegistry();
+        reg.Upsert(Alpha, Req("alpha-only", 3000, "alpha-secret"));
+
+        // A foreign machine id under another tenant resolves to nothing - and leaks no token.
+        Assert.Null(reg.Get(Beta, "alpha-only"));
+        Assert.Null(reg.GetToken(Beta, "alpha-only"));
+        Assert.Null(reg.GetNetworkAddress(Beta, "alpha-only"));
+        Assert.Empty(reg.ListLaunchers(Beta));
+
+        // Case-insensitive WITHIN the owning tenant.
+        Assert.NotNull(reg.Get(Alpha, "ALPHA-ONLY"));
+    }
+
+    [Fact]
+    public void Heartbeat_is_scoped_to_the_owning_tenant()
+    {
+        var reg = new LauncherRegistry();
+        reg.Upsert(Alpha, Req("box", 4000, "t"));
+
+        Assert.True(reg.Heartbeat(Alpha, "box"));    // owner heartbeat lands
+        Assert.False(reg.Heartbeat(Beta, "box"));    // another tenant's heartbeat for the same name is unknown (410)
+    }
+
+    [Fact]
+    public void Two_tenants_same_machine_name_are_isolated_in_the_connection_registry()
+    {
+        var reg = new LauncherConnectionRegistry();
+        const string machine = "SHARED-BOX";
+        reg.RegisterConnection(Alpha, machine, "conn-alpha");
+        reg.RegisterConnection(Beta, machine, "conn-beta");
+
+        Assert.Equal("conn-alpha", reg.GetActiveConnectionId(Alpha, machine));
+        Assert.Equal("conn-beta", reg.GetActiveConnectionId(Beta, machine));
+        Assert.True(reg.IsStreamConnected(Alpha, machine));
+        Assert.True(reg.IsStreamConnected(Beta, machine));
+
+        // Alpha reconnecting for the same machine name does NOT supersede Beta's connection.
+        reg.RegisterConnection(Alpha, machine, "conn-alpha-2");
+        Assert.Equal("conn-alpha-2", reg.GetActiveConnectionId(Alpha, machine));
+        Assert.Equal("conn-beta", reg.GetActiveConnectionId(Beta, machine));
+
+        // Disconnect by connection id clears only that one entry.
+        reg.Unregister("conn-beta");
+        Assert.False(reg.IsStreamConnected(Beta, machine));
+        Assert.True(reg.IsStreamConnected(Alpha, machine));
+    }
+}

--- a/src/CcDirector.Gateway/Api/LauncherCommandRouter.cs
+++ b/src/CcDirector.Gateway/Api/LauncherCommandRouter.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -17,21 +18,23 @@ namespace CcDirector.Gateway.Api;
 /// </summary>
 internal static class LauncherCommandRouter
 {
-    /// <summary>The signature of the "send a command down a launcher's stream" hook, non-null only when stream mode is on.</summary>
-    public delegate Task<LauncherCommandResult?> SendLauncherCommandAsync(string machineName, LauncherCommand command, CancellationToken ct);
+    /// <summary>The signature of the "send a command down a launcher's stream" hook, non-null only when stream
+    /// mode is on. The tenant scopes the connection lookup to the caller's own launcher (tenant, machine).</summary>
+    public delegate Task<LauncherCommandResult?> SendLauncherCommandAsync(TenantId tenant, string machineName, LauncherCommand command, CancellationToken ct);
 
     /// <summary>
-    /// Try to route a command down the launcher's stream. Returns the stream result, or null to signal the
-    /// caller to fall back to its existing HTTP relay (stream mode off, or the launcher is not stream-connected).
+    /// Try to route a command down the CALLING TENANT's launcher stream. Returns the stream result, or null to
+    /// signal the caller to fall back to its existing HTTP relay (stream mode off, or the launcher is not
+    /// stream-connected for this tenant+machine).
     /// </summary>
     public static async Task<LauncherCommandResult?> TrySendAsync(
-        SendLauncherCommandAsync? sendCommand, string machineName, LauncherCommand command, CancellationToken ct)
+        SendLauncherCommandAsync? sendCommand, TenantId tenant, string machineName, LauncherCommand command, CancellationToken ct)
     {
         if (sendCommand is null)
             return null;
 
-        var result = await sendCommand(machineName, command, ct);
-        FileLog.Write($"[LauncherCommandRouter] {command.Verb} machine={machineName}: {(result is null ? "no stream -> HTTP relay fallback" : $"stream status={result.Status}")}");
+        var result = await sendCommand(tenant, machineName, command, ct);
+        FileLog.Write($"[LauncherCommandRouter] {command.Verb} tenant={tenant.Value} machine={machineName}: {(result is null ? "no stream -> HTTP relay fallback" : $"stream status={result.Status}")}");
         return result;
     }
 }

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
@@ -206,20 +207,33 @@ internal static class MachineEndpoints
         // spawn with no explicit run auto-seats onto the mission's run. After a successful spawn the new
         // session is recorded as a run PARTICIPANT - the persisted run-to-session membership governance
         // reads. Null (old callers, tests) seats nothing and changes nothing.
-        Workflows.WorkflowRunStore? workflowRuns = null)
+        Workflows.WorkflowRunStore? workflowRuns = null,
+        // The tenant boundary. Every launcher-registry read/write is now scoped to the CALLING tenant,
+        // resolved from the authenticated device key (never the machine name in the path/body). Null on
+        // self-host, where the single tenant is Local. The launcher/machine families stay denied on hosted
+        // for now; this makes the registries tenant-correct by construction so a future un-deny is safe.
+        HostedTenantBoundary? boundary = null)
     {
         if (spawner is null) throw new ArgumentNullException(nameof(spawner));
 
         FileLog.Write($"[MachineEndpoints] mapping {LauncherPrefix} + {MachinePrefix}; hosted={GatewayHostedMode.IsHosted} - on hosted EVERY route in both groups is refused via the shared refusal primitive (issue #1917)");
 
         var launcherGroup = HostedRouteDeny.ExclusiveGroup(outer, LauncherPrefix, LauncherDenial());
-        MapLauncherRoutes(launcherGroup, launchers);
+        MapLauncherRoutes(launcherGroup, launchers, boundary);
 
         var machineGroup = HostedRouteDeny.ExclusiveGroup(outer, MachinePrefix, MachineDenial());
-        MapMachineRoutes(machineGroup, launchers, spawner, sendLauncherCommand, missions, workflowRuns);
+        MapMachineRoutes(machineGroup, launchers, spawner, sendLauncherCommand, missions, workflowRuns, boundary);
 
         return (launcherGroup, machineGroup);
     }
+
+    /// <summary>The calling tenant, resolved from the authenticated device key. Null means no tenant is
+    /// bound (hosted with an unbound key) - the caller must refuse with 403.</summary>
+    private static TenantId? ReqTenant(HttpContext ctx, HostedTenantBoundary? boundary)
+        => GatewayEndpoints.ResolveReadTenant(ctx, boundary);
+
+    private static IResult NoTenant() =>
+        Results.Json(new { error = "no tenant is bound to this request" }, statusCode: 403);
 
     /// <summary>
     /// The four launcher self-registration routes, mapped relative to <see cref="LauncherPrefix"/> so the full
@@ -229,12 +243,14 @@ internal static class MachineEndpoints
     /// (register), Heartbeat, Remove (unregister) - live here, ON-ROUTE, so every one of them closes with the
     /// group; there is no off-route launcher-registry writer to host-gate separately.
     /// </summary>
-    private static void MapLauncherRoutes(HostedDenyGroup app, LauncherRegistry launchers)
+    private static void MapLauncherRoutes(HostedDenyGroup app, LauncherRegistry launchers, HostedTenantBoundary? boundary)
     {
         // ===== Launcher self-registration surface =====
+        // The launcher's own machine name is client-supplied; the OWNING TENANT is not - it is resolved from
+        // the launcher's authenticated device key, so a launcher registers only into its own tenant partition.
 
         // POST /launchers/register - the launcher POSTs this on startup and after reconnects.
-        app.MapPost("/register", (LauncherRegistrationRequest req) =>
+        app.MapPost("/register", (LauncherRegistrationRequest req, HttpContext ctx) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.MachineName))
                 return Results.BadRequest(new { error = "machineName is required" });
@@ -242,16 +258,18 @@ internal static class MachineEndpoints
                 return Results.BadRequest(new { error = "port must be > 0" });
             if (string.IsNullOrWhiteSpace(req.Token))
                 return Results.BadRequest(new { error = "token is required" });
+            if (ReqTenant(ctx, boundary) is not { } tenant) return NoTenant();
 
-            FileLog.Write($"[MachineEndpoints] POST /launchers/register: machine={req.MachineName}, port={req.Port}, pid={req.Pid}, version={req.Version}");
-            var dto = launchers.Upsert(req);
+            FileLog.Write($"[MachineEndpoints] POST /launchers/register: tenant={tenant.Value}, machine={req.MachineName}, port={req.Port}, pid={req.Pid}, version={req.Version}");
+            var dto = launchers.Upsert(tenant, req);
             return Results.Json(dto, statusCode: 201);
         });
 
         // POST /launchers/{machine}/heartbeat - keep-alive from the launcher every 30 s.
-        app.MapPost("/{machine}/heartbeat", (string machine) =>
+        app.MapPost("/{machine}/heartbeat", (string machine, HttpContext ctx) =>
         {
-            var ok = launchers.Heartbeat(machine);
+            if (ReqTenant(ctx, boundary) is not { } tenant) return NoTenant();
+            var ok = launchers.Heartbeat(tenant, machine);
             if (!ok)
             {
                 FileLog.Write($"[MachineEndpoints] POST /launchers/{machine}/heartbeat: unknown -> 410");
@@ -262,18 +280,20 @@ internal static class MachineEndpoints
         });
 
         // DELETE /launchers/{machine} - graceful unregister on launcher shutdown.
-        app.MapDelete("/{machine}", (string machine) =>
+        app.MapDelete("/{machine}", (string machine, HttpContext ctx) =>
         {
-            launchers.Remove(machine);
+            if (ReqTenant(ctx, boundary) is not { } tenant) return NoTenant();
+            launchers.Remove(tenant, machine);
             FileLog.Write($"[MachineEndpoints] DELETE /launchers/{machine}: removed");
             return Results.Json(new { ok = true });
         });
 
-        // GET /launchers - list all registered launchers (machine name, port, last-seen).
-        app.MapGet("", () =>
+        // GET /launchers - list the CALLING TENANT's registered launchers (never another tenant's).
+        app.MapGet("", (HttpContext ctx) =>
         {
-            var list = launchers.ListLaunchers();
-            FileLog.Write($"[MachineEndpoints] GET /launchers: count={list.Count}");
+            if (ReqTenant(ctx, boundary) is not { } tenant) return NoTenant();
+            var list = launchers.ListLaunchers(tenant);
+            FileLog.Write($"[MachineEndpoints] GET /launchers: tenant={tenant.Value}, count={list.Count}");
             return Results.Json(list);
         });
     }
@@ -287,22 +307,26 @@ internal static class MachineEndpoints
         MachineSessionSpawner spawner,
         LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand,
         Core.Sessions.MissionStore? missions,
-        Workflows.WorkflowRunStore? workflowRuns)
+        Workflows.WorkflowRunStore? workflowRuns,
+        HostedTenantBoundary? boundary)
     {
         // ===== Machine relay surface =====
+        // The target machine name is in the path; the caller's TENANT comes from the authenticated key, and
+        // the launcher/connection is resolved as (callerTenant, machine) - so a caller can only ever reach a
+        // launcher its OWN tenant registered, never another tenant's machine of the same bare name.
 
         // POST /machines/{machine}/director/restart
         app.MapPost("/{machine}/director/restart", async (string machine, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/director/restart: caller={ctx.Connection.RemoteIpAddress}");
-            return await RelayDirectorLifecycleAsync(machine, "restart", ctx, launchers, sendLauncherCommand, ct);
+            return await RelayDirectorLifecycleAsync(machine, "restart", ctx, launchers, sendLauncherCommand, boundary, ct);
         });
 
         // POST /machines/{machine}/director/start
         app.MapPost("/{machine}/director/start", async (string machine, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/director/start: caller={ctx.Connection.RemoteIpAddress}");
-            return await RelayDirectorLifecycleAsync(machine, "start", ctx, launchers, sendLauncherCommand, ct);
+            return await RelayDirectorLifecycleAsync(machine, "start", ctx, launchers, sendLauncherCommand, boundary, ct);
         });
 
         // POST /machines/{machine}/sessions - "start a session on another computer". Resolve the machine
@@ -429,13 +453,14 @@ internal static class MachineEndpoints
         app.MapPost("/{machine}/director/stop", async (string machine, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/director/stop: caller={ctx.Connection.RemoteIpAddress}");
-            return await RelayDirectorLifecycleAsync(machine, "stop", ctx, launchers, sendLauncherCommand, ct);
+            return await RelayDirectorLifecycleAsync(machine, "stop", ctx, launchers, sendLauncherCommand, boundary, ct);
         });
 
         // POST /machines/{machine}/launch - relay a generic launch request to the launcher.
         app.MapPost("/{machine}/launch", async (string machine, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/launch: caller={ctx.Connection.RemoteIpAddress}");
+            if (ReqTenant(ctx, boundary) is not { } tenant) return NoTenant();
 
             // Forward the original request body verbatim to the launcher.
             LaunchRelayBody? body = null;
@@ -453,11 +478,11 @@ internal static class MachineEndpoints
                 Cwd = body?.Cwd,
                 Headless = body?.Headless ?? false,
             };
-            var launchStreamResult = await LauncherCommandRouter.TrySendAsync(sendLauncherCommand, machine, launchStreamCmd, ct);
+            var launchStreamResult = await LauncherCommandRouter.TrySendAsync(sendLauncherCommand, tenant, machine, launchStreamCmd, ct);
             if (launchStreamResult is not null)
                 return MapLauncherStreamResult(machine, "launch", launchStreamResult);
 
-            var (launcher, token, networkAddress, err) = ResolveLauncher(machine, launchers);
+            var (launcher, token, networkAddress, err) = ResolveLauncher(tenant, machine, launchers);
             if (err is not null)
             {
                 FileLog.Write($"[MachineEndpoints] /machines/{machine}/launch: {err.Value.log}");
@@ -498,8 +523,10 @@ internal static class MachineEndpoints
     /// </summary>
     private static async Task<IResult> RelayDirectorLifecycleAsync(
         string machine, string verb, HttpContext ctx, LauncherRegistry launchers,
-        LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand, CancellationToken ct)
+        LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand, HostedTenantBoundary? boundary, CancellationToken ct)
     {
+        if (ReqTenant(ctx, boundary) is not { } tenant) return NoTenant();
+
         // Parse optional body for confirmProtected flag and target exe path.
         // Use JsonDocument to avoid internal-class reflection issues with System.Text.Json.
         // Do NOT gate on ContentLength - transfer-encoded bodies may have no explicit length.
@@ -550,11 +577,11 @@ internal static class MachineEndpoints
             Path = exePathFromBody,
             ConfirmProtected = confirmProtectedFromBody == true,
         };
-        var streamResult = await LauncherCommandRouter.TrySendAsync(sendLauncherCommand, machine, streamCmd, ct);
+        var streamResult = await LauncherCommandRouter.TrySendAsync(sendLauncherCommand, tenant, machine, streamCmd, ct);
         if (streamResult is not null)
             return MapLauncherStreamResult(machine, verb, streamResult);
 
-        var (launcher, token, networkAddress, err) = ResolveLauncher(machine, launchers);
+        var (launcher, token, networkAddress, err) = ResolveLauncher(tenant, machine, launchers);
         if (err is not null)
         {
             FileLog.Write($"[MachineEndpoints] /machines/{machine}/director/{verb}: {err.Value.log}");
@@ -592,23 +619,23 @@ internal static class MachineEndpoints
     /// success or (null, null, null, (log, result)) on failure.
     /// </summary>
     private static (LauncherDto? launcher, string? token, string? networkAddress, (string log, IResult result)? err)
-        ResolveLauncher(string machine, LauncherRegistry launchers)
+        ResolveLauncher(TenantId tenant, string machine, LauncherRegistry launchers)
     {
-        var launcher = launchers.Get(machine);
+        var launcher = launchers.Get(tenant, machine);
         if (launcher is null)
         {
-            return (null, null, null, ($"launcher not registered for machine={machine}",
+            return (null, null, null, ($"launcher not registered for tenant={tenant.Value}, machine={machine}",
                 Results.Json(new { error = $"no launcher registered for machine '{machine}'", machine }, statusCode: 404)));
         }
 
-        var token = launchers.GetToken(machine);
+        var token = launchers.GetToken(tenant, machine);
         if (string.IsNullOrEmpty(token))
         {
-            return (null, null, null, ($"launcher token missing for machine={machine}",
+            return (null, null, null, ($"launcher token missing for tenant={tenant.Value}, machine={machine}",
                 Results.Json(new { error = "launcher token not available" }, statusCode: 500)));
         }
 
-        var networkAddress = launchers.GetNetworkAddress(machine) ?? "";
+        var networkAddress = launchers.GetNetworkAddress(tenant, machine) ?? "";
         return (launcher, token, networkAddress, null);
     }
 

--- a/src/CcDirector.Gateway/Discovery/LauncherRegistry.cs
+++ b/src/CcDirector.Gateway/Discovery/LauncherRegistry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -11,7 +12,11 @@ namespace CcDirector.Gateway.Discovery;
 /// startup and heartbeats every 30 s. The Gateway relay uses the stored port + token to
 /// forward lifecycle verbs to the remote launcher's loopback REST API.
 ///
-/// Keys are machine names (case-insensitive). One machine -> one launcher entry.
+/// Keys are the composite <see cref="LauncherKey"/> - the OWNING TENANT plus the machine name
+/// (case-insensitive). A machine name is unique only within a tenant, so the tenant is half the key:
+/// one tenant naming a machine can only ever reach its OWN launcher entry, never another tenant's launcher
+/// registered under the same bare machine name. This mirrors the composite (tenant, id) keying of
+/// <see cref="DirectorRegistry"/>.
 ///
 /// Issue #331.
 /// </summary>
@@ -19,6 +24,12 @@ public sealed class LauncherRegistry
 {
     /// <summary>How long without a heartbeat before a launcher is considered stale and swept.</summary>
     public static TimeSpan HeartbeatTimeout { get; } = TimeSpan.FromSeconds(90);
+
+    /// <summary>The composite key: the owning tenant plus the machine name (canonicalized, case-insensitive).</summary>
+    private readonly record struct LauncherKey(TenantId Tenant, string Machine);
+
+    private static LauncherKey Key(TenantId tenant, string machineName) =>
+        new(tenant, machineName.Trim().ToLowerInvariant());
 
     private sealed class Entry
     {
@@ -28,16 +39,15 @@ public sealed class LauncherRegistry
         public DateTime LastSeenAt;
     }
 
-    private readonly ConcurrentDictionary<string, Entry> _launchers =
-        new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<LauncherKey, Entry> _launchers = new();
 
     private Timer? _sweepTimer;
 
     /// <summary>
-    /// Register or refresh a launcher. Returns the stored <see cref="LauncherDto"/> for
+    /// Register or refresh the calling tenant's launcher. Returns the stored <see cref="LauncherDto"/> for
     /// the 201/200 response body (no token exposed).
     /// </summary>
-    public LauncherDto Upsert(LauncherRegistrationRequest req)
+    public LauncherDto Upsert(TenantId tenant, LauncherRegistrationRequest req)
     {
         var now = DateTime.UtcNow;
         var dto = new LauncherDto
@@ -51,82 +61,76 @@ public sealed class LauncherRegistry
             LastSeenAt = now,
         };
 
-        _launchers[req.MachineName] = new Entry
+        _launchers[Key(tenant, req.MachineName)] = new Entry
         {
             Dto = dto,
             Token = req.Token,
             LastSeenAt = now,
         };
 
-        FileLog.Write($"[LauncherRegistry] Upsert: machine={req.MachineName}, port={req.Port}, networkAddress={req.NetworkAddress}, pid={req.Pid}, version={req.Version}");
+        FileLog.Write($"[LauncherRegistry] Upsert: tenant={tenant.Value}, machine={req.MachineName}, port={req.Port}, networkAddress={req.NetworkAddress}, pid={req.Pid}, version={req.Version}");
         return dto;
     }
 
     /// <summary>
-    /// Record a heartbeat from a known launcher. Returns true if the launcher was found;
-    /// false (-> 410) if it is unknown (it should re-register).
+    /// Record a heartbeat from a known launcher of the calling tenant. Returns true if found;
+    /// false (-> 410) if unknown (it should re-register).
     /// </summary>
-    public bool Heartbeat(string machineName)
+    public bool Heartbeat(TenantId tenant, string machineName)
     {
-        if (!_launchers.TryGetValue(machineName, out var entry))
+        if (!_launchers.TryGetValue(Key(tenant, machineName), out var entry))
         {
-            FileLog.Write($"[LauncherRegistry] Heartbeat: unknown machine={machineName} -> 410");
+            FileLog.Write($"[LauncherRegistry] Heartbeat: unknown tenant={tenant.Value}, machine={machineName} -> 410");
             return false;
         }
 
         var now = DateTime.UtcNow;
         entry.LastSeenAt = now;
         entry.Dto.LastSeenAt = now;
-        FileLog.Write($"[LauncherRegistry] Heartbeat: machine={machineName}");
+        FileLog.Write($"[LauncherRegistry] Heartbeat: tenant={tenant.Value}, machine={machineName}");
         return true;
     }
 
     /// <summary>
-    /// Remove a launcher entry (called on graceful launcher shutdown).
+    /// Remove the calling tenant's launcher entry (called on graceful launcher shutdown).
     /// </summary>
-    public void Remove(string machineName)
+    public void Remove(TenantId tenant, string machineName)
     {
-        if (_launchers.TryRemove(machineName, out _))
-            FileLog.Write($"[LauncherRegistry] Remove: machine={machineName}");
+        if (_launchers.TryRemove(Key(tenant, machineName), out _))
+            FileLog.Write($"[LauncherRegistry] Remove: tenant={tenant.Value}, machine={machineName}");
     }
 
     /// <summary>
-    /// Look up a launcher by machine name. Returns null if not registered.
+    /// Look up the calling tenant's launcher by machine name. Returns null if not registered.
     /// </summary>
-    public LauncherDto? Get(string machineName)
-    {
-        return _launchers.TryGetValue(machineName, out var e) ? e.Dto : null;
-    }
+    public LauncherDto? Get(TenantId tenant, string machineName) =>
+        _launchers.TryGetValue(Key(tenant, machineName), out var e) ? e.Dto : null;
 
     /// <summary>
-    /// Retrieve the relay token for a launcher. Returns null if not registered.
+    /// Retrieve the relay token for the calling tenant's launcher. Returns null if not registered.
     /// </summary>
-    public string? GetToken(string machineName)
-    {
-        return _launchers.TryGetValue(machineName, out var e) ? e.Token : null;
-    }
+    public string? GetToken(TenantId tenant, string machineName) =>
+        _launchers.TryGetValue(Key(tenant, machineName), out var e) ? e.Token : null;
 
     /// <summary>
-    /// Retrieve the network address for a launcher (tailnet hostname or IP).
-    /// Returns empty string when the launcher is co-located with the Gateway (loopback).
-    /// Returns null when the machine is not registered.
+    /// Retrieve the network address for the calling tenant's launcher (tailnet hostname or IP).
+    /// Empty string when co-located with the Gateway (loopback); null when not registered.
     /// </summary>
-    public string? GetNetworkAddress(string machineName)
-    {
-        return _launchers.TryGetValue(machineName, out var e) ? e.Dto.NetworkAddress : null;
-    }
+    public string? GetNetworkAddress(TenantId tenant, string machineName) =>
+        _launchers.TryGetValue(Key(tenant, machineName), out var e) ? e.Dto.NetworkAddress : null;
 
     /// <summary>
-    /// All registered launchers, as public DTOs (no tokens).
+    /// The calling tenant's registered launchers, as public DTOs (no tokens). Never another tenant's.
     /// </summary>
-    public IReadOnlyList<LauncherDto> ListLaunchers()
-    {
-        return _launchers.Values.Select(e => e.Dto).ToList();
-    }
+    public IReadOnlyList<LauncherDto> ListLaunchers(TenantId tenant) =>
+        _launchers
+            .Where(kv => kv.Key.Tenant.Equals(tenant))
+            .Select(kv => kv.Value.Dto)
+            .ToList();
 
     /// <summary>
     /// Start the periodic stale-entry sweep (removes launchers that have not heartbeat
-    /// within <see cref="HeartbeatTimeout"/>).
+    /// within <see cref="HeartbeatTimeout"/>). Tenant-agnostic: it removes stale entries by full key.
     /// </summary>
     public void StartSweep()
     {
@@ -144,7 +148,7 @@ public sealed class LauncherRegistry
             if (kv.Value.LastSeenAt < cutoff)
             {
                 if (_launchers.TryRemove(kv.Key, out var removed))
-                    FileLog.Write($"[LauncherRegistry] Sweep: removed stale launcher machine={kv.Key} (last-seen={removed.LastSeenAt:o})");
+                    FileLog.Write($"[LauncherRegistry] Sweep: removed stale launcher tenant={kv.Key.Tenant.Value}, machine={kv.Key.Machine} (last-seen={removed.LastSeenAt:o})");
             }
         }
     }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2255,7 +2255,9 @@ public sealed class GatewayHost : IAsyncDisposable
             // stamp the resolved mission name onto the create request forwarded to the Director.
             missions: Missions,
             // Workflows mission (phase 5b): seat spawns on workflow runs and record participants.
-            workflowRuns: _workflowRuns);
+            workflowRuns: _workflowRuns,
+            // Tenant boundary: every launcher-registry read/write is scoped to the calling tenant.
+            boundary: _tenantBoundary);
 
         // The Cockpit Settings page surface (docs/architecture/gateway/SETTINGS_OWNERSHIP.md):
         // one snapshot GET plus brain-restart and autostart actions. Reads this host directly
@@ -2670,11 +2672,11 @@ public sealed class GatewayHost : IAsyncDisposable
     /// which the caller treats as "no stream" and falls back to the HTTP relay. Any non-null result - success
     /// OR a typed failure - means the stream handled the command and its outcome is authoritative.
     /// </summary>
-    public async Task<LauncherCommandResult?> SendLauncherCommandAsync(string machineName, LauncherCommand command, CancellationToken ct = default)
+    public async Task<LauncherCommandResult?> SendLauncherCommandAsync(Core.Tenancy.TenantId tenant, string machineName, LauncherCommand command, CancellationToken ct = default)
     {
         if (command is null) throw new ArgumentNullException(nameof(command));
 
-        var connectionId = LauncherConnections.GetActiveConnectionId(machineName);
+        var connectionId = LauncherConnections.GetActiveConnectionId(tenant, machineName);
         var hub = _app?.Services.GetService(typeof(Microsoft.AspNetCore.SignalR.IHubContext<Streaming.LauncherHub>))
             as Microsoft.AspNetCore.SignalR.IHubContext<Streaming.LauncherHub>;
         if (connectionId is null || hub is null)

--- a/src/CcDirector.Gateway/Streaming/LauncherConnectionRegistry.cs
+++ b/src/CcDirector.Gateway/Streaming/LauncherConnectionRegistry.cs
@@ -1,16 +1,20 @@
 using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Gateway.Streaming;
 
 /// <summary>
 /// launcher-persistent-join: the Gateway's map of which machine's cc-launcher is currently connected over a
-/// persistent stream, keyed by machine name (case-insensitive) with the SignalR connection id as the value.
+/// persistent stream, keyed by <see cref="MachineKey"/> - the OWNING TENANT plus the machine name
+/// (case-insensitive) - with the SignalR connection id as the value.
 ///
 /// It is the launcher twin of the connection-tracking half of <see cref="PushedSessionStore"/>, but far
 /// simpler: a launcher pushes no session state, so there is nothing to cache - only the live connection id
-/// the Gateway addresses a command DOWN. One machine -> one active connection. A new connection from the
-/// same machine (a launcher restart / reconnect) supersedes the prior one.
+/// the Gateway addresses a command DOWN. One (tenant, machine) -> one active connection. A new connection
+/// from the same machine under the same tenant supersedes the prior one; a different tenant's launcher for a
+/// machine of the same bare name is a DIFFERENT entry and cannot supersede it - machine names are not unique
+/// across tenants, so the tenant is half the key.
 ///
 /// Thread-safe via a <see cref="ConcurrentDictionary{TKey,TValue}"/>. Registered as a DI singleton so the
 /// hub (constructed per-invocation by SignalR's container) and <c>GatewayHost.SendLauncherCommandAsync</c>
@@ -18,28 +22,35 @@ namespace CcDirector.Gateway.Streaming;
 /// </summary>
 public sealed class LauncherConnectionRegistry
 {
-    private readonly ConcurrentDictionary<string, string> _byMachine =
-        new(StringComparer.OrdinalIgnoreCase);
+    /// <summary>The composite key: a machine name is unique only WITHIN a tenant, so the tenant is part of
+    /// the key. The machine name is canonicalized (trimmed, lower-cased) so keying is case-insensitive.</summary>
+    private readonly record struct MachineKey(TenantId Tenant, string Machine);
+
+    private static MachineKey Key(TenantId tenant, string machineName) =>
+        new(tenant, machineName.Trim().ToLowerInvariant());
+
+    private readonly ConcurrentDictionary<MachineKey, string> _byMachine = new();
 
     /// <summary>
-    /// Mark <paramref name="connectionId"/> as the active stream connection for <paramref name="machineName"/>,
-    /// superseding any prior connection for that machine (a reconnect wins).
+    /// Mark <paramref name="connectionId"/> as the active stream connection for the owning tenant's
+    /// <paramref name="machineName"/>, superseding any prior connection for that (tenant, machine).
     /// </summary>
-    public void RegisterConnection(string machineName, string connectionId)
+    public void RegisterConnection(TenantId tenant, string machineName, string connectionId)
     {
         if (string.IsNullOrWhiteSpace(machineName))
             throw new ArgumentException("machineName is required", nameof(machineName));
         if (string.IsNullOrWhiteSpace(connectionId))
             throw new ArgumentException("connectionId is required", nameof(connectionId));
 
-        _byMachine[machineName] = connectionId;
-        FileLog.Write($"[LauncherConnectionRegistry] RegisterConnection: machine={machineName}, conn={Short(connectionId)} is now the active connection");
+        _byMachine[Key(tenant, machineName)] = connectionId;
+        FileLog.Write($"[LauncherConnectionRegistry] RegisterConnection: tenant={tenant.Value}, machine={machineName}, conn={Short(connectionId)} is now the active connection");
     }
 
     /// <summary>
     /// Clear the entry whose active connection is <paramref name="connectionId"/>. A late disconnect from a
-    /// superseded connection removes nothing (the newer connection owns the machine), because the atomic
-    /// key/value remove only succeeds when the stored connection id still matches.
+    /// superseded connection removes nothing (the newer connection owns the (tenant, machine)), because the
+    /// atomic key/value remove only succeeds when the stored connection id still matches. Scanning by the
+    /// connection id needs no tenant - a connection id belongs to exactly one entry.
     /// </summary>
     public void Unregister(string connectionId)
     {
@@ -51,26 +62,24 @@ public sealed class LauncherConnectionRegistry
             if (!string.Equals(kv.Value, connectionId, StringComparison.Ordinal))
                 continue;
 
-            // Atomic compare-and-remove: only removes when the machine still maps to THIS connection id,
-            // so a superseded connection's late disconnect cannot wipe a newer active connection.
-            if (((ICollection<KeyValuePair<string, string>>)_byMachine).Remove(kv))
-                FileLog.Write($"[LauncherConnectionRegistry] Unregister: machine={kv.Key}, conn={Short(connectionId)} cleared");
+            if (((ICollection<KeyValuePair<MachineKey, string>>)_byMachine).Remove(kv))
+                FileLog.Write($"[LauncherConnectionRegistry] Unregister: tenant={kv.Key.Tenant.Value}, machine={kv.Key.Machine}, conn={Short(connectionId)} cleared");
             else
-                FileLog.Write($"[LauncherConnectionRegistry] Unregister IGNORED (superseded): machine={kv.Key}, conn={Short(connectionId)}");
+                FileLog.Write($"[LauncherConnectionRegistry] Unregister IGNORED (superseded): tenant={kv.Key.Tenant.Value}, machine={kv.Key.Machine}, conn={Short(connectionId)}");
             return;
         }
     }
 
     /// <summary>
-    /// The active stream connection id for a machine's launcher, or null when none. The Gateway uses it to
-    /// address a command DOWN the stream to that launcher.
+    /// The active stream connection id for the tenant's machine launcher, or null when none. The Gateway
+    /// uses it to address a command DOWN the stream to that launcher - and only ever finds the caller's own.
     /// </summary>
-    public string? GetActiveConnectionId(string machineName) =>
-        _byMachine.TryGetValue(machineName, out var connectionId) ? connectionId : null;
+    public string? GetActiveConnectionId(TenantId tenant, string machineName) =>
+        _byMachine.TryGetValue(Key(tenant, machineName), out var connectionId) ? connectionId : null;
 
-    /// <summary>True when this machine's launcher currently has an active stream connection.</summary>
-    public bool IsStreamConnected(string machineName) =>
-        _byMachine.ContainsKey(machineName);
+    /// <summary>True when this tenant's launcher for the machine currently has an active stream connection.</summary>
+    public bool IsStreamConnected(TenantId tenant, string machineName) =>
+        _byMachine.ContainsKey(Key(tenant, machineName));
 
     private static string Short(string? id) =>
         string.IsNullOrEmpty(id) ? "(none)" : (id.Length <= 8 ? id : id[..8]);

--- a/src/CcDirector.Gateway/Streaming/LauncherHub.cs
+++ b/src/CcDirector.Gateway/Streaming/LauncherHub.cs
@@ -1,5 +1,8 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Util;
 using Microsoft.AspNetCore.SignalR;
 
 namespace CcDirector.Gateway.Streaming;
@@ -25,15 +28,22 @@ namespace CcDirector.Gateway.Streaming;
 public sealed class LauncherHub : Hub
 {
     private const string MachineNameItemKey = "cc.launcherMachine";
+    private const string TenantIdItemKey = "cc.tenantId";
 
     private readonly LauncherConnectionRegistry _registry;
+    private readonly HostedTenantBoundary? _tenantBoundary;
 
-    public LauncherHub(LauncherConnectionRegistry registry)
+    public LauncherHub(LauncherConnectionRegistry registry, HostedTenantBoundary? tenantBoundary = null)
     {
         _registry = registry;
+        _tenantBoundary = tenantBoundary;
     }
 
-    /// <summary>Bind this connection to a machine's launcher. Must be the first message; aborts on a bad name.</summary>
+    /// <summary>Bind this connection to the calling tenant's machine launcher. Must be the first message;
+    /// aborts on a bad name or - on hosted - a device key that resolves to no tenant (deny by default,
+    /// exactly like <see cref="DirectorHub"/>). The machine name is client-supplied; the TENANT is not - it
+    /// comes from the authenticated device key, so one account cannot register a launcher into another's
+    /// partition.</summary>
     public void Hello(LauncherStreamHello hello)
     {
         if (hello is null || string.IsNullOrWhiteSpace(hello.MachineName))
@@ -52,9 +62,32 @@ public sealed class LauncherHub : Hub
             return;
         }
 
+        var resolved = ResolveConnectionTenant();
+        if (resolved is not { } tenant)
+        {
+            FileLog.Write($"[LauncherHub] Hello REJECTED (hosted: the authenticated device key resolves to no tenant): conn={Short(Context.ConnectionId)}");
+            Context.Abort();
+            return;
+        }
+
         Context.Items[MachineNameItemKey] = machine;
-        _registry.RegisterConnection(machine, Context.ConnectionId);
-        FileLog.Write($"[LauncherHub] Hello: machine={machine} bound to conn={Short(Context.ConnectionId)} (port={hello.Port}, version={hello.Version})");
+        Context.Items[TenantIdItemKey] = tenant;
+        _registry.RegisterConnection(tenant, machine, Context.ConnectionId);
+        FileLog.Write($"[LauncherHub] Hello: tenant={tenant.Value}, machine={machine} bound to conn={Short(Context.ConnectionId)} (port={hello.Port}, version={hello.Version})");
+    }
+
+    /// <summary>The tenant that owns this connection, from the authenticated device key (never the payload).
+    /// On self-host (no boundary) this is <see cref="TenantId.Local"/>; on hosted a key with no bound tenant
+    /// returns null and the connection is aborted.</summary>
+    private TenantId? ResolveConnectionTenant()
+    {
+        if (_tenantBoundary is null)
+            return TenantId.Local;
+
+        var key = Context.GetHttpContext()?.Items.TryGetValue(AuthMiddleware.DeviceKeyItemKey, out var value) == true
+            ? value as string
+            : null;
+        return _tenantBoundary.ResolveForDeviceKey(key);
     }
 
     public override Task OnConnectedAsync()


### PR DESCRIPTION
Multi-tenancy, area two (in-memory control plane), step 3.

The launcher subsystem keyed on bare machine name with no tenant - one account could reach another's launcher, its relay token, or its machine. It was safe only because the /launchers + /machines family is denied on hosted and the hub is unmapped there - the deny-crutch the multi-tenancy model removes.

Now both registries key by (tenant, machine) - the same composite keying as DirectorRegistry - so naming another tenant's machine is structurally impossible. LauncherHub.Hello resolves the tenant from the authenticated device key and aborts on null (deny-by-default), exactly like DirectorHub.Hello. MachineEndpoints, the command router, and SendLauncherCommandAsync thread the caller's resolved tenant through every registry access and the relay path.

The hosted deny and hub-not-mapped-on-hosted stay: no new hosted exposure. This makes the registries correct-by-construction so a future 'machine control on hosted' un-deny is a small, safe flip. New two-tenant isolation tests prove a colliding machine name is isolated; the full launcher suite (89 tests, incl. hub integration) is green.