### PR TITLE
chore: bump react-router to clear three High advisories (cockpit + mobile)

### DIFF
--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -15,7 +15,7 @@
     "@devthrottle/client-core": "*",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router-dom": "6.28.0"
+    "react-router-dom": "6.30.4"
   },
   "devDependencies": {
     "@testing-library/dom": "10.4.1",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -15,7 +15,7 @@
     "@xterm/xterm": "5.5.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router-dom": "6.28.0"
+    "react-router-dom": "6.30.4"
   },
   "devDependencies": {
     "@types/react": "18.3.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@devthrottle/client-core": "*",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "react-router-dom": "6.28.0"
+        "react-router-dom": "6.30.4"
       },
       "devDependencies": {
         "@testing-library/dom": "10.4.1",
@@ -46,7 +46,7 @@
         "@xterm/xterm": "5.5.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "react-router-dom": "6.28.0"
+        "react-router-dom": "6.30.4"
       },
       "devDependencies": {
         "@types/react": "18.3.12",
@@ -2670,9 +2670,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
-      "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -7160,12 +7160,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.0.tgz",
-      "integrity": "sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.21.0"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -7175,13 +7175,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.0.tgz",
-      "integrity": "sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.21.0",
-        "react-router": "6.28.0"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -10207,7 +10207,7 @@
       },
       "peerDependencies": {
         "react": "^18.3.1",
-        "react-router-dom": "^6.28.0"
+        "react-router-dom": "^6.30.4"
       }
     }
   }

--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "react": "^18.3.1",
-    "react-router-dom": "^6.28.0"
+    "react-router-dom": "^6.30.4"
   },
   "devDependencies": {
     "@types/react": "18.3.12",


### PR DESCRIPTION
## What

Bumps `react-router-dom` from `6.28.0` to `6.30.4` in the cockpit app, the mobile app, and the shared `@devthrottle/client-core` peer range. This pulls `react-router@6.30.4` and `@remix-run/router@1.23.3`.

## Why

`npm audit` reported the react-router XSS-via-open-redirect advisory (GHSA-2w69-qvjg-hvjx) as three High-severity findings across `@remix-run/router`, `react-router`, and `react-router-dom` (vulnerable range `@remix-run/router <= 1.23.1`). The 6.30.4 line ships `@remix-run/router@1.23.3`, which clears it. Stays on the 6.x line (no v7 major).

## Audit before / after (root workspace)

- Before: 14 vulnerabilities (2 low, 3 moderate, 8 high, 1 critical)
- After: 11 vulnerabilities (2 low, 3 moderate, 5 high, 1 critical)
- The exact 3 High findings removed are the react-router chain. The remaining 5 High are unrelated (brace-expansion, fast-uri, js-yaml) and out of scope for this change.

## Verification

- `npm run typecheck` (all workspaces): clean
- cockpit `npm run build`: pass
- mobile `npm run build`: pass
- cockpit tests: 150 passed
- client-core tests: 586 passed
- Both react-router-dom pins kept in lockstep at 6.30.4
