### PR TITLE
feat(director): client handling for the cancellation cutoff - stop retrying + 'subscription required'

### DIFF
--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
@@ -192,7 +192,8 @@ public partial class GatewayConnectionPanel : UserControl
         // A prior failure (or a lost tailnet identity) opens Step 1 in REPAIR mode (Phase 5): the failing
         // leg is named, diagnostics render inline, and the rediscovery scan offers the new address. Repair
         // reconnects a known Gateway, so it skips the choice.
-        if (status is GatewayConnectionStatus.Failed or GatewayConnectionStatus.NoTailnetIdentity)
+        if (status is GatewayConnectionStatus.Failed or GatewayConnectionStatus.NoTailnetIdentity
+            or GatewayConnectionStatus.SubscriptionRequired)
             return new GatewayConnectionPanel(GatewayPanelStep.Connect, repairMode: true, consumer, showChoiceFirst: false);
 
         // Otherwise a fresh connect: open on the gateway CHOICE step (#1808a).
@@ -674,6 +675,7 @@ public partial class GatewayConnectionPanel : UserControl
         GatewayConnectionStatus.Connected => "CONNECTED - this Director's tunnel to the Gateway is up, which is what lets the two reach each other.",
         GatewayConnectionStatus.Failed => $"NOT CONNECTED - {m.FailureSummary}",
         GatewayConnectionStatus.NoTailnetIdentity => $"No tailnet identity - {m.FailureSummary}",
+        GatewayConnectionStatus.SubscriptionRequired => $"SUBSCRIPTION REQUIRED - {m.FailureSummary}",
         GatewayConnectionStatus.Connecting => "Connecting - the tunnel is dialing. Re-open diagnostics in a few seconds.",
         _ => "No Gateway is configured.",
     };

--- a/src/CcDirector.ControlApi/GatewayConnectionMonitor.cs
+++ b/src/CcDirector.ControlApi/GatewayConnectionMonitor.cs
@@ -33,6 +33,15 @@ public enum GatewayConnectionStatus
     /// ~15s of Tailscale coming up - no restart.
     /// </summary>
     NoTailnetIdentity,
+
+    /// <summary>
+    /// The hosted subscription (or device enrollment) for this Gateway has lapsed or been revoked, so the
+    /// Gateway refused the tunnel with a TERMINAL 401/402. The Director STOPPED reconnecting - there is no point
+    /// hammering a locked door - and this state names the fix on screen (renew the subscription / re-enroll)
+    /// with a link to Billing. Distinct from <see cref="Failed"/> (which keeps retrying) and from
+    /// <see cref="Connecting"/>: a red, non-retrying "your subscription lapsed" state.
+    /// </summary>
+    SubscriptionRequired,
 }
 
 /// <summary>
@@ -166,6 +175,28 @@ public sealed class GatewayConnectionMonitor
             FailureSummary = summary;
         }
         FileLog.Write($"[GatewayConnectionMonitor] Tailnet identity failure: {summary}");
+        Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// The Gateway refused the tunnel with a TERMINAL 401/402 - the hosted subscription lapsed or the device
+    /// was revoked (e.g. the customer stopped paying). The Director has STOPPED its reconnect loop, so this
+    /// surfaces the reason and the fix (renew / re-enroll) instead of a forever-yellow "connecting" or a
+    /// retrying red. <see cref="LastVerifiedAt"/> survives so the UI can show "connected until HH:mm". Sticky
+    /// NotConfigured (a local-only Director never hits this). Cleared by <see cref="Reset"/> on a settings
+    /// change or a re-enrollment, which restarts the tunnel.
+    /// </summary>
+    public void MarkSubscriptionRequired(string summary)
+    {
+        lock (_lock)
+        {
+            // NotConfigured is sticky until Reset(true): a local-only Director never goes here.
+            if (Status == GatewayConnectionStatus.NotConfigured) return;
+            if (Status == GatewayConnectionStatus.SubscriptionRequired && FailureSummary == summary) return; // no churn
+            Status = GatewayConnectionStatus.SubscriptionRequired;
+            FailureSummary = summary;
+        }
+        FileLog.Write("[GatewayConnectionMonitor] subscription required - tunnel refused (terminal 401/402); reconnect stopped");
         Changed?.Invoke();
     }
 

--- a/src/CcDirector.ControlApi/GatewayStreamClient.cs
+++ b/src/CcDirector.ControlApi/GatewayStreamClient.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Http;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Network;
 using CcDirector.Core.Sessions;
@@ -235,11 +237,20 @@ public sealed class GatewayStreamClient : IAsyncDisposable
 
         while (!_disposed)
         {
-            if (await TryConnectAsync())
+            var outcome = await TryConnectAsync();
+            if (outcome == ConnectOutcome.Connected)
             {
                 await ReseedAsync();
                 _monitor?.MarkTunnelConnected();   // tunnel up = the two-way connection is proven (green)
                 await WaitUntilClosedAsync();      // returns when auto-reconnect has exhausted its attempts
+            }
+            else if (outcome == ConnectOutcome.SubscriptionRequired)
+            {
+                // The Gateway refused the device key (subscription lapsed / revoked). STOP - do not hammer a
+                // locked door. The status names the fix (renew / re-enroll); a settings change or a fresh
+                // enrollment rebuilds this client and re-dials.
+                _monitor?.MarkSubscriptionRequired("This gateway needs an active subscription - renew your subscription or re-enroll this device.");
+                break;
             }
             if (_disposed) break;
             _monitor?.MarkTunnelConnecting();      // dropped / dialing again (yellow) until the next connect
@@ -247,20 +258,55 @@ public sealed class GatewayStreamClient : IAsyncDisposable
         }
     }
 
-    private async Task<bool> TryConnectAsync()
+    private enum ConnectOutcome
     {
-        if (_connection is null) return false;
+        /// <summary>The tunnel is up.</summary>
+        Connected,
+        /// <summary>A retryable failure (Gateway down, network blip) - keep re-dialing.</summary>
+        Retry,
+        /// <summary>A TERMINAL refusal: the Gateway rejected the device key with 401/402 (the hosted
+        /// subscription lapsed or the device was revoked). Do NOT keep hammering - stop and surface it.</summary>
+        SubscriptionRequired,
+    }
+
+    private async Task<ConnectOutcome> TryConnectAsync()
+    {
+        if (_connection is null) return ConnectOutcome.Retry;
         try
         {
             await _connection.StartAsync();
             FileLog.Write($"[GatewayStreamClient] connected to {_config.Url}");
-            return true;
+            return ConnectOutcome.Connected;
+        }
+        catch (Exception ex) when (IsSubscriptionRequired(ex))
+        {
+            // Terminal: the per-device key is no longer accepted (revoked / subscription lapsed). Re-dialing
+            // would just get refused again forever, so stop and let the connection status say why (the fix is
+            // to renew the subscription / re-enroll, which restarts the client).
+            FileLog.Write("[GatewayStreamClient] connect REFUSED (subscription required / device revoked) - stopping reconnect");
+            return ConnectOutcome.SubscriptionRequired;
         }
         catch (Exception ex)
         {
             FileLog.Write($"[GatewayStreamClient] connect failed (will retry): {ex.Message}");
-            return false;
+            return ConnectOutcome.Retry;
         }
+    }
+
+    /// <summary>
+    /// A tunnel-connect exception is a TERMINAL "subscription required" when the Gateway refused the device
+    /// key with 401 (credential revoked) or 402 (hosted subscription required). The key is a fixed per-device
+    /// credential, never refreshed, so a 401/402 means it is no longer valid - not a transient blip - and the
+    /// only fix is renewing the subscription or re-enrolling. Walks the inner-exception chain because SignalR
+    /// wraps the negotiate failure.
+    /// </summary>
+    private static bool IsSubscriptionRequired(Exception ex)
+    {
+        for (Exception? e = ex; e is not null; e = e.InnerException)
+            if (e is HttpRequestException hre
+                && hre.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.PaymentRequired)
+                return true;
+        return false;
     }
 
     private async Task WaitUntilClosedAsync()


### PR DESCRIPTION
The gateway side of the cancellation cutoff (MTR-15) denies + revokes a non-paying tenant. This is the CLIENT half: the Director's app reacts gracefully instead of spinning on errors.

- **Stop hammering:** GatewayStreamClient now tells a TERMINAL refusal (401 credential revoked / 402 subscription required - the fixed per-device key is no longer accepted) apart from a retryable failure, and STOPS the reconnect loop instead of re-dialing every 5s forever.
- **Say why:** a new GatewayConnectionStatus.SubscriptionRequired (with a message) is set; the desktop connection panel renders a red 'SUBSCRIPTION REQUIRED - renew your subscription or re-enroll this device' verdict.
- **Voice/Wingman unchanged:** the 'you don't have this feature' 402 message already flows into the shared CreditsNotice banner (epic thefrederiksen/devthrottle_internal#661) - reused, not rebuilt.

A settings change or re-enrollment rebuilds the client and re-dials. Follow-up (small): a dedicated 'Go to Billing' button on the panel; wiring the same state into the web cockpit/mobile surfaces.