### PR TITLE
release: bump main to v1.7.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.7.3</Version>
+    <Version>1.7.4</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Main is branch-protected, so the v1.7.4 tag's version-bump commit could not land on main directly - the release built fine from the tag (run 30007310009), but Directory.Build.props on main still read 1.7.3. This cherry-picks the exact tag commit (0f254693) so the next cut starts clean, matching how v1.7.1 was done.