### PR TITLE
fix(gateway): stop the hosted owner-turn check deleting every snooze it just set

### DIFF
--- a/src/CcDirector.Gateway.Tests/SnoozeRegistryTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeRegistryTests.cs
@@ -431,6 +431,26 @@ public sealed class SnoozeRegistryTests : IDisposable
     }
 
     [Fact]
+    public void A_hold_is_not_superseded_when_its_baseline_lost_sub_microsecond_ticks_to_the_store()
+    {
+        // Regression for the hosted "snooze dies ~200ms after it is set" bug. The baseline captured at hold
+        // time is the owner's last-turn stamp at full .NET 100ns tick precision; the hosted store (Postgres
+        // timestamptz) keeps only MICROSECONDS, so the baseline read back has its sub-microsecond ticks
+        // dropped. The SAME owner turn, still in memory at full precision, then read as strictly LATER than
+        // its own truncated baseline and deleted every hosted snooze on the next Director push. The compare
+        // must happen at the store's microsecond resolution so a value that merely round-tripped is not seen
+        // as newer than itself. (Self-host stored the baseline as full-precision TEXT and never hit this.)
+        var second = new DateTime(2026, 7, 23, 12, 2, 31, DateTimeKind.Utc);
+        var baselineFromStore = second.AddTicks(5537880);      // microsecond-aligned (…7880): what Postgres returns
+        var liveTurnFullPrecision = second.AddTicks(5537882);  // the IDENTICAL owner turn at full 100ns tick precision
+
+        var entry = new SnoozeRegistry.SnoozeEntry("s1", second.AddHours(1), "dir-1", null, baselineFromStore);
+
+        Assert.False(entry.SupersededByOwnerTurn(liveTurnFullPrecision)); // same turn -> the hold SURVIVES
+        Assert.True(entry.SupersededByOwnerTurn(second.AddMinutes(1)));   // a genuinely later turn still supersedes
+    }
+
+    [Fact]
     public void A_re_snooze_clears_an_elapsed_tombstone_and_arms_a_fresh_clock()
     {
         var reg = NewReg();

--- a/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
+++ b/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
@@ -113,8 +113,24 @@ public sealed class SnoozeRegistry
         {
             if (lastOwnerTurnAtUtc is not DateTime turn) return false;
             if (OwnerTurnBaselineUtc is not DateTime baseline) return true;
-            return turn.ToUniversalTime() > baseline.ToUniversalTime();
+            // COMPARE AT THE STORE'S RESOLUTION, NOT .NET's. The baseline round-trips through the snooze
+            // store between being captured and being read back here, and the hosted store (Postgres
+            // timestamptz) keeps only MICROSECOND precision - it drops the sub-microsecond ticks a .NET
+            // DateTime carries. The live turn value, in contrast, comes straight from the in-memory session
+            // DTO at full 100-nanosecond tick precision. So the SAME owner turn reads as 1-9 ticks LATER
+            // than its own persisted baseline, a strict `>` calls that "the owner is back", and the hold is
+            // deleted on the very next Director push - ~200ms after it was set, on EVERY hosted snooze
+            // (armed or deferred). Self-host stores the baseline as full-precision TEXT and never hit this,
+            // which is why it only broke on the hosted phone. Truncating both sides to microseconds makes a
+            // value that merely round-tripped equal to itself; a genuine later turn (milliseconds or more
+            // away - a human driving a turn) still supersedes.
+            return ToMicroseconds(turn.ToUniversalTime()) > ToMicroseconds(baseline.ToUniversalTime());
         }
+
+        // Floor a UTC instant to whole microseconds (Postgres timestamptz resolution). One microsecond is
+        // 10 ticks of 100ns, so drop the remainder. Store-agnostic: a full-precision (self-host TEXT)
+        // baseline and a microsecond (hosted Postgres) baseline both compare correctly after this.
+        private static DateTime ToMicroseconds(DateTime dt) => dt.AddTicks(-(dt.Ticks % 10));
     }
 
     /// <summary>


### PR DESCRIPTION
## The bug (proven from the live gateway log)

The mobile voice-mode Snooze button "does nothing" on the hosted gateway. Traced to the owner-turn supersession check in `SnoozeRegistry.SupersededByOwnerTurn`.

It compared the live `LastOwnerTurnAtUtc` (full .NET 100ns tick precision, from the in-memory session DTO) against the baseline captured when the hold was set and read back from the store. On hosted, that baseline round-trips through Postgres `timestamptz`, which keeps only **microseconds** and drops the sub-microsecond ticks. So the *same* owner turn read as strictly later than its own persisted baseline, the strict `>` ruled "the owner is back", and the snooze was deleted on the very next Director push — ~200ms after it was set, before the client's next poll. Every hosted snooze (armed or deferred) died this way. Self-host stores the baseline as full-precision TEXT and never hit it, which is why only the hosted phone was affected.

Live-log evidence:
```
12:18:22.755 [SnoozeRegistry] Snooze: sid=ac81306e..., untilUtc=...13:18:22Z   (created)
12:18:22.950 [SnoozeRegistry] ClearIfSupersededByOwnerTurn: owner turn 12:02:31.5537882 past baseline 12:02:31.5537880 -> hold dropped
12:18:23.070 POST /sessions/.../hold -> 200
```
The two timestamps are the same owner turn, two ticks (200ns) apart.

## The fix

Compare both operands at the store's microsecond resolution, so a value that merely round-tripped is not seen as newer than itself. A genuine later turn (milliseconds or more away) still supersedes.

## Proof

- New regression test `A_hold_is_not_superseded_when_its_baseline_lost_sub_microsecond_ticks_to_the_store`: **fails without the fix** (`Expected False, Actual True`), **passes with it**.
- `SnoozeRegistryTests`: **31/31 green**.