### PR TITLE
Serve Transcription Health per-tenant on hosted (#2059)

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedContentDenyGroupFilterTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentDenyGroupFilterTests.cs
@@ -89,7 +89,6 @@ public sealed class HostedContentDenyGroupFilterTests
     // remaining denied content-read families keep their group-filter proof.
     private static string PrefixFor(string family) => family switch
     {
-        "transcription" => "transcription/",
         "instructions" => "gateway/wingman/instructions/",
         _ => throw new ArgumentOutOfRangeException(nameof(family)),
     };
@@ -99,15 +98,13 @@ public sealed class HostedContentDenyGroupFilterTests
     /// <summary>The second future route, whose parameter is a custom binder we can watch run (or not run).</summary>
     private static string BindingProbePath(string family) => PrefixFor(family) + "probe-binding";
 
-    private const string TranscriptionRefusal = "transcription analysis is not available on the hosted gateway";
     private const string InstructionsRefusal = "the wingman instructions surface is not available on the hosted gateway";
 
     /// <summary>Which family, its group-mapper, and the refusal its filter must produce.</summary>
-    public static TheoryData<string> Families() => new() { "transcription", "instructions" };
+    public static TheoryData<string> Families() => new() { "instructions" };
 
     private static string RefusalFor(string family) => family switch
     {
-        "transcription" => TranscriptionRefusal,
         "instructions" => InstructionsRefusal,
         _ => throw new ArgumentOutOfRangeException(nameof(family)),
     };
@@ -187,8 +184,6 @@ public sealed class HostedContentDenyGroupFilterTests
     // ===== 2. SELF-HOST: the same body-bound route still BINDS and SERVES, over BOTH non-hosted forms =====
 
     [Theory]
-    [InlineData("transcription", null)]
-    [InlineData("transcription", "0")]
     [InlineData("instructions", null)]
     [InlineData("instructions", "0")]
     public async Task A_route_added_to_the_group_still_binds_and_serves_on_self_host(string family, string? hostedValue)
@@ -311,9 +306,6 @@ public sealed class HostedContentDenyGroupFilterTests
 
             switch (family)
             {
-                case "transcription":
-                    return TranscriptionAnalysisEndpoint.Map(app);
-
                 case "instructions":
                     db = new GatewayDbTestHarness();
                     return WingmanInstructionsEndpoint.Map(

--- a/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
@@ -132,23 +132,17 @@ internal static class ContentFingerprint
 }
 
 /// <summary>
-/// Four route families that serve one account's CONTENT to any other account's authenticated device key
-/// are refused on the hosted Gateway. Issues #1897, #1853 (read side), #1896 and #1884.
+/// The wingman-instructions content family is refused on the hosted Gateway (issue #1853, read side): the
+/// single-owner wingman prompt has no per-tenant version to serve.
 ///
-/// All four share one defect: the store behind them has a single on-disk root with no tenant anywhere in
-/// the path, the file name, or the record, and the route addresses it by something that is not a tenant
-/// boundary - a positional index, a turn id, or an identifier the CALLER supplies. Public signup on the
-/// backing account project is open, so "any authenticated caller" means the public.
-///
-///   /transcription/*                     one shared local history with no tenant partition.
 ///   /gateway/wingman/instructions/*       the single-owner wingman prompt - one active prompt every
 ///                                        account's wingman speaks through, with no per-tenant version to
 ///                                        serve.
-///   /wingman/utterance/*                  staged audio and the assembled transcript, keyed solely by a
-///                                        caller-supplied Idempotency-Key under a shared root.
-///   /dictation/*                          the same VoiceUploadStore shape: re-registering another
-///                                        account's upload id returns ITS transcript from the terminal
-///                                        tombstone, with no session lookup in the way.
+///
+/// Sibling content families that USED to be refused here have since been tenant-partitioned and now SERVE
+/// per-tenant, so they left this file: the two upload families /wingman/utterance/* and /dictation/*
+/// (issue #1884), and /transcription/* Transcription Health (issue #2059 - proved in
+/// HostedTranscriptionServeTests).
 ///
 /// WHY A DENY AND NOT A PARTITION. The tenant is not missing from the query, it is missing from the DATA.
 /// These records were written with no tenant on them, so there is nothing to filter by; attributing them
@@ -208,10 +202,9 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
 {
     private const string Token = "test-token";
 
-    private const string TranscriptionRefusal = "transcription analysis is not available on the hosted gateway";
     private const string InstructionsRefusal = "the wingman instructions surface is not available on the hosted gateway";
-    // The utterance and dictation refusal constants were removed with their theories (issue #1884, un-deny):
-    // those two upload families are now served tenant-partitioned on hosted, not refused.
+    // The utterance/dictation (issue #1884) and transcription-analysis (issue #2059) refusal constants were
+    // removed with their theories: those surfaces are now served tenant-partitioned on hosted, not refused.
 
     private GatewayHost _gateway = null!;
     private HttpClient _http = null!;
@@ -268,31 +261,11 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
         try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
     }
 
-    /// <summary>
-    /// The local Transcription Health history is unavailable on a shared hosted Gateway because its store
-    /// has no tenant partition.
-    /// </summary>
-    [Theory]
-    [InlineData("transcription/turns")]
-    [InlineData("transcription/turns?limit=2000")]
-    [InlineData("transcription/stats")]
-    [InlineData("transcription/terms")]
-    public async Task Transcription_analysis_reads_are_refused_to_an_enrolled_tenant(string path)
-    {
-        var resp = await Send(HttpMethod.Get, path);
-        // Fingerprint FIRST, status second: a renamed route must redden on "this is not the refusal
-        // body", not on "404 != 404". Asserting status ahead of the body would prove a route changed.
-        await AssertBodyIsNothingButTheRefusal(resp, TranscriptionRefusal, $"GET {path}");
-        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
-    }
-
-    [Fact]
-    public async Task Transcription_history_clear_is_refused_to_an_enrolled_tenant()
-    {
-        var resp = await Send(HttpMethod.Delete, "transcription/history");
-        await AssertBodyIsNothingButTheRefusal(resp, TranscriptionRefusal, "DELETE transcription/history");
-        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
-    }
+    // NOTE (issue #2059): the /transcription/* Transcription Health surface is NO LONGER denied here - the
+    // history store was tenant-partitioned and the routes now SERVE the caller's own tenant (403 when
+    // unresolved). Its hostile two-tenant proof is HostedTranscriptionServeTests; its self-host control
+    // remains in HostedContentReadSelfHostControlTests below. What stays denied here is the wingman-
+    // instructions single-owner prompt.
 
     /// <summary>
     /// Issue #1853. The wingman-instructions group is the single-owner wingman prompt: one active prompt
@@ -349,7 +322,6 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
     /// same body, because the refusal was never about who is asking.
     /// </summary>
     [Theory]
-    [InlineData("GET", "transcription/turns", null, TranscriptionRefusal)]
     [InlineData("GET", "gateway/wingman/instructions", null, InstructionsRefusal)]
     public async Task Every_family_is_refused_to_a_caller_carrying_no_tenant_at_all(
         string method, string path, string? body, string refusal)

--- a/src/CcDirector.Gateway.Tests/HostedTranscriptionServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedTranscriptionServeTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #2059: the Transcription Health surface (/transcription/stats, /turns, /terms, DELETE /history) used
+/// to be denied on the hosted Gateway because the history store carried no tenant. The store is now
+/// partitioned by tenant (<see cref="TranscriptionHistoryLog.DirectoryFor"/>), so the routes SERVE per-tenant.
+///
+/// This is the hostile A/B proof on a real HOSTED GatewayHost with TWO fully enrolled tenants and one unbound
+/// device:
+///   1. SERVE - the reads answer 200 for an enrolled tenant (not the old 404 refusal).
+///   2. FAIL CLOSED - they answer 403 for a device whose key resolves to NO tenant, never the Local partition.
+///   3. ISOLATED - a turn recorded in tenant A's history is counted in A's stats and INVISIBLE to B's.
+///
+/// Self-host is unchanged (the single Local tenant reads the existing flat store) and is exercised by
+/// HostedContentReadSelfHostControlTests with hosted mode off.
+/// </summary>
+[Collection("GatewayHostedMode")]
+public sealed class HostedTranscriptionServeTests : IAsyncLifetime
+{
+    private const string Token = "test-token-txn-serve";
+
+    private readonly string _root;
+    private readonly string? _priorRoot;
+    private readonly string? _priorHosted;
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-txn-serve-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _httpA = null!;
+    private HttpClient _httpB = null!;
+    private HttpClient _httpUnbound = null!;
+    private TenantId _tenantA;
+
+    public HostedTranscriptionServeTests()
+    {
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-txn-serve-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+
+        _httpA = Enrolled("dev-a", "sub-alice", "alice@example.com", out _tenantA);
+        _httpB = Enrolled("dev-b", "sub-bob", "bob@example.com", out _);
+
+        var unboundKey = _gateway.Devices.Register("dev-unbound", "MA").DeviceKey;
+        _httpUnbound = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _httpUnbound.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", unboundKey);
+
+        // Record ONE turn into tenant A's history partition, through the same per-tenant log the write path
+        // uses. Nothing is recorded for tenant B.
+        TranscriptionHistoryLog.ForTenant(_tenantA).Record(new TranscriptionHistoryRecord
+        {
+            TimestampUtc = DateTime.UtcNow,
+            TurnId = "alpha-turn",
+            Outcome = "ok",
+            TranscriptionMs = 120,
+            CleanupMs = 10,
+            Corrected = false,
+        });
+    }
+
+    private HttpClient Enrolled(string deviceId, string subject, string email, out TenantId tenant)
+    {
+        var key = _gateway.Devices.Register(deviceId, "MA").DeviceKey;
+        var minted = _gateway.TenantRegistry.MintOrLookupBySubject(subject, email);
+        _gateway.Devices.SetAccountBinding(deviceId, subject, minted.Value);
+        tenant = minted;
+        var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", key);
+        return http;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _httpA.Dispose();
+        _httpB.Dispose();
+        _httpUnbound.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    /// <summary>SERVE: the reads answer 200 for an enrolled tenant on hosted, not the old 404 refusal.</summary>
+    [Theory]
+    [InlineData("transcription/stats")]
+    [InlineData("transcription/turns")]
+    [InlineData("transcription/terms")]
+    public async Task Transcription_reads_serve_an_enrolled_tenant_on_hosted(string path)
+    {
+        var resp = await _httpA.GetAsync(path);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+    }
+
+    /// <summary>FAIL CLOSED: a device with no bound tenant is refused 403, never served the Local partition.</summary>
+    [Theory]
+    [InlineData("transcription/stats")]
+    [InlineData("transcription/turns")]
+    [InlineData("transcription/terms")]
+    public async Task Transcription_reads_refuse_an_unresolved_tenant_with_403(string path)
+    {
+        var resp = await _httpUnbound.GetAsync(path);
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    /// <summary>Control: an unauthenticated caller is still rejected by the host-wide auth gate.</summary>
+    [Fact]
+    public async Task An_unauthenticated_caller_is_still_rejected()
+    {
+        using var noAuth = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        Assert.Equal(HttpStatusCode.Unauthorized, (await noAuth.GetAsync("transcription/turns")).StatusCode);
+    }
+
+    /// <summary>ISOLATED: the turn recorded in tenant A's history is counted for A and INVISIBLE to B.</summary>
+    [Fact]
+    public async Task One_tenants_transcription_history_is_invisible_to_another_on_hosted()
+    {
+        // Tenant A sees its own turn.
+        using (var aStats = await Json(_httpA, "transcription/stats"))
+            Assert.Equal(1, aStats.RootElement.GetProperty("totalTurns").GetInt32());
+        using (var aTurns = await Json(_httpA, "transcription/turns"))
+        {
+            var turns = aTurns.RootElement.GetProperty("turns").EnumerateArray().ToArray();
+            Assert.Contains(turns, t => t.GetProperty("turnId").GetString() == "alpha-turn");
+        }
+
+        // Tenant B sees NONE of it.
+        using (var bStats = await Json(_httpB, "transcription/stats"))
+            Assert.Equal(0, bStats.RootElement.GetProperty("totalTurns").GetInt32());
+        using (var bTurns = await Json(_httpB, "transcription/turns"))
+            Assert.Empty(bTurns.RootElement.GetProperty("turns").EnumerateArray());
+    }
+
+    private static async Task<JsonDocument> Json(HttpClient http, string path)
+    {
+        var resp = await http.GetAsync(path);
+        resp.EnsureSuccessStatusCode();
+        return JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+    }
+
+    internal static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -520,7 +520,8 @@ internal static class GatewayDictationEndpoint
             }
 
             var result = await transcription.TranscribeAsync(
-                audio, "audio." + (req.Ext ?? "wav"), req.Mime ?? "audio/wav", applyCorrection: true, CancellationToken.None);
+                audio, "audio." + (req.Ext ?? "wav"), req.Mime ?? "audio/wav", applyCorrection: true, CancellationToken.None,
+                tenant: tenant);
             if (MapNonOkTranscription(result, uploadId, store) is { } nonOk)
                 return nonOk;
 

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -600,7 +600,8 @@ internal static class GatewayWingmanVoiceEndpoint
 
             // Transcribe WITH the validated dictionary correction applied (the SAME engine every other
             // surface uses; fails open to the raw transcript in local mode or on any cleanup error).
-            var result = await transcription.TranscribeAsync(bytes, fileName, contentType, applyCorrection: true, ct);
+            var result = await transcription.TranscribeAsync(bytes, fileName, contentType, applyCorrection: true, ct,
+                tenant: GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary));
             // Out of credits / monthly cap (issue #939): map to the shared 402 state (branch by code)
             // instead of flattening it into a generic 502 - so the client shows the consistent
             // add-credits message and keeps the recording, not "transcription failed".
@@ -823,7 +824,7 @@ internal static class GatewayWingmanVoiceEndpoint
 
         app.MapPost("/wingman/utterance/{uploadId}/complete", async (string uploadId, UtteranceCompleteRequest? req, HttpContext ctx, CancellationToken ct) =>
         {
-            if (!gate.TryOpen(ctx, out var uploads, out _, out var deny)) return deny;
+            if (!gate.TryOpen(ctx, out var uploads, out var reqTenant, out var deny)) return deny;
             if (req is null || req.TotalChunks <= 0)
                 return Results.Json(new { error = "totalChunks (>0) is required" }, statusCode: StatusCodes.Status400BadRequest);
             if (!uploads.Exists(uploadId))
@@ -855,7 +856,8 @@ internal static class GatewayWingmanVoiceEndpoint
             // Transcribe through the single owner WITH the validated dictionary correction applied (the
             // SAME engine every other surface uses; fails open to raw in local mode or on any error).
             var result = await transcription.TranscribeAsync(
-                assembledAudio, "audio." + (req.Ext ?? "webm"), req.Mime ?? "audio/webm", applyCorrection: true, ct);
+                assembledAudio, "audio." + (req.Ext ?? "webm"), req.Mime ?? "audio/webm", applyCorrection: true, ct,
+                tenant: reqTenant);
             uploads.Delete(uploadId);
             // Out of credits / monthly cap (issue #939): map to the shared 402 state (branch by code)
             // instead of flattening it into a generic 502 - so the client shows the consistent

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -589,7 +589,7 @@ internal static class RecordingEndpoints
         // contribution is never fleet-global. (The Transcription Health READ surface is issue #2059.)
         var tenantHistory = tenant == TenantId.Local
             ? history
-            : new TranscriptionHistoryLog(Path.Combine(TranscriptionHistoryLog.DefaultDirectory(), TenantFolder(tenant)));
+            : TranscriptionHistoryLog.ForTenant(tenant);
 
         FileLog.Write($"[RecordingEndpoints] BuildService tenant={tenant.ToLogString()}: root={root}, collection={collectionDir}");
 

--- a/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
@@ -1,6 +1,8 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.Transcription;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 
@@ -15,8 +17,11 @@ namespace CcDirector.Gateway.Api;
 ///   DELETE /transcription/history
 ///
 /// The history never includes transcript text or provider error bodies, is retained for 30 days, and
-/// can be cleared by the owner. This feature is self-host only because its file store has no tenant
-/// partition on a shared hosted Gateway.
+/// can be cleared by the owner. It SERVES PER-TENANT on hosted (issue #2059): the store is partitioned by
+/// tenant (see <see cref="TranscriptionHistoryLog.DirectoryFor"/>), so each route resolves the caller's
+/// tenant and reads only that tenant's history; a request with no resolvable tenant is refused (403), never
+/// served the Local partition. Self-host resolves to the single Local tenant and reads the existing flat
+/// store, unchanged.
 /// </summary>
 internal static class TranscriptionAnalysisEndpoint
 {
@@ -25,53 +30,72 @@ internal static class TranscriptionAnalysisEndpoint
     private const int DefaultTermTop = 25;
 
     internal const string Prefix = "/transcription";
-    internal const string RefusalMessage = "transcription analysis is not available on the hosted gateway";
 
-    private static HostedDenial Denial() => new(
-        family: "transcription-analysis",
-        message: RefusalMessage,
-        reason: "the local transcription history is process-global and has no tenant partition",
-        unDenyInstruction: "tenant-partition the history writer and reader before enabling this feature on hosted",
-        statusCode: StatusCodes.Status404NotFound);
+    /// <summary>The 403 a route answers when the caller's tenant cannot be resolved (issue #2059). On the
+    /// hosted Gateway an authenticated request whose device key has no bound tenant is refused, NEVER served
+    /// the Local partition. Self-host always resolves to Local, so this never fires there.</summary>
+    private static IResult TenantRequired()
+        => Results.Json(new { error = "a tenant could not be resolved for this request" },
+            statusCode: StatusCodes.Status403Forbidden);
 
-    public static HostedDenyGroup Map(
+    public static void Map(
         IEndpointRouteBuilder outer,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null,
         TranscriptionHistoryReader? reader = null,
         TranscriptionAudioArchive? audioArchive = null)
     {
-        var history = reader ?? new TranscriptionHistoryReader();
-        var audio = audioArchive ?? new TranscriptionAudioArchive();
-        FileLog.Write($"[TranscriptionAnalysisEndpoint] mapping {Prefix} history; hosted={GatewayHostedMode.IsHosted}");
-        var group = HostedRouteDeny.Group(outer, Prefix, Denial());
-        MapRoutes(group, history, audio);
-        return group;
+        FileLog.Write($"[TranscriptionAnalysisEndpoint] mapping {Prefix} history PER-TENANT (issue #2059); hosted={GatewayHostedMode.IsHosted} - each route resolves the caller's tenant, 403 when unresolved");
+        var app = outer.MapGroup(Prefix);
+        MapRoutes(app, tenantBoundary, reader, audioArchive);
     }
 
+    // The reader/audio for the CALLER's tenant. A test-supplied reader (self-host fixtures) is used verbatim;
+    // otherwise a reader/archive over the tenant's own partition is built.
+    private static TranscriptionHistoryReader ReaderFor(TenantId tenant, TranscriptionHistoryReader? overrideReader)
+        => overrideReader ?? new TranscriptionHistoryReader(TranscriptionHistoryLog.DirectoryFor(tenant));
+
+    private static TranscriptionAudioArchive AudioFor(TenantId tenant, TranscriptionAudioArchive? overrideArchive)
+        => overrideArchive ?? new TranscriptionAudioArchive(TranscriptionAudioArchive.DirectoryFor(tenant));
+
     private static void MapRoutes(
-        HostedDenyGroup app,
-        TranscriptionHistoryReader history,
-        TranscriptionAudioArchive audioArchive)
+        IEndpointRouteBuilder app,
+        Tenancy.HostedTenantBoundary? tenantBoundary,
+        TranscriptionHistoryReader? reader,
+        TranscriptionAudioArchive? audioArchive)
     {
         app.MapGet("/stats", (HttpContext ctx) =>
-            Results.Json(history.ComputeStats(ResolveSince(ctx))));
+        {
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (t is null) return TenantRequired();
+            return Results.Json(ReaderFor(t.Value, reader).ComputeStats(ResolveSince(ctx)));
+        });
 
         app.MapGet("/turns", (HttpContext ctx) =>
         {
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (t is null) return TenantRequired();
             var limit = ClampInt(ctx.Request.Query["limit"], DefaultTurnLimit, 0, MaxTurnLimit);
-            return Results.Json(new { turns = history.Load(ResolveSince(ctx), limit) });
+            return Results.Json(new { turns = ReaderFor(t.Value, reader).Load(ResolveSince(ctx), limit) });
         });
 
         app.MapGet("/terms", (HttpContext ctx) =>
         {
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (t is null) return TenantRequired();
             var top = ClampInt(ctx.Request.Query["top"], DefaultTermTop, 1, 1000);
-            return Results.Json(new { terms = history.TopCorrections(top, ResolveSince(ctx)) });
+            return Results.Json(new { terms = ReaderFor(t.Value, reader).TopCorrections(top, ResolveSince(ctx)) });
         });
 
-        app.MapDelete("/history", () => Results.Json(new
+        app.MapDelete("/history", (HttpContext ctx) =>
         {
-            removedFiles = history.Clear(),
-            removedAudioClips = audioArchive.Clear(),
-        }));
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (t is null) return TenantRequired();
+            return Results.Json(new
+            {
+                removedFiles = ReaderFor(t.Value, reader).Clear(),
+                removedAudioClips = AudioFor(t.Value, audioArchive).Clear(),
+            });
+        });
     }
 
     private static DateTime? ResolveSince(HttpContext ctx)

--- a/src/CcDirector.Gateway/Api/TranscriptionBatchEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionBatchEndpoint.cs
@@ -36,10 +36,18 @@ internal static class TranscriptionBatchEndpoint
         IEndpointRouteBuilder app,
         KeyVault vault,
         TranscriptionHistoryLog? history = null,
-        TranscriptionAudioArchive? audioArchive = null)
+        TranscriptionAudioArchive? audioArchive = null,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null)
     {
         app.MapPost("/transcription", async (HttpContext ctx) =>
         {
+            // Per-tenant (issue #2059): the transcription-health record this turn writes goes to the caller's
+            // own partition. A request with no resolvable tenant is refused (403), never Local.
+            var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "a tenant could not be resolved for this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+
             var correct = string.Equals(ctx.Request.Query["correct"].ToString(), "true", StringComparison.OrdinalIgnoreCase);
 
             // Read the whole clip into memory. These are short clips (seconds), so the memory cost is
@@ -57,7 +65,7 @@ internal static class TranscriptionBatchEndpoint
             FileLog.Write($"[TranscriptionBatchEndpoint] POST /transcription: bytes={audio.Length}, contentType={contentType}, correct={correct}");
 
             var service = new GatewayTranscriptionService(vault, history: history, audioArchive: audioArchive);
-            var result = await service.TranscribeAsync(audio, fileName, contentType, correct, ctx.RequestAborted);
+            var result = await service.TranscribeAsync(audio, fileName, contentType, correct, ctx.RequestAborted, tenant: reqTenant.Value);
 
             return result.Outcome switch
             {

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2221,12 +2221,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // through this one endpoint - it resolves the mode + key and runs the right provider (in-process
         // Whisper, or the resolved provider-compatible batch endpoint). Optional ?correct=true also runs
         // the validated dictionary correction, keeping that out of the callers too.
-        TranscriptionBatchEndpoint.Map(_app, _keyVault, _transcriptionHistory, _transcriptionAudioArchive);
+        TranscriptionBatchEndpoint.Map(_app, _keyVault, _transcriptionHistory, _transcriptionAudioArchive, _tenantBoundary);
 
         // Read-only analysis over the LOCAL minimized transcription history: latency percentiles, cleanup
         // behaviour, most-corrected terms, and word frequencies, so any agent can query the Gateway to
         // see how fast and how good transcription is - all from data on this machine, never a server.
-        Api.TranscriptionAnalysisEndpoint.Map(_app);
+        Api.TranscriptionAnalysisEndpoint.Map(_app, _tenantBoundary);
 
         // Text-in / text-out cleanup: run ONLY the deterministic dictionary correction over supplied
         // text + a supplied term list (no audio). The engine the multilingual eval harness drives, and

--- a/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
+++ b/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
@@ -104,7 +104,8 @@ public sealed class GatewayTranscriptionService
     /// <param name="applyCorrection">When true, run the validated dictionary corrector on the raw text.</param>
     /// <param name="ct">Cancellation token.</param>
     public async Task<GatewayTranscriptionResult> TranscribeAsync(
-        byte[] audio, string fileName, string contentType, bool applyCorrection, CancellationToken ct)
+        byte[] audio, string fileName, string contentType, bool applyCorrection, CancellationToken ct,
+        CcDirector.Core.Tenancy.TenantId? tenant = null)
     {
         if (audio is null) throw new ArgumentNullException(nameof(audio));
 
@@ -145,7 +146,7 @@ public sealed class GatewayTranscriptionService
             swTranscribe.Stop();
             FileLog.Write($"[GatewayTranscriptionService] TranscribeAsync OUT OF CREDITS: mode={mode}, code={ex.Code}");
             RecordHistory(turnId, "out_of_credits",
-                swTranscribe.ElapsedMilliseconds, 0, applyCorrection, raw: null, cleanup: null);
+                swTranscribe.ElapsedMilliseconds, 0, applyCorrection, raw: null, cleanup: null, tenant: tenant);
             return GatewayTranscriptionResult.OutOfCredits(mode, routing.Endpoint.Model, ex.Code, ex.Message);
         }
         catch (TranscriptionPermanentException ex)
@@ -157,7 +158,7 @@ public sealed class GatewayTranscriptionService
             swTranscribe.Stop();
             FileLog.Write($"[GatewayTranscriptionService] TranscribeAsync PERMANENT: mode={mode}, code={ex.Code}, {ex.Message}");
             RecordHistory(turnId, "permanent_error",
-                swTranscribe.ElapsedMilliseconds, 0, applyCorrection, raw: null, cleanup: null);
+                swTranscribe.ElapsedMilliseconds, 0, applyCorrection, raw: null, cleanup: null, tenant: tenant);
             return GatewayTranscriptionResult.PermanentError(mode, routing.Endpoint.Model, ex.Code, ex.Message);
         }
         catch (Exception ex)
@@ -168,7 +169,7 @@ public sealed class GatewayTranscriptionService
             swTranscribe.Stop();
             FileLog.Write($"[GatewayTranscriptionService] TranscribeAsync provider FAILED: mode={mode}, {ex.Message}");
             RecordHistory(turnId, "provider_error",
-                swTranscribe.ElapsedMilliseconds, 0, applyCorrection, raw: null, cleanup: null);
+                swTranscribe.ElapsedMilliseconds, 0, applyCorrection, raw: null, cleanup: null, tenant: tenant);
             return GatewayTranscriptionResult.ProviderError(mode, routing.Endpoint.Model, ex.Message);
         }
 
@@ -182,29 +183,23 @@ public sealed class GatewayTranscriptionService
         FileLog.Write($"[GatewayTranscriptionService] TranscribeAsync OK: mode={mode}, corrected={applyCorrection}, "
                       + $"transcribeMs={swTranscribe.ElapsedMilliseconds}, cleanupMs={(applyCorrection ? swCleanup.ElapsedMilliseconds : 0)}, chars={text.Length}");
         RecordHistory(turnId, "ok", swTranscribe.ElapsedMilliseconds,
-            applyCorrection ? swCleanup.ElapsedMilliseconds : 0, applyCorrection, raw, cleanup);
+            applyCorrection ? swCleanup.ElapsedMilliseconds : 0, applyCorrection, raw, cleanup, tenant: tenant);
         return GatewayTranscriptionResult.Ok(text, mode, routing.Endpoint.Model);
     }
 
-    /// <summary>Append one minimized turn to local Transcription Health history.</summary>
+    /// <summary>Append one minimized turn to the caller tenant's Transcription Health history (issue #2059).
+    /// When a tenant is supplied the record is written to THAT tenant's partition
+    /// (<see cref="TranscriptionHistoryLog.ForTenant"/>); when it is null the injected <see cref="_history"/>
+    /// is used (self-host, tests, and the recording path which already injects its own per-tenant log). The
+    /// old hosted write-skip is gone: the write is now per-tenant on hosted, so it accumulates in the caller's
+    /// own partition and its Transcription Health page reads it back - never another tenant's.</summary>
     private void RecordHistory(
         string turnId, string outcome, long transcribeMs, long cleanupMs, bool corrected,
-        string? raw, CleanupOutcome? cleanup)
+        string? raw, CleanupOutcome? cleanup, CcDirector.Core.Tenancy.TenantId? tenant = null)
     {
-        // HOSTED WRITE GATE (deny-by-default, defense in depth for the transcription-analysis read deny
-        // #1897). The shared history has no tenant in its path, file name, or records, and its ONLY
-        // reader is the now-denied analysis group (verified: nothing billing / usage-metering / quota
-        // consumes it, so gating undercounts nothing). Continuing to append every account's local history
-        // to one shared file on hosted would accumulate cross-tenant data at rest that nothing on hosted can
-        // even read - so stop the write. Self-host is single-tenant and unchanged.
-        if (GatewayHostedMode.IsHosted)
-        {
-            FileLog.Write("[GatewayTranscriptionService] transcription history write SKIPPED on hosted: the shared local history has no tenant and its only reader is denied");
-            return;
-        }
-
+        var log = tenant is { } tv ? TranscriptionHistoryLog.ForTenant(tv) : _history;
         var finalText = cleanup?.Text ?? raw;
-        _history.Record(new TranscriptionHistoryRecord
+        log.Record(new TranscriptionHistoryRecord
         {
             TimestampUtc = DateTime.UtcNow,
             TurnId = turnId,

--- a/src/CcDirector.Gateway/Transcription/TranscriptionAudioArchive.cs
+++ b/src/CcDirector.Gateway/Transcription/TranscriptionAudioArchive.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
@@ -70,6 +71,16 @@ public sealed class TranscriptionAudioArchive
 
     /// <summary>The per-user transcription-audio directory. Resolved per call, never cached.</summary>
     public static string DefaultDirectory() => CcStorage.TranscriptionAudio();
+
+    /// <summary>This tenant's troubleshooting-audio directory (issue #2059). Local keeps the existing flat
+    /// directory (self-host unchanged); every other tenant gets its own subdirectory, so one tenant clearing
+    /// its history never touches another tenant's archived audio.</summary>
+    public static string DirectoryFor(Core.Tenancy.TenantId tenant)
+    {
+        if (tenant == Core.Tenancy.TenantId.Local) return DefaultDirectory();
+        var chars = tenant.Value.Select(c => char.IsLetterOrDigit(c) || c is '-' or '_' ? c : '_').ToArray();
+        return System.IO.Path.Combine(DefaultDirectory(), new string(chars));
+    }
 
     /// <summary>The file a clip for <paramref name="turnId"/> lands in.</summary>
     public string FileFor(string turnId, string extension)

--- a/src/CcDirector.Gateway/Transcription/TranscriptionHistoryLog.cs
+++ b/src/CcDirector.Gateway/Transcription/TranscriptionHistoryLog.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using CcDirector.Core.Dictation;
@@ -30,6 +31,23 @@ public sealed class TranscriptionHistoryLog
     }
 
     public static string DefaultDirectory() => CcStorage.TranscriptionHistory();
+
+    /// <summary>
+    /// This tenant's transcription-history directory (issue #2059). The single Local tenant keeps the existing
+    /// flat directory, so a self-host install's history does not move; every other tenant gets its own
+    /// subdirectory. This is the ONE source of truth for the per-tenant layout - both the writers (dictation,
+    /// voice, batch, recording) and the Transcription Health reader resolve the same directory from it, so a
+    /// tenant reads back exactly the history written for it and never another tenant's.
+    /// </summary>
+    public static string DirectoryFor(Core.Tenancy.TenantId tenant)
+    {
+        if (tenant == Core.Tenancy.TenantId.Local) return DefaultDirectory();
+        var chars = tenant.Value.Select(c => char.IsLetterOrDigit(c) || c is '-' or '_' ? c : '_').ToArray();
+        return Path.Combine(DefaultDirectory(), new string(chars));
+    }
+
+    /// <summary>A history log over a specific tenant's partition (issue #2059).</summary>
+    public static TranscriptionHistoryLog ForTenant(Core.Tenancy.TenantId tenant) => new(DirectoryFor(tenant));
 
     public string FileFor(DateTime utcNow)
         => Path.Combine(_directory, $"transcription-{utcNow:yyyyMMdd}.jsonl");


### PR DESCRIPTION
Serve the Transcription Health surface per-tenant on the hosted Gateway instead of denying it.

The store is now partitioned by tenant (`TranscriptionHistoryLog.DirectoryFor(tenant)` is the single source of truth for the layout; `TranscriptionAudioArchive` matches it). Write paths stamp the caller's tenant; the hosted write-skip guard is removed now that every write is per-tenant. `TranscriptionAnalysisEndpoint` resolves the caller's tenant, reads only that tenant's partition, and returns 403 when no tenant resolves (never the Local partition). Self-host resolves to Local and reads the existing flat store, unchanged.

Hostile two-tenant coverage in `HostedTranscriptionServeTests`: serve for an enrolled tenant, 403 for an unbound device, and tenant A cannot see tenant B's recorded turn.

Closes #2059
