### PR TITLE
Source Control phase 1: fail-closed orphaned-worktree detector service

### DIFF
--- a/src/CcDirector.Core.Tests/WorktreeInventoryIntegrationTests.cs
+++ b/src/CcDirector.Core.Tests/WorktreeInventoryIntegrationTests.cs
@@ -1,0 +1,278 @@
+using System.Diagnostics;
+using System.Text;
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Integration tests that drive real git against throwaway repositories, including a local
+/// bare "origin" so the origin-branch-gone (C2) and contained-in-main (C3) signals are exercised
+/// exactly as they behave in production. Each test gets a fresh repository (xunit builds a new
+/// instance per test) so scenarios never leak into one another.
+///
+/// These carry the two must-pass acceptance criteria from issue #503:
+///   * a worktree with uncommitted work is NEVER in the safe set, and
+///   * a squash-merged-then-deleted branch IS correctly classified as safe.
+/// </summary>
+public sealed class WorktreeInventoryIntegrationTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _origin;
+    private readonly string _primary;
+
+    public WorktreeInventoryIntegrationTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "ccd-worktree-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        _origin = Path.Combine(_root, "origin.git");
+        _primary = Path.Combine(_root, "primary");
+
+        // Bare origin with a deterministic default branch, then a clone as the primary checkout.
+        RunGit(_root, "-c", "init.defaultBranch=main", "init", "--bare", _origin);
+        RunGit(_root, "-c", "init.defaultBranch=main", "clone", _origin, _primary);
+        ConfigureIdentity(_primary);
+
+        // An initial commit on main, pushed to origin so origin/main exists.
+        WriteFile(_primary, "README.md", "initial\n");
+        RunGit(_primary, "add", "-A");
+        RunGit(_primary, "commit", "-m", "initial commit");
+        RunGit(_primary, "branch", "-M", "main");
+        RunGit(_primary, "push", "-u", "origin", "main");
+    }
+
+    public void Dispose()
+    {
+        // git worktrees hold handles; retry a little to be robust on Windows.
+        for (int attempt = 0; attempt < 3; attempt++)
+        {
+            try { Directory.Delete(_root, recursive: true); return; }
+            catch { Thread.Sleep(100); }
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Must-pass acceptance: uncommitted work is NEVER safe, even when the branch is fully merged.
+    // -------------------------------------------------------------------------------------------
+    [Fact]
+    public async Task UncommittedWork_IsNeverSafe_EvenWhenBranchIsMerged()
+    {
+        var wt = Path.Combine(_root, "wt-dirty");
+        RunGit(_primary, "worktree", "add", "-b", "dirty", wt, "main");
+        WriteFile(wt, "feature.txt", "work\n");
+        RunGit(wt, "add", "-A");
+        RunGit(wt, "commit", "-m", "feature work");
+        RunGit(wt, "push", "-u", "origin", "dirty");
+
+        // Merge it into main so - absent the dirt - it would be classified safe.
+        RunGit(_primary, "merge", "--ff-only", "dirty");
+        RunGit(_primary, "push", "origin", "main");
+
+        // Now plant an untracked file: the worktree is no longer clean.
+        WriteFile(wt, "scratch.tmp", "uncommitted\n");
+
+        var inventory = await new WorktreeInventoryService().GetInventoryAsync(_primary);
+
+        Assert.True(inventory.Success, inventory.Error);
+        var dirty = Assert.Single(inventory.Worktrees, w => w.Branch == "dirty");
+        Assert.Equal(WorktreeSafety.NeedsAttention, dirty.Safety);
+        Assert.Equal(WorktreeSafetyReason.UncommittedChanges, dirty.Reason);
+        Assert.DoesNotContain(inventory.SafeToReap, w => w.Branch == "dirty");
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Must-pass acceptance: a squash-merged branch whose origin branch was deleted IS safe.
+    // git cherry cannot see the squash (different patch-id) - only origin-branch-gone catches it.
+    // -------------------------------------------------------------------------------------------
+    [Fact]
+    public async Task SquashMergedThenOriginBranchDeleted_IsSafe_ViaOriginBranchGone()
+    {
+        var wt = Path.Combine(_root, "wt-squash");
+        RunGit(_primary, "worktree", "add", "-b", "squashme", wt, "main");
+        WriteFile(wt, "a.txt", "one\n");
+        RunGit(wt, "add", "-A");
+        RunGit(wt, "commit", "-m", "commit one");
+        WriteFile(wt, "b.txt", "two\n");
+        RunGit(wt, "add", "-A");
+        RunGit(wt, "commit", "-m", "commit two");
+        RunGit(wt, "push", "-u", "origin", "squashme");
+
+        // Squash the two commits into a single commit on main (a different patch-id).
+        RunGit(_primary, "merge", "--squash", "squashme");
+        RunGit(_primary, "commit", "-m", "squash squashme into main");
+        RunGit(_primary, "push", "origin", "main");
+
+        // Delete the origin branch, as delete-branch-on-merge would.
+        RunGit(_primary, "push", "origin", "--delete", "squashme");
+
+        var inventory = await new WorktreeInventoryService().GetInventoryAsync(_primary);
+
+        Assert.True(inventory.Success, inventory.Error);
+        var squash = Assert.Single(inventory.Worktrees, w => w.Branch == "squashme");
+        Assert.Equal(WorktreeSafety.SafeToReap, squash.Safety);
+        Assert.Equal(WorktreeSafetyReason.OriginBranchGone, squash.Reason);
+        Assert.Contains(inventory.SafeToReap, w => w.Branch == "squashme");
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // A branch whose commits are all in origin/main (real merge, branch still on origin) is safe
+    // via the contained-in-main (C3) signal.
+    // -------------------------------------------------------------------------------------------
+    [Fact]
+    public async Task BranchContainedInMain_WithOriginBranchStillPresent_IsSafe_ViaContainedInMain()
+    {
+        var wt = Path.Combine(_root, "wt-contained");
+        RunGit(_primary, "worktree", "add", "-b", "contained", wt, "main");
+        WriteFile(wt, "c.txt", "contained\n");
+        RunGit(wt, "add", "-A");
+        RunGit(wt, "commit", "-m", "contained commit");
+        RunGit(wt, "push", "-u", "origin", "contained"); // keep origin branch present
+
+        // Fast-forward main to include the commit (same sha), then push. Do NOT delete the branch.
+        RunGit(_primary, "merge", "--ff-only", "contained");
+        RunGit(_primary, "push", "origin", "main");
+
+        var inventory = await new WorktreeInventoryService().GetInventoryAsync(_primary);
+
+        Assert.True(inventory.Success, inventory.Error);
+        var contained = Assert.Single(inventory.Worktrees, w => w.Branch == "contained");
+        Assert.Equal(WorktreeSafety.SafeToReap, contained.Safety);
+        Assert.Equal(WorktreeSafetyReason.ContainedInMain, contained.Reason);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // A branch with a commit not in origin/main is stranded and never safe.
+    // -------------------------------------------------------------------------------------------
+    [Fact]
+    public async Task BranchAheadOfMain_IsStranded_AndReportsAheadCount()
+    {
+        var wt = Path.Combine(_root, "wt-ahead");
+        RunGit(_primary, "worktree", "add", "-b", "ahead", wt, "main");
+        WriteFile(wt, "d.txt", "ahead\n");
+        RunGit(wt, "add", "-A");
+        RunGit(wt, "commit", "-m", "unmerged work");
+        RunGit(wt, "push", "-u", "origin", "ahead"); // origin branch exists, not merged
+
+        var inventory = await new WorktreeInventoryService().GetInventoryAsync(_primary);
+
+        Assert.True(inventory.Success, inventory.Error);
+        var ahead = Assert.Single(inventory.Worktrees, w => w.Branch == "ahead");
+        Assert.Equal(WorktreeSafety.NeedsAttention, ahead.Safety);
+        Assert.Equal(WorktreeSafetyReason.NotProvenMerged, ahead.Reason);
+        Assert.Equal(1, ahead.AheadOfMain);
+        Assert.DoesNotContain(inventory.SafeToReap, w => w.Branch == "ahead");
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // A detached-HEAD worktree at a commit that is an ancestor of origin/main is safe.
+    // -------------------------------------------------------------------------------------------
+    [Fact]
+    public async Task DetachedHead_AncestorOfMain_IsSafe()
+    {
+        var initialSha = RunGit(_primary, "rev-parse", "HEAD").Trim();
+
+        // Advance main so the initial commit is a strict ancestor.
+        WriteFile(_primary, "README.md", "second\n");
+        RunGit(_primary, "add", "-A");
+        RunGit(_primary, "commit", "-m", "second commit");
+        RunGit(_primary, "push", "origin", "main");
+
+        var wt = Path.Combine(_root, "wt-detached");
+        RunGit(_primary, "worktree", "add", "--detach", wt, initialSha);
+
+        var inventory = await new WorktreeInventoryService().GetInventoryAsync(_primary);
+
+        Assert.True(inventory.Success, inventory.Error);
+        var detached = Assert.Single(inventory.Worktrees, w => w.IsDetachedHead);
+        Assert.Equal(WorktreeSafety.SafeToReap, detached.Safety);
+        Assert.Equal(WorktreeSafetyReason.DetachedHeadAncestorOfMain, detached.Reason);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // The primary checkout is always present, flagged primary, and never in the safe set.
+    // -------------------------------------------------------------------------------------------
+    [Fact]
+    public async Task PrimaryCheckout_IsFlagged_AndNeverSafe()
+    {
+        var inventory = await new WorktreeInventoryService().GetInventoryAsync(_primary);
+
+        Assert.True(inventory.Success, inventory.Error);
+        var primary = inventory.Worktrees[0];
+        Assert.True(primary.IsPrimary);
+        Assert.Equal(WorktreeSafety.NeedsAttention, primary.Safety);
+        Assert.Equal(WorktreeSafetyReason.PrimaryCheckout, primary.Reason);
+        Assert.DoesNotContain(inventory.SafeToReap, w => w.IsPrimary);
+        Assert.DoesNotContain(inventory.NeedsAttention, w => w.IsPrimary);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // The badge count equals the number of safe-to-reap worktrees.
+    // -------------------------------------------------------------------------------------------
+    [Fact]
+    public async Task BadgeCount_EqualsNumberOfSafeToReapWorktrees()
+    {
+        // One safe (contained), one stranded (ahead).
+        var safe = Path.Combine(_root, "wt-safe");
+        RunGit(_primary, "worktree", "add", "-b", "safe", safe, "main");
+        WriteFile(safe, "s.txt", "s\n");
+        RunGit(safe, "add", "-A");
+        RunGit(safe, "commit", "-m", "safe work");
+        RunGit(safe, "push", "-u", "origin", "safe");
+        RunGit(_primary, "merge", "--ff-only", "safe");
+        RunGit(_primary, "push", "origin", "main");
+
+        var stranded = Path.Combine(_root, "wt-stranded");
+        RunGit(_primary, "worktree", "add", "-b", "stranded", stranded, "main");
+        WriteFile(stranded, "t.txt", "t\n");
+        RunGit(stranded, "add", "-A");
+        RunGit(stranded, "commit", "-m", "stranded work");
+        RunGit(stranded, "push", "-u", "origin", "stranded");
+
+        var inventory = await new WorktreeInventoryService().GetInventoryAsync(_primary);
+
+        Assert.True(inventory.Success, inventory.Error);
+        Assert.Equal(inventory.SafeToReap.Count, inventory.SafeToReapCount);
+        Assert.Equal(1, inventory.SafeToReapCount);
+        Assert.Contains(inventory.SafeToReap, w => w.Branch == "safe");
+        Assert.Contains(inventory.NeedsAttention, w => w.Branch == "stranded");
+    }
+
+    // ----- helpers -----
+
+    private void ConfigureIdentity(string repo)
+    {
+        RunGit(repo, "config", "user.email", "test@cc-director.local");
+        RunGit(repo, "config", "user.name", "CC Director Test");
+        RunGit(repo, "config", "commit.gpgsign", "false");
+    }
+
+    private static void WriteFile(string repo, string relPath, string content)
+    {
+        var full = Path.Combine(repo, relPath);
+        var dir = Path.GetDirectoryName(full);
+        if (dir != null) Directory.CreateDirectory(dir);
+        File.WriteAllText(full, content);
+    }
+
+    private static string RunGit(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        using var p = Process.Start(psi)!;
+        var stdout = p.StandardOutput.ReadToEnd();
+        var stderr = p.StandardError.ReadToEnd();
+        p.WaitForExit();
+        if (p.ExitCode != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed (exit {p.ExitCode}): {stderr}");
+        return stdout;
+    }
+}

--- a/src/CcDirector.Core.Tests/WorktreeListParserTests.cs
+++ b/src/CcDirector.Core.Tests/WorktreeListParserTests.cs
@@ -1,0 +1,103 @@
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+public class WorktreeListParserTests
+{
+    [Fact]
+    public void Parse_SingleBranchWorktree_ExtractsPathHeadAndShortBranch()
+    {
+        var porcelain =
+            "worktree /home/user/repo\n" +
+            "HEAD 1111111111111111111111111111111111111111\n" +
+            "branch refs/heads/main\n";
+
+        var entries = WorktreeListParser.Parse(porcelain);
+
+        var e = Assert.Single(entries);
+        Assert.Equal("/home/user/repo", e.Path);
+        Assert.Equal("1111111111111111111111111111111111111111", e.Head);
+        Assert.Equal("main", e.Branch);
+        Assert.False(e.IsDetached);
+        Assert.False(e.IsBare);
+    }
+
+    [Fact]
+    public void Parse_MultipleWorktrees_KeepsOrderMainFirst()
+    {
+        var porcelain =
+            "worktree /repo/main\n" +
+            "HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" +
+            "branch refs/heads/main\n" +
+            "\n" +
+            "worktree /repo/feature\n" +
+            "HEAD bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n" +
+            "branch refs/heads/feature-x\n";
+
+        var entries = WorktreeListParser.Parse(porcelain);
+
+        Assert.Equal(2, entries.Count);
+        Assert.Equal("/repo/main", entries[0].Path);
+        Assert.Equal("main", entries[0].Branch);
+        Assert.Equal("/repo/feature", entries[1].Path);
+        Assert.Equal("feature-x", entries[1].Branch);
+    }
+
+    [Fact]
+    public void Parse_DetachedHead_HasNoBranchAndIsFlaggedDetached()
+    {
+        var porcelain =
+            "worktree /repo/detached\n" +
+            "HEAD cccccccccccccccccccccccccccccccccccccccc\n" +
+            "detached\n";
+
+        var e = Assert.Single(WorktreeListParser.Parse(porcelain));
+        Assert.Null(e.Branch);
+        Assert.True(e.IsDetached);
+        Assert.Equal("cccccccccccccccccccccccccccccccccccccccc", e.Head);
+    }
+
+    [Fact]
+    public void Parse_BareRepository_IsFlaggedBare()
+    {
+        var porcelain =
+            "worktree /repo/bare\n" +
+            "bare\n";
+
+        var e = Assert.Single(WorktreeListParser.Parse(porcelain));
+        Assert.True(e.IsBare);
+    }
+
+    [Fact]
+    public void Parse_CrlfLineEndings_AreHandled()
+    {
+        var porcelain =
+            "worktree /repo/main\r\n" +
+            "HEAD dddddddddddddddddddddddddddddddddddddddd\r\n" +
+            "branch refs/heads/main\r\n";
+
+        var e = Assert.Single(WorktreeListParser.Parse(porcelain));
+        Assert.Equal("/repo/main", e.Path);
+        Assert.Equal("main", e.Branch);
+    }
+
+    [Fact]
+    public void Parse_EmptyOrNullInput_ReturnsNoEntries()
+    {
+        Assert.Empty(WorktreeListParser.Parse(""));
+        Assert.Empty(WorktreeListParser.Parse(null!));
+    }
+
+    [Fact]
+    public void Parse_BranchWithSlashes_KeepsFullShortName()
+    {
+        var porcelain =
+            "worktree /repo/feat\n" +
+            "HEAD eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\n" +
+            "branch refs/heads/feature/source-control\n";
+
+        var e = Assert.Single(WorktreeListParser.Parse(porcelain));
+        Assert.Equal("feature/source-control", e.Branch);
+    }
+}

--- a/src/CcDirector.Core.Tests/WorktreeSafetyEvaluatorTests.cs
+++ b/src/CcDirector.Core.Tests/WorktreeSafetyEvaluatorTests.cs
@@ -1,0 +1,155 @@
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Exhaustive, I/O-free tests of the fail-closed safety decision. These pin the exact rule
+/// from issue #503: safe only if not-primary AND clean AND proven-merged; otherwise stranded.
+/// </summary>
+public class WorktreeSafetyEvaluatorTests
+{
+    private static WorktreeFacts Base() => new()
+    {
+        IsPrimary = false,
+        IsDetachedHead = false,
+        IsClean = true,
+        PullRequestMerged = false,
+        OriginBranchGone = false,
+        ContainedInMain = false,
+        DetachedHeadIsAncestorOfMain = false,
+        InspectionSucceeded = true,
+    };
+
+    // --- Guardrail A: the primary checkout is never safe, whatever else is true ---
+
+    [Fact]
+    public void Primary_IsNeverSafe_EvenWhenCleanAndMerged()
+    {
+        var facts = Base() with
+        {
+            IsPrimary = true,
+            PullRequestMerged = true,
+            OriginBranchGone = true,
+            ContainedInMain = true,
+        };
+
+        var v = WorktreeSafetyEvaluator.Evaluate(facts);
+
+        Assert.Equal(WorktreeSafety.NeedsAttention, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.PrimaryCheckout, v.Reason);
+    }
+
+    // --- Guardrail B: any content at all is never safe, even when merged ---
+
+    [Fact]
+    public void Dirty_IsNeverSafe_EvenWhenMerged()
+    {
+        var facts = new WorktreeFacts
+        {
+            IsClean = false,
+            PullRequestMerged = true,
+            OriginBranchGone = true,
+            ContainedInMain = true,
+            InspectionSucceeded = true,
+        };
+
+        var v = WorktreeSafetyEvaluator.Evaluate(facts);
+
+        Assert.Equal(WorktreeSafety.NeedsAttention, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.UncommittedChanges, v.Reason);
+    }
+
+    // --- Fail closed: a failed probe is never safe ---
+
+    [Fact]
+    public void InspectionFailed_IsNeverSafe()
+    {
+        var facts = new WorktreeFacts
+        {
+            IsClean = true,
+            ContainedInMain = true,
+            InspectionSucceeded = false,
+        };
+
+        var v = WorktreeSafetyEvaluator.Evaluate(facts);
+
+        Assert.Equal(WorktreeSafety.NeedsAttention, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.InspectionFailed, v.Reason);
+    }
+
+    // --- Each single merge signal is sufficient (C1, C2, C3) ---
+
+    [Fact]
+    public void CleanBranch_WithMergedPullRequest_IsSafe()
+    {
+        var v = WorktreeSafetyEvaluator.Evaluate(Base() with { PullRequestMerged = true });
+        Assert.Equal(WorktreeSafety.SafeToReap, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.PullRequestMerged, v.Reason);
+    }
+
+    [Fact]
+    public void CleanBranch_WithOriginBranchGone_IsSafe()
+    {
+        var v = WorktreeSafetyEvaluator.Evaluate(Base() with { OriginBranchGone = true });
+        Assert.Equal(WorktreeSafety.SafeToReap, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.OriginBranchGone, v.Reason);
+    }
+
+    [Fact]
+    public void CleanBranch_ContainedInMain_IsSafe()
+    {
+        var v = WorktreeSafetyEvaluator.Evaluate(Base() with { ContainedInMain = true });
+        Assert.Equal(WorktreeSafety.SafeToReap, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.ContainedInMain, v.Reason);
+    }
+
+    // --- No merge signal: stranded ---
+
+    [Fact]
+    public void CleanBranch_WithNoMergeSignal_IsStranded()
+    {
+        var v = WorktreeSafetyEvaluator.Evaluate(Base());
+        Assert.Equal(WorktreeSafety.NeedsAttention, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.NotProvenMerged, v.Reason);
+    }
+
+    // --- Detached HEAD: safe only if it is an ancestor of origin/main ---
+
+    [Fact]
+    public void DetachedHead_AncestorOfMain_IsSafe()
+    {
+        var v = WorktreeSafetyEvaluator.Evaluate(Base() with
+        {
+            IsDetachedHead = true,
+            DetachedHeadIsAncestorOfMain = true,
+        });
+        Assert.Equal(WorktreeSafety.SafeToReap, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.DetachedHeadAncestorOfMain, v.Reason);
+    }
+
+    [Fact]
+    public void DetachedHead_NotAncestorOfMain_IsStranded()
+    {
+        var v = WorktreeSafetyEvaluator.Evaluate(Base() with
+        {
+            IsDetachedHead = true,
+            DetachedHeadIsAncestorOfMain = false,
+        });
+        Assert.Equal(WorktreeSafety.NeedsAttention, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.NotProvenMerged, v.Reason);
+    }
+
+    [Fact]
+    public void DetachedHead_Dirty_IsStranded_RegardlessOfAncestry()
+    {
+        var v = WorktreeSafetyEvaluator.Evaluate(Base() with
+        {
+            IsDetachedHead = true,
+            DetachedHeadIsAncestorOfMain = true,
+            IsClean = false,
+        });
+        Assert.Equal(WorktreeSafety.NeedsAttention, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.UncommittedChanges, v.Reason);
+    }
+}

--- a/src/CcDirector.Core/Git/GhMergedPullRequestProbe.cs
+++ b/src/CcDirector.Core/Git/GhMergedPullRequestProbe.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics;
+using System.Text;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// Implements the pull-request-merged signal (C1) by shelling the GitHub CLI (<c>gh</c>).
+/// If <c>gh</c> is not installed, not authenticated, or errors for any reason, both probes
+/// return false so the local git signals (C2 origin-branch-gone, C3 contained-in-main) decide.
+/// </summary>
+public sealed class GhMergedPullRequestProbe : IMergedPullRequestProbe
+{
+    public Task<bool> IsBranchMergedAsync(string repoPath, string branch, CancellationToken ct = default) =>
+        AnyPullRequestAsync(repoPath, branch, "merged", ct);
+
+    public Task<bool> HasOpenPullRequestAsync(string repoPath, string branch, CancellationToken ct = default) =>
+        AnyPullRequestAsync(repoPath, branch, "open", ct);
+
+    private static async Task<bool> AnyPullRequestAsync(string repoPath, string branch, string state, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(branch) || string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
+            return false;
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "gh",
+            WorkingDirectory = repoPath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in new[] { "pr", "list", "--head", branch, "--state", state, "--json", "number", "--limit", "1" })
+            psi.ArgumentList.Add(a);
+
+        FileLog.Write($"[GhMergedPullRequestProbe] gh pr list --head {branch} --state {state}");
+
+        var stdout = new StringBuilder();
+        try
+        {
+            using var proc = new Process { StartInfo = psi };
+            proc.OutputDataReceived += (_, e) => { if (e.Data != null) stdout.Append(e.Data); };
+            proc.Start();
+            proc.BeginOutputReadLine();
+            proc.BeginErrorReadLine();
+            await proc.WaitForExitAsync(ct);
+
+            if (proc.ExitCode != 0)
+            {
+                FileLog.Write($"[GhMergedPullRequestProbe] gh unavailable/failed (exit={proc.ExitCode}) - relying on local git signals");
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            // gh not installed, or the process could not start - fall through to local git signals.
+            FileLog.Write($"[GhMergedPullRequestProbe] gh could not run ({ex.Message}) - relying on local git signals");
+            return false;
+        }
+
+        // gh returns a JSON array; a non-empty array means at least one matching pull request.
+        var text = stdout.ToString().Trim();
+        return text.Length > 0 && text != "[]" && text.Contains("\"number\"", StringComparison.Ordinal);
+    }
+}

--- a/src/CcDirector.Core/Git/GitCommandRunner.cs
+++ b/src/CcDirector.Core/Git/GitCommandRunner.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics;
+using System.Text;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// Result of a single <c>git</c> invocation: the exit code plus captured stdout/stderr.
+/// The exit code is kept because some commands (e.g. <c>merge-base --is-ancestor</c>)
+/// communicate their answer through the exit status rather than output.
+/// </summary>
+public sealed class GitCommandResult
+{
+    public bool Success { get; init; }
+    public int ExitCode { get; init; }
+    public string Output { get; init; } = "";
+    public string Error { get; init; } = "";
+}
+
+/// <summary>
+/// Runs a single <c>git</c> command in a working directory and captures its result.
+/// Shared by the worktree inventory and reaper services so every git call is logged
+/// and its exit code is available. Uses <see cref="ProcessStartInfo.ArgumentList"/> so
+/// arguments are passed without shell quoting hazards.
+/// </summary>
+public sealed class GitCommandRunner
+{
+    /// <summary>
+    /// Runs <c>git &lt;args&gt;</c> in <paramref name="workingDirectory"/> and returns its result.
+    /// </summary>
+    public async Task<GitCommandResult> RunAsync(string workingDirectory, string[] args, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(workingDirectory) || !Directory.Exists(workingDirectory))
+            return new GitCommandResult { Success = false, ExitCode = -1, Error = $"working directory not found: {workingDirectory}" };
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        FileLog.Write($"[GitCommandRunner] git {string.Join(' ', args)} (cwd={workingDirectory})");
+
+        using var proc = new Process { StartInfo = psi };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) stdout.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) stderr.AppendLine(e.Data); };
+
+        proc.Start();
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        await proc.WaitForExitAsync(ct);
+
+        var result = new GitCommandResult
+        {
+            Success = proc.ExitCode == 0,
+            ExitCode = proc.ExitCode,
+            Output = stdout.ToString().TrimEnd(),
+            Error = stderr.ToString().TrimEnd(),
+        };
+        if (!result.Success)
+            FileLog.Write($"[GitCommandRunner] git exit={proc.ExitCode}: {result.Error}");
+        return result;
+    }
+}

--- a/src/CcDirector.Core/Git/IMergedPullRequestProbe.cs
+++ b/src/CcDirector.Core/Git/IMergedPullRequestProbe.cs
@@ -1,0 +1,31 @@
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// The authoritative pull-request-merged signal (C1). This is the ONLY signal that reliably
+/// recognises a multi-commit branch that was squash-merged into a single commit on main.
+/// It is optional: with delete-branch-on-merge on (which it is for our repositories), the
+/// origin-branch-gone signal (C2) already catches squashes without a GitHub token. When no
+/// token or <c>gh</c> is available the probe returns false, and the local git signals decide.
+/// </summary>
+public interface IMergedPullRequestProbe
+{
+    /// <summary>True only if the branch has a MERGED pull request on origin. False if none, or unknown.</summary>
+    Task<bool> IsBranchMergedAsync(string repoPath, string branch, CancellationToken ct = default);
+
+    /// <summary>True if the branch has an OPEN pull request on origin (display only). False if none, or unknown.</summary>
+    Task<bool> HasOpenPullRequestAsync(string repoPath, string branch, CancellationToken ct = default);
+}
+
+/// <summary>
+/// The no-signal probe: always reports "not merged" and "no open pull request". Used when a
+/// GitHub token is unavailable, so the verdict rests entirely on the local git signals (C2/C3).
+/// This is not a fallback that hides a problem - C1 is documented as an optional extra signal.
+/// </summary>
+public sealed class NullMergedPullRequestProbe : IMergedPullRequestProbe
+{
+    public Task<bool> IsBranchMergedAsync(string repoPath, string branch, CancellationToken ct = default) =>
+        Task.FromResult(false);
+
+    public Task<bool> HasOpenPullRequestAsync(string repoPath, string branch, CancellationToken ct = default) =>
+        Task.FromResult(false);
+}

--- a/src/CcDirector.Core/Git/WorktreeInventoryService.cs
+++ b/src/CcDirector.Core/Git/WorktreeInventoryService.cs
@@ -1,0 +1,195 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// Enumerates every worktree for a repository and computes each one's fail-closed
+/// safe-to-reap verdict, exactly as issue #503 defines it. This is the detector: it
+/// gathers the git facts and delegates the decision to <see cref="WorktreeSafetyEvaluator"/>.
+/// The UI renders the result; it never re-derives a verdict.
+/// </summary>
+public sealed class WorktreeInventoryService
+{
+    private readonly GitCommandRunner _git;
+    private readonly IMergedPullRequestProbe _pullRequestProbe;
+
+    public WorktreeInventoryService(GitCommandRunner? git = null, IMergedPullRequestProbe? pullRequestProbe = null)
+    {
+        _git = git ?? new GitCommandRunner();
+        _pullRequestProbe = pullRequestProbe ?? new NullMergedPullRequestProbe();
+    }
+
+    /// <summary>
+    /// Enumerates the worktrees of <paramref name="repositoryPath"/> and returns their verdicts.
+    /// When <paramref name="fetchPrune"/> is true a <c>git fetch --prune</c> runs first so the
+    /// origin-branch-gone signal (C2) is current.
+    /// </summary>
+    public async Task<WorktreeInventory> GetInventoryAsync(string repositoryPath, bool fetchPrune = true, CancellationToken ct = default)
+    {
+        FileLog.Write($"[WorktreeInventoryService] GetInventoryAsync: repo={repositoryPath}, fetchPrune={fetchPrune}");
+        try
+        {
+            if (string.IsNullOrWhiteSpace(repositoryPath) || !Directory.Exists(repositoryPath))
+                return Failure(repositoryPath, $"repository path not found: {repositoryPath}");
+
+            // Learn which origin branches were deleted (delete-branch-on-merge => gone == merged).
+            if (fetchPrune)
+                await _git.RunAsync(repositoryPath, new[] { "fetch", "--prune" }, ct);
+
+            var mainRef = await ResolveMainRefAsync(repositoryPath, ct);
+
+            var listResult = await _git.RunAsync(repositoryPath, new[] { "worktree", "list", "--porcelain" }, ct);
+            if (!listResult.Success)
+                return Failure(repositoryPath, $"git worktree list failed: {listResult.Error}");
+
+            var rawEntries = WorktreeListParser.Parse(listResult.Output);
+            var worktrees = new List<WorktreeInfo>();
+            bool primaryAssigned = false;
+
+            foreach (var entry in rawEntries)
+            {
+                if (entry.IsBare)
+                    continue; // a bare repository has no primary checkout to protect or reap
+
+                // Git lists the main working tree first; it is the primary checkout.
+                bool isPrimary = !primaryAssigned;
+                primaryAssigned = true;
+
+                worktrees.Add(await BuildInfoAsync(repositoryPath, entry, isPrimary, mainRef, ct));
+            }
+
+            var safeCount = worktrees.Count(w => w.Safety == WorktreeSafety.SafeToReap);
+            FileLog.Write($"[WorktreeInventoryService] inventory: {worktrees.Count} worktrees, {safeCount} safe to reap");
+
+            return new WorktreeInventory
+            {
+                RepositoryPath = repositoryPath,
+                Worktrees = worktrees,
+                Success = true,
+            };
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[WorktreeInventoryService] GetInventoryAsync FAILED: {ex.Message}");
+            return Failure(repositoryPath, ex.Message);
+        }
+    }
+
+    private async Task<WorktreeInfo> BuildInfoAsync(string repositoryPath, RawWorktreeEntry entry, bool isPrimary, string? mainRef, CancellationToken ct)
+    {
+        // Cleanliness is measured inside the worktree itself.
+        var statusResult = await _git.RunAsync(entry.Path, new[] { "status", "--porcelain" }, ct);
+        int dirtyCount = statusResult.Success
+            ? statusResult.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length
+            : 0;
+        bool isClean = statusResult.Success && dirtyCount == 0;
+
+        // Every merge signal needs origin/main; if we could not resolve it, fail closed.
+        bool inspectionOk = statusResult.Success && mainRef != null;
+
+        bool prMerged = false, hasOpenPr = false, originGone = false, containedInMain = false, detachedAncestor = false;
+        int ahead = 0, behind = 0;
+
+        if (mainRef != null && !isPrimary)
+        {
+            if (entry.IsDetached)
+            {
+                // Detached HEAD: safe only if its commit is an ancestor of origin/main.
+                var ancestor = await _git.RunAsync(repositoryPath, new[] { "merge-base", "--is-ancestor", entry.Head, mainRef }, ct);
+                // exit 0 => ancestor, exit 1 => not an ancestor. Any other exit is a real error.
+                inspectionOk &= ancestor.ExitCode is 0 or 1;
+                detachedAncestor = ancestor.ExitCode == 0;
+            }
+            else if (entry.Branch != null)
+            {
+                // C2: has the origin branch been deleted (after the prune above)?
+                var lsRemote = await _git.RunAsync(repositoryPath, new[] { "ls-remote", "--heads", "origin", entry.Branch }, ct);
+                inspectionOk &= lsRemote.Success;
+                originGone = lsRemote.Success && string.IsNullOrWhiteSpace(lsRemote.Output);
+
+                // C3: does the branch add anything origin/main lacks? git cherry marks such commits with '+'.
+                var cherry = await _git.RunAsync(repositoryPath, new[] { "cherry", mainRef, entry.Branch }, ct);
+                inspectionOk &= cherry.Success;
+                containedInMain = cherry.Success && !HasUniqueCommits(cherry.Output);
+
+                // Ahead/behind counts for the needs-attention display.
+                var counts = await _git.RunAsync(repositoryPath, new[] { "rev-list", "--left-right", "--count", $"{mainRef}...{entry.Branch}" }, ct);
+                (behind, ahead) = ParseLeftRightCount(counts.Output);
+
+                // C1: authoritative pull-request-merged signal (optional).
+                prMerged = await _pullRequestProbe.IsBranchMergedAsync(repositoryPath, entry.Branch, ct);
+                hasOpenPr = await _pullRequestProbe.HasOpenPullRequestAsync(repositoryPath, entry.Branch, ct);
+            }
+        }
+
+        var facts = new WorktreeFacts
+        {
+            IsPrimary = isPrimary,
+            IsDetachedHead = entry.IsDetached,
+            IsClean = isClean,
+            PullRequestMerged = prMerged,
+            OriginBranchGone = originGone,
+            ContainedInMain = containedInMain,
+            DetachedHeadIsAncestorOfMain = detachedAncestor,
+            InspectionSucceeded = inspectionOk,
+        };
+
+        var verdict = WorktreeSafetyEvaluator.Evaluate(facts);
+
+        return new WorktreeInfo
+        {
+            Path = entry.Path,
+            Branch = entry.Branch,
+            HeadCommit = entry.Head,
+            IsPrimary = isPrimary,
+            IsDetachedHead = entry.IsDetached,
+            IsClean = isClean,
+            DirtyFileCount = dirtyCount,
+            AheadOfMain = ahead,
+            BehindMain = behind,
+            HasOpenPullRequest = hasOpenPr,
+            Safety = verdict.Safety,
+            Reason = verdict.Reason,
+            Explanation = verdict.Explanation,
+        };
+    }
+
+    /// <summary>True if <c>git cherry</c> output contains a commit the upstream lacks (a line starting with '+').</summary>
+    private static bool HasUniqueCommits(string cherryOutput) =>
+        cherryOutput
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Any(line => line.TrimStart().StartsWith('+'));
+
+    /// <summary>
+    /// Parses <c>git rev-list --left-right --count A...B</c> output ("&lt;left&gt;\t&lt;right&gt;").
+    /// Left is commits in A (origin/main) not B, i.e. how far the branch is behind; right is
+    /// commits in B not A, i.e. how far the branch is ahead. Returns (behind, ahead).
+    /// </summary>
+    private static (int Behind, int Ahead) ParseLeftRightCount(string output)
+    {
+        var parts = output.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length >= 2 && int.TryParse(parts[0], out var left) && int.TryParse(parts[1], out var right))
+            return (left, right);
+        return (0, 0);
+    }
+
+    private async Task<string?> ResolveMainRefAsync(string repositoryPath, CancellationToken ct)
+    {
+        var main = await _git.RunAsync(repositoryPath, new[] { "rev-parse", "--verify", "--quiet", "origin/main" }, ct);
+        if (main.Success && !string.IsNullOrWhiteSpace(main.Output))
+            return "origin/main";
+
+        var master = await _git.RunAsync(repositoryPath, new[] { "rev-parse", "--verify", "--quiet", "origin/master" }, ct);
+        if (master.Success && !string.IsNullOrWhiteSpace(master.Output))
+            return "origin/master";
+
+        FileLog.Write($"[WorktreeInventoryService] could not resolve origin/main or origin/master in {repositoryPath}");
+        return null;
+    }
+
+    private static WorktreeInventory Failure(string repositoryPath, string error)
+    {
+        FileLog.Write($"[WorktreeInventoryService] inventory FAILED: {error}");
+        return new WorktreeInventory { RepositoryPath = repositoryPath, Success = false, Error = error };
+    }
+}

--- a/src/CcDirector.Core/Git/WorktreeListParser.cs
+++ b/src/CcDirector.Core/Git/WorktreeListParser.cs
@@ -1,0 +1,86 @@
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// Parses the output of <c>git worktree list --porcelain</c> into raw entries.
+/// Pure and side-effect free so the parsing can be unit-tested against fixed fixtures.
+/// Git always lists the repository's main working tree first, then the linked worktrees.
+/// </summary>
+public static class WorktreeListParser
+{
+    /// <summary>
+    /// Parses porcelain worktree output. Each record is separated by a blank line and
+    /// carries a <c>worktree &lt;path&gt;</c> line, a <c>HEAD &lt;sha&gt;</c> line, and either
+    /// a <c>branch refs/heads/&lt;name&gt;</c> line or a <c>detached</c> marker.
+    /// </summary>
+    public static IReadOnlyList<RawWorktreeEntry> Parse(string porcelain)
+    {
+        var entries = new List<RawWorktreeEntry>();
+
+        string? path = null;
+        string? head = null;
+        string? branch = null;
+        bool detached = false;
+        bool bare = false;
+
+        void Flush()
+        {
+            if (path != null)
+            {
+                entries.Add(new RawWorktreeEntry
+                {
+                    Path = path,
+                    Head = head ?? "",
+                    Branch = branch,
+                    IsDetached = detached,
+                    IsBare = bare,
+                });
+            }
+            path = null;
+            head = null;
+            branch = null;
+            detached = false;
+            bare = false;
+        }
+
+        foreach (var rawLine in (porcelain ?? "").Replace("\r\n", "\n").Split('\n'))
+        {
+            var line = rawLine.TrimEnd();
+            if (line.Length == 0)
+            {
+                Flush();
+                continue;
+            }
+
+            if (line.StartsWith("worktree ", StringComparison.Ordinal))
+            {
+                // A new record begins - flush any in-progress one first.
+                Flush();
+                path = line["worktree ".Length..].Trim();
+            }
+            else if (line.StartsWith("HEAD ", StringComparison.Ordinal))
+            {
+                head = line["HEAD ".Length..].Trim();
+            }
+            else if (line.StartsWith("branch ", StringComparison.Ordinal))
+            {
+                branch = ShortBranch(line["branch ".Length..].Trim());
+            }
+            else if (line == "detached")
+            {
+                detached = true;
+            }
+            else if (line == "bare")
+            {
+                bare = true;
+            }
+        }
+
+        Flush();
+        return entries;
+    }
+
+    private static string ShortBranch(string reference) =>
+        reference.StartsWith("refs/heads/", StringComparison.Ordinal)
+            ? reference["refs/heads/".Length..]
+            : reference;
+}

--- a/src/CcDirector.Core/Git/WorktreeModels.cs
+++ b/src/CcDirector.Core/Git/WorktreeModels.cs
@@ -1,0 +1,159 @@
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// The two states a worktree can be in from the reaper's point of view.
+/// The verdict is computed once, on the service side, and the UI only renders it
+/// (the "dumb client" rule in CLAUDE.md).
+/// </summary>
+public enum WorktreeSafety
+{
+    /// <summary>Work is provably on origin/main and the tree is clean - safe to remove mechanically.</summary>
+    SafeToReap,
+
+    /// <summary>Carries unmerged commits, uncommitted content, or is the primary checkout - never auto-removed.</summary>
+    NeedsAttention,
+}
+
+/// <summary>
+/// The specific signal that decided a worktree's safety verdict, so the UI can show a
+/// one-line reason and the reaper can log its proof-of-safety.
+/// </summary>
+public enum WorktreeSafetyReason
+{
+    // --- Safe-to-reap reasons (each is sufficient proof the work reached origin/main) ---
+
+    /// <summary>C1: the branch's pull request is merged (authoritative; recognises squash merges).</summary>
+    PullRequestMerged,
+
+    /// <summary>C2: the origin branch no longer exists after a prune - with delete-branch-on-merge, gone means merged.</summary>
+    OriginBranchGone,
+
+    /// <summary>C3: <c>git cherry</c> reports the branch adds nothing origin/main lacks.</summary>
+    ContainedInMain,
+
+    /// <summary>Detached-HEAD case: its HEAD commit is an ancestor of origin/main.</summary>
+    DetachedHeadAncestorOfMain,
+
+    // --- Needs-attention reasons (never auto-removed) ---
+
+    /// <summary>The repository's primary checkout - never removed.</summary>
+    PrimaryCheckout,
+
+    /// <summary>The tree has modified, staged, or untracked content - deleting would lose work.</summary>
+    UncommittedChanges,
+
+    /// <summary>No merge signal could be established - fail closed, treat as stranded.</summary>
+    NotProvenMerged,
+
+    /// <summary>A required git probe failed, so safety could not be proven - fail closed.</summary>
+    InspectionFailed,
+}
+
+/// <summary>
+/// The plain facts about a worktree, gathered from git, that feed the pure
+/// <see cref="WorktreeSafetyEvaluator"/>. Keeping the facts separate from the git
+/// calls lets the fail-closed decision be unit-tested exhaustively without a repository.
+/// </summary>
+public sealed record WorktreeFacts
+{
+    /// <summary>True when this is the repository's main working tree (guardrail A).</summary>
+    public bool IsPrimary { get; init; }
+
+    /// <summary>True when the worktree is on a detached HEAD rather than a branch.</summary>
+    public bool IsDetachedHead { get; init; }
+
+    /// <summary>True when <c>git status --porcelain</c> is empty (no content at all).</summary>
+    public bool IsClean { get; init; }
+
+    /// <summary>C1: the branch has a merged pull request.</summary>
+    public bool PullRequestMerged { get; init; }
+
+    /// <summary>C2: the origin branch was deleted after a prune.</summary>
+    public bool OriginBranchGone { get; init; }
+
+    /// <summary>C3: <c>git cherry</c> is clean - the branch adds nothing origin/main lacks.</summary>
+    public bool ContainedInMain { get; init; }
+
+    /// <summary>Detached-HEAD case: the HEAD commit is an ancestor of origin/main.</summary>
+    public bool DetachedHeadIsAncestorOfMain { get; init; }
+
+    /// <summary>
+    /// False when a required git probe failed (e.g. origin/main could not be resolved),
+    /// forcing a fail-closed verdict rather than a guess.
+    /// </summary>
+    public bool InspectionSucceeded { get; init; } = true;
+}
+
+/// <summary>The evaluator's decision: the safety bucket, the deciding reason, and a one-line explanation.</summary>
+public sealed class WorktreeVerdict
+{
+    public WorktreeSafety Safety { get; init; }
+    public WorktreeSafetyReason Reason { get; init; }
+    public string Explanation { get; init; } = "";
+}
+
+/// <summary>
+/// A raw entry parsed from <c>git worktree list --porcelain</c>, before any safety reasoning.
+/// </summary>
+public sealed class RawWorktreeEntry
+{
+    public string Path { get; init; } = "";
+    public string Head { get; init; } = "";
+
+    /// <summary>The short branch name, or null for a detached HEAD.</summary>
+    public string? Branch { get; init; }
+
+    public bool IsDetached { get; init; }
+    public bool IsBare { get; init; }
+}
+
+/// <summary>
+/// The full, display-ready record for one worktree: its identity, its dirty/ahead/behind
+/// counts, and the computed safety verdict. The UI renders these verbatim.
+/// </summary>
+public sealed class WorktreeInfo
+{
+    public string Path { get; init; } = "";
+
+    /// <summary>The short branch name, or null for a detached HEAD.</summary>
+    public string? Branch { get; init; }
+
+    public string HeadCommit { get; init; } = "";
+    public bool IsPrimary { get; init; }
+    public bool IsDetachedHead { get; init; }
+    public bool IsClean { get; init; }
+
+    /// <summary>Number of modified/staged/untracked entries reported by <c>git status --porcelain</c>.</summary>
+    public int DirtyFileCount { get; init; }
+
+    public int AheadOfMain { get; init; }
+    public int BehindMain { get; init; }
+    public bool HasOpenPullRequest { get; init; }
+
+    public WorktreeSafety Safety { get; init; }
+    public WorktreeSafetyReason Reason { get; init; }
+    public string Explanation { get; init; } = "";
+}
+
+/// <summary>
+/// The result of enumerating a repository's worktrees: the full list plus success/error,
+/// with convenience projections into the safe-to-reap and needs-attention groups the UI shows.
+/// </summary>
+public sealed class WorktreeInventory
+{
+    public string RepositoryPath { get; init; } = "";
+    public IReadOnlyList<WorktreeInfo> Worktrees { get; init; } = Array.Empty<WorktreeInfo>();
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+
+    /// <summary>The worktrees proven safe to reap right now - what the badge counts and the button removes.</summary>
+    public IReadOnlyList<WorktreeInfo> SafeToReap =>
+        Worktrees.Where(w => w.Safety == WorktreeSafety.SafeToReap).ToList();
+
+    /// <summary>Stranded or dirty worktrees a human or agent must decide about (excludes the primary checkout).</summary>
+    public IReadOnlyList<WorktreeInfo> NeedsAttention =>
+        Worktrees.Where(w => w.Safety == WorktreeSafety.NeedsAttention && !w.IsPrimary).ToList();
+
+    /// <summary>The badge count: how many worktrees can be reaped now.</summary>
+    public int SafeToReapCount => Worktrees.Count(w => w.Safety == WorktreeSafety.SafeToReap);
+}

--- a/src/CcDirector.Core/Git/WorktreeSafetyEvaluator.cs
+++ b/src/CcDirector.Core/Git/WorktreeSafetyEvaluator.cs
@@ -1,0 +1,67 @@
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// The fail-closed heart of the reaper: given the plain facts about a worktree, decides
+/// whether it is safe to reap. Pure and total - no I/O - so every branch of the decision
+/// is unit-testable. The rule is exactly the one in issue #503:
+///
+/// A worktree is safe to reap ONLY IF all of:
+///   A. it is not the primary checkout, and
+///   B. its tree is clean (no modified, staged, or untracked content), and
+///   C. its work is proven merged by at least one of:
+///        C1 pull request merged, C2 origin branch gone, C3 contained in origin/main;
+///        for a detached HEAD, C is "HEAD is an ancestor of origin/main".
+///
+/// If none of C can be established, the worktree is treated as stranded. We would rather
+/// leave a safe worktree than delete an unsafe one.
+/// </summary>
+public static class WorktreeSafetyEvaluator
+{
+    public static WorktreeVerdict Evaluate(WorktreeFacts facts)
+    {
+        // Guardrail A: never the primary checkout. Checked first so nothing else can override it.
+        if (facts.IsPrimary)
+            return NeedsAttention(WorktreeSafetyReason.PrimaryCheckout,
+                "Primary checkout - never removed.");
+
+        // Fail closed: if a required git probe failed we cannot prove anything about this worktree.
+        if (!facts.InspectionSucceeded)
+            return NeedsAttention(WorktreeSafetyReason.InspectionFailed,
+                "Could not inspect this worktree - treated as unsafe.");
+
+        // Guardrail B: any content at all means work could be lost.
+        if (!facts.IsClean)
+            return NeedsAttention(WorktreeSafetyReason.UncommittedChanges,
+                "Uncommitted or untracked content present.");
+
+        // Detached HEAD: safe only if its HEAD commit is already contained in origin/main.
+        if (facts.IsDetachedHead)
+        {
+            return facts.DetachedHeadIsAncestorOfMain
+                ? Safe(WorktreeSafetyReason.DetachedHeadAncestorOfMain,
+                    "Detached HEAD is contained in origin/main.")
+                : NeedsAttention(WorktreeSafetyReason.NotProvenMerged,
+                    "Detached HEAD is not contained in origin/main.");
+        }
+
+        // Branch: proven merged by at least one signal. Order is most-authoritative first.
+        if (facts.PullRequestMerged)
+            return Safe(WorktreeSafetyReason.PullRequestMerged, "Pull request merged.");
+
+        if (facts.OriginBranchGone)
+            return Safe(WorktreeSafetyReason.OriginBranchGone, "Origin branch deleted after merge.");
+
+        if (facts.ContainedInMain)
+            return Safe(WorktreeSafetyReason.ContainedInMain, "All commits already contained in origin/main.");
+
+        // No merge signal - stranded.
+        return NeedsAttention(WorktreeSafetyReason.NotProvenMerged,
+            "Commits not proven to be in origin/main.");
+    }
+
+    private static WorktreeVerdict Safe(WorktreeSafetyReason reason, string explanation) =>
+        new() { Safety = WorktreeSafety.SafeToReap, Reason = reason, Explanation = explanation };
+
+    private static WorktreeVerdict NeedsAttention(WorktreeSafetyReason reason, string explanation) =>
+        new() { Safety = WorktreeSafety.NeedsAttention, Reason = reason, Explanation = explanation };
+}


### PR DESCRIPTION
## Phase 1 of the Director Source Control tab (issue thefrederiksen/devthrottle_internal#503)

The detector half: enumerate every worktree for a repository and compute a fail-closed safe-to-reap verdict. No UI yet - that is phase 2; the reaper button is phase 3.

### The verdict (exactly as the spec defines it)
A worktree is **safe to reap** only if **all** of:
- **A** it is not the primary checkout,
- **B** its tree is clean (`git status --porcelain` empty - any content at all disqualifies it), and
- **C** its work is proven merged by at least one of:
  - **C1** pull request merged (authoritative; the only reliable squash signal),
  - **C2** origin branch gone after `git fetch --prune` (with delete-branch-on-merge, gone means merged - catches squashes with no token),
  - **C3** `git cherry origin/main B` clean (branch adds nothing main lacks).
  - Detached HEAD: safe only if its commit is an ancestor of origin/main.

If none of C can be established, the worktree is treated as **stranded** and never marked safe. We would rather leave a safe worktree than delete an unsafe one.

### Design
- `WorktreeSafetyEvaluator` is a pure, total function (no I/O), so the fail-closed decision is unit-tested exhaustively.
- `WorktreeInventoryService` gathers the git facts and delegates the decision - the verdict is computed once, in one place, for the UI to render verbatim (the dumb-client rule).
- `IMergedPullRequestProbe` makes C1 optional and injectable; it degrades to the local git signals when `gh`/token is absent.

### Files
- `src/CcDirector.Core/Git/GitCommandRunner.cs`
- `src/CcDirector.Core/Git/WorktreeModels.cs`
- `src/CcDirector.Core/Git/WorktreeListParser.cs`
- `src/CcDirector.Core/Git/WorktreeSafetyEvaluator.cs`
- `src/CcDirector.Core/Git/WorktreeInventoryService.cs`
- `src/CcDirector.Core/Git/IMergedPullRequestProbe.cs` + `GhMergedPullRequestProbe.cs`
- 3 test files (24 tests)

### Tests
- Pure parser tests, an exhaustive I/O-free fail-closed matrix, and real-git integration tests against a local bare origin.
- Both must-pass acceptance criteria are covered:
  - a worktree with uncommitted work is **never** in the safe set, even when its branch is fully merged, and
  - a squash-merged branch whose origin branch was deleted is correctly classified **safe** (via C2, since C3 cannot see the squash).
- New tests: 24 green. Full Core.Tests suite: 3320 passed, 8 skipped, 0 failed.