### PR TITLE
Source Control: third worktree state - in use by an open session

### DIFF
--- a/src/CcDirector.Avalonia.Tests/WorktreesViewTests.cs
+++ b/src/CcDirector.Avalonia.Tests/WorktreesViewTests.cs
@@ -47,6 +47,17 @@ public class WorktreesViewTests
         IsClean = true,
     };
 
+    private static WorktreeInfo InUse(string branch, params string[] sessions) => new()
+    {
+        Path = $"/repo/{branch}",
+        Branch = branch,
+        Safety = WorktreeSafety.InUseBySession,
+        Reason = WorktreeSafetyReason.LiveSessionOpen,
+        Explanation = "Safe to remove, but a session is still open in it.",
+        IsClean = true,
+        OpenSessions = sessions,
+    };
+
     private static WorktreeInventory Inventory(params WorktreeInfo[] worktrees) =>
         new() { RepositoryPath = "/repo", Worktrees = worktrees, Success = true };
 
@@ -175,5 +186,55 @@ public class WorktreesViewTests
         var row = Assert.Single(WorktreesView.BuildSafeRows(Inventory(Safe("feat-a"))));
         Assert.False(row.HasTimestamp);
         Assert.Equal("", row.Timestamp);
+    }
+
+    // --- In-use-by-a-session (third case) rendering ---
+
+    [Fact]
+    public void BuildInUseRows_ContainsInUseWorktrees_WithSessionNames()
+    {
+        var inv = Inventory(Primary(), Safe("free"), InUse("busy", "ERP KB Builder (#109)"));
+
+        var row = Assert.Single(WorktreesView.BuildInUseRows(inv));
+        Assert.Equal("busy", row.Title);
+        Assert.Contains("ERP KB Builder (#109)", row.Detail);
+        Assert.True(row.HasDetail);
+    }
+
+    [Fact]
+    public void BuildSafeRows_ExcludesInUseWorktrees()
+    {
+        var inv = Inventory(Safe("free"), InUse("busy", "Sess (#1)"));
+
+        var safe = WorktreesView.BuildSafeRows(inv);
+        Assert.Single(safe);
+        Assert.Equal("free", safe[0].Title);
+        Assert.DoesNotContain(safe, r => r.Title == "busy");
+        Assert.Equal(1, inv.SafeToReapCount); // only "free"; the in-use "busy" is excluded
+    }
+
+    [Fact]
+    public void SessionsFor_MultipleSessions_JoinsWithComma()
+    {
+        var w = InUse("busy", "A (#1)", "B (#2)");
+        Assert.Equal("Open sessions: A (#1), B (#2)", WorktreesView.SessionsFor(w));
+    }
+
+    [Fact]
+    public void SessionsFor_SingleSession_UsesSingular()
+    {
+        var w = InUse("busy", "A (#1)");
+        Assert.Equal("Open session: A (#1)", WorktreesView.SessionsFor(w));
+    }
+
+    [Fact]
+    public void BuildReport_IncludesInUseGroup()
+    {
+        var inv = Inventory(Safe("free"), InUse("busy", "Sess (#7)"));
+        var report = WorktreesView.BuildReport(inv);
+        Assert.Contains("IN USE BY AN OPEN SESSION", report);
+        Assert.Contains("busy", report);
+        Assert.Contains("sess (#7)", report); // lower-cased in the report
+        Assert.Contains("In use by a session: 1", report);
     }
 }

--- a/src/CcDirector.Avalonia/Controls/SourceControlView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/SourceControlView.axaml.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using CcDirector.Core.Git;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Avalonia.Controls;
@@ -22,13 +25,14 @@ public partial class SourceControlView : UserControl
     public event Action<int>? OrphanedCountChanged;
 
     /// <summary>
-    /// Supplies the working directories of live sessions, which the reaper on the Worktrees page
-    /// must never remove. Forwarded to that page. Set by the host, which knows the fleet.
+    /// Supplies the live sessions on this machine (with working directories), so the Worktrees page
+    /// can show a session-occupied worktree as "in use" and never reap it. Forwarded to that page.
+    /// Set by the host, which knows the fleet.
     /// </summary>
-    public Func<IReadOnlySet<string>>? ProtectedPathsProvider
+    public Func<CancellationToken, Task<IReadOnlyList<LiveSessionRef>>>? LiveSessionsProvider
     {
-        get => WorktreesPage.ProtectedPathsProvider;
-        set => WorktreesPage.ProtectedPathsProvider = value;
+        get => WorktreesPage.LiveSessionsProvider;
+        set => WorktreesPage.LiveSessionsProvider = value;
     }
 
     public SourceControlView()

--- a/src/CcDirector.Avalonia/Controls/WorktreesView.axaml
+++ b/src/CcDirector.Avalonia/Controls/WorktreesView.axaml
@@ -178,6 +178,32 @@
                         <ItemsControl x:Name="SafeList" />
                     </StackPanel>
 
+                    <!-- In use by an open session -->
+                    <StackPanel x:Name="InUseSection" Spacing="6" IsVisible="False">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBlock Text="IN USE BY AN OPEN SESSION"
+                                       Foreground="#CCCCCC"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       VerticalAlignment="Center" />
+                            <Border Background="#1B2A3A"
+                                    CornerRadius="8"
+                                    Padding="6,1"
+                                    VerticalAlignment="Center">
+                                <TextBlock x:Name="InUseCountText"
+                                           Text="0"
+                                           Foreground="#3B82F6"
+                                           FontSize="10"
+                                           FontWeight="SemiBold" />
+                            </Border>
+                        </StackPanel>
+                        <TextBlock Text="Work is already on origin/main, but a session is still open in these - held back until you close it. Never removed while in use."
+                                   Foreground="#888888"
+                                   FontSize="10"
+                                   TextWrapping="Wrap" />
+                        <ItemsControl x:Name="InUseList" />
+                    </StackPanel>
+
                     <!-- Needs attention -->
                     <StackPanel x:Name="NeedsSection" Spacing="6" IsVisible="False">
                         <StackPanel Orientation="Horizontal" Spacing="8">

--- a/src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -39,6 +40,7 @@ public partial class WorktreesView : UserControl
 {
     private static readonly ISolidColorBrush SafeBrush = new SolidColorBrush(Color.Parse("#22C55E"));
     private static readonly ISolidColorBrush AttentionBrush = new SolidColorBrush(Color.Parse("#F59E0B"));
+    private static readonly ISolidColorBrush InUseBrush = new SolidColorBrush(Color.Parse("#3B82F6"));
 
     private readonly WorktreeInventoryService _service = new();
     private readonly WorktreeReaperService _reaper = new();
@@ -51,10 +53,11 @@ public partial class WorktreesView : UserControl
     public event Action<int>? OrphanedCountChanged;
 
     /// <summary>
-    /// Supplies the working directories of live sessions, which the reaper must never remove.
-    /// Set by the host (which knows the fleet); if null, only the primary checkout is protected.
+    /// Supplies the live sessions on this machine (with their working directories), so a git-safe
+    /// worktree a session is running in is shown as "in use" and never reaped. Best-effort: set by
+    /// the host, which knows the fleet; when null or it fails, the view falls back to no session data.
     /// </summary>
-    public Func<IReadOnlySet<string>>? ProtectedPathsProvider { get; set; }
+    public Func<CancellationToken, Task<IReadOnlyList<LiveSessionRef>>>? LiveSessionsProvider { get; set; }
 
     /// <summary>The number of worktrees currently safe to reap - the badge count.</summary>
     public int OrphanedCount { get; private set; }
@@ -80,8 +83,10 @@ public partial class WorktreesView : UserControl
         _lastInventory = null;
         SafeList.ItemsSource = null;
         NeedsList.ItemsSource = null;
+        InUseList.ItemsSource = null;
         SafeSection.IsVisible = false;
         NeedsSection.IsVisible = false;
+        InUseSection.IsVisible = false;
         EmptyText.IsVisible = false;
         ContentScroller.IsVisible = false;
         StatusText.Text = "Loading worktrees...";
@@ -133,7 +138,10 @@ public partial class WorktreesView : UserControl
 
         try
         {
-            var inventory = await Task.Run(() => _service.GetInventoryAsync(repoPath));
+            // Ask the host which sessions are live on this machine (best-effort) so a git-safe
+            // worktree with a session in it is shown as "in use" rather than "safe to reap".
+            var liveSessions = await FetchLiveSessionsAsync();
+            var inventory = await Task.Run(() => _service.GetInventoryAsync(repoPath, true, liveSessions));
 
             // Ignore stale results if the view was re-pointed while we were scanning.
             if (_repoPath != repoPath)
@@ -167,16 +175,20 @@ public partial class WorktreesView : UserControl
         }
 
         var safeRows = BuildSafeRows(inventory);
+        var inUseRows = BuildInUseRows(inventory);
         var needsRows = BuildNeedsRows(inventory);
 
         SafeList.ItemsSource = safeRows;
+        InUseList.ItemsSource = inUseRows;
         NeedsList.ItemsSource = needsRows;
 
         SafeCountText.Text = safeRows.Count.ToString();
+        InUseCountText.Text = inUseRows.Count.ToString();
         NeedsCountText.Text = needsRows.Count.ToString();
         SafeSection.IsVisible = safeRows.Count > 0;
+        InUseSection.IsVisible = inUseRows.Count > 0;
         NeedsSection.IsVisible = needsRows.Count > 0;
-        EmptyText.IsVisible = safeRows.Count == 0 && needsRows.Count == 0;
+        EmptyText.IsVisible = safeRows.Count == 0 && inUseRows.Count == 0 && needsRows.Count == 0;
 
         StatusText.IsVisible = false;
         ContentScroller.IsVisible = true;
@@ -200,20 +212,12 @@ public partial class WorktreesView : UserControl
     /// <summary>Show the confirmation overlay listing exactly what will be removed.</summary>
     private void ReapButton_Click(object? sender, RoutedEventArgs e)
     {
+        // Worktrees a live session is running in are already classified out of the safe set, so
+        // the safe list is exactly what the button removes.
         if (_lastInventory is not { Success: true } inventory || inventory.SafeToReapCount == 0)
             return;
 
-        var protectedPaths = GetProtectedPaths();
-        var toRemove = inventory.SafeToReap
-            .Where(w => !protectedPaths.Contains(WorktreeReaperService.NormalizePath(w.Path)))
-            .ToList();
-
-        if (toRemove.Count == 0)
-        {
-            ShowBanner("Every safe worktree is currently in use by a live session, so nothing was removed.");
-            return;
-        }
-
+        var toRemove = inventory.SafeToReap.ToList();
         ConfirmTitle.Text = $"Remove {toRemove.Count} orphaned worktree{(toRemove.Count == 1 ? "" : "s")}?";
         ConfirmList.Text = string.Join(Environment.NewLine,
             toRemove.Select(w => $"{(w.Branch ?? "(detached HEAD)")}  ->  {w.Path}"));
@@ -246,7 +250,10 @@ public partial class WorktreesView : UserControl
 
         try
         {
-            var protectedPaths = GetProtectedPaths();
+            // Re-fetch live sessions at the moment of acting so a session opened since the scan is
+            // still protected (belt-and-suspenders on top of the detector's classification).
+            var liveSessions = await FetchLiveSessionsAsync();
+            var protectedPaths = ToProtectedSet(liveSessions);
             var result = await Task.Run(() => _reaper.ReapAsync(repoPath, protectedPaths));
 
             if (_repoPath != repoPath)
@@ -301,17 +308,28 @@ public partial class WorktreesView : UserControl
         ResultBanner.IsVisible = true;
     }
 
-    private IReadOnlySet<string> GetProtectedPaths()
+    /// <summary>Fetch live sessions from the host (best-effort). Never throws - falls back to none.</summary>
+    private async Task<IReadOnlyList<LiveSessionRef>> FetchLiveSessionsAsync()
     {
         try
         {
-            return ProtectedPathsProvider?.Invoke() ?? new HashSet<string>();
+            if (LiveSessionsProvider is { } provider)
+                return await provider(CancellationToken.None) ?? Array.Empty<LiveSessionRef>();
         }
         catch (Exception ex)
         {
-            FileLog.Write($"[WorktreesView] GetProtectedPaths FAILED: {ex.Message}");
-            return new HashSet<string>();
+            FileLog.Write($"[WorktreesView] FetchLiveSessionsAsync FAILED (proceeding without session data): {ex.Message}");
         }
+        return Array.Empty<LiveSessionRef>();
+    }
+
+    private static IReadOnlySet<string> ToProtectedSet(IReadOnlyList<LiveSessionRef> liveSessions)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var s in liveSessions)
+            if (!string.IsNullOrWhiteSpace(s.RepoPath))
+                set.Add(WorktreeReaperService.NormalizePath(s.RepoPath));
+        return set;
     }
 
     // ----- pure builders (unit-tested without a UI) -----
@@ -327,6 +345,17 @@ public partial class WorktreesView : UserControl
             AccentBrush = SafeBrush,
         }).ToList();
 
+    internal static IReadOnlyList<WorktreeRowItem> BuildInUseRows(WorktreeInventory inventory) =>
+        inventory.InUseBySession.Select(w => new WorktreeRowItem
+        {
+            Title = TitleFor(w),
+            Path = w.Path,
+            Detail = SessionsFor(w),
+            Reason = w.Explanation,
+            Timestamp = FormatActivity(w.LastActivityUtc),
+            AccentBrush = InUseBrush,
+        }).ToList();
+
     internal static IReadOnlyList<WorktreeRowItem> BuildNeedsRows(WorktreeInventory inventory) =>
         inventory.NeedsAttention.Select(w => new WorktreeRowItem
         {
@@ -337,6 +366,12 @@ public partial class WorktreesView : UserControl
             Timestamp = FormatActivity(w.LastActivityUtc),
             AccentBrush = AttentionBrush,
         }).ToList();
+
+    /// <summary>"Open session: A, B" for the in-use group.</summary>
+    internal static string SessionsFor(WorktreeInfo w) =>
+        w.OpenSessions.Count == 0
+            ? ""
+            : $"Open session{(w.OpenSessions.Count == 1 ? "" : "s")}: {string.Join(", ", w.OpenSessions)}";
 
     private static string TitleFor(WorktreeInfo w) =>
         w.IsDetachedHead ? "(detached HEAD)" : (w.Branch ?? "(no branch)");
@@ -371,7 +406,7 @@ public partial class WorktreesView : UserControl
     {
         var sb = new StringBuilder();
         sb.AppendLine($"Worktree report for {inventory.RepositoryPath}");
-        sb.AppendLine($"Safe to reap: {inventory.SafeToReap.Count}   Needs attention: {inventory.NeedsAttention.Count}");
+        sb.AppendLine($"Safe to reap: {inventory.SafeToReap.Count}   In use by a session: {inventory.InUseBySession.Count}   Needs attention: {inventory.NeedsAttention.Count}");
         sb.AppendLine();
 
         sb.AppendLine("SAFE TO REAP");
@@ -382,6 +417,21 @@ public partial class WorktreesView : UserControl
             sb.AppendLine($"  {TitleFor(w)}");
             sb.AppendLine($"    path:   {w.Path}");
             AppendActivity(sb, w);
+            sb.AppendLine($"    reason: {w.Explanation}");
+        }
+        sb.AppendLine();
+
+        sb.AppendLine("IN USE BY AN OPEN SESSION");
+        if (inventory.InUseBySession.Count == 0)
+            sb.AppendLine("  (none)");
+        foreach (var w in inventory.InUseBySession)
+        {
+            var sessions = SessionsFor(w);
+            sb.AppendLine($"  {TitleFor(w)}");
+            sb.AppendLine($"    path:   {w.Path}");
+            AppendActivity(sb, w);
+            if (sessions.Length > 0)
+                sb.AppendLine($"    {sessions.ToLowerInvariant()}");
             sb.AppendLine($"    reason: {w.Explanation}");
         }
         sb.AppendLine();

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -244,8 +244,9 @@ public partial class MainWindow : Window
         // Wire source control view file event
         SourceControlView.ViewFileRequested += OnGitViewFileRequested;
         SourceControlView.OrphanedCountChanged += OnOrphanedWorktreeCountChanged;
-        // The reaper must never remove a worktree a live session is using: feed it their paths.
-        SourceControlView.ProtectedPathsProvider = GetLiveSessionWorkingDirectories;
+        // Feed the Worktrees page the live sessions on this machine (fleet-wide across Director
+        // slots) so a session-occupied worktree is shown as "in use" and never reaped.
+        SourceControlView.LiveSessionsProvider = GetLiveSessionsOnThisMachineAsync;
 
         // Wire prompt input text changes for slash command autocomplete
         PromptInput.TextChanged += PromptInput_TextChanged;
@@ -4121,19 +4122,57 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// The working directories of every live session - the reaper must never remove one of these,
-    /// because deleting a worktree a session is running in would pull the ground out from under it.
+    /// The live sessions on THIS machine and their working directories, used so the Worktrees page
+    /// can flag a worktree a session is running in. Prefers the Gateway's fleet list (which spans
+    /// every Director slot on the machine, closing the cross-slot gap); falls back to this Director's
+    /// own sessions when no Gateway is connected. Best-effort - never throws.
     /// </summary>
-    private IReadOnlySet<string> GetLiveSessionWorkingDirectories()
+    private async Task<IReadOnlyList<Core.Git.LiveSessionRef>> GetLiveSessionsOnThisMachineAsync(CancellationToken ct)
     {
-        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var vm in _sessions)
+        var machine = Environment.MachineName;
+        try
         {
-            var path = vm.Session.RepoPath;
-            if (!string.IsNullOrWhiteSpace(path))
-                set.Add(path);
+            var app = global::Avalonia.Application.Current as App;
+            var fleetTask = app?.ControlApiHost?.ListFleetSessionsAsync(ct);
+            if (fleetTask != null)
+            {
+                var fleet = await fleetTask;
+                var refs = fleet
+                    .Where(s => IsSessionAlive(s)
+                                && string.Equals(s.MachineName, machine, StringComparison.OrdinalIgnoreCase)
+                                && !string.IsNullOrWhiteSpace(s.RepoPath))
+                    .Select(s => new Core.Git.LiveSessionRef { RepoPath = s.RepoPath, Label = FleetSessionLabel(s) })
+                    .ToList();
+                return refs;
+            }
         }
-        return set;
+        catch (Exception ex)
+        {
+            FileLog.Write($"[MainWindow] GetLiveSessionsOnThisMachineAsync fleet query failed, using local sessions: {ex.Message}");
+        }
+
+        // No Gateway (or the fleet call failed): fall back to this Director's own sessions.
+        return _sessions
+            .Where(vm => !string.IsNullOrWhiteSpace(vm.Session.RepoPath))
+            .Select(vm => new Core.Git.LiveSessionRef
+            {
+                RepoPath = vm.Session.RepoPath,
+                Label = vm.Session.Number is int n ? $"{vm.DisplayName} (#{n})" : vm.DisplayName,
+            })
+            .ToList();
+    }
+
+    /// <summary>A session is genuinely alive when it has not exited/failed and did not crash.</summary>
+    private static bool IsSessionAlive(Gateway.Contracts.SessionDto s) =>
+        !string.Equals(s.Status, "Exited", StringComparison.OrdinalIgnoreCase)
+        && !string.Equals(s.Status, "Failed", StringComparison.OrdinalIgnoreCase)
+        && !string.Equals(s.ActivityState, "Exited", StringComparison.OrdinalIgnoreCase)
+        && !s.Crashed;
+
+    private static string FleetSessionLabel(Gateway.Contracts.SessionDto s)
+    {
+        var name = string.IsNullOrWhiteSpace(s.Name) ? "session" : s.Name;
+        return s.Number is int n ? $"{name} (#{n})" : name;
     }
 
     private void BtnSend_Click(object? sender, RoutedEventArgs e)

--- a/src/CcDirector.Core.Tests/WorktreeInventoryIntegrationTests.cs
+++ b/src/CcDirector.Core.Tests/WorktreeInventoryIntegrationTests.cs
@@ -263,6 +263,56 @@ public sealed class WorktreeInventoryIntegrationTests : IDisposable
         }
     }
 
+    // -------------------------------------------------------------------------------------------
+    // A git-safe worktree that a live session is running in is classified "in use", not safe.
+    // -------------------------------------------------------------------------------------------
+    [Fact]
+    public async Task SafeWorktree_WithLiveSession_IsClassifiedInUse_NotSafe()
+    {
+        var wt = Path.Combine(_root, "wt-busy");
+        RunGit(_primary, "worktree", "add", "-b", "busy", wt, "main");
+        WriteFile(wt, "b.txt", "work\n");
+        RunGit(wt, "add", "-A");
+        RunGit(wt, "commit", "-m", "busy work");
+        RunGit(wt, "push", "-u", "origin", "busy");
+        RunGit(_primary, "merge", "--ff-only", "busy");
+        RunGit(_primary, "push", "origin", "main");
+
+        var live = new List<LiveSessionRef> { new() { RepoPath = wt, Label = "Busy Session (#9)" } };
+        var inventory = await new WorktreeInventoryService().GetInventoryAsync(_primary, fetchPrune: true, liveSessions: live);
+
+        Assert.True(inventory.Success, inventory.Error);
+        var busy = Assert.Single(inventory.Worktrees, w => w.Branch == "busy");
+        Assert.Equal(WorktreeSafety.InUseBySession, busy.Safety);
+        Assert.Equal(WorktreeSafetyReason.LiveSessionOpen, busy.Reason);
+        Assert.Contains("Busy Session (#9)", busy.OpenSessions);
+        Assert.DoesNotContain(inventory.SafeToReap, w => w.Branch == "busy");
+        Assert.Contains(inventory.InUseBySession, w => w.Branch == "busy");
+        Assert.Equal(0, inventory.SafeToReapCount);
+    }
+
+    [Fact]
+    public async Task SafeWorktree_WithNoMatchingSession_StaysSafe()
+    {
+        var wt = Path.Combine(_root, "wt-free");
+        RunGit(_primary, "worktree", "add", "-b", "free", wt, "main");
+        WriteFile(wt, "f.txt", "work\n");
+        RunGit(wt, "add", "-A");
+        RunGit(wt, "commit", "-m", "free work");
+        RunGit(wt, "push", "-u", "origin", "free");
+        RunGit(_primary, "merge", "--ff-only", "free");
+        RunGit(_primary, "push", "origin", "main");
+
+        // A live session, but in a DIFFERENT directory - must not affect this worktree.
+        var live = new List<LiveSessionRef> { new() { RepoPath = Path.Combine(_root, "somewhere-else"), Label = "Other (#3)" } };
+        var inventory = await new WorktreeInventoryService().GetInventoryAsync(_primary, fetchPrune: true, liveSessions: live);
+
+        Assert.True(inventory.Success, inventory.Error);
+        var free = Assert.Single(inventory.Worktrees, w => w.Branch == "free");
+        Assert.Equal(WorktreeSafety.SafeToReap, free.Safety);
+        Assert.Empty(free.OpenSessions);
+    }
+
     // ----- helpers -----
 
     private void ConfigureIdentity(string repo)

--- a/src/CcDirector.Core.Tests/WorktreeSafetyEvaluatorTests.cs
+++ b/src/CcDirector.Core.Tests/WorktreeSafetyEvaluatorTests.cs
@@ -152,4 +152,51 @@ public class WorktreeSafetyEvaluatorTests
         Assert.Equal(WorktreeSafety.NeedsAttention, v.Safety);
         Assert.Equal(WorktreeSafetyReason.UncommittedChanges, v.Reason);
     }
+
+    // --- Third case: git-safe but a live session is open in the worktree ---
+
+    [Fact]
+    public void CleanBranch_ThatWouldBeSafe_WithLiveSession_IsInUseNotSafe()
+    {
+        var v = WorktreeSafetyEvaluator.Evaluate(Base() with { OriginBranchGone = true, HasLiveSession = true });
+        Assert.Equal(WorktreeSafety.InUseBySession, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.LiveSessionOpen, v.Reason);
+    }
+
+    [Fact]
+    public void ContainedInMain_WithLiveSession_IsInUse()
+    {
+        var v = WorktreeSafetyEvaluator.Evaluate(Base() with { ContainedInMain = true, HasLiveSession = true });
+        Assert.Equal(WorktreeSafety.InUseBySession, v.Safety);
+    }
+
+    [Fact]
+    public void DetachedHead_AncestorOfMain_WithLiveSession_IsInUse()
+    {
+        var v = WorktreeSafetyEvaluator.Evaluate(Base() with
+        {
+            IsDetachedHead = true,
+            DetachedHeadIsAncestorOfMain = true,
+            HasLiveSession = true,
+        });
+        Assert.Equal(WorktreeSafety.InUseBySession, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.LiveSessionOpen, v.Reason);
+    }
+
+    [Fact]
+    public void Dirty_WithLiveSession_StaysNeedsAttention_NotInUse()
+    {
+        // A dirty worktree was never safe; a live session does not change that.
+        var v = WorktreeSafetyEvaluator.Evaluate(Base() with { IsClean = false, HasLiveSession = true });
+        Assert.Equal(WorktreeSafety.NeedsAttention, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.UncommittedChanges, v.Reason);
+    }
+
+    [Fact]
+    public void StrandedBranch_WithLiveSession_StaysNeedsAttention()
+    {
+        var v = WorktreeSafetyEvaluator.Evaluate(Base() with { HasLiveSession = true });
+        Assert.Equal(WorktreeSafety.NeedsAttention, v.Safety);
+        Assert.Equal(WorktreeSafetyReason.NotProvenMerged, v.Reason);
+    }
 }

--- a/src/CcDirector.Core/Git/WorktreeInventoryService.cs
+++ b/src/CcDirector.Core/Git/WorktreeInventoryService.cs
@@ -22,11 +22,13 @@ public sealed class WorktreeInventoryService
     /// <summary>
     /// Enumerates the worktrees of <paramref name="repositoryPath"/> and returns their verdicts.
     /// When <paramref name="fetchPrune"/> is true a <c>git fetch --prune</c> runs first so the
-    /// origin-branch-gone signal (C2) is current.
+    /// origin-branch-gone signal (C2) is current. <paramref name="liveSessions"/> (already filtered
+    /// to this machine and to genuinely-alive sessions) lets a git-safe worktree that a session is
+    /// running in be classified "in use" rather than "safe to reap".
     /// </summary>
-    public async Task<WorktreeInventory> GetInventoryAsync(string repositoryPath, bool fetchPrune = true, CancellationToken ct = default)
+    public async Task<WorktreeInventory> GetInventoryAsync(string repositoryPath, bool fetchPrune = true, IReadOnlyList<LiveSessionRef>? liveSessions = null, CancellationToken ct = default)
     {
-        FileLog.Write($"[WorktreeInventoryService] GetInventoryAsync: repo={repositoryPath}, fetchPrune={fetchPrune}");
+        FileLog.Write($"[WorktreeInventoryService] GetInventoryAsync: repo={repositoryPath}, fetchPrune={fetchPrune}, liveSessions={liveSessions?.Count ?? 0}");
         try
         {
             if (string.IsNullOrWhiteSpace(repositoryPath) || !Directory.Exists(repositoryPath))
@@ -37,6 +39,7 @@ public sealed class WorktreeInventoryService
                 await _git.RunAsync(repositoryPath, new[] { "fetch", "--prune" }, ct);
 
             var mainRef = await ResolveMainRefAsync(repositoryPath, ct);
+            var sessionsByPath = BuildSessionMap(liveSessions);
 
             var listResult = await _git.RunAsync(repositoryPath, new[] { "worktree", "list", "--porcelain" }, ct);
             if (!listResult.Success)
@@ -55,7 +58,7 @@ public sealed class WorktreeInventoryService
                 bool isPrimary = !primaryAssigned;
                 primaryAssigned = true;
 
-                worktrees.Add(await BuildInfoAsync(repositoryPath, entry, isPrimary, mainRef, ct));
+                worktrees.Add(await BuildInfoAsync(repositoryPath, entry, isPrimary, mainRef, sessionsByPath, ct));
             }
 
             var safeCount = worktrees.Count(w => w.Safety == WorktreeSafety.SafeToReap);
@@ -75,7 +78,7 @@ public sealed class WorktreeInventoryService
         }
     }
 
-    private async Task<WorktreeInfo> BuildInfoAsync(string repositoryPath, RawWorktreeEntry entry, bool isPrimary, string? mainRef, CancellationToken ct)
+    private async Task<WorktreeInfo> BuildInfoAsync(string repositoryPath, RawWorktreeEntry entry, bool isPrimary, string? mainRef, IReadOnlyDictionary<string, List<string>> sessionsByPath, CancellationToken ct)
     {
         // Cleanliness is measured inside the worktree itself.
         var statusResult = await _git.RunAsync(entry.Path, new[] { "status", "--porcelain" }, ct);
@@ -122,6 +125,12 @@ public sealed class WorktreeInventoryService
             }
         }
 
+        // A live session sitting in this worktree (matched by full path) - only meaningful for a
+        // non-primary worktree that would otherwise be safe.
+        var openSessions = sessionsByPath.TryGetValue(WorktreeReaperService.NormalizePath(entry.Path), out var labels)
+            ? labels
+            : new List<string>();
+
         var facts = new WorktreeFacts
         {
             IsPrimary = isPrimary,
@@ -132,6 +141,7 @@ public sealed class WorktreeInventoryService
             ContainedInMain = containedInMain,
             DetachedHeadIsAncestorOfMain = detachedAncestor,
             InspectionSucceeded = inspectionOk,
+            HasLiveSession = !isPrimary && openSessions.Count > 0,
         };
 
         var verdict = WorktreeSafetyEvaluator.Evaluate(facts);
@@ -150,6 +160,7 @@ public sealed class WorktreeInventoryService
             BehindMain = behind,
             HasOpenPullRequest = hasOpenPr,
             LastActivityUtc = lastActivity,
+            OpenSessions = openSessions,
             Safety = verdict.Safety,
             Reason = verdict.Reason,
             Explanation = verdict.Explanation,
@@ -211,6 +222,28 @@ public sealed class WorktreeInventoryService
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Groups the live-session refs by normalized worktree path, so a worktree lookup is O(1).
+    /// Multiple sessions can sit in the same directory, so the value is a list of labels.
+    /// </summary>
+    private static IReadOnlyDictionary<string, List<string>> BuildSessionMap(IReadOnlyList<LiveSessionRef>? liveSessions)
+    {
+        var map = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        if (liveSessions == null)
+            return map;
+
+        foreach (var s in liveSessions)
+        {
+            if (string.IsNullOrWhiteSpace(s.RepoPath))
+                continue;
+            var key = WorktreeReaperService.NormalizePath(s.RepoPath);
+            if (!map.TryGetValue(key, out var labels))
+                map[key] = labels = new List<string>();
+            labels.Add(string.IsNullOrWhiteSpace(s.Label) ? s.RepoPath : s.Label);
+        }
+        return map;
     }
 
     /// <summary>True if <c>git cherry</c> output contains a commit the upstream lacks (a line starting with '+').</summary>

--- a/src/CcDirector.Core/Git/WorktreeModels.cs
+++ b/src/CcDirector.Core/Git/WorktreeModels.cs
@@ -10,6 +10,12 @@ public enum WorktreeSafety
     /// <summary>Work is provably on origin/main and the tree is clean - safe to remove mechanically.</summary>
     SafeToReap,
 
+    /// <summary>
+    /// Git-safe (work on origin/main, tree clean) BUT a live session is running in it. Never offered
+    /// for reap while the session is open - deleting it would pull the ground out from under the session.
+    /// </summary>
+    InUseBySession,
+
     /// <summary>Carries unmerged commits, uncommitted content, or is the primary checkout - never auto-removed.</summary>
     NeedsAttention,
 }
@@ -33,6 +39,9 @@ public enum WorktreeSafetyReason
 
     /// <summary>Detached-HEAD case: its HEAD commit is an ancestor of origin/main.</summary>
     DetachedHeadAncestorOfMain,
+
+    /// <summary>Git-safe, but a live session is running in the worktree - held back from reaping.</summary>
+    LiveSessionOpen,
 
     // --- Needs-attention reasons (never auto-removed) ---
 
@@ -82,6 +91,22 @@ public sealed record WorktreeFacts
     /// forcing a fail-closed verdict rather than a guess.
     /// </summary>
     public bool InspectionSucceeded { get; init; } = true;
+
+    /// <summary>True when a live session's working directory is this worktree - it is held back from reaping.</summary>
+    public bool HasLiveSession { get; init; }
+}
+
+/// <summary>
+/// A live session's working directory plus a short human label, used to detect which worktrees are
+/// currently occupied by an open session. The caller supplies these (already filtered to this machine
+/// and to genuinely-alive sessions); the detector only matches paths.
+/// </summary>
+public sealed class LiveSessionRef
+{
+    public string RepoPath { get; init; } = "";
+
+    /// <summary>A short label for the UI, e.g. "ERP KB Builder (#109)".</summary>
+    public string Label { get; init; } = "";
 }
 
 /// <summary>The evaluator's decision: the safety bucket, the deciding reason, and a one-line explanation.</summary>
@@ -137,6 +162,9 @@ public sealed class WorktreeInfo
     /// </summary>
     public DateTime? LastActivityUtc { get; init; }
 
+    /// <summary>Labels of the live sessions running in this worktree (empty when none).</summary>
+    public IReadOnlyList<string> OpenSessions { get; init; } = Array.Empty<string>();
+
     public WorktreeSafety Safety { get; init; }
     public WorktreeSafetyReason Reason { get; init; }
     public string Explanation { get; init; } = "";
@@ -156,6 +184,10 @@ public sealed class WorktreeInventory
     /// <summary>The worktrees proven safe to reap right now - what the badge counts and the button removes.</summary>
     public IReadOnlyList<WorktreeInfo> SafeToReap =>
         Worktrees.Where(w => w.Safety == WorktreeSafety.SafeToReap).ToList();
+
+    /// <summary>Git-safe worktrees that a live session is currently running in - shown, but never reaped.</summary>
+    public IReadOnlyList<WorktreeInfo> InUseBySession =>
+        Worktrees.Where(w => w.Safety == WorktreeSafety.InUseBySession).ToList();
 
     /// <summary>Stranded or dirty worktrees a human or agent must decide about (excludes the primary checkout).</summary>
     public IReadOnlyList<WorktreeInfo> NeedsAttention =>

--- a/src/CcDirector.Core/Git/WorktreeReaperService.cs
+++ b/src/CcDirector.Core/Git/WorktreeReaperService.cs
@@ -89,7 +89,7 @@ public sealed class WorktreeReaperService
             var protectedSet = BuildProtectedSet(protectedPaths);
 
             // Re-run the safety check immediately before acting - state can change between load and click.
-            var inventory = await _inventory.GetInventoryAsync(repositoryPath, fetchPrune: true, ct);
+            var inventory = await _inventory.GetInventoryAsync(repositoryPath, fetchPrune: true, liveSessions: null, ct);
             if (!inventory.Success)
                 return ReapResult.Failure($"could not enumerate worktrees: {inventory.Error}");
 

--- a/src/CcDirector.Core/Git/WorktreeSafetyEvaluator.cs
+++ b/src/CcDirector.Core/Git/WorktreeSafetyEvaluator.cs
@@ -38,7 +38,7 @@ public static class WorktreeSafetyEvaluator
         if (facts.IsDetachedHead)
         {
             return facts.DetachedHeadIsAncestorOfMain
-                ? Safe(WorktreeSafetyReason.DetachedHeadAncestorOfMain,
+                ? Safe(facts, WorktreeSafetyReason.DetachedHeadAncestorOfMain,
                     "Detached HEAD is contained in origin/main.")
                 : NeedsAttention(WorktreeSafetyReason.NotProvenMerged,
                     "Detached HEAD is not contained in origin/main.");
@@ -46,21 +46,32 @@ public static class WorktreeSafetyEvaluator
 
         // Branch: proven merged by at least one signal. Order is most-authoritative first.
         if (facts.PullRequestMerged)
-            return Safe(WorktreeSafetyReason.PullRequestMerged, "Pull request merged.");
+            return Safe(facts, WorktreeSafetyReason.PullRequestMerged, "Pull request merged.");
 
         if (facts.OriginBranchGone)
-            return Safe(WorktreeSafetyReason.OriginBranchGone, "Origin branch deleted after merge.");
+            return Safe(facts, WorktreeSafetyReason.OriginBranchGone, "Origin branch deleted after merge.");
 
         if (facts.ContainedInMain)
-            return Safe(WorktreeSafetyReason.ContainedInMain, "All commits already contained in origin/main.");
+            return Safe(facts, WorktreeSafetyReason.ContainedInMain, "All commits already contained in origin/main.");
 
         // No merge signal - stranded.
         return NeedsAttention(WorktreeSafetyReason.NotProvenMerged,
             "Commits not proven to be in origin/main.");
     }
 
-    private static WorktreeVerdict Safe(WorktreeSafetyReason reason, string explanation) =>
-        new() { Safety = WorktreeSafety.SafeToReap, Reason = reason, Explanation = explanation };
+    /// <summary>
+    /// A git-safe verdict, EXCEPT when a live session is running in the worktree: then it becomes
+    /// "in use by a session" and is held back from reaping until the session closes.
+    /// </summary>
+    private static WorktreeVerdict Safe(WorktreeFacts facts, WorktreeSafetyReason reason, string explanation) =>
+        facts.HasLiveSession
+            ? new WorktreeVerdict
+            {
+                Safety = WorktreeSafety.InUseBySession,
+                Reason = WorktreeSafetyReason.LiveSessionOpen,
+                Explanation = "Safe to remove, but a session is still open in it.",
+            }
+            : new WorktreeVerdict { Safety = WorktreeSafety.SafeToReap, Reason = reason, Explanation = explanation };
 
     private static WorktreeVerdict NeedsAttention(WorktreeSafetyReason reason, string explanation) =>
         new() { Safety = WorktreeSafety.NeedsAttention, Reason = reason, Explanation = explanation };


### PR DESCRIPTION
Implements spec thefrederiksen/devthrottle_internal#505 (follow-up to #503).

## Problem
A worktree can be git-safe to reap (merged, clean) while a session is still open and running inside it - deleting it yanks the working directory out from under a live agent. The previous reap guard only saw the local Director's own sessions, so a worktree held by a session on a different Director slot on the same machine was shown plain-green safe.

## What this adds
- A **third worktree state, "In use by an open session."** The detector receives the live sessions on this machine; a worktree that would be `SafeToReap` but whose path matches a live session's working directory becomes `InUseBySession` (reason `LiveSessionOpen`). Dirty/stranded worktrees are unaffected. The verdict is folded once, on the service side (dumb-client rule).
- A **third UI group** (blue), "In use by an open session", naming the session(s) in each worktree (e.g. "Open session: ERP KB Builder (#109)"). Excluded from the red count and the Remove button; also listed in the copy report.
- **Fleet-wide session data:** `MainWindow` asks the Gateway's fleet list for live sessions on THIS machine - spanning every Director slot, closing the cross-slot hole - and falls back to this Director's own sessions when no Gateway is connected. Liveness = not exited/failed and not crashed. Best-effort: if the fleet list is unavailable, the feature degrades without error.
- The reaper's runtime skip-guard stays as a backstop, now fed by the same freshly-fetched fleet list at the moment of removal.

## Tests
- Evaluator: git-safe + live session -> InUseBySession; dirty/stranded + live session -> unchanged.
- Core integration: a safe worktree with a matching live session is classified in-use and excluded from the safe count; a non-matching session leaves it safe.
- UI: the in-use row builder, safe rows exclude in-use, session-label formatting, and the report's in-use group.
- Full Core.Tests: 3334 passed, 8 skipped, 0 failed. Full Avalonia.Tests: 255 passed, 0 failed.