### PR TITLE
fix(setup): the launcher install health check must verify identity, not just liveness (issue 2042)

### DIFF
--- a/tools/cc-director-setup-engine.Tests/LauncherHealthProbeTests.cs
+++ b/tools/cc-director-setup-engine.Tests/LauncherHealthProbeTests.cs
@@ -1,0 +1,44 @@
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>The health answer's IDENTITY rules (issue #2042): liveness alone never certifies an
+/// install when the expected version is known.</summary>
+public class LauncherHealthProbeTests
+{
+    [Fact]
+    public void Parse_WellFormedAnswer_ReadsIdentity()
+    {
+        var h = LauncherHealthProbe.Parse("""{"ok":true,"version":"1.7.4+abc","pid":77,"uptimeS":3}""");
+        Assert.True(h.Ok);
+        Assert.Equal("1.7.4+abc", h.Version);
+        Assert.Equal(77, h.Pid);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not json")]
+    [InlineData("{\"ok\":false}")]
+    public void Parse_GarbageOrNotOk_NeverOk(string body) =>
+        Assert.False(LauncherHealthProbe.Parse(body).Ok);
+
+    [Theory]
+    [InlineData("1.7.4", "1.7.4", true)]
+    [InlineData("1.7.4", "1.7.4+d26a09", true)]     // build metadata ignored
+    [InlineData("v1.7.4", "1.7.4.0", true)]          // normalized forms match
+    [InlineData("1.7.4", "1.7.1", false)]            // the issue #2042 incident shape
+    [InlineData("1.7.4", null, false)]               // expected but nothing reported
+    [InlineData(null, "9.9.9", true)]                // nothing expected: cannot check, accept
+    public void VersionMatches_ComparesNormalizedAndIgnoresBuildMetadata(string? expected, string? reported, bool matches) =>
+        Assert.Equal(matches, LauncherHealthProbe.VersionMatches(expected, reported));
+
+    [Fact]
+    public void Certifies_RequiresOkAndIdentity()
+    {
+        Assert.True(LauncherHealthProbe.Certifies(new LauncherHealth(true, "1.7.4", 1), "1.7.4"));
+        Assert.False(LauncherHealthProbe.Certifies(new LauncherHealth(true, "1.7.1", 1), "1.7.4"));
+        Assert.False(LauncherHealthProbe.Certifies(new LauncherHealth(false, "1.7.4", 1), "1.7.4"));
+        Assert.False(LauncherHealthProbe.Certifies(null, "1.7.4"));
+    }
+}

--- a/tools/cc-director-setup-engine.Tests/LauncherMacInstallerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/LauncherMacInstallerTests.cs
@@ -30,15 +30,29 @@ public class LauncherMacInstallerTests : IDisposable
         try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { /* best effort */ }
     }
 
-    /// <summary>An HTTP handler whose every response has the given status code.</summary>
-    private sealed class FixedStatusHandler(HttpStatusCode status) : HttpMessageHandler
+    /// <summary>An HTTP handler whose every response has the given status code and body.</summary>
+    private sealed class FixedStatusHandler(HttpStatusCode status, string body = "") : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
-            => Task.FromResult(new HttpResponseMessage(status));
+            => Task.FromResult(new HttpResponseMessage(status) { Content = new StringContent(body) });
     }
 
-    private HttpClient HealthyClient() => new(new FixedStatusHandler(HttpStatusCode.OK));
+    /// <summary>A launcher /healthz answer: identity travels in the body (issue #2042).</summary>
+    private static string HealthBody(string version, int pid = 4242) =>
+        $$"""{"ok":true,"version":"{{version}}","pid":{{pid}},"uptimeS":1}""";
+
+    private HttpClient HealthyClient(string version = "1.7.4") =>
+        new(new FixedStatusHandler(HttpStatusCode.OK, HealthBody(version)));
     private HttpClient DeadClient() => new(new FixedStatusHandler(HttpStatusCode.ServiceUnavailable));
+
+    /// <summary>Record the launcher version the runner would have written when placing the binary -
+    /// the identity the health check must then see answering the port.</summary>
+    private void RecordPlacedLauncherVersion(string version)
+    {
+        var manifest = InstalledManifest.Load(_layout);
+        manifest.Set(ComponentRegistry.Launcher.Id, version);
+        manifest.Save(_layout);
+    }
 
     private void PlaceLauncherBinary()
     {
@@ -178,5 +192,70 @@ public class LauncherMacInstallerTests : IDisposable
 
         Assert.False(result.Success);
         Assert.Contains("launch agent", result.Message);
+    }
+
+    [Fact]
+    public async Task InstallAsync_WrongVersionAnswersThePort_FailsLoudNamingBothVersions()
+    {
+        if (!OperatingSystem.IsMacOS()) return;
+
+        // The real incident (issue #2042): the machine's OLD launcher held port 7900 and answered
+        // the health poll, so a completely failed install of the new binary still looked green.
+        PlaceLauncherBinary();
+        WritePlist();
+        RecordPlacedLauncherVersion("1.7.4");
+        var installer = new LauncherMacInstaller(_layout,
+            HealthyClient(version: "1.7.1"),
+            runCommand: (_, _) => (0, ""),
+            startProcess: (_, _, _) => 1234,
+            launchAgentPlistPath: _plistPath,
+            healthTimeout: TimeSpan.FromMilliseconds(1200));
+
+        var result = await installer.InstallAsync();
+
+        Assert.False(result.Success);
+        Assert.Contains("1.7.1", result.Message);
+        Assert.Contains("1.7.4", result.Message);
+        Assert.Contains("refusing to certify", result.Message);
+    }
+
+    [Fact]
+    public async Task InstallAsync_MatchingVersionAnswers_SucceedsAndReportsIdentity()
+    {
+        if (!OperatingSystem.IsMacOS()) return;
+
+        PlaceLauncherBinary();
+        WritePlist();
+        RecordPlacedLauncherVersion("1.7.4");
+        var installer = new LauncherMacInstaller(_layout,
+            HealthyClient(version: "1.7.4+abcdef"),   // build metadata must not break the match
+            runCommand: (_, _) => (0, ""),
+            startProcess: (_, _, _) => 1234,
+            launchAgentPlistPath: _plistPath);
+
+        var result = await installer.InstallAsync();
+
+        Assert.True(result.Success);
+        Assert.Contains(result.Steps, s => s.Contains("OK (version 1.7.4+abcdef, process id 4242)"));
+    }
+
+    [Fact]
+    public async Task InstallAsync_NoRecordedVersion_LegacyOkAnswerStillSucceeds()
+    {
+        if (!OperatingSystem.IsMacOS()) return;
+
+        // No installed.json entry (nothing was recorded): identity cannot be checked, so a
+        // well-formed ok answer is accepted - the pre-#2042 behavior, minus blind 200-trust.
+        PlaceLauncherBinary();
+        WritePlist();
+        var installer = new LauncherMacInstaller(_layout,
+            HealthyClient(),
+            runCommand: (_, _) => (0, ""),
+            startProcess: (_, _, _) => 1234,
+            launchAgentPlistPath: _plistPath);
+
+        var result = await installer.InstallAsync();
+
+        Assert.True(result.Success);
     }
 }

--- a/tools/cc-director-setup-engine/LauncherHealthProbe.cs
+++ b/tools/cc-director-setup-engine/LauncherHealthProbe.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>One /healthz answer from a launcher: liveness plus IDENTITY (version, process id).</summary>
+public sealed record LauncherHealth(bool Ok, string? Version, int Pid);
+
+/// <summary>
+/// Polls a launcher's /healthz until the answering launcher is provably the one just installed
+/// (issue #2042). The old check accepted ANY 200 from the fixed port - so on a machine where a
+/// launcher was already running, a completely failed install of the new binary still reported
+/// "healthy": the poll was answered by the pre-existing process. Liveness is not identity. The
+/// probe reads the version stamped in the health payload and only certifies the install when it
+/// matches the version that was just placed; a mismatched responder at the deadline fails loud,
+/// naming both versions, instead of certifying a stranger.
+/// </summary>
+public static class LauncherHealthProbe
+{
+    /// <summary>
+    /// Wait until /healthz at <paramref name="healthUrl"/> answers with ok=true AND, when
+    /// <paramref name="expectedVersion"/> is known, the matching version. Returns the final
+    /// health answer (identity-verified on success), or null when nothing answered at all.
+    /// A responder whose version never matches keeps being polled until the deadline - during a
+    /// kickstart swap the OLD launcher can legitimately answer for a moment before the new one
+    /// takes the port - and is returned as-is at the deadline so the caller can fail loud.
+    /// </summary>
+    public static async Task<LauncherHealth?> WaitForHealthyAsync(
+        HttpClient http, string healthUrl, string? expectedVersion, TimeSpan timeout, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+        LauncherHealth? last = null;
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline && !ct.IsCancellationRequested)
+        {
+            try
+            {
+                using var resp = await http.GetAsync(healthUrl, ct);
+                if (resp.IsSuccessStatusCode)
+                {
+                    last = Parse(await resp.Content.ReadAsStringAsync(ct));
+                    if (last is { Ok: true } && VersionMatches(expectedVersion, last.Version))
+                        return last;
+                }
+            }
+            catch
+            {
+                // not up yet
+            }
+            try { await Task.Delay(1000, ct); } catch (OperationCanceledException) { return last; }
+        }
+        return last;
+    }
+
+    /// <summary>True when the answer certifies the install: ok, and version-matched when one was expected.</summary>
+    public static bool Certifies(LauncherHealth? health, string? expectedVersion) =>
+        health is { Ok: true } && VersionMatches(expectedVersion, health.Version);
+
+    /// <summary>No expectation always matches (legacy launchers without a version field cannot be
+    /// checked); otherwise both sides must parse and compare equal, build metadata ignored.</summary>
+    public static bool VersionMatches(string? expected, string? reported)
+    {
+        if (string.IsNullOrWhiteSpace(expected)) return true;
+        var e = VersionUtil.TryParse(expected);
+        var r = VersionUtil.TryParse(reported);
+        return e is not null && r is not null && e == r;
+    }
+
+    /// <summary>Parse a /healthz body; unparseable input reads as a not-ok answer, never a throw.</summary>
+    public static LauncherHealth Parse(string body)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+            var ok = root.TryGetProperty("ok", out var okEl) && okEl.ValueKind == JsonValueKind.True;
+            var version = root.TryGetProperty("version", out var vEl) && vEl.ValueKind == JsonValueKind.String
+                ? vEl.GetString() : null;
+            var pid = root.TryGetProperty("pid", out var pEl) && pEl.TryGetInt32(out var p) ? p : 0;
+            return new LauncherHealth(ok, version, pid);
+        }
+        catch (JsonException)
+        {
+            return new LauncherHealth(false, null, 0);
+        }
+    }
+}

--- a/tools/cc-director-setup-engine/LauncherMacInstaller.cs
+++ b/tools/cc-director-setup-engine/LauncherMacInstaller.cs
@@ -98,11 +98,23 @@ public sealed class LauncherMacInstaller
             }
         }
 
+        // Identity-verified health (issue #2042): the answer must come from the launcher version
+        // just placed, not from whatever process happens to hold the port. The expected version is
+        // what the runner recorded for the launcher when it placed the binary moments ago.
+        var expectedVersion = new InstalledStateReader(_layout).Read(ComponentRegistry.Launcher).Version;
         var healthUrl = $"http://127.0.0.1:{LauncherTrayInstaller.LauncherDefaultPort}/healthz";
-        var up = await WaitForHttpAsync(healthUrl, _healthTimeout, ct);
-        steps.Add($"launcher health endpoint on port {LauncherTrayInstaller.LauncherDefaultPort}: {(up ? "OK" : "no response")}");
-        if (!up)
+        var health = await LauncherHealthProbe.WaitForHealthyAsync(_http, healthUrl, expectedVersion, _healthTimeout, ct);
+        if (health is null)
+        {
+            steps.Add($"launcher health endpoint on port {LauncherTrayInstaller.LauncherDefaultPort}: no response");
             return Fail(steps, $"Launcher started but did not answer on port {LauncherTrayInstaller.LauncherDefaultPort}. Check {_layout.LogsDir}.");
+        }
+        if (!LauncherHealthProbe.Certifies(health, expectedVersion))
+        {
+            steps.Add($"launcher health endpoint on port {LauncherTrayInstaller.LauncherDefaultPort}: answered by version {health.Version ?? "unknown"} (process id {health.Pid})");
+            return Fail(steps, $"A launcher is answering on port {LauncherTrayInstaller.LauncherDefaultPort}, but it reports version {health.Version ?? "unknown"}, not the freshly installed {expectedVersion} - refusing to certify this install. Another launcher instance likely holds the port; check {_layout.LogsDir}.");
+        }
+        steps.Add($"launcher health endpoint on port {LauncherTrayInstaller.LauncherDefaultPort}: OK (version {health.Version ?? "unversioned"}, process id {health.Pid})");
 
         var registered = File.Exists(_launchAgentPlistPath);
         steps.Add($"launch agent property list: {(registered ? "registered" : "NOT registered")} at {_launchAgentPlistPath}");

--- a/tools/cc-director-setup-engine/LauncherTrayInstaller.cs
+++ b/tools/cc-director-setup-engine/LauncherTrayInstaller.cs
@@ -75,11 +75,21 @@ public sealed class LauncherTrayInstaller
             return Fail(steps, $"Failed to start the Launcher tray app: {ex.Message}");
         }
 
-        // 3. Wait for health.
-        var up = await WaitForHttpAsync($"http://127.0.0.1:{LauncherDefaultPort}/healthz", TimeSpan.FromSeconds(20), ct);
-        steps.Add($"launcher healthz on {LauncherDefaultPort}: {(up ? "OK" : "no response")}");
+        // 3. Wait for health - identity-verified (issue #2042): the answer must come from the
+        // launcher version just placed, not from whatever process happens to hold the port.
+        var expectedVersion = new InstalledStateReader(_layout).Read(ComponentRegistry.Launcher).Version;
+        var health = await LauncherHealthProbe.WaitForHealthyAsync(
+            _http, $"http://127.0.0.1:{LauncherDefaultPort}/healthz", expectedVersion, TimeSpan.FromSeconds(20), ct);
+        var up = LauncherHealthProbe.Certifies(health, expectedVersion);
+        steps.Add(health is null
+            ? $"launcher healthz on {LauncherDefaultPort}: no response"
+            : up
+                ? $"launcher healthz on {LauncherDefaultPort}: OK (version {health.Version ?? "unversioned"}, process id {health.Pid})"
+                : $"launcher healthz on {LauncherDefaultPort}: answered by version {health.Version ?? "unknown"} (process id {health.Pid}), not the freshly installed {expectedVersion}");
         if (!up)
-            return Fail(steps, $"Launcher tray app started but did not answer on {LauncherDefaultPort}. Check {_layout.LogsDir}.");
+            return Fail(steps, health is null
+                ? $"Launcher tray app started but did not answer on {LauncherDefaultPort}. Check {_layout.LogsDir}."
+                : $"A launcher is answering on port {LauncherDefaultPort}, but it reports version {health.Version ?? "unknown"}, not the freshly installed {expectedVersion} - refusing to certify this install. Another launcher instance likely holds the port; check {_layout.LogsDir}.");
 
         // 4. Verify the autostart Run key (written by the app on startup).
         var registered = LauncherAutostart.IsRegistered();


### PR DESCRIPTION
Closes #2042.

## The bug, as it actually bit

The launcher install was certified by polling the fixed port 7900 and accepting ANY 200. On a machine where a launcher was already running, a completely failed install of the new binary still reported "healthy" - the poll was answered by the pre-existing process. This exact false positive hid a failing launcher install through days of installer verification on Sorens-Mac-mini; it surfaced only when the owner challenged the QA report's "pass" and the install was re-run with the old launcher stopped (which produced the first genuinely witnessed launcher install success).

## The fix

The launcher's `/healthz` already reports `{ok, version, pid}` unauthenticated; the installers just ignored the identity fields. The new `LauncherHealthProbe`:

- polls until the answering launcher's **version matches the version the runner just placed** (read from `installed.json`, written moments earlier - so no caller signature changes);
- keeps polling through a kickstart window where the OLD launcher may still legitimately answer;
- at the deadline with a mismatched responder, **fails loud naming both versions** ("a launcher is answering on port 7900, but it reports version 1.7.1, not the freshly installed 1.7.4 - refusing to certify");
- reports identity on success ("OK (version 1.7.4, process id N)") so logs prove who answered;
- accepts a version-less answer only when no expectation exists (legacy), and no longer counts a bare 200 with no well-formed body as healthy.

Both platforms get the same treatment: the Windows tray installer and the macOS launchd installer.

## Tests

20 tests in the touched area (9 installer + 11 probe), including the incident-shaped case: recorded version 1.7.4, responder reports 1.7.1 - fails loud with both versions named. Revert-proof: with the identity gate disabled, exactly the four identity tests fail and the sixteen controls stay green. Full engine suite: 373 passed; the 29 failures are the known pre-existing macOS-environment ones (Windows shim and Python tools tests), present without this change.