### PR TITLE
feat(gateway): hosted paywall - entitlement reader + enrollment gate (402)

### DIFF
--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
@@ -267,6 +267,10 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                         .HasColumnType("text")
                         .HasColumnName("stripe_subscription_id");
 
+                    b.Property<string>("Tier")
+                        .HasColumnType("text")
+                        .HasColumnName("tier");
+
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("updated_at");

--- a/src/CcDirector.Gateway.Tests/Data/EntitlementSchemaQualificationTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/EntitlementSchemaQualificationTests.cs
@@ -152,17 +152,20 @@ public sealed class EntitlementSchemaQualificationTests
                     "CREATE TABLE gateway.entitlements (" +
                     "subject uuid NOT NULL PRIMARY KEY, status text NOT NULL, " +
                     "current_period_end timestamptz NULL, stripe_subscription_id text NULL, " +
-                    "updated_at timestamptz NULL, livemode boolean NULL);");
-                // Seed one live, active entitlement. The subject is bound as a native uuid parameter so it lands
-                // in the uuid column exactly as the payment side would write it.
+                    "updated_at timestamptz NULL, livemode boolean NULL, tier text NULL);");
+                // Seed one live, active entitlement on the hosted tier. The subject is bound as a native uuid
+                // parameter so it lands in the uuid column exactly as the payment side would write it.
                 ctx.Database.ExecuteSqlRaw(
-                    "INSERT INTO gateway.entitlements (subject, status, livemode) VALUES ({0}, 'active', true);",
+                    "INSERT INTO gateway.entitlements (subject, status, livemode, tier) VALUES ({0}, 'active', true, 'hosted');",
                     subjectGuid);
             }
 
             var registry = new EntitlementRegistry(db, requireLivemode: true);
-            var outcome = registry.LookupBySubject(subject, DateTime.UtcNow);
-            Assert.Equal(EntitlementOutcome.Entitled, outcome);
+            // The full read: the join lands on the uuid column (the 42883 trap is guarded), the outcome is
+            // Entitled, and the tier is read back off the same row.
+            var decision = registry.Evaluate(subject, DateTime.UtcNow);
+            Assert.Equal(EntitlementOutcome.Entitled, decision.Outcome);
+            Assert.Equal(EntitlementRegistry.TierHosted, decision.Tier);
         }
         finally
         {

--- a/src/CcDirector.Gateway.Tests/HostedEntitlementGateTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedEntitlementGateTests.cs
@@ -69,8 +69,10 @@ public sealed class HostedEntitlementGateTests : IDisposable
         DeviceType = "workstation",
     };
 
-    /// <summary>Creates the payment-side table this Gateway only reads, and optionally seeds one row.</summary>
-    private GatewayDatabase OpenWithEntitlements(string? status = null, DateTime? periodEnd = null, bool? livemode = true)
+    /// <summary>Creates the payment-side table this Gateway only reads, and optionally seeds one row. The
+    /// table carries the two-tier <c>tier</c> column exactly as the payment side's schema does, so the
+    /// Gateway's read (which selects it) resolves.</summary>
+    private GatewayDatabase OpenWithEntitlements(string? status = null, DateTime? periodEnd = null, bool? livemode = true, string? tier = null)
     {
         var db = _harness.Open();
         using var ctx = db.CreateUnscopedContext();
@@ -78,13 +80,13 @@ public sealed class HostedEntitlementGateTests : IDisposable
             "CREATE TABLE IF NOT EXISTS entitlements (" +
             "subject TEXT NOT NULL PRIMARY KEY, status TEXT NOT NULL, " +
             "current_period_end TEXT NULL, stripe_subscription_id TEXT NULL, updated_at TEXT NULL, " +
-            "livemode INTEGER NULL)");
+            "livemode INTEGER NULL, tier TEXT NULL)");
 
         if (status is not null)
         {
             ctx.Database.ExecuteSqlRaw(
-                "INSERT INTO entitlements (subject, status, current_period_end, livemode) VALUES ({0}, {1}, {2}, {3})",
-                Subject, status, periodEnd, livemode);
+                "INSERT INTO entitlements (subject, status, current_period_end, livemode, tier) VALUES ({0}, {1}, {2}, {3}, {4})",
+                Subject, status, periodEnd, livemode, tier);
         }
         return db;
     }
@@ -288,5 +290,81 @@ public sealed class HostedEntitlementGateTests : IDisposable
 
         Assert.Equal(200, result.Status);
         Assert.NotNull(result.Response);
+    }
+
+    [Theory]
+    [InlineData("hosted")]
+    [InlineData("pro")]
+    [InlineData(null)]
+    public void Enrollment_grants_on_any_active_entitlement_regardless_of_tier(string? tier)
+    {
+        // The gate is TIER-AGNOSTIC. Enrolling is "may this account reach a hosted tenant at all", which BOTH
+        // plans grant - so a live active row enrolls whether its tier is hosted, pro, or (on an older row that
+        // predates the column) null. The tier decides a capability INSIDE the tenant, read separately; it must
+        // never become a second, silent paywall on enrollment. If this ever reddens for one tier, the gate has
+        // started refusing a plan that paid.
+        var db = OpenWithEntitlements(EntitlementRegistry.StatusActive, tier: tier);
+        var (devices, tenants, validator) = Wire(db);
+
+        var result = HostedEnrollmentEndpoint.Enroll(Token(), Req(), devices, tenants, validator,
+            new EntitlementRegistry(db, requireLivemode: false), DateTime.UtcNow);
+
+        Assert.Equal(200, result.Status);
+        Assert.NotNull(result.Response);
+    }
+
+    [Theory]
+    [InlineData("hosted")]
+    [InlineData("pro")]
+    public void Evaluate_exposes_the_tier_alongside_an_entitled_outcome(string tier)
+    {
+        // The reader SURFACES the plan for the capability that cares (the wingman): Evaluate returns the tier
+        // paired with the entitled outcome, from the same single read the gate uses - so the two can never
+        // disagree about the same row.
+        var db = OpenWithEntitlements(EntitlementRegistry.StatusActive, tier: tier);
+
+        var decision = new EntitlementRegistry(db, requireLivemode: false).Evaluate(Subject, DateTime.UtcNow);
+
+        Assert.Equal(EntitlementOutcome.Entitled, decision.Outcome);
+        Assert.Equal(tier, decision.Tier);
+    }
+
+    [Fact]
+    public void Evaluate_exposes_a_null_tier_on_an_older_row_that_predates_the_column()
+    {
+        // A row written before the tier column existed reads back as a null tier - not an error, just an older
+        // row - and it still ENTITLES (the gate is tier-agnostic). Null tier is the capability side's problem
+        // to interpret, not the gate's.
+        var db = OpenWithEntitlements(EntitlementRegistry.StatusActive, tier: null);
+
+        var decision = new EntitlementRegistry(db, requireLivemode: false).Evaluate(Subject, DateTime.UtcNow);
+
+        Assert.Equal(EntitlementOutcome.Entitled, decision.Outcome);
+        Assert.Null(decision.Tier);
+    }
+
+    [Fact]
+    public void Evaluate_carries_no_tier_when_the_read_finds_nothing()
+    {
+        // Absence: the read succeeds and finds no row. No outcome to grant, and no tier to expose.
+        var db = OpenWithEntitlements();   // table exists, no row for this subject
+
+        var decision = new EntitlementRegistry(db, requireLivemode: false).Evaluate(Subject, DateTime.UtcNow);
+
+        Assert.Equal(EntitlementOutcome.NotEntitled, decision.Outcome);
+        Assert.Null(decision.Tier);
+    }
+
+    [Fact]
+    public void Evaluate_carries_no_tier_when_the_read_fails()
+    {
+        // Ignorance: the read FAILS (the payment-side table is absent, as a lost SELECT grant looks from here).
+        // Unknown, and a null tier - a failed read establishes nothing, so it exposes nothing.
+        var db = _harness.Open();          // no entitlements table created
+
+        var decision = new EntitlementRegistry(db, requireLivemode: false).Evaluate(Subject, DateTime.UtcNow);
+
+        Assert.Equal(EntitlementOutcome.Unknown, decision.Outcome);
+        Assert.Null(decision.Tier);
     }
 }

--- a/src/CcDirector.Gateway.Tests/HostedMobileAccountEnrollTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedMobileAccountEnrollTests.cs
@@ -101,7 +101,7 @@ public sealed class HostedMobileAccountEnrollTests : IDisposable
             "CREATE TABLE IF NOT EXISTS entitlements (" +
             "subject TEXT NOT NULL PRIMARY KEY, status TEXT NOT NULL, " +
             "current_period_end TEXT NULL, stripe_subscription_id TEXT NULL, updated_at TEXT NULL, " +
-            "livemode INTEGER NULL)");
+            "livemode INTEGER NULL, tier TEXT NULL)");
         if (entitled)
         {
             ctx.Database.ExecuteSqlRaw(

--- a/src/CcDirector.Gateway/Data/Entities/EntitlementEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/EntitlementEntity.cs
@@ -39,6 +39,18 @@ public sealed class EntitlementEntity
     /// <summary>The payment provider's subscription reference. Read-only here, and never logged.</summary>
     public string? StripeSubscriptionId { get; set; }
 
+    /// <summary>
+    /// Which paid plan this entitlement grants: <c>hosted</c> or <c>pro</c>. Written by the payment side and
+    /// read-only here. NULLABLE on purpose: rows written before this column existed (or by a webhook that has
+    /// not been updated) arrive null, and a null tier is not an error - it is an older row.
+    ///
+    /// The tier does NOT gate hosted ENROLLMENT: any live, paid entitlement of EITHER tier lets an account
+    /// enroll a device, because enrolling is "may this account reach a hosted tenant at all", which both plans
+    /// grant. The tier decides a CAPABILITY inside the tenant (the wingman), which is a separate concern read
+    /// off this same value - so the reader exposes it, and the enrollment gate ignores it.
+    /// </summary>
+    public string? Tier { get; set; }
+
     /// <summary>When the payment side last wrote this row (UTC).</summary>
     public DateTime? UpdatedAt { get; set; }
 

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -365,6 +365,11 @@ public sealed class GatewayDbContext : DbContext
             b.Property(e => e.StripeSubscriptionId).HasColumnName("stripe_subscription_id");
             b.Property(e => e.UpdatedAt).HasColumnName("updated_at");
             b.Property(e => e.Livemode).HasColumnName("livemode");
+            // The two-tier plan column (hosted|pro), nullable. A plain text column on BOTH providers - no
+            // value converter and no uuid concern, unlike Subject - so it is mapped here in the provider-agnostic
+            // block, not in the Postgres-only section below. Read and exposed by EntitlementRegistry; never
+            // gates enrollment (either tier enrolls).
+            b.Property(e => e.Tier).HasColumnName("tier");
         });
 
         modelBuilder.Entity<TenantEntity>(b =>

--- a/src/CcDirector.Gateway/Data/Migrations/GatewayDbContextModelSnapshot.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/GatewayDbContextModelSnapshot.cs
@@ -258,6 +258,10 @@ namespace CcDirector.Gateway.Data.Migrations
                         .HasColumnType("TEXT")
                         .HasColumnName("stripe_subscription_id");
 
+                    b.Property<string>("Tier")
+                        .HasColumnType("TEXT")
+                        .HasColumnName("tier");
+
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("TEXT")
                         .HasColumnName("updated_at");

--- a/src/CcDirector.Gateway/Tenancy/EntitlementRegistry.cs
+++ b/src/CcDirector.Gateway/Tenancy/EntitlementRegistry.cs
@@ -34,6 +34,22 @@ public enum EntitlementOutcome
 }
 
 /// <summary>
+/// The full result of one entitlement read: the three-way <see cref="EntitlementOutcome"/> and the plan
+/// <see cref="Tier"/> the row carries (<c>hosted</c>, <c>pro</c>, or null on an older row / a read that found
+/// or read nothing).
+///
+/// The two fields answer DIFFERENT questions and must be read together. <see cref="Outcome"/> answers "may
+/// this account reach hosted at all" - the enrollment gate's question, which is tier-agnostic. <see cref="Tier"/>
+/// answers "which plan" - a capability question (the wingman) - and it is meaningful ONLY when paired with an
+/// <see cref="EntitlementOutcome.Entitled"/> outcome: a tier next to <see cref="EntitlementOutcome.NotEntitled"/>
+/// is the plan of a non-granting row and grants nothing, and a tier is always null on
+/// <see cref="EntitlementOutcome.Unknown"/> because a failed read establishes nothing.
+/// </summary>
+/// <param name="Outcome">The three-way entitlement outcome. Never fold the three into two.</param>
+/// <param name="Tier">The plan tier the row records (hosted|pro), or null. Never gates enrollment.</param>
+public sealed record EntitlementDecision(EntitlementOutcome Outcome, string? Tier);
+
+/// <summary>
 /// Reads the paid-entitlement record for a hosted account, at enrollment time.
 ///
 /// This is the gate that makes hosted a paid product: without it, enrolling is free and the billing side
@@ -80,6 +96,12 @@ public sealed class EntitlementRegistry
     /// <summary>
     /// Look up whether a verified account subject may enroll. See <see cref="EntitlementOutcome"/> for why
     /// the answer has three states; the caller MUST handle all three and must not collapse them.
+    ///
+    /// This is the enrollment gate's read, and it is deliberately TIER-AGNOSTIC: a live, paid entitlement of
+    /// EITHER tier (hosted or pro) enrolls, because enrolling is "may this account reach a hosted tenant at
+    /// all", which both plans grant. The tier is read and exposed by <see cref="Evaluate"/> for the capability
+    /// that cares about it (the wingman); it never changes this outcome. This method returns only the outcome
+    /// so an enrollment caller cannot accidentally start gating on tier.
     /// </summary>
     /// <param name="accountSubject">The verified account subject. The caller must have validated the token
     /// this came from; this method does not re-verify it.</param>
@@ -87,13 +109,29 @@ public sealed class EntitlementRegistry
     /// boundary is testable at an exact instant rather than only in whichever direction the clock happens
     /// to be pointing when the suite runs.</param>
     public EntitlementOutcome LookupBySubject(string accountSubject, DateTime nowUtc)
+        => Evaluate(accountSubject, nowUtc).Outcome;
+
+    /// <summary>
+    /// The full entitlement read: the three-way <see cref="EntitlementOutcome"/> AND the plan
+    /// <see cref="EntitlementDecision.Tier"/> the row carries. One read, one place - the enrollment gate takes
+    /// the outcome (tier-agnostic) and the wingman capability takes the tier, so the two can never disagree
+    /// about the same row.
+    ///
+    /// The tier is exposed as the row records it, and is meaningful ONLY paired with the outcome: a tier
+    /// alongside <see cref="EntitlementOutcome.NotEntitled"/> is the plan of a NON-granting row and confers
+    /// nothing, and a failed read carries no tier at all (null) because we read nothing.
+    /// </summary>
+    /// <param name="accountSubject">The verified account subject. The caller must have validated the token
+    /// this came from; this method does not re-verify it.</param>
+    /// <param name="nowUtc">The moment to judge the paid period against, injected for exact-boundary tests.</param>
+    public EntitlementDecision Evaluate(string accountSubject, DateTime nowUtc)
     {
         // A blank subject is not a failed read - it is a caller error, and answering Unknown would invite a
-        // retry loop that can never succeed. There is no entitlement for nobody.
+        // retry loop that can never succeed. There is no entitlement for nobody, and no tier.
         if (string.IsNullOrWhiteSpace(accountSubject))
         {
-            FileLog.Write("[EntitlementRegistry] LookupBySubject: NOT ENTITLED - no account subject was supplied");
-            return EntitlementOutcome.NotEntitled;
+            FileLog.Write("[EntitlementRegistry] Evaluate: NOT ENTITLED - no account subject was supplied");
+            return new EntitlementDecision(EntitlementOutcome.NotEntitled, null);
         }
 
         var subject = accountSubject.Trim();
@@ -109,8 +147,9 @@ public sealed class EntitlementRegistry
             // IGNORANCE, NOT ABSENCE. Every failure lands here - connection refused, timeout, the scoped
             // role losing its SELECT grant, a malformed row. None of them tell us the account is unpaid, so
             // none of them may deny, and none of them may grant. Logged loud and by TYPE, because a
-            // persistent failure here stops every enrollment on the box and must not be quiet.
-            FileLog.Write($"[EntitlementRegistry] LookupBySubject: READ FAILED ({ex.GetType().Name}) - answering UNKNOWN, " +
+            // persistent failure here stops every enrollment on the box and must not be quiet. No tier: we
+            // read nothing, so there is nothing to expose.
+            FileLog.Write($"[EntitlementRegistry] Evaluate: READ FAILED ({ex.GetType().Name}) - answering UNKNOWN, " +
                           "which must be retried and must NEVER be treated as unpaid or as paid");
 
             // DIAGNOSTIC. On a PostgreSQL failure, add the two fields that let the server's OWN error be read
@@ -123,17 +162,21 @@ public sealed class EntitlementRegistry
             // never-log-the-subject rule is preserved: the subject is still never written here.
             var pg = ex as Npgsql.PostgresException ?? ex.InnerException as Npgsql.PostgresException;
             if (pg is not null)
-                FileLog.Write($"[EntitlementRegistry] LookupBySubject: PostgreSQL error SqlState={pg.SqlState} MessageText={pg.MessageText}");
+                FileLog.Write($"[EntitlementRegistry] Evaluate: PostgreSQL error SqlState={pg.SqlState} MessageText={pg.MessageText}");
 
-            return EntitlementOutcome.Unknown;
+            return new EntitlementDecision(EntitlementOutcome.Unknown, null);
         }
 
         // From here the read SUCCEEDED, so whatever we conclude is knowledge.
         if (row is null)
         {
-            FileLog.Write("[EntitlementRegistry] LookupBySubject: NOT ENTITLED - the read succeeded and the account has no entitlement record");
-            return EntitlementOutcome.NotEntitled;
+            FileLog.Write("[EntitlementRegistry] Evaluate: NOT ENTITLED - the read succeeded and the account has no entitlement record");
+            return new EntitlementDecision(EntitlementOutcome.NotEntitled, null);
         }
+
+        // The plan the row records (hosted|pro), normalized to null-if-blank. Exposed with WHATEVER outcome
+        // follows - it is the row's data. It never influences the outcome below.
+        var tier = string.IsNullOrWhiteSpace(row.Tier) ? null : row.Tier!.Trim();
 
         // LIVE MONEY ONLY on the production hosted Gateway. A payment-provider TEST-mode subscription costs
         // nothing to create, so honouring one is a paywall bypass in the deny-OPEN direction - the expensive
@@ -147,14 +190,14 @@ public sealed class EntitlementRegistry
         // self-host - which has no billing at all - is untouched.
         if (_requireLivemode && row.Livemode != true)
         {
-            FileLog.Write("[EntitlementRegistry] LookupBySubject: NOT ENTITLED - the entitlement is not a live-mode subscription (a test-mode or unrecorded one is not an entitlement)");
-            return EntitlementOutcome.NotEntitled;
+            FileLog.Write("[EntitlementRegistry] Evaluate: NOT ENTITLED - the entitlement is not a live-mode subscription (a test-mode or unrecorded one is not an entitlement)");
+            return new EntitlementDecision(EntitlementOutcome.NotEntitled, tier);
         }
 
         var status = (row.Status ?? "").Trim();
 
         if (string.Equals(status, StatusActive, StringComparison.OrdinalIgnoreCase))
-            return EntitlementOutcome.Entitled;
+            return new EntitlementDecision(EntitlementOutcome.Entitled, tier);
 
         // The dunning grace window: a payment that failed is being retried, and the customer has paid for
         // the period already. Entitled until that period ends, and not one moment after.
@@ -168,14 +211,14 @@ public sealed class EntitlementRegistry
             && row.CurrentPeriodEnd is { } periodEnd
             && nowUtc < periodEnd)
         {
-            FileLog.Write("[EntitlementRegistry] LookupBySubject: ENTITLED within the payment-retry grace window (payment is past due, the paid period has not ended)");
-            return EntitlementOutcome.Entitled;
+            FileLog.Write("[EntitlementRegistry] Evaluate: ENTITLED within the payment-retry grace window (payment is past due, the paid period has not ended)");
+            return new EntitlementDecision(EntitlementOutcome.Entitled, tier);
         }
 
         // Canceled, past_due with the period ended or with no period recorded, or any state this code does
         // not recognise. An unrecognised state is NOT entitled - we do not guess in the paying direction.
-        FileLog.Write($"[EntitlementRegistry] LookupBySubject: NOT ENTITLED - the read succeeded and the record's state does not grant access (state='{status}')");
-        return EntitlementOutcome.NotEntitled;
+        FileLog.Write($"[EntitlementRegistry] Evaluate: NOT ENTITLED - the read succeeded and the record's state does not grant access (state='{status}')");
+        return new EntitlementDecision(EntitlementOutcome.NotEntitled, tier);
     }
 
     /// <summary>The state meaning a live, paid subscription.</summary>
@@ -183,4 +226,10 @@ public sealed class EntitlementRegistry
 
     /// <summary>The state meaning a payment failed and is being retried - entitled only until the paid period ends.</summary>
     public const string StatusPastDue = "past_due";
+
+    /// <summary>The hosted plan tier.</summary>
+    public const string TierHosted = "hosted";
+
+    /// <summary>The pro plan tier.</summary>
+    public const string TierPro = "pro";
 }


### PR DESCRIPTION
## What this is

Increment 1 of the hosted paywall (G3): the Gateway's shared entitlement reader plus the enrollment-time gate that refuses an unpaid account. Self-host has no gate and is unchanged.

The reader (`EntitlementRegistry`) and the 402 gate in `HostedEnrollmentEndpoint.Enroll` were established earlier; this increment completes the reader by adding the two-tier `tier` column (hosted|pro) it now reads and exposes, with the gate kept deliberately tier-agnostic.

## The shared reader - `EntitlementRegistry`

Reads `gateway.entitlements` keyed by the verified account subject and returns a strict three-way outcome that must never be folded into two:

- **Entitled** - the read SUCCEEDED and the row is a live, paid entitlement: `status in (active, past_due)`, `livemode = true` on the production hosted Gateway, and (for `past_due`) `now < current_period_end`. `active` grants; `past_due` grants only until the paid period ends (strict `<`, so the exact end instant is already outside).
- **NotEntitled** - the read SUCCEEDED and no row qualifies (absent / canceled / non-live / period elapsed / unrecognised state). Absence and expiry are answers.
- **Unknown** - the read FAILED (connection, timeout, lost SELECT grant, malformed row, the uuid/text mismatch below). Ignorance, never a verdict; on a PostgresException the SqlState + MessageText are logged (never the subject).

### The `tier` column (this increment's delta)

- `EntitlementEntity.Tier` (nullable text) mapped to column `tier` on both providers.
- New `EntitlementRegistry.Evaluate(subject, now)` returns `EntitlementDecision(Outcome, Tier)` from a single read; `LookupBySubject` now delegates to `Evaluate(...).Outcome`.
- The **enrollment gate grants on any active entitlement of EITHER tier** - tier never gates enrollment (it is a capability signal for the wingman, read separately). A null tier on an older row still entitles.

### The uuid/text type trap

`gateway.tenants.AccountSubject` is `text` while `gateway.entitlements.subject` is `uuid`. The reader looks the entitlement up by the subject **directly as the entity primary key** - no cross-type SQL join is emitted. A `string`<->`Guid` value converter (`HasConversion` + `HasColumnType("uuid")`, Postgres-only) makes Npgsql bind the lookup as a native `uuid` parameter, so the predicate is `uuid = uuid` and the 42883 that would 503 every hosted request cannot arise. Proven by a real-Postgres test that reads a `uuid`-column row through the Gateway's own reader.

## The enrollment gate

In `HostedEnrollmentEndpoint.Enroll`, between subject-verification and `MintOrLookupBySubject`:

- **Entitled** -> proceed (mint tenant, bind device key).
- **NotEntitled** -> **402 Payment Required**, no tenant mint, no device key.
- **Unknown** -> **503** (temporary), no tenant mint, no device key.
- **Self-host** (null entitlement registry) -> no gate, unchanged.

No subject / email / PII is logged on any path.

## Tests

- Reader + gate: three outcomes on their own code paths, the absence/ignorance controls kept separate, livemode-required (false and NULL both refused on hosted), past_due-until-period-end including the exact-boundary refusal, tier-agnostic enrollment (hosted / pro / null all enroll), and `Evaluate` exposing the tier alongside Entitled.
- Real-PostgreSQL gated tests (`CC_GATEWAY_TEST_PG_CONNECTION`) prove the uuid-column read and the tier read end-to-end, and that a failed read logs SqlState/MessageText but never the subject.

## Sequencing note

The Gateway read now selects the `tier` column, so the website migration that adds `gateway.entitlements.tier` must land before this deploys; without the column the read fails to Unknown -> 503 (fail-closed, retryable, no mint) - safe, but it is a hard predecessor. Draft: not for merge or deploy in this increment.
