### PR TITLE
Repository screen slice 2: repository list view

### DIFF
--- a/src/CcDirector.Avalonia.Tests/RepositoryListViewRenderTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoryListViewRenderTests.cs
@@ -1,0 +1,21 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using CcDirector.Avalonia.Controls;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+public class RepositoryListViewRenderTests
+{
+    [AvaloniaFact]
+    public void RepositoryListView_LoadsAndLaysOut()
+    {
+        var view = new RepositoryListView();
+        var window = new Window { Content = view, Width = 900, Height = 600 };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(view);
+    }
+}

--- a/src/CcDirector.Avalonia.Tests/RepositoryListViewTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoryListViewTests.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using CcDirector.Avalonia.Controls;
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+public class RepositoryListViewTests
+{
+    private static RepositoryStatus Repo(
+        string name,
+        RepoProvider provider = RepoProvider.GitHub,
+        string? org = "acme",
+        bool clean = true,
+        int uncommitted = 0,
+        int ahead = 0,
+        int behind = 0,
+        int behindMain = 0,
+        bool detached = false,
+        int worktrees = 0,
+        int safe = 0,
+        int inUse = 0,
+        int attn = 0) => new()
+    {
+        Path = $"/repo/{name}",
+        Name = name,
+        Provider = provider,
+        Org = org,
+        IsClean = clean,
+        UncommittedCount = uncommitted,
+        AheadCount = ahead,
+        BehindCount = behind,
+        BehindMainCount = behindMain,
+        IsDetachedHead = detached,
+        WorktreeCount = worktrees,
+        WorktreesSafeToReap = safe,
+        WorktreesInUse = inUse,
+        WorktreesNeedAttention = attn,
+        Success = true,
+    };
+
+    [Theory]
+    [InlineData(RepoProvider.GitHub, "GitHub")]
+    [InlineData(RepoProvider.AzureDevOps, "Azure DevOps")]
+    [InlineData(RepoProvider.Other, "Git")]
+    [InlineData(RepoProvider.None, "local")]
+    public void ProviderLabel_Maps(RepoProvider p, string expected) =>
+        Assert.Equal(expected, RepositoryListView.ProviderLabel(p));
+
+    [Fact]
+    public void WhereText_CleanVsDirty()
+    {
+        Assert.Equal("clean", RepositoryListView.WhereText(Repo("a", clean: true)));
+        Assert.Equal("3 uncommitted", RepositoryListView.WhereText(Repo("a", clean: false, uncommitted: 3)));
+    }
+
+    [Fact]
+    public void SyncText_Cases()
+    {
+        Assert.Equal("up to date", RepositoryListView.SyncText(Repo("a")));
+        Assert.Equal("ahead 2", RepositoryListView.SyncText(Repo("a", ahead: 2)));
+        Assert.Equal("behind 5", RepositoryListView.SyncText(Repo("a", behind: 5)));
+        Assert.Equal("ahead 1, behind main 3", RepositoryListView.SyncText(Repo("a", ahead: 1, behindMain: 3)));
+        Assert.Equal("detached HEAD", RepositoryListView.SyncText(Repo("a", detached: true)));
+    }
+
+    [Fact]
+    public void WorktreeText_Cases()
+    {
+        Assert.Equal("no worktrees", RepositoryListView.WorktreeText(Repo("a")));
+        Assert.Equal("1 worktree · 1 safe", RepositoryListView.WorktreeText(Repo("a", worktrees: 1, safe: 1)));
+        Assert.Equal("3 worktrees · 1 safe · 1 in use · 1 attention",
+            RepositoryListView.WorktreeText(Repo("a", worktrees: 3, safe: 1, inUse: 1, attn: 1)));
+    }
+
+    [Fact]
+    public void BuildRows_OrdersSafeReapThenDirtyThenName()
+    {
+        var rows = RepositoryListView.BuildRows(new[]
+        {
+            Repo("zeta"),
+            Repo("dirty", clean: false, uncommitted: 2),
+            Repo("reapable", worktrees: 2, safe: 2),
+            Repo("alpha"),
+        });
+
+        Assert.Equal("reapable", rows[0].Name);  // has safe-to-reap worktrees
+        Assert.Equal("dirty", rows[1].Name);     // then uncommitted work
+        Assert.Equal("alpha", rows[2].Name);     // then alphabetical
+        Assert.Equal("zeta", rows[3].Name);
+    }
+
+    [Fact]
+    public void BuildRows_CarriesDisplayFields()
+    {
+        var row = Assert.Single(RepositoryListView.BuildRows(new[]
+        {
+            Repo("widget", provider: RepoProvider.AzureDevOps, org: "mindzie", worktrees: 2, safe: 1, inUse: 1),
+        }));
+        Assert.Equal("widget", row.Name);
+        Assert.Equal("Azure DevOps", row.Provider);
+        Assert.True(row.HasProvider);
+        Assert.Contains("mindzie", row.SubPath);
+        Assert.Equal("2 worktrees · 1 safe · 1 in use", row.Worktrees);
+    }
+
+    [Fact]
+    public void BuildSummary_CountsReposDirtyAndReapable()
+    {
+        var summary = RepositoryListView.BuildSummary(new[]
+        {
+            Repo("a"),
+            Repo("b", clean: false, uncommitted: 1),
+            Repo("c", worktrees: 3, safe: 2),
+        });
+        Assert.Equal("3 on disk · 1 with uncommitted work · 2 worktrees to reap", summary);
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml
+++ b/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml
@@ -1,0 +1,74 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:CcDirector.Avalonia.Controls"
+             x:Class="CcDirector.Avalonia.Controls.RepositoryListView"
+             Background="#1E1E1E">
+
+    <UserControl.DataTemplates>
+        <DataTemplate DataType="controls:RepoRowItem">
+            <Border Background="#252526"
+                    BorderBrush="#3C3C3C"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    Padding="12,9"
+                    Margin="0,0,0,7">
+                <Grid ColumnDefinitions="*,Auto,Auto,Auto">
+                    <!-- Identity -->
+                    <StackPanel Grid.Column="0" Spacing="3" VerticalAlignment="Center">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBlock Text="{Binding Name}" Foreground="#CCCCCC" FontSize="14" FontWeight="Medium" />
+                            <Border Background="Transparent" BorderBrush="#3C3C3C" BorderThickness="1" CornerRadius="4"
+                                    Padding="6,1" VerticalAlignment="Center" IsVisible="{Binding HasProvider}">
+                                <TextBlock Text="{Binding Provider}" Foreground="#8A8A8A" FontSize="9.5" />
+                            </Border>
+                        </StackPanel>
+                        <TextBlock Text="{Binding SubPath}" Foreground="#666666" FontSize="10.5"
+                                   FontFamily="Cascadia Mono, Consolas" TextTrimming="CharacterEllipsis" />
+                    </StackPanel>
+
+                    <!-- Where / dirty -->
+                    <Border Grid.Column="1" CornerRadius="6" Padding="7,2" Margin="8,0,0,0" VerticalAlignment="Center"
+                            Background="{Binding WhereBg}" BorderBrush="{Binding WhereBr}" BorderThickness="1">
+                        <TextBlock Text="{Binding Where}" Foreground="{Binding WhereFg}" FontSize="10.5"
+                                   FontFamily="Cascadia Mono, Consolas" />
+                    </Border>
+
+                    <!-- Sync -->
+                    <TextBlock Grid.Column="2" Text="{Binding Sync}" Foreground="#8A8A8A" FontSize="11"
+                               FontFamily="Cascadia Mono, Consolas" VerticalAlignment="Center"
+                               Margin="14,0,0,0" MinWidth="120" />
+
+                    <!-- Worktrees -->
+                    <Border Grid.Column="3" CornerRadius="6" Padding="7,2" Margin="14,0,0,0" VerticalAlignment="Center"
+                            Background="{Binding WorktreeBg}" BorderBrush="{Binding WorktreeBr}" BorderThickness="1">
+                        <TextBlock Text="{Binding Worktrees}" Foreground="{Binding WorktreeFg}" FontSize="10.5"
+                                   FontFamily="Cascadia Mono, Consolas" />
+                    </Border>
+                </Grid>
+            </Border>
+        </DataTemplate>
+    </UserControl.DataTemplates>
+
+    <Grid RowDefinitions="Auto,*">
+        <!-- Header -->
+        <Border Grid.Row="0" Background="#252526" BorderBrush="#3C3C3C" BorderThickness="0,0,0,1" Padding="12,8">
+            <Grid ColumnDefinitions="Auto,*,Auto">
+                <TextBlock Grid.Column="0" Text="REPOSITORIES" Foreground="#CCCCCC" FontSize="12"
+                           FontWeight="SemiBold" VerticalAlignment="Center" />
+                <TextBlock Grid.Column="1" x:Name="SummaryText" Text="" Foreground="#8A8A8A" FontSize="11"
+                           VerticalAlignment="Center" Margin="12,0,0,0" />
+                <Button Grid.Column="2" x:Name="RefreshButton" Content="Refresh" Background="#3C3C3C"
+                        Foreground="#CCCCCC" Padding="12,4" FontSize="11" Click="RefreshButton_Click" />
+            </Grid>
+        </Border>
+
+        <Panel Grid.Row="1">
+            <TextBlock x:Name="StatusText" Text="Scanning repositories..." Foreground="#888888" FontSize="12"
+                       FontStyle="Italic" HorizontalAlignment="Center" VerticalAlignment="Center" IsVisible="True" />
+            <ScrollViewer x:Name="ContentScroller" VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled" IsVisible="False">
+                <ItemsControl x:Name="RepoList" Margin="12" />
+            </ScrollViewer>
+        </Panel>
+    </Grid>
+</UserControl>

--- a/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Git;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia.Controls;
+
+/// <summary>One repository row, built from a <see cref="RepositoryStatus"/> - plain display data.</summary>
+public sealed class RepoRowItem
+{
+    public string Name { get; init; } = "";
+    public string SubPath { get; init; } = "";
+    public string Provider { get; init; } = "";
+    public bool HasProvider => Provider.Length > 0;
+    public string Where { get; init; } = "";
+    public string Sync { get; init; } = "";
+    public string Worktrees { get; init; } = "";
+
+    public ISolidColorBrush WhereFg { get; init; } = Brushes.Gray;
+    public ISolidColorBrush WhereBg { get; init; } = Brushes.Transparent;
+    public ISolidColorBrush WhereBr { get; init; } = Brushes.Gray;
+    public ISolidColorBrush WorktreeFg { get; init; } = Brushes.Gray;
+    public ISolidColorBrush WorktreeBg { get; init; } = Brushes.Transparent;
+    public ISolidColorBrush WorktreeBr { get; init; } = Brushes.Gray;
+
+    public string Path { get; init; } = "";
+}
+
+/// <summary>
+/// The Repository list: every repository on disk under the configured root directories, with its
+/// where/dirty state, sync, and worktree summary. Renders the verdict computed by
+/// <see cref="RepositoryStatusService"/>; passes live sessions through so a worktree a session is in
+/// is counted as "in use", not "safe".
+/// </summary>
+public partial class RepositoryListView : UserControl
+{
+    private static readonly ISolidColorBrush Green = new SolidColorBrush(Color.Parse("#22C55E"));
+    private static readonly ISolidColorBrush GreenBg = new SolidColorBrush(Color.Parse("#1B3A2A"));
+    private static readonly ISolidColorBrush GreenBr = new SolidColorBrush(Color.Parse("#1E5138"));
+    private static readonly ISolidColorBrush Amber = new SolidColorBrush(Color.Parse("#F59E0B"));
+    private static readonly ISolidColorBrush AmberBg = new SolidColorBrush(Color.Parse("#3A2A1B"));
+    private static readonly ISolidColorBrush AmberBr = new SolidColorBrush(Color.Parse("#5A4326"));
+    private static readonly ISolidColorBrush Muted = new SolidColorBrush(Color.Parse("#8A8A8A"));
+    private static readonly ISolidColorBrush MutedBg = new SolidColorBrush(Color.Parse("#2D2D30"));
+    private static readonly ISolidColorBrush MutedBr = new SolidColorBrush(Color.Parse("#3C3C3C"));
+
+    private readonly RepositoryStatusService _service = new();
+    private RootDirectoryStore? _store;
+    private bool _isLoading;
+
+    /// <summary>Live sessions on this machine, so the worktree summary distinguishes in-use from safe. Optional.</summary>
+    public Func<CancellationToken, Task<IReadOnlyList<LiveSessionRef>>>? LiveSessionsProvider { get; set; }
+
+    public RepositoryListView()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>Point the view at the configured root directories and scan.</summary>
+    public void Attach(RootDirectoryStore store)
+    {
+        FileLog.Write("[RepositoryListView] Attach");
+        _store = store;
+        _ = RefreshAsync();
+    }
+
+    private void RefreshButton_Click(object? sender, RoutedEventArgs e) => _ = RefreshAsync();
+
+    private async Task RefreshAsync()
+    {
+        if (_store is null || _isLoading)
+            return;
+
+        _isLoading = true;
+        StatusText.Text = "Scanning repositories...";
+        StatusText.IsVisible = true;
+        ContentScroller.IsVisible = false;
+
+        try
+        {
+            var roots = _store.Roots.Select(r => r.Path).Where(p => !string.IsNullOrWhiteSpace(p)).ToList();
+            var sessions = await FetchLiveSessionsAsync();
+            var statuses = await Task.Run(() => _service.ScanAsync(roots, sessions));
+
+            var rows = BuildRows(statuses);
+            RepoList.ItemsSource = rows;
+
+            if (rows.Count == 0)
+            {
+                StatusText.Text = roots.Count == 0
+                    ? "No root directories are configured. Add one in Repositories."
+                    : "No repositories found under the configured root directories.";
+                StatusText.IsVisible = true;
+                ContentScroller.IsVisible = false;
+            }
+            else
+            {
+                SummaryText.Text = BuildSummary(statuses);
+                StatusText.IsVisible = false;
+                ContentScroller.IsVisible = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryListView] RefreshAsync FAILED: {ex.Message}");
+            StatusText.Text = $"Could not scan repositories: {ex.Message}";
+            StatusText.IsVisible = true;
+            ContentScroller.IsVisible = false;
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task<IReadOnlyList<LiveSessionRef>> FetchLiveSessionsAsync()
+    {
+        try
+        {
+            if (LiveSessionsProvider is { } provider)
+                return await provider(CancellationToken.None) ?? Array.Empty<LiveSessionRef>();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryListView] FetchLiveSessionsAsync FAILED (proceeding without session data): {ex.Message}");
+        }
+        return Array.Empty<LiveSessionRef>();
+    }
+
+    // ----- pure builders (unit-tested without a UI) -----
+
+    internal static IReadOnlyList<RepoRowItem> BuildRows(IReadOnlyList<RepositoryStatus> statuses) =>
+        statuses
+            .OrderByDescending(s => s.WorktreesSafeToReap)
+            .ThenByDescending(s => s.UncommittedCount)
+            .ThenBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(ToRow)
+            .ToList();
+
+    private static RepoRowItem ToRow(RepositoryStatus s)
+    {
+        bool dirty = !s.IsClean;
+        bool hasReap = s.WorktreesSafeToReap > 0;
+        return new RepoRowItem
+        {
+            Name = s.Name,
+            SubPath = SubPathFor(s),
+            Provider = ProviderLabel(s.Provider),
+            Where = WhereText(s),
+            Sync = SyncText(s),
+            Worktrees = WorktreeText(s),
+            WhereFg = dirty ? Amber : Green,
+            WhereBg = dirty ? AmberBg : GreenBg,
+            WhereBr = dirty ? AmberBr : GreenBr,
+            WorktreeFg = hasReap ? Green : Muted,
+            WorktreeBg = hasReap ? GreenBg : MutedBg,
+            WorktreeBr = hasReap ? GreenBr : MutedBr,
+            Path = s.Path,
+        };
+    }
+
+    internal static string ProviderLabel(RepoProvider p) => p switch
+    {
+        RepoProvider.GitHub => "GitHub",
+        RepoProvider.AzureDevOps => "Azure DevOps",
+        RepoProvider.Other => "Git",
+        _ => "local",
+    };
+
+    private static string SubPathFor(RepositoryStatus s) =>
+        s.Org is { Length: > 0 } ? $"{s.Org} · {s.Path}" : s.Path;
+
+    internal static string WhereText(RepositoryStatus s) =>
+        s.IsClean ? "clean" : $"{s.UncommittedCount} uncommitted";
+
+    internal static string SyncText(RepositoryStatus s)
+    {
+        if (s.IsDetachedHead)
+            return "detached HEAD";
+
+        var parts = new List<string>();
+        if (s.AheadCount > 0) parts.Add($"ahead {s.AheadCount}");
+        if (s.BehindCount > 0) parts.Add($"behind {s.BehindCount}");
+        if (s.BehindMainCount > 0) parts.Add($"behind main {s.BehindMainCount}");
+        return parts.Count == 0 ? "up to date" : string.Join(", ", parts);
+    }
+
+    internal static string WorktreeText(RepositoryStatus s)
+    {
+        if (s.WorktreeCount == 0)
+            return "no worktrees";
+
+        var parts = new List<string> { $"{s.WorktreeCount} worktree{(s.WorktreeCount == 1 ? "" : "s")}" };
+        if (s.WorktreesSafeToReap > 0) parts.Add($"{s.WorktreesSafeToReap} safe");
+        if (s.WorktreesInUse > 0) parts.Add($"{s.WorktreesInUse} in use");
+        if (s.WorktreesNeedAttention > 0) parts.Add($"{s.WorktreesNeedAttention} attention");
+        return string.Join(" · ", parts);
+    }
+
+    internal static string BuildSummary(IReadOnlyList<RepositoryStatus> statuses)
+    {
+        int repos = statuses.Count;
+        int dirty = statuses.Count(s => !s.IsClean);
+        int reap = statuses.Sum(s => s.WorktreesSafeToReap);
+        return $"{repos} on disk · {dirty} with uncommitted work · {reap} worktrees to reap";
+    }
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -3692,6 +3692,12 @@ public partial class MainWindow : Window
                 }
             }
         }));
+        session.Menu.Items.Add(Item("Repository status...", async () =>
+        {
+            FileLog.Write("[MainWindow] Menu: Repository status");
+            var window = new RepositoryScreenWindow(AppRef().RootDirectoryStore, GetLiveSessionsOnThisMachineAsync);
+            await window.ShowDialog(this);
+        }));
         if (alpha)
         {
             session.Menu.Items.Add(new NativeMenuItemSeparator());

--- a/src/CcDirector.Avalonia/RepositoryScreenWindow.axaml
+++ b/src/CcDirector.Avalonia/RepositoryScreenWindow.axaml
@@ -1,0 +1,12 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:CcDirector.Avalonia.Controls"
+        x:Class="CcDirector.Avalonia.RepositoryScreenWindow"
+        Title="Repositories"
+        Width="920" Height="620"
+        MinWidth="680" MinHeight="420"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True"
+        Background="#1E1E1E">
+    <controls:RepositoryListView x:Name="ListView" />
+</Window>

--- a/src/CcDirector.Avalonia/RepositoryScreenWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/RepositoryScreenWindow.axaml.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Git;
+
+namespace CcDirector.Avalonia;
+
+/// <summary>
+/// A thin window hosting the Repository list. Transitional shell while the screen is a pop-up; the
+/// list control is the same one that will embed in the main window later.
+/// </summary>
+public partial class RepositoryScreenWindow : Window
+{
+    public RepositoryScreenWindow()
+    {
+        InitializeComponent();
+    }
+
+    public RepositoryScreenWindow(RootDirectoryStore store,
+        Func<CancellationToken, Task<IReadOnlyList<LiveSessionRef>>>? liveSessionsProvider = null) : this()
+    {
+        ListView.LiveSessionsProvider = liveSessionsProvider;
+        ListView.Attach(store);
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+}


### PR DESCRIPTION
Slice 2 of the Repository screen (spec thefrederiksen/devthrottle_internal#506). Director-only UI, reading the slice-1 service.

## What this adds
`RepositoryListView` - every repository on disk under the configured root directories, one row each with:
- **Provider + org** (self-identified from the remote URL - GitHub / Azure DevOps).
- **Where / dirty** - clean vs N uncommitted.
- **Sync** - ahead / behind / behind main, or detached.
- **Worktree summary** - total, safe-to-reap, in use by a session, needs attention.

Live sessions are passed through (MainWindow's fleet provider) so a worktree a session is running in is counted as **in use**, not safe. Rows are ordered safe-to-reap first, then uncommitted, then by name, so what needs action is at the top. Async scan with immediate feedback; clear message on failure or when no roots are configured.

Reachable via **Session -> "Repository status..."** in a thin hosting window. This is transitional - the same list control will embed in the main window in a later slice; the existing Repository Manager dialog is untouched.

## Tests
- Pure builders: provider label, where/sync/worktree text, row ordering + fields, summary line.
- Headless render test constructs and lays out the control.
- 11 new tests; full Avalonia.Tests suite 266 passed, 0 failed.

## Next slices
Per-repo detail (Changes / Worktrees / Branches, reusing the shipped views); Pull requests tab; session flag; then embed the screen in the main window.