### PR TITLE
feat(update): auto-apply a staged Director update when no sessions are running

### DIFF
--- a/src/CcDirector.Avalonia/App.axaml.cs
+++ b/src/CcDirector.Avalonia/App.axaml.cs
@@ -49,6 +49,13 @@ public partial class App : Application
     public SchedulerService? Scheduler { get; private set; }
     public UpdateService? Updater { get; private set; }
 
+    /// <summary>
+    /// One-shot guard so a staged update is auto-applied exactly once (issue #2047). Both the
+    /// "update staged" and "session ended" triggers can race; the first to flip this from 0 to 1
+    /// launches the relauncher and requests shutdown, the rest no-op. 0 = not started, 1 = started.
+    /// </summary>
+    private int _autoUpdateApplyStarted;
+
     public bool SandboxMode { get; private set; }
 
     public override void Initialize()
@@ -312,11 +319,23 @@ public partial class App : Application
 
             Updater = new UpdateService(options);
             Updater.UpdateStaged += staged =>
+            {
+                // Always surface the "Restart now" banner so a person can still restart by hand
+                // (and can do so even while sessions are running). Then try to apply automatically:
+                // if this Director is idle it restarts into the new build with no human step, and if
+                // it is busy the update is simply held until the last session ends (issue #2047).
                 global::Avalonia.Threading.Dispatcher.UIThread.Post(
                     () => mainWindow.ShowUpdateReady(staged.Version));
+                TryAutoApplyStagedUpdateWhenIdle("update-staged");
+            };
             Updater.ProgressChanged += progress =>
                 global::Avalonia.Threading.Dispatcher.UIThread.Post(
                     () => mainWindow.OnUpdateProgress(progress));
+
+            // When a machine was busy at stage time, apply the held update as soon as it goes idle:
+            // OnSessionRemoved fires AFTER the session leaves tracking, so the count we read reflects
+            // the post-removal state (issue #2047). Handler is idempotent and never throws.
+            SessionManager.OnSessionRemoved += _ => TryAutoApplyStagedUpdateWhenIdle("session-ended");
 
             FileLog.Write($"[App] StartUpdateService: enabled={enabled}, current={current}, target={options.InstallTarget}");
 
@@ -364,6 +383,78 @@ public partial class App : Application
         {
             FileLog.Write($"[App] StartUpdateService FAILED: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Auto-apply a staged update, but ONLY when it is safe: a verified update must be staged and
+    /// this Director must have zero running sessions (issue #2047). When safe, it reuses the exact
+    /// startup apply path (<see cref="UpdateInstaller.TryApplyStagedUpdateAtStartup"/>) so it inherits
+    /// every existing safety check unchanged -- bounded apply attempts, pinned-bad-version, and the
+    /// post-restart health check with automatic rollback -- then requests a normal shutdown so the
+    /// relauncher can swap the build and bring the Director back up. When sessions are running the
+    /// staged update is left untouched (the "Restart now" banner stays); it is retried the next time
+    /// a session ends and on every periodic update cycle. Called from background threads (the update
+    /// loop and the session-removed event); catches and logs everything and never throws.
+    /// </summary>
+    private void TryAutoApplyStagedUpdateWhenIdle(string reason)
+    {
+        try
+        {
+            var state = UpdaterState.Load();
+            var hasStaged = !string.IsNullOrEmpty(state.StagedVersion)
+                            && !string.IsNullOrEmpty(state.StagedExecutable)
+                            && !string.IsNullOrEmpty(state.InstallTarget);
+
+            var runningSessions = SessionManager?.ListSessions().Count ?? 0;
+            if (!UpdateInstaller.ShouldAutoApplyWhenIdle(hasStaged, runningSessions))
+            {
+                if (hasStaged)
+                    FileLog.Write($"[App] Auto-update held ({reason}): {runningSessions} session(s) running; staged {state.StagedVersion} will apply when the Director is idle.");
+                return;
+            }
+
+            // One-shot: the update-staged and session-ended triggers can fire together. Only the
+            // first caller past this gate launches the relauncher; a second would spawn a second
+            // relauncher racing for the same install path.
+            if (System.Threading.Interlocked.CompareExchange(ref _autoUpdateApplyStarted, 1, 0) != 0)
+            {
+                FileLog.Write($"[App] Auto-update already in progress; ignoring duplicate trigger ({reason}).");
+                return;
+            }
+
+            FileLog.Write($"[App] Auto-update ({reason}): no sessions running; applying staged {state.StagedVersion}.");
+            if (UpdateInstaller.TryApplyStagedUpdateAtStartup(out var failureNotice))
+            {
+                // The relauncher is running and waiting for us to exit before it swaps the build.
+                RequestShutdownForUpdate();
+                return;
+            }
+
+            // Nothing was applied (e.g. the staged build was pinned as bad, or apply attempts were
+            // exhausted). Release the one-shot so a later, healthy stage can still auto-apply.
+            System.Threading.Interlocked.Exchange(ref _autoUpdateApplyStarted, 0);
+            if (!string.IsNullOrEmpty(failureNotice))
+                FileLog.Write($"[App] Auto-update did not apply ({reason}): {failureNotice}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[App] TryAutoApplyStagedUpdateWhenIdle FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Request the normal graceful application shutdown so a launched update relauncher can swap the
+    /// build and relaunch (issue #2047). Posts to the UI thread; the classic desktop lifetime's
+    /// Shutdown runs <see cref="OnShutdown"/> (stop sessions -- none, engine, control API) and the
+    /// process exits, at which point the waiting relauncher applies the staged build.
+    /// </summary>
+    private void RequestShutdownForUpdate()
+    {
+        global::Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+        {
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
+                lifetime.Shutdown();
+        });
     }
 
     /// <summary>

--- a/src/CcDirector.Core.Tests/Update/UpdateInstallerAutoApplyGateTests.cs
+++ b/src/CcDirector.Core.Tests/Update/UpdateInstallerAutoApplyGateTests.cs
@@ -1,0 +1,44 @@
+using CcDirector.Core.Update;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Update;
+
+/// <summary>
+/// The zero-sessions gate for auto-applying a staged update (issue #2047). The Director
+/// restarts itself into a staged build with no human step, but ONLY when no sessions are
+/// running, so a running session is never interrupted. These cover the pure decision; the
+/// relaunch/shutdown side effects live in App.axaml.cs.
+/// </summary>
+public class UpdateInstallerAutoApplyGateTests
+{
+    [Fact]
+    public void ShouldAutoApply_StagedAndNoSessions_True()
+    {
+        Assert.True(UpdateInstaller.ShouldAutoApplyWhenIdle(hasStagedUpdate: true, runningSessionCount: 0));
+    }
+
+    [Fact]
+    public void ShouldAutoApply_StagedButSessionsRunning_False()
+    {
+        Assert.False(UpdateInstaller.ShouldAutoApplyWhenIdle(hasStagedUpdate: true, runningSessionCount: 1));
+    }
+
+    [Fact]
+    public void ShouldAutoApply_ManySessionsRunning_False()
+    {
+        Assert.False(UpdateInstaller.ShouldAutoApplyWhenIdle(hasStagedUpdate: true, runningSessionCount: 7));
+    }
+
+    [Fact]
+    public void ShouldAutoApply_NothingStaged_False()
+    {
+        // No staged update: nothing to apply even when the machine is completely idle.
+        Assert.False(UpdateInstaller.ShouldAutoApplyWhenIdle(hasStagedUpdate: false, runningSessionCount: 0));
+    }
+
+    [Fact]
+    public void ShouldAutoApply_NothingStagedAndSessionsRunning_False()
+    {
+        Assert.False(UpdateInstaller.ShouldAutoApplyWhenIdle(hasStagedUpdate: false, runningSessionCount: 3));
+    }
+}

--- a/src/CcDirector.Core/Update/UpdateInstaller.cs
+++ b/src/CcDirector.Core/Update/UpdateInstaller.cs
@@ -71,6 +71,16 @@ public static class UpdateInstaller
            && oldExists && oldLength > 0;
 
     /// <summary>
+    /// Decide whether a staged update may be auto-applied right now WITHOUT waiting for a human
+    /// to restart (issue #2047): only when a verified update is staged AND the Director has zero
+    /// running sessions, so restarting into the new build can never interrupt live work. This is
+    /// the same principle as the Gateway shutdown gate -- a Director with any live session is never
+    /// restarted out from under it. Pure decision, unit-tested.
+    /// </summary>
+    public static bool ShouldAutoApplyWhenIdle(bool hasStagedUpdate, int runningSessionCount)
+        => hasStagedUpdate && runningSessionCount == 0;
+
+    /// <summary>
     /// If a verified, newer update has been staged for THIS install path, launch the
     /// relauncher to apply it and return true (the caller must then exit so the swap can
     /// proceed). Called at startup, before any session exists, so applying an update never


### PR DESCRIPTION
Closes #2047.

## What this does

Makes the Director finish an update on its own when it is safe to. Today the Director downloads, verifies, and stages a new build in the background, then waits for a person to click "Restart now". This adds the missing trigger: **when a verified update is staged and the Director has zero running sessions, it restarts itself into the new build with no human step.** When any session is running it leaves the sessions untouched and holds the staged update, applying it the moment the machine goes idle.

This is the version-one auto-update behaviour: it never interrupts a running session.

## How

- `UpdateInstaller.ShouldAutoApplyWhenIdle(hasStagedUpdate, runningSessionCount)` — a pure, unit-tested gate: apply only when something is staged and the session count is zero.
- `App.TryAutoApplyStagedUpdateWhenIdle` — checks the gate against `SessionManager.ListSessions().Count`, and when it passes reuses the existing startup apply path `UpdateInstaller.TryApplyStagedUpdateAtStartup`, then requests a normal shutdown so the relauncher swaps the build and brings the Director back up.
- Two triggers: right after an update is staged (the existing `UpdateStaged` event), and on `SessionManager.OnSessionRemoved` (so a busy machine applies the held update as soon as its last session ends — the event fires after the session leaves tracking, so the count is accurate).
- A one-shot `Interlocked` guard stops the two triggers from racing to launch two relaunchers.

## What is reused unchanged (the safe part)

All the hard and risky machinery already existed and is untouched:
- The cross-platform self-restart: `LaunchRelauncher` → `ApplyUpdate` → `SwapWindows`/`SwapMac` → `Relaunch` (Windows `Process.Start`, macOS `/usr/bin/open`).
- Bounded apply attempts, half-swap recovery, post-restart health check, and automatic rollback to the previous build (issue #242).

## Scope

Director only. The Launcher and Gateway already self-update. The "Restart now" banner still shows so a person can restart by hand at any time. A per-tenant off switch (default on) and busy-machine handover documents are explicit follow-ons.

## Testing

- `dotnet build` of `CcDirector.Avalonia`: clean (0 warnings, 0 errors).
- `dotnet test` of `CcDirector.Core.Tests` filtered to `UpdateInstaller`: 20 passed, including 5 new gate tests (`UpdateInstallerAutoApplyGateTests`).

Because the behaviour ships inside the Director build, existing installed machines only get it after their next update; from then on they keep themselves current on their own. This needs to go out in a release.
