### PR TITLE
Repository service phase 4: pinned, non-modal Repositories view

### DIFF
--- a/src/CcDirector.Avalonia.Tests/RepositoriesViewRenderTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoriesViewRenderTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using CcDirector.Avalonia.Controls;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+public class RepositoriesViewRenderTests
+{
+    [AvaloniaFact]
+    public void RepositoriesView_LoadsAndAttachesToMonitorAndRoots()
+    {
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => Array.Empty<string>(),
+            compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = p, Success = true }));
+        var store = new RootDirectoryStore(
+            Path.Combine(Path.GetTempPath(), "ccd-reposview-" + Guid.NewGuid().ToString("N") + ".json"));
+
+        var view = new RepositoriesView();
+        var window = new Window { Content = view, Width = 900, Height = 600 };
+        window.Show();
+        view.Attach(monitor, store, () => { });
+        // Attaching again is idempotent (opening the pinned view repeatedly).
+        view.Attach(monitor, store, () => { });
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(view);
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml
+++ b/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml
@@ -1,0 +1,68 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:CcDirector.Avalonia.Controls"
+             x:Class="CcDirector.Avalonia.Controls.RepositoriesView"
+             Background="#1E1E1E">
+
+    <UserControl.Styles>
+        <Style Selector="Button.railItem">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Foreground" Value="#AAAAAA" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+            <Setter Property="Padding" Value="12,7" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="CornerRadius" Value="0" />
+        </Style>
+        <Style Selector="Button.railItem:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#2A2D2E" />
+        </Style>
+        <Style Selector="Button.railItem.active">
+            <Setter Property="Background" Value="#094771" />
+            <Setter Property="Foreground" Value="#FFFFFF" />
+        </Style>
+        <Style Selector="Button.railItem.active /template/ ContentPresenter">
+            <Setter Property="Background" Value="#094771" />
+        </Style>
+    </UserControl.Styles>
+
+    <Grid ColumnDefinitions="Auto,1,*">
+        <Border Grid.Column="0" Background="#252526" MinWidth="140">
+            <StackPanel Spacing="1" Margin="0,6,0,0">
+                <TextBlock Text="REPOSITORIES" Foreground="#888888" FontSize="10"
+                           FontWeight="SemiBold" Margin="12,2,12,8" />
+                <Button x:Name="ReposRailButton" Classes="railItem active" Click="ReposRailButton_Click">
+                    <TextBlock Text="Repositories" VerticalAlignment="Center" />
+                </Button>
+                <Button x:Name="RootsRailButton" Classes="railItem" Click="RootsRailButton_Click">
+                    <TextBlock Text="Root folders" VerticalAlignment="Center" />
+                </Button>
+            </StackPanel>
+        </Border>
+
+        <Border Grid.Column="1" Background="#3C3C3C" />
+
+        <Panel Grid.Column="2">
+            <controls:RepositoryListView x:Name="ReposPage" IsVisible="True" />
+
+            <ScrollViewer x:Name="RootsPage" IsVisible="False" VerticalScrollBarVisibility="Auto">
+                <StackPanel Margin="16" Spacing="10">
+                    <TextBlock Text="Root folders" Foreground="#CCCCCC" FontSize="14" FontWeight="SemiBold" />
+                    <TextBlock Text="The directories scanned for repositories. Editing them inline moves here next; for now this shows what is registered."
+                               Foreground="#888888" FontSize="11" TextWrapping="Wrap" MaxWidth="560" />
+                    <ItemsControl x:Name="RootsList">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="#252526" BorderBrush="#3C3C3C" BorderThickness="1"
+                                        CornerRadius="4" Padding="12,8" Margin="0,0,0,6">
+                                    <TextBlock Text="{Binding}" Foreground="#CCCCCC" FontSize="12"
+                                               FontFamily="Cascadia Mono, Consolas" TextWrapping="Wrap" />
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </ScrollViewer>
+        </Panel>
+    </Grid>
+</UserControl>

--- a/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Git;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia.Controls;
+
+/// <summary>
+/// The Repositories home: a left sub-rail hosting the live repository list and the root-folder
+/// registration, shown as a pinned, non-modal view inside the main window (issue #507, phase 4).
+/// It renders the always-current model from the background <see cref="RepositoryMonitor"/>; it does
+/// not scan.
+/// </summary>
+public partial class RepositoriesView : UserControl
+{
+    private bool _attached;
+
+    public RepositoriesView()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Wire the live model and the registered roots. Idempotent - safe to call each time the view is
+    /// opened; the monitor subscription is set up once, the roots list is refreshed each time.
+    /// </summary>
+    public void Attach(RepositoryMonitor monitor, RootDirectoryStore store, Action onRefreshRequested)
+    {
+        if (!_attached)
+        {
+            FileLog.Write("[RepositoriesView] Attach");
+            ReposPage.RefreshRequested += onRefreshRequested;
+            ReposPage.Attach(monitor);
+            _attached = true;
+        }
+        RootsList.ItemsSource = store.Roots
+            .Select(r => $"{(string.IsNullOrWhiteSpace(r.Label) ? r.Path : r.Label)}   [{r.ProviderDisplayName}]   {r.Path}")
+            .ToList();
+    }
+
+    private void ReposRailButton_Click(object? sender, RoutedEventArgs e) => ShowRoots(false);
+    private void RootsRailButton_Click(object? sender, RoutedEventArgs e) => ShowRoots(true);
+
+    private void ShowRoots(bool roots)
+    {
+        ReposPage.IsVisible = !roots;
+        RootsPage.IsVisible = roots;
+        SetActive(ReposRailButton, !roots);
+        SetActive(RootsRailButton, roots);
+    }
+
+    private static void SetActive(Button button, bool active)
+    {
+        if (active) button.Classes.Add("active");
+        else button.Classes.Remove("active");
+    }
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -389,6 +389,22 @@
                 <!-- Communications / Connections moved to the top toolbar
                      (their pending-count badge rides along with them). -->
 
+                <!-- Pinned Repositories entry: opens the non-modal Repositories view over the
+                     center content, just above the connection indicators (issue #507, phase 4). -->
+                <Button x:Name="BtnRepositories" DockPanel.Dock="Bottom"
+                        Click="BtnRepositories_Click"
+                        Background="#2A2A2A" BorderBrush="#3C3C3C" BorderThickness="1"
+                        Margin="8,4,8,6" Padding="10,8" CornerRadius="4"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" Cursor="Hand"
+                        ToolTip.Tip="Repositories and worktrees across your machine">
+                    <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                        <TextBlock Text="[R]" Foreground="#4A9EFF" FontFamily="Cascadia Mono, Consolas"
+                                   FontSize="12" VerticalAlignment="Center" />
+                        <TextBlock Text="Repositories" Foreground="#CCCCCC" FontSize="12"
+                                   FontWeight="SemiBold" VerticalAlignment="Center" />
+                    </StackPanel>
+                </Button>
+
                 <!-- Session list -->
                 <ListBox x:Name="SessionList"
                          Background="Transparent"
@@ -1533,6 +1549,40 @@
 
                 <!-- ConnectionsView fills the rest -->
                 <controls:ConnectionsView x:Name="ConnectionsView" />
+            </DockPanel>
+        </Border>
+
+        <!-- Repositories overlay: the pinned, non-modal repository/worktree home over the center
+             content (issue #507, phase 4). Leaves the session rail (column 0) clickable. -->
+        <Border x:Name="RepositoriesOverlay"
+                Grid.Row="0" Grid.RowSpan="2" Grid.Column="2"
+                Background="{DynamicResource PanelBackground}"
+                ZIndex="10"
+                IsVisible="False">
+            <DockPanel>
+                <Border DockPanel.Dock="Top"
+                        Background="{DynamicResource SidebarBackground}"
+                        BorderBrush="#3C3C3C" BorderThickness="0,0,0,1"
+                        Padding="12,8">
+                    <DockPanel>
+                        <Button x:Name="BtnRepositoriesClose"
+                                DockPanel.Dock="Right"
+                                Content="[x] Close"
+                                Click="BtnRepositoriesClose_Click"
+                                Background="Transparent"
+                                Foreground="#888888"
+                                BorderThickness="0"
+                                Cursor="Hand"
+                                Padding="8,4"
+                                FontSize="12" />
+                        <TextBlock Text="Repositories"
+                                   Foreground="{DynamicResource TextForeground}"
+                                   FontSize="16" FontWeight="Bold"
+                                   VerticalAlignment="Center" />
+                    </DockPanel>
+                </Border>
+
+                <controls:RepositoriesView x:Name="RepositoriesView" />
             </DockPanel>
         </Border>
 

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -934,7 +934,8 @@ public partial class MainWindow : Window
     /// </summary>
     private bool IsContentOverlayOpen()
         => CommsOverlay.IsVisible
-           || ConnectionsOverlay.IsVisible;
+           || ConnectionsOverlay.IsVisible
+           || RepositoriesOverlay.IsVisible;
 
     /// <summary>
     /// Show the full-screen home page exactly when this Director has zero sessions - it is
@@ -1759,6 +1760,8 @@ public partial class MainWindow : Window
             if (_connectionsInitialized)
                 ConnectionsView.StopPolling();
         }
+        if (RepositoriesOverlay.IsVisible)
+            RepositoriesOverlay.IsVisible = false;
 
         if (vm == _activeSession) return;
 
@@ -3692,13 +3695,7 @@ public partial class MainWindow : Window
                 }
             }
         }));
-        session.Menu.Items.Add(Item("Repository status...", async () =>
-        {
-            FileLog.Write("[MainWindow] Menu: Repository status");
-            var app = AppRef();
-            var window = new RepositoryScreenWindow(app.RepositoryMonitor, app.StartRepositoryRescan);
-            await window.ShowDialog(this);
-        }));
+        // "Repository status..." moved to the pinned Repositories entry in the sidebar (issue #507).
         if (alpha)
         {
             session.Menu.Items.Add(new NativeMenuItemSeparator());
@@ -4052,6 +4049,39 @@ public partial class MainWindow : Window
         if (_connectionsInitialized)
             ConnectionsView.StopPolling();
         UpdateHomeVisibility(); // restore Home if still at zero sessions (#447)
+    }
+
+    private void BtnRepositories_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[MainWindow] BtnRepositories_Click: opening Repositories view");
+
+        // Close other center overlays first.
+        if (CommsOverlay.IsVisible)
+        {
+            CommsOverlay.IsVisible = false;
+            if (_commsInitialized)
+                CommManagerView.StopPolling();
+        }
+        if (ConnectionsOverlay.IsVisible)
+        {
+            ConnectionsOverlay.IsVisible = false;
+            if (_connectionsInitialized)
+                ConnectionsView.StopPolling();
+        }
+
+        if (global::Avalonia.Application.Current is App app)
+        {
+            RepositoriesView.Attach(app.RepositoryMonitor, app.RootDirectoryStore, app.StartRepositoryRescan);
+            RepositoriesOverlay.IsVisible = true;
+        }
+        UpdateHomeVisibility(); // hide Home so the overlay is not buried behind it
+    }
+
+    private void BtnRepositoriesClose_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[MainWindow] BtnRepositoriesClose_Click: closing Repositories view");
+        RepositoriesOverlay.IsVisible = false;
+        UpdateHomeVisibility();
     }
 
     private void SwitchLeftTab(string tab)


### PR DESCRIPTION
Phase 4 of the unified repositories feature (spec thefrederiksen/devthrottle_internal#507). Moves the Repository screen out of a blocking pop-up and into the main window.

## What this adds
- A **pinned "Repositories" entry** at the bottom of the session sidebar, just above the connection indicators. Clicking it opens the Repositories view as an **overlay over the center content** (column 2) - the session rail stays visible and clickable, so you can switch between sessions and repositories freely. Selecting a session closes it. **Non-modal**, unlike the old dialog.
- **`RepositoriesView`**: a left sub-rail hosting the **live Repositories list** (subscribed to the background `RepositoryMonitor` - it never scans) and a **Root folders** page listing the registered roots. Mirrors the Source Control tab's rail; extensible for worktree detail.
- The **"Repository status..." menu item is removed** - the pinned entry replaces it.

Follows the existing Connections/Comms overlay pattern exactly (column-2 `Border`, `ZIndex 10`), so the sidebar stays usable and there is no modal block.

## Not yet (next steps, per #507)
Inline editing on the Root folders page (fold in the registration dialog), worktree drill-down, and the "hand to an agent" action.

## Tests
- Headless render test constructs the container and attaches it to a monitor + roots (idempotent open).
- Full Avalonia.Tests: 269 passed, 0 failed.