### PR TITLE
fix(tools): teach cc_storage the macOS data directory

### DIFF
--- a/tools/cc_storage/storage.py
+++ b/tools/cc_storage/storage.py
@@ -16,6 +16,7 @@ Environment variable overrides:
 """
 
 import os
+import sys
 from pathlib import Path
 
 
@@ -26,13 +27,25 @@ class CcStorage:
 
     @staticmethod
     def _base() -> Path:
-        """Base directory for cc-director local app data."""
+        """Base directory for cc-director local app data.
+
+        Must resolve to the SAME directory the Director itself uses, or the
+        Python tools silently read an empty world beside the real one. On
+        Windows that is %LOCALAPPDATA%/cc-director. On macOS the Director
+        lives in ~/Library/Application Support/cc-director - before this
+        branch existed the tools fell through to ~/.cc-director there and
+        could not see the Director's config (gateway address and token
+        included), which is how 'cc-devthrottle email owner' came to report
+        an unreachable Gateway on a fully enrolled Mac.
+        """
         override = os.environ.get("CC_DIRECTOR_ROOT")
         if override:
             return Path(override)
         local = os.environ.get("LOCALAPPDATA")
         if local:
             return Path(local) / "cc-director"
+        if sys.platform == "darwin":
+            return Path.home() / "Library" / "Application Support" / "cc-director"
         return Path.home() / ".cc-director"
 
     @staticmethod


### PR DESCRIPTION
Found while trying to use `cc-devthrottle email owner` on the Mac: the Python tools' shared path resolver (`cc_storage`) knows `CC_DIRECTOR_ROOT` and the Windows `LOCALAPPDATA`, and otherwise falls back to `~/.cc-director`. It has no macOS branch, but the Director on macOS lives in `~/Library/Application Support/cc-director` - so every Python tool on a Mac silently reads and writes an empty parallel world. Concretely: the email command reported an unreachable Gateway on a fully enrolled machine, because it could not see the gateway address and token in the real config.

## The fix

`CcStorage._base()` resolves to `~/Library/Application Support/cc-director` on macOS - after the explicit `CC_DIRECTOR_ROOT` override and the Windows environment variable, before the generic dotfile fallback. One branch, matching where the Director actually keeps its world.

## Verified on Sorens-Mac-mini

- Resolution order proven by direct execution: default resolves to the Application Support path; `CC_DIRECTOR_ROOT` still wins; `LOCALAPPDATA` still wins where set.
- With the installed tools patched the same way, `cc-devthrottle email owner` now reads the real config with no override and reaches the hosted Gateway (its remaining failure is the separate hosted-Gateway `/account/email` credential gap, reported to the hosted-gateway mission).
- The machine's stray `~/.cc-director` data (llm and photos settings, gmail and outlook credentials, vault database) was merged into the real directory, and the old directory parked aside as `~/.cc-director.migrated-2026-07-23`.

Ships to installed machines through the next Python tools bundle build.