### PR TITLE
Fix: Repository status window opened to nothing (null named control)

### DIFF
--- a/src/CcDirector.Avalonia.Tests/RepositoryListViewRenderTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoryListViewRenderTests.cs
@@ -1,7 +1,10 @@
+using System;
+using System.IO;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using CcDirector.Avalonia.Controls;
+using CcDirector.Core.Configuration;
 using Xunit;
 
 namespace CcDirector.Avalonia.Tests;
@@ -17,5 +20,20 @@ public class RepositoryListViewRenderTests
         Dispatcher.UIThread.RunJobs();
 
         Assert.NotNull(view);
+    }
+
+    [AvaloniaFact]
+    public void RepositoryScreenWindow_Constructs_AndWiresNamedControls()
+    {
+        // Reproduces the "Repository status..." menu path. A hand-written InitializeComponent that
+        // skipped the generated named-field hookup left ListView null and threw in this constructor.
+        var store = new RootDirectoryStore(
+            Path.Combine(Path.GetTempPath(), "ccd-rootstore-" + Guid.NewGuid().ToString("N") + ".json"));
+
+        var window = new global::CcDirector.Avalonia.RepositoryScreenWindow(store, null);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(window);
     }
 }

--- a/src/CcDirector.Avalonia/RepositoryScreenWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/RepositoryScreenWindow.axaml.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Git;
 
@@ -17,6 +16,8 @@ public partial class RepositoryScreenWindow : Window
 {
     public RepositoryScreenWindow()
     {
+        // The generated InitializeComponent wires the x:Name controls (ListView). Do NOT replace it
+        // with a bare AvaloniaXamlLoader.Load(this) - that skips the field hookup and leaves ListView null.
         InitializeComponent();
     }
 
@@ -26,6 +27,4 @@ public partial class RepositoryScreenWindow : Window
         ListView.LiveSessionsProvider = liveSessionsProvider;
         ListView.Attach(store);
     }
-
-    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 }


### PR DESCRIPTION
The Session -> "Repository status..." menu item appeared to do nothing. RepositoryScreenWindow hand-wrote InitializeComponent as a bare AvaloniaXamlLoader.Load(this), which skips the generated x:Name field hookup - so ListView was null and the constructor threw NullReferenceException. Uses the generated InitializeComponent like every other window. Adds a headless test that constructs the window via the menu's constructor (reproduced the crash before the fix). Full Avalonia.Tests: 267 passed.