### PR TITLE
Repository background service phase 1: monitor + streaming screen

### DIFF
--- a/src/CcDirector.Avalonia.Tests/RepositoryListViewRenderTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoryListViewRenderTests.cs
@@ -1,16 +1,28 @@
-using System;
-using System.IO;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using CcDirector.Avalonia.Controls;
-using CcDirector.Core.Configuration;
+using CcDirector.Core.Git;
 using Xunit;
 
 namespace CcDirector.Avalonia.Tests;
 
 public class RepositoryListViewRenderTests
 {
+    private static RepositoryMonitor MonitorWith(params string[] names)
+        => new(
+            enumerate: _ => names,
+            compute: (p, _, _) => Task.FromResult(new RepositoryStatus
+            {
+                Path = p,
+                Name = p,
+                Provider = RepoProvider.GitHub,
+                Branch = "main",
+                IsClean = true,
+                Success = true,
+            }));
+
     [AvaloniaFact]
     public void RepositoryListView_LoadsAndLaysOut()
     {
@@ -23,14 +35,29 @@ public class RepositoryListViewRenderTests
     }
 
     [AvaloniaFact]
+    public async Task RepositoryListView_RendersMonitorModel()
+    {
+        var monitor = MonitorWith("alpha", "beta", "gamma");
+        await monitor.RescanAsync(new[] { "/roots" });
+
+        var view = new RepositoryListView();
+        var window = new Window { Content = view, Width = 900, Height = 600 };
+        window.Show();
+        view.Attach(monitor);
+        Dispatcher.UIThread.RunJobs();
+
+        // The view rendered the monitor's three repositories without scanning anything itself.
+        Assert.Equal(3, monitor.Snapshot().Count);
+    }
+
+    [AvaloniaFact]
     public void RepositoryScreenWindow_Constructs_AndWiresNamedControls()
     {
         // Reproduces the "Repository status..." menu path. A hand-written InitializeComponent that
         // skipped the generated named-field hookup left ListView null and threw in this constructor.
-        var store = new RootDirectoryStore(
-            Path.Combine(Path.GetTempPath(), "ccd-rootstore-" + Guid.NewGuid().ToString("N") + ".json"));
+        var monitor = MonitorWith("alpha");
 
-        var window = new global::CcDirector.Avalonia.RepositoryScreenWindow(store, null);
+        var window = new global::CcDirector.Avalonia.RepositoryScreenWindow(monitor);
         window.Show();
         Dispatcher.UIThread.RunJobs();
 

--- a/src/CcDirector.Avalonia/App.axaml.cs
+++ b/src/CcDirector.Avalonia/App.axaml.cs
@@ -11,6 +11,8 @@ using CcDirector.Core.Account;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Claude;
 using CcDirector.Core.Configuration;
+using System.Linq;
+using CcDirector.Core.Git;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Settings;
 using CcDirector.Core.Storage;
@@ -28,6 +30,12 @@ public partial class App : Application
     public List<RepositoryConfig> Repositories { get; private set; } = new();
     public RepositoryRegistry RepositoryRegistry { get; private set; } = null!;
     public RootDirectoryStore RootDirectoryStore { get; private set; } = null!;
+
+    /// <summary>
+    /// The always-current model of the repositories under the registered roots. Owned by the app,
+    /// scanned in the background from startup; the Repository screen subscribes and renders it.
+    /// </summary>
+    public RepositoryMonitor RepositoryMonitor { get; } = new();
     public SessionStateStore SessionStateStore { get; private set; } = null!;
 
     /// <summary>
@@ -141,6 +149,19 @@ public partial class App : Application
         StartUpdateService(mainWindow);
     }
 
+    /// <summary>
+    /// Kick off a background rescan of the registered root directories into <see cref="RepositoryMonitor"/>.
+    /// Fire-and-forget; results stream into the model as each repository is computed.
+    /// </summary>
+    public void StartRepositoryRescan()
+    {
+        var roots = RootDirectoryStore.Roots
+            .Select(r => r.Path)
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .ToList();
+        _ = System.Threading.Tasks.Task.Run(() => RepositoryMonitor.RescanAsync(roots));
+    }
+
     private void InitializeServices(SplashScreen splash)
     {
         RepositoryRegistry = new RepositoryRegistry();
@@ -149,6 +170,10 @@ public partial class App : Application
 
         RootDirectoryStore = new RootDirectoryStore();
         RootDirectoryStore.Load();
+
+        // Start scanning repositories in the background right away, so the Repository screen has
+        // content the moment it is opened (issue #507, phase 1).
+        StartRepositoryRescan();
 
         SessionStateStore = new SessionStateStore();
 

--- a/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Media;
-using CcDirector.Core.Configuration;
+using Avalonia.Threading;
 using CcDirector.Core.Git;
 using CcDirector.Core.Utilities;
 
@@ -51,87 +49,73 @@ public partial class RepositoryListView : UserControl
     private static readonly ISolidColorBrush MutedBg = new SolidColorBrush(Color.Parse("#2D2D30"));
     private static readonly ISolidColorBrush MutedBr = new SolidColorBrush(Color.Parse("#3C3C3C"));
 
-    private readonly RepositoryStatusService _service = new();
-    private RootDirectoryStore? _store;
-    private bool _isLoading;
+    private RepositoryMonitor? _monitor;
 
-    /// <summary>Live sessions on this machine, so the worktree summary distinguishes in-use from safe. Optional.</summary>
-    public Func<CancellationToken, Task<IReadOnlyList<LiveSessionRef>>>? LiveSessionsProvider { get; set; }
+    /// <summary>Raised when the user clicks Refresh; the host triggers the monitor to rescan.</summary>
+    public event Action? RefreshRequested;
 
     public RepositoryListView()
     {
         InitializeComponent();
     }
 
-    /// <summary>Point the view at the configured root directories and scan.</summary>
-    public void Attach(RootDirectoryStore store)
+    /// <summary>
+    /// Subscribe to the background monitor and render its current model. The view never scans - it
+    /// displays what the service already knows and updates as results stream in.
+    /// </summary>
+    public void Attach(RepositoryMonitor monitor)
     {
         FileLog.Write("[RepositoryListView] Attach");
-        _store = store;
-        _ = RefreshAsync();
+        Detach();
+        _monitor = monitor;
+        monitor.Upserted += OnModelChanged;
+        monitor.Removed += OnModelChanged;
+        monitor.ProgressChanged += OnProgressChanged;
+        RenderFromMonitor();
     }
 
-    private void RefreshButton_Click(object? sender, RoutedEventArgs e) => _ = RefreshAsync();
-
-    private async Task RefreshAsync()
+    public void Detach()
     {
-        if (_store is null || _isLoading)
+        if (_monitor is { } m)
+        {
+            m.Upserted -= OnModelChanged;
+            m.Removed -= OnModelChanged;
+            m.ProgressChanged -= OnProgressChanged;
+            _monitor = null;
+        }
+    }
+
+    private void OnModelChanged(RepositoryStatus _) => Dispatcher.UIThread.Post(RenderFromMonitor);
+    private void OnProgressChanged() => Dispatcher.UIThread.Post(RenderFromMonitor);
+
+    private void RefreshButton_Click(object? sender, RoutedEventArgs e) => RefreshRequested?.Invoke();
+
+    private void RenderFromMonitor()
+    {
+        if (_monitor is null)
             return;
 
-        _isLoading = true;
-        StatusText.Text = "Scanning repositories...";
-        StatusText.IsVisible = true;
-        ContentScroller.IsVisible = false;
+        var statuses = _monitor.Snapshot();
+        RepoList.ItemsSource = BuildRows(statuses);
 
-        try
+        bool scanning = _monitor.IsScanning;
+        if (statuses.Count == 0)
         {
-            var roots = _store.Roots.Select(r => r.Path).Where(p => !string.IsNullOrWhiteSpace(p)).ToList();
-            var sessions = await FetchLiveSessionsAsync();
-            var statuses = await Task.Run(() => _service.ScanAsync(roots, sessions));
-
-            var rows = BuildRows(statuses);
-            RepoList.ItemsSource = rows;
-
-            if (rows.Count == 0)
-            {
-                StatusText.Text = roots.Count == 0
-                    ? "No root directories are configured. Add one in Repositories."
-                    : "No repositories found under the configured root directories.";
-                StatusText.IsVisible = true;
-                ContentScroller.IsVisible = false;
-            }
-            else
-            {
-                SummaryText.Text = BuildSummary(statuses);
-                StatusText.IsVisible = false;
-                ContentScroller.IsVisible = true;
-            }
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[RepositoryListView] RefreshAsync FAILED: {ex.Message}");
-            StatusText.Text = $"Could not scan repositories: {ex.Message}";
+            StatusText.Text = scanning
+                ? "Scanning repositories..."
+                : "No repositories found under the configured root directories.";
             StatusText.IsVisible = true;
             ContentScroller.IsVisible = false;
         }
-        finally
+        else
         {
-            _isLoading = false;
+            StatusText.IsVisible = false;
+            ContentScroller.IsVisible = true;
         }
-    }
 
-    private async Task<IReadOnlyList<LiveSessionRef>> FetchLiveSessionsAsync()
-    {
-        try
-        {
-            if (LiveSessionsProvider is { } provider)
-                return await provider(CancellationToken.None) ?? Array.Empty<LiveSessionRef>();
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[RepositoryListView] FetchLiveSessionsAsync FAILED (proceeding without session data): {ex.Message}");
-        }
-        return Array.Empty<LiveSessionRef>();
+        SummaryText.Text = scanning
+            ? $"Scanning... {_monitor.ScanDone} of {_monitor.ScanTotal}"
+            : BuildSummary(statuses);
     }
 
     // ----- pure builders (unit-tested without a UI) -----

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -3695,7 +3695,8 @@ public partial class MainWindow : Window
         session.Menu.Items.Add(Item("Repository status...", async () =>
         {
             FileLog.Write("[MainWindow] Menu: Repository status");
-            var window = new RepositoryScreenWindow(AppRef().RootDirectoryStore, GetLiveSessionsOnThisMachineAsync);
+            var app = AppRef();
+            var window = new RepositoryScreenWindow(app.RepositoryMonitor, app.StartRepositoryRescan);
             await window.ShowDialog(this);
         }));
         if (alpha)

--- a/src/CcDirector.Avalonia/RepositoryScreenWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/RepositoryScreenWindow.axaml.cs
@@ -1,16 +1,13 @@
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Avalonia.Controls;
-using CcDirector.Core.Configuration;
 using CcDirector.Core.Git;
 
 namespace CcDirector.Avalonia;
 
 /// <summary>
 /// A thin window hosting the Repository list. Transitional shell while the screen is a pop-up; the
-/// list control is the same one that will embed in the main window later.
+/// list control is the same one that will embed in the main window later. The window only displays -
+/// the <see cref="RepositoryMonitor"/> owns the state and the scanning.
 /// </summary>
 public partial class RepositoryScreenWindow : Window
 {
@@ -21,10 +18,10 @@ public partial class RepositoryScreenWindow : Window
         InitializeComponent();
     }
 
-    public RepositoryScreenWindow(RootDirectoryStore store,
-        Func<CancellationToken, Task<IReadOnlyList<LiveSessionRef>>>? liveSessionsProvider = null) : this()
+    public RepositoryScreenWindow(RepositoryMonitor monitor, Action? onRefreshRequested = null) : this()
     {
-        ListView.LiveSessionsProvider = liveSessionsProvider;
-        ListView.Attach(store);
+        if (onRefreshRequested != null)
+            ListView.RefreshRequested += onRefreshRequested;
+        ListView.Attach(monitor);
     }
 }

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -1,0 +1,105 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+public class RepositoryMonitorTests
+{
+    private static RepositoryStatus Status(string path) => new()
+    {
+        Path = path,
+        Name = System.IO.Path.GetFileName(path),
+        Provider = RepoProvider.GitHub,
+        Branch = "main",
+        IsClean = true,
+        Success = true,
+    };
+
+    private static RepositoryMonitor MonitorOver(IReadOnlyList<string> paths, Action? perCompute = null)
+        => new(
+            enumerate: _ => paths,
+            compute: (p, _, _) => { perCompute?.Invoke(); return Task.FromResult(Status(p)); });
+
+    [Fact]
+    public async Task Rescan_StreamsEachRepository_AndBuildsModel()
+    {
+        var monitor = MonitorOver(new[] { "/r/a", "/r/b", "/r/c" });
+        var upserts = new List<string>();
+        monitor.Upserted += s => upserts.Add(s.Name);
+
+        await monitor.RescanAsync(new[] { "/r" });
+
+        Assert.Equal(new[] { "a", "b", "c" }, upserts);          // streamed one at a time, in order
+        Assert.Equal(3, monitor.Snapshot().Count);
+        Assert.False(monitor.IsScanning);
+        Assert.Equal(3, monitor.ScanDone);
+        Assert.Equal(3, monitor.ScanTotal);
+    }
+
+    [Fact]
+    public async Task Rescan_ReportsProgress_AndCompletes()
+    {
+        var monitor = MonitorOver(new[] { "/r/a", "/r/b" });
+        var progressDone = new List<int>();
+        bool completed = false;
+        monitor.ProgressChanged += () => progressDone.Add(monitor.ScanDone);
+        monitor.ScanCompleted += () => completed = true;
+
+        await monitor.RescanAsync(new[] { "/r" });
+
+        Assert.Contains(1, progressDone);
+        Assert.Contains(2, progressDone);
+        Assert.True(completed);
+    }
+
+    [Fact]
+    public async Task Rescan_Again_RemovesRepositoriesNoLongerFound()
+    {
+        var first = new[] { "/r/a", "/r/b", "/r/c" };
+        var paths = new List<string>(first);
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => paths.ToList(),
+            compute: (p, _, _) => Task.FromResult(Status(p)));
+
+        await monitor.RescanAsync(new[] { "/r" });
+        Assert.Equal(3, monitor.Snapshot().Count);
+
+        // "c" is gone on the second scan.
+        paths.Remove("/r/c");
+        var removed = new List<string>();
+        monitor.Removed += s => removed.Add(s.Name);
+
+        await monitor.RescanAsync(new[] { "/r" });
+
+        Assert.Equal(new[] { "c" }, removed);
+        Assert.Equal(2, monitor.Snapshot().Count);
+        Assert.DoesNotContain(monitor.Snapshot(), s => s.Name == "c");
+    }
+
+    [Fact]
+    public async Task Rescan_Upsert_UpdatesExistingEntryInPlace()
+    {
+        var dirty = false;
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => new[] { "/r/a" },
+            compute: (p, _, _) => Task.FromResult(new RepositoryStatus
+            {
+                Path = p,
+                Name = "a",
+                IsClean = !dirty,
+                UncommittedCount = dirty ? 5 : 0,
+                Success = true,
+            }));
+
+        await monitor.RescanAsync(new[] { "/r" });
+        Assert.True(monitor.Snapshot()[0].IsClean);
+
+        dirty = true;
+        await monitor.RescanAsync(new[] { "/r" });
+
+        var only = Assert.Single(monitor.Snapshot());
+        Assert.False(only.IsClean);
+        Assert.Equal(5, only.UncommittedCount);
+    }
+}

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -1,0 +1,142 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// A long-lived, in-memory model of the repositories under the registered root directories, updated
+/// by progressive background scans. It is the source of truth the Repository screen (and, later, the
+/// per-session Worktrees tab and the Cockpit) render - they subscribe and display; they never scan.
+///
+/// A rescan streams results: each repository is published as soon as it is computed
+/// (<see cref="Upserted"/>), progress is reported as it goes, and repositories no longer found are
+/// removed at the end (<see cref="Removed"/>). Events fire on the scanning thread; UI subscribers
+/// marshal to their dispatcher.
+///
+/// This is phase 1 of the background service (devthrottle_internal#507): the model + progressive
+/// streaming. The warm-start cache, the file watcher, live session occupancy, and the Gateway push
+/// are later phases.
+/// </summary>
+public sealed class RepositoryMonitor
+{
+    private readonly Func<IEnumerable<string>, IReadOnlyList<string>> _enumerate;
+    private readonly Func<string, IReadOnlyList<LiveSessionRef>?, CancellationToken, Task<RepositoryStatus>> _compute;
+
+    private readonly object _gate = new();
+    private readonly Dictionary<string, RepositoryStatus> _byPath = new(StringComparer.OrdinalIgnoreCase);
+    private CancellationTokenSource? _cts;
+
+    /// <summary>True while a scan is in progress.</summary>
+    public bool IsScanning { get; private set; }
+
+    /// <summary>How many repositories have been computed in the current/last scan.</summary>
+    public int ScanDone { get; private set; }
+
+    /// <summary>How many repositories the current/last scan set out to compute.</summary>
+    public int ScanTotal { get; private set; }
+
+    /// <summary>Raised when a repository's status is added or updated in the model.</summary>
+    public event Action<RepositoryStatus>? Upserted;
+
+    /// <summary>Raised when a repository is removed from the model (no longer found on disk).</summary>
+    public event Action<RepositoryStatus>? Removed;
+
+    /// <summary>Raised when <see cref="IsScanning"/>, <see cref="ScanDone"/>, or <see cref="ScanTotal"/> changes.</summary>
+    public event Action? ProgressChanged;
+
+    /// <summary>Raised once when a scan finishes (not raised when a scan is superseded/cancelled).</summary>
+    public event Action? ScanCompleted;
+
+    public RepositoryMonitor(
+        Func<IEnumerable<string>, IReadOnlyList<string>>? enumerate = null,
+        Func<string, IReadOnlyList<LiveSessionRef>?, CancellationToken, Task<RepositoryStatus>>? compute = null)
+    {
+        _enumerate = enumerate ?? DefaultEnumerate;
+        _compute = compute ?? DefaultCompute;
+    }
+
+    /// <summary>A thread-safe copy of the current model.</summary>
+    public IReadOnlyList<RepositoryStatus> Snapshot()
+    {
+        lock (_gate)
+            return _byPath.Values.ToList();
+    }
+
+    /// <summary>
+    /// Rescan the given roots, streaming each repository's status into the model as it is computed.
+    /// A new rescan supersedes any in-flight one.
+    /// </summary>
+    public async Task RescanAsync(IEnumerable<string> roots, IReadOnlyList<LiveSessionRef>? sessions = null, CancellationToken externalCt = default)
+    {
+        CancellationTokenSource cts;
+        lock (_gate)
+        {
+            _cts?.Cancel();
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(externalCt);
+            cts = _cts;
+        }
+        var ct = cts.Token;
+
+        var paths = _enumerate(roots);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        lock (_gate) { IsScanning = true; ScanTotal = paths.Count; ScanDone = 0; }
+        ProgressChanged?.Invoke();
+        FileLog.Write($"[RepositoryMonitor] rescan started: {paths.Count} repositories");
+
+        try
+        {
+            foreach (var path in paths)
+            {
+                ct.ThrowIfCancellationRequested();
+                var status = await _compute(path, sessions, ct);
+                var key = WorktreeReaperService.NormalizePath(status.Path);
+                seen.Add(key);
+                lock (_gate) { _byPath[key] = status; ScanDone++; }
+                Upserted?.Invoke(status);
+                ProgressChanged?.Invoke();
+            }
+
+            // Reconcile: drop repositories that were in the model but not found this scan.
+            List<RepositoryStatus> removed;
+            lock (_gate)
+            {
+                removed = _byPath.Where(kv => !seen.Contains(kv.Key)).Select(kv => kv.Value).ToList();
+                foreach (var r in removed)
+                    _byPath.Remove(WorktreeReaperService.NormalizePath(r.Path));
+            }
+            foreach (var r in removed)
+                Removed?.Invoke(r);
+        }
+        catch (OperationCanceledException)
+        {
+            FileLog.Write("[RepositoryMonitor] rescan superseded/cancelled");
+            return; // a newer scan owns the model now
+        }
+        finally
+        {
+            lock (_gate) { IsScanning = false; }
+            ProgressChanged?.Invoke();
+        }
+
+        FileLog.Write($"[RepositoryMonitor] rescan completed: {ScanDone}/{ScanTotal}");
+        ScanCompleted?.Invoke();
+    }
+
+    private static IReadOnlyList<string> DefaultEnumerate(IEnumerable<string> roots)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>();
+        foreach (var root in roots)
+        {
+            if (string.IsNullOrWhiteSpace(root))
+                continue;
+            foreach (var (_, path) in RemoteRepoProvider.ScanLocalRepos(root))
+                if (seen.Add(WorktreeReaperService.NormalizePath(path)))
+                    result.Add(path);
+        }
+        return result;
+    }
+
+    private static async Task<RepositoryStatus> DefaultCompute(string path, IReadOnlyList<LiveSessionRef>? sessions, CancellationToken ct)
+        => await new RepositoryStatusService().GetStatusAsync(path, sessions, fetchPrune: false, ct);
+}


### PR DESCRIPTION
Phase 1 of the repository/worktree background service (spec thefrederiksen/devthrottle_internal#507). Replaces the on-demand scan that blocked on open.

## What this adds
- **`RepositoryMonitor` (Core)** - a long-lived in-memory model of the repos under the registered roots. A rescan **streams**: each repository is published (`Upserted`) the moment it is computed, progress is reported as it goes, and repositories no longer found are removed at the end. Injectable enumerate/compute keep it unit-testable. This is the source of truth the UI renders.
- **App owns the monitor** and starts a background rescan **at startup**, so the Repository screen has content the moment it opens - no blocking scan.
- **`RepositoryListView` subscribes** to the monitor and renders its model plus a "Scanning... N of M" progress line, updating live as results stream in. It never scans; Refresh asks the app to rescan.

## Not in this phase (later, per #507)
Live session occupancy (in-use), the warm-start JSON cache, the FileSystemWatcher, and the Gateway push. For now a scan runs without session data, so a worktree a session occupies is not yet marked "in use".

## Tests
- Monitor: streaming order, progress + completion, reconcile-on-rescan (removals), in-place upsert. (4)
- Headless: the view renders a monitor's model without scanning.
- Full Core.Tests 3349 passed, 8 skipped, 0 failed. Full Avalonia.Tests 268 passed, 0 failed.

## Mockup
Scanning / streaming / warm-start / watching states: https://claude.ai/code/artifact/fb5ee489-fb68-4d9f-835a-ac7c5f3d896d