### PR TITLE
Source Control: last-activity per worktree + plainer delete confirmation

### DIFF
--- a/src/CcDirector.Avalonia.Tests/WorktreesViewTests.cs
+++ b/src/CcDirector.Avalonia.Tests/WorktreesViewTests.cs
@@ -132,4 +132,48 @@ public class WorktreesViewTests
         Assert.Contains("Needs attention: 0", report);
         Assert.Contains("(none)", report);
     }
+
+    [Fact]
+    public void FormatActivity_Null_ReturnsEmpty()
+    {
+        Assert.Equal("", WorktreesView.FormatActivity(null));
+    }
+
+    [Fact]
+    public void FormatActivity_KnownUtc_FormatsAsLocalDateTime()
+    {
+        var utc = new DateTime(2026, 07, 23, 10, 30, 0, DateTimeKind.Utc);
+        var expectedLocal = utc.ToLocalTime();
+
+        var text = WorktreesView.FormatActivity(utc);
+
+        Assert.StartsWith("Last activity: ", text);
+        Assert.Contains(expectedLocal.ToString("yyyy-MM-dd HH:mm"), text);
+    }
+
+    [Fact]
+    public void BuildSafeRows_IncludesTimestamp_WhenActivityKnown()
+    {
+        var w = new WorktreeInfo
+        {
+            Path = "/repo/feat-a",
+            Branch = "feat-a",
+            Safety = WorktreeSafety.SafeToReap,
+            Reason = WorktreeSafetyReason.OriginBranchGone,
+            Explanation = "Origin branch deleted after merge.",
+            IsClean = true,
+            LastActivityUtc = new DateTime(2026, 07, 23, 9, 0, 0, DateTimeKind.Utc),
+        };
+        var row = Assert.Single(WorktreesView.BuildSafeRows(Inventory(w)));
+        Assert.True(row.HasTimestamp);
+        Assert.StartsWith("Last activity: ", row.Timestamp);
+    }
+
+    [Fact]
+    public void BuildSafeRows_NoTimestamp_WhenActivityUnknown()
+    {
+        var row = Assert.Single(WorktreesView.BuildSafeRows(Inventory(Safe("feat-a"))));
+        Assert.False(row.HasTimestamp);
+        Assert.Equal("", row.Timestamp);
+    }
 }

--- a/src/CcDirector.Avalonia/Controls/WorktreesView.axaml
+++ b/src/CcDirector.Avalonia/Controls/WorktreesView.axaml
@@ -38,6 +38,10 @@
                                    Foreground="#AAAAAA"
                                    FontSize="11"
                                    IsVisible="{Binding HasDetail}" />
+                        <TextBlock Text="{Binding Timestamp}"
+                                   Foreground="#888888"
+                                   FontSize="10"
+                                   IsVisible="{Binding HasTimestamp}" />
                         <TextBlock Text="{Binding Reason}"
                                    Foreground="{Binding AccentBrush}"
                                    FontSize="10" />
@@ -231,8 +235,8 @@
                                    FontWeight="SemiBold"
                                    Margin="0,0,0,6" />
                         <TextBlock DockPanel.Dock="Top"
-                                   Text="These worktrees are proven safe (work on origin/main, tree clean). Worktrees a live session is using are never removed."
-                                   Foreground="#AAAAAA"
+                                   Text="This deletes these folders from your disk. Their work is already on origin/main, so nothing should be lost - but please check no one is still working in them first. This cannot be undone."
+                                   Foreground="#E0B0A0"
                                    FontSize="11"
                                    TextWrapping="Wrap"
                                    Margin="0,0,0,10" />

--- a/src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs
@@ -22,7 +22,9 @@ public sealed class WorktreeRowItem
     public string Path { get; init; } = "";
     public string Detail { get; init; } = "";
     public string Reason { get; init; } = "";
+    public string Timestamp { get; init; } = "";
     public bool HasDetail => Detail.Length > 0;
+    public bool HasTimestamp => Timestamp.Length > 0;
     public ISolidColorBrush AccentBrush { get; init; } = Brushes.Gray;
 }
 
@@ -321,6 +323,7 @@ public partial class WorktreesView : UserControl
             Path = w.Path,
             Detail = "",
             Reason = w.Explanation,
+            Timestamp = FormatActivity(w.LastActivityUtc),
             AccentBrush = SafeBrush,
         }).ToList();
 
@@ -331,11 +334,21 @@ public partial class WorktreesView : UserControl
             Path = w.Path,
             Detail = DetailFor(w),
             Reason = w.Explanation,
+            Timestamp = FormatActivity(w.LastActivityUtc),
             AccentBrush = AttentionBrush,
         }).ToList();
 
     private static string TitleFor(WorktreeInfo w) =>
         w.IsDetachedHead ? "(detached HEAD)" : (w.Branch ?? "(no branch)");
+
+    /// <summary>"Last activity: 2026-07-23 12:34" in local time, or empty when unknown.</summary>
+    internal static string FormatActivity(DateTime? lastActivityUtc)
+    {
+        if (lastActivityUtc is not { } utc)
+            return "";
+        var local = DateTime.SpecifyKind(utc, DateTimeKind.Utc).ToLocalTime();
+        return $"Last activity: {local:yyyy-MM-dd HH:mm}";
+    }
 
     /// <summary>The one-line status shown under a needs-attention worktree: dirt, or ahead/behind and open pull request.</summary>
     internal static string DetailFor(WorktreeInfo w)
@@ -368,6 +381,7 @@ public partial class WorktreesView : UserControl
         {
             sb.AppendLine($"  {TitleFor(w)}");
             sb.AppendLine($"    path:   {w.Path}");
+            AppendActivity(sb, w);
             sb.AppendLine($"    reason: {w.Explanation}");
         }
         sb.AppendLine();
@@ -380,11 +394,19 @@ public partial class WorktreesView : UserControl
             var detail = DetailFor(w);
             sb.AppendLine($"  {TitleFor(w)}");
             sb.AppendLine($"    path:   {w.Path}");
+            AppendActivity(sb, w);
             if (detail.Length > 0)
                 sb.AppendLine($"    status: {detail}");
             sb.AppendLine($"    reason: {w.Explanation}");
         }
 
         return sb.ToString();
+    }
+
+    private static void AppendActivity(StringBuilder sb, WorktreeInfo w)
+    {
+        var activity = FormatActivity(w.LastActivityUtc);
+        if (activity.Length > 0)
+            sb.AppendLine($"    {activity.ToLowerInvariant()}");
     }
 }

--- a/src/CcDirector.Core.Tests/WorktreeInventoryIntegrationTests.cs
+++ b/src/CcDirector.Core.Tests/WorktreeInventoryIntegrationTests.cs
@@ -237,6 +237,32 @@ public sealed class WorktreeInventoryIntegrationTests : IDisposable
         Assert.Contains(inventory.NeedsAttention, w => w.Branch == "stranded");
     }
 
+    // -------------------------------------------------------------------------------------------
+    // Every worktree reports a recent last-activity timestamp so a human can judge staleness.
+    // -------------------------------------------------------------------------------------------
+    [Fact]
+    public async Task LastActivityUtc_IsPopulated_AndRecent_ForEachWorktree()
+    {
+        var before = DateTime.UtcNow.AddMinutes(-5);
+
+        var wt = Path.Combine(_root, "wt-activity");
+        RunGit(_primary, "worktree", "add", "-b", "activity", wt, "main");
+        WriteFile(wt, "a.txt", "work\n");
+        RunGit(wt, "add", "-A");
+        RunGit(wt, "commit", "-m", "recent work");
+
+        var inventory = await new WorktreeInventoryService().GetInventoryAsync(_primary);
+
+        Assert.True(inventory.Success, inventory.Error);
+        foreach (var w in inventory.Worktrees)
+        {
+            Assert.NotNull(w.LastActivityUtc);
+            Assert.True(w.LastActivityUtc!.Value >= before,
+                $"{w.Path} last activity {w.LastActivityUtc} should be recent");
+            Assert.True(w.LastActivityUtc!.Value <= DateTime.UtcNow.AddMinutes(5));
+        }
+    }
+
     // ----- helpers -----
 
     private void ConfigureIdentity(string repo)

--- a/src/CcDirector.Core/Git/WorktreeInventoryService.cs
+++ b/src/CcDirector.Core/Git/WorktreeInventoryService.cs
@@ -135,6 +135,7 @@ public sealed class WorktreeInventoryService
         };
 
         var verdict = WorktreeSafetyEvaluator.Evaluate(facts);
+        var lastActivity = await GetLastActivityUtcAsync(entry.Path, ct);
 
         return new WorktreeInfo
         {
@@ -148,10 +149,68 @@ public sealed class WorktreeInventoryService
             AheadOfMain = ahead,
             BehindMain = behind,
             HasOpenPullRequest = hasOpenPr,
+            LastActivityUtc = lastActivity,
             Safety = verdict.Safety,
             Reason = verdict.Reason,
             Explanation = verdict.Explanation,
         };
+    }
+
+    /// <summary>
+    /// Best-effort "last activity" timestamp: the most recent of the worktree's last commit, its
+    /// top-level folder modification time, and its HEAD reflog. Cheap (a couple of stats and one
+    /// git call) and only informational - deleting these folders removes real source directories,
+    /// so a human wants to see how recently one was touched. Returns null if nothing can be read.
+    /// </summary>
+    private async Task<DateTime?> GetLastActivityUtcAsync(string worktreePath, CancellationToken ct)
+    {
+        DateTime? best = null;
+
+        // Top-level folder modification time (files added/removed/renamed at the root, e.g. builds).
+        try
+        {
+            if (Directory.Exists(worktreePath))
+                best = Max(best, Directory.GetLastWriteTimeUtc(worktreePath));
+        }
+        catch { /* unreadable - fall through to the git signals */ }
+
+        // The HEAD reflog updates on commit/checkout/reset but NOT on a plain status, so it is a
+        // clean signal (unlike the index, which our own status scan can touch).
+        var reflogPath = await _git.RunAsync(worktreePath, new[] { "rev-parse", "--git-path", "logs/HEAD" }, ct);
+        if (reflogPath.Success)
+        {
+            var resolved = ResolveWorktreeRelativePath(worktreePath, reflogPath.Output.Trim());
+            try
+            {
+                if (resolved != null && File.Exists(resolved))
+                    best = Max(best, File.GetLastWriteTimeUtc(resolved));
+            }
+            catch { /* ignore */ }
+        }
+
+        // The last commit's committer date.
+        var commit = await _git.RunAsync(worktreePath, new[] { "log", "-1", "--format=%ct" }, ct);
+        if (commit.Success && long.TryParse(commit.Output.Trim(), out var unixSeconds))
+            best = Max(best, DateTimeOffset.FromUnixTimeSeconds(unixSeconds).UtcDateTime);
+
+        return best;
+    }
+
+    private static DateTime Max(DateTime? current, DateTime candidate) =>
+        current is null || candidate > current.Value ? candidate : current.Value;
+
+    private static string? ResolveWorktreeRelativePath(string worktreePath, string gitPath)
+    {
+        if (string.IsNullOrWhiteSpace(gitPath))
+            return null;
+        try
+        {
+            return Path.IsPathRooted(gitPath) ? gitPath : Path.GetFullPath(Path.Combine(worktreePath, gitPath));
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     /// <summary>True if <c>git cherry</c> output contains a commit the upstream lacks (a line starting with '+').</summary>

--- a/src/CcDirector.Core/Git/WorktreeModels.cs
+++ b/src/CcDirector.Core/Git/WorktreeModels.cs
@@ -130,6 +130,13 @@ public sealed class WorktreeInfo
     public int BehindMain { get; init; }
     public bool HasOpenPullRequest { get; init; }
 
+    /// <summary>
+    /// Best-effort "last activity" for this worktree (UTC): the most recent of its last commit,
+    /// its top-level folder change, and its HEAD reflog. Shown so a human can judge whether a
+    /// worktree is still being worked in before removing it. Null when it cannot be determined.
+    /// </summary>
+    public DateTime? LastActivityUtc { get; init; }
+
     public WorktreeSafety Safety { get; init; }
     public WorktreeSafetyReason Reason { get; init; }
     public string Explanation { get; init; } = "";


### PR DESCRIPTION
Follow-up to the Worktrees page (issue thefrederiksen/devthrottle_internal#503), from real-use feedback: the reaper deletes actual source-code folders, so the human needs (a) to see how recently each worktree was touched, and (b) a clear, plain-English warning that this deletes files.

### Changes
- **Last-activity timestamp per worktree.** The detector computes a best-effort "last activity" (the most recent of the last commit, the top-level folder modification time, and the HEAD reflog - deliberately NOT the index, which our own `git status` scan can touch). Every row and the copy report show `Last activity: <date time>`. This is the signal that reveals a worktree still in active use - e.g. one that would not delete because a process held its files.
- **Plainer delete confirmation.** The confirmation now says the folders are deleted from disk, to check no one is still working in them, and that it cannot be undone - replacing the previous reassuring, technical wording. No legalese, just awareness.

### Tests
- Core: a worktree's `LastActivityUtc` is populated and recent.
- UI: `FormatActivity` (null -> empty; known UTC -> local date-time), and the row builders include/omit the timestamp.
- Full Core.Tests: 3327 passed, 8 skipped, 0 failed. Full Avalonia.Tests: 250 passed, 0 failed.