### PR TITLE
Add slot provisioning and rollback workflows for the hosted Gateway

### DIFF
--- a/.github/workflows/provision-hosted-gateway-slots.yml
+++ b/.github/workflows/provision-hosted-gateway-slots.yml
@@ -1,0 +1,125 @@
+name: Provision hosted Gateway slots
+
+# One-time (idempotent, safe to re-run) infrastructure change that moves the hosted Gateway onto an
+# App Service tier that supports DEPLOYMENT SLOTS and creates a warmed "staging" slot. This is what lets
+# a deploy become a warmed slot swap - the old instance keeps serving until the new one is proven healthy,
+# so the external outage drops from a ~95s in-place restart to a few seconds of hand-off.
+#
+# This does NOT deploy application code and it does NOT run on a push. A human starts it deliberately from
+# the Actions UI or with `gh workflow run provision-hosted-gateway-slots.yml`. Like the deploy workflow it
+# needs NO stored secret - only the Azure OIDC federated login as the devthrottle-hosted-gateway service
+# principal (Contributor on the subscription, which can change the plan SKU and create slots).
+#
+# What it ensures, each step create-if-absent / set-in-place:
+#   1. The App Service Plan is at a slot-capable SKU (S1 by default). Basic (B1) supports zero slots.
+#   2. A "staging" slot exists, its configuration cloned from production (same image, same app settings
+#      incl. the Supabase connection and CC_DIRECTOR_ROOT, so it behaves like production while warming).
+#   3. The Azure Files share is mounted on staging (configuration-source does not clone storage mounts).
+#   4. The swap warmup gate is set: a swap into production is not completed until the incoming instance
+#      answers /healthz 200, so users never cut over to a cold instance.
+#   5. The staging slot is STOPPED. Steady state is ONE running instance writing the shared file mount;
+#      the deploy pipeline starts staging only for the duration of a deploy and stops it again after the
+#      swap, so the two-writers-on-the-share window is bounded to the warmup, never permanent.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_sku:
+        description: App Service Plan SKU to ensure (S1 is the cheapest tier with deployment slots)
+        required: false
+        default: S1
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AZURE_RG: rg-devthrottle-hosted-gateway
+  PLAN: plan-devthrottle-gw
+  APP: devthrottle-gw
+  SLOT: staging
+  STORAGE: stdevthrottlegw
+  SHARE: gwdata
+  MOUNT_PATH: /home/gateway/cc-director
+
+jobs:
+  provision:
+    name: Ensure S1 plan and a warmed staging slot
+    runs-on: ubuntu-latest
+    environment: hosted-gateway-production
+
+    steps:
+      - name: Azure login (OIDC, no stored secret)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_GW_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_GW_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_GW_SUBSCRIPTION_ID }}
+
+      - name: Show current plan SKU
+        run: az appservice plan show -g "$AZURE_RG" -n "$PLAN" --query "{name:sku.name,tier:sku.tier,capacity:sku.capacity}" -o json
+
+      - name: Ensure the plan is at a slot-capable SKU
+        run: |
+          CUR=$(az appservice plan show -g "$AZURE_RG" -n "$PLAN" --query "sku.name" -o tsv)
+          echo "Current SKU: $CUR ; target: ${{ inputs.target_sku }}"
+          if [ "$CUR" != "${{ inputs.target_sku }}" ]; then
+            az appservice plan update -g "$AZURE_RG" -n "$PLAN" --sku "${{ inputs.target_sku }}" -o none
+            echo "Upgraded plan $PLAN to ${{ inputs.target_sku }}"
+          else
+            echo "Plan already at ${{ inputs.target_sku }} - nothing to do"
+          fi
+
+      - name: Ensure the staging slot exists (config cloned from production)
+        run: |
+          if az webapp deployment slot list -g "$AZURE_RG" -n "$APP" --query "[?name=='$SLOT'] | length(@)" -o tsv | grep -q '^1$'; then
+            echo "Slot '$SLOT' already exists"
+          else
+            az webapp deployment slot create -g "$AZURE_RG" -n "$APP" --slot "$SLOT" \
+              --configuration-source "$APP" -o none
+            echo "Created slot '$SLOT' with configuration cloned from production"
+          fi
+
+      - name: Mount the Azure Files share on the staging slot
+        run: |
+          KEY=$(az storage account keys list -g "$AZURE_RG" --account-name "$STORAGE" --query '[0].value' -o tsv)
+          if az webapp config storage-account list -g "$AZURE_RG" -n "$APP" --slot "$SLOT" \
+               --query "[?name=='gwdata'] | length(@)" -o tsv 2>/dev/null | grep -q '^1$'; then
+            echo "Mount 'gwdata' already present on staging -> update"
+            az webapp config storage-account update -g "$AZURE_RG" -n "$APP" --slot "$SLOT" \
+              --custom-id gwdata --storage-type AzureFiles --share-name "$SHARE" \
+              --account-name "$STORAGE" --access-key "$KEY" --mount-path "$MOUNT_PATH" -o none
+          else
+            az webapp config storage-account add -g "$AZURE_RG" -n "$APP" --slot "$SLOT" \
+              --custom-id gwdata --storage-type AzureFiles --share-name "$SHARE" \
+              --account-name "$STORAGE" --access-key "$KEY" --mount-path "$MOUNT_PATH" -o none
+          fi
+          echo "Azure Files share mounted on staging at $MOUNT_PATH"
+
+      - name: Match production runtime flags on staging (Always On, WebSockets, HTTPS only)
+        run: |
+          az webapp config set -g "$AZURE_RG" -n "$APP" --slot "$SLOT" \
+            --always-on true --web-sockets-enabled true -o none
+          az webapp update -g "$AZURE_RG" -n "$APP" --slot "$SLOT" --https-only true -o none
+
+      - name: Set the swap warmup gate (production and staging)
+        run: |
+          # The platform will not complete a swap until the instance being moved into the destination slot
+          # answers /healthz with 200. Set identically on both slots so a forward swap and a swap-back are
+          # equally gated. These are platform settings, harmless to swap (identical on both sides).
+          az webapp config appsettings set -g "$AZURE_RG" -n "$APP" --settings \
+            WEBSITE_SWAP_WARMUP_PING_PATH=/healthz \
+            WEBSITE_SWAP_WARMUP_PING_STATUSES=200 -o none
+          az webapp config appsettings set -g "$AZURE_RG" -n "$APP" --slot "$SLOT" --settings \
+            WEBSITE_SWAP_WARMUP_PING_PATH=/healthz \
+            WEBSITE_SWAP_WARMUP_PING_STATUSES=200 -o none
+
+      - name: Stop the staging slot (steady state is one running instance)
+        run: az webapp stop -g "$AZURE_RG" -n "$APP" --slot "$SLOT" -o none
+
+      - name: Report final state
+        run: |
+          echo "== Plan =="
+          az appservice plan show -g "$AZURE_RG" -n "$PLAN" --query "{name:sku.name,tier:sku.tier}" -o table
+          echo "== Slots =="
+          az webapp deployment slot list -g "$AZURE_RG" -n "$APP" --query "[].{name:name,state:state}" -o table

--- a/.github/workflows/rollback-hosted-gateway.yml
+++ b/.github/workflows/rollback-hosted-gateway.yml
@@ -1,0 +1,88 @@
+name: Rollback hosted Gateway
+
+# Emergency levers for the hosted Gateway, run by a human deliberately. Two actions:
+#
+#   swap-back  - a deploy swapped bad code into production; the previous instance is still sitting in the
+#                staging slot, so swapping again puts it straight back. This is the fast recovery: seconds,
+#                no rebuild. Only valid right after a bad deploy and before the staging slot is stopped or
+#                overwritten by the next deploy.
+#
+#   downgrade  - abandon slots and return the plan to Basic (B1). Deletes the staging slot first (a slot
+#                cannot exist on Basic). Use only if we decide to stop paying for the Standard tier; it
+#                brings back the ~95s in-place-restart deploys.
+#
+# OIDC login only, no stored secret, same service principal as the deploy and provisioning workflows.
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Which rollback to run
+        required: true
+        type: choice
+        options:
+          - swap-back
+          - downgrade
+      downgrade_sku:
+        description: SKU to return to when action=downgrade (Basic B1 has no slots)
+        required: false
+        default: B1
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AZURE_RG: rg-devthrottle-hosted-gateway
+  PLAN: plan-devthrottle-gw
+  APP: devthrottle-gw
+  SLOT: staging
+  GATEWAY_URL: https://devthrottle-gw.azurewebsites.net
+
+jobs:
+  rollback:
+    name: Roll the hosted Gateway back
+    runs-on: ubuntu-latest
+    environment: hosted-gateway-production
+
+    steps:
+      - name: Azure login (OIDC, no stored secret)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_GW_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_GW_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_GW_SUBSCRIPTION_ID }}
+
+      - name: Swap the previous instance back into production
+        if: ${{ inputs.action == 'swap-back' }}
+        run: |
+          # The staging slot must be running to be swapped. Start it (a no-op if already up), then swap.
+          az webapp start -g "$AZURE_RG" -n "$APP" --slot "$SLOT" -o none
+          az webapp deployment slot swap -g "$AZURE_RG" -n "$APP" \
+            --slot "$SLOT" --target-slot production -o none
+          echo "Swapped '$SLOT' back into production. Verifying /healthz..."
+          for i in $(seq 1 30); do
+            code=$(curl -s -m 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/healthz" || true)
+            echo "attempt $i: HTTP $code"
+            [ "$code" = "200" ] && { echo "Recovered."; break; }
+            sleep 3
+          done
+          curl -s -m 15 "${GATEWAY_URL}/healthz"; echo
+          az webapp stop -g "$AZURE_RG" -n "$APP" --slot "$SLOT" -o none
+          echo "Staging stopped; steady state restored to one running instance."
+
+      - name: Downgrade the plan (delete staging, return to Basic)
+        if: ${{ inputs.action == 'downgrade' }}
+        run: |
+          if az webapp deployment slot list -g "$AZURE_RG" -n "$APP" --query "[?name=='$SLOT'] | length(@)" -o tsv | grep -q '^1$'; then
+            az webapp deployment slot delete -g "$AZURE_RG" -n "$APP" --slot "$SLOT"
+            echo "Deleted slot '$SLOT'"
+          fi
+          az appservice plan update -g "$AZURE_RG" -n "$PLAN" --sku "${{ inputs.downgrade_sku }}" -o none
+          echo "Plan returned to ${{ inputs.downgrade_sku }}. Deploys are back to in-place restart."
+
+      - name: Report
+        if: always()
+        run: |
+          az appservice plan show -g "$AZURE_RG" -n "$PLAN" --query "{sku:sku.name}" -o table
+          az webapp deployment slot list -g "$AZURE_RG" -n "$APP" --query "[].{name:name,state:state}" -o table 2>/dev/null || true


### PR DESCRIPTION
## What

Two manual, OIDC-only operational workflows that move the hosted Gateway onto zero-downtime slot deploys. This is the infrastructure half of taking the deploy outage from ~95s (in-place restart) to a few seconds (warmed slot swap).

Neither deploys application code, and neither runs on a push - a human starts them deliberately. They need no stored secret, only the existing Azure federated login.

### provision-hosted-gateway-slots
Idempotent, safe to re-run:
- Ensures the App Service Plan is at a slot-capable SKU (S1 by default; Basic supports zero slots).
- Creates a `staging` slot with its configuration cloned from production (same image, same app settings including the Supabase connection and storage root).
- Mounts the same Azure Files share on staging.
- Sets the swap warmup gate (`WEBSITE_SWAP_WARMUP_PING_PATH=/healthz`, statuses 200) so a swap is never completed until the incoming instance is healthy.
- Stops the staging slot, so steady state stays a single running instance writing the shared mount. The deploy pipeline runs staging only for the duration of a deploy.

### rollback-hosted-gateway
- `swap-back`: returns the previous instance (still in the staging slot) to production in seconds, no rebuild.
- `downgrade`: deletes the staging slot and returns the plan to Basic, if slots are ever abandoned.

## Notes

The paired deploy-pipeline change (deploy to staging, warm, swap, stop) lands in a follow-up so this infrastructure can be provisioned and the staging slot smoke-tested first.