### PR TITLE
Bake the source commit into the runtime image so /healthz reports it

### DIFF
--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -135,7 +135,11 @@ jobs:
 
           # Poll the STAGING hostname until it answers 200 with the new commit, sustained 3 times: proof the
           # new image booted and migrated cleanly. No user is on staging, so this costs no outage.
+          # up_since marks when staging first started answering 200. If it serves 200 but never reports the
+          # shipped commit, that is not a slow boot - it is the wrong image or a missing COCKPIT_COMMIT in the
+          # runtime image, so fail FAST with that diagnosis instead of burning the whole boot timeout.
           streak=0
+          up_since=""
           deadline=$(( $(date +%s) + 600 ))
           while [ "$(date +%s)" -lt "$deadline" ]; do
             body=$(curl -s -m 10 -w '\n%{http_code}' "${STAGING_URL}/healthz" 2>/dev/null || printf '\n000')
@@ -146,6 +150,16 @@ jobs:
               [ "$streak" -ge 3 ] && break
             else
               streak=0; echo "staging HTTP $code commit=${commit:-<none>} (warming)"
+              if [ "$code" = "200" ]; then
+                [ -z "$up_since" ] && up_since=$(date +%s)
+                if [ $(( $(date +%s) - up_since )) -gt 150 ]; then
+                  echo "ERROR: staging has served 200 for over 150s but never reports commit $TARGET (got"
+                  echo "       '${commit:-<none>}'). The running image is not the shipped build, or the runtime"
+                  echo "       image does not carry COCKPIT_COMMIT. Aborting before the swap; production untouched."
+                  echo "outcome=failed" >> "$GITHUB_OUTPUT"
+                  exit 1
+                fi
+              fi
             fi
             sleep 3
           done

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,6 +134,16 @@ ENV CC_DIRECTOR_ROOT=/home/gateway/cc-director
 # environment-specific values / credentials, so they stay App Service settings and are NOT baked here. The
 # Gateway refuses to start (HostedStartupContract) if any of the three is missing.
 ENV CC_GATEWAY_HOSTED=1
+
+# Bake the source commit into the RUNTIME image so the Gateway process can report it at /healthz. ARG does
+# not cross stage boundaries, so the build-stage COCKPIT_COMMIT (used to stamp the cockpit assets) is not
+# visible here - it must be re-declared. The deploy pipeline reads /healthz .commit to tell the old
+# container apart from the new one during a slot swap; without this the field is null at run time and the
+# warmed-swap deploy cannot confirm the new image is serving. Like CC_GATEWAY_HOSTED above, baking it into
+# the image (rather than an App Service setting) means a slot swap or config restore cannot drop it.
+ARG COCKPIT_COMMIT
+ENV COCKPIT_COMMIT=${COCKPIT_COMMIT}
+
 USER gateway
 
 # The Gateway binds to loopback (127.0.0.1:7878) by design - it is reached over the tunnel, not a public


### PR DESCRIPTION
## What

The first warmed-swap deploy aborted safely at the warm gate: staging booted and served `/healthz` 200, but the `commit` field was always absent, so the pipeline could never confirm the new image was serving and timed out. Production was never touched - the fail-safe worked.

## Root cause

`COCKPIT_COMMIT` was declared only in the **build** stage of the Dockerfile (where it stamps the cockpit's static assets). A build ARG does not cross stage boundaries, so the **runtime** stage - where the Gateway process runs and reads the env - never had it, and `/healthz` reported null.

## Fix

- Re-declare `ARG COCKPIT_COMMIT` and bake `ENV COCKPIT_COMMIT` in the runtime stage, next to `CC_GATEWAY_HOSTED` (which is baked into the image for the same class of reason: a value the running Gateway needs must not live only in an App Service setting a slot swap can drop).
- Make the warm gate fail fast: if staging serves 200 for over 150s but never reports the shipped commit, abort with that diagnosis rather than burning the full boot timeout.

## Proof

Verified by re-running the warmed-swap deploy after merge (the previous run at 30059146566 timed out at exactly this gate).