### PR TITLE
fix(terminal): pace clipboard paste off the UI thread

### DIFF
--- a/src/CcDirector.Terminal.Avalonia.Tests/PasteOffUiThreadTests.cs
+++ b/src/CcDirector.Terminal.Avalonia.Tests/PasteOffUiThreadTests.cs
@@ -1,0 +1,114 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Xunit;
+
+namespace CcDirector.Terminal.Avalonia.Tests;
+
+/// <summary>
+/// Regression guard for the slow-paste fix. Pasting into the terminal used to type the clipboard one
+/// chunk at a time while awaiting back onto the Avalonia UI thread. On a Director hosting many
+/// sessions the UI thread is saturated with rendering, so the per-chunk delay continuations sat
+/// unscheduled for seconds: a real 92-character claude /login code took 22.6s on this machine, with
+/// 11 chunks stalling over 800ms each (one for 7.3s), while the same paste was near-instant on an
+/// idle machine. The fix runs the pacing loop on the thread pool (Task.Run + ConfigureAwait(false)),
+/// so paste speed no longer depends on UI-thread availability.
+///
+/// These tests reproduce the exact condition - a fully blocked UI thread - and assert that the real
+/// production pacing (<see cref="TerminalControl.HarnessPaceChunksAsync"/>) sails through it, whereas
+/// the old naive UI-thread-resuming loop stalls for the whole block. The contrast is the point: if a
+/// change makes the production pacing resume on the UI thread again, the first assertion fails.
+/// </summary>
+public sealed class PasteOffUiThreadTests
+{
+    // The paste that bit the user: a 92-character single-line code, no newlines.
+    private const int PasteLen = 92;
+
+    // How long the "render storm" pins the UI thread. Far longer than the ~180ms a 92-char paste
+    // needs when it is not blocked, so the stall - if present - is unmistakable.
+    private static readonly TimeSpan BlockDuration = TimeSpan.FromMilliseconds(2500);
+
+    [AvaloniaFact]
+    public async Task Production_pacing_does_not_stall_while_ui_thread_is_blocked()
+    {
+        var terminal = new TerminalControl();
+        var text = new string('x', PasteLen);
+
+        var stamps = new ConcurrentQueue<double>();
+        var clock = Stopwatch.StartNew();
+
+        // Pin the UI thread for the whole block, then run the REAL pacing. Because it runs on the
+        // thread pool, its chunks land during the block instead of waiting for it to end.
+        var block = BlockUiThread(BlockDuration);
+        await terminal.HarnessPaceChunksAsync(text, _ => stamps.Enqueue(clock.Elapsed.TotalMilliseconds));
+        await block;
+
+        var (span, maxGap, count) = Analyze(stamps);
+
+        Assert.True(count > 1, $"expected multiple chunks, got {count}");
+        Assert.True(span < 1000,
+            $"paste should finish well before the {BlockDuration.TotalMilliseconds}ms UI-thread block; took {span:F0}ms");
+        Assert.True(maxGap < 500,
+            $"no chunk should stall behind the blocked UI thread; largest gap was {maxGap:F0}ms");
+    }
+
+    [AvaloniaFact]
+    public async Task Naive_ui_thread_pacing_DOES_stall_while_ui_thread_is_blocked()
+    {
+        // This is the OLD behavior, inlined: await Task.Delay with no ConfigureAwait(false) and no
+        // Task.Run, so every continuation resumes on the (blocked) UI thread. Asserting that THIS
+        // stalls proves the block above genuinely saturates the UI thread - otherwise the first
+        // test would pass for the wrong reason (a block that never actually bit).
+        var text = new string('x', PasteLen);
+        var stamps = new ConcurrentQueue<double>();
+        var clock = Stopwatch.StartNew();
+
+        var block = BlockUiThread(BlockDuration);
+        await NaiveUiThreadPace(text, _ => stamps.Enqueue(clock.Elapsed.TotalMilliseconds));
+        await block;
+
+        var (span, _, count) = Analyze(stamps);
+
+        Assert.True(count > 1, $"expected multiple chunks, got {count}");
+        Assert.True(span > BlockDuration.TotalMilliseconds - 500,
+            $"naive UI-thread pacing should be held off for ~the whole {BlockDuration.TotalMilliseconds}ms block; " +
+            $"span was only {span:F0}ms");
+    }
+
+    /// <summary>The naive loop the fix replaced: chunked, but resuming on the UI thread.</summary>
+    private static async Task NaiveUiThreadPace(string text, Action<byte[]> send)
+    {
+        const int chunk = 8;
+        for (int i = 0; i < text.Length; i += chunk)
+        {
+            send(System.Text.Encoding.UTF8.GetBytes(text.Substring(i, Math.Min(chunk, text.Length - i))));
+            await Task.Delay(15); // no ConfigureAwait(false): continuation returns to the UI thread
+        }
+    }
+
+    /// <summary>Post a job that spins the UI thread for <paramref name="d"/>, blocking the dispatcher
+    /// completely. Returns a task that completes when the block ends.</summary>
+    private static Task BlockUiThread(TimeSpan d)
+    {
+        var tcs = new TaskCompletionSource();
+        Dispatcher.UIThread.Post(() =>
+        {
+            var until = Stopwatch.GetTimestamp() + (long)(d.TotalSeconds * Stopwatch.Frequency);
+            while (Stopwatch.GetTimestamp() < until) { /* pin the UI thread */ }
+            tcs.SetResult();
+        }, DispatcherPriority.Normal);
+        return tcs.Task;
+    }
+
+    private static (double span, double maxGap, int count) Analyze(ConcurrentQueue<double> stamps)
+    {
+        var times = stamps.ToArray();
+        Array.Sort(times);
+        double maxGap = 0;
+        for (int i = 1; i < times.Length; i++)
+            maxGap = Math.Max(maxGap, times[i] - times[i - 1]);
+        double span = times.Length == 0 ? 0 : times[^1] - times[0];
+        return (span, maxGap, times.Length);
+    }
+}

--- a/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
+++ b/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
@@ -132,8 +132,17 @@ public class TerminalControl : Control
     // Link detection state
     private ContextMenu? _linkContextMenu;
 
-    // Paste state
-    private bool _isPasting;
+    // Paste state. Read on the background paste thread, set on the UI thread (the
+    // Cancel Paste menu item), so it is volatile to guarantee the cancel is seen.
+    private volatile bool _isPasting;
+
+    // Paste pacing. Clipboard text is sent to the agent TUI in small chunks with a
+    // short delay between them so interactive prompts (claude /login) do not drop
+    // characters. The chunk is small enough to be one atomic pipe write that the TUI
+    // reads in a single pass; chunking rather than one-char-at-a-time cuts the number
+    // of delays (and therefore the number of chances to stall) by this factor.
+    private const int PasteChunkSize = 8;
+    private const int PasteChunkDelayMs = 15;
 
     // Renderer mode
     private ITerminalRenderer _renderer = new OriginalRenderer();
@@ -1667,17 +1676,29 @@ public class TerminalControl : Control
     }
 
     /// <summary>
-    /// Paste clipboard text to the terminal as slow keystrokes.
-    /// Sends each character individually with a small delay so the terminal
-    /// can process them (required for interactive prompts like claude /login).
+    /// Paste clipboard text to the terminal as throttled keystrokes.
+    /// Sends the text in small chunks with a short delay between chunks so the agent
+    /// TUI can process them (required for interactive prompts like claude /login,
+    /// which drop characters if fed too fast).
+    ///
+    /// The send loop runs on a background thread, NOT the Avalonia UI thread.
+    /// SendInput only writes bytes to the ConPty pipe, so it does not need the UI
+    /// thread - and on a Director hosting many sessions the UI thread is often
+    /// saturated with rendering, which used to leave the per-chunk Task.Delay
+    /// continuations unscheduled for seconds at a time. A 92-char /login code took
+    /// 22s on a loaded machine for exactly this reason (11 characters stalled over
+    /// 800ms each, one for 7.3s), while the same paste was near-instant on an idle
+    /// machine. Pacing off the UI thread makes paste speed independent of render load.
     /// </summary>
     private async Task PasteToTerminalAsync()
     {
-        if (_session == null || _isPasting) return;
+        var session = _session;
+        if (session == null || _isPasting) return;
 
         string? text;
         try
         {
+            // Clipboard access must happen on the UI thread.
             var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
             if (clipboard == null) return;
             text = await clipboard.GetTextAsync();
@@ -1698,20 +1719,56 @@ public class TerminalControl : Control
 
         try
         {
-            foreach (var ch in text)
-            {
-                if (!_isPasting) break; // Cancelled
-
-                var bytes = Encoding.UTF8.GetBytes(new[] { ch });
-                _session.SendInput(bytes);
-                await Task.Delay(15);
-            }
-
+            await PaceChunksAsync(text, bytes => session.SendInput(bytes)).ConfigureAwait(false);
             FileLog.Write($"[TerminalControl] PasteToTerminalAsync: complete ({text.Length} chars sent)");
         }
         catch (Exception ex)
         {
             FileLog.Write($"[TerminalControl] PasteToTerminalAsync FAILED: {ex.Message}");
+        }
+        finally
+        {
+            _isPasting = false;
+        }
+    }
+
+    /// <summary>
+    /// Sends <paramref name="text"/> to <paramref name="send"/> in <see cref="PasteChunkSize"/>-character
+    /// chunks with a <see cref="PasteChunkDelayMs"/> delay between chunks, stopping early if
+    /// <see cref="_isPasting"/> is cleared (Cancel Paste).
+    ///
+    /// The loop runs inside <see cref="Task.Run(System.Action)"/> and every delay uses
+    /// ConfigureAwait(false), so it executes entirely on the thread pool and NEVER resumes on the
+    /// Avalonia UI thread. This is the whole fix: on a Director hosting many sessions the UI thread is
+    /// often saturated with rendering, and when the pacing awaited back onto it the per-chunk delay
+    /// continuations sat unscheduled for seconds - a 92-character /login code took 22s, with 11 chunks
+    /// stalling over 800ms each (one for 7.3s). Pacing on the thread pool makes paste speed independent
+    /// of render load. Kept as a separate method so a headless test can drive the real pacing against a
+    /// deliberately saturated UI thread. See PasteOffUiThreadTests.
+    /// </summary>
+    private async Task PaceChunksAsync(string text, Action<byte[]> send)
+    {
+        await Task.Run(async () =>
+        {
+            for (int i = 0; i < text.Length; i += PasteChunkSize)
+            {
+                if (!_isPasting) break; // Cancelled
+
+                var chunk = text.Substring(i, Math.Min(PasteChunkSize, text.Length - i));
+                send(Encoding.UTF8.GetBytes(chunk));
+                await Task.Delay(PasteChunkDelayMs).ConfigureAwait(false);
+            }
+        }).ConfigureAwait(false);
+    }
+
+    /// <summary>Test seam: drive the real <see cref="PaceChunksAsync"/> with injected text and a capture
+    /// callback instead of the clipboard and a live session. Mirrors the production _isPasting lifecycle.</summary>
+    internal async Task HarnessPaceChunksAsync(string text, Action<byte[]> send)
+    {
+        _isPasting = true;
+        try
+        {
+            await PaceChunksAsync(text, send).ConfigureAwait(false);
         }
         finally
         {


### PR DESCRIPTION
## Problem

Pasting into the terminal (right-click Paste / Ctrl+V) typed the clipboard one chunk at a time while awaiting back onto the Avalonia UI thread. On a Director hosting many sessions the UI thread is saturated with rendering, so the per-chunk `Task.Delay` continuations sat unscheduled for seconds.

Measured from a real incident on a loaded machine: a 92-character claude `/login` code took **22.6 seconds**. The median chunk was fine (~28ms), but **11 chunks stalled over 800ms each, one for 7.3s** — those 11 stalls were 18.5s of the 22.6s. The same paste was near-instant on an idle machine, which is why it looked machine-dependent.

## Fix

- Run the pacing loop on the thread pool (`Task.Run` + `ConfigureAwait(false)`), so paste speed no longer depends on UI-thread availability. This is the root cause.
- Send in 8-character chunks instead of one character per delay, cutting the number of waits ~8x.
- The 15ms throttle that keeps interactive prompts (`/login`) from dropping characters is unchanged.
- `_isPasting` (the Cancel Paste flag) is now `volatile` since it is read on a background thread and set on the UI thread.

## Proof

New `PasteOffUiThreadTests` reproduces the exact condition — a fully blocked UI thread — against the real production pacing:

- **Production pacing** clears a 2.5s UI-thread block in under 1s (~180ms) with no chunk stall.
- **Old naive UI-thread loop** is held off for the whole block — this second test proves the block genuinely saturates the UI thread, so the first can't pass for the wrong reason.

All 23 terminal tests pass.