### PR TITLE
Measure true external deploy outage and auto-emit deploy metrics

### DIFF
--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -73,12 +73,15 @@ jobs:
       # keeps builds distinguishable; the App Service is pinned by the resulting immutable DIGEST, never
       # the tag, so a rebuild always forces a real pull.
       - name: Build image in ACR
+        id: build
         run: |
+          start=$(date +%s)
           az acr build \
             --registry "$ACR" \
             --image "${IMAGE_NAME}:ci-${{ steps.short.outputs.short }}" \
             --build-arg COCKPIT_COMMIT="${{ steps.short.outputs.short }}" \
             .
+          echo "build_seconds=$(( $(date +%s) - start ))" >> "$GITHUB_OUTPUT"
 
       - name: Read the built image digest
         id: digest
@@ -93,6 +96,19 @@ jobs:
           esac
           echo "Built digest: $DIGEST"
 
+      # Read the commit the LIVE service is running BEFORE we repin - this is the OUTGOING build, and the
+      # /healthz .commit field (added alongside this workflow) is what makes it readable. Used for two
+      # things: the honest-readiness poll below tells "the new image is serving" apart from "the old
+      # container is still answering 200" by commit, and the migration-delta step diffs OUTGOING..target.
+      # Empty when the currently-live image predates the .commit field (only the very first deploy of this
+      # change) - both consumers handle that honestly rather than guessing.
+      - name: Read the outgoing (currently-live) commit
+        id: outgoing
+        run: |
+          OUT=$(curl -s -m 15 "${GATEWAY_URL}/healthz" | jq -r '.commit // empty' 2>/dev/null || true)
+          echo "commit=$OUT" >> "$GITHUB_OUTPUT"
+          echo "Outgoing live commit: ${OUT:-<unknown - image predates the /healthz commit field>}"
+
       - name: Repin the App Service to the new digest
         run: |
           REF="${ACR}.azurecr.io/${IMAGE_NAME}@${{ steps.digest.outputs.digest }}"
@@ -103,22 +119,159 @@ jobs:
             --output none
           echo "Pinned $APP to $REF"
 
-      - name: Restart to pull the digest-pinned image
-        run: az webapp restart --resource-group "$AZURE_RG" --name "$APP" --output none
-
-      # The container pulls the new image, boots and runs EF migrations; expect a brief 502/no-response
-      # window first. Poll /healthz to a real 200 before declaring success.
-      - name: Verify /healthz
+      # Restart, then measure the TRUE external outage the way an outside user experiences it. The previous
+      # "Verify /healthz" step was blind: `az webapp restart` is fire-and-forget, so its first curl hit the
+      # STILL-RUNNING old container, got a 200, and declared success ~77s before the new image actually
+      # served traffic (deploy-ledger baseline: pipeline believed outage ~0, reality ~95s). This step polls
+      # the PUBLIC url every 2s and does not accept a 200 until /healthz reports the commit we just shipped,
+      # sustained 3 times. It records:
+      #   - last_serving: last 200 that was NOT yet the new commit (the old container up, or a bare 200 from
+      #     an image predating the .commit field) - i.e. the last moment traffic was still being served.
+      #   - first_ready: first of the sustained run of 200s on the NEW commit - the moment the new image took
+      #     over external traffic.
+      # external outage = first_ready - last_serving (the dead window), time-to-healthy = first_ready -
+      # t_deploy. The same logic reports a near-zero outage for a warmed slot swap, so it stays honest when
+      # this pipeline moves to slots.
+      - name: Restart and measure true external readiness
+        id: readiness
         run: |
-          for i in $(seq 1 30); do
-            code=$(curl -s -m 15 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/healthz" || true)
-            echo "attempt $i: HTTP $code"
-            if [ "$code" = "200" ]; then
-              echo "Gateway healthy at ${GATEWAY_URL}"
-              curl -s -m 15 "${GATEWAY_URL}/healthz"; echo
-              exit 0
+          TARGET="${{ steps.short.outputs.short }}"
+          t_deploy=$(date +%s)
+          az webapp restart --resource-group "$AZURE_RG" --name "$APP" --output none
+
+          last_serving=""
+          first_ready=""
+          streak=0
+          deadline=$(( t_deploy + 600 ))
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            now=$(date +%s)
+            body=$(curl -s -m 10 -w '\n%{http_code}' "${GATEWAY_URL}/healthz" 2>/dev/null || printf '\n000')
+            code=$(printf '%s' "$body" | tail -n1)
+            json=$(printf '%s' "$body" | sed '$d')
+            commit=$(printf '%s' "$json" | jq -r '.commit // empty' 2>/dev/null || echo "")
+            if [ "$code" = "200" ] && [ "$commit" = "$TARGET" ]; then
+              streak=$(( streak + 1 ))
+              [ -z "$first_ready" ] && first_ready=$now
+              echo "$(date -u +%H:%M:%SZ) HTTP 200 commit=$commit (new, streak $streak)"
+              [ "$streak" -ge 3 ] && break
+            else
+              streak=0
+              first_ready=""
+              if [ "$code" = "200" ]; then
+                last_serving=$now
+                echo "$(date -u +%H:%M:%SZ) HTTP 200 commit=${commit:-<none>} (old container still serving)"
+              else
+                echo "$(date -u +%H:%M:%SZ) HTTP $code (outage)"
+              fi
             fi
-            sleep 10
+            sleep 2
           done
-          echo "ERROR: /healthz did not return 200 within the timeout"
-          exit 1
+
+          if [ -z "$first_ready" ]; then
+            echo "ERROR: new commit $TARGET never served a sustained 200 within the timeout"
+            echo "outcome=failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          if [ -n "$last_serving" ]; then outage=$(( first_ready - last_serving )); else outage=0; fi
+          tth=$(( first_ready - t_deploy ))
+          echo "outage_seconds=$outage" >> "$GITHUB_OUTPUT"
+          echo "time_to_healthy_seconds=$tth" >> "$GITHUB_OUTPUT"
+          echo "outcome=healthy" >> "$GITHUB_OUTPUT"
+          echo "New image ${TARGET} serving. External outage ~${outage}s, time-to-healthy ~${tth}s."
+          curl -s -m 15 "${GATEWAY_URL}/healthz"; echo
+
+      # Does this deploy carry a schema change to the LIVE Supabase Postgres? Diff the Postgres migration set
+      # (the one Database.Migrate() applies on hosted) between the outgoing live commit and the shipped one.
+      # "unknown" (never a guess) when the outgoing commit is not readable - the image predated the .commit
+      # field, or the commit is not in this shallow clone.
+      - name: Detect migration delta
+        id: migration
+        if: always()
+        run: |
+          OUT="${{ steps.outgoing.outputs.commit }}"
+          if [ -z "$OUT" ]; then
+            echo "migration=unknown" >> "$GITHUB_OUTPUT"
+            echo "Outgoing commit unknown - cannot diff migrations."
+            exit 0
+          fi
+          git fetch --depth=200 origin >/dev/null 2>&1 || true
+          if git cat-file -e "${OUT}^{commit}" 2>/dev/null; then
+            n=$(git diff --name-only "$OUT" HEAD -- 'src/CcDirector.Gateway.Migrations.Postgres/Migrations/' | grep -c . || true)
+            if [ "${n:-0}" -gt 0 ]; then
+              echo "migration=yes" >> "$GITHUB_OUTPUT"
+              echo "Migration delta: $n changed Postgres migration file(s) between $OUT and HEAD."
+            else
+              echo "migration=no" >> "$GITHUB_OUTPUT"
+              echo "No Postgres migration change between $OUT and HEAD (code-only deploy)."
+            fi
+          else
+            echo "migration=unknown" >> "$GITHUB_OUTPUT"
+            echo "Outgoing commit $OUT not present in this clone - cannot diff migrations."
+          fi
+
+      # Auto-emit the per-deploy metrics so tracking is automatic, not a hand-measured after-the-fact note.
+      # Runs even on a failed readiness check so a bad deploy is recorded too. Writes a ledger-ready markdown
+      # row to the job summary AND a machine-readable deploy-metrics.json artifact. It does NOT push to the
+      # ledger in the PRIVATE devthrottle_internal repo: that would need a stored cross-repo token, and this
+      # workflow is deliberately secretless (OIDC only). Paste the row from the summary, or wire a scoped PAT
+      # later if fully-hands-off ledger commits are wanted.
+      - name: Emit deploy metrics
+        id: metrics
+        if: always()
+        run: |
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          TARGET="${{ steps.short.outputs.short }}"
+          FULL=$(git rev-parse HEAD)
+          OUTCOME="${{ steps.readiness.outputs.outcome }}"; OUTCOME="${OUTCOME:-failed}"
+          BUILD_S="${{ steps.build.outputs.build_seconds }}"; BUILD_S="${BUILD_S:-}"
+          OUTAGE_S="${{ steps.readiness.outputs.outage_seconds }}"
+          TTH_S="${{ steps.readiness.outputs.time_to_healthy_seconds }}"
+          MIG="${{ steps.migration.outputs.migration }}"; MIG="${MIG:-unknown}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          cat > deploy-metrics.json <<JSON
+          {
+            "timestamp_utc": "$NOW",
+            "commit_short": "$TARGET",
+            "commit_full": "$FULL",
+            "outgoing_commit": "${{ steps.outgoing.outputs.commit }}",
+            "run_id": "${{ github.run_id }}",
+            "run_url": "$RUN_URL",
+            "outcome": "$OUTCOME",
+            "build_seconds": "${BUILD_S}",
+            "external_outage_seconds": "${OUTAGE_S}",
+            "time_to_healthy_seconds": "${TTH_S}",
+            "migration": "$MIG",
+            "rollback": "no"
+          }
+          JSON
+
+          {
+            echo "## Hosted Gateway deploy metrics"
+            echo ""
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| time (UTC) | $NOW |"
+            echo "| commit | \`$TARGET\` |"
+            echo "| outcome | $OUTCOME |"
+            echo "| build | ${BUILD_S:-?}s |"
+            echo "| external outage | ${OUTAGE_S:-?}s |"
+            echo "| time-to-healthy | ${TTH_S:-?}s |"
+            echo "| migration | $MIG |"
+            echo "| rollback | no |"
+            echo "| run | $RUN_URL |"
+            echo ""
+            echo "Ledger-ready row (paste into deploy-ledger.md):"
+            echo ""
+            echo "\`\`\`"
+            echo "$NOW | \`$TARGET\` | ${{ github.run_id }} | build ${BUILD_S:-?}s | migration $MIG | external outage ${OUTAGE_S:-?}s | time-to-healthy ${TTH_S:-?}s | $OUTCOME"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload deploy metrics artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-metrics
+          path: deploy-metrics.json
+          if-no-files-found: warn

--- a/src/CcDirector.Gateway.Contracts/HealthDto.cs
+++ b/src/CcDirector.Gateway.Contracts/HealthDto.cs
@@ -25,6 +25,20 @@ public sealed class HealthDto
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     public int? Sessions { get; set; }
     public string Version { get; set; } = "";
+
+    /// <summary>
+    /// The exact source commit this running image was built from (the short SHA stamped into the container
+    /// as the COCKPIT_COMMIT build argument), or NULL when the responder has no such stamp - in which case
+    /// it is OMITTED from the JSON. Unlike <see cref="Version"/>, which is a hand-bumped product version that
+    /// does NOT change per commit, this identifies the precise deployed build. The deploy pipeline reads it
+    /// to tell the OLD container apart from the NEW one during a redeploy: it polls /healthz until this
+    /// reports the commit it just shipped, which is the only honest signal that the new image is actually
+    /// serving traffic (the old container answers 200 right up until it is recycled). Fleet-global build
+    /// identity, identical for every tenant, so it carries no per-tenant fact and is safe on hosted.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    public string? Commit { get; set; }
+
     public DateTime ServerTime { get; set; } = DateTime.UtcNow;
 
     /// <summary>Director's GUID. Empty when returned by the Gateway aggregator.</summary>

--- a/src/CcDirector.Gateway.Tests/HealthzCommitFieldTests.cs
+++ b/src/CcDirector.Gateway.Tests/HealthzCommitFieldTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// <c>/healthz</c> reports the exact commit the running image was built from (the COCKPIT_COMMIT the
+/// Dockerfile bakes into the container as an ENV), so the deploy pipeline can tell the OLD container apart
+/// from the NEW one during a redeploy. Without this the pipeline's readiness check accepts the still-running
+/// old container's 200 and exits BEFORE the new image is actually serving - it believes the outage is ~0
+/// when the real external outage was ~95s (see deploy-ledger baseline rep 1). The pipeline now polls until
+/// this field equals the commit it just shipped, which is the only honest "the new image is live" signal.
+///
+/// Reported on BOTH the hosted and self-host branches of the handler: build identity is identical for every
+/// tenant, so it carries no per-tenant fact and is safe on the public hosted probe.
+///
+/// The assembly runs sequentially (TestParallelization), so setting COCKPIT_COMMIT here is safe.
+/// </summary>
+public sealed class HealthzCommitFieldTests
+{
+    private const string Token = "test-token";
+
+    [Theory]
+    [InlineData(true)]   // hosted branch
+    [InlineData(false)]  // self-host branch
+    public async Task Healthz_reports_the_built_commit_when_stamped(bool hosted)
+    {
+        var (health, rawJson) = await ProbeHealthz(hosted, commitEnv: "abc1234");
+
+        // The precise deployed build. This is what the deploy pipeline polls for; with the field dropped
+        // from the handler it goes absent and the pipeline can no longer distinguish the new image, so this
+        // pins the change on both tenancy branches.
+        Assert.Equal("abc1234", health.Commit);
+        Assert.Contains("\"commit\"", rawJson);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Healthz_omits_the_commit_when_unstamped(bool hosted)
+    {
+        // No COCKPIT_COMMIT (a local dev run). Absent, not empty-string: HealthDto omits a null Commit, so a
+        // probe reading it can tell "no build stamp" from "built at commit ''" - the same honesty rule the
+        // Directors/Sessions counts follow.
+        var (health, rawJson) = await ProbeHealthz(hosted, commitEnv: null);
+
+        Assert.Null(health.Commit);
+        Assert.DoesNotContain("\"commit\"", rawJson);
+    }
+
+    private static async Task<(HealthDto Health, string RawJson)> ProbeHealthz(bool hosted, string? commitEnv)
+    {
+        var priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        var priorCommit = Environment.GetEnvironmentVariable("COCKPIT_COMMIT");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+        Environment.SetEnvironmentVariable("COCKPIT_COMMIT", commitEnv);
+        var instancesDir = Path.Combine(Path.GetTempPath(), "cc-hz-commit-" + Guid.NewGuid().ToString("N"));
+        var gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: instancesDir,
+            workListsPath: Path.Combine(instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        try
+        {
+            await gateway.StartAsync();
+
+            // NO credential: /healthz is public.
+            using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{gateway.Port}/") };
+            var resp = await http.GetAsync("healthz");
+            resp.EnsureSuccessStatusCode();
+            var raw = await resp.Content.ReadAsStringAsync();
+            var dto = System.Text.Json.JsonSerializer.Deserialize<HealthDto>(raw,
+                          new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web))
+                      ?? throw new InvalidOperationException("healthz returned no body");
+            return (dto, raw);
+        }
+        finally
+        {
+            await gateway.StopAsync();
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", priorHosted);
+            Environment.SetEnvironmentVariable("COCKPIT_COMMIT", priorCommit);
+            // Deliberately NOT deleting instancesDir (see HealthzTenantLeakTests for why a delete here can
+            // crash the whole test process via a late FileSystemWatcher event). The OS reclaims the temp dir.
+        }
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -361,6 +361,14 @@ internal static class GatewayEndpoints
         // ===== REST =====
         app.MapGet("/healthz", () =>
         {
+            // The exact commit this image was built from (COCKPIT_COMMIT is baked into the container as an
+            // ENV in the Dockerfile). NULL when unstamped (e.g. a local dev run) - HealthDto omits it then.
+            // The deploy pipeline polls /healthz until this equals the commit it just shipped: that is the
+            // honest "the new image is now serving" signal, because the OLD container keeps answering 200
+            // until the very moment it is recycled. Reported on both the hosted and self-host branches -
+            // build identity is the same for every tenant, so it carries no per-tenant fact.
+            var commit = Environment.GetEnvironmentVariable("COCKPIT_COMMIT");
+
             // Hosted Multi-Tenancy (session-serving PR2): /healthz is PUBLIC - it is the unauthenticated
             // liveness probe every Director and endpoint selector dials, so it carries no credential and
             // therefore has NO TENANT. On the hosted Gateway the fleet counts below are fleet-GLOBAL: an
@@ -381,6 +389,7 @@ internal static class GatewayEndpoints
                 {
                     Status = "ok",
                     Version = version,
+                    Commit = commit,
                     ServerTime = DateTime.UtcNow,
                 });
             }
@@ -402,6 +411,7 @@ internal static class GatewayEndpoints
                 Directors = directors.Count,
                 Sessions = totalSessions,
                 Version = version,
+                Commit = commit,
                 ServerTime = DateTime.UtcNow,
             });
         });


### PR DESCRIPTION
## What

The hosted-gateway deploy pipeline reported a near-zero outage while the real external downtime was about 95 seconds (see the deploy ledger baseline). The verify step curled the public health endpoint right after issuing an asynchronous App Service restart, so its first curl hit the still-running old container, got a 200, and the run finished about 77 seconds before the new image actually served traffic.

This makes the measurement honest and records it automatically. It does not by itself shorten the outage - it is the instrument that proves any future reduction (deployment slots) actually works.

## Changes

- **Health endpoint reports the built commit.** The container already bakes its source commit in as `COCKPIT_COMMIT`; expose it as the health response `commit` field (omitted when unstamped, mirroring how the fleet counts are omitted). This is the signal that distinguishes the old container from the new one, on both the hosted and self-host branches.
- **Verify step measures true external readiness.** It polls the public URL and refuses a 200 until the health endpoint reports the shipped commit, sustained three times, recording the last-serving moment before the gap and the first-serving moment of the new image. The same logic reports a near-zero outage for a warmed slot swap.
- **Migration detection.** Diffs the Postgres migration set between the outgoing live commit and the shipped one.
- **Auto-emitted metrics.** Build time, external outage, time-to-healthy, migration yes/no and rollback, as a ledger-ready row in the job summary plus a machine-readable artifact.

## Tests

New tests assert the health commit field is present when stamped and omitted when not, on both tenancy branches. Existing health tenant-leak tests still pass. The outage-measurement algorithm was validated against scripted sequences (normal outage, instant slot-like swap, bootstrap without the field, flapping instance).