### PR TITLE
fix(gateway): repoint the three-segment routing test at a live endpoint (main is red)

### DIFF
--- a/src/CcDirector.Gateway.Tests/BrowserPageRoutesTests.cs
+++ b/src/CcDirector.Gateway.Tests/BrowserPageRoutesTests.cs
@@ -77,7 +77,7 @@ public sealed class BrowserPageRoutesTests : IAsyncLifetime
     [InlineData("GET", "/healthz", "text/html")]               // not a dual-use path
     [InlineData("GET", "/lists", "application/json")]           // Work-List API client stays JSON
     [InlineData("GET", "/lists", null)]                        // curl / script default stays JSON
-    [InlineData("GET", "/sessions/abc/turnbriefs", "text/html")] // 3 segments = API only
+    [InlineData("GET", "/sessions/abc/wingman", "text/html")]   // 3 segments = API only
     [InlineData("GET", "/directors/abc/repos", "text/html")]     // 3 segments = API only
     // Audited NON-collisions: a React page whose OWN path has no top-level single-segment JSON
     // endpoint must NOT be a page-request root, so its nested JSON path is never shadowed for a
@@ -145,12 +145,13 @@ public sealed class BrowserPageRoutesTests : IAsyncLifetime
     [Fact]
     public async Task Three_segment_api_subpath_is_untouched_even_for_browsers()
     {
-        using var req = new HttpRequestMessage(HttpMethod.Get, "sessions/00000000-0000-0000-0000-000000000000/turnbriefs");
+        using var req = new HttpRequestMessage(HttpMethod.Get, "sessions/00000000-0000-0000-0000-000000000000/wingman");
         req.Headers.Accept.ParseAdd("text/html");
 
         var resp = await _http.SendAsync(req);
 
-        // The turn-brief API endpoint answered (JSON), never the Cockpit interstitial.
+        // The wingman API endpoint answered (JSON: 404 for the unknown session), never the
+        // Cockpit interstitial.
         Assert.NotEqual(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
         Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
     }


### PR DESCRIPTION
Main's CI is red since the turn-brief subsystem deletion (pull request 2028): `BrowserPageRoutesTests.Three_segment_api_subpath_is_untouched_even_for_browsers` still probed `sessions/{id}/turnbriefs`. With that endpoint gone the request falls through to the Director tunnel proxy and answers 503 ServiceUnavailable when no director is connected, failing the test on main and on every pull request based on it (first seen on pull request 2029).

The test's invariant is about routing - a three-segment API subpath must never be swallowed by the browser-shell router - not about turn briefs. It now probes `sessions/{id}/wingman`, which answers a gateway-local JSON 404 for the unknown session, satisfying both assertions deterministically.

Bisected on Sorens-Mac-mini: the test fails at 62230a6d (the 2028 merge) and passes at its parent; all 38 BrowserPageRoutesTests pass with this change.