### PR TITLE
docs: dictionary suggestions mockup for per-tenant transcript mining

### DIFF
--- a/docs/reviews/dictation-dictionary-suggestions-mockup-2026-07-23.html
+++ b/docs/reviews/dictation-dictionary-suggestions-mockup-2026-07-23.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Dictionary suggestions - mockup</title>
+<style>
+  :root {
+    --bg: #0f1216; --panel: #171b21; --panel2: #1e242c; --line: #2a323c;
+    --text: #e6eaef; --muted: #9aa5b1; --accent: #4c8dff; --accent2: #2f6fe0;
+    --red: #ff4d4f; --green: #34c759; --chip: #232a33;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+         background: var(--bg); color: var(--text); font-size: 14px; }
+  .frame { display: grid; grid-template-columns: 220px 1fr; min-height: 100vh; }
+  /* left rail */
+  .rail { background: #12161b; border-right: 1px solid var(--line); padding: 16px 10px; }
+  .brand { font-weight: 700; letter-spacing: .3px; padding: 6px 10px 16px; color: #fff; }
+  .nav a { display: flex; align-items: center; justify-content: space-between; gap: 8px;
+           padding: 9px 10px; border-radius: 8px; color: var(--muted); text-decoration: none; margin-bottom: 2px; }
+  .nav a.active { background: var(--panel2); color: #fff; }
+  .nav a:hover { background: #1a1f26; }
+  .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--red);
+         box-shadow: 0 0 0 3px rgba(255,77,79,.18); display: inline-block; }
+  .count { background: var(--red); color: #fff; font-size: 11px; font-weight: 700;
+           border-radius: 10px; padding: 1px 7px; min-width: 18px; text-align: center; }
+  /* main */
+  .main { padding: 26px 34px; max-width: 940px; }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  .sub { color: var(--muted); margin: 0 0 22px; }
+  .card { background: var(--panel); border: 1px solid var(--line); border-radius: 12px;
+          padding: 18px 20px; margin-bottom: 22px; }
+  .suggest { border-color: rgba(255,77,79,.45); box-shadow: 0 0 0 1px rgba(255,77,79,.12) inset; }
+  .card-head { display: flex; align-items: center; gap: 10px; margin-bottom: 4px; }
+  .card-head h2 { font-size: 16px; margin: 0; }
+  .card-head .why { color: var(--muted); margin: 2px 0 14px; font-size: 13px; }
+  .srow { display: grid; grid-template-columns: 22px 1fr auto; align-items: center;
+          gap: 12px; padding: 11px 0; border-top: 1px solid var(--line); }
+  .srow:first-of-type { border-top: none; }
+  .term { font-weight: 600; }
+  .heard { color: var(--muted); font-size: 12.5px; margin-top: 2px; }
+  .heard b { color: #cdd6df; font-weight: 600; }
+  .freq { color: var(--muted); font-size: 12px; white-space: nowrap; }
+  input[type=checkbox] { width: 16px; height: 16px; accent-color: var(--accent); }
+  .actions { display: flex; gap: 10px; align-items: center; margin-top: 16px; padding-top: 14px;
+             border-top: 1px solid var(--line); }
+  .btn { border: 1px solid var(--line); background: var(--panel2); color: var(--text);
+         padding: 9px 15px; border-radius: 8px; font-weight: 600; cursor: pointer; font-size: 13px; }
+  .btn.primary { background: var(--accent2); border-color: var(--accent2); color: #fff; }
+  .btn.ghost { background: transparent; }
+  .spacer { flex: 1; }
+  /* existing dictionary */
+  .chips { display: flex; flex-wrap: wrap; gap: 7px; }
+  .chip { background: var(--chip); border: 1px solid var(--line); border-radius: 999px;
+          padding: 5px 11px; font-size: 12.5px; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { text-align: left; padding: 8px 6px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; }
+  /* annotation callouts */
+  .note { position: relative; }
+  .callout { background: #2a2410; border: 1px dashed #b8912e; color: #f3d98a;
+             border-radius: 8px; padding: 8px 12px; font-size: 12.5px; margin: 10px 0 0; }
+  .legend { color: var(--muted); font-size: 12px; margin-top: 30px; border-top: 1px solid var(--line); padding-top: 14px; }
+</style>
+</head>
+<body>
+<div class="frame">
+  <!-- LEFT NAV RAIL -->
+  <aside class="rail">
+    <div class="brand">DevThrottle</div>
+    <nav class="nav">
+      <a href="#"><span>Fleet Map</span></a>
+      <a href="#"><span>Transcription Health</span></a>
+      <a href="#" class="active"><span>Dictionary</span><span class="count">4</span></a>
+      <a href="#"><span>Transcripts</span></a>
+      <a href="#"><span>Settings</span></a>
+    </nav>
+    <div class="callout">The red count on <b>Dictionary</b> is the number of pending suggestions. It clears to nothing once they are added or dismissed.</div>
+  </aside>
+
+  <!-- MAIN -->
+  <main class="main">
+    <h1>Dictionary</h1>
+    <p class="sub">Terms that bias transcription, plus corrections for words the model keeps getting wrong.</p>
+
+    <!-- SUGGESTIONS CARD -->
+    <section class="card suggest">
+      <div class="card-head">
+        <span class="dot"></span>
+        <h2>4 suggestions from your recent dictation</h2>
+      </div>
+      <p class="why">We looked at what the model heard across your recent transcripts and found terms it repeatedly got wrong. Tick the ones to keep and add them in one step. Nothing changes until you press Add.</p>
+
+      <div class="srow">
+        <input type="checkbox" checked>
+        <div>
+          <div class="term">mindzie</div>
+          <div class="heard">heard as <b>Mindsee</b>, <b>Mindsy</b>, <b>Mindzee</b>, <b>Mindsea</b></div>
+        </div>
+        <div class="freq">wrong 53 of 97 times</div>
+      </div>
+
+      <div class="srow">
+        <input type="checkbox" checked>
+        <div>
+          <div class="term">ConPty</div>
+          <div class="heard">heard as <b>Con-TY</b></div>
+        </div>
+        <div class="freq">wrong 80 of 144 times</div>
+      </div>
+
+      <div class="srow">
+        <input type="checkbox" checked>
+        <div>
+          <div class="term">Frederiksen</div>
+          <div class="heard">heard as <b>Fredriksson</b>, <b>Fredrickson</b>, <b>Fredrikson</b></div>
+        </div>
+        <div class="freq">wrong 98 of 364 times</div>
+      </div>
+
+      <div class="srow">
+        <input type="checkbox">
+        <div>
+          <div class="term">Supabase</div>
+          <div class="heard">heard as <b>Superbase</b></div>
+        </div>
+        <div class="freq">wrong 1 of 3 times</div>
+      </div>
+
+      <div class="actions">
+        <button class="btn primary">Add 3 selected to dictionary</button>
+        <button class="btn ghost">Dismiss all</button>
+        <div class="spacer"></div>
+        <span class="freq">Unticked items are remembered and will not be suggested again.</span>
+      </div>
+    </section>
+
+    <!-- EXISTING DICTIONARY (context) -->
+    <section class="card">
+      <div class="card-head"><h2>Vocabulary</h2></div>
+      <p class="why">Proper nouns the model is nudged toward. Safe - it only biases, never replaces.</p>
+      <div class="chips">
+        <span class="chip">mindzie</span><span class="chip">Frederiksen</span><span class="chip">Soren</span>
+        <span class="chip">Center Consulting</span><span class="chip">DevThrottle</span><span class="chip">ConPty</span>
+        <span class="chip">SignalR</span><span class="chip">Kestrel</span><span class="chip">Postgres</span>
+        <span class="chip">Cockpit</span><span class="chip">Wingman</span><span class="chip">Gateway</span>
+      </div>
+    </section>
+
+    <section class="card">
+      <div class="card-head"><h2>Corrections</h2></div>
+      <p class="why">Wrong spellings that get replaced with the right term. Only non-word spellings, so real text is never corrupted.</p>
+      <table>
+        <tr><th>Correct term</th><th>Replaces</th></tr>
+        <tr><td>mindzie</td><td>Mindsee, Mindsy, Mindzee, Mindsea, Mindzy</td></tr>
+        <tr><td>ConPty</td><td>Con-TY, ConTY, Conpity</td></tr>
+        <tr><td>Frederiksen</td><td>Fredriksson, Fredrickson, Fredrikson</td></tr>
+      </table>
+    </section>
+
+    <div class="legend">
+      Mockup for issue #2075 - dictation dictionary suggestions. The counts shown are illustrative,
+      drawn from real mined figures. Not a live screen; layout and copy for review only.
+      Same select-and-apply flow is also available over the API for people who script it.
+    </div>
+  </main>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Adds the screen mockup referenced by the dictation transcript-mining work: the pending-suggestions red marker on the Dictionary nav item, a suggestions panel with per-term evidence and checkboxes, and the select-and-add flow. Documentation only.