### PR TITLE
Repositories v1 polish: warm-start cache + pinned badge and active state

### DIFF
--- a/src/CcDirector.Avalonia/App.axaml.cs
+++ b/src/CcDirector.Avalonia/App.axaml.cs
@@ -35,7 +35,9 @@ public partial class App : Application
     /// The always-current model of the repositories under the registered roots. Owned by the app,
     /// scanned in the background from startup; the Repository screen subscribes and renders it.
     /// </summary>
-    public RepositoryMonitor RepositoryMonitor { get; } = new();
+    public RepositoryMonitor RepositoryMonitor { get; } = new(
+        cachePath: System.IO.Path.Combine(
+            CcDirector.Core.Storage.CcStorage.ToolConfig("director"), "repo-worktree-cache.json"));
     public SessionStateStore SessionStateStore { get; private set; } = null!;
 
     /// <summary>
@@ -171,8 +173,9 @@ public partial class App : Application
         RootDirectoryStore = new RootDirectoryStore();
         RootDirectoryStore.Load();
 
-        // Start scanning repositories in the background right away, so the Repository screen has
-        // content the moment it is opened (issue #507, phase 1).
+        // Warm start: show the last run's repositories instantly from the cache, then scan in the
+        // background to re-verify and reconcile (issue #507, phase 2).
+        RepositoryMonitor.LoadCache();
         StartRepositoryRescan();
 
         SessionStateStore = new SessionStateStore();

--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -397,12 +397,22 @@
                         Margin="8,4,8,6" Padding="10,8" CornerRadius="4"
                         HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" Cursor="Hand"
                         ToolTip.Tip="Repositories and worktrees across your machine">
-                    <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
-                        <TextBlock Text="[R]" Foreground="#4A9EFF" FontFamily="Cascadia Mono, Consolas"
-                                   FontSize="12" VerticalAlignment="Center" />
-                        <TextBlock Text="Repositories" Foreground="#CCCCCC" FontSize="12"
-                                   FontWeight="SemiBold" VerticalAlignment="Center" />
-                    </StackPanel>
+                    <DockPanel LastChildFill="True">
+                        <!-- Orphaned-worktree count: the reap opportunity, visible without opening. -->
+                        <Border x:Name="RepositoriesBadge" DockPanel.Dock="Right"
+                                Background="#EF4444" CornerRadius="8" Padding="6,1"
+                                VerticalAlignment="Center" IsVisible="False"
+                                ToolTip.Tip="Worktrees safe to reap">
+                            <TextBlock x:Name="RepositoriesBadgeText" Text="0" Foreground="White"
+                                       FontSize="9" FontWeight="SemiBold" />
+                        </Border>
+                        <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                            <TextBlock Text="[R]" Foreground="#4A9EFF" FontFamily="Cascadia Mono, Consolas"
+                                       FontSize="12" VerticalAlignment="Center" />
+                            <TextBlock Text="Repositories" Foreground="#CCCCCC" FontSize="12"
+                                       FontWeight="SemiBold" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </DockPanel>
                 </Button>
 
                 <!-- Session list -->

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -248,6 +248,15 @@ public partial class MainWindow : Window
         // slots) so a session-occupied worktree is shown as "in use" and never reaped.
         SourceControlView.LiveSessionsProvider = GetLiveSessionsOnThisMachineAsync;
 
+        // Keep the pinned Repositories badge (safe-to-reap worktree count) in sync with the scan.
+        if (global::Avalonia.Application.Current is App appForRepo)
+        {
+            appForRepo.RepositoryMonitor.Upserted += _ => Dispatcher.UIThread.Post(UpdateRepositoriesBadge);
+            appForRepo.RepositoryMonitor.Removed += _ => Dispatcher.UIThread.Post(UpdateRepositoriesBadge);
+            appForRepo.RepositoryMonitor.ProgressChanged += () => Dispatcher.UIThread.Post(UpdateRepositoriesBadge);
+            UpdateRepositoriesBadge();
+        }
+
         // Wire prompt input text changes for slash command autocomplete
         PromptInput.TextChanged += PromptInput_TextChanged;
         PromptInput.LostFocus += (_, _) => SlashCommandPopup.IsOpen = false;
@@ -1761,7 +1770,10 @@ public partial class MainWindow : Window
                 ConnectionsView.StopPolling();
         }
         if (RepositoriesOverlay.IsVisible)
+        {
             RepositoriesOverlay.IsVisible = false;
+            SetRepositoriesActive(false);
+        }
 
         if (vm == _activeSession) return;
 
@@ -4058,6 +4070,7 @@ public partial class MainWindow : Window
         {
             RepositoriesView.Attach(app.RepositoryMonitor, app.RootDirectoryStore, app.StartRepositoryRescan);
             RepositoriesOverlay.IsVisible = true;
+            SetRepositoriesActive(true);
         }
         UpdateHomeVisibility(); // hide Home so the overlay is not buried behind it
     }
@@ -4066,7 +4079,26 @@ public partial class MainWindow : Window
     {
         FileLog.Write("[MainWindow] BtnRepositoriesClose_Click: closing Repositories view");
         RepositoriesOverlay.IsVisible = false;
+        SetRepositoriesActive(false);
         UpdateHomeVisibility();
+    }
+
+    /// <summary>Highlight the pinned Repositories entry while its view is open.</summary>
+    private void SetRepositoriesActive(bool active)
+    {
+        BtnRepositories.Background = new global::Avalonia.Media.SolidColorBrush(
+            global::Avalonia.Media.Color.Parse(active ? "#094771" : "#2A2A2A"));
+    }
+
+    /// <summary>Show the safe-to-reap worktree count on the pinned Repositories entry.</summary>
+    private void UpdateRepositoriesBadge()
+    {
+        var monitor = (global::Avalonia.Application.Current as App)?.RepositoryMonitor;
+        if (monitor is null)
+            return;
+        int reap = monitor.Snapshot().Sum(s => s.WorktreesSafeToReap);
+        RepositoriesBadgeText.Text = reap.ToString();
+        RepositoriesBadge.IsVisible = reap > 0;
     }
 
     private void SwitchLeftTab(string tab)

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -78,6 +78,39 @@ public class RepositoryMonitorTests
     }
 
     [Fact]
+    public async Task Cache_WarmStart_ShowsLastRunInstantly_ThenReconciles()
+    {
+        var cachePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-monitor-cache-" + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            // First monitor: scan finds a, b, c and persists the cache.
+            var m1 = new RepositoryMonitor(
+                enumerate: _ => new[] { "/r/a", "/r/b", "/r/c" },
+                compute: (p, _, _) => Task.FromResult(Status(p)),
+                cachePath: cachePath);
+            await m1.RescanAsync(new[] { "/r" });
+            Assert.True(File.Exists(cachePath));
+
+            // Second monitor (next launch): warm-start shows all three BEFORE any scan.
+            var m2 = new RepositoryMonitor(
+                enumerate: _ => new[] { "/r/a", "/r/b" }, // "c" is gone now
+                compute: (p, _, _) => Task.FromResult(Status(p)),
+                cachePath: cachePath);
+            m2.LoadCache();
+            Assert.Equal(3, m2.Snapshot().Count); // instant content, no scan yet
+
+            // The scan then reconciles - "c" drops.
+            await m2.RescanAsync(new[] { "/r" });
+            Assert.Equal(2, m2.Snapshot().Count);
+            Assert.DoesNotContain(m2.Snapshot(), s => s.Name == "c");
+        }
+        finally
+        {
+            if (File.Exists(cachePath)) File.Delete(cachePath);
+        }
+    }
+
+    [Fact]
     public async Task Rescan_Upsert_UpdatesExistingEntryInPlace()
     {
         var dirty = false;

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Git;
@@ -24,6 +25,7 @@ public sealed class RepositoryMonitor
     private readonly object _gate = new();
     private readonly Dictionary<string, RepositoryStatus> _byPath = new(StringComparer.OrdinalIgnoreCase);
     private CancellationTokenSource? _cts;
+    private readonly string? _cachePath;
 
     /// <summary>True while a scan is in progress.</summary>
     public bool IsScanning { get; private set; }
@@ -48,10 +50,60 @@ public sealed class RepositoryMonitor
 
     public RepositoryMonitor(
         Func<IEnumerable<string>, IReadOnlyList<string>>? enumerate = null,
-        Func<string, IReadOnlyList<LiveSessionRef>?, CancellationToken, Task<RepositoryStatus>>? compute = null)
+        Func<string, IReadOnlyList<LiveSessionRef>?, CancellationToken, Task<RepositoryStatus>>? compute = null,
+        string? cachePath = null)
     {
         _enumerate = enumerate ?? DefaultEnumerate;
         _compute = compute ?? DefaultCompute;
+        _cachePath = cachePath;
+    }
+
+    /// <summary>
+    /// Warm start: load the last run's repositories from the JSON cache into the model, so a screen
+    /// opened before the first scan finishes shows content immediately. The scan then re-verifies and
+    /// reconciles. Best-effort and silent - a bad or missing cache just means an empty warm start.
+    /// </summary>
+    public void LoadCache()
+    {
+        if (string.IsNullOrEmpty(_cachePath) || !File.Exists(_cachePath))
+            return;
+        try
+        {
+            var cached = JsonSerializer.Deserialize<List<RepositoryStatus>>(File.ReadAllText(_cachePath));
+            if (cached == null)
+                return;
+            lock (_gate)
+            {
+                foreach (var s in cached)
+                    if (!string.IsNullOrWhiteSpace(s.Path))
+                        _byPath[WorktreeReaperService.NormalizePath(s.Path)] = s;
+            }
+            FileLog.Write($"[RepositoryMonitor] warm-start: loaded {cached.Count} repositories from cache");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryMonitor] LoadCache failed: {ex.Message}");
+        }
+    }
+
+    private void SaveCache()
+    {
+        if (string.IsNullOrEmpty(_cachePath))
+            return;
+        try
+        {
+            List<RepositoryStatus> snapshot;
+            lock (_gate)
+                snapshot = _byPath.Values.ToList();
+            var dir = Path.GetDirectoryName(_cachePath);
+            if (dir != null)
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(_cachePath, JsonSerializer.Serialize(snapshot));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryMonitor] SaveCache failed: {ex.Message}");
+        }
     }
 
     /// <summary>A thread-safe copy of the current model.</summary>
@@ -106,6 +158,9 @@ public sealed class RepositoryMonitor
             }
             foreach (var r in removed)
                 Removed?.Invoke(r);
+
+            // Persist the verified model so the next launch warm-starts.
+            SaveCache();
         }
         catch (OperationCanceledException)
         {


### PR DESCRIPTION
Three improvements to the Repositories feature (spec thefrederiksen/devthrottle_internal#507), wrapping v1.

- **Warm-start cache (phase 2).** The monitor persists the verified model to `repo-worktree-cache.json` after each scan, and loads it on startup - so the Repository screen shows the last run's repositories **instantly**, before the first scan finishes; the background scan then re-verifies and reconciles. Best-effort; a missing/bad cache just means an empty warm start.
- **Count badge on the pinned entry.** The total safe-to-reap worktree count shows (red) on the `[R] Repositories` button, so the cleanup opportunity is visible without opening the view. Kept in sync with the live scan.
- **Active state.** The pinned entry highlights while the Repositories view is open; reverts on close or when a session is selected.

## Tests
- Monitor cache round-trip: warm-start shows the last run instantly, then the scan reconciles (drops what's gone).
- Full Core.Tests 3350 passed, 8 skipped, 0 failed. Full Avalonia.Tests 268 passed, 0 failed.