### PR TITLE
Source Control phase 2: read-only Worktrees page + page rail

### DIFF
--- a/src/CcDirector.Avalonia.Tests/SourceControlViewRenderTests.cs
+++ b/src/CcDirector.Avalonia.Tests/SourceControlViewRenderTests.cs
@@ -1,0 +1,38 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using CcDirector.Avalonia.Controls;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// Headless render guards: construct and lay out the Source Control container and its Worktrees
+/// page on the real Avalonia headless platform. This catches runtime XAML load, resource, and
+/// binding errors that the compiler does not - constructing the control runs InitializeComponent.
+/// </summary>
+public class SourceControlViewRenderTests
+{
+    [AvaloniaFact]
+    public void SourceControlView_LoadsAndLaysOut_WithBothPages()
+    {
+        var view = new SourceControlView();
+        var window = new Window { Content = view, Width = 900, Height = 600 };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        // Reaching here means the XAML for the container AND both hosted pages loaded and laid out.
+        Assert.NotNull(view);
+    }
+
+    [AvaloniaFact]
+    public void WorktreesView_LoadsWithZeroOrphanCount()
+    {
+        var view = new WorktreesView();
+        var window = new Window { Content = view, Width = 700, Height = 500 };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(0, view.OrphanedCount);
+    }
+}

--- a/src/CcDirector.Avalonia.Tests/WorktreesViewTests.cs
+++ b/src/CcDirector.Avalonia.Tests/WorktreesViewTests.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+using CcDirector.Avalonia.Controls;
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// Tests the Worktrees page's pure display builders - the row lists and the copy-to-clipboard
+/// report - without constructing any UI. The safety verdict itself is decided (and tested) in
+/// Core; here we only prove the view renders that verdict faithfully.
+/// </summary>
+public class WorktreesViewTests
+{
+    private static WorktreeInfo Safe(string branch, string reason = "Origin branch deleted after merge.") => new()
+    {
+        Path = $"/repo/{branch}",
+        Branch = branch,
+        Safety = WorktreeSafety.SafeToReap,
+        Reason = WorktreeSafetyReason.OriginBranchGone,
+        Explanation = reason,
+        IsClean = true,
+    };
+
+    private static WorktreeInfo Stranded(string branch, int ahead = 1, int behind = 0, bool clean = true, int dirty = 0, bool openPr = false) => new()
+    {
+        Path = $"/repo/{branch}",
+        Branch = branch,
+        Safety = WorktreeSafety.NeedsAttention,
+        Reason = clean ? WorktreeSafetyReason.NotProvenMerged : WorktreeSafetyReason.UncommittedChanges,
+        Explanation = clean ? "Commits not proven to be in origin/main." : "Uncommitted or untracked content present.",
+        IsClean = clean,
+        DirtyFileCount = dirty,
+        AheadOfMain = ahead,
+        BehindMain = behind,
+        HasOpenPullRequest = openPr,
+    };
+
+    private static WorktreeInfo Primary() => new()
+    {
+        Path = "/repo",
+        Branch = "main",
+        IsPrimary = true,
+        Safety = WorktreeSafety.NeedsAttention,
+        Reason = WorktreeSafetyReason.PrimaryCheckout,
+        Explanation = "Primary checkout - never removed.",
+        IsClean = true,
+    };
+
+    private static WorktreeInventory Inventory(params WorktreeInfo[] worktrees) =>
+        new() { RepositoryPath = "/repo", Worktrees = worktrees, Success = true };
+
+    [Fact]
+    public void BuildSafeRows_ContainsOnlySafeWorktrees()
+    {
+        var inv = Inventory(Primary(), Safe("feat-a"), Stranded("feat-b"));
+
+        var rows = WorktreesView.BuildSafeRows(inv);
+
+        var row = Assert.Single(rows);
+        Assert.Equal("feat-a", row.Title);
+        Assert.Equal("/repo/feat-a", row.Path);
+        Assert.Equal("Origin branch deleted after merge.", row.Reason);
+    }
+
+    [Fact]
+    public void BuildNeedsRows_ExcludesPrimaryAndSafe()
+    {
+        var inv = Inventory(Primary(), Safe("feat-a"), Stranded("feat-b"));
+
+        var rows = WorktreesView.BuildNeedsRows(inv);
+
+        var row = Assert.Single(rows);
+        Assert.Equal("feat-b", row.Title);
+        Assert.DoesNotContain(rows, r => r.Title == "main");
+    }
+
+    [Fact]
+    public void DetailFor_DirtyWorktree_ReportsUncommittedCount()
+    {
+        var w = Stranded("dirty", clean: false, dirty: 3);
+        Assert.Equal("3 uncommitted file(s)", WorktreesView.DetailFor(w));
+    }
+
+    [Fact]
+    public void DetailFor_CleanAheadBehindWithOpenPr_ComposesAllParts()
+    {
+        var w = Stranded("busy", ahead: 2, behind: 5, openPr: true);
+        Assert.Equal("ahead 2, behind 5, open pull request", WorktreesView.DetailFor(w));
+    }
+
+    [Fact]
+    public void DetailFor_DetachedTitle_UsesDetachedLabel()
+    {
+        var w = new WorktreeInfo
+        {
+            Path = "/repo/det",
+            Branch = null,
+            IsDetachedHead = true,
+            Safety = WorktreeSafety.SafeToReap,
+            Explanation = "Detached HEAD is contained in origin/main.",
+            IsClean = true,
+        };
+        var rows = WorktreesView.BuildSafeRows(Inventory(w));
+        Assert.Equal("(detached HEAD)", Assert.Single(rows).Title);
+    }
+
+    [Fact]
+    public void BuildReport_ListsBothGroups_AndCounts()
+    {
+        var inv = Inventory(Primary(), Safe("feat-a"), Stranded("feat-b", ahead: 1));
+
+        var report = WorktreesView.BuildReport(inv);
+
+        Assert.Contains("Safe to reap: 1", report);
+        Assert.Contains("Needs attention: 1", report);
+        Assert.Contains("SAFE TO REAP", report);
+        Assert.Contains("feat-a", report);
+        Assert.Contains("NEEDS ATTENTION", report);
+        Assert.Contains("feat-b", report);
+        Assert.Contains("Worktree report for /repo", report);
+        // The primary checkout is neither safe nor needs-attention, so its own path line is absent.
+        Assert.DoesNotContain("path:   /repo\r\n", report);
+        Assert.DoesNotContain("path:   /repo\n", report);
+    }
+
+    [Fact]
+    public void BuildReport_EmptyGroups_ShowNone()
+    {
+        var report = WorktreesView.BuildReport(Inventory(Primary()));
+        Assert.Contains("Safe to reap: 0", report);
+        Assert.Contains("Needs attention: 0", report);
+        Assert.Contains("(none)", report);
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/SourceControlView.axaml
+++ b/src/CcDirector.Avalonia/Controls/SourceControlView.axaml
@@ -1,0 +1,82 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:CcDirector.Avalonia.Controls"
+             x:Class="CcDirector.Avalonia.Controls.SourceControlView"
+             Background="#1E1E1E">
+
+    <UserControl.Styles>
+        <!-- Left page-rail item -->
+        <Style Selector="Button.railItem">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Foreground" Value="#AAAAAA" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+            <Setter Property="Padding" Value="12,7" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="CornerRadius" Value="0" />
+        </Style>
+        <Style Selector="Button.railItem:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#2A2D2E" />
+        </Style>
+        <Style Selector="Button.railItem.active">
+            <Setter Property="Background" Value="#094771" />
+            <Setter Property="Foreground" Value="#FFFFFF" />
+        </Style>
+        <Style Selector="Button.railItem.active /template/ ContentPresenter">
+            <Setter Property="Background" Value="#094771" />
+        </Style>
+    </UserControl.Styles>
+
+    <Grid ColumnDefinitions="Auto,1,*">
+
+        <!-- Left page rail -->
+        <Border Grid.Column="0"
+                Background="#252526"
+                MinWidth="132">
+            <StackPanel Spacing="1" Margin="0,6,0,0">
+                <TextBlock Text="SOURCE CONTROL"
+                           Foreground="#888888"
+                           FontSize="10"
+                           FontWeight="SemiBold"
+                           Margin="12,2,12,8" />
+
+                <Button x:Name="ChangesRailButton"
+                        Classes="railItem active"
+                        Click="ChangesRailButton_Click">
+                    <TextBlock Text="Changes" VerticalAlignment="Center" />
+                </Button>
+
+                <Button x:Name="WorktreesRailButton"
+                        Classes="railItem"
+                        Click="WorktreesRailButton_Click">
+                    <DockPanel LastChildFill="False">
+                        <TextBlock Text="Worktrees" VerticalAlignment="Center" />
+                        <Border DockPanel.Dock="Right"
+                                x:Name="WorktreesRailBadge"
+                                Background="#EF4444"
+                                CornerRadius="8"
+                                Padding="6,1"
+                                Margin="8,0,0,0"
+                                VerticalAlignment="Center"
+                                IsVisible="False">
+                            <TextBlock x:Name="WorktreesRailBadgeText"
+                                       Text="0"
+                                       Foreground="White"
+                                       FontSize="9"
+                                       FontWeight="SemiBold" />
+                        </Border>
+                    </DockPanel>
+                </Button>
+            </StackPanel>
+        </Border>
+
+        <!-- Separator -->
+        <Border Grid.Column="1" Background="#3C3C3C" />
+
+        <!-- Page content -->
+        <Panel Grid.Column="2">
+            <controls:GitChangesView x:Name="ChangesPage" IsVisible="True" />
+            <controls:WorktreesView x:Name="WorktreesPage" IsVisible="False" />
+        </Panel>
+    </Grid>
+</UserControl>

--- a/src/CcDirector.Avalonia/Controls/SourceControlView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/SourceControlView.axaml.cs
@@ -1,0 +1,74 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia.Controls;
+
+/// <summary>
+/// The Source Control tab's container. Hosts a left page rail with two pages - "Changes"
+/// (the existing per-session git file-changes view) and "Worktrees" (the repository's
+/// worktree listing and, in a later phase, the reaper). New pages can be added to the rail
+/// without disturbing the outer tab. Forwards the host lifecycle (Attach/Detach) to both
+/// pages and re-raises the events the host cares about.
+/// </summary>
+public partial class SourceControlView : UserControl
+{
+    /// <summary>Forwarded from the Changes page so the host can open a file in the document viewer.</summary>
+    public event Action<string>? ViewFileRequested;
+
+    /// <summary>Raised when the worktree safe-to-reap count changes, so the host can badge the outer tab.</summary>
+    public event Action<int>? OrphanedCountChanged;
+
+    public SourceControlView()
+    {
+        InitializeComponent();
+        ChangesPage.ViewFileRequested += path => ViewFileRequested?.Invoke(path);
+        WorktreesPage.OrphanedCountChanged += OnWorktreesOrphanedCountChanged;
+    }
+
+    /// <summary>Point both pages at the repository. The rail resets to the default Changes page.</summary>
+    public void Attach(string repoPath)
+    {
+        FileLog.Write($"[SourceControlView] Attach: {repoPath}");
+        ShowPage(worktrees: false);
+        ChangesPage.Attach(repoPath);
+        WorktreesPage.Attach(repoPath);
+    }
+
+    /// <summary>Tear down both pages when the session context goes away.</summary>
+    public void Detach()
+    {
+        FileLog.Write("[SourceControlView] Detach");
+        ChangesPage.Detach();
+        WorktreesPage.Detach();
+    }
+
+    private void ChangesRailButton_Click(object? sender, RoutedEventArgs e) => ShowPage(worktrees: false);
+
+    private void WorktreesRailButton_Click(object? sender, RoutedEventArgs e) => ShowPage(worktrees: true);
+
+    private void ShowPage(bool worktrees)
+    {
+        ChangesPage.IsVisible = !worktrees;
+        WorktreesPage.IsVisible = worktrees;
+
+        SetActive(ChangesRailButton, !worktrees);
+        SetActive(WorktreesRailButton, worktrees);
+    }
+
+    private static void SetActive(Button button, bool active)
+    {
+        if (active)
+            button.Classes.Add("active");
+        else
+            button.Classes.Remove("active");
+    }
+
+    private void OnWorktreesOrphanedCountChanged(int count)
+    {
+        WorktreesRailBadgeText.Text = count.ToString();
+        WorktreesRailBadge.IsVisible = count > 0;
+        OrphanedCountChanged?.Invoke(count);
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/WorktreesView.axaml
+++ b/src/CcDirector.Avalonia/Controls/WorktreesView.axaml
@@ -1,0 +1,186 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:CcDirector.Avalonia.Controls"
+             x:Class="CcDirector.Avalonia.Controls.WorktreesView"
+             Background="#1E1E1E">
+
+    <UserControl.DataTemplates>
+        <!-- One worktree row -->
+        <DataTemplate DataType="controls:WorktreeRowItem">
+            <Border Background="#252526"
+                    BorderBrush="#3C3C3C"
+                    BorderThickness="1"
+                    CornerRadius="3"
+                    Padding="10,7"
+                    Margin="0,0,0,6">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="10" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <!-- Left accent bar (green = safe, amber = needs attention) -->
+                    <Border Grid.Column="0"
+                            Background="{Binding AccentBrush}"
+                            CornerRadius="2" />
+
+                    <StackPanel Grid.Column="2" Spacing="2">
+                        <TextBlock Text="{Binding Title}"
+                                   Foreground="#CCCCCC"
+                                   FontSize="13"
+                                   FontWeight="Medium" />
+                        <TextBlock Text="{Binding Path}"
+                                   Foreground="#666666"
+                                   FontSize="10"
+                                   TextTrimming="CharacterEllipsis" />
+                        <TextBlock Text="{Binding Detail}"
+                                   Foreground="#AAAAAA"
+                                   FontSize="11"
+                                   IsVisible="{Binding HasDetail}" />
+                        <TextBlock Text="{Binding Reason}"
+                                   Foreground="{Binding AccentBrush}"
+                                   FontSize="10" />
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </DataTemplate>
+    </UserControl.DataTemplates>
+
+    <Grid RowDefinitions="Auto,*">
+
+        <!-- Header bar -->
+        <Border Grid.Row="0"
+                Background="#252526"
+                BorderBrush="#3C3C3C"
+                BorderThickness="0,0,0,1"
+                Padding="10,6">
+            <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto">
+                <TextBlock Grid.Column="0"
+                           Text="WORKTREES"
+                           Foreground="#CCCCCC"
+                           FontSize="12"
+                           FontWeight="SemiBold"
+                           VerticalAlignment="Center" />
+
+                <!-- Orphaned (safe-to-reap) count: the red dot with a count -->
+                <Border Grid.Column="1"
+                        x:Name="OrphanBadge"
+                        Background="#EF4444"
+                        CornerRadius="8"
+                        Padding="6,1"
+                        Margin="8,0,0,0"
+                        VerticalAlignment="Center"
+                        IsVisible="False">
+                    <TextBlock x:Name="OrphanBadgeText"
+                               Text="0"
+                               Foreground="White"
+                               FontSize="9"
+                               FontWeight="SemiBold" />
+                </Border>
+
+                <Button Grid.Column="3"
+                        x:Name="CopyReportButton"
+                        Content="Copy report"
+                        Background="#3C3C3C"
+                        Foreground="#CCCCCC"
+                        Padding="10,3"
+                        FontSize="11"
+                        Margin="0,0,6,0"
+                        Click="CopyReportButton_Click"
+                        ToolTip.Tip="Copy the full worktree listing as text" />
+
+                <Button Grid.Column="4"
+                        x:Name="RefreshButton"
+                        Content="Refresh"
+                        Background="#3C3C3C"
+                        Foreground="#CCCCCC"
+                        Padding="10,3"
+                        FontSize="11"
+                        Click="RefreshButton_Click"
+                        ToolTip.Tip="Re-scan worktrees (runs git fetch --prune)" />
+            </Grid>
+        </Border>
+
+        <!-- Content -->
+        <Panel Grid.Row="1">
+
+            <!-- Loading / status -->
+            <TextBlock x:Name="StatusText"
+                       Text="Loading worktrees..."
+                       Foreground="#888888"
+                       FontSize="12"
+                       FontStyle="Italic"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       IsVisible="True" />
+
+            <ScrollViewer x:Name="ContentScroller"
+                          HorizontalScrollBarVisibility="Disabled"
+                          VerticalScrollBarVisibility="Auto"
+                          IsVisible="False">
+                <StackPanel Margin="10" Spacing="10">
+
+                    <!-- Safe to reap -->
+                    <StackPanel x:Name="SafeSection" Spacing="6" IsVisible="False">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBlock Text="SAFE TO REAP"
+                                       Foreground="#CCCCCC"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       VerticalAlignment="Center" />
+                            <Border Background="#1B3A2A"
+                                    CornerRadius="8"
+                                    Padding="6,1"
+                                    VerticalAlignment="Center">
+                                <TextBlock x:Name="SafeCountText"
+                                           Text="0"
+                                           Foreground="#22C55E"
+                                           FontSize="10"
+                                           FontWeight="SemiBold" />
+                            </Border>
+                        </StackPanel>
+                        <TextBlock Text="Work already on origin/main and the tree is clean - nothing is lost by removing these."
+                                   Foreground="#888888"
+                                   FontSize="10"
+                                   TextWrapping="Wrap" />
+                        <ItemsControl x:Name="SafeList" />
+                    </StackPanel>
+
+                    <!-- Needs attention -->
+                    <StackPanel x:Name="NeedsSection" Spacing="6" IsVisible="False">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBlock Text="NEEDS ATTENTION"
+                                       Foreground="#CCCCCC"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       VerticalAlignment="Center" />
+                            <Border Background="#3A2A1B"
+                                    CornerRadius="8"
+                                    Padding="6,1"
+                                    VerticalAlignment="Center">
+                                <TextBlock x:Name="NeedsCountText"
+                                           Text="0"
+                                           Foreground="#F59E0B"
+                                           FontSize="10"
+                                           FontWeight="SemiBold" />
+                            </Border>
+                        </StackPanel>
+                        <TextBlock Text="Carries unmerged commits or uncommitted content - a human or agent must decide. Never auto-removed."
+                                   Foreground="#888888"
+                                   FontSize="10"
+                                   TextWrapping="Wrap" />
+                        <ItemsControl x:Name="NeedsList" />
+                    </StackPanel>
+
+                    <!-- Empty (only the primary checkout, no linked worktrees) -->
+                    <TextBlock x:Name="EmptyText"
+                               Text="No linked worktrees for this repository."
+                               Foreground="#555555"
+                               FontSize="12"
+                               IsVisible="False" />
+                </StackPanel>
+            </ScrollViewer>
+        </Panel>
+    </Grid>
+</UserControl>

--- a/src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CcDirector.Core.Git;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia.Controls;
+
+/// <summary>
+/// One row in the worktree listing, built from a <see cref="WorktreeInfo"/>. Plain display
+/// data - the safety verdict is decided on the service side and this only renders it.
+/// </summary>
+public sealed class WorktreeRowItem
+{
+    public string Title { get; init; } = "";
+    public string Path { get; init; } = "";
+    public string Detail { get; init; } = "";
+    public string Reason { get; init; } = "";
+    public bool HasDetail => Detail.Length > 0;
+    public ISolidColorBrush AccentBrush { get; init; } = Brushes.Gray;
+}
+
+/// <summary>
+/// The read-only Worktrees page inside the Source Control tab. Enumerates every worktree for
+/// the selected repository and renders two groups - safe to reap, and needs attention - plus a
+/// copy-to-clipboard report. No delete button: the reaper is a later phase. The verdict comes
+/// wholly from <see cref="WorktreeInventoryService"/>; this view never re-derives it.
+/// </summary>
+public partial class WorktreesView : UserControl
+{
+    private static readonly ISolidColorBrush SafeBrush = new SolidColorBrush(Color.Parse("#22C55E"));
+    private static readonly ISolidColorBrush AttentionBrush = new SolidColorBrush(Color.Parse("#F59E0B"));
+
+    private readonly WorktreeInventoryService _service = new();
+    private string? _repoPath;
+    private WorktreeInventory? _lastInventory;
+    private bool _isLoading;
+
+    /// <summary>Raised (on the UI thread) whenever the safe-to-reap count changes, so the host can badge the tab.</summary>
+    public event Action<int>? OrphanedCountChanged;
+
+    /// <summary>The number of worktrees currently safe to reap - the badge count.</summary>
+    public int OrphanedCount { get; private set; }
+
+    public WorktreesView()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>Point the view at a repository and kick off a scan. Immediate "Loading..." feedback.</summary>
+    public void Attach(string repoPath)
+    {
+        FileLog.Write($"[WorktreesView] Attach: {repoPath}");
+        _repoPath = repoPath;
+        _ = RefreshAsync();
+    }
+
+    /// <summary>Clear the view when the session context goes away.</summary>
+    public void Detach()
+    {
+        FileLog.Write("[WorktreesView] Detach");
+        _repoPath = null;
+        _lastInventory = null;
+        SafeList.ItemsSource = null;
+        NeedsList.ItemsSource = null;
+        SafeSection.IsVisible = false;
+        NeedsSection.IsVisible = false;
+        EmptyText.IsVisible = false;
+        ContentScroller.IsVisible = false;
+        StatusText.Text = "Loading worktrees...";
+        StatusText.IsVisible = true;
+        SetOrphanedCount(0);
+    }
+
+    private void RefreshButton_Click(object? sender, RoutedEventArgs e)
+    {
+        _ = RefreshAsync();
+    }
+
+    private async void CopyReportButton_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            if (_lastInventory == null)
+                return;
+            var report = BuildReport(_lastInventory);
+            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+            if (clipboard != null)
+                await clipboard.SetTextAsync(report);
+            FileLog.Write("[WorktreesView] copied worktree report to clipboard");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[WorktreesView] CopyReportButton_Click FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Scan the repository off the UI thread, then render the result. Shows a clear message on
+    /// failure rather than silently degrading.
+    /// </summary>
+    private async Task RefreshAsync()
+    {
+        var repoPath = _repoPath;
+        if (string.IsNullOrWhiteSpace(repoPath) || _isLoading)
+            return;
+
+        _isLoading = true;
+        StatusText.Text = "Loading worktrees...";
+        StatusText.IsVisible = true;
+        ContentScroller.IsVisible = false;
+
+        try
+        {
+            var inventory = await Task.Run(() => _service.GetInventoryAsync(repoPath));
+
+            // Ignore stale results if the view was re-pointed while we were scanning.
+            if (_repoPath != repoPath)
+                return;
+
+            _lastInventory = inventory;
+            Render(inventory);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[WorktreesView] RefreshAsync FAILED: {ex.Message}");
+            StatusText.Text = $"Could not read worktrees: {ex.Message}";
+            StatusText.IsVisible = true;
+            ContentScroller.IsVisible = false;
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private void Render(WorktreeInventory inventory)
+    {
+        if (!inventory.Success)
+        {
+            StatusText.Text = $"Could not read worktrees: {inventory.Error}";
+            StatusText.IsVisible = true;
+            ContentScroller.IsVisible = false;
+            SetOrphanedCount(0);
+            return;
+        }
+
+        var safeRows = BuildSafeRows(inventory);
+        var needsRows = BuildNeedsRows(inventory);
+
+        SafeList.ItemsSource = safeRows;
+        NeedsList.ItemsSource = needsRows;
+
+        SafeCountText.Text = safeRows.Count.ToString();
+        NeedsCountText.Text = needsRows.Count.ToString();
+        SafeSection.IsVisible = safeRows.Count > 0;
+        NeedsSection.IsVisible = needsRows.Count > 0;
+        EmptyText.IsVisible = safeRows.Count == 0 && needsRows.Count == 0;
+
+        StatusText.IsVisible = false;
+        ContentScroller.IsVisible = true;
+
+        SetOrphanedCount(inventory.SafeToReapCount);
+    }
+
+    private void SetOrphanedCount(int count)
+    {
+        OrphanedCount = count;
+        OrphanBadgeText.Text = count.ToString();
+        OrphanBadge.IsVisible = count > 0;
+        OrphanedCountChanged?.Invoke(count);
+    }
+
+    // ----- pure builders (unit-tested without a UI) -----
+
+    internal static IReadOnlyList<WorktreeRowItem> BuildSafeRows(WorktreeInventory inventory) =>
+        inventory.SafeToReap.Select(w => new WorktreeRowItem
+        {
+            Title = TitleFor(w),
+            Path = w.Path,
+            Detail = "",
+            Reason = w.Explanation,
+            AccentBrush = SafeBrush,
+        }).ToList();
+
+    internal static IReadOnlyList<WorktreeRowItem> BuildNeedsRows(WorktreeInventory inventory) =>
+        inventory.NeedsAttention.Select(w => new WorktreeRowItem
+        {
+            Title = TitleFor(w),
+            Path = w.Path,
+            Detail = DetailFor(w),
+            Reason = w.Explanation,
+            AccentBrush = AttentionBrush,
+        }).ToList();
+
+    private static string TitleFor(WorktreeInfo w) =>
+        w.IsDetachedHead ? "(detached HEAD)" : (w.Branch ?? "(no branch)");
+
+    /// <summary>The one-line status shown under a needs-attention worktree: dirt, or ahead/behind and open pull request.</summary>
+    internal static string DetailFor(WorktreeInfo w)
+    {
+        if (!w.IsClean)
+            return $"{w.DirtyFileCount} uncommitted file(s)";
+
+        var parts = new List<string>();
+        if (w.AheadOfMain > 0)
+            parts.Add($"ahead {w.AheadOfMain}");
+        if (w.BehindMain > 0)
+            parts.Add($"behind {w.BehindMain}");
+        if (w.HasOpenPullRequest)
+            parts.Add("open pull request");
+        return string.Join(", ", parts);
+    }
+
+    /// <summary>Renders the whole inventory as plain text to hand to an agent (ASCII only).</summary>
+    internal static string BuildReport(WorktreeInventory inventory)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Worktree report for {inventory.RepositoryPath}");
+        sb.AppendLine($"Safe to reap: {inventory.SafeToReap.Count}   Needs attention: {inventory.NeedsAttention.Count}");
+        sb.AppendLine();
+
+        sb.AppendLine("SAFE TO REAP");
+        if (inventory.SafeToReap.Count == 0)
+            sb.AppendLine("  (none)");
+        foreach (var w in inventory.SafeToReap)
+        {
+            sb.AppendLine($"  {TitleFor(w)}");
+            sb.AppendLine($"    path:   {w.Path}");
+            sb.AppendLine($"    reason: {w.Explanation}");
+        }
+        sb.AppendLine();
+
+        sb.AppendLine("NEEDS ATTENTION");
+        if (inventory.NeedsAttention.Count == 0)
+            sb.AppendLine("  (none)");
+        foreach (var w in inventory.NeedsAttention)
+        {
+            var detail = DetailFor(w);
+            sb.AppendLine($"  {TitleFor(w)}");
+            sb.AppendLine($"    path:   {w.Path}");
+            if (detail.Length > 0)
+                sb.AppendLine($"    status: {detail}");
+            sb.AppendLine($"    reason: {w.Explanation}");
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -883,6 +883,20 @@
                                     Padding="12,4"
                                     FontSize="12"
                                     Click="SourceControlTabButton_Click" />
+                            <!-- Orphaned-worktree count: the red dot that sits on the Source Control tab -->
+                            <Border x:Name="SourceControlOrphanBadge"
+                                    Background="#EF4444"
+                                    CornerRadius="8"
+                                    Padding="6,1"
+                                    VerticalAlignment="Center"
+                                    IsVisible="False"
+                                    ToolTip.Tip="Worktrees safe to reap">
+                                <TextBlock x:Name="SourceControlOrphanBadgeText"
+                                           Text="0"
+                                           Foreground="White"
+                                           FontSize="9"
+                                           FontWeight="SemiBold" />
+                            </Border>
                             <!-- Separator between fixed tabs and document tabs -->
                             <Border x:Name="DocTabSeparator"
                                     Width="1" Height="16"
@@ -954,7 +968,7 @@
 
                     <!-- Source Control panel -->
                     <Panel x:Name="SourceControlPanel" IsVisible="False">
-                        <controls:GitChangesView x:Name="GitChangesView" />
+                        <controls:SourceControlView x:Name="SourceControlView" />
                     </Panel>
 
                     <!-- Document viewer panel (dynamic content swapped per tab) -->

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -242,7 +242,8 @@ public partial class MainWindow : Window
         _sessionManager.OnSessionRemoved += OnExternalSessionRemoved;
 
         // Wire source control view file event
-        GitChangesView.ViewFileRequested += OnGitViewFileRequested;
+        SourceControlView.ViewFileRequested += OnGitViewFileRequested;
+        SourceControlView.OrphanedCountChanged += OnOrphanedWorktreeCountChanged;
 
         // Wire prompt input text changes for slash command autocomplete
         PromptInput.TextChanged += PromptInput_TextChanged;
@@ -1603,7 +1604,7 @@ public partial class MainWindow : Window
                     vm.Session.OnActivityStateChanged -= OnActiveSessionActivityChanged;
                     vm.Session.OnPendingPromptTextChanged -= OnActiveSessionPendingPromptTextChanged;
                     TerminalHost.Detach();
-                    GitChangesView.Detach();
+                    SourceControlView.Detach();
                     _activeSession = null;
 
                     SetSessionHeaderVisible(false);
@@ -1770,7 +1771,7 @@ public partial class MainWindow : Window
             _activeSession.Session.OnPendingPromptTextChanged -= OnActiveSessionPendingPromptTextChanged;
             _activeSession.Session.OnIsTranscribingChanged -= OnActiveSessionTranscribingChanged;
             TerminalHost.Detach();
-            GitChangesView.Detach();
+            SourceControlView.Detach();
         }
 
         _activeSession = vm;
@@ -1787,7 +1788,7 @@ public partial class MainWindow : Window
             PromptBarBorder.IsVisible = false;
             TabBarRefreshButton.IsVisible = false;
             TabBarCaptureButton.IsVisible = false;
-            GitChangesView.Detach();
+            SourceControlView.Detach();
             return;
         }
 
@@ -1814,7 +1815,7 @@ public partial class MainWindow : Window
         UpdateScrollBar();
 
         // Attach source control (hide tab if no .git)
-        GitChangesView.Attach(vm.Session.RepoPath);
+        SourceControlView.Attach(vm.Session.RepoPath);
         UpdateSourceControlTabVisibility(vm.Session.RepoPath);
 
         // Show prompt bar
@@ -1946,7 +1947,7 @@ public partial class MainWindow : Window
             _activeSession.Session.OnPendingPromptTextChanged -= OnActiveSessionPendingPromptTextChanged;
         }
         TerminalHost.Detach();
-        GitChangesView.Detach();
+        SourceControlView.Detach();
         _activeSession = null;
 
         var snapshots = _sessions.ToList();
@@ -2439,7 +2440,7 @@ public partial class MainWindow : Window
             vm.Session.OnActivityStateChanged -= OnActiveSessionActivityChanged;
             vm.Session.OnPendingPromptTextChanged -= OnActiveSessionPendingPromptTextChanged;
             TerminalHost.Detach();
-            GitChangesView.Detach();
+            SourceControlView.Detach();
             _activeSession = null;
 
             SetSessionHeaderVisible(false);
@@ -4110,6 +4111,13 @@ public partial class MainWindow : Window
         FileLog.Write($"[MainWindow] UpdateSourceControlTabVisibility: hasGit={hasGit}");
     }
 
+    /// <summary>Mirror the worktree safe-to-reap count onto the Source Control tab as a red badge.</summary>
+    private void OnOrphanedWorktreeCountChanged(int count)
+    {
+        SourceControlOrphanBadgeText.Text = count.ToString();
+        SourceControlOrphanBadge.IsVisible = count > 0;
+    }
+
     private void BtnSend_Click(object? sender, RoutedEventArgs e)
     {
         SendPrompt();
@@ -5381,7 +5389,7 @@ public partial class MainWindow : Window
 
         // Detach terminal and source control
         TerminalHost.Detach();
-        GitChangesView.Detach();
+        SourceControlView.Detach();
         _activeSession = null;
 
         // Stop git status polling


### PR DESCRIPTION
## Phase 2 of the Director Source Control tab (issue thefrederiksen/devthrottle_internal#503)

Adds the read-only worktree listing UI. The reaper button is phase 3.

### Placement decision
The Director's existing "Source Control" tab is per-session and shows that session's git file changes (stage/commit). Rather than a separate top-level view, this restructures that tab into a **left page rail** with two pages, extensible for more Source Control pages later:
- **Changes** (default) - the existing per-session file view, unchanged.
- **Worktrees** (new) - the repository's worktree listing.

### The Worktrees page
- Two groups, rendered verbatim from the Core detector's verdict (dumb client): **Safe to reap** and **Needs attention**, each with a count and a one-line reason per worktree.
- A **copy-to-clipboard** text report of the whole listing, to hand to an agent for the stranded set.
- A **red count badge** = safe-to-reap total, on the Worktrees rail item and mirrored onto the outer Source Control tab (the "red dot with a count" from the spec).
- No delete button yet (phase 3). Loads asynchronously with immediate "Loading..." feedback; fails with a clear message rather than degrading.

### Wiring
`SourceControlView` wraps the existing `GitChangesView` plus the new `WorktreesView`, forwards the host lifecycle (`Attach`/`Detach`) and the view-file event, and re-raises the orphan-count change so `MainWindow` can badge the outer tab. `MainWindow` hosts the wrapper in place of `GitChangesView`.

### Files
- `src/CcDirector.Avalonia/Controls/SourceControlView.axaml` + `.axaml.cs`
- `src/CcDirector.Avalonia/Controls/WorktreesView.axaml` + `.axaml.cs`
- `src/CcDirector.Avalonia/MainWindow.axaml` + `.axaml.cs` (host the wrapper, add the outer-tab badge)
- 2 test files

### Tests
- Pure builders (row lists, detail line, report formatter): 7 tests.
- Headless render tests construct and lay out both controls on the Avalonia headless platform, catching runtime XAML/binding errors: 2 tests.
- Full Avalonia.Tests suite: 246 passed, 0 failed.

Complies with docs/VisualStyle.md (dark palette, badge/section idioms, font sizes).

### Carried into phase 3 (the reaper)
The reaper must never remove the primary checkout **or any worktree that is a live fleet session's working directory** - a guard required regardless of UI placement.