### PR TITLE
feat(gateway): tenant-scoped worker seam (G8 increment 2) + cron on hosted

### DIFF
--- a/src/CcDirector.Gateway.Tests/Tenancy/TenantScopedSweepTests.cs
+++ b/src/CcDirector.Gateway.Tests/Tenancy/TenantScopedSweepTests.cs
@@ -1,0 +1,108 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Tenancy;
+
+/// <summary>
+/// The worker seam of the structural tenancy gate (G8 increment 2). These tests pin the fan-out contract that
+/// lets a background job run tenant-isolated: self-host fires the body once under Local; hosted fires it once
+/// per tenant, EACH inside that tenant's ambient scope (so the body's tenant-scoped reads resolve to that
+/// tenant and no other). The hosted fan-out test is also the revert-proof: if <c>ForEachTenantAsync</c> stopped
+/// entering the scope, the body's <c>Current</c> read would throw (deny-by-default) and the test would go red.
+/// </summary>
+public sealed class TenantScopedSweepTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _harness = new();
+
+    public void Dispose() => _harness.Dispose();
+
+    /// <summary>A minimal sweep that runs a supplied body through the seam, for assertions.</summary>
+    private sealed class ProbeSweep : TenantScopedSweep
+    {
+        private readonly Func<Task> _body;
+        public ProbeSweep(HostedTenantBoundary boundary, TenantRegistry tenants, Func<Task> body)
+            : base(boundary, tenants) => _body = body;
+        public Task RunAsync(CancellationToken ct = default) => ForEachTenantAsync(_body, ct);
+    }
+
+    [Fact]
+    public async Task SelfHost_RunsBodyExactlyOnce_UnderLocal_IgnoringTheCensus()
+    {
+        var ctx = new SingleTenantContext();
+        var registry = new TenantRegistry(_harness.Open(ctx));
+        var boundary = new HostedTenantBoundary(ctx, new DeviceRegistry());
+        // Even with tenants in the census, self-host must fire ONCE under Local, never enumerate them.
+        registry.MintOrLookupBySubject("sub-a", "a@example.com");
+        registry.MintOrLookupBySubject("sub-b", "b@example.com");
+
+        var seen = new List<string>();
+        await new ProbeSweep(boundary, registry, () => { seen.Add(ctx.Current.Value); return Task.CompletedTask; })
+            .RunAsync();
+
+        Assert.Single(seen);
+        Assert.Equal(TenantId.Local.Value, seen[0]);
+    }
+
+    [Fact]
+    public async Task Hosted_FiresOncePerTenant_EachUnderItsOwnScope()
+    {
+        var ambient = new AsyncLocalTenantContext();
+        var registry = new TenantRegistry(_harness.Open(ambient));
+        var boundary = new HostedTenantBoundary(ambient, new DeviceRegistry());
+        var tA = registry.MintOrLookupBySubject("sub-a", "a@example.com").Value;
+        var tB = registry.MintOrLookupBySubject("sub-b", "b@example.com").Value;
+
+        var seen = new List<string>();
+        // The body reads the AMBIENT tenant. It resolves ONLY because the seam entered a scope; without the
+        // scope this read throws (deny-by-default) - which is exactly the revert-proof.
+        await new ProbeSweep(boundary, registry, () => { seen.Add(ambient.Current.Value); return Task.CompletedTask; })
+            .RunAsync();
+
+        Assert.Equal(2, seen.Count);
+        Assert.Contains(tA, seen);
+        Assert.Contains(tB, seen);
+        // No body run saw a tenant other than the two in the census (no leaked/fixed/Local tenant).
+        Assert.All(seen, t => Assert.Contains(t, new[] { tA, tB }));
+    }
+
+    [Fact]
+    public async Task Hosted_OneTenantBodyThrowing_DoesNotAbortTheOthers()
+    {
+        var ambient = new AsyncLocalTenantContext();
+        var registry = new TenantRegistry(_harness.Open(ambient));
+        var boundary = new HostedTenantBoundary(ambient, new DeviceRegistry());
+        var tA = registry.MintOrLookupBySubject("sub-a", "a@example.com").Value;
+        var tB = registry.MintOrLookupBySubject("sub-b", "b@example.com").Value;
+        var tC = registry.MintOrLookupBySubject("sub-c", "c@example.com").Value;
+
+        var seen = new List<string>();
+        await new ProbeSweep(boundary, registry, () =>
+        {
+            var current = ambient.Current.Value;
+            seen.Add(current);
+            if (current == tB) throw new InvalidOperationException("tenant B body fails");
+            return Task.CompletedTask;
+        }).RunAsync();
+
+        // Every tenant was visited; B's failure did not abort A or C (per-tenant isolation).
+        Assert.Equal(3, seen.Count);
+        Assert.Contains(tA, seen);
+        Assert.Contains(tC, seen);
+    }
+
+    [Fact]
+    public async Task Hosted_EmptyCensus_RunsTheBodyZeroTimes()
+    {
+        var ambient = new AsyncLocalTenantContext();
+        var registry = new TenantRegistry(_harness.Open(ambient));
+        var boundary = new HostedTenantBoundary(ambient, new DeviceRegistry());
+
+        var count = 0;
+        await new ProbeSweep(boundary, registry, () => { count++; return Task.CompletedTask; }).RunAsync();
+
+        Assert.Equal(0, count);
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -413,6 +413,10 @@ public sealed class GatewayHost : IAsyncDisposable
     // G8 increment 2: the cron sweep now fires through the per-tenant tenancy seam (TenantScopedSweep) so it
     // can run ON hosted, tenant-isolated, instead of being disabled. Constructed alongside _cronEngine.
     private Running.CronTenantSweep? _cronSweep;
+    // Reentrancy guard for the cron sweep. On hosted the per-tenant fan-out can take longer than the 60s tick,
+    // so a later tick must NOT start a second overlapping sweep (that could double-fire a job in the window
+    // between a tenant's ListAll and MarkFired). 0 = idle, 1 = a sweep is in flight (Interlocked-owned).
+    private int _cronSweepInFlight;
     // The cron firing sweep (epic #479, #483): wakes ~every minute and fires due jobs. Created in
     // StartAsync, disposed in StopAsync.
     private System.Threading.Timer? _cronTimer;
@@ -2592,15 +2596,32 @@ public sealed class GatewayHost : IAsyncDisposable
 
     private void SweepCron()
     {
+        // Skip this tick if the previous sweep is still fanning out (hosted, many tenants). Overlapping sweeps
+        // could double-fire a non-overlap-guarded job; one at a time is correct and a skipped tick simply
+        // fires on the next one (cron granularity is a minute, not a second).
+        if (Interlocked.CompareExchange(ref _cronSweepInFlight, 1, 0) != 0)
+            return;
+        _ = RunCronSweepAsync();
+    }
+
+    private async Task RunCronSweepAsync()
+    {
         try
         {
             // G8 increment 2: fire through the per-tenant seam (fans out over the tenant census on hosted,
-            // once under Local on self-host) instead of calling the engine with no ambient tenant.
-            _ = _cronSweep?.SweepAsync(CancellationToken.None);
+            // once under Local on self-host) instead of calling the engine with no ambient tenant. Awaited
+            // here (not fire-and-forget) so the guard is released only when the whole fan-out is done and so
+            // a fault in any tenant's async work is logged rather than lost.
+            if (_cronSweep is not null)
+                await _cronSweep.SweepAsync(CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             FileLog.Write($"[GatewayHost] cron sweep FAILED: {ex.Message}");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _cronSweepInFlight, 0);
         }
     }
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -410,6 +410,9 @@ public sealed class GatewayHost : IAsyncDisposable
     private readonly CronJobStore _cronJobs;
     private readonly CronRunHistoryStore _cronRuns;
     private readonly Running.CronEngine _cronEngine;
+    // G8 increment 2: the cron sweep now fires through the per-tenant tenancy seam (TenantScopedSweep) so it
+    // can run ON hosted, tenant-isolated, instead of being disabled. Constructed alongside _cronEngine.
+    private Running.CronTenantSweep? _cronSweep;
     // The cron firing sweep (epic #479, #483): wakes ~every minute and fires due jobs. Created in
     // StartAsync, disposed in StopAsync.
     private System.Threading.Timer? _cronTimer;
@@ -1004,6 +1007,9 @@ public sealed class GatewayHost : IAsyncDisposable
             // run-now request scope on hosted, the single Local scope on self-host - the same seam the notifier
             // reads. A run-now for tenant A's cj_ id must never be refused by tenant B's in-flight same-id job.
             resolveTenant: () => _tenantPass.Current);
+        // G8 increment 2: wrap the cron engine in the per-tenant worker seam so the background sweep enters
+        // each tenant's scope before it reads the tenant-scoped cron_jobs store.
+        _cronSweep = new Running.CronTenantSweep(_tenantBoundary, TenantRegistry, _cronEngine);
 
         // Web Push (mobile app-icon "needs you" dot): load (or generate on first run) the VAPID key
         // pair and the set of subscribed devices. The notifier that fans out to these is built and
@@ -2372,19 +2378,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // Cron firing sweep (epic #479, #483): wake ~every minute and fire due jobs. The first tick
         // also catches up a fire that came due while the Gateway was down (at most once per job).
         //
-        // Skipped when HOSTED (Hosted Multi-Tenancy): the cron drain reads the tenant-scoped cron_jobs store,
-        // which has no ambient tenant on a background timer and so would fail closed every tick. Firing cron
-        // per-tenant is part of the session-serving increment (the same increment makes these sweeps
-        // fail-loud/observed rather than fire-and-forget). Same guard shape as the NetDiag monitor below.
-        if (!GatewayHostedMode.IsHosted)
-        {
-            _cronTimer = new System.Threading.Timer(_ => SweepCron(), null, CronSweepInterval, CronSweepInterval);
-            FileLog.Write($"[GatewayHost] cron sweep started: every {CronSweepInterval.TotalSeconds:0}s");
-        }
-        else
-        {
-            FileLog.Write("[GatewayHost] cron sweep NOT started (hosted): per-tenant cron firing lands in the session-serving increment");
-        }
+        // G8 increment 2: the cron drain reads the tenant-scoped cron_jobs store. It now fires through the
+        // per-tenant worker seam (CronTenantSweep / TenantScopedSweep), which enters each tenant's ambient
+        // scope before reading, so the sweep runs ON hosted (tenant-isolated) instead of being disabled. On
+        // self-host the seam fires once under Local - the same single fire as before.
+        _cronTimer = new System.Threading.Timer(_ => SweepCron(), null, CronSweepInterval, CronSweepInterval);
+        FileLog.Write($"[GatewayHost] cron sweep started: every {CronSweepInterval.TotalSeconds:0}s ({(GatewayHostedMode.IsHosted ? "hosted, per-tenant via TenantScopedSweep" : "self-host, single Local tenant")})");
 
         // Scheduled-run auto-dismiss (issue #1200): close automated runs that declared themselves done, by
         // sending the kill verb DOWN the Director stream. The close has no REST fallback by design (the
@@ -2595,7 +2594,9 @@ public sealed class GatewayHost : IAsyncDisposable
     {
         try
         {
-            _ = _cronEngine.EvaluateDueAsync(CancellationToken.None);
+            // G8 increment 2: fire through the per-tenant seam (fans out over the tenant census on hosted,
+            // once under Local on self-host) instead of calling the engine with no ambient tenant.
+            _ = _cronSweep?.SweepAsync(CancellationToken.None);
         }
         catch (Exception ex)
         {

--- a/src/CcDirector.Gateway/Running/CronTenantSweep.cs
+++ b/src/CcDirector.Gateway/Running/CronTenantSweep.cs
@@ -1,0 +1,29 @@
+using CcDirector.Gateway.Tenancy;
+
+namespace CcDirector.Gateway.Running;
+
+/// <summary>
+/// Fires the cron engine ONCE PER TENANT through the tenancy worker seam (G8 increment 2,
+/// <see cref="TenantScopedSweep"/>). The cron drain reads the tenant-scoped <c>cron_jobs</c> store, so a
+/// background timer - which has no ambient tenant - could not fire it on hosted without failing closed every
+/// tick; that is why hosted cron was previously DISABLED rather than tenant-aware. Running it through the
+/// seam enters each tenant's ambient scope in turn, so hosted cron now runs safely and tenant-isolated: one
+/// tenant's due jobs are evaluated against only that tenant's <c>cron_jobs</c> rows. On self-host the seam
+/// fires the body exactly once under <see cref="Core.Tenancy.TenantId.Local"/>, identical to the single
+/// pre-seam fire.
+/// </summary>
+internal sealed class CronTenantSweep : TenantScopedSweep
+{
+    private readonly CronEngine _cronEngine;
+
+    public CronTenantSweep(HostedTenantBoundary boundary, TenantRegistry tenants, CronEngine cronEngine)
+        : base(boundary, tenants)
+    {
+        _cronEngine = cronEngine ?? throw new ArgumentNullException(nameof(cronEngine));
+    }
+
+    /// <summary>Fire all due cron jobs for every tenant (hosted) or the single Local tenant (self-host). The
+    /// per-tenant fan-out is isolated: a failure firing one tenant's jobs does not abort the others.</summary>
+    public Task SweepAsync(CancellationToken ct = default)
+        => ForEachTenantAsync(() => _cronEngine.EvaluateDueAsync(ct), ct);
+}

--- a/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
+++ b/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
@@ -115,6 +115,24 @@ public sealed class TenantRegistry
     }
 
     /// <summary>
+    /// The whole tenant census - every tenant id in the <c>tenants</c> mapping table. This is the fan-out
+    /// source for <see cref="TenantScopedSweep"/>: a background worker enumerates it once per cycle and runs
+    /// its per-tenant body inside each tenant's scope. Read through the UNSCOPED context because the mapping
+    /// table carries no tenant_id and no query filter (reading it needs no ambient tenant), exactly as the
+    /// mint/lookup paths do. Read-only; never mints. An empty census (no tenants yet) yields an empty list.
+    /// </summary>
+    public IReadOnlyList<TenantId> AllTenantIds()
+    {
+        using var ctx = _db.CreateUnscopedContext();
+        return ctx.Tenants
+            .AsNoTracking()
+            .Select(t => t.Id)
+            .ToList()
+            .Select(id => new TenantId(id))
+            .ToList();
+    }
+
+    /// <summary>
     /// The display email recorded on a tenant's row, or null when there is none (issue #1856). Read-only:
     /// it neither mints nor writes.
     ///

--- a/src/CcDirector.Gateway/Tenancy/TenantScopedSweep.cs
+++ b/src/CcDirector.Gateway/Tenancy/TenantScopedSweep.cs
@@ -1,0 +1,88 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// The worker seam of the structural tenancy gate (G8 increment 2). A background job has no HTTP request and
+/// no SignalR connection, so nothing enters a tenant scope for it. Any background job that touches
+/// tenant-scoped stores MUST run its per-tenant work through this base, which owns the fan-out over the tenant
+/// census (<see cref="TenantRegistry"/>) and enters the ambient scope once PER TENANT. Inside an entered scope
+/// the body calls the SAME stores as a request handler (<c>GatewayDatabase.CreateContext()</c>), which resolves
+/// the current tenant exactly as a request does.
+///
+/// Two properties make this the ONLY safe way to run a hosted background sweep:
+/// <list type="bullet">
+/// <item>A body that forgot to enter a scope calls <c>CreateContext()</c> with no ambient tenant and FAILS
+/// CLOSED at runtime (the <c>AsyncLocalTenantContext.Current</c> throw) - it can never silently read another
+/// tenant's rows or default to Local.</item>
+/// <item>The DT-TEN-3 architecture test (increment 2) makes a worker that touches a store WITHOUT going
+/// through this base FAIL THE BUILD, so the skip is caught statically even when the offending path is disabled
+/// on hosted and its runtime throw would never fire in test.</item>
+/// </list>
+///
+/// Self-host is single-tenant and must not be burdened: when <see cref="HostedTenantBoundary.IsHosted"/> is
+/// false the census is not enumerated at all - the body runs exactly ONCE under <see cref="TenantId.Local"/>
+/// (<c>EnterScope</c> is a no-op and <c>Current</c> is already Local), identical to today's single fire.
+/// </summary>
+public abstract class TenantScopedSweep
+{
+    private readonly HostedTenantBoundary _boundary;
+    private readonly TenantRegistry _tenants;
+
+    protected TenantScopedSweep(HostedTenantBoundary boundary, TenantRegistry tenants)
+    {
+        _boundary = boundary ?? throw new ArgumentNullException(nameof(boundary));
+        _tenants = tenants ?? throw new ArgumentNullException(nameof(tenants));
+    }
+
+    /// <summary>
+    /// Run <paramref name="body"/> once per tenant, each invocation inside that tenant's ambient scope.
+    ///
+    /// Self-host (<see cref="HostedTenantBoundary.IsHosted"/> false): runs the body EXACTLY ONCE under
+    /// <see cref="TenantId.Local"/>; the census is never enumerated.
+    ///
+    /// Hosted: enumerates the tenant census and, for EACH tenant, enters that tenant's scope and awaits the
+    /// body. The fan-out is per-tenant ISOLATED - one tenant's body throwing is caught and logged and does NOT
+    /// abort the remaining tenants (mirroring the existing cron sweep's boundary try/catch). No tenant id,
+    /// subject, or email is ever written to the log.
+    ///
+    /// Entitlement note (MTR-15 / the cancellation cutoff): a cancelled tenant's workers must not keep running.
+    /// The cutoff adds the per-tenant entitlement-lease consultation as a filter in front of this fan-out (the
+    /// lease is the shared signal); tenancy and entitlement stay separate mechanisms. Until the cutoff lands,
+    /// this base is a pure tenant fan-out.
+    /// </summary>
+    /// <param name="body">The per-tenant work. It reads/writes through the ambient-scoped stores exactly as a
+    /// request handler does; it must NOT capture or resolve a tenant of its own.</param>
+    /// <param name="ct">Cancellation for a long census; checked between tenants so a shutdown is prompt.</param>
+    protected async Task ForEachTenantAsync(Func<Task> body, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+
+        if (!_boundary.IsHosted)
+        {
+            // Self-host: one tenant, always resolved. EnterScope is a no-op and Current == Local, so this is
+            // byte-for-byte the single fire the worker did before it was moved onto the seam.
+            using (_boundary.EnterScope(TenantId.Local))
+                await body().ConfigureAwait(false);
+            return;
+        }
+
+        foreach (var tenant in _tenants.AllTenantIds())
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                using (_boundary.EnterScope(tenant))
+                    await body().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Per-tenant isolation: one tenant's failure must never abort the sweep for the others. The
+                // tenant id is deliberately NOT logged (it is not PII, but the log line stays identity-free by
+                // policy); the exception type is enough to triage.
+                FileLog.Write($"[TenantScopedSweep] per-tenant body failed, continuing with the next tenant ({ex.GetType().Name})");
+            }
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Tenancy/TenantScopedSweep.cs
+++ b/src/CcDirector.Gateway/Tenancy/TenantScopedSweep.cs
@@ -16,9 +16,11 @@ namespace CcDirector.Gateway.Tenancy;
 /// <item>A body that forgot to enter a scope calls <c>CreateContext()</c> with no ambient tenant and FAILS
 /// CLOSED at runtime (the <c>AsyncLocalTenantContext.Current</c> throw) - it can never silently read another
 /// tenant's rows or default to Local.</item>
-/// <item>The DT-TEN-3 architecture test (increment 2) makes a worker that touches a store WITHOUT going
-/// through this base FAIL THE BUILD, so the skip is caught statically even when the offending path is disabled
-/// on hosted and its runtime throw would never fire in test.</item>
+/// <item>A follow-up static architecture gate (DT-TEN-3) is intended to make a worker that touches a store
+/// WITHOUT going through this base FAIL THE BUILD - catching a skip statically even when the offending path is
+/// disabled on hosted and its runtime throw would never fire in test. DT-TEN-3 is NOT shipped in this
+/// increment (it is deferred); until it lands, the runtime fail-closed guarantee above is the sole
+/// enforcement, so a NEW worker must be routed through this base by review, not yet by the build.</item>
 /// </list>
 ///
 /// Self-host is single-tenant and must not be burdened: when <see cref="HostedTenantBoundary.IsHosted"/> is


### PR DESCRIPTION
G8 increment 2: the worker seam the cancellation cutoff (MTR-15) will ride on.

- **TenantScopedSweep** - the base every background job touching tenant-scoped stores runs through. Fans out over the tenant census (TenantRegistry.AllTenantIds, new) and enters each tenant's ambient scope in turn; self-host fires once under Local. A worker that forgets its scope fails closed at runtime (the AsyncLocalTenantContext throw).
- **CronTenantSweep** migrates the cron sweep onto the seam and turns it ON for hosted (it was previously disabled because a background timer has no ambient tenant). Cron now fires inside each tenant's scope, reading only that tenant's cron_jobs. Self-host behavior unchanged.
- Tests (4, green): self-host fires once under Local ignoring the census; hosted fires once per tenant each under its own scope; per-tenant failure does not abort others; empty census fires zero times. The hosted test is the revert-proof.

Follow-ups (not in this PR): the DT-TEN-3 static gate (enforces that no worker bypasses the seam) and migrating the other disabled-on-hosted workers one at a time. The cutoff will add the per-tenant entitlement-lease filter (a cancelled tenant's cron must not keep firing).