### PR TITLE
feat(browsers): drivable automation browsers - engine, Control API, CLI, and Director UI (slices 1+2)

### DIFF
--- a/docs/features/feature-inventory.yaml
+++ b/docs/features/feature-inventory.yaml
@@ -110,14 +110,24 @@ features:
     summary: Tree of uncommitted git changes per session with file status indicators and a right-click menu (View File, Copy Path, Add to .gitignore).
 
   - id: repository-manager
-    title: Repository Manager
+    title: Repositories
     category: source-control
     status: implemented
-    screen: dialog
+    screen: view
     source:
-      - src/CcDirector.Avalonia/RepositoryManagerDialog.axaml
+      - src/CcDirector.Avalonia/Controls/RepositoriesView.axaml
     screenshot: repository-manager.png
-    summary: Manage known repositories and quick-launch sessions from them.
+    summary: Repositories and worktrees across the machine, opened from the pinned Repositories entry in the left rail (replaced the old Repository Manager dialog).
+
+  - id: browsers
+    title: Browsers
+    category: automation
+    status: implemented
+    screen: view
+    source:
+      - src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml
+      - src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml
+    summary: Drivable, signed-in-once automation browsers - a pinned rail group with status dots and one-click Start / Sign in / Attach, plus a Settings tab to create, sign in, rename, and remove them. Agents attach through Browser Harness.
 
   - id: clone-repo
     title: Clone Repository

--- a/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml
+++ b/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml
@@ -1,0 +1,171 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="CcDirector.Avalonia.Controls.BrowserSettingsView">
+
+    <!-- Settings > Browsers: the workshop for drivable automation browsers (Browsers feature,
+         slice 2). Create, sign in once, rename, stop/start, remove - every verdict shown here is the
+         Core fold (AutomationBrowserViewFold) rendered verbatim; this view decides layout only.
+         Hosted inside SettingsDialog, so its shared styles (card, hint, sectionTitle, dialogButton,
+         primaryButton, settingsInput) resolve from the dialog's Window.Styles. -->
+
+    <Grid RowDefinitions="Auto,Auto,Auto,*" Margin="0,4,0,0">
+
+        <!-- Header: what this is, the honest one-sign-in rule, and the primary actions. -->
+        <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,14,8">
+            <TextBlock Classes="sectionTitle" Text="Browsers" />
+            <TextBlock Classes="hint"
+                       Text="Real, signed-in browsers your agents can drive through Browser Harness. Each one is a dedicated browser profile DevThrottle creates - never your everyday browser. You sign it in once, by hand, and the login lasts for months; after that any agent on this machine attaches with one command. The one sign-in cannot be automated away: modern browsers block driving your main profile and encrypt its logins, so a dedicated profile with a single hand sign-in is the honest design." />
+            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
+                <Button x:Name="NewBrowserButton" Classes="primaryButton" Content="+ New browser"
+                        MinWidth="130" Click="BtnNewBrowser_Click"
+                        ToolTip.Tip="Create a new drivable browser profile" />
+                <Button x:Name="RefreshButton" Classes="dialogButton" Content="Refresh"
+                        Click="BtnRefresh_Click"
+                        ToolTip.Tip="Re-check each browser's live status" />
+                <TextBlock x:Name="StatusText" Text="" Foreground="#888888" FontSize="11"
+                           TextWrapping="Wrap" VerticalAlignment="Center" MaxWidth="480" />
+            </StackPanel>
+        </StackPanel>
+
+        <!-- Browser Harness missing: the feature stays visible and explains how to turn it on. -->
+        <Border Grid.Row="1" x:Name="HarnessBanner" IsVisible="False"
+                Background="#1E1E1E" BorderBrush="#3C3C3C" BorderThickness="1"
+                CornerRadius="6" Padding="14" Margin="0,0,14,10">
+            <Grid ColumnDefinitions="4,*">
+                <Border Grid.Column="0" Background="#F0B848" CornerRadius="2" />
+                <StackPanel Grid.Column="1" Spacing="6" Margin="12,0,0,0">
+                    <TextBlock Text="Turn on browser control" Foreground="#CCCCCC"
+                               FontSize="13" FontWeight="SemiBold" />
+                    <TextBlock Classes="hint"
+                               Text="To let your agents drive these browsers, install Browser Harness - the open-source tool DevThrottle uses. Your browsers below stay listed and ready; they just cannot be driven until it is installed." />
+                    <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
+                        <Button Classes="dialogButton" Content="Install Browser Harness"
+                                MinWidth="180" Click="BtnInstallHarness_Click"
+                                ToolTip.Tip="Open the Browser Harness install guide in your browser" />
+                        <Button Classes="dialogButton" Content="Check again"
+                                Click="BtnRefresh_Click"
+                                ToolTip.Tip="Re-check whether browser-harness is now on PATH" />
+                    </StackPanel>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Inline create panel, shown by + New browser. -->
+        <Border Grid.Row="2" x:Name="CreatePanel" Classes="card" IsVisible="False" Margin="0,0,14,10">
+            <StackPanel Spacing="8">
+                <TextBlock Classes="sectionTitle" Margin="0" Text="New browser" />
+                <TextBlock Classes="hint"
+                           Text="Name it after the identity it will hold (for example the account or client it signs in as). DevThrottle creates a fresh, dedicated profile - your everyday browser is never touched." />
+                <Grid ColumnDefinitions="*,140,Auto,Auto" Margin="0,4,0,0">
+                    <TextBox x:Name="CreateNameBox" Grid.Column="0" Classes="settingsInput"
+                             Watermark="e.g. Center Consulting" />
+                    <ComboBox x:Name="CreateKindCombo" Grid.Column="1" Margin="8,0,0,0"
+                              VerticalAlignment="Stretch" HorizontalAlignment="Stretch" />
+                    <Button Grid.Column="2" Classes="primaryButton" Content="Create"
+                            Margin="8,0,0,0" MinWidth="90" Click="BtnCreate_Click" />
+                    <Button Grid.Column="3" Classes="dialogButton" Content="Cancel"
+                            Margin="8,0,0,0" Click="BtnCreateCancel_Click" />
+                </Grid>
+                <TextBlock x:Name="CreateError" Text="" Foreground="#EF4444" FontSize="11"
+                           TextWrapping="Wrap" IsVisible="False" />
+            </StackPanel>
+        </Border>
+
+        <!-- One card per browser. -->
+        <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
+                      Padding="0,0,14,0">
+            <StackPanel Spacing="8">
+                <ItemsControl x:Name="BrowserCards">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Background="#1E1E1E" BorderBrush="#3C3C3C" BorderThickness="1"
+                                    CornerRadius="6" Padding="14,12" Margin="0,0,0,8">
+                                <Grid ColumnDefinitions="Auto,*,Auto,Auto" VerticalAlignment="Center">
+
+                                    <!-- Browser icon: the kind's letter on its color. -->
+                                    <Border Grid.Column="0" Width="34" Height="34" CornerRadius="8"
+                                            Background="{Binding IconBackground}" VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding IconLetter}" Foreground="White"
+                                                   FontSize="15" FontWeight="Bold"
+                                                   HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                    </Border>
+
+                                    <!-- Name (or the inline rename editor) + subtitle. -->
+                                    <StackPanel Grid.Column="1" Margin="12,0,12,0" VerticalAlignment="Center" Spacing="2">
+                                        <StackPanel Orientation="Horizontal" Spacing="8"
+                                                    IsVisible="{Binding !IsRenaming}">
+                                            <TextBlock Text="{Binding Name}" Foreground="#CCCCCC"
+                                                       FontSize="14" FontWeight="SemiBold"
+                                                       VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+                                            <Button Classes="dialogButton" Content="Rename" MinWidth="0"
+                                                    Height="22" Padding="8,0" FontSize="10"
+                                                    Tag="{Binding Id}" Click="BtnRenameStart_Click"
+                                                    IsEnabled="{Binding NotBusy}"
+                                                    ToolTip.Tip="Rename this browser (DevThrottle's own name - the browser profile itself is untouched)" />
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal" Spacing="6"
+                                                    IsVisible="{Binding IsRenaming}">
+                                            <TextBox Classes="settingsInput" MinWidth="220" Height="26" Padding="6,3"
+                                                     FontSize="12" Text="{Binding EditName, Mode=TwoWay}" />
+                                            <Button Classes="primaryButton" Content="Save" MinWidth="60" Height="26"
+                                                    Tag="{Binding Id}" Click="BtnRenameSave_Click" />
+                                            <Button Classes="dialogButton" Content="Cancel" MinWidth="60" Height="26"
+                                                    Tag="{Binding Id}" Click="BtnRenameCancel_Click" />
+                                        </StackPanel>
+                                        <TextBlock Text="{Binding Subtitle}" Foreground="#888888" FontSize="11.5"
+                                                   TextTrimming="CharacterEllipsis" />
+                                    </StackPanel>
+
+                                    <!-- Status pill: the fold's label on the fold's color. -->
+                                    <Border Grid.Column="2" CornerRadius="10" Padding="10,3" Margin="0,0,12,0"
+                                            Background="{Binding PillBackground}" VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding StatusLabel}" FontSize="11" FontWeight="SemiBold"
+                                                   Foreground="{Binding PillForeground}" />
+                                    </Border>
+
+                                    <!-- Actions for the current status. -->
+                                    <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="6"
+                                                VerticalAlignment="Center">
+                                        <Button Classes="primaryButton" Content="Sign in once" MinWidth="110"
+                                                IsVisible="{Binding ShowSignIn}" IsEnabled="{Binding NotBusy}"
+                                                Tag="{Binding Id}" Click="BtnSignIn_Click"
+                                                ToolTip.Tip="Open this browser on its sign-in page for the one-time hand sign-in" />
+                                        <Button Classes="dialogButton" Content="Start" MinWidth="70"
+                                                IsVisible="{Binding ShowStart}" IsEnabled="{Binding NotBusy}"
+                                                Tag="{Binding Id}" Click="BtnStart_Click"
+                                                ToolTip.Tip="Launch this browser so an agent can attach to it" />
+                                        <Button Classes="dialogButton" Content="Copy attach command" MinWidth="150"
+                                                IsVisible="{Binding ShowAttach}" IsEnabled="{Binding NotBusy}"
+                                                Tag="{Binding Id}" Click="BtnAttach_Click"
+                                                ToolTip.Tip="{Binding AttachToolTip}" />
+                                        <Button Classes="dialogButton" Content="Stop" MinWidth="60"
+                                                IsVisible="{Binding ShowStop}" IsEnabled="{Binding NotBusy}"
+                                                Tag="{Binding Id}" Click="BtnStop_Click"
+                                                ToolTip.Tip="Close this browser cleanly (its login is kept)" />
+                                        <Button Classes="iconButton"
+                                                Tag="{Binding Id}" Click="BtnRemove_Click"
+                                                IsEnabled="{Binding NotBusy}"
+                                                ToolTip.Tip="Remove this browser and permanently delete its profile folder">
+                                            <Canvas Width="12" Height="14" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                <Rectangle Canvas.Left="0" Canvas.Top="2" Width="12" Height="1.6" Fill="#E06C6C" />
+                                                <Rectangle Canvas.Left="4" Canvas.Top="0" Width="4" Height="2" Fill="#E06C6C" />
+                                                <Path Data="M 1,4 L 11,4 L 10,14 L 2,14 Z" Fill="#E06C6C" />
+                                                <Rectangle Canvas.Left="4" Canvas.Top="6" Width="1" Height="6" Fill="#252526" />
+                                                <Rectangle Canvas.Left="7" Canvas.Top="6" Width="1" Height="6" Fill="#252526" />
+                                            </Canvas>
+                                        </Button>
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <TextBlock x:Name="EmptyText" IsVisible="False"
+                           Text="No browsers yet. Click + New browser to create one - DevThrottle opens it, you sign in once, and from then on your agents drive it."
+                           Foreground="#888888" FontSize="12" FontStyle="Italic" Margin="4,4,0,0"
+                           TextWrapping="Wrap" />
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml.cs
@@ -1,0 +1,417 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using CcDirector.Core.Browsers;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia.Controls;
+
+/// <summary>
+/// Settings > Browsers: create, sign-in-once, rename, stop/start, and remove drivable automation
+/// browsers. Every action calls the same <see cref="AutomationBrowserService"/> engine the Control API
+/// exposes to agents, and every verdict shown is the Core fold rendered verbatim - the tab is a layout
+/// over the one source of truth, never a second implementation of it.
+/// </summary>
+public partial class BrowserSettingsView : UserControl
+{
+    /// <summary>Raised after any successful change (create/rename/remove/start/stop/sign-in) so the
+    /// host can refresh other Browsers surfaces (the rail group).</summary>
+    public event EventHandler? Changed;
+
+    private IReadOnlyList<AutomationBrowserView> _views = Array.Empty<AutomationBrowserView>();
+    private readonly HashSet<string> _renamingIds = new(StringComparer.OrdinalIgnoreCase);
+    private bool _refreshing;
+
+    public BrowserSettingsView()
+    {
+        InitializeComponent();
+        AttachedToVisualTree += (_, _) => _ = RefreshAsync();
+    }
+
+    /// <summary>Open the inline create panel (used by the Browsers menu's "New Browser...").</summary>
+    public void OpenCreatePanel()
+    {
+        CreatePanel.IsVisible = true;
+        CreateNameBox.Focus();
+    }
+
+    /// <summary>Re-read the registry, probe live status, and repaint the whole tab.</summary>
+    public async Task RefreshAsync()
+    {
+        if (_refreshing) return;
+        _refreshing = true;
+        try
+        {
+            StatusText.Text = "Checking browsers...";
+
+            var harnessInstalled = false;
+            IReadOnlyList<AutomationBrowserView> views = Array.Empty<AutomationBrowserView>();
+            IReadOnlyList<BrowserInfo> installed = Array.Empty<BrowserInfo>();
+            await Task.Run(async () =>
+            {
+                harnessInstalled = AutomationBrowserViewFold.IsHarnessInstalled();
+                installed = BrowserLauncher.DetectBrowsers();
+                views = await AutomationBrowserViewFold.ListAsync().ConfigureAwait(false);
+            });
+
+            _views = views;
+            HarnessBanner.IsVisible = !harnessInstalled;
+            EmptyText.IsVisible = views.Count == 0;
+            StatusText.Text = "";
+
+            // The create panel offers only the browsers actually installed on this machine.
+            var kinds = installed.Select(b => b.Kind.ToString()).ToList();
+            var selected = CreateKindCombo.SelectedItem as string;
+            CreateKindCombo.ItemsSource = kinds;
+            CreateKindCombo.SelectedItem = kinds.Contains(selected ?? "") ? selected : kinds.FirstOrDefault();
+            NewBrowserButton.IsEnabled = kinds.Count > 0;
+            if (kinds.Count == 0)
+                StatusText.Text = "No Chrome or Edge installation was found on this machine, so no browser can be created.";
+
+            BrowserCards.ItemsSource = views.Select(v => new BrowserCardViewModel(v)
+            {
+                IsRenaming = _renamingIds.Contains(v.Id),
+            }).ToList();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowserSettingsView] RefreshAsync FAILED: {ex.Message}");
+            StatusText.Text = $"Could not read the browsers list: {ex.Message}";
+        }
+        finally
+        {
+            _refreshing = false;
+        }
+    }
+
+    private async Task RefreshAndNotifyAsync()
+    {
+        await RefreshAsync();
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    private Window OwnerWindow()
+        => TopLevel.GetTopLevel(this) as Window
+           ?? throw new InvalidOperationException("BrowserSettingsView has no owner window.");
+
+    private BrowserCardViewModel? CardFor(object? sender)
+    {
+        var id = (sender as Button)?.Tag as string;
+        return (BrowserCards.ItemsSource as IEnumerable<BrowserCardViewModel>)?.FirstOrDefault(c => c.Id == id);
+    }
+
+    // ---- header actions ----
+
+    private void BtnNewBrowser_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[BrowserSettingsView] BtnNewBrowser_Click");
+        CreateError.IsVisible = false;
+        OpenCreatePanel();
+    }
+
+    private async void BtnRefresh_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[BrowserSettingsView] BtnRefresh_Click");
+        await RefreshAsync();
+    }
+
+    private void BtnInstallHarness_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnInstallHarness_Click -> {AutomationBrowserViewFold.HarnessInstallUrl}");
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(AutomationBrowserViewFold.HarnessInstallUrl)
+                { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnInstallHarness_Click FAILED: {ex.Message}");
+            StatusText.Text = $"Could not open the install guide: {ex.Message}";
+        }
+    }
+
+    // ---- create ----
+
+    private async void BtnCreate_Click(object? sender, RoutedEventArgs e)
+    {
+        var name = CreateNameBox.Text?.Trim() ?? "";
+        var kindText = CreateKindCombo.SelectedItem as string;
+        FileLog.Write($"[BrowserSettingsView] BtnCreate_Click: name={name}, kind={kindText}");
+
+        try
+        {
+            if (name.Length == 0)
+                throw new ArgumentException("Give the browser a name first.");
+            if (!Enum.TryParse<BrowserKind>(kindText, ignoreCase: true, out var kind))
+                throw new ArgumentException("Pick which browser to use.");
+
+            CreateError.IsVisible = false;
+            await Task.Run(() => AutomationBrowserService.Create(name, kind));
+
+            CreateNameBox.Text = "";
+            CreatePanel.IsVisible = false;
+            StatusText.Text = $"Created \"{name}\". Next: Sign in once, so it holds a login your agents can use.";
+            await RefreshAndNotifyAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnCreate_Click FAILED: {ex.Message}");
+            CreateError.Text = ex.Message;
+            CreateError.IsVisible = true;
+        }
+    }
+
+    private void BtnCreateCancel_Click(object? sender, RoutedEventArgs e)
+    {
+        CreatePanel.IsVisible = false;
+        CreateError.IsVisible = false;
+    }
+
+    // ---- per-card actions ----
+
+    private async void BtnStart_Click(object? sender, RoutedEventArgs e)
+    {
+        var card = CardFor(sender);
+        if (card is null) return;
+
+        try
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnStart_Click: id={card.Id}");
+            card.IsBusy = true;
+            StatusText.Text = $"Starting \"{card.Name}\"...";
+            await Task.Run(() => AutomationBrowserService.LaunchAsync(card.Id));
+            StatusText.Text = $"\"{card.Name}\" is up.";
+            await RefreshAndNotifyAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnStart_Click FAILED: id={card.Id}, {ex.Message}");
+            card.IsBusy = false;
+            StatusText.Text = ex.Message;
+        }
+    }
+
+    private async void BtnStop_Click(object? sender, RoutedEventArgs e)
+    {
+        var card = CardFor(sender);
+        if (card is null) return;
+
+        try
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnStop_Click: id={card.Id}");
+            card.IsBusy = true;
+            StatusText.Text = $"Stopping \"{card.Name}\"...";
+            await Task.Run(() => AutomationBrowserService.StopAsync(card.Id));
+            StatusText.Text = $"Stopped \"{card.Name}\". Its login is kept - start it again any time.";
+            await RefreshAndNotifyAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnStop_Click FAILED: id={card.Id}, {ex.Message}");
+            card.IsBusy = false;
+            StatusText.Text = ex.Message;
+        }
+    }
+
+    private async void BtnSignIn_Click(object? sender, RoutedEventArgs e)
+    {
+        var card = CardFor(sender);
+        if (card is null) return;
+
+        try
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnSignIn_Click: id={card.Id}");
+            var view = _views.First(v => v.Id == card.Id);
+            card.IsBusy = true;
+            if (await BrowserSignInFlow.RunAsync(OwnerWindow(), view))
+                StatusText.Text = $"\"{card.Name}\" is signed in and ready to drive.";
+            await RefreshAndNotifyAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnSignIn_Click FAILED: id={card.Id}, {ex.Message}");
+            card.IsBusy = false;
+            StatusText.Text = ex.Message;
+        }
+    }
+
+    private async void BtnAttach_Click(object? sender, RoutedEventArgs e)
+    {
+        var card = CardFor(sender);
+        if (card is null) return;
+
+        try
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnAttach_Click: id={card.Id}");
+            var view = _views.First(v => v.Id == card.Id);
+            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard
+                ?? throw new InvalidOperationException("The clipboard is not available.");
+            await clipboard.SetTextAsync(view.AttachCommand);
+            StatusText.Text = $"Copied: {view.AttachCommand}";
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnAttach_Click FAILED: id={card.Id}, {ex.Message}");
+            StatusText.Text = ex.Message;
+        }
+    }
+
+    // ---- rename ----
+
+    private void BtnRenameStart_Click(object? sender, RoutedEventArgs e)
+    {
+        var card = CardFor(sender);
+        if (card is null) return;
+        FileLog.Write($"[BrowserSettingsView] BtnRenameStart_Click: id={card.Id}");
+        _renamingIds.Add(card.Id);
+        card.EditName = card.Name;
+        card.IsRenaming = true;
+    }
+
+    private void BtnRenameCancel_Click(object? sender, RoutedEventArgs e)
+    {
+        var card = CardFor(sender);
+        if (card is null) return;
+        _renamingIds.Remove(card.Id);
+        card.IsRenaming = false;
+    }
+
+    private async void BtnRenameSave_Click(object? sender, RoutedEventArgs e)
+    {
+        var card = CardFor(sender);
+        if (card is null) return;
+
+        try
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnRenameSave_Click: id={card.Id}, newName={card.EditName}");
+            await Task.Run(() => AutomationBrowserService.Rename(card.Id, card.EditName));
+            _renamingIds.Remove(card.Id);
+            StatusText.Text = $"Renamed to \"{card.EditName.Trim()}\".";
+            await RefreshAndNotifyAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnRenameSave_Click FAILED: id={card.Id}, {ex.Message}");
+            StatusText.Text = ex.Message;
+        }
+    }
+
+    // ---- remove ----
+
+    private async void BtnRemove_Click(object? sender, RoutedEventArgs e)
+    {
+        var card = CardFor(sender);
+        if (card is null) return;
+
+        try
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnRemove_Click: id={card.Id}");
+            var view = _views.First(v => v.Id == card.Id);
+
+            var signedInClause = view.LastSignedInUtc is null
+                ? "It has never been signed in."
+                : $"It was signed in on {view.LastSignedInUtc.Value.ToLocalTime():yyyy-MM-dd}, and that login is deleted with it.";
+            var dialog = new ConfirmDialog(
+                "Remove browser",
+                $"This closes \"{view.Name}\" and permanently deletes its profile folder. {signedInClause} " +
+                "To use this identity again you would have to create a new browser and sign in again.",
+                confirmLabel: "Delete browser",
+                cancelLabel: "Cancel");
+            if (await dialog.ShowDialog<bool?>(OwnerWindow()) != true) return;
+
+            card.IsBusy = true;
+            StatusText.Text = $"Removing \"{view.Name}\"...";
+            await Task.Run(() => AutomationBrowserService.RemoveAsync(view.Id));
+            StatusText.Text = $"Removed \"{view.Name}\".";
+            await RefreshAndNotifyAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnRemove_Click FAILED: id={card.Id}, {ex.Message}");
+            card.IsBusy = false;
+            StatusText.Text = ex.Message;
+        }
+    }
+
+    /// <summary>
+    /// One rendered browser card: the fold's strings verbatim, plus the brushes this surface maps the
+    /// fold's names to, plus the two bits of transient UI state (renaming, busy).
+    /// </summary>
+    public sealed class BrowserCardViewModel : INotifyPropertyChanged
+    {
+        private static readonly IBrush ChromeIcon = Brush.Parse("#0F6CBD");
+        private static readonly IBrush EdgeIcon = Brush.Parse("#1AA1B8");
+        private static readonly IBrush PillGreyBg = Brush.Parse("#3C3C3C");
+        private static readonly IBrush PillDarkText = Brush.Parse("#141413");
+        private static readonly IBrush PillLightText = Brush.Parse("#CCCCCC");
+
+        private bool _isRenaming;
+        private bool _isBusy;
+        private string _editName = "";
+
+        public BrowserCardViewModel(AutomationBrowserView view)
+        {
+            Id = view.Id;
+            Name = view.Name;
+            Subtitle = $"{view.Subtitle}  (port {view.Port})";
+            StatusLabel = view.StatusLabel;
+            AttachToolTip = $"Copy to the clipboard: {view.AttachCommand}";
+            IconLetter = view.Browser.Length > 0 ? view.Browser[..1] : "?";
+            IconBackground = string.Equals(view.Browser, "Edge", StringComparison.OrdinalIgnoreCase) ? EdgeIcon : ChromeIcon;
+
+            ShowStart = view.Status == AutomationBrowserStatus.Stopped;
+            ShowSignIn = view.Status == AutomationBrowserStatus.NeedsSignIn;
+            ShowAttach = view.Status == AutomationBrowserStatus.Ready;
+            ShowStop = view.Status != AutomationBrowserStatus.Stopped;
+
+            // The pill's color IS the fold's dot color; only the text contrast is chosen here.
+            PillBackground = view.Status == AutomationBrowserStatus.Stopped
+                ? PillGreyBg
+                : StatusPalette.BrushFor(view.DotColor);
+            PillForeground = view.Status == AutomationBrowserStatus.Stopped ? PillLightText : PillDarkText;
+        }
+
+        public string Id { get; }
+        public string Name { get; }
+        public string Subtitle { get; }
+        public string StatusLabel { get; }
+        public string AttachToolTip { get; }
+        public string IconLetter { get; }
+        public IBrush IconBackground { get; }
+        public IBrush PillBackground { get; }
+        public IBrush PillForeground { get; }
+        public bool ShowStart { get; }
+        public bool ShowSignIn { get; }
+        public bool ShowAttach { get; }
+        public bool ShowStop { get; }
+
+        public bool IsRenaming
+        {
+            get => _isRenaming;
+            set { _isRenaming = value; Raise(nameof(IsRenaming)); }
+        }
+
+        public bool IsBusy
+        {
+            get => _isBusy;
+            set { _isBusy = value; Raise(nameof(IsBusy)); Raise(nameof(NotBusy)); }
+        }
+
+        public bool NotBusy => !_isBusy;
+
+        public string EditName
+        {
+            get => _editName;
+            set { _editName = value; Raise(nameof(EditName)); }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void Raise(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/BrowserSignInFlow.cs
+++ b/src/CcDirector.Avalonia/Controls/BrowserSignInFlow.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using CcDirector.Core.Browsers;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia.Controls;
+
+/// <summary>
+/// The one-time human sign-in flow, shared by the rail group and the Settings tab so the wording and
+/// the steps cannot drift: bring the browser up with its account page open, wait for the human to say
+/// they finished, and only then record the sign-in. The credentials are typed by the HUMAN in the
+/// browser window - DevThrottle only opens the page and records the confirmation. This is the honest
+/// constraint the whole feature designs around: the one sign-in cannot be automated away.
+/// </summary>
+internal static class BrowserSignInFlow
+{
+    /// <summary>Run the flow. Returns true when the human confirmed the sign-in (recorded), false when
+    /// they chose "Not yet" (nothing recorded; the browser stays on the sign-in page).</summary>
+    public static async Task<bool> RunAsync(Window owner, AutomationBrowserView view)
+    {
+        if (owner is null) throw new ArgumentNullException(nameof(owner));
+        if (view is null) throw new ArgumentNullException(nameof(view));
+
+        FileLog.Write($"[BrowserSignInFlow] RunAsync: id={view.Id}");
+        await Task.Run(() => AutomationBrowserService.SignInAsync(view.Id));
+
+        var dialog = new ConfirmDialog(
+            "Sign in once",
+            $"A \"{view.Name}\" window just opened on its sign-in page. Sign in by hand in that window - " +
+            "DevThrottle never types your credentials. The login is saved in this browser's own profile " +
+            "and lasts until the account signs it out.\n\nWhen you are signed in, click Done.",
+            confirmLabel: "Done - I am signed in",
+            cancelLabel: "Not yet");
+        var confirmed = await dialog.ShowDialog<bool?>(owner) == true;
+
+        if (confirmed)
+        {
+            AutomationBrowserService.MarkSignedIn(view.Id);
+            FileLog.Write($"[BrowserSignInFlow] RunAsync: id={view.Id} confirmed signed in");
+        }
+
+        return confirmed;
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml
+++ b/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml
@@ -1,0 +1,126 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="CcDirector.Avalonia.Controls.BrowsersRailGroup">
+
+    <!-- The pinned Browsers group in the left rail (Browsers feature, slice 2). Sits directly above
+         the pinned Repositories entry and follows its visual language: the same button chrome for the
+         header, the same 12px semibold row names. Every row renders the Core fold
+         (AutomationBrowserView) verbatim - dot color, subtitle, and which single action to offer are
+         all decided in CcDirector.Core.Browsers.AutomationBrowserViewFold, never here (rule 7). -->
+
+    <UserControl.Styles>
+        <Style Selector="Button.railRow">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="10,5" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style Selector="Button.railRow:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#2A2A2A" />
+        </Style>
+        <!-- The per-row action link (Start / Sign in / Attach): quiet text, no button chrome. -->
+        <Style Selector="Button.rowAction">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="6,2" />
+            <Setter Property="CornerRadius" Value="3" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+        <Style Selector="Button.rowAction:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#3C3C3C" />
+        </Style>
+    </UserControl.Styles>
+
+    <StackPanel>
+        <!-- Group header: same chrome as the pinned Repositories button below it. Click = expand/
+             collapse; the + on the right opens Settings > Browsers to add one. -->
+        <Button x:Name="HeaderButton"
+                Click="HeaderButton_Click"
+                Background="#2A2A2A" BorderBrush="#3C3C3C" BorderThickness="1"
+                Margin="8,4,8,0" Padding="10,8" CornerRadius="4"
+                HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Cursor="Hand"
+                ToolTip.Tip="Real, signed-in browsers your agents can drive through Browser Harness">
+            <DockPanel LastChildFill="True">
+                <!-- Right side of the header: setup nudge OR count, then add, then the chevron. -->
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                    <TextBlock x:Name="SetupLabel" Text="Setup" Foreground="#F0B848"
+                               FontSize="10" FontWeight="SemiBold" VerticalAlignment="Center"
+                               IsVisible="False"
+                               ToolTip.Tip="Browser Harness is not installed yet - click to set it up" />
+                    <Border x:Name="CountBadge" Background="#3C3C3C" CornerRadius="8" Padding="6,1"
+                            VerticalAlignment="Center" IsVisible="False">
+                        <TextBlock x:Name="CountText" Text="0" Foreground="#CCCCCC"
+                                   FontSize="9" FontWeight="SemiBold" />
+                    </Border>
+                    <Button x:Name="AddButton" Classes="rowAction" Content="+"
+                            Foreground="#CCCCCC" FontSize="13" Padding="5,0"
+                            Click="AddButton_Click"
+                            ToolTip.Tip="Add a browser" />
+                    <Path x:Name="Chevron" Fill="#888888" VerticalAlignment="Center"
+                          Data="M 0,0 L 4,4 L 8,0" Stretch="None" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                    <TextBlock Text="[B]" Foreground="#4A9EFF" FontFamily="Cascadia Mono, Consolas"
+                               FontSize="12" VerticalAlignment="Center" />
+                    <TextBlock Text="Browsers" Foreground="#CCCCCC" FontSize="12"
+                               FontWeight="SemiBold" VerticalAlignment="Center" />
+                </StackPanel>
+            </DockPanel>
+        </Button>
+
+        <!-- The expanded body. -->
+        <StackPanel x:Name="BodyPanel" Margin="8,2,8,0">
+
+            <!-- One row per browser. Everything shown is the Core fold, verbatim. -->
+            <ItemsControl x:Name="RowsList">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Button Classes="railRow" Tag="{Binding Id}" Click="Row_Click"
+                                Opacity="{Binding RowOpacity}"
+                                ToolTip.Tip="{Binding RowToolTip}">
+                            <Grid ColumnDefinitions="Auto,*,Auto" VerticalAlignment="Center">
+                                <Ellipse Grid.Column="0" Width="8" Height="8" Margin="2,0,9,0"
+                                         VerticalAlignment="Center" Fill="{Binding DotBrush}" />
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                    <TextBlock Text="{Binding Name}" Foreground="#CCCCCC"
+                                               FontSize="12" FontWeight="SemiBold"
+                                               TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Text="{Binding Subtitle}" Foreground="#888888"
+                                               FontSize="10" TextTrimming="CharacterEllipsis" />
+                                </StackPanel>
+                                <Button Grid.Column="2" Classes="rowAction"
+                                        Content="{Binding ActionLabel}"
+                                        Foreground="{Binding ActionForeground}"
+                                        IsVisible="{Binding ActionVisible}"
+                                        Tag="{Binding Id}" Click="RowAction_Click"
+                                        ToolTip.Tip="{Binding ActionToolTip}" />
+                            </Grid>
+                        </Button>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
+            <!-- Shown when Browser Harness is missing: the feature advertises itself with the
+                 discovered-but-dimmed rows above and this inline install link. -->
+            <Button x:Name="InstallLink" Classes="railRow" IsVisible="False"
+                    Click="InstallLink_Click"
+                    ToolTip.Tip="Open the Browser Harness install guide in your browser">
+                <TextBlock Text="Install Browser Harness" Foreground="#4A9EFF"
+                           FontSize="11" FontWeight="SemiBold" />
+            </Button>
+
+            <!-- Shown when the harness is installed but no browser exists yet. -->
+            <Button x:Name="AddFirstLink" Classes="railRow" IsVisible="False"
+                    Click="AddButton_Click"
+                    ToolTip.Tip="Create your first drivable browser in Settings">
+                <TextBlock Text="Add a browser..." Foreground="#4A9EFF"
+                           FontSize="11" FontWeight="SemiBold" />
+            </Button>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CcDirector.Core.Browsers;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia.Controls;
+
+/// <summary>
+/// The pinned "Browsers" group in the left rail: one row per drivable automation browser, each with a
+/// status dot and the single next action (Start / Sign in / Attach). Rows render the Core fold
+/// (<see cref="AutomationBrowserViewFold"/>) verbatim - this control decides layout, never meaning.
+/// When Browser Harness is not installed the group stays visible but dimmed, with an inline install
+/// link, so the feature advertises itself instead of hiding (mockup state 2).
+/// </summary>
+public partial class BrowsersRailGroup : UserControl
+{
+    /// <summary>Raised when the user wants the management surface (Settings > Browsers): the header
+    /// +, a click on a row, or the "Add a browser..." empty-state link.</summary>
+    public event EventHandler? ManageRequested;
+
+    /// <summary>Raised with a short user-facing message (action feedback or a failure) for the host
+    /// window's notification strip.</summary>
+    public event EventHandler<string>? Notified;
+
+    private static readonly IBrush AccentBrush = Brush.Parse("#4A9EFF");
+    private static readonly IBrush AmberBrush = Brush.Parse("#F0B848");
+
+    private readonly DispatcherTimer _refreshTimer;
+    private IReadOnlyList<AutomationBrowserView> _views = Array.Empty<AutomationBrowserView>();
+    private bool _harnessInstalled;
+    private bool _expanded = true;
+    private bool _refreshing;
+
+    public BrowsersRailGroup()
+    {
+        InitializeComponent();
+
+        // Status is a live port probe, so it can drift (the user closes a browser window by hand);
+        // a slow background re-poll keeps the dots honest without hammering the ports.
+        _refreshTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(30) };
+        _refreshTimer.Tick += (_, _) => _ = RefreshAsync();
+
+        AttachedToVisualTree += (_, _) =>
+        {
+            _refreshTimer.Start();
+            _ = RefreshAsync();
+        };
+        DetachedFromVisualTree += (_, _) => _refreshTimer.Stop();
+    }
+
+    /// <summary>
+    /// Re-read the registry, probe each browser's live status, and repaint the group. Safe to call
+    /// from anywhere; overlapping calls collapse into one.
+    /// </summary>
+    public async Task RefreshAsync()
+    {
+        if (_refreshing) return;
+        _refreshing = true;
+        try
+        {
+            var harnessInstalled = false;
+            IReadOnlyList<AutomationBrowserView> views = Array.Empty<AutomationBrowserView>();
+            await Task.Run(async () =>
+            {
+                harnessInstalled = AutomationBrowserViewFold.IsHarnessInstalled();
+                views = await AutomationBrowserViewFold.ListAsync().ConfigureAwait(false);
+            });
+
+            _views = views;
+            _harnessInstalled = harnessInstalled;
+            Render(views, harnessInstalled);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowsersRailGroup] RefreshAsync FAILED: {ex.Message}");
+            Notified?.Invoke(this, $"Could not read the browsers list: {ex.Message}");
+        }
+        finally
+        {
+            _refreshing = false;
+        }
+    }
+
+    private void Render(IReadOnlyList<AutomationBrowserView> views, bool harnessInstalled)
+    {
+        CountBadge.IsVisible = harnessInstalled && views.Count > 0;
+        CountText.Text = views.Count.ToString();
+        SetupLabel.IsVisible = !harnessInstalled;
+        InstallLink.IsVisible = _expanded && !harnessInstalled;
+        AddFirstLink.IsVisible = _expanded && harnessInstalled && views.Count == 0;
+        BodyPanel.IsVisible = _expanded;
+        Chevron.Data = Geometry.Parse(_expanded ? "M 0,0 L 4,4 L 8,0" : "M 0,0 L 4,4 L 0,8");
+
+        RowsList.ItemsSource = views.Select(v => new BrowserRailRow
+        {
+            Id = v.Id,
+            Name = v.Name,
+            Subtitle = v.Subtitle,
+            DotBrush = StatusPalette.BrushFor(v.DotColor),
+            // Dimmed advertising rows when the harness is missing: discoverable, not operable.
+            RowOpacity = harnessInstalled ? 1.0 : 0.45,
+            ActionVisible = harnessInstalled,
+            ActionLabel = v.ActionLabel,
+            ActionForeground = v.Status == AutomationBrowserStatus.NeedsSignIn ? AmberBrush : AccentBrush,
+            ActionToolTip = v.Status switch
+            {
+                AutomationBrowserStatus.Stopped => "Start this browser",
+                AutomationBrowserStatus.NeedsSignIn => "Open the sign-in page for the one-time hand sign-in",
+                _ => "Copy the command that points an agent's Browser Harness at this browser",
+            },
+            RowToolTip = $"{v.Subtitle} ({v.StatusLabel}). Click to manage in Settings.",
+        }).ToList();
+    }
+
+    // ---- header ----
+
+    private void HeaderButton_Click(object? sender, RoutedEventArgs e)
+    {
+        _expanded = !_expanded;
+        FileLog.Write($"[BrowsersRailGroup] HeaderButton_Click: expanded={_expanded}");
+        Render(_views, _harnessInstalled);
+    }
+
+    private void AddButton_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[BrowsersRailGroup] AddButton_Click");
+        ManageRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void InstallLink_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            FileLog.Write($"[BrowsersRailGroup] InstallLink_Click -> {AutomationBrowserViewFold.HarnessInstallUrl}");
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(AutomationBrowserViewFold.HarnessInstallUrl)
+                { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowsersRailGroup] InstallLink_Click FAILED: {ex.Message}");
+            Notified?.Invoke(this, $"Could not open the install guide: {ex.Message}");
+        }
+    }
+
+    // ---- rows ----
+
+    private void Row_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[BrowsersRailGroup] Row_Click -> manage");
+        ManageRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    private async void RowAction_Click(object? sender, RoutedEventArgs e)
+    {
+        // Stop the click from also triggering the row's own click (which navigates to Settings).
+        e.Handled = true;
+
+        var id = (sender as Button)?.Tag as string;
+        var view = _views.FirstOrDefault(v => v.Id == id);
+        if (view is null) return;
+
+        try
+        {
+            FileLog.Write($"[BrowsersRailGroup] RowAction_Click: id={view.Id}, status={view.Status}");
+            switch (view.Status)
+            {
+                case AutomationBrowserStatus.Stopped:
+                    Notified?.Invoke(this, $"Starting \"{view.Name}\"...");
+                    await Task.Run(() => AutomationBrowserService.LaunchAsync(view.Id));
+                    Notified?.Invoke(this, $"\"{view.Name}\" is up.");
+                    break;
+
+                case AutomationBrowserStatus.NeedsSignIn:
+                    await RunSignInFlowAsync(view);
+                    break;
+
+                case AutomationBrowserStatus.Ready:
+                    var top = TopLevel.GetTopLevel(this);
+                    if (top?.Clipboard is null)
+                        throw new InvalidOperationException("The clipboard is not available.");
+                    await top.Clipboard.SetTextAsync(view.AttachCommand);
+                    Notified?.Invoke(this, $"Attach command for \"{view.Name}\" copied to the clipboard.");
+                    break;
+            }
+
+            await RefreshAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowsersRailGroup] RowAction_Click FAILED: id={id}, {ex.Message}");
+            Notified?.Invoke(this, ex.Message);
+        }
+    }
+
+    /// <summary>The one-time human sign-in, via the shared <see cref="BrowserSignInFlow"/> so the rail
+    /// and the Settings tab run the identical flow and wording.</summary>
+    private async Task RunSignInFlowAsync(AutomationBrowserView view)
+    {
+        var owner = TopLevel.GetTopLevel(this) as Window;
+        if (owner is null)
+            throw new InvalidOperationException("No owner window for the sign-in confirmation dialog.");
+
+        Notified?.Invoke(this, $"Opening the sign-in page in \"{view.Name}\"...");
+        if (await BrowserSignInFlow.RunAsync(owner, view))
+            Notified?.Invoke(this, $"\"{view.Name}\" is signed in and ready to drive.");
+    }
+
+    /// <summary>One rendered rail row: the fold's strings plus the brushes this surface maps them to.</summary>
+    public sealed class BrowserRailRow
+    {
+        public string Id { get; init; } = "";
+        public string Name { get; init; } = "";
+        public string Subtitle { get; init; } = "";
+        public IBrush DotBrush { get; init; } = Brushes.Gray;
+        public double RowOpacity { get; init; } = 1.0;
+        public bool ActionVisible { get; init; }
+        public string ActionLabel { get; init; } = "";
+        public IBrush ActionForeground { get; init; } = Brushes.White;
+        public string ActionToolTip { get; init; } = "";
+        public string RowToolTip { get; init; } = "";
+    }
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -240,48 +240,26 @@
                      opens the Gateway Connection panel on the resolver's current step. All colors, glyphs,
                      text and the tooltip are set from code-behind via GatewayStatusBoxPresenter, which runs
                      the same GatewayConnectionStateResolver the panel uses (so box and panel never disagree). -->
+                <!-- Slimmed to a compact chip (Browsers feature, slice 2): a status dot plus the
+                     presenter's short verdict. The dot and text carry the four visual states; the two
+                     full check lines (which gateway, which account) moved into the tooltip. Same click
+                     target, same panel. -->
                 <Border x:Name="GatewayStatusBox" DockPanel.Dock="Bottom"
-                        Margin="8,0,8,4" Padding="10,8" CornerRadius="4"
-                        Background="#3A331B" BorderBrush="#F0B848" BorderThickness="1"
+                        Margin="8,0,8,6" Padding="10,5" CornerRadius="12"
+                        Background="#2A2A2A" BorderBrush="#3C3C3C" BorderThickness="1"
+                        HorizontalAlignment="Left"
                         Cursor="Hand"
                         Focusable="True"
                         KeyDown="GatewayStatusBox_KeyDown"
                         PointerPressed="GatewayStatusBox_PointerPressed">
-                    <StackPanel Spacing="6">
-                        <!-- Line 1: WHICH gateway this Director is pointed at. The marker (green check /
-                             amber ring / red cross) reinforces connected / connecting / failed. The line names
-                             the gateway host first and appends the resolved verdict in parentheses, so neither
-                             color nor glyph is the only way to learn the state. With no gateway selected yet
-                             (brand new) the host is empty and this whole row is hidden from code-behind. -->
-                        <StackPanel x:Name="GatewayConnectedRow" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                            <Viewbox Width="15" Height="15" VerticalAlignment="Center">
-                                <Path x:Name="GatewayConnectedMarker"
-                                      Fill="#F0B848"
-                                      Data="M8,1 A7,7 0 1 0 8,15 A7,7 0 1 0 8,1 Z M8,3 A5,5 0 1 1 8,13 A5,5 0 1 1 8,3 Z" />
-                            </Viewbox>
-                            <TextBlock x:Name="GatewayConnectedLine"
-                                       Text=""
-                                       FontSize="11" FontWeight="SemiBold"
-                                       Foreground="#F0B848"
-                                       TextWrapping="Wrap" MaxWidth="176"
-                                       MaxLines="2" TextTrimming="CharacterEllipsis"
-                                       VerticalAlignment="Center" />
-                        </StackPanel>
-                        <!-- Line 2: Account signed in (the Gateway's own account report). -->
-                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                            <Viewbox Width="15" Height="15" VerticalAlignment="Center">
-                                <Path x:Name="GatewaySignedInMarker"
-                                      Fill="#777777"
-                                      Data="M8,1 A7,7 0 1 0 8,15 A7,7 0 1 0 8,1 Z M8,3 A5,5 0 1 1 8,13 A5,5 0 1 1 8,3 Z" />
-                            </Viewbox>
-                            <TextBlock x:Name="GatewaySignedInLine"
-                                       Text="Sign in"
-                                       FontSize="11" FontWeight="SemiBold"
-                                       Foreground="#777777"
-                                       TextWrapping="Wrap" MaxWidth="176"
-                                       MaxLines="2" TextTrimming="CharacterEllipsis"
-                                       VerticalAlignment="Center" />
-                        </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="7" VerticalAlignment="Center">
+                        <Ellipse x:Name="GatewayChipDot" Width="8" Height="8"
+                                 Fill="#F0B848" VerticalAlignment="Center" />
+                        <TextBlock x:Name="GatewayChipText"
+                                   Text="Checking Gateway..."
+                                   FontSize="11" FontWeight="SemiBold"
+                                   Foreground="#F0B848"
+                                   VerticalAlignment="Center" />
                     </StackPanel>
                 </Border>
 
@@ -414,6 +392,13 @@
                         </StackPanel>
                     </DockPanel>
                 </Button>
+
+                <!-- Pinned Browsers group (Browsers feature, slice 2): the drivable, signed-in-once
+                     automation browsers on this machine, one row each with a status dot and the single
+                     next action. Sits directly above the pinned Repositories entry. All content is the
+                     Core fold rendered verbatim; the control raises ManageRequested to open
+                     Settings > Browsers. -->
+                <controls:BrowsersRailGroup x:Name="BrowsersRail" DockPanel.Dock="Bottom" />
 
                 <!-- Session list -->
                 <ListBox x:Name="SessionList"

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -257,6 +257,11 @@ public partial class MainWindow : Window
             UpdateRepositoriesBadge();
         }
 
+        // Pinned Browsers group (Browsers feature, slice 2): manage lands on Settings > Browsers,
+        // and its action/failure feedback rides the shared notification strip.
+        BrowsersRail.ManageRequested += (_, _) => _ = OpenSettingsAsync(onBrowsersTab: true);
+        BrowsersRail.Notified += (_, message) => Dispatcher.UIThread.Post(() => ShowNotification(message));
+
         // Wire prompt input text changes for slash command autocomplete
         PromptInput.TextChanged += PromptInput_TextChanged;
         PromptInput.LostFocus += (_, _) => SlashCommandPopup.IsOpen = false;
@@ -662,20 +667,17 @@ public partial class MainWindow : Window
 
         var content = GatewayStatusBoxPresenter.Describe(inputs, _boxGatewayHost, _boxAccountEmail);
 
-        var (bg, border) = BoxColors(content.Visual);
-        GatewayStatusBox.Background = Brush.Parse(bg);
-        GatewayStatusBox.BorderBrush = Brush.Parse(border);
-        PaintCheckLine(GatewayConnectedMarker, GatewayConnectedLine, content.Connected);
-        PaintCheckLine(GatewaySignedInMarker, GatewaySignedInLine, content.SignedIn);
-        // Line 1 names WHICH gateway; when none is selected yet the line is empty and the whole row is
-        // hidden so a brand-new box does not show a marker with no verdict. (Line 2 never goes empty, so
-        // the same rule never collapses the Sign in nudge.)
-        GatewayConnectedRow.IsVisible = !string.IsNullOrEmpty(content.Connected.Text);
-        ToolTip.SetTip(GatewayStatusBox, content.Tooltip);
-        var accessibleName = string.IsNullOrEmpty(content.Connected.Text)
+        // The chip form: the dot and the short verdict carry the state; the two full check lines
+        // (which gateway, which account) live in the tooltip so no information was lost in the slim-down.
+        var (dot, text) = ChipStyle(content.Visual);
+        GatewayChipDot.Fill = Brush.Parse(dot);
+        GatewayChipText.Text = content.ChipText;
+        GatewayChipText.Foreground = Brush.Parse(text);
+        var detail = string.IsNullOrEmpty(content.Connected.Text)
             ? content.SignedIn.Text
             : $"{content.Connected.Text}. {content.SignedIn.Text}";
-        AutomationProperties.SetName(GatewayStatusBox, accessibleName);
+        ToolTip.SetTip(GatewayStatusBox, $"{detail}.\n{content.Tooltip}");
+        AutomationProperties.SetName(GatewayStatusBox, detail);
         AutomationProperties.SetHelpText(GatewayStatusBox, content.Tooltip);
 
         // A missing gateway is NOT an error (a legitimate local-only Director); only the red failure
@@ -720,33 +722,16 @@ public partial class MainWindow : Window
         };
     }
 
-    // The box surface applies colors and glyphs; the presenter's per-line marker state decides which
-    // (spec section 6). Colors live here with the surface, not in the Core presenter.
-    private static void PaintCheckLine(global::Avalonia.Controls.Shapes.Path marker, TextBlock text, GatewayStatusLine line)
+    // The chip surface applies colors; the presenter's visual state decides which (spec section 6).
+    // Colors live here with the surface, not in the Core presenter. Green keeps the text muted (all is
+    // well, nothing shouts); the attention and failure states color the text with the dot.
+    private static (string Dot, string Text) ChipStyle(GatewayStatusBoxVisual visual) => visual switch
     {
-        var (glyph, color) = MarkerStyle(line.Marker);
-        marker.Data = Geometry.Parse(glyph);
-        marker.Fill = Brush.Parse(color);
-        text.Text = line.Text;
-        text.Foreground = Brush.Parse(color);
-    }
-
-    private static (string Glyph, string Color) MarkerStyle(GatewayCheckState marker) => marker switch
-    {
-        GatewayCheckState.Passed => (GatewayIconCheck, "#22C55E"),   // green filled check
-        GatewayCheckState.Working => (GatewayIconRing, "#F0B848"),   // amber ring, in progress
-        GatewayCheckState.Failed => (GatewayIconCross, "#EF4444"),   // red cross, connection failed
-        GatewayCheckState.Pending => (GatewayIconRing, "#F0B848"),   // amber ring, the actionable nudge
-        _ => (GatewayIconRing, "#777777"),                           // muted ring, cannot tell yet
-    };
-
-    private static (string Background, string Border) BoxColors(GatewayStatusBoxVisual visual) => visual switch
-    {
-        GatewayStatusBoxVisual.Green => ("#1B3A2A", "#22C55E"),
-        GatewayStatusBoxVisual.Red => ("#3A1B1B", "#DC2626"),
-        // Amber (needs attention) and Yellow (verifying) share the warm scheme; the line content and
-        // markers carry the distinction (line 1 appends "(Connecting...)" for yellow).
-        _ => ("#3A331B", "#F0B848"),
+        GatewayStatusBoxVisual.Green => ("#22C55E", "#CCCCCC"),
+        GatewayStatusBoxVisual.Red => ("#EF4444", "#EF4444"),
+        // Amber (needs attention) and Yellow (verifying) share the warm scheme; the chip text carries
+        // the distinction ("Sign in" / "No Gateway" versus "Connecting...").
+        _ => ("#F0B848", "#F0B848"),
     };
 
     /// <summary>
@@ -3724,6 +3709,15 @@ public partial class MainWindow : Window
         view.Menu.Items.Add(Item("Gateway Connection (preview)...", OpenGatewayConnectionPreview));
         menu.Items.Add(view);
 
+        // ===== Browsers =====
+        // Top-level on purpose (Browsers feature, slice 2): the drivable-browser capability is a
+        // headline feature and the menu entry is how it advertises itself. Both items land on
+        // Settings > Browsers - the rail group is the everyday launch surface.
+        var browsers = new NativeMenuItem("Browsers") { Menu = new NativeMenu() };
+        browsers.Menu.Items.Add(Item("New Browser...", () => _ = OpenSettingsAsync(onBrowsersTab: true, openBrowserCreate: true)));
+        browsers.Menu.Items.Add(Item("Manage Browsers...", () => _ = OpenSettingsAsync(onBrowsersTab: true)));
+        menu.Items.Add(browsers);
+
         // ===== Tools (alpha only - none of these are verified working yet) =====
         if (alpha)
         {
@@ -3854,22 +3848,35 @@ public partial class MainWindow : Window
     /// <summary>
     /// Open the CC Director Settings dialog. When <paramref name="onGatewayTab"/> is true the
     /// dialog is shown on the Gateway tab (issue #442: the no-Gateway needs-attention indicator
-    /// routes here so the user lands on the field they must set).
+    /// routes here so the user lands on the field they must set). <paramref name="onBrowsersTab"/>
+    /// lands on the Browsers tab (the rail group and the Browsers menu route here), and
+    /// <paramref name="openBrowserCreate"/> also opens its inline new-browser panel.
     /// </summary>
-    private async Task OpenSettingsAsync(bool onGatewayTab = false, bool onToolsTab = false)
+    private async Task OpenSettingsAsync(
+        bool onGatewayTab = false, bool onToolsTab = false,
+        bool onBrowsersTab = false, bool openBrowserCreate = false)
     {
-        FileLog.Write($"[MainWindow] OpenSettingsAsync: onGatewayTab={onGatewayTab}, onToolsTab={onToolsTab}");
+        FileLog.Write($"[MainWindow] OpenSettingsAsync: onGatewayTab={onGatewayTab}, onToolsTab={onToolsTab}, onBrowsersTab={onBrowsersTab}");
         var dialog = new SettingsDialog(ReloadScreenshotsPanelAsync);
+        // Live-sync the pinned rail group with every change made on the Browsers tab, so the rail
+        // behind the open dialog never shows a browser that was just renamed or removed.
+        dialog.BrowsersView.Changed += (_, _) => _ = BrowsersRail.RefreshAsync();
         if (onGatewayTab)
             dialog.SelectGatewayTab();
         else if (onToolsTab)
             dialog.SelectToolsTab();
+        else if (onBrowsersTab)
+            dialog.SelectBrowsersTab(openBrowserCreate);
         await dialog.ShowDialog<bool?>(this);
 
         // The Tools tab can download/repair tools while the dialog is open, so re-run the health
         // check on close - this clears the rail indicator once the toolset is whole again.
         _lastToolHealth = null;
         _ = RefreshToolHealthAsync(force: true);
+
+        // The Browsers tab can create/rename/remove/sign-in browsers; repaint the rail group so the
+        // pinned rows match the moment the dialog closes.
+        _ = BrowsersRail.RefreshAsync();
     }
 
     private async void BtnHelp_Click(object? sender, RoutedEventArgs e)

--- a/src/CcDirector.Avalonia/SettingsDialog.axaml
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml
@@ -264,6 +264,13 @@
                 </Grid>
             </TabItem>
 
+            <TabItem Header="Browsers">
+                <!-- Browsers feature (slice 2): the workshop for drivable automation browsers -
+                     create, sign in once, rename, remove. The rail's pinned Browsers group is the
+                     launch surface; this tab is where they are set up. All logic lives in the view. -->
+                <controls:BrowserSettingsView x:Name="BrowsersView" />
+            </TabItem>
+
             <TabItem Header="Directories">
                 <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Padding="0,0,14,0">
                     <StackPanel Spacing="8" Margin="0,4,0,0">

--- a/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
@@ -635,12 +635,25 @@ public partial class SettingsDialog : Window
         SettingsTabs.SelectedIndex = gatewayTabIndex;
     }
 
+    /// <summary>Select the Browsers tab (the drivable automation browsers workshop). The main window's
+    /// pinned Browsers rail group and the Browsers menu route here; <paramref name="openCreate"/> also
+    /// opens the inline new-browser panel (the menu's "New Browser...").</summary>
+    public void SelectBrowsersTab(bool openCreate = false)
+    {
+        // Tab order in SettingsDialog.axaml: Account(0), Gateway(1), Agents(2), Browsers(3).
+        const int browsersTabIndex = 3;
+        SettingsTabs.SelectedIndex = browsersTabIndex;
+        if (openCreate)
+            BrowsersView.OpenCreatePanel();
+    }
+
     /// <summary>Select the Tools tab so the download-and-repair button is visible. The main window's
     /// rail tools indicator routes here when a tool is missing or failing.</summary>
     public void SelectToolsTab()
     {
-        // Tab order in SettingsDialog.axaml: Account(0), Gateway(1), Agents(2), Directories(3), Advanced(4), Tools(5).
-        const int toolsTabIndex = 5;
+        // Tab order in SettingsDialog.axaml: Account(0), Gateway(1), Agents(2), Browsers(3),
+        // Directories(4), Advanced(5), Tools(6).
+        const int toolsTabIndex = 6;
         SettingsTabs.SelectedIndex = toolsTabIndex;
     }
 

--- a/src/CcDirector.ControlApi/BrowserEndpoints.cs
+++ b/src/CcDirector.ControlApi/BrowserEndpoints.cs
@@ -1,0 +1,206 @@
+using CcDirector.Core.Browsers;
+using CcDirector.Core.Utilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Loopback Control-API surface for DevThrottle's automation browsers (the drivable, signed-in-once
+/// Chromium instances an agent attaches to via browser-harness). The Python <c>cc-devthrottle browser</c>
+/// verbs call these, and later the desktop rail will read the SAME endpoints - so the fold (status label,
+/// account, attach environment) is computed HERE, once, and every client renders it verbatim.
+///
+/// Machine-locality is enforced by construction: a browser's debug port is loopback and its data
+/// directory is on THIS machine, so only the LOCAL Director (the one the CLI talks to over its own
+/// CC_DIRECTOR_API) can start or drive it. There is deliberately no relay of these verbs to another
+/// Director - a browser cannot be driven through a tunnel.
+/// </summary>
+internal static class BrowserEndpoints
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        // GET /browsers - every browser on THIS machine, each with its folded status + account + attach env.
+        app.MapGet("/browsers", async (CancellationToken ct) =>
+        {
+            var browsers = AutomationBrowserRegistry.Load();
+            var dtos = new List<BrowserDto>(browsers.Count);
+            foreach (var b in browsers)
+                dtos.Add(await FoldAsync(b, ct).ConfigureAwait(false));
+            return Results.Json(new { browsers = dtos });
+        });
+
+        // POST /browsers { name, browser } - register + provision a new browser (does not launch it).
+        app.MapPost("/browsers", async (CreateBrowserRequest req, CancellationToken ct) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.Name))
+                return Results.BadRequest(new { error = "name is required" });
+            if (!TryParseKind(req.Browser, out var kind))
+                return Results.BadRequest(new { error = $"unknown browser \"{req.Browser}\" - use chrome or edge" });
+
+            try
+            {
+                var created = AutomationBrowserService.Create(req.Name, kind);
+                var dto = await FoldAsync(created, ct).ConfigureAwait(false);
+                return Results.Json(dto, statusCode: StatusCodes.Status201Created);
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        });
+
+        // POST /browsers/{id}/start - launch if down (idempotent), wait until the port answers.
+        app.MapPost("/browsers/{id}/start", async (string id, CancellationToken ct) =>
+        {
+            return await GuardedAsync(id, async b =>
+            {
+                var launched = await AutomationBrowserService.LaunchAsync(b.Id, ct).ConfigureAwait(false);
+                return Results.Json(await FoldAsync(launched, ct).ConfigureAwait(false));
+            });
+        });
+
+        // GET /browsers/{id}/attach - the BU_NAME / BU_CDP_URL the harness attaches with.
+        app.MapGet("/browsers/{id}/attach", (string id) =>
+        {
+            return Guarded(id, b =>
+            {
+                var attach = AutomationBrowserRegistry.AttachInfoFor(b);
+                return Results.Json(new { buName = attach.BuName, buCdpUrl = attach.BuCdpUrl });
+            });
+        });
+
+        // POST /browsers/{id}/signin { done } - done:true records the human finished; otherwise launch +
+        // open the account page for the human to sign in by hand (credentials are NEVER automated).
+        app.MapPost("/browsers/{id}/signin", async (string id, SignInRequest? req, CancellationToken ct) =>
+        {
+            return await GuardedAsync(id, async b =>
+            {
+                if (req?.Done == true)
+                {
+                    var confirmed = AutomationBrowserService.MarkSignedIn(b.Id);
+                    return Results.Json(await FoldAsync(confirmed, ct).ConfigureAwait(false));
+                }
+
+                var opened = await AutomationBrowserService.SignInAsync(b.Id, ct).ConfigureAwait(false);
+                return Results.Json(await FoldAsync(opened, ct).ConfigureAwait(false));
+            });
+        });
+
+        // POST /browsers/{id}/rename { name }
+        app.MapPost("/browsers/{id}/rename", async (string id, RenameBrowserRequest req, CancellationToken ct) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.Name))
+                return Results.BadRequest(new { error = "name is required" });
+
+            return await GuardedAsync(id, async b =>
+            {
+                try
+                {
+                    var renamed = AutomationBrowserService.Rename(b.Id, req.Name);
+                    return Results.Json(await FoldAsync(renamed, ct).ConfigureAwait(false));
+                }
+                catch (InvalidOperationException ex)
+                {
+                    return Results.BadRequest(new { error = ex.Message });
+                }
+            });
+        });
+
+        // DELETE /browsers/{id} - stop it, delete its folder, drop the entry.
+        app.MapDelete("/browsers/{id}", async (string id, CancellationToken ct) =>
+        {
+            return await GuardedAsync(id, async b =>
+            {
+                try
+                {
+                    await AutomationBrowserService.RemoveAsync(b.Id, ct).ConfigureAwait(false);
+                    return Results.Json(new { removed = true, id = b.Id, name = b.Name });
+                }
+                catch (IOException ex)
+                {
+                    return Results.Json(new { removed = false, error = ex.Message }, statusCode: StatusCodes.Status409Conflict);
+                }
+            });
+        });
+    }
+
+    // --- folding + helpers ---
+
+    /// <summary>Compute the finished view of a browser: live status, human status label, and the account
+    /// it is signed in as (read from its own Local State). Clients render these verbatim.</summary>
+    private static async Task<BrowserDto> FoldAsync(AutomationBrowser b, CancellationToken ct)
+    {
+        var status = await AutomationBrowserService.StatusAsync(b, ct).ConfigureAwait(false);
+        var attach = AutomationBrowserRegistry.AttachInfoFor(b);
+        string? account = null;
+        try { account = AutomationBrowserService.ReadAccount(b); }
+        catch (Exception ex) { FileLog.Write($"[BrowserEndpoints] ReadAccount id={b.Id} failed (non-fatal): {ex.Message}"); }
+
+        return new BrowserDto
+        {
+            Id = b.Id,
+            Name = b.Name,
+            Browser = b.Kind.ToString(),
+            Port = b.Port,
+            Status = status.ToString(),
+            StatusLabel = StatusLabel(status),
+            Account = account,
+            BuName = attach.BuName,
+            BuCdpUrl = attach.BuCdpUrl,
+            UserDataDir = b.UserDataDir,
+            CreatedUtc = b.CreatedUtc,
+            LastSignedInUtc = b.LastSignedInUtc,
+        };
+    }
+
+    private static string StatusLabel(AutomationBrowserStatus status) => status switch
+    {
+        AutomationBrowserStatus.Stopped => "Stopped",
+        AutomationBrowserStatus.NeedsSignIn => "Needs sign-in",
+        AutomationBrowserStatus.Ready => "Ready",
+        _ => status.ToString(),
+    };
+
+    private static bool TryParseKind(string? value, out BrowserKind kind)
+        => Enum.TryParse(value?.Trim(), ignoreCase: true, out kind);
+
+    /// <summary>Resolve the browser or return a 404 naming it; run <paramref name="body"/> otherwise (sync).</summary>
+    private static IResult Guarded(string id, Func<AutomationBrowser, IResult> body)
+    {
+        var browser = AutomationBrowserRegistry.Find(id);
+        if (browser is null)
+            return Results.Json(new { error = $"No automation browser \"{id}\" on this machine." }, statusCode: StatusCodes.Status404NotFound);
+        return body(browser);
+    }
+
+    /// <summary>Async form of <see cref="Guarded"/>.</summary>
+    private static async Task<IResult> GuardedAsync(string id, Func<AutomationBrowser, Task<IResult>> body)
+    {
+        var browser = AutomationBrowserRegistry.Find(id);
+        if (browser is null)
+            return Results.Json(new { error = $"No automation browser \"{id}\" on this machine." }, statusCode: StatusCodes.Status404NotFound);
+        return await body(browser).ConfigureAwait(false);
+    }
+
+    private sealed record CreateBrowserRequest(string Name, string Browser);
+    private sealed record RenameBrowserRequest(string Name);
+    private sealed record SignInRequest(bool Done);
+
+    private sealed class BrowserDto
+    {
+        public string Id { get; init; } = "";
+        public string Name { get; init; } = "";
+        public string Browser { get; init; } = "";
+        public int Port { get; init; }
+        public string Status { get; init; } = "";
+        public string StatusLabel { get; init; } = "";
+        public string? Account { get; init; }
+        public string BuName { get; init; } = "";
+        public string BuCdpUrl { get; init; } = "";
+        public string UserDataDir { get; init; } = "";
+        public DateTime CreatedUtc { get; init; }
+        public DateTime? LastSignedInUtc { get; init; }
+    }
+}

--- a/src/CcDirector.ControlApi/BrowserEndpoints.cs
+++ b/src/CcDirector.ControlApi/BrowserEndpoints.cs
@@ -1,5 +1,4 @@
 using CcDirector.Core.Browsers;
-using CcDirector.Core.Utilities;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -9,8 +8,9 @@ namespace CcDirector.ControlApi;
 /// <summary>
 /// Loopback Control-API surface for DevThrottle's automation browsers (the drivable, signed-in-once
 /// Chromium instances an agent attaches to via browser-harness). The Python <c>cc-devthrottle browser</c>
-/// verbs call these, and later the desktop rail will read the SAME endpoints - so the fold (status label,
-/// account, attach environment) is computed HERE, once, and every client renders it verbatim.
+/// verbs call these, and the Director's own rail and Settings tab render the SAME fold in-process - the
+/// finished view (status label, dot color, subtitle, action, attach command) is computed once by
+/// <see cref="AutomationBrowserViewFold"/> and every client renders it verbatim.
 ///
 /// Machine-locality is enforced by construction: a browser's debug port is loopback and its data
 /// directory is on THIS machine, so only the LOCAL Director (the one the CLI talks to over its own
@@ -21,14 +21,17 @@ internal static class BrowserEndpoints
 {
     public static void Map(IEndpointRouteBuilder app)
     {
-        // GET /browsers - every browser on THIS machine, each with its folded status + account + attach env.
+        // GET /browsers - every browser on THIS machine, each fully folded, plus whether
+        // browser-harness itself is installed (the rail's dimmed "advertise" state keys off this).
         app.MapGet("/browsers", async (CancellationToken ct) =>
         {
-            var browsers = AutomationBrowserRegistry.Load();
-            var dtos = new List<BrowserDto>(browsers.Count);
-            foreach (var b in browsers)
-                dtos.Add(await FoldAsync(b, ct).ConfigureAwait(false));
-            return Results.Json(new { browsers = dtos });
+            var views = await AutomationBrowserViewFold.ListAsync(ct).ConfigureAwait(false);
+            return Results.Json(new
+            {
+                browsers = views,
+                harnessInstalled = AutomationBrowserViewFold.IsHarnessInstalled(),
+                harnessInstallUrl = AutomationBrowserViewFold.HarnessInstallUrl,
+            });
         });
 
         // POST /browsers { name, browser } - register + provision a new browser (does not launch it).
@@ -42,8 +45,8 @@ internal static class BrowserEndpoints
             try
             {
                 var created = AutomationBrowserService.Create(req.Name, kind);
-                var dto = await FoldAsync(created, ct).ConfigureAwait(false);
-                return Results.Json(dto, statusCode: StatusCodes.Status201Created);
+                var view = await AutomationBrowserViewFold.FoldAsync(created, ct).ConfigureAwait(false);
+                return Results.Json(view, statusCode: StatusCodes.Status201Created);
             }
             catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
             {
@@ -57,7 +60,18 @@ internal static class BrowserEndpoints
             return await GuardedAsync(id, async b =>
             {
                 var launched = await AutomationBrowserService.LaunchAsync(b.Id, ct).ConfigureAwait(false);
-                return Results.Json(await FoldAsync(launched, ct).ConfigureAwait(false));
+                return Results.Json(await AutomationBrowserViewFold.FoldAsync(launched, ct).ConfigureAwait(false));
+            });
+        });
+
+        // POST /browsers/{id}/stop - close the browser cleanly (CDP Browser.close, with the tracked-pid
+        // kill as the wedge safety net). A browser that is already down is a no-op.
+        app.MapPost("/browsers/{id}/stop", async (string id, CancellationToken ct) =>
+        {
+            return await GuardedAsync(id, async b =>
+            {
+                await AutomationBrowserService.StopAsync(b.Id, ct).ConfigureAwait(false);
+                return Results.Json(await AutomationBrowserViewFold.FoldAsync(b, ct).ConfigureAwait(false));
             });
         });
 
@@ -80,11 +94,11 @@ internal static class BrowserEndpoints
                 if (req?.Done == true)
                 {
                     var confirmed = AutomationBrowserService.MarkSignedIn(b.Id);
-                    return Results.Json(await FoldAsync(confirmed, ct).ConfigureAwait(false));
+                    return Results.Json(await AutomationBrowserViewFold.FoldAsync(confirmed, ct).ConfigureAwait(false));
                 }
 
                 var opened = await AutomationBrowserService.SignInAsync(b.Id, ct).ConfigureAwait(false);
-                return Results.Json(await FoldAsync(opened, ct).ConfigureAwait(false));
+                return Results.Json(await AutomationBrowserViewFold.FoldAsync(opened, ct).ConfigureAwait(false));
             });
         });
 
@@ -99,7 +113,7 @@ internal static class BrowserEndpoints
                 try
                 {
                     var renamed = AutomationBrowserService.Rename(b.Id, req.Name);
-                    return Results.Json(await FoldAsync(renamed, ct).ConfigureAwait(false));
+                    return Results.Json(await AutomationBrowserViewFold.FoldAsync(renamed, ct).ConfigureAwait(false));
                 }
                 catch (InvalidOperationException ex)
                 {
@@ -126,42 +140,7 @@ internal static class BrowserEndpoints
         });
     }
 
-    // --- folding + helpers ---
-
-    /// <summary>Compute the finished view of a browser: live status, human status label, and the account
-    /// it is signed in as (read from its own Local State). Clients render these verbatim.</summary>
-    private static async Task<BrowserDto> FoldAsync(AutomationBrowser b, CancellationToken ct)
-    {
-        var status = await AutomationBrowserService.StatusAsync(b, ct).ConfigureAwait(false);
-        var attach = AutomationBrowserRegistry.AttachInfoFor(b);
-        string? account = null;
-        try { account = AutomationBrowserService.ReadAccount(b); }
-        catch (Exception ex) { FileLog.Write($"[BrowserEndpoints] ReadAccount id={b.Id} failed (non-fatal): {ex.Message}"); }
-
-        return new BrowserDto
-        {
-            Id = b.Id,
-            Name = b.Name,
-            Browser = b.Kind.ToString(),
-            Port = b.Port,
-            Status = status.ToString(),
-            StatusLabel = StatusLabel(status),
-            Account = account,
-            BuName = attach.BuName,
-            BuCdpUrl = attach.BuCdpUrl,
-            UserDataDir = b.UserDataDir,
-            CreatedUtc = b.CreatedUtc,
-            LastSignedInUtc = b.LastSignedInUtc,
-        };
-    }
-
-    private static string StatusLabel(AutomationBrowserStatus status) => status switch
-    {
-        AutomationBrowserStatus.Stopped => "Stopped",
-        AutomationBrowserStatus.NeedsSignIn => "Needs sign-in",
-        AutomationBrowserStatus.Ready => "Ready",
-        _ => status.ToString(),
-    };
+    // --- helpers ---
 
     private static bool TryParseKind(string? value, out BrowserKind kind)
         => Enum.TryParse(value?.Trim(), ignoreCase: true, out kind);
@@ -187,20 +166,4 @@ internal static class BrowserEndpoints
     private sealed record CreateBrowserRequest(string Name, string Browser);
     private sealed record RenameBrowserRequest(string Name);
     private sealed record SignInRequest(bool Done);
-
-    private sealed class BrowserDto
-    {
-        public string Id { get; init; } = "";
-        public string Name { get; init; } = "";
-        public string Browser { get; init; } = "";
-        public int Port { get; init; }
-        public string Status { get; init; } = "";
-        public string StatusLabel { get; init; } = "";
-        public string? Account { get; init; }
-        public string BuName { get; init; } = "";
-        public string BuCdpUrl { get; init; } = "";
-        public string UserDataDir { get; init; } = "";
-        public DateTime CreatedUtc { get; init; }
-        public DateTime? LastSignedInUtc { get; init; }
-    }
 }

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -494,6 +494,11 @@ public sealed class ControlApiHost : IAsyncDisposable
 
         ControlEndpoints.Map(_app, _sessionManager, DirectorId, _version, _requestShutdownAsync, _authEnabled, _repositoryRegistry, _turnSummaryCache, gatewayUrl, _proactiveExplain, GatewayMonitor, resolveTailnetEndpoint, () => _gatewayClient, messageSteward, _missionStore, ct => signedInUserProvider.ResolveAsync(ct));
 
+        // DevThrottle's automation browsers (the drivable, signed-in-once Chromium instances). Loopback,
+        // machine-local surface backed by AutomationBrowserService; the CLI 'browser' verbs and the
+        // desktop rail both read these.
+        BrowserEndpoints.Map(_app);
+
         // Gateway Cleanup mission: the Director floor's tunnel-bounce. An operator/launcher can force
         // this Director to re-establish its OUTBOUND tunnel without a full restart. Loopback floor route.
         _app.MapPost("/reconnect", async (HttpContext ctx) =>

--- a/src/CcDirector.Core.Tests/Browsers/AutomationBrowserRegistryTests.cs
+++ b/src/CcDirector.Core.Tests/Browsers/AutomationBrowserRegistryTests.cs
@@ -1,0 +1,214 @@
+using CcDirector.Core.Browsers;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Browsers;
+
+/// <summary>
+/// Tests for <see cref="AutomationBrowserRegistry"/>: the JSON CRUD, slug/id minting, name and port
+/// uniqueness, the 9310+ port allocation, and the attach-environment formatting. Every method runs
+/// against an isolated CC_DIRECTOR_ROOT so it reads and writes a throwaway registry.json. The
+/// "CcStorageRoot" collection serializes all classes that redirect the process-wide root so they do
+/// not race. Port allocation is driven with an injected probe, so nothing here opens a real socket.
+/// </summary>
+[Collection("CcStorageRoot")]
+public sealed class AutomationBrowserRegistryTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+
+    // Always-free probe: makes Create allocate 9310, 9311, ... deterministically (claimed ports are
+    // still skipped by the allocator, so successive creates step upward).
+    private static readonly Func<int, bool> AllFree = _ => true;
+
+    public AutomationBrowserRegistryTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-autobrowser-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    // -- Create / Load round-trip --
+
+    [Fact]
+    public void Create_PersistsEntry_LoadReadsItBack()
+    {
+        var created = AutomationBrowserRegistry.Create("Center Consulting", BrowserKind.Chrome, AllFree);
+
+        var all = AutomationBrowserRegistry.Load();
+        var loaded = Assert.Single(all);
+        Assert.Equal(created.Id, loaded.Id);
+        Assert.Equal("Center Consulting", loaded.Name);
+        Assert.Equal(BrowserKind.Chrome, loaded.Kind);
+        Assert.Equal(created.Port, loaded.Port);
+        Assert.Null(loaded.LastSignedInUtc);
+        // The user-data-dir sits under the browsers root and is named for the id.
+        Assert.Equal(Path.Combine(AutomationBrowserRegistry.RootDirectory(), created.Id), loaded.UserDataDir);
+    }
+
+    [Fact]
+    public void Load_NoRegistryFile_ReturnsEmpty()
+    {
+        Assert.Empty(AutomationBrowserRegistry.Load());
+    }
+
+    [Fact]
+    public void Create_MintsSlugIdFromName()
+    {
+        var created = AutomationBrowserRegistry.Create("Center Consulting", BrowserKind.Chrome, AllFree);
+        Assert.Equal("center-consulting", created.Id);
+    }
+
+    // -- Name uniqueness --
+
+    [Fact]
+    public void Create_DuplicateName_Throws_CaseInsensitive()
+    {
+        AutomationBrowserRegistry.Create("Work", BrowserKind.Chrome, AllFree);
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => AutomationBrowserRegistry.Create("work", BrowserKind.Edge, AllFree));
+        Assert.Contains("already exists", ex.Message);
+    }
+
+    [Fact]
+    public void Create_TwoNamesThatSlugToSameId_GetDistinctIds()
+    {
+        var a = AutomationBrowserRegistry.Create("Center Consulting", BrowserKind.Chrome, AllFree);
+        // A different NAME (so the name-uniqueness rule allows it) that slugifies to the same base.
+        var b = AutomationBrowserRegistry.Create("center consulting!", BrowserKind.Chrome, AllFree);
+        Assert.Equal("center-consulting", a.Id);
+        Assert.Equal("center-consulting-2", b.Id);
+    }
+
+    // -- Port allocation --
+
+    [Fact]
+    public void Create_AllocatesPortsFrom9310Upward()
+    {
+        var a = AutomationBrowserRegistry.Create("A", BrowserKind.Chrome, AllFree);
+        var b = AutomationBrowserRegistry.Create("B", BrowserKind.Chrome, AllFree);
+        Assert.Equal(AutomationBrowserRegistry.PortRangeStart, a.Port);      // 9310
+        Assert.Equal(AutomationBrowserRegistry.PortRangeStart + 1, b.Port);  // 9311
+    }
+
+    [Fact]
+    public void AllocatePort_SkipsClaimedAndBusyPorts()
+    {
+        var existing = new[]
+        {
+            new AutomationBrowser("a", "A", BrowserKind.Chrome, "dir-a", 9310, DateTime.UtcNow, null),
+        };
+        // 9311 is "busy" per the probe; 9310 is already claimed. Next free is 9312.
+        Func<int, bool> probe = port => port != 9311;
+
+        var port = AutomationBrowserRegistry.AllocatePort(existing, probe);
+
+        Assert.Equal(9312, port);
+    }
+
+    [Fact]
+    public void AllocatePort_RangeExhausted_Throws()
+    {
+        var existing = Enumerable.Empty<AutomationBrowser>().ToList();
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => AutomationBrowserRegistry.AllocatePort(existing, _ => false));
+        Assert.Contains("No free automation-browser port", ex.Message);
+    }
+
+    // -- Rename --
+
+    [Fact]
+    public void Rename_ChangesNameButKeepsIdPortAndDir()
+    {
+        var created = AutomationBrowserRegistry.Create("Old Name", BrowserKind.Chrome, AllFree);
+
+        var renamed = AutomationBrowserRegistry.Rename("Old Name", "New Name");
+
+        Assert.Equal("New Name", renamed.Name);
+        Assert.Equal(created.Id, renamed.Id);
+        Assert.Equal(created.Port, renamed.Port);
+        Assert.Equal(created.UserDataDir, renamed.UserDataDir);
+        Assert.Equal("New Name", AutomationBrowserRegistry.Get(created.Id).Name);
+    }
+
+    [Fact]
+    public void Rename_ToAnExistingName_Throws()
+    {
+        AutomationBrowserRegistry.Create("One", BrowserKind.Chrome, AllFree);
+        AutomationBrowserRegistry.Create("Two", BrowserKind.Chrome, AllFree);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => AutomationBrowserRegistry.Rename("Two", "one"));
+        Assert.Contains("already named", ex.Message);
+    }
+
+    // -- Remove --
+
+    [Fact]
+    public void RemoveEntry_DropsBrowser_GetThenThrows()
+    {
+        AutomationBrowserRegistry.Create("Gone", BrowserKind.Chrome, AllFree);
+
+        AutomationBrowserRegistry.RemoveEntry("Gone");
+
+        Assert.Empty(AutomationBrowserRegistry.Load());
+        Assert.Throws<KeyNotFoundException>(() => AutomationBrowserRegistry.Get("Gone"));
+    }
+
+    // -- Sign-in marker --
+
+    [Fact]
+    public void MarkSignedIn_SetsLastSignedInUtc()
+    {
+        AutomationBrowserRegistry.Create("Acct", BrowserKind.Chrome, AllFree);
+        Assert.Null(AutomationBrowserRegistry.Get("Acct").LastSignedInUtc);
+
+        var updated = AutomationBrowserRegistry.MarkSignedIn("Acct");
+
+        Assert.NotNull(updated.LastSignedInUtc);
+        Assert.NotNull(AutomationBrowserRegistry.Get("Acct").LastSignedInUtc);
+    }
+
+    // -- Lookup --
+
+    [Fact]
+    public void Find_ByIdAndByName_BothResolve_UnknownIsNull()
+    {
+        var created = AutomationBrowserRegistry.Create("Look Me Up", BrowserKind.Chrome, AllFree);
+
+        Assert.Equal(created.Id, AutomationBrowserRegistry.Find("look-me-up")?.Id);
+        Assert.Equal(created.Id, AutomationBrowserRegistry.Find("Look Me Up")?.Id);
+        Assert.Null(AutomationBrowserRegistry.Find("nope"));
+    }
+
+    // -- Attach environment formatting --
+
+    [Fact]
+    public void AttachInfoFor_UsesIdAsBuNameAndLoopbackPortUrl()
+    {
+        var browser = new AutomationBrowser("center-consulting", "Center Consulting", BrowserKind.Chrome,
+            "dir", 9317, DateTime.UtcNow, null);
+
+        var attach = AutomationBrowserRegistry.AttachInfoFor(browser);
+
+        Assert.Equal("center-consulting", attach.BuName);
+        Assert.Equal("http://127.0.0.1:9317", attach.BuCdpUrl);
+    }
+
+    // -- Slug rules --
+
+    [Theory]
+    [InlineData("Center Consulting", "center-consulting")]
+    [InlineData("  Trim  Me  ", "trim-me")]
+    [InlineData("Weird!!!Name??", "weird-name")]
+    [InlineData("UPPER", "upper")]
+    public void Slugify_ProducesCleanSlugs(string input, string expected)
+    {
+        Assert.Equal(expected, AutomationBrowserRegistry.Slugify(input));
+    }
+}

--- a/src/CcDirector.Core.Tests/Browsers/AutomationBrowserViewFoldTests.cs
+++ b/src/CcDirector.Core.Tests/Browsers/AutomationBrowserViewFoldTests.cs
@@ -1,0 +1,129 @@
+using CcDirector.Core.Browsers;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Browsers;
+
+/// <summary>
+/// Proves the pure display fold for automation browsers - the ONE place that decides the status label,
+/// the status dot color, the subtitle, the offered action, and the attach command. The Control API
+/// serializes this fold for the CLI and the Director's rail and Settings tab render it in-process, so
+/// these mappings are the contract every surface shows verbatim.
+/// </summary>
+public sealed class AutomationBrowserViewFoldTests
+{
+    private static AutomationBrowser Browser(BrowserKind kind = BrowserKind.Chrome) => new(
+        Id: "center-consulting",
+        Name: "Center Consulting",
+        Kind: kind,
+        UserDataDir: @"C:\data\browsers\center-consulting",
+        Port: 9310,
+        CreatedUtc: new DateTime(2026, 7, 23, 12, 0, 0, DateTimeKind.Utc),
+        LastSignedInUtc: null);
+
+    // ---- The three per-status verdicts (label, dot, action) --------------------------------------
+
+    [Fact]
+    public void Fold_Ready_IsGreenAttach()
+    {
+        var view = AutomationBrowserViewFold.Fold(Browser(), AutomationBrowserStatus.Ready, "soren@centerconsulting.com");
+
+        Assert.Equal("Ready", view.StatusLabel);
+        Assert.Equal("green", view.DotColor);
+        Assert.Equal("Attach", view.ActionLabel);
+        Assert.Equal("Chrome - soren@centerconsulting.com", view.Subtitle);
+    }
+
+    [Fact]
+    public void Fold_NeedsSignIn_IsYellowSignIn()
+    {
+        var view = AutomationBrowserViewFold.Fold(Browser(), AutomationBrowserStatus.NeedsSignIn, account: null);
+
+        Assert.Equal("Needs sign-in", view.StatusLabel);
+        Assert.Equal("yellow", view.DotColor);
+        Assert.Equal("Sign in", view.ActionLabel);
+        Assert.Equal("Chrome - not signed in yet", view.Subtitle);
+    }
+
+    [Fact]
+    public void Fold_Stopped_IsGreyStart()
+    {
+        var view = AutomationBrowserViewFold.Fold(Browser(BrowserKind.Edge), AutomationBrowserStatus.Stopped, account: null);
+
+        Assert.Equal("Stopped", view.StatusLabel);
+        Assert.Equal("grey", view.DotColor);
+        Assert.Equal("Start", view.ActionLabel);
+        Assert.Equal("Edge - stopped", view.Subtitle);
+    }
+
+    // ---- Subtitle rules ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Subtitle_AccountWinsOverStateWords_InEveryStatus()
+    {
+        // The signed-in account is the most useful fact; when known it is shown regardless of status
+        // (a stopped browser that HAS a login still names whose login it holds).
+        Assert.Equal("Chrome - a@b.com", AutomationBrowserViewFold.Subtitle(BrowserKind.Chrome, AutomationBrowserStatus.Stopped, "a@b.com"));
+        Assert.Equal("Chrome - a@b.com", AutomationBrowserViewFold.Subtitle(BrowserKind.Chrome, AutomationBrowserStatus.NeedsSignIn, "a@b.com"));
+        Assert.Equal("Chrome - a@b.com", AutomationBrowserViewFold.Subtitle(BrowserKind.Chrome, AutomationBrowserStatus.Ready, "a@b.com"));
+    }
+
+    [Fact]
+    public void Subtitle_ReadyWithUnreadableAccount_SaysSignedIn()
+    {
+        // Ready means the human confirmed sign-in; an unreadable profile must not demote that to a
+        // "not signed in" wording.
+        Assert.Equal("Chrome - signed in", AutomationBrowserViewFold.Subtitle(BrowserKind.Chrome, AutomationBrowserStatus.Ready, account: null));
+    }
+
+    // ---- Attach command ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Fold_AttachCommand_UsesTheSlugId_NotTheFreeTextName()
+    {
+        // The id is shell-safe by construction; the free-text name is not.
+        var view = AutomationBrowserViewFold.Fold(Browser(), AutomationBrowserStatus.Ready, account: null);
+
+        Assert.Equal("eval \"$(cc-devthrottle browser attach 'center-consulting')\"", view.AttachCommand);
+        Assert.Equal("center-consulting", view.BuName);
+        Assert.Equal("http://127.0.0.1:9310", view.BuCdpUrl);
+    }
+
+    [Fact]
+    public void AttachCommand_EmptyId_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => AutomationBrowserViewFold.AttachCommand(""));
+    }
+
+    // ---- Carried-through identity fields ----------------------------------------------------------
+
+    [Fact]
+    public void Fold_CarriesTheBrowserIdentityVerbatim()
+    {
+        var browser = Browser();
+        var view = AutomationBrowserViewFold.Fold(browser, AutomationBrowserStatus.Stopped, account: null);
+
+        Assert.Equal(browser.Id, view.Id);
+        Assert.Equal(browser.Name, view.Name);
+        Assert.Equal("Chrome", view.Browser);
+        Assert.Equal(browser.Port, view.Port);
+        Assert.Equal(browser.UserDataDir, view.UserDataDir);
+        Assert.Equal(browser.CreatedUtc, view.CreatedUtc);
+        Assert.Null(view.LastSignedInUtc);
+        Assert.Equal(AutomationBrowserStatus.Stopped, view.Status);
+    }
+
+    // ---- Guard rails ------------------------------------------------------------------------------
+
+    [Fact]
+    public void Fold_UnknownStatus_ThrowsInsteadOfInventingAVerdict()
+    {
+        var bogus = (AutomationBrowserStatus)99;
+        Assert.Throws<ArgumentOutOfRangeException>(() => AutomationBrowserViewFold.Fold(Browser(), bogus, account: null));
+    }
+
+    [Fact]
+    public void Fold_NullBrowser_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => AutomationBrowserViewFold.Fold(null!, AutomationBrowserStatus.Ready, account: null));
+    }
+}

--- a/src/CcDirector.Core.Tests/GatewayConnection/GatewayStatusBoxPresenterTests.cs
+++ b/src/CcDirector.Core.Tests/GatewayConnection/GatewayStatusBoxPresenterTests.cs
@@ -226,6 +226,46 @@ public sealed class GatewayStatusBoxPresenterTests
         Assert.Equal(GatewayCheckState.Unknown, content.SignedIn.Marker);
     }
 
+    // ---- The compact chip verdict ----------------------------------------------------------------
+
+    [Fact]
+    public void ChipText_MapsAllSixResolverStatesToShortVerdicts()
+    {
+        // The chip is the box's slim form: one short phrase per resolver state, folded here so the
+        // surface can never invent a wording. The full check lines live on in the tooltip.
+        Assert.Equal("No Gateway", GatewayStatusBoxPresenter.ChipText(GatewayConnectionState.NotConfigured));
+        Assert.Equal("Connecting...", GatewayStatusBoxPresenter.ChipText(GatewayConnectionState.Connecting));
+        Assert.Equal("Connection failed", GatewayStatusBoxPresenter.ChipText(GatewayConnectionState.ConnectFailed));
+        Assert.Equal("Sign in", GatewayStatusBoxPresenter.ChipText(GatewayConnectionState.ConnectedNotSignedIn));
+        Assert.Equal("Connected", GatewayStatusBoxPresenter.ChipText(GatewayConnectionState.AllGreen));
+        Assert.Equal("Unreachable", GatewayStatusBoxPresenter.ChipText(GatewayConnectionState.WasConnectedNowUnreachable));
+    }
+
+    [Fact]
+    public void Describe_AllGreen_ChipSaysConnected_TooltipKeepsTheDetail()
+    {
+        var content = GatewayStatusBoxPresenter.Describe(
+            AllGreenInputs(), gatewayHost: "SOREN_NORTH", accountEmail: "soren@centerconsulting.com");
+
+        Assert.Equal("Connected", content.ChipText);
+        Assert.Contains("SOREN_NORTH", content.Tooltip);
+        Assert.Contains("soren@centerconsulting.com", content.Tooltip);
+    }
+
+    [Fact]
+    public void Describe_ConnectedNotSignedIn_ChipNudgesSignIn()
+    {
+        var inputs = AllGreenInputs() with
+        {
+            DeviceKeyPresent = false,
+            Account = GatewayAccountSignInState.SignedOut,
+        };
+
+        var content = GatewayStatusBoxPresenter.Describe(inputs, gatewayHost: "SOREN_NORTH", accountEmail: null);
+
+        Assert.Equal("Sign in", content.ChipText);
+    }
+
     [Fact]
     public void VisualFor_MapsAllSixResolverStatesToFourVisualStates()
     {

--- a/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
+++ b/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
@@ -51,6 +51,12 @@ public sealed class NoCrossMachineLoopbackGuardTests
         ["src/CcDirector.Launcher/LauncherHost.cs"] = "Local launcher loopback bind.",
         ["src/CcDirector.Launcher/Program.cs"] = "Self-update helper POSTs /shutdown + probes /healthz on the launcher's own loopback (same machine).",
         ["src/CcDirector.Core/Account/LoopbackLoginListener.cs"] = "Binds an HttpListener on 127.0.0.1 only (operating-system-assigned ephemeral port) to receive the first-run browser sign-in hand-back; same-machine loopback trust boundary (security rule DT-07, issue #581).",
+        // Browsers feature: an automation browser's Chrome remote-debugging port is bound by Chrome on
+        // loopback, so machine-locality is the feature's designed security property - only an agent on
+        // THIS machine can attach (handover 2026-07-23). These three carry the loopback literal on purpose.
+        ["src/CcDirector.Core/Browsers/AutomationBrowser.cs"] = "Doc comment: BU_CDP_URL is http://127.0.0.1:<port> - the debug port is loopback by design (machine-local browsers).",
+        ["src/CcDirector.Core/Browsers/AutomationBrowserRegistry.cs"] = "AttachInfoFor builds the same-machine BU_CDP_URL (http://127.0.0.1:{port}); Chrome binds the debug port on loopback, and the loopback port probe binds 127.0.0.1 to test freeness.",
+        ["src/CcDirector.Core/Browsers/AutomationBrowserService.cs"] = "Probes and CDP-closes the browser over its own loopback debug port (http://127.0.0.1:{port}/json/version); same machine by construction.",
 
         // --- Loopback DETECTION / classification / labelling (the no-loopback policy itself) ---
         ["src/CcDirector.Core/Network/TailscaleIdentity.cs"] = "Formats a CLEARLY-LABELLED local-only fallback string; never advertised cross-machine.",

--- a/src/CcDirector.Core/Browsers/AutomationBrowser.cs
+++ b/src/CcDirector.Core/Browsers/AutomationBrowser.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace CcDirector.Core.Browsers;
 
 /// <summary>
@@ -37,6 +39,7 @@ public sealed record AutomationBrowser(
 /// The lifecycle state of an <see cref="AutomationBrowser"/>, folded ONCE here so every reader (CLI
 /// table, and later the rail UI) renders the same verdict verbatim rather than re-deriving it.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AutomationBrowserStatus
 {
     /// <summary>The browser's debug port is not answering - the browser is not running.</summary>

--- a/src/CcDirector.Core/Browsers/AutomationBrowser.cs
+++ b/src/CcDirector.Core/Browsers/AutomationBrowser.cs
@@ -1,0 +1,61 @@
+namespace CcDirector.Core.Browsers;
+
+/// <summary>
+/// A DevThrottle-owned, agent-drivable browser. Unlike a real personal profile (which Chrome 136+
+/// refuses to expose over remote-debugging, and whose logged-in session App-Bound Encryption refuses
+/// to copy), an <see cref="AutomationBrowser"/> is a SEPARATE Chromium user-data directory with its
+/// OWN fixed remote-debugging port. It is signed in ONCE by the human and thereafter driven hands-off
+/// by an agent through the browser-harness / Chrome DevTools Protocol.
+///
+/// Machine-locality is a real property, not a caveat: the directory and the loopback debug port only
+/// mean anything on the machine they live on, so a browser is owned by the LOCAL Director and is only
+/// drivable by an agent on that same machine (mirroring how repositories and sessions are per-machine).
+/// </summary>
+/// <param name="Id">Stable slug derived from the name at creation (e.g. "center-consulting"). Used as
+/// the <c>BU_NAME</c> the harness attaches with and as the on-disk sub-directory name. Never changes,
+/// even when <paramref name="Name"/> is edited.</param>
+/// <param name="Name">Human-facing, user-editable label (e.g. "Center Consulting").</param>
+/// <param name="Kind">Which Chromium browser this drives (Chrome or Edge).</param>
+/// <param name="UserDataDir">This browser's dedicated <c>--user-data-dir</c> (absolute path). Never a
+/// real personal profile - always a folder DevThrottle created under <see cref="Storage.CcStorage.Browsers"/>.</param>
+/// <param name="Port">The fixed <c>--remote-debugging-port</c> this browser always launches on, so the
+/// attach environment (<c>BU_CDP_URL</c>) is stable across restarts.</param>
+/// <param name="CreatedUtc">When the browser was created.</param>
+/// <param name="LastSignedInUtc">When the human last confirmed they signed this browser in, or null if
+/// it has never been signed in. Null is what makes <see cref="AutomationBrowserStatus.NeedsSignIn"/>
+/// distinguishable from <see cref="AutomationBrowserStatus.Ready"/>.</param>
+public sealed record AutomationBrowser(
+    string Id,
+    string Name,
+    BrowserKind Kind,
+    string UserDataDir,
+    int Port,
+    DateTime CreatedUtc,
+    DateTime? LastSignedInUtc);
+
+/// <summary>
+/// The lifecycle state of an <see cref="AutomationBrowser"/>, folded ONCE here so every reader (CLI
+/// table, and later the rail UI) renders the same verdict verbatim rather than re-deriving it.
+/// </summary>
+public enum AutomationBrowserStatus
+{
+    /// <summary>The browser's debug port is not answering - the browser is not running.</summary>
+    Stopped,
+
+    /// <summary>The browser is running but has never been signed in (<see cref="AutomationBrowser.LastSignedInUtc"/> is null).
+    /// An agent can attach, but pages behind a login will bounce to a sign-in screen.</summary>
+    NeedsSignIn,
+
+    /// <summary>The browser is running AND has been signed in - fully drivable by an agent.</summary>
+    Ready,
+}
+
+/// <summary>
+/// The two environment variables browser-harness reads to attach to a specific browser. Returned by
+/// <see cref="AutomationBrowserService.AttachInfo"/> and printed by <c>cc-devthrottle browser attach</c>
+/// as shell <c>export</c> lines, so <c>eval "$(cc-devthrottle browser attach 'Name')"</c> points the
+/// harness at the right browser. This REPLACES the personal ad-hoc <c>env cencon</c> command.
+/// </summary>
+/// <param name="BuName">The value for <c>BU_NAME</c> - the browser's <see cref="AutomationBrowser.Id"/>.</param>
+/// <param name="BuCdpUrl">The value for <c>BU_CDP_URL</c> - <c>http://127.0.0.1:&lt;port&gt;</c>.</param>
+public sealed record AttachInfo(string BuName, string BuCdpUrl);

--- a/src/CcDirector.Core/Browsers/AutomationBrowserRegistry.cs
+++ b/src/CcDirector.Core/Browsers/AutomationBrowserRegistry.cs
@@ -1,0 +1,319 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Browsers;
+
+/// <summary>
+/// The persistent store of DevThrottle's automation browsers: the single JSON list at
+/// <c>&lt;appdata&gt;/browsers/registry.json</c> plus the rules that keep it consistent (unique names,
+/// unique ports) and the allocation of a fresh debug port and on-disk directory for a new browser.
+///
+/// This is the DATA layer. Behavior that touches a live browser process (launch, is-it-up, sign-in,
+/// stop) lives in <see cref="AutomationBrowserService"/>. Kept static and file-backed to match the
+/// sibling <see cref="BrowserDefaultStore"/>; a process-wide lock serializes the read-modify-write so
+/// the rail UI and a Control-API call in the same Director cannot clobber each other's edits.
+///
+/// No-fallback rule (CLAUDE.md / CodingStyle): a malformed registry.json THROWS rather than being
+/// silently reset - we never destroy the user's list to hide a parse problem. Lookups that miss THROW
+/// with a message naming the browser that was asked for.
+/// </summary>
+public static class AutomationBrowserRegistry
+{
+    /// <summary>The first debug port we hand out. Chosen well above the Director's own range
+    /// (<c>PortAllocator</c> 7879-7898) and above the personal harness's historical 9224, so a
+    /// DevThrottle browser never collides with either.</summary>
+    public const int PortRangeStart = 9310;
+
+    /// <summary>Upper bound for automation-browser debug ports. 190 slots is far more browsers than a
+    /// human would ever create; exhausting it THROWS rather than silently reusing a live port.</summary>
+    public const int PortRangeEnd = 9499;
+
+    private static readonly object WriteLock = new();
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    /// <summary>The browsers root directory (<c>&lt;appdata&gt;/browsers</c>). Created on demand.</summary>
+    public static string RootDirectory() => CcStorage.Browsers();
+
+    /// <summary>Absolute path of the registry file.</summary>
+    public static string RegistryPath() => Path.Combine(RootDirectory(), "registry.json");
+
+    /// <summary>
+    /// Read every registered browser. A missing file yields an empty list (a machine with no browsers
+    /// yet is not an error). A present-but-unparseable file THROWS.
+    /// </summary>
+    public static IReadOnlyList<AutomationBrowser> Load()
+    {
+        var path = RegistryPath();
+        if (!File.Exists(path))
+        {
+            FileLog.Write("[AutomationBrowserRegistry] Load: no registry.json yet, returning empty list");
+            return Array.Empty<AutomationBrowser>();
+        }
+
+        var json = File.ReadAllText(path);
+        if (string.IsNullOrWhiteSpace(json))
+            return Array.Empty<AutomationBrowser>();
+
+        var list = JsonSerializer.Deserialize<List<AutomationBrowser>>(json, JsonOptions)
+            ?? throw new InvalidOperationException($"registry.json parsed to null: {path}");
+        FileLog.Write($"[AutomationBrowserRegistry] Load: browsers={list.Count}");
+        return list;
+    }
+
+    /// <summary>Returns the browser whose id or name matches <paramref name="idOrName"/> (id first,
+    /// then case-insensitive name), or null when none match. Null is not an error here - callers that
+    /// require the browser should use <see cref="Get"/>.</summary>
+    public static AutomationBrowser? Find(string idOrName)
+    {
+        if (string.IsNullOrWhiteSpace(idOrName)) return null;
+        var all = Load();
+        return all.FirstOrDefault(b => string.Equals(b.Id, idOrName, StringComparison.OrdinalIgnoreCase))
+            ?? all.FirstOrDefault(b => string.Equals(b.Name, idOrName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>Returns the browser matching <paramref name="idOrName"/> or THROWS naming what was asked
+    /// for (no silent null).</summary>
+    public static AutomationBrowser Get(string idOrName)
+        => Find(idOrName)
+           ?? throw new KeyNotFoundException($"No automation browser named \"{idOrName}\". Run 'browser list' to see the browsers on this machine.");
+
+    /// <summary>
+    /// Register a brand-new browser: validates the name is non-empty and unused, mints a unique slug id,
+    /// allocates a free debug port and a dedicated user-data directory under the browsers root, persists
+    /// the entry, and returns it. Does NOT launch anything - that is <see cref="AutomationBrowserService"/>.
+    /// </summary>
+    /// <param name="name">Human-facing label; must be non-empty and not already used (case-insensitive).</param>
+    /// <param name="kind">Which browser this drives.</param>
+    /// <param name="isPortFree">Predicate used to probe candidate ports; defaults to a real loopback bind.
+    /// Injectable so port allocation is unit-testable without opening sockets.</param>
+    public static AutomationBrowser Create(string name, BrowserKind kind, Func<int, bool>? isPortFree = null)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("A browser name is required.", nameof(name));
+
+        lock (WriteLock)
+        {
+            var list = Load().ToList();
+
+            if (list.Any(b => string.Equals(b.Name, name.Trim(), StringComparison.OrdinalIgnoreCase)))
+                throw new InvalidOperationException($"A browser named \"{name.Trim()}\" already exists. Pick a different name or remove the existing one.");
+
+            var id = UniqueSlug(name, list);
+            var port = AllocatePort(list, isPortFree ?? IsPortFreeToBind);
+            var dir = Path.Combine(RootDirectory(), id);
+
+            var browser = new AutomationBrowser(
+                Id: id,
+                Name: name.Trim(),
+                Kind: kind,
+                UserDataDir: dir,
+                Port: port,
+                CreatedUtc: DateTime.UtcNow,
+                LastSignedInUtc: null);
+
+            list.Add(browser);
+            SaveList(list);
+            FileLog.Write($"[AutomationBrowserRegistry] Create: id={id}, kind={kind}, port={port}, dir={dir}");
+            return browser;
+        }
+    }
+
+    /// <summary>Replace the stored entry that has the same <see cref="AutomationBrowser.Id"/> as
+    /// <paramref name="updated"/>. THROWS if no such id exists.</summary>
+    public static void Update(AutomationBrowser updated)
+    {
+        if (updated is null) throw new ArgumentNullException(nameof(updated));
+
+        lock (WriteLock)
+        {
+            var list = Load().ToList();
+            var index = list.FindIndex(b => string.Equals(b.Id, updated.Id, StringComparison.OrdinalIgnoreCase));
+            if (index < 0)
+                throw new KeyNotFoundException($"No automation browser with id \"{updated.Id}\" to update.");
+            list[index] = updated;
+            SaveList(list);
+            FileLog.Write($"[AutomationBrowserRegistry] Update: id={updated.Id}");
+        }
+    }
+
+    /// <summary>Rename a browser's human-facing label (the id/port/directory are unchanged). THROWS if the
+    /// new name is empty or already used by a DIFFERENT browser.</summary>
+    public static AutomationBrowser Rename(string idOrName, string newName)
+    {
+        if (string.IsNullOrWhiteSpace(newName))
+            throw new ArgumentException("A new name is required.", nameof(newName));
+
+        lock (WriteLock)
+        {
+            var list = Load().ToList();
+            var index = IndexOfOrThrow(list, idOrName);
+            var target = list[index];
+
+            if (list.Any(b => !string.Equals(b.Id, target.Id, StringComparison.OrdinalIgnoreCase)
+                           && string.Equals(b.Name, newName.Trim(), StringComparison.OrdinalIgnoreCase)))
+                throw new InvalidOperationException($"Another browser is already named \"{newName.Trim()}\".");
+
+            var renamed = target with { Name = newName.Trim() };
+            list[index] = renamed;
+            SaveList(list);
+            FileLog.Write($"[AutomationBrowserRegistry] Rename: id={target.Id}, newName={renamed.Name}");
+            return renamed;
+        }
+    }
+
+    /// <summary>Remove a browser's entry from the registry (the on-disk directory is deleted by
+    /// <see cref="AutomationBrowserService.Remove"/>, which also stops the process first). THROWS if the
+    /// browser is not found.</summary>
+    public static AutomationBrowser RemoveEntry(string idOrName)
+    {
+        lock (WriteLock)
+        {
+            var list = Load().ToList();
+            var index = IndexOfOrThrow(list, idOrName);
+            var removed = list[index];
+            list.RemoveAt(index);
+            SaveList(list);
+            FileLog.Write($"[AutomationBrowserRegistry] RemoveEntry: id={removed.Id}");
+            return removed;
+        }
+    }
+
+    /// <summary>Mark that the human has signed this browser in, now. Returns the updated entry.</summary>
+    public static AutomationBrowser MarkSignedIn(string idOrName)
+    {
+        lock (WriteLock)
+        {
+            var list = Load().ToList();
+            var index = IndexOfOrThrow(list, idOrName);
+            var updated = list[index] with { LastSignedInUtc = DateTime.UtcNow };
+            list[index] = updated;
+            SaveList(list);
+            FileLog.Write($"[AutomationBrowserRegistry] MarkSignedIn: id={updated.Id}");
+            return updated;
+        }
+    }
+
+    /// <summary>
+    /// The <c>BU_NAME</c> / <c>BU_CDP_URL</c> pair the harness attaches with. Pure (no process contact),
+    /// so it is unit-testable: <c>BU_NAME</c> is the id and <c>BU_CDP_URL</c> is loopback + the fixed port.
+    /// </summary>
+    public static AttachInfo AttachInfoFor(AutomationBrowser browser)
+    {
+        if (browser is null) throw new ArgumentNullException(nameof(browser));
+        return new AttachInfo(browser.Id, $"http://127.0.0.1:{browser.Port}");
+    }
+
+    // --- internals ---
+
+    private static int IndexOfOrThrow(List<AutomationBrowser> list, string idOrName)
+    {
+        if (string.IsNullOrWhiteSpace(idOrName))
+            throw new ArgumentException("A browser id or name is required.", nameof(idOrName));
+
+        var index = list.FindIndex(b => string.Equals(b.Id, idOrName, StringComparison.OrdinalIgnoreCase));
+        if (index < 0)
+            index = list.FindIndex(b => string.Equals(b.Name, idOrName, StringComparison.OrdinalIgnoreCase));
+        if (index < 0)
+            throw new KeyNotFoundException($"No automation browser named \"{idOrName}\". Run 'browser list' to see the browsers on this machine.");
+        return index;
+    }
+
+    private static void SaveList(List<AutomationBrowser> list)
+    {
+        Directory.CreateDirectory(RootDirectory());
+        var path = RegistryPath();
+        var json = JsonSerializer.Serialize(list, JsonOptions);
+
+        // Atomic replace: write a temp file then move over the target so a crash mid-write can never
+        // leave a half-written registry.json (which Load would then throw on).
+        var tmp = path + ".tmp";
+        File.WriteAllText(tmp, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        File.Move(tmp, path, overwrite: true);
+    }
+
+    /// <summary>
+    /// First free debug port at or above <see cref="PortRangeStart"/> that is (a) not already claimed by
+    /// a browser in <paramref name="existing"/> and (b) currently bindable per <paramref name="isPortFree"/>.
+    /// Exposed internally so allocation can be unit-tested with a fake probe. THROWS when the range is exhausted.
+    /// </summary>
+    internal static int AllocatePort(IReadOnlyList<AutomationBrowser> existing, Func<int, bool> isPortFree)
+    {
+        var claimed = existing.Select(b => b.Port).ToHashSet();
+        for (var p = PortRangeStart; p <= PortRangeEnd; p++)
+        {
+            if (claimed.Contains(p)) continue;
+            if (!isPortFree(p)) continue;
+            return p;
+        }
+        throw new InvalidOperationException(
+            $"No free automation-browser port in range {PortRangeStart}..{PortRangeEnd}. Remove an unused browser to free one.");
+    }
+
+    /// <summary>
+    /// Turn a human name into a stable, unique, filesystem- and BU_NAME-safe slug: lowercase, spaces and
+    /// punctuation collapsed to single hyphens, edges trimmed. Collisions with an existing id get a
+    /// numeric suffix ("-2", "-3", ...). Exposed internally for unit tests.
+    /// </summary>
+    internal static string UniqueSlug(string name, IReadOnlyList<AutomationBrowser> existing)
+    {
+        var basis = Slugify(name);
+        if (basis.Length == 0) basis = "browser";
+
+        var taken = existing.Select(b => b.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (!taken.Contains(basis)) return basis;
+
+        for (var n = 2; ; n++)
+        {
+            var candidate = $"{basis}-{n}";
+            if (!taken.Contains(candidate)) return candidate;
+        }
+    }
+
+    internal static string Slugify(string name)
+    {
+        var sb = new StringBuilder(name.Length);
+        var lastWasHyphen = false;
+        foreach (var ch in name.Trim().ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                sb.Append(ch);
+                lastWasHyphen = false;
+            }
+            else if (!lastWasHyphen)
+            {
+                sb.Append('-');
+                lastWasHyphen = true;
+            }
+        }
+        return sb.ToString().Trim('-');
+    }
+
+    /// <summary>Real port probe: true when 127.0.0.1:<paramref name="port"/> can be bound right now
+    /// (nobody is listening). Chrome binds the debug port on loopback, so loopback is the right scope.</summary>
+    private static bool IsPortFreeToBind(int port)
+    {
+        try
+        {
+            using var listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Start();
+            listener.Stop();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/CcDirector.Core/Browsers/AutomationBrowserService.cs
+++ b/src/CcDirector.Core/Browsers/AutomationBrowserService.cs
@@ -31,6 +31,15 @@ public static class AutomationBrowserService
     private static readonly TimeSpan LaunchReadyTimeout = TimeSpan.FromSeconds(20);
 
     /// <summary>
+    /// The processes THIS Director launched, by browser id. Held for the Director's lifetime so a
+    /// browser whose CDP connection wedges (up but unresponsive to <c>Browser.close</c>) can still be
+    /// stopped by killing the exact process we started - no WMI, no command-line matching, and never a
+    /// blanket kill by name. A browser launched by a previous Director has no entry here; for those the
+    /// CDP close is the only stop path and a wedge is reported, not guessed at.
+    /// </summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, Process> LaunchedProcesses = new();
+
+    /// <summary>
     /// Register AND provision a new browser: resolves the exe for <paramref name="kind"/> via
     /// <see cref="BrowserLauncher.DetectBrowsers"/> (THROWS if that browser is not installed), then
     /// records the entry (unique name, allocated port, dedicated directory). Does not launch it.
@@ -152,17 +161,59 @@ public static class AutomationBrowserService
         => BrowserLauncher.DetectBrowsers().FirstOrDefault(b => b.Kind == kind)?.ExePath ?? string.Empty;
 
     /// <summary>
-    /// Stop the browser cleanly if it is running, by sending Chrome DevTools Protocol
-    /// <c>Browser.close</c> over the browser-level WebSocket. This is chosen over killing by process id
-    /// or command line because it is portable (Core targets a plain framework, not a Windows TFM),
-    /// needs no extra dependency, and works even for a browser this Director did not itself launch (e.g.
-    /// one left running from a previous Director). A browser that is already down is a no-op.
+    /// Stop the browser cleanly if it is running: Chrome DevTools Protocol <c>Browser.close</c> first
+    /// (portable, works even for a browser a previous Director launched), then - only when the port
+    /// stays up because the CDP connection is wedged - a <c>Process.Kill</c> of the exact process THIS
+    /// Director launched (see <see cref="LaunchedProcesses"/>). A browser that is already down is a
+    /// no-op. THROWS when the browser cannot be brought down at all (up, wedged, and not ours to kill),
+    /// naming what to do - never a silent "probably stopped".
     /// </summary>
     public static async Task StopAsync(string idOrName, CancellationToken ct = default)
     {
         var browser = AutomationBrowserRegistry.Get(idOrName);
         FileLog.Write($"[AutomationBrowserService] StopAsync: id={browser.Id}, port={browser.Port}");
+        if (!await TryShutDownAsync(browser, ct).ConfigureAwait(false))
+            throw new TimeoutException(
+                $"Browser \"{browser.Name}\" did not shut down: its debug port {browser.Port} is still answering " +
+                "after a close request and it was not launched by this Director, so there is no process to stop. " +
+                "Close the browser window by hand.");
+    }
+
+    /// <summary>
+    /// Bring the browser down: CDP <c>Browser.close</c>, wait for the port to release, and if it stays
+    /// up fall back to killing the tracked process this Director launched. Returns true when the port is
+    /// down (including "was never up"), false when the browser is still answering after every path we
+    /// legitimately have.
+    /// </summary>
+    private static async Task<bool> TryShutDownAsync(AutomationBrowser browser, CancellationToken ct)
+    {
         await CloseViaCdpAsync(browser, ct).ConfigureAwait(false);
+        if (await WaitUntilDownAsync(browser, ct).ConfigureAwait(false))
+        {
+            ForgetLaunchedProcess(browser.Id);
+            return true;
+        }
+
+        // The port is still answering after Browser.close - the wedged-CDP case. Kill the exact
+        // process we started, if this Director started it (tracked pid; never a kill by name).
+        if (LaunchedProcesses.TryGetValue(browser.Id, out var process) && !process.HasExited)
+        {
+            FileLog.Write($"[AutomationBrowserService] TryShutDownAsync: id={browser.Id} CDP close did not release port {browser.Port}, killing tracked pid={process.Id}");
+            process.Kill(entireProcessTree: true);
+            if (await WaitUntilDownAsync(browser, ct).ConfigureAwait(false))
+            {
+                ForgetLaunchedProcess(browser.Id);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void ForgetLaunchedProcess(string browserId)
+    {
+        if (LaunchedProcesses.TryRemove(browserId, out var process))
+            process.Dispose();
     }
 
     /// <summary>
@@ -176,8 +227,10 @@ public static class AutomationBrowserService
         var browser = AutomationBrowserRegistry.Get(idOrName);
         FileLog.Write($"[AutomationBrowserService] RemoveAsync: id={browser.Id}");
 
-        await CloseViaCdpAsync(browser, ct).ConfigureAwait(false);
-        await WaitUntilDownAsync(browser, ct).ConfigureAwait(false);
+        // A shutdown that fails here is not fatal on its own: the folder delete below throws the
+        // actionable error if the browser is genuinely still holding its directory.
+        if (!await TryShutDownAsync(browser, ct).ConfigureAwait(false))
+            FileLog.Write($"[AutomationBrowserService] RemoveAsync: id={browser.Id} still up after shutdown attempts; the folder delete will report if it is locked");
 
         if (Directory.Exists(browser.UserDataDir))
         {
@@ -235,6 +288,26 @@ public static class AutomationBrowserService
         var process = Process.Start(startInfo)
             ?? throw new InvalidOperationException($"Failed to start {browser.Kind} for browser \"{browser.Name}\" ({exe}).");
         FileLog.Write($"[AutomationBrowserService] StartProcess: id={browser.Id} pid={process.Id}");
+
+        // Track the process we launched so a wedged-CDP stop can kill exactly this pid and nothing
+        // else. Only the FIRST launch per browser is the owning process: when an instance is already
+        // running, passing the same --user-data-dir makes this new process hand its URL to the running
+        // one and exit, so overwriting the tracked entry with it would lose the real pid.
+        var tracked = LaunchedProcesses.GetOrAdd(browser.Id, process);
+        if (!ReferenceEquals(tracked, process))
+        {
+            if (tracked.HasExited)
+            {
+                LaunchedProcesses[browser.Id] = process;
+                tracked.Dispose();
+            }
+            else
+            {
+                // The already-running instance owns the browser; this new process only handed it a
+                // URL and exits on its own. Release its handle (Dispose never kills the process).
+                process.Dispose();
+            }
+        }
     }
 
     private static async Task WaitUntilUpAsync(AutomationBrowser browser, CancellationToken ct)
@@ -250,28 +323,25 @@ public static class AutomationBrowserService
             $"Browser \"{browser.Name}\" was launched but its debug port {browser.Port} did not come up within {LaunchReadyTimeout.TotalSeconds:0}s.");
     }
 
-    private static async Task WaitUntilDownAsync(AutomationBrowser browser, CancellationToken ct)
+    /// <summary>True when the debug port stops answering within the timeout; false when it stays up.</summary>
+    private static async Task<bool> WaitUntilDownAsync(AutomationBrowser browser, CancellationToken ct)
     {
         var deadline = DateTime.UtcNow + LaunchReadyTimeout;
         while (DateTime.UtcNow < deadline)
         {
             if (!await IsUpAsync(browser, ct).ConfigureAwait(false))
-                return;
+                return true;
             await Task.Delay(250, ct).ConfigureAwait(false);
         }
-        // Not fatal on its own; the folder-delete step will throw the actionable error if it is still locked.
         FileLog.Write($"[AutomationBrowserService] WaitUntilDownAsync: id={browser.Id} still up after {LaunchReadyTimeout.TotalSeconds:0}s");
+        return false;
     }
 
     /// <summary>
     /// Send CDP <c>Browser.close</c> over the browser-level WebSocket advertised by <c>/json/version</c>.
     /// A down browser is a no-op. The websocket disconnecting as Chrome exits is expected, not an error.
-    ///
-    /// Slice-2 hardening (tracked for the rail UI work, not needed yet): a browser that is UP but whose
-    /// CDP connection is wedged cannot be closed this way. Since the Director already holds the launched
-    /// <see cref="Process"/> handle in memory for its lifetime, a tracked-pid <c>Process.Kill()</c> is the
-    /// portable safety net (no WMI, no command-line matching) when the CDP close does not bring the port
-    /// down within the timeout. Left out of slice 1 to keep the stop path single and simple.
+    /// A browser that is UP but whose CDP connection is wedged cannot be closed this way - that case is
+    /// handled by the tracked-pid kill in <see cref="TryShutDownAsync"/>.
     /// </summary>
     private static async Task CloseViaCdpAsync(AutomationBrowser browser, CancellationToken ct)
     {

--- a/src/CcDirector.Core/Browsers/AutomationBrowserService.cs
+++ b/src/CcDirector.Core/Browsers/AutomationBrowserService.cs
@@ -266,6 +266,12 @@ public static class AutomationBrowserService
     /// <summary>
     /// Send CDP <c>Browser.close</c> over the browser-level WebSocket advertised by <c>/json/version</c>.
     /// A down browser is a no-op. The websocket disconnecting as Chrome exits is expected, not an error.
+    ///
+    /// Slice-2 hardening (tracked for the rail UI work, not needed yet): a browser that is UP but whose
+    /// CDP connection is wedged cannot be closed this way. Since the Director already holds the launched
+    /// <see cref="Process"/> handle in memory for its lifetime, a tracked-pid <c>Process.Kill()</c> is the
+    /// portable safety net (no WMI, no command-line matching) when the CDP close does not bring the port
+    /// down within the timeout. Left out of slice 1 to keep the stop path single and simple.
     /// </summary>
     private static async Task CloseViaCdpAsync(AutomationBrowser browser, CancellationToken ct)
     {

--- a/src/CcDirector.Core/Browsers/AutomationBrowserService.cs
+++ b/src/CcDirector.Core/Browsers/AutomationBrowserService.cs
@@ -1,0 +1,317 @@
+using System.Diagnostics;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Browsers;
+
+/// <summary>
+/// The behavior layer over <see cref="AutomationBrowserRegistry"/>: it turns a registered
+/// <see cref="AutomationBrowser"/> into a running, attachable Chromium instance and reports its live
+/// status. Everything here honors the constraints we PROVED on a real machine:
+///
+///   * A drivable browser MUST use its OWN <c>--user-data-dir</c> and <c>--remote-debugging-port</c>.
+///     Chrome 136+ refuses remote-debugging on the default profile, and App-Bound Encryption refuses
+///     to carry a login into a copied profile - so we never touch a personal profile. Each browser is
+///     its own folder, signed in ONCE by the human.
+///   * Machine-local: the debug port is loopback, so only an agent on THIS machine can attach.
+///
+/// No-fallback rule: a request for a browser that is not installed, or that will not come up, THROWS
+/// with a message naming the target. We never silently substitute another browser or swallow a failed
+/// launch.
+/// </summary>
+public static class AutomationBrowserService
+{
+    // A single short-timeout client for the loopback control probes. Chrome answers /json/version
+    // almost instantly when it is up; 2s is generous and keeps a "down" verdict snappy.
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(2) };
+
+    /// <summary>How long we wait for a freshly launched browser's debug port to start answering.</summary>
+    private static readonly TimeSpan LaunchReadyTimeout = TimeSpan.FromSeconds(20);
+
+    /// <summary>
+    /// Register AND provision a new browser: resolves the exe for <paramref name="kind"/> via
+    /// <see cref="BrowserLauncher.DetectBrowsers"/> (THROWS if that browser is not installed), then
+    /// records the entry (unique name, allocated port, dedicated directory). Does not launch it.
+    /// </summary>
+    public static AutomationBrowser Create(string name, BrowserKind kind)
+    {
+        FileLog.Write($"[AutomationBrowserService] Create: name={name}, kind={kind}");
+        // Fail loudly and early if the requested browser is not installed - no point registering a
+        // browser we could never launch.
+        _ = ResolveInstalled(kind);
+        return AutomationBrowserRegistry.Create(name, kind);
+    }
+
+    /// <summary>
+    /// Launch the browser if it is not already up (idempotent), then wait for its debug port to answer.
+    /// Returns the registry entry. THROWS if the exe is missing or the port never comes up.
+    /// </summary>
+    public static async Task<AutomationBrowser> LaunchAsync(string idOrName, CancellationToken ct = default)
+    {
+        var browser = AutomationBrowserRegistry.Get(idOrName);
+        FileLog.Write($"[AutomationBrowserService] LaunchAsync: id={browser.Id}, port={browser.Port}");
+
+        if (await IsUpAsync(browser, ct).ConfigureAwait(false))
+        {
+            FileLog.Write($"[AutomationBrowserService] LaunchAsync: id={browser.Id} already up, no-op");
+            return browser;
+        }
+
+        StartProcess(browser, url: null);
+        await WaitUntilUpAsync(browser, ct).ConfigureAwait(false);
+        FileLog.Write($"[AutomationBrowserService] LaunchAsync: id={browser.Id} is up on {browser.Port}");
+        return browser;
+    }
+
+    /// <summary>
+    /// True when the browser's debug port answers <c>/json/version</c> with success. This is a probe of
+    /// an external process, so a connection failure is the ANSWER ("not running"), not a hidden problem -
+    /// hence the narrow catch. It is not a fallback: nothing is substituted, we simply report "down".
+    /// </summary>
+    public static async Task<bool> IsUpAsync(AutomationBrowser browser, CancellationToken ct = default)
+    {
+        if (browser is null) throw new ArgumentNullException(nameof(browser));
+        try
+        {
+            using var resp = await Http.GetAsync(VersionUrl(browser.Port), ct).ConfigureAwait(false);
+            return resp.IsSuccessStatusCode;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            // Port refused / no answer within the timeout => the browser is not running.
+            return false;
+        }
+    }
+
+    /// <summary>Convenience overload: probe by id or name.</summary>
+    public static Task<bool> IsUpAsync(string idOrName, CancellationToken ct = default)
+        => IsUpAsync(AutomationBrowserRegistry.Get(idOrName), ct);
+
+    /// <summary>The attach environment (<c>BU_NAME</c> / <c>BU_CDP_URL</c>) for this browser.</summary>
+    public static AttachInfo AttachInfo(string idOrName)
+        => AutomationBrowserRegistry.AttachInfoFor(AutomationBrowserRegistry.Get(idOrName));
+
+    /// <summary>
+    /// Start the one-time human sign-in: ensure the browser is up, then open its account page as a new
+    /// tab. The sign-in itself is the HUMAN's hands - we NEVER automate credentials. The caller confirms
+    /// completion separately via <see cref="MarkSignedIn"/>.
+    /// </summary>
+    public static async Task<AutomationBrowser> SignInAsync(string idOrName, CancellationToken ct = default)
+    {
+        var browser = await LaunchAsync(idOrName, ct).ConfigureAwait(false);
+        FileLog.Write($"[AutomationBrowserService] SignInAsync: id={browser.Id} opening account page");
+        StartProcess(browser, url: AccountUrl(browser.Kind));
+        return browser;
+    }
+
+    /// <summary>Record that the human confirmed sign-in for this browser (sets LastSignedInUtc = now).</summary>
+    public static AutomationBrowser MarkSignedIn(string idOrName)
+        => AutomationBrowserRegistry.MarkSignedIn(idOrName);
+
+    /// <summary>Rename a browser's label (id/port/directory unchanged).</summary>
+    public static AutomationBrowser Rename(string idOrName, string newName)
+        => AutomationBrowserRegistry.Rename(idOrName, newName);
+
+    /// <summary>
+    /// Fold the live status: <see cref="AutomationBrowserStatus.Stopped"/> when the port is down; otherwise
+    /// <see cref="AutomationBrowserStatus.NeedsSignIn"/> when it has never been signed in, else
+    /// <see cref="AutomationBrowserStatus.Ready"/>. Folded ONCE here so every client renders it verbatim.
+    /// </summary>
+    public static async Task<AutomationBrowserStatus> StatusAsync(AutomationBrowser browser, CancellationToken ct = default)
+    {
+        if (browser is null) throw new ArgumentNullException(nameof(browser));
+        if (!await IsUpAsync(browser, ct).ConfigureAwait(false))
+            return AutomationBrowserStatus.Stopped;
+        return browser.LastSignedInUtc is null
+            ? AutomationBrowserStatus.NeedsSignIn
+            : AutomationBrowserStatus.Ready;
+    }
+
+    /// <summary>Convenience overload: fold status by id or name.</summary>
+    public static Task<AutomationBrowserStatus> StatusAsync(string idOrName, CancellationToken ct = default)
+        => StatusAsync(AutomationBrowserRegistry.Get(idOrName), ct);
+
+    /// <summary>
+    /// The signed-in account this browser holds, read from the browser's OWN <c>Local State</c> (its
+    /// dedicated user-data directory), or null when it has not been signed in yet. This is our own
+    /// folder, so the profile's display name / account in <c>info_cache</c> is plainly readable - unlike
+    /// a real personal profile's cookies, which App-Bound Encryption locks. Reused
+    /// <see cref="BrowserLauncher.GetProfiles"/> so the parse lives in one place.
+    /// </summary>
+    public static string? ReadAccount(AutomationBrowser browser)
+    {
+        if (browser is null) throw new ArgumentNullException(nameof(browser));
+        var info = new BrowserInfo(browser.Kind, browser.Kind.ToString(), ExePathOrEmpty(browser.Kind), browser.UserDataDir);
+        var profiles = BrowserLauncher.GetProfiles(info);
+        return profiles.FirstOrDefault(p => p.Account is not null)?.Account;
+    }
+
+    private static string ExePathOrEmpty(BrowserKind kind)
+        => BrowserLauncher.DetectBrowsers().FirstOrDefault(b => b.Kind == kind)?.ExePath ?? string.Empty;
+
+    /// <summary>
+    /// Stop the browser cleanly if it is running, by sending Chrome DevTools Protocol
+    /// <c>Browser.close</c> over the browser-level WebSocket. This is chosen over killing by process id
+    /// or command line because it is portable (Core targets a plain framework, not a Windows TFM),
+    /// needs no extra dependency, and works even for a browser this Director did not itself launch (e.g.
+    /// one left running from a previous Director). A browser that is already down is a no-op.
+    /// </summary>
+    public static async Task StopAsync(string idOrName, CancellationToken ct = default)
+    {
+        var browser = AutomationBrowserRegistry.Get(idOrName);
+        FileLog.Write($"[AutomationBrowserService] StopAsync: id={browser.Id}, port={browser.Port}");
+        await CloseViaCdpAsync(browser, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Remove a browser entirely: stop it (CDP close), wait for the port to release, delete its
+    /// user-data directory, and drop its registry entry. THROWS if the directory cannot be deleted
+    /// because the browser is still holding it (we surface that rather than leaving a half-removed
+    /// browser) - the caller can retry after the process has fully exited.
+    /// </summary>
+    public static async Task RemoveAsync(string idOrName, CancellationToken ct = default)
+    {
+        var browser = AutomationBrowserRegistry.Get(idOrName);
+        FileLog.Write($"[AutomationBrowserService] RemoveAsync: id={browser.Id}");
+
+        await CloseViaCdpAsync(browser, ct).ConfigureAwait(false);
+        await WaitUntilDownAsync(browser, ct).ConfigureAwait(false);
+
+        if (Directory.Exists(browser.UserDataDir))
+        {
+            try
+            {
+                Directory.Delete(browser.UserDataDir, recursive: true);
+            }
+            catch (IOException ex)
+            {
+                throw new IOException(
+                    $"Could not delete the folder for browser \"{browser.Name}\" at {browser.UserDataDir} - it may still be running. Close it and try again. ({ex.Message})", ex);
+            }
+        }
+
+        AutomationBrowserRegistry.RemoveEntry(browser.Id);
+        FileLog.Write($"[AutomationBrowserService] RemoveAsync: id={browser.Id} removed");
+    }
+
+    // --- internals ---
+
+    /// <summary>Resolve the installed <see cref="BrowserInfo"/> for a kind, or THROW naming the browser.</summary>
+    private static BrowserInfo ResolveInstalled(BrowserKind kind)
+    {
+        var found = BrowserLauncher.DetectBrowsers().FirstOrDefault(b => b.Kind == kind);
+        if (found is null)
+            throw new InvalidOperationException(
+                $"{kind} is not installed on this machine, so a {kind} automation browser cannot be created.");
+        return found;
+    }
+
+    /// <summary>
+    /// Launch (or, when <paramref name="url"/> is set, open a tab in) the browser with its dedicated
+    /// data directory and fixed debug port. Passing the same <c>--user-data-dir</c> while an instance is
+    /// already running makes Chrome route the URL to that instance as a new tab, which is how sign-in
+    /// opens the account page in the very browser the agent will drive.
+    /// </summary>
+    private static void StartProcess(AutomationBrowser browser, string? url)
+    {
+        var exe = ResolveInstalled(browser.Kind).ExePath;
+        Directory.CreateDirectory(browser.UserDataDir);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = exe,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add($"--user-data-dir={browser.UserDataDir}");
+        startInfo.ArgumentList.Add($"--remote-debugging-port={browser.Port}");
+        startInfo.ArgumentList.Add("--no-first-run");
+        startInfo.ArgumentList.Add("--no-default-browser-check");
+        if (!string.IsNullOrWhiteSpace(url))
+            startInfo.ArgumentList.Add(url);
+
+        FileLog.Write($"[AutomationBrowserService] StartProcess: id={browser.Id}, exe={exe}, url={url ?? "(none)"}");
+        var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Failed to start {browser.Kind} for browser \"{browser.Name}\" ({exe}).");
+        FileLog.Write($"[AutomationBrowserService] StartProcess: id={browser.Id} pid={process.Id}");
+    }
+
+    private static async Task WaitUntilUpAsync(AutomationBrowser browser, CancellationToken ct)
+    {
+        var deadline = DateTime.UtcNow + LaunchReadyTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await IsUpAsync(browser, ct).ConfigureAwait(false))
+                return;
+            await Task.Delay(250, ct).ConfigureAwait(false);
+        }
+        throw new TimeoutException(
+            $"Browser \"{browser.Name}\" was launched but its debug port {browser.Port} did not come up within {LaunchReadyTimeout.TotalSeconds:0}s.");
+    }
+
+    private static async Task WaitUntilDownAsync(AutomationBrowser browser, CancellationToken ct)
+    {
+        var deadline = DateTime.UtcNow + LaunchReadyTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (!await IsUpAsync(browser, ct).ConfigureAwait(false))
+                return;
+            await Task.Delay(250, ct).ConfigureAwait(false);
+        }
+        // Not fatal on its own; the folder-delete step will throw the actionable error if it is still locked.
+        FileLog.Write($"[AutomationBrowserService] WaitUntilDownAsync: id={browser.Id} still up after {LaunchReadyTimeout.TotalSeconds:0}s");
+    }
+
+    /// <summary>
+    /// Send CDP <c>Browser.close</c> over the browser-level WebSocket advertised by <c>/json/version</c>.
+    /// A down browser is a no-op. The websocket disconnecting as Chrome exits is expected, not an error.
+    /// </summary>
+    private static async Task CloseViaCdpAsync(AutomationBrowser browser, CancellationToken ct)
+    {
+        string? wsUrl;
+        try
+        {
+            using var resp = await Http.GetAsync(VersionUrl(browser.Port), ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode) return;
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            using var doc = JsonDocument.Parse(body);
+            wsUrl = doc.RootElement.TryGetProperty("webSocketDebuggerUrl", out var w) ? w.GetString() : null;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            // Already down - nothing to close.
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(wsUrl))
+        {
+            FileLog.Write($"[AutomationBrowserService] CloseViaCdpAsync: id={browser.Id} no webSocketDebuggerUrl, cannot CDP-close");
+            return;
+        }
+
+        using var socket = new ClientWebSocket();
+        try
+        {
+            await socket.ConnectAsync(new Uri(wsUrl), ct).ConfigureAwait(false);
+            var payload = Encoding.UTF8.GetBytes("{\"id\":1,\"method\":\"Browser.close\"}");
+            await socket.SendAsync(payload, WebSocketMessageType.Text, endOfMessage: true, ct).ConfigureAwait(false);
+            // Chrome tears the socket down as it exits; we do not need to read a reply.
+            FileLog.Write($"[AutomationBrowserService] CloseViaCdpAsync: id={browser.Id} Browser.close sent");
+        }
+        catch (WebSocketException)
+        {
+            // The socket dropping as the browser exits is the expected outcome of a successful close.
+        }
+    }
+
+    private static string VersionUrl(int port) => $"http://127.0.0.1:{port}/json/version";
+
+    /// <summary>The sign-in landing page appropriate to the browser's identity provider.</summary>
+    private static string AccountUrl(BrowserKind kind) => kind switch
+    {
+        BrowserKind.Chrome => "https://accounts.google.com/",
+        BrowserKind.Edge => "https://login.live.com/",
+        _ => "https://www.google.com/",
+    };
+}

--- a/src/CcDirector.Core/Browsers/AutomationBrowserViewFold.cs
+++ b/src/CcDirector.Core/Browsers/AutomationBrowserViewFold.cs
@@ -1,0 +1,177 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Browsers;
+
+/// <summary>
+/// The finished, render-ready view of one automation browser. Every display decision a client would
+/// otherwise make - the status label, the status dot color, the subtitle under the name, which single
+/// action to offer, the exact attach command - is folded ONCE here (CLAUDE.md rule 7: the client is
+/// dumb). The Control API serializes this record verbatim for the CLI, and the Director's own rail and
+/// Settings tab render the SAME record in-process, so no two surfaces can disagree about a browser.
+/// </summary>
+/// <param name="Id">Stable slug id (also the <c>BU_NAME</c>).</param>
+/// <param name="Name">Human-facing, user-editable label.</param>
+/// <param name="Browser">"Chrome" or "Edge".</param>
+/// <param name="Port">The fixed remote-debugging port.</param>
+/// <param name="Status">The folded lifecycle state (see <see cref="AutomationBrowserStatus"/>).</param>
+/// <param name="StatusLabel">The human status text: "Ready" / "Needs sign-in" / "Stopped".</param>
+/// <param name="DotColor">The status dot's color NAME from the one shared palette ("green" /
+/// "yellow" / "grey") - surfaces map the name to a brush via their palette wrapper.</param>
+/// <param name="Subtitle">The one-line description under the name, e.g. "Chrome - user@x.com".</param>
+/// <param name="ActionLabel">The single next action to offer: "Start" / "Sign in" / "Attach".</param>
+/// <param name="Account">The signed-in account read from the browser's own profile, or null.</param>
+/// <param name="BuName">The <c>BU_NAME</c> browser-harness attaches with.</param>
+/// <param name="BuCdpUrl">The <c>BU_CDP_URL</c> browser-harness attaches with.</param>
+/// <param name="AttachCommand">The complete one-liner an agent runs to attach the harness.</param>
+/// <param name="UserDataDir">The browser's dedicated user-data directory.</param>
+/// <param name="CreatedUtc">When the browser was created.</param>
+/// <param name="LastSignedInUtc">When the human last confirmed sign-in, or null if never.</param>
+public sealed record AutomationBrowserView(
+    string Id,
+    string Name,
+    string Browser,
+    int Port,
+    AutomationBrowserStatus Status,
+    string StatusLabel,
+    string DotColor,
+    string Subtitle,
+    string ActionLabel,
+    string? Account,
+    string BuName,
+    string BuCdpUrl,
+    string AttachCommand,
+    string UserDataDir,
+    DateTime CreatedUtc,
+    DateTime? LastSignedInUtc);
+
+/// <summary>
+/// Folds an <see cref="AutomationBrowser"/> into its <see cref="AutomationBrowserView"/>, and answers
+/// whether browser-harness (the tool that actually drives these browsers) is installed on this machine.
+/// The mapping itself is pure and unit-tested (<see cref="Fold"/>); the async entry points add the two
+/// live reads (the debug-port probe and the profile's account) on top.
+/// </summary>
+public static class AutomationBrowserViewFold
+{
+    /// <summary>Where "Install Browser Harness" sends the user.</summary>
+    public const string HarnessInstallUrl = "https://github.com/browser-use/browser-harness/blob/main/install.md";
+
+    /// <summary>The executable browser-harness ships on PATH; its presence IS the install check.</summary>
+    public const string HarnessExecutable = "browser-harness";
+
+    /// <summary>True when browser-harness is installed (resolvable on PATH) on this machine.</summary>
+    public static bool IsHarnessInstalled() => ExecutableResolver.Resolve(HarnessExecutable) is not null;
+
+    /// <summary>Fold every registered browser on this machine into its render-ready view.</summary>
+    public static async Task<IReadOnlyList<AutomationBrowserView>> ListAsync(CancellationToken ct = default)
+    {
+        var browsers = AutomationBrowserRegistry.Load();
+        var views = new List<AutomationBrowserView>(browsers.Count);
+        foreach (var browser in browsers)
+            views.Add(await FoldAsync(browser, ct).ConfigureAwait(false));
+        return views;
+    }
+
+    /// <summary>Fold one browser: probe its live status, read its signed-in account, then map.</summary>
+    public static async Task<AutomationBrowserView> FoldAsync(AutomationBrowser browser, CancellationToken ct = default)
+    {
+        if (browser is null) throw new ArgumentNullException(nameof(browser));
+
+        var status = await AutomationBrowserService.StatusAsync(browser, ct).ConfigureAwait(false);
+
+        // The account is decoration on the subtitle, never load-bearing: an unreadable profile (first
+        // run, mid-write Local State) must not take the whole list down, so this read alone is allowed
+        // to degrade to "no account shown" - and it logs when it does.
+        string? account = null;
+        try
+        {
+            account = AutomationBrowserService.ReadAccount(browser);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[AutomationBrowserViewFold] ReadAccount id={browser.Id} failed (non-fatal): {ex.Message}");
+        }
+
+        return Fold(browser, status, account);
+    }
+
+    /// <summary>
+    /// The pure mapping from (browser, live status, account) to the finished view. No I/O, fully
+    /// unit-tested - this is where the display rules live and the ONLY place they may live.
+    /// </summary>
+    public static AutomationBrowserView Fold(AutomationBrowser browser, AutomationBrowserStatus status, string? account)
+    {
+        if (browser is null) throw new ArgumentNullException(nameof(browser));
+
+        var attach = AutomationBrowserRegistry.AttachInfoFor(browser);
+        return new AutomationBrowserView(
+            Id: browser.Id,
+            Name: browser.Name,
+            Browser: browser.Kind.ToString(),
+            Port: browser.Port,
+            Status: status,
+            StatusLabel: StatusLabel(status),
+            DotColor: DotColor(status),
+            Subtitle: Subtitle(browser.Kind, status, account),
+            ActionLabel: ActionLabel(status),
+            Account: account,
+            BuName: attach.BuName,
+            BuCdpUrl: attach.BuCdpUrl,
+            AttachCommand: AttachCommand(browser.Id),
+            UserDataDir: browser.UserDataDir,
+            CreatedUtc: browser.CreatedUtc,
+            LastSignedInUtc: browser.LastSignedInUtc);
+    }
+
+    /// <summary>The human status text every surface shows verbatim.</summary>
+    public static string StatusLabel(AutomationBrowserStatus status) => status switch
+    {
+        AutomationBrowserStatus.Stopped => "Stopped",
+        AutomationBrowserStatus.NeedsSignIn => "Needs sign-in",
+        AutomationBrowserStatus.Ready => "Ready",
+        _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown automation browser status"),
+    };
+
+    /// <summary>The status dot's color NAME in the one shared session palette: running and signed in is
+    /// green, running but never signed in is yellow (attention), not running is grey.</summary>
+    public static string DotColor(AutomationBrowserStatus status) => status switch
+    {
+        AutomationBrowserStatus.Stopped => "grey",
+        AutomationBrowserStatus.NeedsSignIn => "yellow",
+        AutomationBrowserStatus.Ready => "green",
+        _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown automation browser status"),
+    };
+
+    /// <summary>The single next action a surface offers for this browser.</summary>
+    public static string ActionLabel(AutomationBrowserStatus status) => status switch
+    {
+        AutomationBrowserStatus.Stopped => "Start",
+        AutomationBrowserStatus.NeedsSignIn => "Sign in",
+        AutomationBrowserStatus.Ready => "Attach",
+        _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown automation browser status"),
+    };
+
+    /// <summary>The one-line description under the name: the browser kind, then the most useful fact
+    /// (the signed-in account when known, otherwise the state in plain words).</summary>
+    public static string Subtitle(BrowserKind kind, AutomationBrowserStatus status, string? account)
+    {
+        if (!string.IsNullOrWhiteSpace(account))
+            return $"{kind} - {account}";
+
+        return status switch
+        {
+            AutomationBrowserStatus.Stopped => $"{kind} - stopped",
+            AutomationBrowserStatus.NeedsSignIn => $"{kind} - not signed in yet",
+            AutomationBrowserStatus.Ready => $"{kind} - signed in",
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown automation browser status"),
+        };
+    }
+
+    /// <summary>The complete attach one-liner an agent runs. Built on the slug id (never the free-text
+    /// name) so the command is always shell-safe.</summary>
+    public static string AttachCommand(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            throw new ArgumentException("A browser id is required.", nameof(id));
+        return $"eval \"$(cc-devthrottle browser attach '{id}')\"";
+    }
+}

--- a/src/CcDirector.Core/GatewayConnection/GatewayStatusBoxPresenter.cs
+++ b/src/CcDirector.Core/GatewayConnection/GatewayStatusBoxPresenter.cs
@@ -39,11 +39,15 @@ public sealed record GatewayStatusLine(GatewayCheckState Marker, string Text);
 /// <param name="Connected">The "Connected" (Gateway reachable) check line.</param>
 /// <param name="SignedIn">The "Signed in" (account) check line.</param>
 /// <param name="Tooltip">The hover text summarizing the current state and the click action.</param>
+/// <param name="ChipText">The two-or-three-word verdict the compact chip renders next to its status
+/// dot. The chip is the box's slim form: the dot carries the visual state, this text names it, and
+/// the two full check lines live on in <paramref name="Tooltip"/>.</param>
 public sealed record GatewayStatusBoxContent(
     GatewayStatusBoxVisual Visual,
     GatewayStatusLine Connected,
     GatewayStatusLine SignedIn,
-    string Tooltip);
+    string Tooltip,
+    string ChipText);
 
 /// <summary>
 /// Turns a resolved Gateway connection snapshot into the single status box's content (design spec section
@@ -82,8 +86,25 @@ public static class GatewayStatusBoxPresenter
         var connected = ConnectedLine(resolved, inputs.GatewayConfigured, gatewayHost);
         var signedIn = SignedInLine(resolved.SignedInCheck, accountEmail);
         var tooltip = Tooltip(resolved.State, inputs.FailedLeg, gatewayHost, accountEmail);
-        return new GatewayStatusBoxContent(visual, connected, signedIn, tooltip);
+        var chipText = ChipText(resolved.State);
+        return new GatewayStatusBoxContent(visual, connected, signedIn, tooltip, chipText);
     }
+
+    /// <summary>
+    /// The compact chip's verdict, one short phrase per resolver state. Folded here - not in the
+    /// surface - so the slim chip can never invent a wording of its own: green earns "Connected",
+    /// connected-but-signed-out nudges "Sign in", and the failure states name the failure.
+    /// </summary>
+    public static string ChipText(GatewayConnectionState state) => state switch
+    {
+        GatewayConnectionState.NotConfigured => "No Gateway",
+        GatewayConnectionState.Connecting => "Connecting...",
+        GatewayConnectionState.ConnectFailed => "Connection failed",
+        GatewayConnectionState.WasConnectedNowUnreachable => "Unreachable",
+        GatewayConnectionState.ConnectedNotSignedIn => "Sign in",
+        GatewayConnectionState.AllGreen => "Connected",
+        _ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown gateway connection state"),
+    };
 
     /// <summary>Collapse the six resolver states to the box's four visual states (spec section 6 table).</summary>
     public static GatewayStatusBoxVisual VisualFor(GatewayConnectionState state) => state switch

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -59,6 +59,16 @@ public static class CcStorage
     public static string Config() => Path.Combine(Base(), "config");
 
     /// <summary>
+    /// DevThrottle's OWN automation-browser root: browsers/. Holds the registry.json describing each
+    /// agent-drivable browser and, beside it, one <c>&lt;id&gt;/</c> sub-directory per browser that is that
+    /// browser's dedicated Chromium <c>--user-data-dir</c>. This is intentionally NOT the personal
+    /// bh-profiles location and NOT cc-director\connections - DevThrottle owns this tree so its
+    /// browsers are per-machine state the local Director alone manages. Resolved through the root so
+    /// CC_DIRECTOR_ROOT redirects it for tests.
+    /// </summary>
+    public static string Browsers() => Path.Combine(Base(), "browsers");
+
+    /// <summary>
     /// Director instance-discovery directory: config/director/instances/. Each running Director writes
     /// a <c>{directorId}.json</c> here and the Gateway watches it. Honors the
     /// <c>CC_DIRECTOR_INSTANCES_DIR</c> override (issue #322) so tests can pin JUST this directory to a

--- a/tools/cc-devthrottle/src/browser_ops.py
+++ b/tools/cc-devthrottle/src/browser_ops.py
@@ -1,0 +1,177 @@
+"""Automation-browser operations for cc-devthrottle.
+
+These verbs manage DevThrottle's OWN drivable browsers - the signed-in-once Chromium instances an
+agent attaches to through browser-harness. They act on the LOCAL Director (CC_DIRECTOR_API): a
+browser's debug port is loopback and its data directory is on this machine, so browsers are
+machine-local and only an agent on the same machine can drive them.
+
+All rendering decisions the user sees (status label, account, the attach environment) are FOLDED by
+the Director and returned on the DTO; this module only lays them out.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+import typer
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+# session_ops installs the ASCII-only Rich patch at import; cli imports it eagerly, so tables here
+# render with plain ASCII too. cc_shared.director is the loopback Control-API client.
+from cc_shared import director
+
+console = Console()
+
+
+def _browsers() -> List[Dict[str, Any]]:
+    """Every automation browser on this machine, each already folded (status/account/attach)."""
+    payload = director.get_json("browsers") or {}
+    return payload.get("browsers", payload.get("Browsers", [])) or []
+
+
+def _resolve(target: str) -> Dict[str, Any]:
+    """Resolve a user-typed id or name to its browser DTO, or exit with a helpful list.
+
+    Resolving here (rather than passing a raw name into the URL) keeps every subsequent call on the
+    URL-safe slug id and lets us name the available browsers when nothing matches.
+    """
+    browsers = _browsers()
+    key = target.strip().lower()
+    for b in browsers:
+        if director.field(b, "id", "Id").lower() == key:
+            return b
+    for b in browsers:
+        if director.field(b, "name", "Name").lower() == key:
+            return b
+
+    if browsers:
+        names = ", ".join(f'"{director.field(b, "name", "Name")}"' for b in browsers)
+        console.print(f'[red]No automation browser matching "{target}".[/red] On this machine: {names}.')
+    else:
+        console.print(
+            f'[red]No automation browser matching "{target}".[/red] '
+            "There are none on this machine yet - create one with "
+            "'cc-devthrottle browser create --name \"...\" --browser chrome'."
+        )
+    raise typer.Exit(code=1)
+
+
+def list_browsers(json_output: bool) -> None:
+    """List the automation browsers on this machine."""
+    browsers = _browsers()
+
+    if json_output:
+        print(json.dumps(browsers, indent=2))
+        return
+
+    if not browsers:
+        console.print(
+            "No automation browsers on this machine yet. Create one with:\n"
+            '  cc-devthrottle browser create --name "Center Consulting" --browser chrome'
+        )
+        return
+
+    table = Table(show_header=True, header_style="bold", box=box.ASCII)
+    table.add_column("NAME")
+    table.add_column("BROWSER")
+    table.add_column("STATUS")
+    table.add_column("ACCOUNT")
+    for b in browsers:
+        name = director.field(b, "name", "Name") or "(unnamed)"
+        kind = director.field(b, "browser", "Browser") or "-"
+        status = director.field(b, "statusLabel", "StatusLabel") or director.field(b, "status", "Status") or "-"
+        account = director.field(b, "account", "Account") or "-"
+        table.add_row(name, kind, status, account)
+
+    console.print(table)
+
+
+def create_browser(name: str, browser: str, json_output: bool) -> None:
+    """Register a new drivable browser (does not launch it)."""
+    dto = director.post_json("browsers", {"name": name, "browser": browser})
+    if json_output:
+        print(json.dumps(dto, indent=2))
+        return
+    bname = director.field(dto, "name", "Name")
+    kind = director.field(dto, "browser", "Browser")
+    console.print(
+        f'[green]Created[/green] browser "{bname}" ({kind}).\n'
+        f'Sign it in once with:  cc-devthrottle browser signin "{bname}"'
+    )
+
+
+def signin_browser(target: str, done: bool, json_output: bool) -> None:
+    """Open the account page for a one-time human sign-in, or (with --done) record it complete."""
+    browser = _resolve(target)
+    bid = director.field(browser, "id", "Id")
+    dto = director.post_json(f"browsers/{bid}/signin", {"done": bool(done)})
+    if json_output:
+        print(json.dumps(dto, indent=2))
+        return
+
+    bname = director.field(dto, "name", "Name")
+    if done:
+        console.print(f'[green]Recorded[/green]: "{bname}" is signed in and ready to drive.')
+    else:
+        console.print(
+            f'Opened the sign-in page in "{bname}". Sign in BY HAND in that window (credentials are '
+            "never automated).\n"
+            f'When the account is signed in, run:  cc-devthrottle browser signin "{bname}" --done'
+        )
+
+
+def start_browser(target: str, json_output: bool) -> None:
+    """Launch the browser if it is down, then print how to attach to it."""
+    browser = _resolve(target)
+    bid = director.field(browser, "id", "Id")
+    dto = director.post_json(f"browsers/{bid}/start", {})
+    if json_output:
+        print(json.dumps(dto, indent=2))
+        return
+
+    bname = director.field(dto, "name", "Name")
+    status = director.field(dto, "statusLabel", "StatusLabel")
+    bu_name = director.field(dto, "buName", "BuName")
+    bu_url = director.field(dto, "buCdpUrl", "BuCdpUrl")
+    console.print(f'[green]Started[/green] "{bname}" ({status}). Attach the harness with:')
+    console.print(f'  eval "$(cc-devthrottle browser attach \'{bname}\')"')
+    console.print(f"    BU_NAME={bu_name}")
+    console.print(f"    BU_CDP_URL={bu_url}")
+
+
+def attach_browser(target: str) -> None:
+    """Print ONLY the two export lines, so `eval "$(... attach 'X')"` points the harness at it."""
+    browser = _resolve(target)
+    bid = director.field(browser, "id", "Id")
+    info = director.get_json(f"browsers/{bid}/attach")
+    bu_name = director.field(info, "buName", "BuName")
+    bu_url = director.field(info, "buCdpUrl", "BuCdpUrl")
+    # Plain print, no Rich: this output is meant to be eval'd by a shell.
+    print(f"export BU_NAME={bu_name}")
+    print(f"export BU_CDP_URL={bu_url}")
+
+
+def rename_browser(target: str, to: str, json_output: bool) -> None:
+    """Rename a browser's label (its id, port, and folder are unchanged)."""
+    browser = _resolve(target)
+    bid = director.field(browser, "id", "Id")
+    dto = director.post_json(f"browsers/{bid}/rename", {"name": to})
+    if json_output:
+        print(json.dumps(dto, indent=2))
+        return
+    console.print(f'[green]Renamed[/green] to "{director.field(dto, "name", "Name")}".')
+
+
+def remove_browser(target: str, json_output: bool) -> None:
+    """Stop the browser, delete its folder, and drop it from the registry."""
+    browser = _resolve(target)
+    bid = director.field(browser, "id", "Id")
+    bname = director.field(browser, "name", "Name")
+    result = director.delete(f"browsers/{bid}")
+    if json_output:
+        print(json.dumps(result, indent=2))
+        return
+    console.print(f'[green]Removed[/green] "{bname}".')

--- a/tools/cc-devthrottle/src/browser_ops.py
+++ b/tools/cc-devthrottle/src/browser_ops.py
@@ -154,6 +154,19 @@ def attach_browser(target: str) -> None:
     print(f"export BU_CDP_URL={bu_url}")
 
 
+def stop_browser(target: str, json_output: bool) -> None:
+    """Close a running browser cleanly. Its login and folder are kept; only the process exits."""
+    browser = _resolve(target)
+    bid = director.field(browser, "id", "Id")
+    dto = director.post_json(f"browsers/{bid}/stop", {})
+    if json_output:
+        print(json.dumps(dto, indent=2))
+        return
+    bname = director.field(dto, "name", "Name")
+    status = director.field(dto, "statusLabel", "StatusLabel")
+    console.print(f'[green]Stopped[/green] "{bname}" ({status}). Its login is kept - start it again any time.')
+
+
 def rename_browser(target: str, to: str, json_output: bool) -> None:
     """Rename a browser's label (its id, port, and folder are unchanged)."""
     browser = _resolve(target)

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -490,6 +490,13 @@ _ACTIONS = [
         "mutatesState": False,
         "args": [],
     },
+    {
+        "id": "browser-stop",
+        "description": "Close a running automation browser cleanly (its login is kept).",
+        "command": 'cc-devthrottle browser stop "Center Consulting"',
+        "mutatesState": True,
+        "args": [],
+    },
 ]
 
 
@@ -534,6 +541,15 @@ def browser_start(
 ) -> None:
     """Launch the browser if it is down, then print how to attach to it."""
     browser_ops.start_browser(name, json_output)
+
+
+@browser_app.command("stop")
+def browser_stop(
+    name: str = typer.Argument(..., help="Browser name or id."),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """Close a running browser cleanly (its login is kept; start it again any time)."""
+    browser_ops.stop_browser(name, json_output)
 
 
 @browser_app.command("attach")

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from . import __version__
+from . import browser_ops
 from . import diag_ops
 from . import email_ops
 from . import mission_ops
@@ -73,6 +74,11 @@ autostart_app = typer.Typer(
     add_completion=False,
     no_args_is_help=True,
 )
+browser_app = typer.Typer(
+    help="Manage DevThrottle's drivable automation browsers (signed in once, driven by an agent; machine-local).",
+    add_completion=False,
+    no_args_is_help=True,
+)
 app.add_typer(session_app, name="session")
 app.add_typer(mission_app, name="mission")
 app.add_typer(message_app, name="message")
@@ -83,6 +89,7 @@ app.add_typer(setup_app, name="setup")
 app.add_typer(email_app, name="email")
 app.add_typer(diag_app, name="diag")
 app.add_typer(autostart_app, name="autostart")
+app.add_typer(browser_app, name="browser")
 console = Console()
 
 _ACTIONS = [
@@ -448,6 +455,41 @@ _ACTIONS = [
         "mutatesState": False,
         "args": [],
     },
+    {
+        "id": "browser-list",
+        "description": "List this machine's drivable automation browsers (name, browser, status, account).",
+        "command": "cc-devthrottle browser list --json",
+        "mutatesState": False,
+        "args": [],
+    },
+    {
+        "id": "browser-create",
+        "description": "Register a new drivable browser (does not launch it).",
+        "command": 'cc-devthrottle browser create --name "Center Consulting" --browser chrome',
+        "mutatesState": True,
+        "args": [],
+    },
+    {
+        "id": "browser-signin",
+        "description": "Open the account page for a one-time human sign-in; add --done to mark it complete.",
+        "command": 'cc-devthrottle browser signin "Center Consulting"',
+        "mutatesState": True,
+        "args": [],
+    },
+    {
+        "id": "browser-start",
+        "description": "Launch a browser if it is down, then print how to attach the harness.",
+        "command": 'cc-devthrottle browser start "Center Consulting"',
+        "mutatesState": True,
+        "args": [],
+    },
+    {
+        "id": "browser-attach",
+        "description": "Print the BU_NAME/BU_CDP_URL export lines to attach browser-harness to a browser.",
+        "command": 'eval "$(cc-devthrottle browser attach \'Center Consulting\')"',
+        "mutatesState": False,
+        "args": [],
+    },
 ]
 
 
@@ -455,6 +497,70 @@ def _version_callback(value: bool) -> None:
     if value:
         console.print(f"cc-devthrottle v{__version__}")
         raise typer.Exit()
+
+
+@browser_app.command("list")
+def browser_list(
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """List the drivable automation browsers on this machine."""
+    browser_ops.list_browsers(json_output)
+
+
+@browser_app.command("create")
+def browser_create(
+    name: str = typer.Option(..., "--name", help='Human-facing name, e.g. "Center Consulting".'),
+    browser: str = typer.Option("chrome", "--browser", help="Which browser: chrome or edge."),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """Register a new drivable browser (does not launch it)."""
+    browser_ops.create_browser(name, browser, json_output)
+
+
+@browser_app.command("signin")
+def browser_signin(
+    name: str = typer.Argument(..., help="Browser name or id."),
+    done: bool = typer.Option(False, "--done", help="Record that the human finished signing in."),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """Open the account page for a one-time hand sign-in, or (with --done) mark it complete."""
+    browser_ops.signin_browser(name, done, json_output)
+
+
+@browser_app.command("start")
+def browser_start(
+    name: str = typer.Argument(..., help="Browser name or id."),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """Launch the browser if it is down, then print how to attach to it."""
+    browser_ops.start_browser(name, json_output)
+
+
+@browser_app.command("attach")
+def browser_attach(
+    name: str = typer.Argument(..., help="Browser name or id."),
+) -> None:
+    """Print ONLY the export lines, so: eval "$(cc-devthrottle browser attach 'Name')\"."""
+    browser_ops.attach_browser(name)
+
+
+@browser_app.command("rename")
+def browser_rename(
+    name: str = typer.Argument(..., help="Current browser name or id."),
+    to: str = typer.Option(..., "--to", help="New name."),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """Rename a browser's label (id, port, and folder are unchanged)."""
+    browser_ops.rename_browser(name, to, json_output)
+
+
+@browser_app.command("remove")
+def browser_remove(
+    name: str = typer.Argument(..., help="Browser name or id."),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """Stop the browser, delete its folder, and drop it from the registry."""
+    browser_ops.remove_browser(name, json_output)
 
 
 @app.callback()

--- a/tools/cc-devthrottle/tests/test_browser_ops.py
+++ b/tools/cc-devthrottle/tests/test_browser_ops.py
@@ -1,0 +1,97 @@
+"""Tests for cc-devthrottle automation-browser operations.
+
+Focus: the attach output MUST be exactly two eval-able export lines (so
+`eval "$(cc-devthrottle browser attach 'Name')"` points browser-harness at the browser), and target
+resolution accepts a name or an id and fails loudly on an unknown target.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import typer  # noqa: E402
+from src import browser_ops  # noqa: E402
+
+
+def _stub_director(monkeypatch, browsers, attach=None):
+    """Point browser_ops.director at canned responses keyed by request path."""
+
+    def fake_get_json(path):
+        if path == "browsers":
+            return {"browsers": browsers}
+        if path.endswith("/attach"):
+            return attach
+        raise AssertionError(f"unexpected GET {path}")
+
+    monkeypatch.setattr(browser_ops.director, "get_json", fake_get_json)
+
+
+SAMPLE = [
+    {
+        "id": "center-consulting",
+        "name": "Center Consulting",
+        "browser": "Chrome",
+        "port": 9310,
+        "status": "Ready",
+        "statusLabel": "Ready",
+        "account": "soren@centerconsulting.com",
+        "buName": "center-consulting",
+        "buCdpUrl": "http://127.0.0.1:9310",
+    }
+]
+
+
+class TestAttach:
+    def test_prints_exactly_two_export_lines(self, monkeypatch, capsys):
+        _stub_director(
+            monkeypatch,
+            SAMPLE,
+            attach={"buName": "center-consulting", "buCdpUrl": "http://127.0.0.1:9310"},
+        )
+
+        browser_ops.attach_browser("Center Consulting")
+
+        out = capsys.readouterr().out.strip().splitlines()
+        assert out == [
+            "export BU_NAME=center-consulting",
+            "export BU_CDP_URL=http://127.0.0.1:9310",
+        ]
+
+    def test_resolves_by_id_too(self, monkeypatch, capsys):
+        _stub_director(
+            monkeypatch,
+            SAMPLE,
+            attach={"buName": "center-consulting", "buCdpUrl": "http://127.0.0.1:9310"},
+        )
+
+        browser_ops.attach_browser("center-consulting")
+
+        out = capsys.readouterr().out
+        assert "export BU_NAME=center-consulting" in out
+        assert "export BU_CDP_URL=http://127.0.0.1:9310" in out
+
+
+class TestResolve:
+    def test_unknown_target_exits_nonzero(self, monkeypatch):
+        _stub_director(monkeypatch, SAMPLE)
+        with pytest.raises(typer.Exit) as exc:
+            browser_ops._resolve("does-not-exist")
+        assert exc.value.exit_code == 1
+
+    def test_matches_name_case_insensitively(self, monkeypatch):
+        _stub_director(monkeypatch, SAMPLE)
+        resolved = browser_ops._resolve("center consulting")
+        assert resolved["id"] == "center-consulting"
+
+
+class TestList:
+    def test_json_output_is_the_raw_browsers(self, monkeypatch, capsys):
+        _stub_director(monkeypatch, SAMPLE)
+        browser_ops.list_browsers(json_output=True)
+        out = capsys.readouterr().out
+        assert '"center-consulting"' in out
+        assert '"soren@centerconsulting.com"' in out

--- a/tools/cc-devthrottle/tests/test_browser_ops.py
+++ b/tools/cc-devthrottle/tests/test_browser_ops.py
@@ -88,6 +88,26 @@ class TestResolve:
         assert resolved["id"] == "center-consulting"
 
 
+class TestStop:
+    def test_posts_stop_and_reports_the_folded_status(self, monkeypatch, capsys):
+        _stub_director(monkeypatch, SAMPLE)
+        posted = {}
+
+        def fake_post_json(path, body):
+            posted["path"] = path
+            posted["body"] = body
+            return {"id": "center-consulting", "name": "Center Consulting", "statusLabel": "Stopped"}
+
+        monkeypatch.setattr(browser_ops.director, "post_json", fake_post_json)
+
+        browser_ops.stop_browser("Center Consulting", json_output=False)
+
+        assert posted["path"] == "browsers/center-consulting/stop"
+        out = capsys.readouterr().out
+        assert "Stopped" in out
+        assert "Center Consulting" in out
+
+
 class TestList:
     def test_json_output_is_the_raw_browsers(self, monkeypatch, capsys):
         _stub_director(monkeypatch, SAMPLE)


### PR DESCRIPTION
DevThrottle Browsers: give any coding agent a real, logged-in Chrome or Edge to drive through Browser Harness - discover, name, sign in once, then one command to attach.

## Slice 1 - engine (previously on this branch)
- C# engine in CcDirector.Core/Browsers: AutomationBrowser, AutomationBrowserRegistry (registry.json, unique names/ports, atomic writes), AutomationBrowserService (create/launch/is-up/attach/sign-in/rename/stop/remove). Reuses BrowserLauncher.DetectBrowsers.
- Control API: /browsers list/create/start/attach/signin/rename/remove.
- Python CLI: the cc-devthrottle browser verb group; attach prints the BU_NAME/BU_CDP_URL export lines.

## Slice 2 - display fold, hardening, and the Director UI (this update)
- One display fold in Core (AutomationBrowserViewFold): status label, dot color, subtitle, single offered action, and the attach command are computed once; the Control API serializes it and the desktop renders it verbatim (rule 7). GET /browsers now also reports harnessInstalled + the install URL.
- Stop hardening the slice-1 note tracked: the Director keeps the process handle it launched per browser; a stop whose CDP Browser.close does not release the port kills exactly that tracked pid. New POST /browsers/{id}/stop and cc-devthrottle browser stop.
- Pinned, collapsible Browsers group in the left rail above Repositories: status dot (green Ready / yellow Needs sign-in / grey Stopped) and one-click Start / Sign in / Attach (copies the attach one-liner). With Browser Harness missing the group stays visible, dimmed, with an inline Install Browser Harness link.
- Settings > Browsers tab: create (only installed browsers offered), guided sign-in-once flow (open account page, human signs in, confirms Done - credentials never automated), rename (DevThrottle-side label), start/stop, copy attach command, remove behind a plain-English confirm naming when the login was made.
- Top-level Browsers menu (New Browser... / Manage Browsers...).
- Gateway connection indicator slimmed to a compact chip (dot + presenter-folded verdict); the two full check lines moved to the tooltip.
- Loopback guard allowlist: the three slice-1 engine files are machine-local loopback BY DESIGN; the guard failure predated slice 2 (slice 1 ran only its own filtered tests).

## The honest constraint (proven on a real machine, see handover 2026-07-23)
A drivable browser is always a dedicated non-default profile signed in ONCE by the human. Chrome 136+ blocks remote debugging on the default profile and App-Bound Encryption blocks copying a login, so DevThrottle never touches the everyday browser and never automates credentials.

## Verification
- Full solution builds with 0 warnings; Core.Tests 3381 passed (incl. 10 new fold tests + 3 chip tests + the loopback guard), Gateway.Tests 3652 passed, Avalonia.Tests 268 passed, all other projects green; Python CLI tests 6 passed.
- Live on SOREN_NORTH with a slot-7 Director: created Center Consulting (Chrome) / mindzie (Edge) / Personal (Chrome); all three fold states rendered in the rail and Settings; browser-harness attached via the folded BU_CDP_URL and drove the launched Chrome to example.com (page_info verified); Stop clicked in the Settings UI closed the Edge instance via CDP; remove deleted a RUNNING browser cleanly (stop, folder delete, registry drop); the no-harness state verified with browser-harness stripped from PATH (dimmed rail + Setup label + install link, and the API folding harnessInstalled:false).