### PR TITLE
Serve the Account device list per-tenant on hosted (fixes contradictory Account page)

### DIFF
--- a/src/CcDirector.Gateway.Tests/Account/AccountDevicesEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/AccountDevicesEndpointTests.cs
@@ -138,7 +138,9 @@ public sealed class AccountDevicesEndpointTests
             app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, requireToken, next));
         }
 
-        AccountDevicesEndpoint.Map(app, account, devices, ThisMachine);
+        // Self-host path: GatewayHostedMode is not hosted here, so the local registry and tenant boundary are
+        // never consulted - a bare registry satisfies the required argument and no boundary is passed.
+        AccountDevicesEndpoint.Map(app, account, devices, ThisMachine, new DeviceRegistry());
         await app.StartAsync();
 
         var baseUrl = app.Urls.First();

--- a/src/CcDirector.Gateway.Tests/HostedAccountDevicesServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedAccountDevicesServeTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1856 / cockpit Account page: the account device list now SERVES the caller's own tenant on the
+/// hosted Gateway instead of reporting a false signed-out state. Before this fix
+/// <c>GET /account/devices</c> read the SELF-HOST Gateway account token, which a shared multi-tenant Gateway
+/// never holds, so it always answered <c>signedIn:false</c> - while <c>GET /account/status</c> (already
+/// hosted-aware) answered <c>signedIn:true</c> for the same caller. The Account page rendered both truthfully
+/// and contradicted itself: a green "Signed in" card above a "the Gateway reports it is no longer signed in"
+/// device panel.
+///
+/// The hostile A/B proof on a real HOSTED GatewayHost with TWO fully enrolled tenants and one unbound device:
+///   1. SERVE - the list answers 200, <c>signedIn:true</c>, and carries the caller tenant's OWN device.
+///   2. ISOLATED - a device registered by tenant A is INVISIBLE to tenant B's list, and neither can revoke
+///      the other's device (a cross-tenant revoke is a 404, indistinguishable from a missing id).
+///   3. FAIL CLOSED - an unbound device key is refused at the auth gate (401, MTR-14B), never served the
+///      Local partition.
+///
+/// Revert-prove: point the GET back at the self-host token path (drop the <c>GatewayHostedMode.IsHosted</c>
+/// branch) and <see cref="Account_devices_serves_the_callers_own_tenant"/> goes RED (signedIn=false), and
+/// <see cref="A_device_registered_by_one_tenant_is_invisible_to_another_on_hosted"/> can no longer even see a
+/// device to compare. Self-host is unchanged (it keeps the cloud-proxy path) and is not exercised here.
+/// </summary>
+[Collection("GatewayHostedMode")]
+public sealed class HostedAccountDevicesServeTests : IAsyncLifetime
+{
+    private const string Token = "test-token-acct-devices-serve";
+
+    private readonly string _root;
+    private readonly string? _priorRoot;
+    private readonly string? _priorHosted;
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-acctdev-serve-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _httpA = null!;        // fully enrolled tenant A, auth device "dev-a"
+    private HttpClient _httpB = null!;        // fully enrolled tenant B, device "dev-b"
+    private HttpClient _httpUnbound = null!;  // enrolled device, NO tenant binding
+    private TenantId _tenantA;
+
+    public HostedAccountDevicesServeTests()
+    {
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-acctdev-serve-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: HostedOwnerSettingsDenyTests.FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+
+        _httpA = Enrolled("dev-a", "sub-alice", "alice@example.com", "MACHINE-A", out _tenantA);
+        _httpB = Enrolled("dev-b", "sub-bob", "bob@example.com", "MACHINE-B", out _);
+
+        // A SECOND device on tenant A's account (a phone alongside the Gateway machine). Bound to the same
+        // account, it is the target of the "revoke my own device" test - revoking it must not log tenant A out
+        // (that would happen only if A revoked dev-a, the key it authenticates with).
+        _gateway.Devices.Register("dev-a2", "PHONE-A");
+        _gateway.Devices.SetAccountBinding("dev-a2", "sub-alice", _tenantA.Value);
+
+        var unboundKey = _gateway.Devices.Register("dev-unbound", "MACHINE-X").DeviceKey;
+        _httpUnbound = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _httpUnbound.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", unboundKey);
+    }
+
+    private HttpClient Enrolled(string deviceId, string subject, string email, string machineName, out TenantId tenant)
+    {
+        var key = _gateway.Devices.Register(deviceId, machineName).DeviceKey;
+        var minted = _gateway.TenantRegistry.MintOrLookupBySubject(subject, email);
+        _gateway.Devices.SetAccountBinding(deviceId, subject, minted.Value);
+        tenant = minted;
+        var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", key);
+        return http;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _httpA.Dispose();
+        _httpB.Dispose();
+        _httpUnbound.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// SERVE: the list answers 200 with signedIn=true and the caller tenant's OWN device - not the
+    /// self-host-only signedIn=false that made the Account page contradict itself.
+    /// </summary>
+    [Fact]
+    public async Task Account_devices_serves_the_callers_own_tenant()
+    {
+        var resp = await _httpA.GetAsync("account/devices");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var body = await resp.Content.ReadFromJsonAsync<AccountDevicesResponseDto>();
+        Assert.NotNull(body);
+        Assert.True(body!.SignedIn);
+        Assert.NotNull(body.Devices);
+        Assert.Contains(body.Devices!, d => d.Id == "dev-a");
+    }
+
+    /// <summary>
+    /// ISOLATED: a device registered by tenant A is INVISIBLE to tenant B's list, and B's own device is
+    /// invisible to A. One account never reads back another's device inventory.
+    /// </summary>
+    [Fact]
+    public async Task A_device_registered_by_one_tenant_is_invisible_to_another_on_hosted()
+    {
+        var a = await (await _httpA.GetAsync("account/devices")).Content.ReadFromJsonAsync<AccountDevicesResponseDto>();
+        var b = await (await _httpB.GetAsync("account/devices")).Content.ReadFromJsonAsync<AccountDevicesResponseDto>();
+
+        Assert.Contains(a!.Devices!, d => d.Id == "dev-a");
+        Assert.DoesNotContain(a.Devices!, d => d.Id == "dev-b");
+
+        Assert.Contains(b!.Devices!, d => d.Id == "dev-b");
+        Assert.DoesNotContain(b.Devices!, d => d.Id == "dev-a");
+    }
+
+    /// <summary>
+    /// ISOLATED (revoke): tenant A cannot revoke tenant B's device. The cross-tenant delete is a 404 -
+    /// indistinguishable from a non-existent id, so A cannot even probe B's device ids - and B's device is
+    /// still listed for B afterwards.
+    /// </summary>
+    [Fact]
+    public async Task A_tenant_cannot_revoke_another_tenants_device_on_hosted()
+    {
+        var resp = await _httpA.DeleteAsync("account/devices/dev-b");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+
+        var b = await (await _httpB.GetAsync("account/devices")).Content.ReadFromJsonAsync<AccountDevicesResponseDto>();
+        Assert.Contains(b!.Devices!, d => d.Id == "dev-b");
+    }
+
+    /// <summary>
+    /// A tenant CAN revoke one of its own devices: revoking tenant A's second device (a phone, not the key it
+    /// authenticates with) answers 200 revoked=true, and A's subsequent list drops that device while keeping
+    /// its still-valid auth device.
+    /// </summary>
+    [Fact]
+    public async Task A_tenant_can_revoke_its_own_device_on_hosted()
+    {
+        var resp = await _httpA.DeleteAsync("account/devices/dev-a2");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var revoke = await resp.Content.ReadFromJsonAsync<RevokeDeviceResponseDto>();
+        Assert.True(revoke!.SignedIn);
+        Assert.True(revoke.Revoked);
+
+        var after = await (await _httpA.GetAsync("account/devices")).Content.ReadFromJsonAsync<AccountDevicesResponseDto>();
+        Assert.DoesNotContain(after!.Devices!, d => d.Id == "dev-a2");
+        Assert.Contains(after.Devices!, d => d.Id == "dev-a");
+    }
+
+    /// <summary>
+    /// FAIL CLOSED: an unbound device key is not a valid hosted credential (MTR-14B), so it is refused at the
+    /// auth gate with 401 - never served the Local partition's device list.
+    /// </summary>
+    [Fact]
+    public async Task An_unbound_device_key_is_denied_on_hosted()
+    {
+        var resp = await _httpUnbound.GetAsync("account/devices");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedRecordingServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedRecordingServeTests.cs
@@ -125,14 +125,17 @@ public sealed class HostedRecordingServeTests : IAsyncLifetime
         Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
     }
 
-    /// <summary>FAIL CLOSED: a device with no bound tenant is refused 403, never served the Local partition.</summary>
+    /// <summary>FAIL CLOSED: a device with no bound tenant is refused, never served the Local partition.
+    /// MTR-14B (#2020): an unbound device on hosted is an invalid credential, so it is now denied at the auth
+    /// gate with 401 before reaching the route's tenant-boundary 403 - the isolation is unchanged, only the
+    /// denial layer moved earlier.</summary>
     [Theory]
     [InlineData("ingest/recordings")]
     [InlineData("ingest/dictionary")]
-    public async Task Ingest_reads_refuse_an_unresolved_tenant_with_403(string path)
+    public async Task Ingest_reads_refuse_an_unresolved_tenant_with_401(string path)
     {
         var resp = await _httpUnbound.GetAsync(path);
-        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
     }
 
     /// <summary>Control: an unauthenticated caller is still rejected by the host-wide auth gate.</summary>

--- a/src/CcDirector.Gateway.Tests/HostedTranscriptionServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedTranscriptionServeTests.cs
@@ -120,15 +120,18 @@ public sealed class HostedTranscriptionServeTests : IAsyncLifetime
         Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
     }
 
-    /// <summary>FAIL CLOSED: a device with no bound tenant is refused 403, never served the Local partition.</summary>
+    /// <summary>FAIL CLOSED: a device with no bound tenant is refused, never served the Local partition.
+    /// MTR-14B (#2020): an unbound device on hosted is an invalid credential, so it is now denied at the auth
+    /// gate with 401 before reaching the route's tenant-boundary 403 - the isolation is unchanged, only the
+    /// denial layer moved earlier.</summary>
     [Theory]
     [InlineData("transcription/stats")]
     [InlineData("transcription/turns")]
     [InlineData("transcription/terms")]
-    public async Task Transcription_reads_refuse_an_unresolved_tenant_with_403(string path)
+    public async Task Transcription_reads_refuse_an_unresolved_tenant_with_401(string path)
     {
         var resp = await _httpUnbound.GetAsync(path);
-        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
     }
 
     /// <summary>Control: an unauthenticated caller is still rejected by the host-wide auth gate.</summary>

--- a/src/CcDirector.Gateway/Api/AccountDevicesEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountDevicesEndpoint.cs
@@ -21,8 +21,19 @@ namespace CcDirector.Gateway.Api;
 /// machines paired to THIS Gateway; this lists the devices registered to the DevThrottle ACCOUNT across
 /// the cloud. Both surfaces coexist.
 ///
+/// HOSTED (issue #1856 pattern): the self-host cloud proxy above is meaningless on the shared multi-tenant
+/// Gateway, which holds NO single account credential - identity arrives per device, bound to the device key
+/// at enrollment. On hosted the two routes answer about the CALLER: they resolve the request's tenant from
+/// its authenticated device key and serve that tenant's own devices from the local device registry (the
+/// database authority since the #2020 cutover), returning 403 when no tenant is bound - NEVER the Local
+/// partition, and NEVER a signedIn=false envelope to an authenticated tenant. This mirrors exactly what
+/// <c>/account/status</c> and the tenant-scoped <c>/devices</c> listing already do. Gated on
+/// <see cref="GatewayHostedMode.IsHosted"/> (not on the boundary having been wired) so a hosted Gateway can
+/// never silently fall through to the self-host answer; a missing boundary FAILS CLOSED with a 503.
+///
 /// Security (carries DT-05): the raw account token NEVER appears in the Cockpit-facing response (the DTOs
-/// have no token field) and is never written to the log on any path.
+/// have no token field) and is never written to the log on any path. On the hosted path no account token
+/// exists and the device rows carry only masked key metadata (prefix/last-four), never a raw key.
 ///
 /// Behaviour at the edges (no fabricated data):
 /// <list type="bullet">
@@ -46,17 +57,35 @@ internal static class AccountDevicesEndpoint
     /// The Gateway-hosted DevThrottle credential service (issue #636). Null on a host that has no
     /// credential service (a non-Windows host); the endpoints then report an explicit signed-out result.
     /// </param>
-    /// <param name="devices">The cloud device-registry client (the injectable cloud egress seam).</param>
+    /// <param name="devices">The cloud device-registry client (the injectable cloud egress seam, self-host).</param>
     /// <param name="thisDeviceName">
     /// This host's machine name, used to mark the Gateway's own device in the list. Injected for tests.
     /// </param>
-    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, DeviceRegistryClient devices, string thisDeviceName)
+    /// <param name="localDevices">
+    /// The local device registry (the database device-credential authority). On hosted this is the source of
+    /// the caller tenant's device list and the target of the per-tenant revoke; unused on the self-host path.
+    /// </param>
+    /// <param name="tenantBoundary">
+    /// The hosted tenant boundary (issue #1856). On hosted it resolves the CALLER's tenant from their
+    /// authenticated device key; omitting it on a hosted Gateway does NOT fall back to the self-host answer -
+    /// the hosted path FAILS CLOSED with a 503. Ignored off hosted mode.
+    /// </param>
+    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, DeviceRegistryClient devices, string thisDeviceName,
+        Pairing.DeviceRegistry localDevices, Tenancy.HostedTenantBoundary? tenantBoundary = null)
     {
         if (devices is null) throw new ArgumentNullException(nameof(devices));
         if (thisDeviceName is null) throw new ArgumentNullException(nameof(thisDeviceName));
+        if (localDevices is null) throw new ArgumentNullException(nameof(localDevices));
 
         app.MapGet("/account/devices", async (HttpContext ctx) =>
         {
+            // Issue #1856: on HOSTED, answer about the CALLER, not about this Gateway's (absent) account
+            // credential. Gated on hosted MODE, not on the boundary being wired, so a hosted Gateway can never
+            // silently take the self-host path and report a false signedIn=false; a missing boundary fails
+            // closed inside HostedDevices.
+            if (GatewayHostedMode.IsHosted)
+                return HostedDevices(ctx, tenantBoundary, localDevices, thisDeviceName);
+
             // Entry point: the delegate is the boundary, so the only try-catch lives here. A signed-out
             // Gateway is an expected state answered explicitly (not an exception); a cloud failure is an
             // unexpected failure caught here and reported as a clear error (never a fabricated list).
@@ -91,6 +120,11 @@ internal static class AccountDevicesEndpoint
             if (string.IsNullOrWhiteSpace(id))
                 return Results.BadRequest(new { error = "id is required" });
 
+            // Issue #1856: on HOSTED, revoke only the caller tenant's OWN device from the local registry. Same
+            // hosted-mode gate and fail-closed rule as the GET.
+            if (GatewayHostedMode.IsHosted)
+                return HostedRevoke(ctx, id, tenantBoundary, localDevices);
+
             // Entry point: same boundary rule as the GET above.
             var token = account?.GetAccessTokenForForwarding();
             if (string.IsNullOrEmpty(token))
@@ -121,6 +155,95 @@ internal static class AccountDevicesEndpoint
                     statusCode: StatusCodes.Status502BadGateway);
             }
         });
+    }
+
+    /// <summary>
+    /// Hosted <c>GET /account/devices</c>: serve the CALLER tenant's own devices from the local registry.
+    /// Fails closed (503) if the boundary is missing on a hosted Gateway, and denies (403) a request with no
+    /// bound tenant - never the Local partition, and never a signedIn=false envelope to an authenticated
+    /// tenant (that false was the exact lie that made the Account page contradict itself).
+    /// </summary>
+    private static IResult HostedDevices(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary, Pairing.DeviceRegistry localDevices, string thisDeviceName)
+    {
+        if (boundary is not { IsHosted: true })
+        {
+            FileLog.Write("[AccountDevicesEndpoint] GET /account/devices (hosted): MISWIRED - hosted mode but no hosted tenant boundary; refusing rather than reporting a false signed-out state.");
+            return Results.Json(new { error = "this hosted gateway cannot resolve the caller's tenant" },
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        var tenant = boundary.ResolveRequestTenant(ctx);
+        if (tenant is null)
+        {
+            FileLog.Write("[AccountDevicesEndpoint] GET /account/devices (hosted): DENIED - no tenant is bound to this request");
+            return Results.Json(new { error = "no tenant is bound to this request" },
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        var records = localDevices.ListForTenant(tenant.Value);
+        var list = new List<AccountDeviceDto>(records.Count);
+        foreach (var record in records)
+            list.Add(ToDto(record, thisDeviceName));
+
+        FileLog.Write($"[AccountDevicesEndpoint] GET /account/devices (hosted): signedIn=true, returned {list.Count} device(s) for the caller's tenant");
+        return Results.Json(new AccountDevicesResponseDto { SignedIn = true, Devices = list });
+    }
+
+    /// <summary>
+    /// Hosted <c>DELETE /account/devices/{id}</c>: revoke a device only when it belongs to the CALLER's own
+    /// tenant. A device id that is not the caller tenant's is a 404 (indistinguishable from a non-existent id,
+    /// so one tenant cannot probe another's device ids), never a cross-tenant revoke.
+    /// </summary>
+    private static IResult HostedRevoke(HttpContext ctx, string id, Tenancy.HostedTenantBoundary? boundary, Pairing.DeviceRegistry localDevices)
+    {
+        if (boundary is not { IsHosted: true })
+        {
+            FileLog.Write($"[AccountDevicesEndpoint] DELETE /account/devices/{id} (hosted): MISWIRED - hosted mode but no hosted tenant boundary; refusing.");
+            return Results.Json(new { error = "this hosted gateway cannot resolve the caller's tenant" },
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        var tenant = boundary.ResolveRequestTenant(ctx);
+        if (tenant is null)
+        {
+            FileLog.Write($"[AccountDevicesEndpoint] DELETE /account/devices/{id} (hosted): DENIED - no tenant is bound to this request");
+            return Results.Json(new { error = "no tenant is bound to this request" },
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        var revoked = localDevices.RemoveForTenant(tenant.Value, id);
+        if (!revoked)
+        {
+            FileLog.Write($"[AccountDevicesEndpoint] DELETE /account/devices/{id} (hosted): not the caller tenant's device -> 404");
+            return Results.Json(new RevokeDeviceResponseDto { SignedIn = true, Id = id, Revoked = false },
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        FileLog.Write($"[AccountDevicesEndpoint] DELETE /account/devices/{id} (hosted): revoked for the caller's tenant");
+        return Results.Json(new RevokeDeviceResponseDto { SignedIn = true, Id = id, Revoked = true });
+    }
+
+    /// <summary>
+    /// Maps a local registry record to the Cockpit-facing DTO for the hosted path. The registry carries the
+    /// device id, machine name, issued time and masked key metadata; platform / device-type / app-version /
+    /// last-seen are not recorded there and are OMITTED (null) rather than guessed. The this-device marker
+    /// matches the record's machine name to this host's machine name (case-insensitive), same as the cloud map.
+    /// </summary>
+    private static AccountDeviceDto ToDto(RegisteredDeviceDto record, string thisDeviceName)
+    {
+        return new AccountDeviceDto
+        {
+            Id = record.DeviceId,
+            Name = record.MachineName,
+            Platform = null,
+            DeviceType = null,
+            AppVersion = null,
+            KeyPrefix = string.IsNullOrEmpty(record.KeyPrefix) ? null : record.KeyPrefix,
+            KeyLast4 = string.IsNullOrEmpty(record.KeyLast4) ? null : record.KeyLast4,
+            CreatedAt = record.IssuedAtUtc.ToString("o"),
+            LastSeenAt = null,
+            ThisDevice = string.Equals(record.MachineName, thisDeviceName, StringComparison.OrdinalIgnoreCase),
+        };
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2188,7 +2188,8 @@ public sealed class GatewayHost : IAsyncDisposable
         // registry GET /devices (issue #469), which is left unchanged. Inherits the host-wide token
         // middleware above, exactly like the other /account routes.
         var accountDevicesClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
-        AccountDevicesEndpoint.Map(_app, Account, new Core.Account.DeviceRegistryClient(accountDevicesClient), Environment.MachineName);
+        AccountDevicesEndpoint.Map(_app, Account, new Core.Account.DeviceRegistryClient(accountDevicesClient), Environment.MachineName,
+            Devices, _tenantBoundary);
 
         // Account credit-balance proxy (issue #884): GET /account/credits. Same proxy shape as the device
         // list - the Gateway reads the balance from the cloud with its own stored account token (JWT) and


### PR DESCRIPTION
The cockpit Account page showed a green "Signed in" card above a "the Gateway reports it is no longer signed in" device panel - two contradictory states at once.

`GET /account/devices` decided signed-in-ness by reading the self-host Gateway account token, which the shared multi-tenant Gateway never holds, so on hosted it always answered `signedIn:false` - while `GET /account/status` (already hosted-aware) answered `signedIn:true` for the same caller. The page rendered both truthfully and contradicted itself.

On hosted the two `/account/devices` routes now answer about the CALLER, mirroring `/account/status` and the tenant-scoped `/devices` listing: they resolve the request's tenant from its authenticated device key and serve/revoke only that tenant's own devices from the local device registry (the database authority since #2020), returning 403 when no tenant is bound - never the Local partition, and never a `signedIn:false` envelope to an authenticated tenant. Gated on `GatewayHostedMode.IsHosted` (not on the boundary being wired) so a hosted Gateway can never fall through to the self-host answer; a missing boundary fails closed with 503. Self-host keeps the cloud-proxy path unchanged.

The client needs no change (rule 7): once the Gateway returns `signedIn:true` with the tenant's devices, the existing dumb-client Account view renders the list.

`HostedAccountDevicesServeTests` - two enrolled tenants + one unbound device - proves serve (`signedIn:true` with the caller's own device), isolation (tenant A's device is invisible to B; neither can revoke the other's - a cross-tenant revoke is a 404), own-device revoke, and 401 for an unbound key.

---

**Also fixes a pre-existing red on main (unrelated to the Account change).** The full Gateway suite was failing 5 tests on `origin/main`: `HostedTranscriptionServeTests` (x3) and `HostedRecordingServeTests` (x2) asserted an unbound device key is refused with 403 at the route boundary. MTR-14B (#2020) deliberately moved that denial earlier - an unbound device on hosted is now an invalid credential rejected at the auth gate with 401 - and updated its sibling `HostedStatsServeTests` to match, but #2058/#2059 merged around the same time and their unbound assertions were never updated (a stale-base collision - each PR's CI was green before the other landed). These 5 assertions are aligned to the shipped 401 behavior, matching the stats sibling. The isolation guarantee is unchanged; only the denial layer moved.
