### PR TITLE
Fix garbled Mac terminals: give spawned agents a real controlling terminal

### DIFF
--- a/src/CcDirector.Core.Tests/UnixPtyBackendTests.cs
+++ b/src/CcDirector.Core.Tests/UnixPtyBackendTests.cs
@@ -71,6 +71,54 @@ public class UnixPtyBackendTests
         }
     }
 
+    /// <summary>
+    /// Regression for the macOS garbled-terminal bug: the spawned child must ACQUIRE the
+    /// pseudo-terminal as its controlling terminal. On macOS that requires the ccd-ptyshim
+    /// (an explicit TIOCSCTTY ioctl in the child); on Linux the kernel grants it on open.
+    /// Without a controlling terminal the terminal has no foreground process group, resizes
+    /// deliver the window-change signal to nobody, and the agent paints at its spawn width
+    /// forever - which every terminal view renders as overlapping garbage.
+    /// </summary>
+    [Fact]
+    public async Task Start_ChildAcquiresControllingTerminal()
+    {
+        if (!OnUnix) return; // PTY backend only runs on macOS/Linux.
+
+        using var backend = new UnixPtyBackend();
+        // `ps -o tty= -p $$` prints the controlling terminal ("ttys012" on macOS, "pts/0"
+        // on Linux) or question marks when there is none.
+        backend.Start("/bin/sh", "-c \"echo CTTY=$(ps -o tty= -p $$)\"", Path.GetTempPath(), 120, 30);
+
+        var output = await WaitForOutputAsync(backend, "CTTY=", TimeSpan.FromSeconds(5));
+
+        Assert.Matches("CTTY=(ttys|pts)", output);
+        Assert.DoesNotContain("CTTY=?", output);
+    }
+
+    /// <summary>
+    /// The end-to-end consequence of the controlling terminal: a PTY resize must reach the
+    /// child as the window-change signal, so the agent repaints at the new geometry. This is
+    /// what Windows ConPty does natively and what the macOS backend silently dropped.
+    /// </summary>
+    [Fact]
+    public async Task Resize_DeliversWindowChangeSignalToChild()
+    {
+        if (!OnUnix) return; // PTY backend only runs on macOS/Linux.
+
+        using var backend = new UnixPtyBackend();
+        backend.Start("/bin/sh",
+            "-c \"trap 'echo GOT_WINCH' WINCH; echo TRAP_READY; while :; do sleep 0.1; done\"",
+            Path.GetTempPath(), 120, 30);
+
+        var ready = await WaitForOutputAsync(backend, "TRAP_READY", TimeSpan.FromSeconds(5));
+        Assert.Contains("TRAP_READY", ready);
+
+        backend.Resize(100, 40);
+
+        var output = await WaitForOutputAsync(backend, "GOT_WINCH", TimeSpan.FromSeconds(5));
+        Assert.Contains("GOT_WINCH", output);
+    }
+
     private static async Task<string> WaitForOutputAsync(UnixPtyBackend backend, string marker, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;

--- a/src/CcDirector.Core/CcDirector.Core.csproj
+++ b/src/CcDirector.Core/CcDirector.Core.csproj
@@ -41,4 +41,36 @@
     <EmbeddedResource Include="Tools\skill-tool-overrides.json" />
   </ItemGroup>
 
+  <!-- macOS controlling-terminal shim (UnixPty/ccd-ptyshim.c, see its header comment).
+       Compiled with clang on macOS builds only and EMBEDDED into this assembly rather than
+       shipped as a loose file, because the Mac Director is distributed as one single-file
+       binary that gets copied around alone (build slots, the app bundle, launcher updates).
+       PtyShim.cs extracts it to the storage root at runtime. The linker ad-hoc signs the
+       binary at link time and that signature survives extraction, which Apple Silicon
+       requires before it will execute anything. Built universal (arm64 + x86_64) so a
+       forced osx-x64 publish keeps working. -->
+  <!-- The properties are set inside a target (not statically) because $(IntermediateOutputPath)
+       is only defined once the SDK's own targets have been imported, after this file's body. -->
+  <Target Name="PreparePtyShimProperties" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+    <PropertyGroup>
+      <PtyShimSource>$(MSBuildProjectDirectory)/UnixPty/ccd-ptyshim.c</PtyShimSource>
+      <PtyShimBinary>$(IntermediateOutputPath)ccd-ptyshim</PtyShimBinary>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="CompilePtyShim" Condition="$([MSBuild]::IsOSPlatform('OSX'))"
+          DependsOnTargets="PreparePtyShimProperties"
+          Inputs="$(PtyShimSource)" Outputs="$(PtyShimBinary)">
+    <Exec Command="clang -O2 -Wall -Werror -mmacosx-version-min=11.0 -arch arm64 -arch x86_64 -o &quot;$(PtyShimBinary)&quot; &quot;$(PtyShimSource)&quot;" />
+  </Target>
+
+  <Target Name="EmbedPtyShim" BeforeTargets="AssignTargetPaths" DependsOnTargets="CompilePtyShim"
+          Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+    <ItemGroup>
+      <EmbeddedResource Include="$(PtyShimBinary)">
+        <LogicalName>ccd-ptyshim</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/CcDirector.Core/UnixPty/PtyShim.cs
+++ b/src/CcDirector.Core/UnixPty/PtyShim.cs
@@ -1,0 +1,85 @@
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.UnixPty;
+
+/// <summary>
+/// Provides the macOS controlling-terminal shim (<c>ccd-ptyshim</c>, see the header comment in
+/// <c>ccd-ptyshim.c</c>) as an on-disk executable. The shim is compiled at build time and embedded
+/// into this assembly - the Mac Director ships as a single self-contained file, so nothing can rely
+/// on loose files next to the executable. This class extracts it on demand to a content-addressed
+/// path under the storage root, so every Director version and build slot on the machine shares one
+/// file per distinct shim build, and a stale copy can never be executed.
+/// </summary>
+[SupportedOSPlatform("macos")]
+internal static class PtyShim
+{
+    private const string ResourceName = "ccd-ptyshim";
+    private static readonly object ExtractLock = new();
+
+    /// <summary>
+    /// Return the absolute path of an executable shim, extracting it from the embedded resource
+    /// if it is not on disk yet. Throws when the resource is missing (a broken macOS build) or
+    /// the extraction fails - a Director that cannot establish controlling terminals must fail
+    /// loudly at spawn time, not silently produce the garbled-terminal behavior this shim fixes.
+    /// </summary>
+    public static string EnsurePresent()
+    {
+        var assembly = typeof(PtyShim).Assembly;
+        using var stream = assembly.GetManifestResourceStream(ResourceName)
+            ?? throw new InvalidOperationException(
+                "Embedded resource 'ccd-ptyshim' is missing from CcDirector.Core. " +
+                "This assembly was not built on macOS; the macOS PTY backend cannot run without it.");
+
+        using var memory = new MemoryStream();
+        stream.CopyTo(memory);
+        var shimBytes = memory.ToArray();
+
+        // Content-addressed file name: same bytes -> same path, new shim build -> new path.
+        var hash = Convert.ToHexString(SHA256.HashData(shimBytes))[..16].ToLowerInvariant();
+        var binDir = Path.Combine(CcStorage.Root(), "bin");
+        var shimPath = Path.Combine(binDir, $"{ResourceName}-{hash}");
+
+        if (File.Exists(shimPath))
+            return shimPath;
+
+        lock (ExtractLock)
+        {
+            if (File.Exists(shimPath))
+                return shimPath;
+
+            FileLog.Write($"[PtyShim] EnsurePresent: extracting {shimBytes.Length} bytes to {shimPath}");
+            Directory.CreateDirectory(binDir);
+
+            // Write to a private temp name, set the execute bit, then rename into place.
+            // The rename is atomic on the same volume, so a concurrent Director process
+            // either wins the rename or sees the winner's finished file - never a torn one.
+            var tempPath = Path.Combine(binDir, $".{ResourceName}-{Guid.NewGuid():N}.tmp");
+            try
+            {
+                File.WriteAllBytes(tempPath, shimBytes);
+                File.SetUnixFileMode(tempPath,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                    UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                    UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+                File.Move(tempPath, shimPath);
+            }
+            catch (IOException) when (File.Exists(shimPath))
+            {
+                // Another process finished the rename first; its file is identical by construction.
+                File.Delete(tempPath);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[PtyShim] EnsurePresent FAILED: {ex.Message}");
+                try { File.Delete(tempPath); } catch { /* best-effort cleanup of the temp file */ }
+                throw;
+            }
+
+            FileLog.Write($"[PtyShim] EnsurePresent: shim ready at {shimPath}");
+            return shimPath;
+        }
+    }
+}

--- a/src/CcDirector.Core/UnixPty/UnixProcessHost.cs
+++ b/src/CcDirector.Core/UnixPty/UnixProcessHost.cs
@@ -62,15 +62,28 @@ public sealed class UnixProcessHost : IDisposable
 
         var resolvedExe = ResolveExecutable(exePath);
 
-        // argv must start with the program name and be null-terminated.
-        var argv = new List<string?> { resolvedExe };
+        // On macOS a session leader does NOT acquire an opened terminal as its controlling
+        // terminal automatically (unlike Linux) - that takes an explicit TIOCSCTTY ioctl issued
+        // by the child itself, which posix_spawn cannot express. So on macOS the spawn target is
+        // the bundled ccd-ptyshim, which performs the ioctl and then execs the real program.
+        // Without this the terminal has no foreground process group, the kernel has nobody to
+        // send the window-change signal to on resize, and the agent keeps painting at its spawn
+        // width forever - rendering as garbled, overlapping text in every terminal view.
+        var spawnTarget = OperatingSystem.IsMacOS() ? PtyShim.EnsurePresent() : resolvedExe;
+
+        // argv must start with the program name and be null-terminated. When spawning through
+        // the shim, the real program (absolute path) and its arguments follow the shim.
+        var argv = new List<string?> { spawnTarget };
+        if (spawnTarget != resolvedExe)
+            argv.Add(resolvedExe);
         argv.AddRange(TokenizeArgs(args));
         argv.Add(null);
 
         var envp = BuildEnvironment(environmentVars);
 
-        // The subordinate device path: the child opens this fresh (as session leader) so it
-        // becomes the controlling terminal, then we dup it onto stdin/stdout/stderr.
+        // The subordinate device path: the child opens this fresh (as session leader) and it
+        // becomes the controlling terminal - granted by the kernel on open (Linux) or claimed
+        // by the shim's TIOCSCTTY (macOS) - then we dup it onto stdin/stdout/stderr.
         var ptsPtr = ptsname(_console.MasterFd);
         if (ptsPtr == IntPtr.Zero)
             throw new InvalidOperationException("ptsname returned null for the PTY master fd.");
@@ -100,10 +113,10 @@ public sealed class UnixProcessHost : IDisposable
                 Check(posix_spawn_file_actions_addchdir_np(fileActions, workingDir),
                     "posix_spawn_file_actions_addchdir_np");
 
-            int rc = posix_spawnp(out _pid, resolvedExe, fileActions, attr, argv.ToArray(), envp);
+            int rc = posix_spawnp(out _pid, spawnTarget, fileActions, attr, argv.ToArray(), envp);
             if (rc != 0)
                 throw new InvalidOperationException(
-                    $"posix_spawnp failed for '{resolvedExe}' (rc={rc}, errno={Marshal.GetLastWin32Error()}).");
+                    $"posix_spawnp failed for '{spawnTarget}' (rc={rc}, errno={Marshal.GetLastWin32Error()}).");
         }
         finally
         {

--- a/src/CcDirector.Core/UnixPty/ccd-ptyshim.c
+++ b/src/CcDirector.Core/UnixPty/ccd-ptyshim.c
@@ -1,0 +1,53 @@
+/*
+ * ccd-ptyshim - acquire the pseudo-terminal as the controlling terminal, then
+ * replace this process with the real program.
+ *
+ * Why this exists: the Director spawns agents via posix_spawn with
+ * POSIX_SPAWN_SETSID and the pseudo-terminal subordinate opened onto standard
+ * input. On Linux that open is enough - a session leader that opens a terminal
+ * automatically acquires it as its controlling terminal. On macOS it is NOT:
+ * the kernel requires an explicit TIOCSCTTY ioctl, issued by the child itself,
+ * between session creation and exec. posix_spawn has no file action for an
+ * ioctl, so the acquisition must happen in a real child process - this shim.
+ *
+ * Without a controlling terminal the terminal has no foreground process group,
+ * so a resize (TIOCSWINSZ on the master) updates the kernel's size record but
+ * the window-change signal is delivered to nobody. The agent then keeps
+ * painting at its spawn width forever, and every viewer that mirrors the new
+ * width renders overlapping garbage - the garbled-terminal bug on macOS.
+ *
+ * Usage: ccd-ptyshim <program> [args...]
+ * Standard input must already be the pseudo-terminal subordinate, and the
+ * process must already be a session leader (POSIX_SPAWN_SETSID).
+ *
+ * Exit codes: 125 = shim precondition failed, 127 = exec failed.
+ * Errors are written to standard error, which is the terminal itself, so a
+ * failure is visible in the session view and in the raw capture.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[])
+{
+    if (argc < 2) {
+        fprintf(stderr, "ccd-ptyshim: usage: ccd-ptyshim <program> [args...]\n");
+        return 125;
+    }
+
+    if (ioctl(STDIN_FILENO, TIOCSCTTY, 0) == -1) {
+        fprintf(stderr, "ccd-ptyshim: TIOCSCTTY on standard input failed: %s\n",
+                strerror(errno));
+        return 125;
+    }
+
+    /* execvp, not execv: the Director usually passes an absolute path, but when its
+     * resolver falls back to a bare command name the old direct posix_spawnp call
+     * would search PATH - the shim must behave identically. */
+    execvp(argv[1], &argv[1]);
+    fprintf(stderr, "ccd-ptyshim: execvp '%s' failed: %s\n", argv[1], strerror(errno));
+    return 127;
+}


### PR DESCRIPTION
## The bug

Sessions hosted on a Mac render as garbled, overlapping text in every terminal view (cockpit, phone, desktop) after the first resize. Windows-hosted sessions are clean.

Root cause: on macOS a session leader does not acquire an opened terminal as its controlling terminal automatically - that requires an explicit TIOCSCTTY ioctl issued by the child itself between session creation and exec, which posix_spawn cannot express. Every Director-spawned agent on macOS therefore ran with no controlling terminal (ps showed "??" for every spawned claude). With no controlling terminal the pseudo-terminal has no foreground process group, so a resize updates the kernel's size record but the window-change signal is delivered to nobody. The agent keeps painting at its spawn width (120 columns) forever, and every viewer that mirrors the new geometry renders those paints as character salad. Windows never had this problem because ResizePseudoConsole notifies the client itself.

## The fix

A fifty-line C shim, `ccd-ptyshim`, becomes the spawn target on macOS: it claims the terminal with TIOCSCTTY, then replaces itself with the real program (execvp, so the previous PATH-search behavior is preserved). From then on the kernel delivers the window-change signal natively on every resize, exactly like Windows - no manual signal sending anywhere.

Distribution fits the single-file model: the shim is compiled by clang during macOS builds (universal arm64 + x86_64, ad-hoc signed by the linker), embedded into CcDirector.Core.dll as a resource, and extracted on demand to a content-addressed path under the storage root (`.../cc-director/bin/ccd-ptyshim-<hash>`). The Mac Director ships as one single-file binary that build slots, the app bundle, and launcher updates copy around alone, so nothing may rely on loose files next to it. The ad-hoc signature survives extraction, which Apple Silicon requires before executing anything. Linux is untouched: its kernel grants the controlling terminal on open, and no shim is compiled or used there.

## Tests

Two regression tests in UnixPtyBackendTests (they run on macOS and Linux):

- `Start_ChildAcquiresControllingTerminal` - the child's controlling terminal is real (`ps -o tty=` prints a terminal, not question marks).
- `Resize_DeliversWindowChangeSignalToChild` - a live resize delivers the window-change signal to the child (shell trap fires).

Verified on the Mac mini: all 12 UnixPtyBackendTests pass, the spawn-adjacent classes (PlatformSessionBackend, TerminalPromptInjection, TerminalRapidResize) pass, and the full Core test suite shows exactly the 16 known pre-existing Mac-only failures - no new ones. The extracted shim was inspected on disk: execute bit set, signature valid, runs.

Note: terminal content that was garbled before this fix stays garbled in scrollback; only paints after the agent's next repaint come out clean.