### PR TITLE
fix(desktop): a snooze survives the offline floor instead of flattening to red

### DIFF
--- a/src/CcDirector.Avalonia.Tests/OfflineFloorRailColorTests.cs
+++ b/src/CcDirector.Avalonia.Tests/OfflineFloorRailColorTests.cs
@@ -88,4 +88,46 @@ public sealed class OfflineFloorRailColorTests
         Assert.Equal("blue", SessionViewModel.RailColor(true, "grey", ActivityState.Working, gatewaySettled: false));
         Assert.Equal("red", SessionViewModel.RailColor(true, "blue", ActivityState.WaitingForInput, gatewaySettled: false));
     }
+
+    // ----- OFFLINE FLOOR + SNOOZE: an explicit user hold survives a tunnel flap, never flattens to red -----
+
+    [Theory]
+    [InlineData(ActivityState.WaitingForInput)]
+    [InlineData(ActivityState.WaitingForPerm)]
+    [InlineData(ActivityState.Idle)]
+    public void Offline_Held_IdleSession_StaysSnoozedGrey_NotRed(ActivityState state)
+    {
+        // The user snoozed this session; the Director caches that as Session.OnHold (a Gateway-owned fact),
+        // and the Gateway last stamped it snoozed-grey. When the tunnel flaps, the floor must KEEP the snooze,
+        // not repaint it red - otherwise the snooze "does not stick" every time the tunnel reconnects.
+        Assert.Equal("grey", SessionViewModel.RailColor(
+            gatewayOffline: true, gatewayStamp: "grey", localActivity: state, gatewaySettled: false, isHeld: true));
+    }
+
+    [Fact]
+    public void Offline_Held_NoStamp_FallsBackToGrey()
+    {
+        // Held but somehow no frozen stamp: still render snoozed-grey, never red.
+        Assert.Equal("grey", SessionViewModel.RailColor(
+            gatewayOffline: true, gatewayStamp: null, localActivity: ActivityState.Idle, gatewaySettled: false, isHeld: true));
+    }
+
+    [Theory]
+    [InlineData(ActivityState.Working)]
+    [InlineData(ActivityState.Starting)]
+    public void Offline_Held_ButWorking_IsStillBlue(ActivityState state)
+    {
+        // Working retires a snooze (the Gateway edge), so a held session that is producing output is blue -
+        // working always wins over the cached hold.
+        Assert.Equal("blue", SessionViewModel.RailColor(
+            gatewayOffline: true, gatewayStamp: "grey", localActivity: state, gatewaySettled: false, isHeld: true));
+    }
+
+    [Fact]
+    public void Offline_NotHeld_IdleSession_IsStillRed()
+    {
+        // The carve-out is ONLY for an explicit hold; an ordinary idle session with no snooze stays red.
+        Assert.Equal("red", SessionViewModel.RailColor(
+            gatewayOffline: true, gatewayStamp: "grey", localActivity: ActivityState.WaitingForInput, gatewaySettled: false, isHeld: false));
+    }
 }

--- a/src/CcDirector.Avalonia/SessionViewModel.cs
+++ b/src/CcDirector.Avalonia/SessionViewModel.cs
@@ -190,7 +190,7 @@ public class SessionViewModel : INotifyPropertyChanged
     /// unrecognised stamp value still falls through to the magenta sentinel in <see cref="StatusColorBrush"/>,
     /// which is the real fail-loud. (docs/new_architecture/session-state.html.)
     /// </summary>
-    private string EffectiveColor => RailColor(IsGatewayOffline, FoldInput.EffectiveColor, Session.ActivityState, IsGatewaySettled);
+    private string EffectiveColor => RailColor(IsGatewayOffline, FoldInput.EffectiveColor, Session.ActivityState, IsGatewaySettled, Session.OnHold);
 
     /// <summary>
     /// The rail dot's colour name. Pure so it is tested without an Avalonia app - the getter above binds the
@@ -215,10 +215,24 @@ public class SessionViewModel : INotifyPropertyChanged
     /// the neutral placeholder when offline because, unlike the Director, they do not host the session and
     /// cannot know what it is doing. (docs/new_architecture/session-state.html.)
     /// </summary>
-    internal static string RailColor(bool gatewayOffline, string? gatewayStamp, ActivityState localActivity, bool gatewaySettled)
+    internal static string RailColor(bool gatewayOffline, string? gatewayStamp, ActivityState localActivity, bool gatewaySettled, bool isHeld = false)
     {
         if (gatewayOffline)
-            return localActivity is ActivityState.Working or ActivityState.Starting ? "blue" : "red";
+        {
+            if (localActivity is ActivityState.Working or ActivityState.Starting)
+                return "blue";
+
+            // A snooze is an explicit, durable hold the USER set, cached on the Director as a Gateway-owned
+            // fact (Session.OnHold, stamped down from SessionDto.OnHold) - a locally-known truth, NOT a
+            // Gateway-only fold input like VoiceAudioReady. So the floor CAN honour it without running the
+            // fold: keep a snoozed idle session snoozed (the grey the Gateway last stamped) instead of
+            // flattening it to red. Without this, a snoozed session reverts to "Needs you" red on every
+            // tunnel reconnect - and when the tunnel flaps, snooze appears to "not stick" at all.
+            if (isHeld)
+                return gatewayStamp ?? "grey";
+
+            return "red";
+        }
 
         if (gatewayStamp is not null)
             return gatewayStamp;


### PR DESCRIPTION
## Symptom
Snoozing an idle session on the desktop does not stick - it pops right back to red almost immediately.

## Root cause
The desktop rail's gateway-offline floor (`SessionViewModel.RailColor`) paints every non-working session red whenever the tunnel is not Connected, ignoring the Gateway stamp - including a session the user explicitly snoozed. On a machine whose gateway tunnel is flapping (reconnecting every ~45s, seen in the live Director logs), this repaints a just-snoozed session red on every reconnect, so the snooze appears never to stick.

## Fix
A snooze is a durable user hold the Director already caches as a Gateway-owned fact (`Session.OnHold`, stamped down from the Gateway) - not a Gateway-only fold input like VoiceAudioReady. So the offline floor can honour it without running the forbidden local fold: an idle held session keeps the snoozed grey the Gateway last stamped; Working still wins (blue, since working retires a snooze); ordinary idle sessions still go red.

Two files. All 237 Avalonia tests pass, including 8 new rail-color cases covering the held path.

## Not in this PR
The underlying tunnel flapping ("the server closed the connection with an error" every ~45s) is a separate, bigger connectivity problem worth its own investigation - this change makes snooze robust to it, but does not fix the flapping.