### PR TITLE
Source Control phase 3: one-button orphaned-worktree reaper

### DIFF
--- a/src/CcDirector.Avalonia/Controls/SourceControlView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/SourceControlView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using CcDirector.Core.Utilities;
@@ -19,6 +20,16 @@ public partial class SourceControlView : UserControl
 
     /// <summary>Raised when the worktree safe-to-reap count changes, so the host can badge the outer tab.</summary>
     public event Action<int>? OrphanedCountChanged;
+
+    /// <summary>
+    /// Supplies the working directories of live sessions, which the reaper on the Worktrees page
+    /// must never remove. Forwarded to that page. Set by the host, which knows the fleet.
+    /// </summary>
+    public Func<IReadOnlySet<string>>? ProtectedPathsProvider
+    {
+        get => WorktreesPage.ProtectedPathsProvider;
+        set => WorktreesPage.ProtectedPathsProvider = value;
+    }
 
     public SourceControlView()
     {

--- a/src/CcDirector.Avalonia/Controls/WorktreesView.axaml
+++ b/src/CcDirector.Avalonia/Controls/WorktreesView.axaml
@@ -47,7 +47,7 @@
         </DataTemplate>
     </UserControl.DataTemplates>
 
-    <Grid RowDefinitions="Auto,*">
+    <Grid RowDefinitions="Auto,Auto,*">
 
         <!-- Header bar -->
         <Border Grid.Row="0"
@@ -55,7 +55,7 @@
                 BorderBrush="#3C3C3C"
                 BorderThickness="0,0,0,1"
                 Padding="10,6">
-            <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto">
+            <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto,Auto">
                 <TextBlock Grid.Column="0"
                            Text="WORKTREES"
                            Foreground="#CCCCCC"
@@ -79,7 +79,20 @@
                                FontWeight="SemiBold" />
                 </Border>
 
+                <!-- Remove orphaned worktrees (shown only when there is at least one) -->
                 <Button Grid.Column="3"
+                        x:Name="ReapButton"
+                        Content="Remove orphaned worktrees"
+                        Background="#8B2E2E"
+                        Foreground="White"
+                        Padding="10,3"
+                        FontSize="11"
+                        Margin="0,0,6,0"
+                        IsVisible="False"
+                        Click="ReapButton_Click"
+                        ToolTip.Tip="Remove the worktrees proven safe to reap" />
+
+                <Button Grid.Column="4"
                         x:Name="CopyReportButton"
                         Content="Copy report"
                         Background="#3C3C3C"
@@ -90,7 +103,7 @@
                         Click="CopyReportButton_Click"
                         ToolTip.Tip="Copy the full worktree listing as text" />
 
-                <Button Grid.Column="4"
+                <Button Grid.Column="5"
                         x:Name="RefreshButton"
                         Content="Refresh"
                         Background="#3C3C3C"
@@ -102,8 +115,22 @@
             </Grid>
         </Border>
 
+        <!-- Result banner (leftovers / skipped after a reap) -->
+        <Border Grid.Row="1"
+                x:Name="ResultBanner"
+                Background="#3A2A1B"
+                BorderBrush="#5A4326"
+                BorderThickness="0,0,0,1"
+                Padding="12,8"
+                IsVisible="False">
+            <TextBlock x:Name="ResultBannerText"
+                       Foreground="#F59E0B"
+                       FontSize="11"
+                       TextWrapping="Wrap" />
+        </Border>
+
         <!-- Content -->
-        <Panel Grid.Row="1">
+        <Panel Grid.Row="2">
 
             <!-- Loading / status -->
             <TextBlock x:Name="StatusText"
@@ -181,6 +208,64 @@
                                IsVisible="False" />
                 </StackPanel>
             </ScrollViewer>
+
+            <!-- Confirmation overlay: shows exactly what will be removed before acting -->
+            <Border x:Name="ConfirmOverlay"
+                    Background="#CC1E1E1E"
+                    IsVisible="False">
+                <Border Background="#252526"
+                        BorderBrush="#3C3C3C"
+                        BorderThickness="1"
+                        CornerRadius="6"
+                        Padding="18"
+                        MaxWidth="560"
+                        MaxHeight="440"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                    <DockPanel>
+                        <TextBlock DockPanel.Dock="Top"
+                                   x:Name="ConfirmTitle"
+                                   Text="Remove worktrees?"
+                                   Foreground="#CCCCCC"
+                                   FontSize="14"
+                                   FontWeight="SemiBold"
+                                   Margin="0,0,0,6" />
+                        <TextBlock DockPanel.Dock="Top"
+                                   Text="These worktrees are proven safe (work on origin/main, tree clean). Worktrees a live session is using are never removed."
+                                   Foreground="#AAAAAA"
+                                   FontSize="11"
+                                   TextWrapping="Wrap"
+                                   Margin="0,0,0,10" />
+                        <StackPanel DockPanel.Dock="Bottom"
+                                    Orientation="Horizontal"
+                                    HorizontalAlignment="Right"
+                                    Spacing="8"
+                                    Margin="0,12,0,0">
+                            <Button x:Name="ConfirmCancelButton"
+                                    Content="Cancel"
+                                    Background="#3C3C3C"
+                                    Foreground="#CCCCCC"
+                                    Padding="14,5"
+                                    FontSize="12"
+                                    Click="ConfirmCancelButton_Click" />
+                            <Button x:Name="ConfirmRemoveButton"
+                                    Content="Remove"
+                                    Background="#8B2E2E"
+                                    Foreground="White"
+                                    Padding="14,5"
+                                    FontSize="12"
+                                    Click="ConfirmRemoveButton_Click" />
+                        </StackPanel>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <TextBlock x:Name="ConfirmList"
+                                       Foreground="#CCCCCC"
+                                       FontFamily="Cascadia Mono, Consolas"
+                                       FontSize="11"
+                                       TextWrapping="NoWrap" />
+                        </ScrollViewer>
+                    </DockPanel>
+                </Border>
+            </Border>
         </Panel>
     </Grid>
 </UserControl>

--- a/src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs
@@ -27,10 +27,11 @@ public sealed class WorktreeRowItem
 }
 
 /// <summary>
-/// The read-only Worktrees page inside the Source Control tab. Enumerates every worktree for
-/// the selected repository and renders two groups - safe to reap, and needs attention - plus a
-/// copy-to-clipboard report. No delete button: the reaper is a later phase. The verdict comes
-/// wholly from <see cref="WorktreeInventoryService"/>; this view never re-derives it.
+/// The Worktrees page inside the Source Control tab. Enumerates every worktree for the selected
+/// repository and renders two groups - safe to reap, and needs attention - plus a copy-to-clipboard
+/// report and a one-button reaper for the safe set. The verdict comes wholly from
+/// <see cref="WorktreeInventoryService"/>; this view never re-derives it. The reaper re-checks
+/// safety immediately before acting and never removes a worktree a live session is using.
 /// </summary>
 public partial class WorktreesView : UserControl
 {
@@ -38,12 +39,20 @@ public partial class WorktreesView : UserControl
     private static readonly ISolidColorBrush AttentionBrush = new SolidColorBrush(Color.Parse("#F59E0B"));
 
     private readonly WorktreeInventoryService _service = new();
+    private readonly WorktreeReaperService _reaper = new();
     private string? _repoPath;
     private WorktreeInventory? _lastInventory;
     private bool _isLoading;
+    private bool _isReaping;
 
     /// <summary>Raised (on the UI thread) whenever the safe-to-reap count changes, so the host can badge the tab.</summary>
     public event Action<int>? OrphanedCountChanged;
+
+    /// <summary>
+    /// Supplies the working directories of live sessions, which the reaper must never remove.
+    /// Set by the host (which knows the fleet); if null, only the primary checkout is protected.
+    /// </summary>
+    public Func<IReadOnlySet<string>>? ProtectedPathsProvider { get; set; }
 
     /// <summary>The number of worktrees currently safe to reap - the badge count.</summary>
     public int OrphanedCount { get; private set; }
@@ -75,11 +84,15 @@ public partial class WorktreesView : UserControl
         ContentScroller.IsVisible = false;
         StatusText.Text = "Loading worktrees...";
         StatusText.IsVisible = true;
+        ReapButton.IsVisible = false;
+        ConfirmOverlay.IsVisible = false;
+        ResultBanner.IsVisible = false;
         SetOrphanedCount(0);
     }
 
     private void RefreshButton_Click(object? sender, RoutedEventArgs e)
     {
+        ResultBanner.IsVisible = false; // clear any stale reap result on an explicit refresh
         _ = RefreshAsync();
     }
 
@@ -166,6 +179,9 @@ public partial class WorktreesView : UserControl
         StatusText.IsVisible = false;
         ContentScroller.IsVisible = true;
 
+        ReapButton.Content = $"Remove {inventory.SafeToReapCount} orphaned worktree{(inventory.SafeToReapCount == 1 ? "" : "s")}";
+        ReapButton.IsVisible = inventory.SafeToReapCount > 0;
+
         SetOrphanedCount(inventory.SafeToReapCount);
     }
 
@@ -175,6 +191,125 @@ public partial class WorktreesView : UserControl
         OrphanBadgeText.Text = count.ToString();
         OrphanBadge.IsVisible = count > 0;
         OrphanedCountChanged?.Invoke(count);
+    }
+
+    // ----- reaper -----
+
+    /// <summary>Show the confirmation overlay listing exactly what will be removed.</summary>
+    private void ReapButton_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_lastInventory is not { Success: true } inventory || inventory.SafeToReapCount == 0)
+            return;
+
+        var protectedPaths = GetProtectedPaths();
+        var toRemove = inventory.SafeToReap
+            .Where(w => !protectedPaths.Contains(WorktreeReaperService.NormalizePath(w.Path)))
+            .ToList();
+
+        if (toRemove.Count == 0)
+        {
+            ShowBanner("Every safe worktree is currently in use by a live session, so nothing was removed.");
+            return;
+        }
+
+        ConfirmTitle.Text = $"Remove {toRemove.Count} orphaned worktree{(toRemove.Count == 1 ? "" : "s")}?";
+        ConfirmList.Text = string.Join(Environment.NewLine,
+            toRemove.Select(w => $"{(w.Branch ?? "(detached HEAD)")}  ->  {w.Path}"));
+        ConfirmOverlay.IsVisible = true;
+    }
+
+    private void ConfirmCancelButton_Click(object? sender, RoutedEventArgs e)
+    {
+        ConfirmOverlay.IsVisible = false;
+    }
+
+    private async void ConfirmRemoveButton_Click(object? sender, RoutedEventArgs e)
+    {
+        ConfirmOverlay.IsVisible = false;
+        await RunReapAsync();
+    }
+
+    private async Task RunReapAsync()
+    {
+        var repoPath = _repoPath;
+        if (string.IsNullOrWhiteSpace(repoPath) || _isReaping)
+            return;
+
+        _isReaping = true;
+        ReapButton.IsEnabled = false;
+        StatusText.Text = "Removing worktrees...";
+        StatusText.IsVisible = true;
+        ContentScroller.IsVisible = false;
+        ResultBanner.IsVisible = false;
+
+        try
+        {
+            var protectedPaths = GetProtectedPaths();
+            var result = await Task.Run(() => _reaper.ReapAsync(repoPath, protectedPaths));
+
+            if (_repoPath != repoPath)
+                return;
+
+            // Re-scan first so the counts, badge, and listing reflect what actually happened,
+            // then lay the result banner on top of the refreshed view.
+            _isReaping = false;
+            await RefreshAsync();
+            ShowReapResult(result);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[WorktreesView] RunReapAsync FAILED: {ex.Message}");
+            await RefreshAsync();
+            ShowBanner($"Reap failed: {ex.Message}");
+        }
+        finally
+        {
+            _isReaping = false;
+            ReapButton.IsEnabled = true;
+        }
+    }
+
+    private void ShowReapResult(ReapResult result)
+    {
+        if (!string.IsNullOrEmpty(result.Error))
+        {
+            ShowBanner($"Reap failed: {result.Error}");
+            return;
+        }
+
+        var parts = new List<string> { $"Removed {result.RemovedCount} worktree(s)." };
+        if (result.Skipped.Count > 0)
+            parts.Add($"Skipped {result.Skipped.Count} in use by a live session.");
+        if (result.Leftovers.Count > 0)
+        {
+            parts.Add($"Could NOT fully delete {result.Leftovers.Count} folder(s) (files locked); they remain and will be retried:");
+            parts.AddRange(result.Leftovers);
+        }
+
+        // Only surface the banner when there is something noteworthy beyond a clean removal.
+        if (result.Skipped.Count > 0 || result.Leftovers.Count > 0)
+            ShowBanner(string.Join(Environment.NewLine, parts));
+        else
+            ResultBanner.IsVisible = false;
+    }
+
+    private void ShowBanner(string message)
+    {
+        ResultBannerText.Text = message;
+        ResultBanner.IsVisible = true;
+    }
+
+    private IReadOnlySet<string> GetProtectedPaths()
+    {
+        try
+        {
+            return ProtectedPathsProvider?.Invoke() ?? new HashSet<string>();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[WorktreesView] GetProtectedPaths FAILED: {ex.Message}");
+            return new HashSet<string>();
+        }
     }
 
     // ----- pure builders (unit-tested without a UI) -----

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -244,6 +244,8 @@ public partial class MainWindow : Window
         // Wire source control view file event
         SourceControlView.ViewFileRequested += OnGitViewFileRequested;
         SourceControlView.OrphanedCountChanged += OnOrphanedWorktreeCountChanged;
+        // The reaper must never remove a worktree a live session is using: feed it their paths.
+        SourceControlView.ProtectedPathsProvider = GetLiveSessionWorkingDirectories;
 
         // Wire prompt input text changes for slash command autocomplete
         PromptInput.TextChanged += PromptInput_TextChanged;
@@ -4116,6 +4118,22 @@ public partial class MainWindow : Window
     {
         SourceControlOrphanBadgeText.Text = count.ToString();
         SourceControlOrphanBadge.IsVisible = count > 0;
+    }
+
+    /// <summary>
+    /// The working directories of every live session - the reaper must never remove one of these,
+    /// because deleting a worktree a session is running in would pull the ground out from under it.
+    /// </summary>
+    private IReadOnlySet<string> GetLiveSessionWorkingDirectories()
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var vm in _sessions)
+        {
+            var path = vm.Session.RepoPath;
+            if (!string.IsNullOrWhiteSpace(path))
+                set.Add(path);
+        }
+        return set;
     }
 
     private void BtnSend_Click(object? sender, RoutedEventArgs e)

--- a/src/CcDirector.Core.Tests/WorktreeReaperServiceTests.cs
+++ b/src/CcDirector.Core.Tests/WorktreeReaperServiceTests.cs
@@ -1,0 +1,202 @@
+using System.Diagnostics;
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Integration tests for the reaper against real git repositories (with a local bare origin).
+/// Proves it removes exactly the safe set, leaves everything else untouched, honours the
+/// live-session guard, and reports - rather than hides - a folder it could not delete.
+/// </summary>
+public sealed class WorktreeReaperServiceTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _origin;
+    private readonly string _primary;
+
+    public WorktreeReaperServiceTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "ccd-reaper-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        _origin = Path.Combine(_root, "origin.git");
+        _primary = Path.Combine(_root, "primary");
+
+        RunGit(_root, "-c", "init.defaultBranch=main", "init", "--bare", _origin);
+        RunGit(_root, "-c", "init.defaultBranch=main", "clone", _origin, _primary);
+        RunGit(_primary, "config", "user.email", "test@cc-director.local");
+        RunGit(_primary, "config", "user.name", "CC Director Test");
+        RunGit(_primary, "config", "commit.gpgsign", "false");
+
+        WriteFile(_primary, "README.md", "initial\n");
+        RunGit(_primary, "add", "-A");
+        RunGit(_primary, "commit", "-m", "initial commit");
+        RunGit(_primary, "branch", "-M", "main");
+        RunGit(_primary, "push", "-u", "origin", "main");
+    }
+
+    public void Dispose()
+    {
+        for (int attempt = 0; attempt < 3; attempt++)
+        {
+            try { Directory.Delete(_root, recursive: true); return; }
+            catch { Thread.Sleep(100); }
+        }
+    }
+
+    /// <summary>Adds a clean, contained-in-main (safe) worktree and returns its path.</summary>
+    private string AddSafeWorktree(string branch)
+    {
+        var wt = Path.Combine(_root, "wt-" + branch);
+        RunGit(_primary, "worktree", "add", "-b", branch, wt, "main");
+        WriteFile(wt, branch + ".txt", "work\n");
+        RunGit(wt, "add", "-A");
+        RunGit(wt, "commit", "-m", branch + " work");
+        RunGit(wt, "push", "-u", "origin", branch);
+        RunGit(_primary, "merge", "--ff-only", branch);
+        RunGit(_primary, "push", "origin", "main");
+        return wt;
+    }
+
+    /// <summary>Adds a stranded (unmerged, still-present-on-origin) worktree and returns its path.</summary>
+    private string AddStrandedWorktree(string branch)
+    {
+        var wt = Path.Combine(_root, "wt-" + branch);
+        RunGit(_primary, "worktree", "add", "-b", branch, wt, "main");
+        WriteFile(wt, branch + ".txt", "unmerged\n");
+        RunGit(wt, "add", "-A");
+        RunGit(wt, "commit", "-m", branch + " unmerged");
+        RunGit(wt, "push", "-u", "origin", branch);
+        return wt;
+    }
+
+    [Fact]
+    public async Task Reap_RemovesTheSafeWorktree_AndLeavesStrandedUntouched()
+    {
+        var safe = AddSafeWorktree("safe");
+        var stranded = AddStrandedWorktree("stranded");
+
+        var result = await new WorktreeReaperService().ReapAsync(_primary);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal(1, result.RemovedCount);
+        Assert.False(Directory.Exists(safe), "safe worktree folder should be gone");
+        Assert.True(Directory.Exists(stranded), "stranded worktree must be untouched");
+
+        // The badge clears: a fresh inventory reports zero safe-to-reap.
+        var after = await new WorktreeInventoryService().GetInventoryAsync(_primary);
+        Assert.Equal(0, after.SafeToReapCount);
+    }
+
+    [Fact]
+    public async Task Reap_NeverRemovesAWorktreeInUseByALiveSession_EvenWhenSafe()
+    {
+        var safe = AddSafeWorktree("busy");
+
+        var protectedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { safe };
+        var result = await new WorktreeReaperService().ReapAsync(_primary, protectedPaths);
+
+        Assert.Equal(0, result.RemovedCount);
+        Assert.Contains(safe, result.Skipped);
+        Assert.True(Directory.Exists(safe), "a live session's worktree must never be removed");
+    }
+
+    [Fact]
+    public async Task Reap_ProtectedPathMatchIsCaseAndTrailingSlashInsensitive()
+    {
+        var safe = AddSafeWorktree("case");
+
+        var protectedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            safe.ToUpperInvariant() + Path.DirectorySeparatorChar,
+        };
+        var result = await new WorktreeReaperService().ReapAsync(_primary, protectedPaths);
+
+        Assert.Equal(0, result.RemovedCount);
+        Assert.True(Directory.Exists(safe));
+    }
+
+    [Fact]
+    public async Task Reap_NeverRemovesThePrimaryCheckout()
+    {
+        AddSafeWorktree("x");
+
+        await new WorktreeReaperService().ReapAsync(_primary);
+
+        Assert.True(Directory.Exists(_primary), "the primary checkout must always survive");
+        Assert.True(Directory.Exists(Path.Combine(_primary, ".git")));
+    }
+
+    [Fact]
+    public async Task Reap_LockedFolder_ReportsLeftover_DoesNotClaimSuccess()
+    {
+        var safe = AddSafeWorktree("locked");
+
+        // Simulate a locked build output: an ignored file held open with no delete share.
+        WriteFile(safe, ".gitignore", "locked/\n");
+        RunGit(safe, "add", ".gitignore");
+        RunGit(safe, "commit", "-m", "ignore locked dir");
+        RunGit(safe, "push", "origin", "locked");
+        RunGit(_primary, "merge", "--ff-only", "locked");
+        RunGit(_primary, "push", "origin", "main");
+
+        var lockedDir = Path.Combine(safe, "locked");
+        Directory.CreateDirectory(lockedDir);
+        var lockedFile = Path.Combine(lockedDir, "held.bin");
+        File.WriteAllText(lockedFile, "output\n");
+
+        using (var _ = new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            var result = await new WorktreeReaperService().ReapAsync(_primary);
+
+            Assert.False(result.Success, "a folder that could not be deleted must not be reported as success");
+            Assert.Contains(safe, result.Leftovers);
+            Assert.True(Directory.Exists(safe), "the locked folder must still be present and reported");
+            var outcome = Assert.Single(result.Outcomes);
+            Assert.False(outcome.Removed);
+            Assert.Equal(safe, outcome.Leftover);
+        }
+    }
+
+    [Fact]
+    public async Task Reap_EmptyRepo_NoWorktrees_IsANoOpSuccess()
+    {
+        var result = await new WorktreeReaperService().ReapAsync(_primary);
+
+        Assert.True(result.Success);
+        Assert.Equal(0, result.RemovedCount);
+        Assert.Empty(result.Leftovers);
+    }
+
+    // ----- helpers -----
+
+    private static void WriteFile(string repo, string relPath, string content)
+    {
+        var full = Path.Combine(repo, relPath);
+        var dir = Path.GetDirectoryName(full);
+        if (dir != null) Directory.CreateDirectory(dir);
+        File.WriteAllText(full, content);
+    }
+
+    private static string RunGit(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        using var p = Process.Start(psi)!;
+        var stdout = p.StandardOutput.ReadToEnd();
+        var stderr = p.StandardError.ReadToEnd();
+        p.WaitForExit();
+        if (p.ExitCode != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed (exit {p.ExitCode}): {stderr}");
+        return stdout;
+    }
+}

--- a/src/CcDirector.Core/Git/WorktreeReaperService.cs
+++ b/src/CcDirector.Core/Git/WorktreeReaperService.cs
@@ -1,0 +1,198 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>The result of removing one worktree, including its proof-of-safety for the audit log.</summary>
+public sealed class ReapOutcome
+{
+    public string Path { get; init; } = "";
+    public string? Branch { get; init; }
+
+    /// <summary>Why this worktree was safe to remove (logged for the audit trail).</summary>
+    public string Proof { get; init; } = "";
+
+    /// <summary>True only when the worktree was fully removed (deregistered and the folder deleted).</summary>
+    public bool Removed { get; init; }
+
+    /// <summary>Set when the folder could not be fully deleted (e.g. Windows-locked build outputs).</summary>
+    public string? Leftover { get; init; }
+
+    public string? Error { get; init; }
+
+    public static ReapOutcome RemovedOk(WorktreeInfo w) =>
+        new() { Path = WorktreeReaperService.NormalizePath(w.Path), Branch = w.Branch, Proof = w.Explanation, Removed = true };
+
+    public static ReapOutcome LeftBehind(WorktreeInfo w) =>
+        new()
+        {
+            Path = WorktreeReaperService.NormalizePath(w.Path),
+            Branch = w.Branch,
+            Proof = w.Explanation,
+            Removed = false,
+            Leftover = WorktreeReaperService.NormalizePath(w.Path),
+            Error = "folder could not be fully deleted (files are locked)",
+        };
+
+    public static ReapOutcome Failed(WorktreeInfo w, string error) =>
+        new() { Path = WorktreeReaperService.NormalizePath(w.Path), Branch = w.Branch, Proof = w.Explanation, Removed = false, Error = error };
+}
+
+/// <summary>The result of a reap run: what was removed, what folders remain, and what was skipped.</summary>
+public sealed class ReapResult
+{
+    public bool Success { get; init; }
+    public IReadOnlyList<ReapOutcome> Outcomes { get; init; } = Array.Empty<ReapOutcome>();
+
+    /// <summary>Folders that could not be fully deleted - reported exactly rather than claimed removed.</summary>
+    public IReadOnlyList<string> Leftovers { get; init; } = Array.Empty<string>();
+
+    /// <summary>Safe worktrees deliberately NOT removed because a live session is using them.</summary>
+    public IReadOnlyList<string> Skipped { get; init; } = Array.Empty<string>();
+
+    public string? Error { get; init; }
+
+    public int RemovedCount => Outcomes.Count(o => o.Removed);
+
+    public static ReapResult Failure(string error) => new() { Success = false, Error = error };
+}
+
+/// <summary>
+/// Removes worktrees that are provably safe to reap. It re-runs the detector immediately before
+/// acting (state can change between the scan and the click), removes ONLY the safe set, protects
+/// the primary checkout and any worktree a live session is using, and - crucially - reports any
+/// folder it could not physically delete rather than claiming success. It only ever removes
+/// worktrees; it never merges, rebases, force-pushes, or deletes origin branches.
+/// </summary>
+public sealed class WorktreeReaperService
+{
+    private readonly WorktreeInventoryService _inventory;
+    private readonly GitCommandRunner _git;
+
+    public WorktreeReaperService(WorktreeInventoryService? inventory = null, GitCommandRunner? git = null)
+    {
+        _git = git ?? new GitCommandRunner();
+        _inventory = inventory ?? new WorktreeInventoryService(_git);
+    }
+
+    /// <summary>
+    /// Re-checks safety and removes every currently safe-to-reap worktree except those whose path
+    /// is in <paramref name="protectedPaths"/> (the working directories of live sessions).
+    /// </summary>
+    public async Task<ReapResult> ReapAsync(string repositoryPath, IReadOnlySet<string>? protectedPaths = null, CancellationToken ct = default)
+    {
+        FileLog.Write($"[WorktreeReaperService] ReapAsync: repo={repositoryPath}");
+        try
+        {
+            if (string.IsNullOrWhiteSpace(repositoryPath) || !Directory.Exists(repositoryPath))
+                return ReapResult.Failure($"repository path not found: {repositoryPath}");
+
+            var protectedSet = BuildProtectedSet(protectedPaths);
+
+            // Re-run the safety check immediately before acting - state can change between load and click.
+            var inventory = await _inventory.GetInventoryAsync(repositoryPath, fetchPrune: true, ct);
+            if (!inventory.Success)
+                return ReapResult.Failure($"could not enumerate worktrees: {inventory.Error}");
+
+            var outcomes = new List<ReapOutcome>();
+            var skipped = new List<string>();
+
+            foreach (var worktree in inventory.SafeToReap)
+            {
+                if (protectedSet.Contains(NormalizePath(worktree.Path)))
+                {
+                    FileLog.Write($"[WorktreeReaperService] SKIP (a live session is using it): {worktree.Path}");
+                    skipped.Add(NormalizePath(worktree.Path));
+                    continue;
+                }
+
+                outcomes.Add(await RemoveOneAsync(repositoryPath, worktree, ct));
+            }
+
+            // One prune at the end clears any admin entries whose directories are now gone.
+            await _git.RunAsync(repositoryPath, new[] { "worktree", "prune" }, ct);
+
+            var leftovers = outcomes.Where(o => o.Leftover != null).Select(o => o.Leftover!).ToList();
+            var result = new ReapResult
+            {
+                Success = outcomes.All(o => o.Removed),
+                Outcomes = outcomes,
+                Leftovers = leftovers,
+                Skipped = skipped,
+            };
+            FileLog.Write($"[WorktreeReaperService] reaped {result.RemovedCount}/{outcomes.Count}, leftovers={leftovers.Count}, skipped={skipped.Count}");
+            return result;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[WorktreeReaperService] ReapAsync FAILED: {ex.Message}");
+            return ReapResult.Failure(ex.Message);
+        }
+    }
+
+    private async Task<ReapOutcome> RemoveOneAsync(string repositoryPath, WorktreeInfo worktree, CancellationToken ct)
+    {
+        FileLog.Write($"[WorktreeReaperService] remove: path={worktree.Path}, branch={worktree.Branch}, proof={worktree.Reason} ({worktree.Explanation})");
+
+        // Re-verify cleanliness at the very last moment. Authoritative, so a failure below can be
+        // treated as a locked-file case rather than guessed at from git's error text.
+        var status = await _git.RunAsync(worktree.Path, new[] { "status", "--porcelain" }, ct);
+        if (!status.Success)
+            return ReapOutcome.Failed(worktree, $"could not verify cleanliness: {status.Error}");
+        if (!string.IsNullOrWhiteSpace(status.Output))
+            return ReapOutcome.Failed(worktree, "worktree became dirty after the safety scan - not removed");
+
+        await _git.RunAsync(repositoryPath, new[] { "worktree", "remove", worktree.Path }, ct);
+
+        if (!Directory.Exists(worktree.Path))
+            return ReapOutcome.RemovedOk(worktree);
+
+        // git could not fully delete the folder (Windows-locked bin/obj DLLs). Finish the job ourselves.
+        FileLog.Write($"[WorktreeReaperService] folder remains after git remove; attempting physical delete: {worktree.Path}");
+        TryDeleteDirectory(worktree.Path);
+        await _git.RunAsync(repositoryPath, new[] { "worktree", "prune" }, ct);
+
+        if (!Directory.Exists(worktree.Path))
+            return ReapOutcome.RemovedOk(worktree);
+
+        FileLog.Write($"[WorktreeReaperService] LEFTOVER (locked files remain): {worktree.Path}");
+        return ReapOutcome.LeftBehind(worktree);
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            // Best effort - locked files remain and are reported as a leftover, not swallowed as success.
+            FileLog.Write($"[WorktreeReaperService] physical delete incomplete for {path}: {ex.Message}");
+        }
+    }
+
+    private static HashSet<string> BuildProtectedSet(IReadOnlySet<string>? protectedPaths)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (protectedPaths != null)
+        {
+            foreach (var p in protectedPaths)
+                if (!string.IsNullOrWhiteSpace(p))
+                    set.Add(NormalizePath(p));
+        }
+        return set;
+    }
+
+    /// <summary>Full-path, trailing-separator-trimmed form used to compare worktree paths across git and the OS.</summary>
+    public static string NormalizePath(string path)
+    {
+        try
+        {
+            return Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+        catch
+        {
+            return path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+    }
+}


### PR DESCRIPTION
## Phase 3 of the Director Source Control tab (issue thefrederiksen/devthrottle_internal#503)

The final phase: the "Remove N orphaned worktrees" button and the Core service behind it.

### What it does
- Re-runs the safety check **immediately before acting** (state can change between load and click), then removes ONLY the worktrees proven safe (work on origin/main, tree clean).
- Opens a confirmation listing **exactly** what will be removed before touching anything.
- After the reap, re-scans so the counts and red badge reflect reality (and clear to zero), with a banner for anything skipped or left behind.
- Logs every removal with its proof-of-safety.

### Guardrails (hard rules)
- **Never the primary checkout** (the detector already excludes it).
- **Never a worktree a live session is using.** `MainWindow` feeds the reaper the working directories of every live session; those are skipped even when git-safe. This is the guard we agreed the reaper needs regardless of where the UI lives.
- Re-verifies cleanliness at the last moment; a worktree that changed since the scan is left alone.
- **Windows locked-file case:** when `git worktree remove` deregisters the worktree but bin/obj DLLs are locked so the folder cannot be deleted, the reaper finishes the delete itself and, if files remain locked, **reports exactly which folders remain rather than claiming success** - a follow-up sweep retries them.
- Removes worktrees only - never merges, rebases, force-pushes, or deletes origin branches. Local-branch deletion is intentionally left out (the spec marks it optional and it is irreversible).

### Files
- `src/CcDirector.Core/Git/WorktreeReaperService.cs` (+ `ReapResult`/`ReapOutcome`)
- `src/CcDirector.Avalonia/Controls/WorktreesView.axaml` + `.axaml.cs` (button, confirmation overlay, result banner, reaper wiring, protected-paths provider)
- `src/CcDirector.Avalonia/Controls/SourceControlView.axaml.cs` (forward the protected-paths provider)
- `src/CcDirector.Avalonia/MainWindow.axaml.cs` (supply live-session working directories)
- `src/CcDirector.Core.Tests/WorktreeReaperServiceTests.cs`

### Tests
Real-git integration tests: safe worktree removed; stranded and primary untouched; a live-session path skipped even when safe; case/trailing-slash-insensitive protection; and the locked-folder case reported as a leftover with `Success == false`.
- Full Core.Tests: 3326 passed, 8 skipped, 0 failed.
- Full Avalonia.Tests: 246 passed, 0 failed.

### Acceptance criteria (issue #503) - all met across the three phases
- Lists every worktree, grouped safe-to-reap vs needs-attention.
- Badge equals the safe-to-reap count and clears to zero after a successful reap.
- The button removes exactly the safe set, leaves everything else untouched, and reports any folder it could not delete.
- A worktree with uncommitted work, or commits not in origin/main, is never in the safe set (proven).
- A squash-merged-then-deleted branch is classified safe (proven).