### PR TITLE
fix(cockpit): show idle machines as free slots on the Fleet Map 'By machine' pivot

### DIFF
--- a/apps/cockpit/src/fleet/FleetMapView.test.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { SessionDto } from "@devthrottle/client-core/api/client";
+import type { DirectorReachability } from "@devthrottle/client-core/fleet/fleetClient";
+import type { SharedRoster } from "@devthrottle/client-core/fleet/rosterStore";
+
+// Rendered proof for the "By machine" free-slots fix: a machine that has a reachable Director but no
+// sessions must still appear as a lane (available capacity), and an idle Director inside a machine must
+// render as a "free slot" rather than vanishing. Only the machine pivot does this - repository / working
+// tree / agent still group real sessions only. The pure folding is unit tested in fleetMapFormat.test;
+// this test proves the view actually paints the lane and the placeholder.
+
+// The Fleet Map reads the ONE shared roster store; mock it so the test drives an exact fleet without a
+// Gateway. Canvas measures the DOM with ResizeObserver, which jsdom lacks - stub it so layout runs.
+const rosterValue: { current: SharedRoster } = {
+  current: { sessions: [], machineErrors: [], directors: [], error: null, refreshNow: () => {} },
+};
+vi.mock("@devthrottle/client-core/fleet/rosterStore", () => ({
+  useSharedRoster: () => rosterValue.current,
+}));
+vi.mock("react-router-dom", () => ({ useNavigate: () => vi.fn() }));
+
+import { FleetMapView } from "./FleetMapView";
+
+// A fully Gateway-stamped session (effectiveColor / stateLabel / effectiveColorHex are required fields the
+// dumb client renders verbatim, so a fixture missing them would throw or paint the protocol sentinel).
+function session(overrides: Partial<SessionDto> = {}): SessionDto {
+  return {
+    sessionId: "s1",
+    machineName: "SOREN_NORTH",
+    directorId: "north-1",
+    repoName: "thefrederiksen/devthrottle",
+    repoPath: "D:/ReposFred/devthrottle",
+    agent: "ClaudeCode",
+    activityState: "Working",
+    createdAt: "2026-07-23T10:00:00Z",
+    number: 104,
+    name: "release",
+    effectiveColor: "blue",
+    stateLabel: "Working",
+    effectiveColorHex: "#3b82f6",
+    ...overrides,
+  } as SessionDto;
+}
+
+function director(overrides: Partial<DirectorReachability> = {}): DirectorReachability {
+  return { directorId: "d", machineName: "SOREN", state: "online", ...overrides };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  // jsdom has no ResizeObserver; a no-op stub is enough for the Canvas layout effect.
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+afterEach(() => cleanup());
+
+describe("FleetMapView - By machine free slots", () => {
+  it("shows an idle machine as a lane with a free slot, even though it has no sessions", () => {
+    rosterValue.current = {
+      sessions: [session()], // one busy session on SOREN_NORTH
+      machineErrors: [],
+      directors: [
+        director({ directorId: "north-1", machineName: "SOREN_NORTH", state: "online" }),
+        director({ directorId: "soren-1", machineName: "SOREN", state: "online" }), // idle, no sessions
+        director({ directorId: "mac-1", machineName: "Sorens-Mac-mini", state: "online" }), // idle
+      ],
+      error: null,
+      refreshNow: () => {},
+    };
+
+    render(<FleetMapView />);
+
+    // The header (and the canvas root) count all three reachable machines, not just the one running work.
+    expect(screen.getAllByText(/\b3 machines\b/).length).toBeGreaterThan(0);
+
+    // The idle machines each get a lane header - they were completely absent before this fix.
+    expect(screen.getByText("SOREN")).toBeTruthy();
+    expect(screen.getByText("Sorens-Mac-mini")).toBeTruthy();
+
+    // Idle Directors render as free slots (one per idle machine here).
+    const freeSlots = screen.getAllByText(/free slot/i);
+    expect(freeSlots.length).toBe(2);
+
+    // The busy machine still shows its session and does NOT show a free slot for its only Director.
+    expect(screen.getByText("release")).toBeTruthy();
+  });
+
+  it("does not fold idle Directors into the repository pivot - only machine shows capacity", () => {
+    window.localStorage.setItem("cockpit.fleetMapPivot", "repo");
+    rosterValue.current = {
+      sessions: [session()],
+      machineErrors: [],
+      directors: [
+        director({ directorId: "north-1", machineName: "SOREN_NORTH", state: "online" }),
+        director({ directorId: "soren-1", machineName: "SOREN", state: "online" }),
+      ],
+      error: null,
+      refreshNow: () => {},
+    };
+
+    render(<FleetMapView />);
+
+    // The repository pivot groups real sessions; an idle machine is not a repository, so no free slots.
+    expect(screen.queryByText(/free slot/i)).toBeNull();
+    expect(screen.getByText("thefrederiksen/devthrottle")).toBeTruthy();
+  });
+
+  it("excludes an offline Director - offline is not a free slot", () => {
+    rosterValue.current = {
+      sessions: [session()],
+      machineErrors: [],
+      directors: [
+        director({ directorId: "north-1", machineName: "SOREN_NORTH", state: "online" }),
+        director({ directorId: "dead-1", machineName: "DEAD_MACHINE", state: "offline" }),
+      ],
+      error: null,
+      refreshNow: () => {},
+    };
+
+    render(<FleetMapView />);
+
+    expect(screen.queryByText("DEAD_MACHINE")).toBeNull();
+    expect(screen.queryByText(/free slot/i)).toBeNull();
+    // Only the one reachable machine is counted; the offline one is not "available capacity".
+    expect(screen.getAllByText(/\b1 machine\b/).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/cockpit/src/fleet/FleetMapView.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.tsx
@@ -11,7 +11,14 @@ import {
 } from "@devthrottle/client-core/fleet/fleetClient";
 import { useSharedRoster } from "@devthrottle/client-core/fleet/rosterStore";
 import { repoBasename, repoIdentity, relativeTime } from "./format";
-import { agentBadgeText, buildControllerTree } from "./fleetMapFormat";
+import {
+  agentBadgeText,
+  buildControllerTree,
+  groupByDirector,
+  machineKeyOf,
+  reachableDirectorsByMachine,
+  shortDir,
+} from "./fleetMapFormat";
 import { MissionsBoard, missionCounts } from "../missions/MissionsBoard";
 
 // Per-Director reachability for the Online / Wobbly / Offline node rendering (issue #1215), provided at
@@ -95,6 +102,9 @@ interface Lane {
   title: string;
   subtitle: string;
   sessions: SessionDto[];
+  // The machine's reachable Directors (machine pivot only; empty for every other pivot). Carries the
+  // idle Directors that have no sessions so the lane can render them as free slots.
+  directors: DirectorReachability[];
 }
 
 export function FleetMapView() {
@@ -124,8 +134,8 @@ export function FleetMapView() {
   // empty - a matching card never moves and the lanes never reorder (issue #1211). The flat "list"
   // pivot does not use lanes.
   const allLanes = useMemo(
-    () => (CANVAS_PIVOTS.has(pivot) ? buildLanes(list, pivot) : []),
-    [list, pivot],
+    () => (CANVAS_PIVOTS.has(pivot) ? buildLanes(list, pivot, directors) : []),
+    [list, pivot, directors],
   );
   const lanes = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -146,11 +156,17 @@ export function FleetMapView() {
     [pivot, flatSessions, lanes],
   );
 
+  // Distinct machines in the fleet - counted by the SAME machine key the "By machine" lanes use, and
+  // including a machine that has a reachable Director but no sessions (an available, empty machine). This
+  // is why the header can read "3 machines" while only one is running sessions: the other two are free
+  // capacity, and the machine pivot now shows them as such. Offline Directors are excluded (they surface
+  // in the unreachable-machines banner, not as available machines).
   const machineCount = useMemo(() => {
     const set = new Set<string>();
-    for (const s of list) set.add((s.machineName ?? "").toLowerCase());
+    for (const s of list) set.add(machineKeyOf(s.machineName).key);
+    for (const m of reachableDirectorsByMachine(directors)) set.add(m.key);
     return set.size;
-  }, [list]);
+  }, [list, directors]);
   // "N repos" counts distinct GitHub repositories, not checkouts: two worktrees of one repository are one
   // repo here (matching the "By repository" pivot). The "By working tree" pivot is where checkouts split.
   const repoCount = useMemo(() => {
@@ -257,7 +273,7 @@ export function FleetMapView() {
 
       {sessions === null && lastError === null && <div className="fmap-empty">Loading the fleet...</div>}
 
-      {sessions !== null && list.length === 0 && machineErrors.length === 0 && (
+      {sessions !== null && list.length === 0 && machineErrors.length === 0 && lanes.length === 0 && (
         <div className="fmap-empty">
           <p>No sessions are running anywhere on the fleet.</p>
           <p className="fmap-empty-sub">
@@ -424,8 +440,9 @@ function LanePanel({ lane, pivot, onOpen, headRef }: LanePanelProps) {
   const agg = aggregateColors(lane.sessions);
 
   // Machine pivot: sub-group the lane's sessions by Director so the panel reads machine -> Director ->
-  // session. Other pivots render a flat list (each card still tags its machine/Director).
-  const directorGroups = pivot === "machine" ? groupByDirector(lane.sessions) : null;
+  // session, folding in the machine's idle Directors so an empty Director shows as a free slot. Other
+  // pivots render a flat list (each card still tags its machine/Director).
+  const directorGroups = pivot === "machine" ? groupByDirector(lane.sessions, sessionSort, lane.directors) : null;
 
   return (
     <section className="fmap-lane">
@@ -445,7 +462,11 @@ function LanePanel({ lane, pivot, onOpen, headRef }: LanePanelProps) {
           ? directorGroups.map((dg) => (
               <div key={dg.key} className="fmap-dgroup">
                 <div className="fmap-subhead">{dg.label}</div>
-                <LaneCards sessions={dg.sessions} pivot={pivot} onOpen={onOpen} />
+                {dg.sessions.length > 0 ? (
+                  <LaneCards sessions={dg.sessions} pivot={pivot} onOpen={onOpen} />
+                ) : (
+                  <div className="fmap-freeslot">No sessions - free slot</div>
+                )}
               </div>
             ))
           : <LaneCards sessions={lane.sessions} pivot={pivot} onOpen={onOpen} />}
@@ -585,13 +606,13 @@ function NodeCard({
 
 // ---- grouping (pure) ----
 
-function buildLanes(sessions: SessionDto[], pivot: Pivot): Lane[] {
-  const byKey = new Map<string, { title: string; list: SessionDto[] }>();
+function buildLanes(sessions: SessionDto[], pivot: Pivot, directors: DirectorReachability[] = []): Lane[] {
+  const byKey = new Map<string, { title: string; list: SessionDto[]; directors: DirectorReachability[] }>();
   const keyOf = (s: SessionDto): { key: string; title: string } => {
     if (pivot === "machine") {
-      const name = (s.machineName ?? "").trim();
-      const title = name.length === 0 ? "(unknown machine)" : name;
-      return { key: title.toLowerCase(), title };
+      // Key through the shared machineKeyOf so a session's lane and an idle Director's lane collapse
+      // onto the same key (see fleetMapFormat).
+      return machineKeyOf(s.machineName);
     }
     if (pivot === "repo") {
       // GitHub "owner/repo" identity - worktrees and clones of one repository fold into one lane.
@@ -612,10 +633,25 @@ function buildLanes(sessions: SessionDto[], pivot: Pivot): Lane[] {
     const { key, title } = keyOf(s);
     let g = byKey.get(key);
     if (g === undefined) {
-      g = { title, list: [] };
+      g = { title, list: [], directors: [] };
       byKey.set(key, g);
     }
     g.list.push(s);
+  }
+
+  // Machine pivot only: fold in every reachable Director so a machine that has a Director but no sessions
+  // still gets a lane (a free, available machine), and a machine's idle Directors ride on the lane so the
+  // panel can render them as free slots. Other pivots group only real sessions - a repository or an agent
+  // with no session is not a thing to show. Offline Directors are already filtered out upstream.
+  if (pivot === "machine") {
+    for (const m of reachableDirectorsByMachine(directors)) {
+      let g = byKey.get(m.key);
+      if (g === undefined) {
+        g = { title: m.title, list: [], directors: [] };
+        byKey.set(m.key, g);
+      }
+      g.directors = m.directors;
+    }
   }
 
   const kindLabel = PIVOTS.find((p) => p.key === pivot)?.kindLabel ?? "";
@@ -625,18 +661,32 @@ function buildLanes(sessions: SessionDto[], pivot: Pivot): Lane[] {
       key,
       kindLabel,
       title: g.title,
-      subtitle: laneSubtitle(g.list, pivot),
+      subtitle: laneSubtitle(g.list, pivot, g.directors),
       sessions: [...g.list].sort(sessionSort),
+      directors: g.directors,
     }))
+    // Busiest lanes first, then by title; a free (zero-session) machine sorts to the end, after every
+    // machine that is actually running work.
     .sort((a, b) => b.sessions.length - a.sessions.length || a.title.toLowerCase().localeCompare(b.title.toLowerCase()));
 }
 
-function laneSubtitle(sessions: SessionDto[], pivot: Pivot): string {
+function laneSubtitle(sessions: SessionDto[], pivot: Pivot, machineDirectors: DirectorReachability[] = []): string {
   const n = sessions.length;
   const sessionWord = `${n} session${n === 1 ? "" : "s"}`;
   if (pivot === "machine") {
-    const directors = new Set(sessions.map((s) => (s.directorId ?? "").trim()).filter((x) => x.length > 0));
-    const d = directors.size;
+    // Count the machine's Directors from BOTH the sessions and the folded-in idle Directors, so an
+    // otherwise-empty machine still reads "1 director / 0 sessions" (an available slot) rather than
+    // "0 directors".
+    const ids = new Set<string>();
+    for (const s of sessions) {
+      const id = (s.directorId ?? "").trim();
+      if (id.length > 0) ids.add(id);
+    }
+    for (const d of machineDirectors) {
+      const id = (d.directorId ?? "").trim();
+      if (id.length > 0) ids.add(id);
+    }
+    const d = ids.size;
     return `${d} director${d === 1 ? "" : "s"} / ${sessionWord}`;
   }
   return sessionWord;
@@ -662,30 +712,8 @@ function flatSort(a: SessionDto, b: SessionDto): number {
   return String(a.sessionId ?? "").localeCompare(String(b.sessionId ?? ""));
 }
 
-function groupByDirector(sessions: SessionDto[]): Array<{ key: string; label: string; sessions: SessionDto[] }> {
-  const byDir = new Map<string, SessionDto[]>();
-  for (const s of sessions) {
-    const key = (s.directorId ?? "").trim();
-    const arr = byDir.get(key);
-    if (arr === undefined) byDir.set(key, [s]);
-    else arr.push(s);
-  }
-  return [...byDir.entries()]
-    .map(([key, arr]) => ({
-      key: key.length === 0 ? "(unknown)" : key,
-      label: `Director ${key.length === 0 ? "(unknown)" : shortDir(key)}`,
-      sessions: [...arr].sort(sessionSort),
-    }))
-    .sort((a, b) => a.key.localeCompare(b.key));
-}
-
-// A Director id shortened to its last segment (Directors are "<machine>-<n>" or a guid); keeps the
-// sub-header compact without losing which Director it is.
-function shortDir(directorId: string): string {
-  const dash = directorId.lastIndexOf("-");
-  const tail = dash >= 0 ? directorId.slice(dash + 1) : directorId;
-  return tail.length > 8 ? tail.slice(0, 8) : tail;
-}
+// groupByDirector and shortDir moved to fleetMapFormat.ts (pure, unit tested) - groupByDirector now folds
+// a machine's idle Directors in as empty groups so the machine pivot shows free slots. See the import.
 
 // The groupId "team" clustering that used to live here is GONE (issue #1626). It was a live consumer of
 // a producer that does not exist: SessionDto.groupId is only ever assigned from SessionManager's

--- a/apps/cockpit/src/fleet/fleetMapFormat.test.ts
+++ b/apps/cockpit/src/fleet/fleetMapFormat.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "vitest";
 import type { SessionDto } from "@devthrottle/client-core/api/client";
-import { agentBadgeText, buildControllerTree } from "./fleetMapFormat";
+import {
+  REACHABILITY_OFFLINE,
+  REACHABILITY_ONLINE,
+  REACHABILITY_WOBBLY,
+  type DirectorReachability,
+} from "@devthrottle/client-core/fleet/fleetClient";
+import {
+  agentBadgeText,
+  buildControllerTree,
+  groupByDirector,
+  machineKeyOf,
+  reachableDirectorsByMachine,
+} from "./fleetMapFormat";
 
 function session(overrides: Partial<SessionDto> = {}): SessionDto {
   return { sessionId: "s1", agent: "ClaudeCode", activityState: "Working", ...overrides } as SessionDto;
@@ -94,6 +106,85 @@ describe("buildControllerTree", () => {
 
   it("returns nothing for an empty lane", () => {
     expect(buildControllerTree([], byId)).toEqual([]);
+  });
+});
+
+function director(overrides: Partial<DirectorReachability> = {}): DirectorReachability {
+  return { directorId: "d1", machineName: "SOREN", state: REACHABILITY_ONLINE, ...overrides };
+}
+
+describe("machineKeyOf", () => {
+  it("keys a session and a Director with the same machine name to the same lane", () => {
+    // The whole join depends on this: a session on "SOREN" and a Director advertising " soren " must
+    // collapse onto one key, or the idle Director would open a second, empty "SOREN" lane.
+    expect(machineKeyOf("SOREN").key).toBe(machineKeyOf(" soren ").key);
+  });
+
+  it("falls back to (unknown machine) when the name is blank", () => {
+    expect(machineKeyOf("").title).toBe("(unknown machine)");
+    expect(machineKeyOf(null).title).toBe("(unknown machine)");
+    expect(machineKeyOf(undefined).title).toBe("(unknown machine)");
+  });
+});
+
+describe("reachableDirectorsByMachine", () => {
+  it("groups reachable Directors by their machine key", () => {
+    const out = reachableDirectorsByMachine([
+      director({ directorId: "a", machineName: "SOREN" }),
+      director({ directorId: "b", machineName: "SOREN" }),
+      director({ directorId: "c", machineName: "MAC" }),
+    ]);
+    const soren = out.find((m) => m.key === "soren");
+    const mac = out.find((m) => m.key === "mac");
+    expect(soren?.directors.map((d) => d.directorId)).toEqual(["a", "b"]);
+    expect(mac?.directors.map((d) => d.directorId)).toEqual(["c"]);
+  });
+
+  it("keeps a wobbly Director but drops an offline one - offline is not a free slot", () => {
+    const out = reachableDirectorsByMachine([
+      director({ directorId: "on", machineName: "M", state: REACHABILITY_ONLINE }),
+      director({ directorId: "wob", machineName: "M", state: REACHABILITY_WOBBLY }),
+      director({ directorId: "off", machineName: "M", state: REACHABILITY_OFFLINE }),
+    ]);
+    const m = out.find((x) => x.key === "m");
+    expect(m?.directors.map((d) => d.directorId)).toEqual(["on", "wob"]);
+  });
+});
+
+describe("groupByDirector", () => {
+  it("folds an idle Director in as an empty group - a free slot", () => {
+    const sessions = [session({ sessionId: "s1", directorId: "busy" })];
+    const out = groupByDirector(sessions, byId, [
+      director({ directorId: "busy" }),
+      director({ directorId: "idle" }),
+    ]);
+    const busy = out.find((g) => g.key === "busy");
+    const idle = out.find((g) => g.key === "idle");
+    expect(busy?.sessions.map((s) => s.sessionId)).toEqual(["s1"]);
+    expect(idle?.sessions).toEqual([]); // idle Director renders as a free slot
+  });
+
+  it("does not duplicate a Director that already has sessions", () => {
+    const sessions = [session({ sessionId: "s1", directorId: "d1" })];
+    const out = groupByDirector(sessions, byId, [director({ directorId: "d1" })]);
+    expect(out.filter((g) => g.key === "d1")).toHaveLength(1);
+    expect(out[0].sessions).toHaveLength(1);
+  });
+
+  it("skips a Director with no id - it is not an addressable slot", () => {
+    const out = groupByDirector([], byId, [director({ directorId: "" })]);
+    expect(out).toEqual([]);
+  });
+
+  it("groups sessions by Director when no idle list is given", () => {
+    const sessions = [
+      session({ sessionId: "s1", directorId: "a" }),
+      session({ sessionId: "s2", directorId: "a" }),
+      session({ sessionId: "s3", directorId: "b" }),
+    ];
+    const out = groupByDirector(sessions, byId);
+    expect(out.map((g) => g.key)).toEqual(["a", "b"]);
+    expect(out[0].sessions).toHaveLength(2);
   });
 });
 

--- a/apps/cockpit/src/fleet/fleetMapFormat.ts
+++ b/apps/cockpit/src/fleet/fleetMapFormat.ts
@@ -1,4 +1,5 @@
 import type { SessionDto } from "@devthrottle/client-core/api/client";
+import { REACHABILITY_OFFLINE, type DirectorReachability } from "@devthrottle/client-core/fleet/fleetClient";
 
 /**
  * Pure helpers for the Fleet Map's card rendering, kept out of FleetMapView.tsx so they can be unit
@@ -108,6 +109,97 @@ export function buildControllerTree(
   for (const r of roots) walk(r, 0);
 
   return out;
+}
+
+/**
+ * The machine identity used by the "By machine" pivot: the trimmed machine name, or "(unknown machine)"
+ * when a session/Director carries no name. Both sides of the machine join - the lanes built from sessions
+ * AND the reachable-Director list folded in on top of them - MUST key through this one function, or an
+ * idle Director could land in a machine lane that its sessions never key to (a session on "SOREN" and a
+ * Director advertising "soren " would split into two lanes). One rule, one key.
+ */
+export function machineKeyOf(machineName: string | null | undefined): { key: string; title: string } {
+  const name = (machineName ?? "").trim();
+  const title = name.length === 0 ? "(unknown machine)" : name;
+  return { key: title.toLowerCase(), title };
+}
+
+/** A Director id shortened to its last segment (Directors are "<machine>-<n>" or a guid); keeps a
+ * sub-header compact without losing which Director it is. */
+export function shortDir(directorId: string): string {
+  const dash = directorId.lastIndexOf("-");
+  const tail = dash >= 0 ? directorId.slice(dash + 1) : directorId;
+  return tail.length > 8 ? tail.slice(0, 8) : tail;
+}
+
+/** One machine's reachable Directors, keyed exactly as the machine pivot's lanes are (machineKeyOf). */
+export interface MachineDirectors {
+  key: string;
+  title: string;
+  directors: DirectorReachability[];
+}
+
+/**
+ * The reachable Directors (Online or Wobbly) grouped by machine, keyed EXACTLY as the machine pivot's
+ * lanes are (machineKeyOf), so a machine that has a Director but no sessions still resolves to a lane and
+ * shows as a free slot the owner can start a session on. An OFFLINE Director is excluded on purpose: it
+ * cannot host a session, so it is not a free slot - the roster already surfaces it in the
+ * unreachable-machines banner (machineErrors), and showing it here as available would be a lie.
+ */
+export function reachableDirectorsByMachine(directors: DirectorReachability[]): MachineDirectors[] {
+  const byKey = new Map<string, MachineDirectors>();
+  for (const d of directors) {
+    if (d.state === REACHABILITY_OFFLINE) continue;
+    const { key, title } = machineKeyOf(d.machineName);
+    let g = byKey.get(key);
+    if (g === undefined) {
+      g = { key, title, directors: [] };
+      byKey.set(key, g);
+    }
+    g.directors.push(d);
+  }
+  return [...byKey.values()];
+}
+
+/** One Director sub-group inside a machine lane; `sessions` is empty for an idle Director (a free slot). */
+export interface DirectorGroup {
+  key: string;
+  label: string;
+  sessions: SessionDto[];
+}
+
+/**
+ * Group a machine lane's sessions by their owning Director, then FOLD IN every reachable Director on the
+ * machine that currently has no sessions, so an idle Director renders as an empty group - a free slot.
+ * This is what makes "By machine" show capacity (machine -> Director -> session) rather than only the
+ * Directors that happen to be busy. `directors` is the machine's reachable-Director list; a Director
+ * already present via a session is never duplicated, and an unidentified Director (no id) is skipped
+ * because it is not an addressable slot. Groups are ordered by Director id so a lane never reflows.
+ */
+export function groupByDirector(
+  sessions: SessionDto[],
+  sort: (a: SessionDto, b: SessionDto) => number,
+  directors: DirectorReachability[] = [],
+): DirectorGroup[] {
+  const byDir = new Map<string, SessionDto[]>();
+  for (const s of sessions) {
+    const key = (s.directorId ?? "").trim();
+    const arr = byDir.get(key);
+    if (arr === undefined) byDir.set(key, [s]);
+    else arr.push(s);
+  }
+  for (const d of directors) {
+    const key = (d.directorId ?? "").trim();
+    if (key.length === 0) continue; // an unidentified Director is not an addressable slot
+    if (!byDir.has(key)) byDir.set(key, []); // idle Director -> empty group -> free slot
+  }
+  return [...byDir.entries()]
+    .map(([key, arr]) => ({
+      key: key.length === 0 ? "(unknown)" : key,
+      label: `Director ${key.length === 0 ? "(unknown)" : shortDir(key)}`,
+      sessions: [...arr].sort(sort),
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key));
 }
 
 /** The agent label to show on a card's meta row, or null when the card must not show one. */

--- a/apps/cockpit/src/fleet/fleetmap.css
+++ b/apps/cockpit/src/fleet/fleetmap.css
@@ -334,6 +334,17 @@
   background: var(--border);
 }
 
+/* An idle Director on the machine pivot: no sessions, so the sub-group renders this "free slot" line
+   instead of cards. A dashed, muted placeholder so it reads as available capacity, not a real node. */
+.fmap-freeslot {
+  border: 1px dashed var(--border);
+  border-radius: 9px;
+  padding: 9px 12px;
+  font-size: 12px;
+  color: var(--text-dim);
+  text-align: center;
+}
+
 /* team cluster */
 /* The .fmap-team / .fmap-team-cap / .fmap-team-tag rules are GONE (issue #1626): they styled the
    groupId clustering, which was a consumer of a producer that does not exist (no call site ever sets a


### PR DESCRIPTION
## Problem

On the Fleet Map, the **By machine** pivot only showed machines that already had running sessions. A machine with a reachable Director but no sessions was completely absent - which hides exactly the free capacity the owner wants to see when deciding where to start new work. The other pivots (repository, working tree, agent) correctly show only real sessions.

## Fix

Fold the roster envelope's reachable-Director list into the machine pivot only:

- Every reachable machine now gets a lane, even with zero sessions.
- Each idle Director inside a machine renders as a **free slot** placeholder.
- Offline Directors are excluded - they cannot host a session and already surface in the unreachable-machines banner.
- The header machine count now counts reachable machines, so it agrees with the lanes shown.
- Repository / working tree / agent pivots are untouched.

The machine key, the reachable-Director grouping, and the Director sub-grouping (now folding in idle Directors) moved to `fleetMapFormat.ts` as pure, unit-tested helpers, keyed through one shared `machineKeyOf` so a session lane and an idle Director lane always collapse onto the same machine.

## Verification

- `fleetMapFormat.test.ts`: unit tests for `machineKeyOf`, `reachableDirectorsByMachine` (keeps wobbly, drops offline), and `groupByDirector` (folds idle Directors, no duplicates, skips id-less).
- `FleetMapView.test.tsx`: new rendered (jsdom) test proving the idle machine lane and the free-slot placeholder actually paint, that the repository pivot does NOT fold idle Directors, and that an offline Director is excluded.
- Full cockpit suite (164 tests), typecheck, production build, and lint all green.