### PR TITLE
Serve Injected text per-tenant on hosted (#2057)

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
@@ -48,14 +48,12 @@ public static class OwnerSettingsRoutes
     /// Issue #2022 part 1 removed five machine-scoped routes (brain restart/config, addressing GET+PUT,
     /// autostart) - they do not exist any more. Issue #2022 part 2 RETIRED the deny for the per-account routes
     /// (the settings snapshot, snooze-default, snooze-presets, time-zone, ai-provider, tts-voice), which now
-    /// SERVE on hosted (proved by <see cref="HostedPerAccountSettingsServeTests"/>). What remains DENIED here
-    /// is the process-global set with no tenant dimension: injected text and transcription mode. Injected
-    /// text stays denied permanently.
+    /// SERVE on hosted (proved by <see cref="HostedPerAccountSettingsServeTests"/>). Injected text was un-denied
+    /// too and now serves per-tenant (issue #2057). What remains DENIED here is the one process-global route
+    /// with no tenant dimension: transcription mode (a single-valued provider fact).
     /// </summary>
     public static readonly Route[] Settings =
     {
-        new("GET",  "gateway/injected-text",            null, SettingsRefusal),
-        new("PUT",  "gateway/injected-text",            "{\"use_yours\":true,\"yours\":\"words from another tenant\"}", SettingsRefusal),
         new("GET",  "gateway/transcription-mode",       null, SettingsRefusal),
         new("PUT",  "gateway/transcription-mode",       "{\"mode\":\"devthrottle\"}", SettingsRefusal),
     };
@@ -72,7 +70,7 @@ public static class OwnerSettingsRoutes
         new("POST", "gateway/ai/test-chat",           "{\"model\":\"some-model\"}", ModelsRefusal),
     };
 
-    /// <summary>All 6 route-and-verb pairs that STILL refuse on hosted after the issue #2022 deny retirement.</summary>
+    /// <summary>All 4 route-and-verb pairs that STILL refuse on hosted after the issue #2022 + #2057 deny retirements.</summary>
     public static IEnumerable<Route> All => Settings.Concat(Models);
 
     /// <summary>
@@ -140,14 +138,13 @@ public static class OwnerSettingsRoutes
 /// <summary>
 /// Issue #1863: the WHOLE owner-settings group is DENIED on the hosted Gateway.
 ///
-/// THE DEFECT (as it stands after issue #2022 part 2). SIX routes across two endpoint classes read and
+/// THE DEFECT (as it stands after issues #2022 + #2057). FOUR routes across two endpoint classes read and
 /// write PROCESS-GLOBAL configuration with no tenant dimension: config.json is one file for the whole
-/// process, so a write is a FLEET-WIDE mutation performed by whichever authenticated caller sent it, and
-/// <c>GET /gateway/injected-text</c> hands back the owner's own agent-launch instruction text to any caller.
-/// The AI catalog and test-chat spend the shared deployment credential with no per-caller scoping. These
-/// STAY refused on hosted. The per-account routes (the settings snapshot, snooze, time zone, ai-provider,
-/// tts-voice, and the five model/voice setters) were UN-DENIED once their runtime consumers were tenant
-/// -threaded - they now serve on hosted, resolving the caller's tenant, and are proved by
+/// process, so a write to transcription mode is a FLEET-WIDE mutation performed by whichever authenticated
+/// caller sent it. The AI catalog and test-chat spend the shared deployment credential with no per-caller
+/// scoping. These STAY refused on hosted. The per-account routes (the settings snapshot, snooze, time zone,
+/// ai-provider, tts-voice, the five model/voice setters, and injected text) were UN-DENIED once their runtime
+/// consumers were tenant-threaded - they now serve on hosted, resolving the caller's tenant, and are proved by
 /// <see cref="HostedPerAccountSettingsServeTests"/>. (Issue #2022 part 1 also removed five machine-scoped
 /// routes - brain restart/config, network addressing, autostart - by taking them off the web page.)
 ///
@@ -256,7 +253,7 @@ public sealed class HostedOwnerSettingsDenyTests : IAsyncLifetime
     [Fact]
     public async Task The_refusal_is_not_an_empty_settings_snapshot()
     {
-        foreach (var path in new[] { "gateway/injected-text", "gateway/transcription-mode" })
+        foreach (var path in new[] { "gateway/transcription-mode" })
         {
             var response = await _http.GetAsync(path);
             var body = await response.Content.ReadAsStringAsync();
@@ -520,8 +517,8 @@ public sealed class HostedOwnerSettingsGroupFilterTests : IAsyncLifetime
     /// A VERB THE ROUTE NEVER SERVED meets the REFUSAL, not a 405 - the headline upgrade the shared refusal
     /// primitive buys over the old request-time group filter, and the reason this rework replaced the filter.
     ///
-    /// <c>gateway/injected-text</c> serves GET and PUT and stays denied on hosted (issue #2022 part 2 un-denied
-    /// the per-account routes but injected text is process-global and stays refused). Under the old
+    /// <c>gateway/transcription-mode</c> serves GET and PUT and stays denied on hosted (a single-valued
+    /// process-global provider fact with no per-tenant answer). Under the old
     /// <c>AddEndpointFilter</c> deny the route's handler was still MAPPED on hosted and the filter ran inside
     /// it, so a POST to that path would be answered by endpoint SELECTION with 405 <c>Allow: GET, PUT</c> -
     /// which discloses that a route exists on a Gateway whose refusal says it does not. The primitive maps a
@@ -542,7 +539,7 @@ public sealed class HostedOwnerSettingsGroupFilterTests : IAsyncLifetime
         try
         {
             // POST a GET/PUT-only route. NOT a 405 - the verb-less refusal answers it, uniformly across verbs.
-            var wrongVerb = await http.PostAsync("/gateway/injected-text", new StringContent(""));
+            var wrongVerb = await http.PostAsync("/gateway/transcription-mode", new StringContent(""));
             await OwnerSettingsRoutes.AssertIsNothingButTheRefusal(wrongVerb, OwnerSettingsRoutes.SettingsRefusal);
             Assert.Empty(wrongVerb.Content.Headers.Allow);
 

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
@@ -273,7 +273,7 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
     private string ReadBack(string key) => key switch
     {
         "snooze-default" => _gateway.TenantSettingsResolver.SnoozeDefaultMinutes(TenantId.Local).ToString(),
-        "injected-text" => InjectedTextConfig.Get().Yours ?? "",
+        "injected-text" => _gateway.TenantSettingsResolver.InjectedText(TenantId.Local).Yours ?? "",
         "snooze-presets" => string.Join(",", _gateway.TenantSettingsResolver.SnoozePresets(TenantId.Local)),
         "time-zone" => _gateway.TenantSettingsResolver.TimeZone(TenantId.Local),
         "transcription-mode" => TranscriptionModeConfig.Get().ToConfigString(),

--- a/src/CcDirector.Gateway.Tests/HostedPerAccountSettingsServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedPerAccountSettingsServeTests.cs
@@ -114,6 +114,8 @@ public sealed class HostedPerAccountSettingsServeTests : IAsyncLifetime
         ("PUT", "gateway/ai-provider",              "{\"provider\":\"devthrottle\"}"),
         ("GET", "gateway/tts-voice",                null),
         ("PUT", "gateway/tts-voice",                "{\"voice\":\"shimmer\"}"),
+        ("GET", "gateway/injected-text",            null),
+        ("PUT", "gateway/injected-text",            "{\"use_yours\":true,\"yours\":\"words for one account only\"}"),
         ("PUT", "gateway/ai/wingman-model",         "{\"model\":\"m-think\"}"),
         ("PUT", "gateway/ai/wingman-fast-model",    "{\"model\":\"m-fast\"}"),
         ("PUT", "gateway/ai/car-mode-model",        "{\"model\":\"m-car\"}"),
@@ -226,6 +228,30 @@ public sealed class HostedPerAccountSettingsServeTests : IAsyncLifetime
 
         Assert.Equal("alpha signing off", await ReadString(_httpA, "gateway/ai-provider", "carModeEndPhrase"));
         Assert.NotEqual("alpha signing off", await ReadString(_httpB, "gateway/ai-provider", "carModeEndPhrase"));
+    }
+
+    /// <summary>
+    /// ISOLATED - the injected agent-launch text (issue #2057). Tenant A turns on its own text; tenant B's
+    /// read is unaffected - B still sees "use ours" and never A's words. This is the launch text each account's
+    /// own Directors download from this same route, so per-tenant here is per-tenant at launch.
+    /// </summary>
+    [Fact]
+    public async Task Injected_text_written_by_one_tenant_is_invisible_to_another_on_hosted()
+    {
+        const string aWords = "alpha-only launch words zqxjv";
+        (await OwnerSettingsRoutes.SendAsync(_httpA, "PUT", "gateway/injected-text",
+            $"{{\"use_yours\":true,\"yours\":\"{aWords}\"}}")).EnsureSuccessStatusCode();
+
+        using (var a = await ReadJson(_httpA, "gateway/injected-text"))
+        {
+            Assert.True(a.RootElement.GetProperty("use_yours").GetBoolean());
+            Assert.Equal(aWords, a.RootElement.GetProperty("yours").GetString());
+        }
+        using (var b = await ReadJson(_httpB, "gateway/injected-text"))
+        {
+            Assert.False(b.RootElement.GetProperty("use_yours").GetBoolean());
+            Assert.NotEqual(aWords, b.RootElement.GetProperty("yours").GetString());
+        }
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
@@ -29,9 +29,9 @@ namespace CcDirector.Gateway.Api;
 ///                                       catalogAvailable }
 ///   PUT  /gateway/ai-provider     body { "provider": "devthrottle" } (resets this tenant's model defaults)
 ///   GET+PUT /gateway/tts-voice
+///   GET+PUT /gateway/injected-text              (per-account agent-launch text; issue #2057)
 ///
 ///   DENIED ON HOSTED (process-global, no tenant dimension):
-///   GET+PUT /gateway/injected-text              (the owner's process-global agent-launch words)
 ///   GET+PUT /gateway/transcription-mode         (single-valued process-global provider fact)
 ///
 /// ISSUE #2022 - THE MACHINE SETTINGS LEFT THIS SURFACE, and the per-account deny was RETIRED. The "This
@@ -41,11 +41,12 @@ namespace CcDirector.Gateway.Api;
 /// longer refuse on hosted: they SERVE, each resolving the caller's tenant and answering 403 on an unresolved
 /// identity - never the Local partition. So self-host IS the hosted Gateway with one tenant on this surface.
 ///
-/// STILL DENIED ON HOSTED (issue #1863). The process-global routes have NO TENANT DIMENSION AT ALL: config.json
-/// is one file for the whole process, so a write is a fleet-wide mutation performed by whichever authenticated
-/// caller sent it, and GET /gateway/injected-text hands back the owner's own agent-launch text. On shared
-/// hosted infrastructure there is no correct per-tenant answer to serve, only a leak to close, so they refuse.
-/// Self-host is single-tenant and these are legitimate owner function there, so on self-host nothing changes.
+/// STILL DENIED ON HOSTED (issue #1863). The remaining process-global route has NO TENANT DIMENSION AT ALL:
+/// config.json is one file for the whole process, so a write to transcription mode is a fleet-wide mutation
+/// performed by whichever authenticated caller sent it, and there is one single-valued provider fact with no
+/// correct per-tenant answer to serve - only a leak to close, so it refuses. (Injected text WAS here; it moved
+/// to a per-account home in issue #2057 and now serves per-tenant.) Self-host is single-tenant and this is a
+/// legitimate owner function there, so on self-host nothing changes.
 /// The AI model CATALOG and test-chat (AiModelsEndpoint) also stay denied on hosted - they spend the shared
 /// deployment provider credential with no per-caller scoping (see that file); the AI tab reads the Gateway-owned
 /// catalogAvailable flag on the ai-provider snapshot to disable browsing/Test on hosted rather than fail.
@@ -121,8 +122,8 @@ internal static class SettingsEndpoints
     ///    <see cref="MapServedRoutes"/>. Each resolves the CALLER's tenant with <c>ResolveReadTenant</c> and
     ///    answers 403 when none resolves - NEVER the Local partition - so they are safe on shared infrastructure
     ///    without a deny: a request that cannot be attributed to a tenant is refused, not served a wrong one.
-    ///  - The machine/process-global routes (injected text, transcription mode) have no per-tenant home and
-    ///    STAY denied on hosted, mapped onto the group handle in <see cref="MapDeniedRoutes"/>.
+    ///  - The remaining process-global route (transcription mode) has no per-tenant home and STAYS denied on
+    ///    hosted, mapped onto the group handle in <see cref="MapDeniedRoutes"/>.
     ///    That method receives ONLY the handle - <paramref name="outer"/> is out of scope there - so a denied
     ///    route cannot be moved onto the ungrouped builder by a one-word edit; changing its group means changing
     ///    the method signature, which moves them all. That is the un-bypassability the deny primitive buys.
@@ -413,31 +414,18 @@ internal static class SettingsEndpoints
             }
         });
 
-        // Issue #2022: the per-user autostart Run-key toggle (PUT /gateway/autostart) left this surface
-        // entirely. Start-at-login is now the installer default plus the `cc-devthrottle autostart
-        // on|off|status` command (the one home that works on a headless Linux server too, where a settings
-        // page cannot); the tray/menu-bar toggle stays as an optional desktop convenience. There is no
-        // machine-scoped autostart endpoint left here for a settings page to call.
-    }
-
-    /// <summary>
-    /// The machine/process-global owner-settings routes that STAY denied on hosted (issue #2022). Takes the
-    /// denied GROUP HANDLE and nothing else - the ungrouped builder is deliberately out of scope here so no
-    /// route can be mapped around the hosted refusal. These two families have NO per-tenant home: injected
-    /// text is the owner's process-global agent-launch words, and transcription mode is a single-valued
-    /// process-global provider fact. On shared hosted infrastructure there is no correct per-tenant answer to
-    /// serve, so they refuse rather than leak a fleet-wide value.
-    /// </summary>
-    private static void MapDeniedRoutes(HostedDenyGroup app, GatewayHost host)
-    {
-        _ = host; // the denied handlers read process-global config, not per-tenant host state; kept for symmetry.
-
-        // The injected text: the whole of what DevThrottle puts in front of an agent at the start of a
-        // session, and the user's choice to run their own words instead of ours. Process-global (the owner's
-        // own words) with no tenant dimension - denied on hosted permanently.
-        app.MapGet("/gateway/injected-text", () =>
+        // The injected text: what DevThrottle puts in front of an agent at the start of a session, and the
+        // user's choice to run their own words instead of ours. PER-ACCOUNT on hosted (issue #2057): each
+        // tenant has its own injected text, stored in the per-tenant settings store and served here for the
+        // CALLER's tenant - the same text the caller's own Directors download from this route to inject at
+        // launch, so a per-tenant read here is a per-tenant launch. A request with no resolvable tenant is
+        // refused (403), never served the Local partition. On self-host the tenant is Local and the resolver
+        // falls back to the existing config.json value, so nothing changes there.
+        app.MapGet("/gateway/injected-text", (HttpContext ctx) =>
         {
-            var s = Core.Configuration.InjectedTextConfig.Get();
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, host.TenantBoundary);
+            if (t is null) return TenantRequired();
+            var s = host.TenantSettingsResolver.InjectedText(t.Value);
             return Results.Json(new
             {
                 use_yours = s.UseYours,
@@ -449,6 +437,8 @@ internal static class SettingsEndpoints
 
         app.MapPut("/gateway/injected-text", async (HttpContext ctx) =>
         {
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, host.TenantBoundary);
+            if (t is null) return TenantRequired();
             try
             {
                 var node = await JsonNode.ParseAsync(ctx.Request.Body, cancellationToken: ctx.RequestAborted);
@@ -480,9 +470,9 @@ internal static class SettingsEndpoints
 
                 var settings = new Core.Configuration.InjectedTextSettings(useYours, yours);
 
-                // Validate before writing, and reject rather than store: a template that cannot render
-                // must never reach a Director, because the failure would land on agents at launch instead
-                // of on the person editing it here.
+                // Validate before writing, and reject rather than store: a template that cannot render must
+                // never reach a Director, because the failure would land on agents at launch instead of on the
+                // person editing it here.
                 var problem = Core.Configuration.InjectedTextConfig.Validate(settings);
                 if (problem is not null)
                 {
@@ -490,8 +480,8 @@ internal static class SettingsEndpoints
                     return Results.BadRequest(new { error = problem });
                 }
 
-                Core.Configuration.InjectedTextConfig.Set(settings);
-                FileLog.Write($"[SettingsEndpoints] injected_text set: use_yours={settings.UseYours}, has_yours={settings.Yours is not null}");
+                host.TenantSettingsResolver.SetInjectedText(t.Value, settings, DateTime.UtcNow);
+                FileLog.Write($"[SettingsEndpoints] injected_text set for tenant={t.Value.ToLogString()}: use_yours={settings.UseYours}, has_yours={settings.Yours is not null}");
                 return Results.Json(new
                 {
                     use_yours = settings.UseYours,
@@ -506,6 +496,25 @@ internal static class SettingsEndpoints
                 return Results.BadRequest(new { error = "invalid JSON" });
             }
         });
+
+        // Issue #2022: the per-user autostart Run-key toggle (PUT /gateway/autostart) left this surface
+        // entirely. Start-at-login is now the installer default plus the `cc-devthrottle autostart
+        // on|off|status` command (the one home that works on a headless Linux server too, where a settings
+        // page cannot); the tray/menu-bar toggle stays as an optional desktop convenience. There is no
+        // machine-scoped autostart endpoint left here for a settings page to call.
+    }
+
+    /// <summary>
+    /// The process-global owner-settings route that STAYS denied on hosted (issue #2022). Takes the denied
+    /// GROUP HANDLE and nothing else - the ungrouped builder is deliberately out of scope here so no route can
+    /// be mapped around the hosted refusal. Transcription mode has NO per-tenant home: it is a single-valued
+    /// process-global provider fact, so on shared hosted infrastructure there is no correct per-tenant answer
+    /// to serve and it refuses rather than leak a fleet-wide value. (Injected text used to be denied here too;
+    /// it moved to a per-account home and now serves in <see cref="MapServedRoutes"/> - issue #2057.)
+    /// </summary>
+    private static void MapDeniedRoutes(HostedDenyGroup app, GatewayHost host)
+    {
+        _ = host; // the denied handler reads process-global config, not per-tenant host state; kept for symmetry.
 
         // Transcription mode: DevThrottle hosted transcription is the only supported production capability.
         // A single-valued process-global provider fact with no tenant dimension - denied on hosted; the AI tab

--- a/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
@@ -43,10 +43,16 @@ public static class TenantSettingKeys
     /// <c>time_zone</c>).</summary>
     public const string TimeZone = "time_zone";
 
+    /// <summary>The injected agent-launch text choice - the "use yours" flag and the user's own text -
+    /// stored as one JSON object so the null-vs-empty distinction survives (global default:
+    /// <c>injected_text</c>). The resolver owns serializing <c>InjectedTextSettings</c> to and from this
+    /// string.</summary>
+    public const string InjectedText = "injected_text";
+
     /// <summary>Every key this resolver serves, for validation and enumeration.</summary>
     public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.Ordinal)
     {
         WingmanModel, WingmanFastModel, TtsModel, TtsVoice,
-        CarModeModel, CarModeEndPhrase, SnoozePresets, SnoozeDefaultMinutes, TimeZone,
+        CarModeModel, CarModeEndPhrase, SnoozePresets, SnoozeDefaultMinutes, TimeZone, InjectedText,
     };
 }

--- a/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
@@ -98,6 +98,24 @@ public sealed class TenantSettingsResolver
         return TimeZoneConfig.Get();
     }
 
+    /// <summary>The tenant's injected agent-launch text choice (use-yours flag + the user's own text), or the
+    /// operator global default when unset or when the stored override cannot be parsed. The null-vs-empty
+    /// distinction on the text is preserved: a corrupt override degrades to the global default (the
+    /// tenant-neutral safe answer), never another tenant's value.</summary>
+    public InjectedTextSettings InjectedText(TenantId tenant)
+    {
+        var raw = _store.Get(tenant, TenantSettingKeys.InjectedText);
+        if (raw is null) return InjectedTextConfig.Get();
+        try
+        {
+            return System.Text.Json.JsonSerializer.Deserialize<InjectedTextSettings>(raw) ?? InjectedTextConfig.Get();
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return InjectedTextConfig.Get();
+        }
+    }
+
     // ---- writes: validate like the global setters, then persist a per-tenant override -------------------
 
     /// <summary>Set the tenant's wingman model for a role.</summary>
@@ -149,6 +167,14 @@ public sealed class TenantSettingsResolver
             throw new ArgumentException($"'{timeZone}' is not a valid time zone id.", nameof(timeZone));
         _store.Set(tenant, TenantSettingKeys.TimeZone, timeZone, nowUtc);
     }
+
+    /// <summary>Set the tenant's injected agent-launch text (the use-yours flag and the text). Serialized as
+    /// one JSON object so a null (cleared) text stays distinct from an empty ("inject nothing") one. Validate
+    /// with <see cref="InjectedTextConfig.Validate"/> before calling, exactly as the global setter's caller
+    /// does - this method persists, it does not re-validate.</summary>
+    public void SetInjectedText(TenantId tenant, InjectedTextSettings settings, DateTime nowUtc)
+        => _store.Set(tenant, TenantSettingKeys.InjectedText,
+            System.Text.Json.JsonSerializer.Serialize(settings), nowUtc);
 
     /// <summary>Reset this tenant's AI model/voice choices to the operator defaults by CLEARING those
     /// overrides (the legacy "reset to provider defaults" action). Snooze, time zone, and car-mode settings are


### PR DESCRIPTION
Closes #2057.

The Injected text page showed "The Gateway rejected the request (error 404)" on the hosted Gateway because the agent-launch text was a single process-global config.json value. Now each account has its own.

- Stored per tenant in the existing tenant_settings store (one JSON value, so the null-vs-empty distinction on the text survives), read via `TenantSettingsResolver.InjectedText` with a read-time fallback to the existing config.json value — self-host and any pre-existing value unchanged. No schema change / migration.
- GET+PUT `/gateway/injected-text` move from the hosted deny group to the per-account served group: resolve the caller's tenant, 403 when unresolved (never Local). The Director downloads its own tenant's text from this same route (its device key resolves its tenant), so no Director change is needed. Only transcription mode remains denied in the group.
- Hostile two-tenant test proves one account's injected text is invisible to another; self-host control proves the page still serves.

Verification: full Gateway suite 3657 passed / 0 failed / 16 skipped; settings suites green on the rebased base.