### PR TITLE
Repository screen slice 1: repository-status service (Core)

### DIFF
--- a/src/CcDirector.Core.Tests/RepositoryStatusServiceTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryStatusServiceTests.cs
@@ -1,0 +1,165 @@
+using System.Diagnostics;
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+public class RepositoryStatusClassifyTests
+{
+    [Theory]
+    [InlineData("https://github.com/foo/bar.git", RepoProvider.GitHub, "foo")]
+    [InlineData("git@github.com:foo/bar.git", RepoProvider.GitHub, "foo")]
+    [InlineData("https://github.com/thefrederiksen/devthrottle", RepoProvider.GitHub, "thefrederiksen")]
+    [InlineData("https://mindzie@dev.azure.com/mindzie/mindzieStudio1/_git/mindzieWeb", RepoProvider.AzureDevOps, "mindzie")]
+    [InlineData("git@ssh.dev.azure.com:v3/mindzie/mindzieStudio1/mindzieWeb", RepoProvider.AzureDevOps, "mindzie")]
+    [InlineData("https://gitlab.com/foo/bar.git", RepoProvider.Other, null)]
+    [InlineData("", RepoProvider.None, null)]
+    [InlineData(null, RepoProvider.None, null)]
+    public void ClassifyRemote_MapsUrlToProviderAndOrg(string? url, RepoProvider provider, string? org)
+    {
+        var (p, o) = RepositoryStatusService.ClassifyRemote(url);
+        Assert.Equal(provider, p);
+        Assert.Equal(org, o);
+    }
+}
+
+/// <summary>
+/// Integration tests over real repositories: a repo's status folds in its remote provider, its
+/// uncommitted count, and its worktree summary.
+/// </summary>
+public sealed class RepositoryStatusServiceTests : IDisposable
+{
+    private readonly string _root;
+
+    public RepositoryStatusServiceTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "ccd-repostatus-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            try { Directory.Delete(_root, recursive: true); return; }
+            catch { Thread.Sleep(100); }
+        }
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_CleanRepo_WithSafeWorktree_SummarisesWorktrees()
+    {
+        var (repo, _) = MakeRepoWithBareOrigin("app");
+
+        // A merged, clean linked worktree -> safe to reap.
+        var wt = Path.Combine(_root, "app-safe");
+        RunGit(repo, "worktree", "add", "-b", "done", wt, "main");
+        WriteFile(wt, "x.txt", "x\n");
+        RunGit(wt, "add", "-A");
+        RunGit(wt, "commit", "-m", "done work");
+        RunGit(wt, "push", "-u", "origin", "done");
+        RunGit(repo, "merge", "--ff-only", "done");
+        RunGit(repo, "push", "origin", "main");
+
+        var status = await new RepositoryStatusService().GetStatusAsync(repo, fetchPrune: false);
+
+        Assert.True(status.Success, status.Error);
+        Assert.Equal("main", status.Branch);
+        Assert.True(status.IsClean);
+        Assert.Equal(0, status.UncommittedCount);
+        Assert.Equal(1, status.WorktreeCount);
+        Assert.Equal(1, status.WorktreesSafeToReap);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_GitHubRemote_DirtyTree_ReportsProviderAndUncommitted()
+    {
+        var repo = Path.Combine(_root, "widget");
+        Directory.CreateDirectory(repo);
+        RunGit(repo, "-c", "init.defaultBranch=main", "init");
+        ConfigureIdentity(repo);
+        RunGit(repo, "remote", "add", "origin", "https://github.com/acme/widget.git");
+        WriteFile(repo, "README.md", "hi\n");
+        RunGit(repo, "add", "-A");
+        RunGit(repo, "commit", "-m", "initial");
+        // Leave an uncommitted change.
+        WriteFile(repo, "dirty.txt", "wip\n");
+
+        var status = await new RepositoryStatusService().GetStatusAsync(repo, fetchPrune: false);
+
+        Assert.True(status.Success, status.Error);
+        Assert.Equal(RepoProvider.GitHub, status.Provider);
+        Assert.Equal("acme", status.Org);
+        Assert.False(status.IsClean);
+        Assert.True(status.UncommittedCount >= 1);
+    }
+
+    [Fact]
+    public async Task ScanAsync_ReturnsReposUnderRoot_ExcludesWorktrees()
+    {
+        MakeRepoWithBareOrigin("one");
+        var (two, _) = MakeRepoWithBareOrigin("two");
+        // A worktree of "two" living under the root has a .git FILE, not a folder - not a repository.
+        RunGit(two, "worktree", "add", "--detach", Path.Combine(_root, "two-wt"));
+
+        var repos = await new RepositoryStatusService().ScanAsync(new[] { _root });
+
+        Assert.Equal(2, repos.Count);
+        Assert.Contains(repos, r => r.Name == "one");
+        Assert.Contains(repos, r => r.Name == "two");
+        Assert.DoesNotContain(repos, r => r.Name == "two-wt");
+    }
+
+    // ----- helpers -----
+
+    private (string Repo, string Origin) MakeRepoWithBareOrigin(string name)
+    {
+        var origin = Path.Combine(_root, name + ".git");
+        var repo = Path.Combine(_root, name);
+        RunGit(_root, "-c", "init.defaultBranch=main", "init", "--bare", origin);
+        RunGit(_root, "-c", "init.defaultBranch=main", "clone", origin, repo);
+        ConfigureIdentity(repo);
+        WriteFile(repo, "README.md", "init\n");
+        RunGit(repo, "add", "-A");
+        RunGit(repo, "commit", "-m", "initial");
+        RunGit(repo, "branch", "-M", "main");
+        RunGit(repo, "push", "-u", "origin", "main");
+        return (repo, origin);
+    }
+
+    private static void ConfigureIdentity(string repo)
+    {
+        RunGit(repo, "config", "user.email", "test@cc-director.local");
+        RunGit(repo, "config", "user.name", "CC Director Test");
+        RunGit(repo, "config", "commit.gpgsign", "false");
+    }
+
+    private static void WriteFile(string repo, string rel, string content)
+    {
+        var full = Path.Combine(repo, rel);
+        var dir = Path.GetDirectoryName(full);
+        if (dir != null) Directory.CreateDirectory(dir);
+        File.WriteAllText(full, content);
+    }
+
+    private static string RunGit(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        using var p = Process.Start(psi)!;
+        var outp = p.StandardOutput.ReadToEnd();
+        var err = p.StandardError.ReadToEnd();
+        p.WaitForExit();
+        if (p.ExitCode != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed ({p.ExitCode}): {err}");
+        return outp;
+    }
+}

--- a/src/CcDirector.Core/Git/RepositoryStatus.cs
+++ b/src/CcDirector.Core/Git/RepositoryStatus.cs
@@ -1,0 +1,61 @@
+namespace CcDirector.Core.Git;
+
+/// <summary>Which hosting service a repository's origin remote points at.</summary>
+public enum RepoProvider
+{
+    /// <summary>No origin remote (or the URL could not be read).</summary>
+    None,
+
+    /// <summary>github.com.</summary>
+    GitHub,
+
+    /// <summary>dev.azure.com / *.visualstudio.com.</summary>
+    AzureDevOps,
+
+    /// <summary>Has a remote, but not one we recognise.</summary>
+    Other,
+}
+
+/// <summary>
+/// The at-a-glance state of one on-disk repository: where its remote lives, how far its branch has
+/// drifted, how much is uncommitted, and a summary of its worktrees. Composed on the service side
+/// from the existing git providers plus the worktree detector; the UI renders it.
+/// </summary>
+public sealed class RepositoryStatus
+{
+    public string Path { get; init; } = "";
+    public string Name { get; init; } = "";
+
+    /// <summary>The origin remote URL, or null when there is no origin.</summary>
+    public string? RemoteUrl { get; init; }
+
+    public RepoProvider Provider { get; init; }
+
+    /// <summary>GitHub owner or Azure DevOps org, parsed from the remote URL; null when unknown.</summary>
+    public string? Org { get; init; }
+
+    public string Branch { get; init; } = "";
+    public bool IsDetachedHead { get; init; }
+    public bool HasUpstream { get; init; }
+
+    public int AheadCount { get; init; }
+    public int BehindCount { get; init; }
+
+    /// <summary>How far the branch is behind origin/main; -1 when it is on main already or unknown.</summary>
+    public int BehindMainCount { get; init; }
+
+    public bool IsClean { get; init; }
+
+    /// <summary>Modified, staged, and untracked entries reported by <c>git status --porcelain</c>.</summary>
+    public int UncommittedCount { get; init; }
+
+    /// <summary>Linked worktrees for this repository (excludes the primary checkout).</summary>
+    public int WorktreeCount { get; init; }
+
+    public int WorktreesSafeToReap { get; init; }
+    public int WorktreesInUse { get; init; }
+    public int WorktreesNeedAttention { get; init; }
+
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+}

--- a/src/CcDirector.Core/Git/RepositoryStatusService.cs
+++ b/src/CcDirector.Core/Git/RepositoryStatusService.cs
@@ -1,0 +1,138 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// Computes the at-a-glance status of on-disk repositories for the Repository screen. It composes
+/// the pieces that already exist - remote URL, sync (ahead/behind), uncommitted count, and the
+/// worktree triage - into one <see cref="RepositoryStatus"/> per repo. Reads only; never fetches by
+/// default (uses the last-known remote-tracking refs), so a whole-machine scan stays fast.
+/// </summary>
+public sealed class RepositoryStatusService
+{
+    private readonly GitCommandRunner _git;
+    private readonly GitStatusProvider _status;
+    private readonly GitSyncStatusProvider _sync;
+    private readonly WorktreeInventoryService _worktrees;
+
+    public RepositoryStatusService(
+        GitCommandRunner? git = null,
+        GitStatusProvider? status = null,
+        GitSyncStatusProvider? sync = null,
+        WorktreeInventoryService? worktrees = null)
+    {
+        _git = git ?? new GitCommandRunner();
+        _status = status ?? new GitStatusProvider();
+        _sync = sync ?? new GitSyncStatusProvider();
+        _worktrees = worktrees ?? new WorktreeInventoryService();
+    }
+
+    /// <summary>
+    /// Enumerates the git repositories directly under each root directory and returns each one's
+    /// status. A worktree (which carries a <c>.git</c> file, not a folder) is not a repository here -
+    /// only real checkouts are returned; a repo's worktrees are summarised on its own status.
+    /// </summary>
+    public async Task<IReadOnlyList<RepositoryStatus>> ScanAsync(
+        IEnumerable<string> rootPaths,
+        IReadOnlyList<LiveSessionRef>? liveSessions = null,
+        CancellationToken ct = default)
+    {
+        FileLog.Write("[RepositoryStatusService] ScanAsync");
+        var results = new List<RepositoryStatus>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var root in rootPaths)
+        {
+            if (string.IsNullOrWhiteSpace(root))
+                continue;
+            foreach (var (_, path) in RemoteRepoProvider.ScanLocalRepos(root))
+            {
+                if (!seen.Add(WorktreeReaperService.NormalizePath(path)))
+                    continue; // a repo reachable from two roots is listed once
+                results.Add(await GetStatusAsync(path, liveSessions, fetchPrune: false, ct));
+            }
+        }
+
+        FileLog.Write($"[RepositoryStatusService] ScanAsync: {results.Count} repositories");
+        return results;
+    }
+
+    /// <summary>
+    /// Builds the status of a single repository. <paramref name="fetchPrune"/> is off by default so a
+    /// scan does not hit the network per repo; pass true for an explicit refresh of one repo.
+    /// </summary>
+    public async Task<RepositoryStatus> GetStatusAsync(
+        string repoPath,
+        IReadOnlyList<LiveSessionRef>? liveSessions = null,
+        bool fetchPrune = false,
+        CancellationToken ct = default)
+    {
+        FileLog.Write($"[RepositoryStatusService] GetStatusAsync: {repoPath}");
+        try
+        {
+            if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
+                return new RepositoryStatus { Path = repoPath, Success = false, Error = $"repository path not found: {repoPath}" };
+
+            var remoteUrl = await ReadOriginUrlAsync(repoPath, ct);
+            var (provider, org) = ClassifyRemote(remoteUrl);
+
+            var sync = await _sync.GetSyncStatusAsync(repoPath);
+            var uncommitted = await _status.GetCountAsync(repoPath);
+            var inventory = await _worktrees.GetInventoryAsync(repoPath, fetchPrune, liveSessions, ct);
+
+            var safe = inventory.SafeToReapCount;
+            var inUse = inventory.InUseBySession.Count;
+            var needs = inventory.NeedsAttention.Count;
+
+            return new RepositoryStatus
+            {
+                Path = repoPath,
+                Name = System.IO.Path.GetFileName(repoPath.TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar)),
+                RemoteUrl = remoteUrl,
+                Provider = provider,
+                Org = org,
+                Branch = sync.BranchName,
+                IsDetachedHead = sync.IsDetachedHead,
+                HasUpstream = sync.HasUpstream,
+                AheadCount = sync.AheadCount,
+                BehindCount = sync.BehindCount,
+                BehindMainCount = sync.BehindMainCount,
+                IsClean = uncommitted == 0,
+                UncommittedCount = uncommitted,
+                WorktreeCount = safe + inUse + needs,
+                WorktreesSafeToReap = safe,
+                WorktreesInUse = inUse,
+                WorktreesNeedAttention = needs,
+                Success = true,
+            };
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryStatusService] GetStatusAsync FAILED: {ex.Message}");
+            return new RepositoryStatus { Path = repoPath, Success = false, Error = ex.Message };
+        }
+    }
+
+    /// <summary>Classifies an origin remote URL into a provider and its owner/org. Pure and testable.</summary>
+    internal static (RepoProvider Provider, string? Org) ClassifyRemote(string? remoteUrl)
+    {
+        if (string.IsNullOrWhiteSpace(remoteUrl))
+            return (RepoProvider.None, null);
+
+        var gh = GitHubUrls.TryGitHubOwnerRepo(remoteUrl);
+        if (gh is { } g)
+            return (RepoProvider.GitHub, g.Owner);
+
+        var az = GitHubUrls.TryAzureDevOpsOrgRepo(remoteUrl);
+        if (az is { } a)
+            return (RepoProvider.AzureDevOps, a.Org);
+
+        return (RepoProvider.Other, null);
+    }
+
+    private async Task<string?> ReadOriginUrlAsync(string repoPath, CancellationToken ct)
+    {
+        var result = await _git.RunAsync(repoPath, new[] { "remote", "get-url", "origin" }, ct);
+        return result.Success && !string.IsNullOrWhiteSpace(result.Output) ? result.Output.Trim() : null;
+    }
+}

--- a/src/CcDirector.Core/Utilities/GitHubUrls.cs
+++ b/src/CcDirector.Core/Utilities/GitHubUrls.cs
@@ -117,6 +117,14 @@ public static class GitHubUrls
         throw new InvalidOperationException($"Origin is not a recognized GitHub or Azure DevOps remote: {originUrl}");
     }
 
+    /// <summary>GitHub (owner, repo) from a remote URL, or null when it is not a github.com remote. Non-throwing.</summary>
+    public static (string Owner, string Repo)? TryGitHubOwnerRepo(string? url)
+        => string.IsNullOrWhiteSpace(url) ? null : TryMatchGitHub(url.Trim());
+
+    /// <summary>Azure DevOps (org, repo) from a remote URL, or null when it is not an Azure DevOps remote. Non-throwing.</summary>
+    public static (string Org, string Repo)? TryAzureDevOpsOrgRepo(string? url)
+        => string.IsNullOrWhiteSpace(url) ? null : TryMatchAzureDevOps(url.Trim());
+
     // GitHub remote -> (owner, repo), or null when the URL is not a github.com remote. Accepts the SSH
     // (git@github.com:owner/repo), ssh:// and https:// shapes; the ".git" suffix is optional.
     private static (string owner, string repo)? TryMatchGitHub(string url)


### PR DESCRIPTION
First slice of the Repository screen (spec thefrederiksen/devthrottle_internal#506). Core only, no UI yet.

## What this adds
A read-only `RepositoryStatusService` that folds each on-disk repo's state into one `RepositoryStatus`:
- **Provider + org** parsed from the origin remote URL (GitHub owner / Azure DevOps org) - so a repo self-identifies, no account registration.
- **Sync** - branch, ahead/behind, behind-main (reusing `GitSyncStatusProvider`).
- **Uncommitted count** (reusing `GitStatusProvider`).
- **Worktree summary** - total, safe-to-reap, in-use-by-a-session, needs-attention (reusing the shipped `WorktreeInventoryService`).

`ScanAsync` enumerates the real repositories under each root directory - a worktree carries a `.git` file (not a folder), so it is never mistaken for a repo. Reads only; never fetches by default so a whole-machine scan stays fast. No new auth: the remote URL is read locally with `git remote get-url`.

Two non-throwing wrappers were added to `GitHubUrls` (`TryGitHubOwnerRepo` / `TryAzureDevOpsOrgRepo`) reusing its existing matchers, so provider/org classification has no duplicated regex.

## Tests
- Provider/org classification: GitHub (https + ssh), Azure DevOps (https + ssh), unknown, empty/null.
- Real-git: a clean repo with a merged worktree summarises worktrees (1 safe); a GitHub-remote repo with a dirty tree reports provider `GitHub`, org, and the uncommitted count; `ScanAsync` returns the repos under a root and excludes worktrees.
- 11 new tests; full Core.Tests suite 3345 passed, 8 skipped, 0 failed.

## Next slices
Repository list + per-repo detail view (Changes / Worktrees / Branches) reading this service; then the Pull requests tab; then the session flag.