### PR TITLE
Named director instances (one exe, many named profiles)

### DIFF
--- a/src/CcDirector.Avalonia/App.axaml.cs
+++ b/src/CcDirector.Avalonia/App.axaml.cs
@@ -13,6 +13,7 @@ using CcDirector.Core.Claude;
 using CcDirector.Core.Configuration;
 using System.Linq;
 using CcDirector.Core.Git;
+using CcDirector.Core.Instances;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Settings;
 using CcDirector.Core.Storage;
@@ -98,6 +99,15 @@ public partial class App : Application
             {
                 try
                 {
+                    // If more than one named instance exists and none was requested on the
+                    // command line, ask which one to launch. Choosing a different instance
+                    // relaunches it and shuts this (default) process down.
+                    if (await MaybePickInstanceAsync(splash))
+                    {
+                        desktop.Shutdown();
+                        return;
+                    }
+
                     await Task.Run(() => InitializeServices(splash));
 
                     // No account startup gate (issue #651): the account lives entirely on the Gateway now,
@@ -162,6 +172,55 @@ public partial class App : Application
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .ToList();
         _ = System.Threading.Tasks.Task.Run(() => RepositoryMonitor.RescanAsync(roots));
+    }
+
+    /// <summary>
+    /// When multiple named instances exist and none was explicitly requested via
+    /// <c>--instance</c>, show the selection box. Returns true when this process should
+    /// abort because it relaunched a different instance; false to continue as the default.
+    /// </summary>
+    private static async Task<bool> MaybePickInstanceAsync(Window owner)
+    {
+        try
+        {
+            if (InstanceContext.WasExplicitlySelected)
+                return false;
+
+            var instances = NamedInstanceRegistry.List();
+            if (instances.Count <= 1)
+                return false;
+
+            var dlg = new SelectDirectorDialog("Which director do you want to launch?");
+            var ok = await dlg.ShowDialog<bool?>(owner);
+            if (ok != true)
+                return false; // cancelled -> continue as the default instance
+
+            if (dlg.WantsNew)
+            {
+                var create = new CreateInstanceDialog();
+                var created = await create.ShowDialog<bool?>(owner);
+                if (created == true && create.CreatedInstance is not null && create.LaunchAfter)
+                {
+                    InstanceProcess.Launch(create.CreatedInstance.Name);
+                    return true;
+                }
+                return false;
+            }
+
+            var slug = dlg.LaunchSlug;
+            if (string.IsNullOrEmpty(slug))
+                return false;
+            if (string.Equals(slug, InstanceContext.Slug, StringComparison.OrdinalIgnoreCase))
+                return false; // picked the current (default) instance -> continue
+
+            InstanceProcess.Launch(slug);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[App] MaybePickInstance FAILED: {ex.Message}");
+            return false;
+        }
     }
 
     private void InitializeServices(SplashScreen splash)

--- a/src/CcDirector.Avalonia/CreateInstanceDialog.axaml
+++ b/src/CcDirector.Avalonia/CreateInstanceDialog.axaml
@@ -1,0 +1,60 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="CcDirector.Avalonia.CreateInstanceDialog"
+        Title="Create named director instance"
+        Width="460" SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="#252526">
+
+    <StackPanel Margin="20" Spacing="4">
+
+        <TextBlock Text="Create named director instance"
+                   Foreground="#CCCCCC" FontSize="16" FontWeight="SemiBold"
+                   Margin="0,0,0,4" />
+        <TextBlock Text="A separate Director profile with its own gateway, port, and data home. Runs alongside your other instances from the same app."
+                   Foreground="#888888" FontSize="12" TextWrapping="Wrap"
+                   Margin="0,0,0,14" />
+
+        <TextBlock Text="Display name" Foreground="#CCCCCC" FontSize="13" Margin="0,0,0,4" />
+        <TextBox x:Name="DisplayNameInput"
+                 Background="#1E1E1E" Foreground="#CCCCCC" CaretBrush="#CCCCCC"
+                 BorderBrush="#3C3C3C" Padding="8,6" FontSize="14"
+                 Watermark="e.g. Company B"
+                 KeyDown="Input_KeyDown" />
+        <TextBlock x:Name="SlugPreview" Foreground="#888888" FontSize="11"
+                   Margin="0,3,0,10" Text="slug: (from the name) · port: auto-assigned" />
+
+        <TextBlock Text="Gateway URL" Foreground="#CCCCCC" FontSize="13" Margin="0,0,0,4" />
+        <TextBox x:Name="GatewayUrlInput"
+                 Background="#1E1E1E" Foreground="#CCCCCC" CaretBrush="#CCCCCC"
+                 BorderBrush="#3C3C3C" Padding="8,6" FontSize="14"
+                 Watermark="e.g. https://gateway.devthrottle.com (optional)"
+                 Margin="0,0,0,10" />
+
+        <TextBlock Text="Gateway token" Foreground="#CCCCCC" FontSize="13" Margin="0,0,0,4" />
+        <TextBox x:Name="GatewayTokenInput"
+                 Background="#1E1E1E" Foreground="#CCCCCC" CaretBrush="#CCCCCC"
+                 BorderBrush="#3C3C3C" Padding="8,6" FontSize="14"
+                 Watermark="only if the gateway requires one"
+                 PasswordChar="•"
+                 Margin="0,0,0,10" />
+
+        <CheckBox x:Name="LaunchAfterCheck" Content="Launch this instance now"
+                  Foreground="#CCCCCC" IsChecked="True" Margin="0,0,0,4" />
+
+        <TextBlock x:Name="ErrorText" Foreground="#F14C4C" FontSize="12"
+                   TextWrapping="Wrap" IsVisible="False" Margin="0,4,0,0" />
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,14,0,0">
+            <Button Content="Create" Width="90" Height="28"
+                    Click="BtnCreate_Click"
+                    Background="#007ACC" Foreground="White"
+                    BorderThickness="0" Margin="0,0,8,0" Cursor="Hand" />
+            <Button Content="Cancel" Width="80" Height="28"
+                    Click="BtnCancel_Click"
+                    Background="#3C3C3C" Foreground="#CCCCCC"
+                    BorderThickness="0" Cursor="Hand" />
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/src/CcDirector.Avalonia/CreateInstanceDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/CreateInstanceDialog.axaml.cs
@@ -1,0 +1,76 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using CcDirector.Core.Instances;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia;
+
+public partial class CreateInstanceDialog : Window
+{
+    /// <summary>The instance that was created, once the dialog closes with true.</summary>
+    public NamedInstance? CreatedInstance { get; private set; }
+
+    /// <summary>Whether the user asked to launch the new instance immediately.</summary>
+    public bool LaunchAfter { get; private set; }
+
+    public CreateInstanceDialog()
+    {
+        InitializeComponent();
+        DisplayNameInput.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == TextBox.TextProperty) UpdateSlugPreview();
+        };
+        Loaded += (_, _) => Dispatcher.UIThread.Post(() => DisplayNameInput.Focus());
+    }
+
+    private void UpdateSlugPreview()
+    {
+        var name = DisplayNameInput.Text ?? "";
+        SlugPreview.Text = string.IsNullOrWhiteSpace(name)
+            ? "slug: (from the name) · port: auto-assigned"
+            : $"slug: {NamedInstanceRegistry.PreviewSlug(name)} · port: auto-assigned";
+    }
+
+    private void Input_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter) { e.Handled = true; Create(); }
+        else if (e.Key == Key.Escape) { e.Handled = true; Close(false); }
+    }
+
+    private void BtnCreate_Click(object? sender, RoutedEventArgs e) => Create();
+
+    private void BtnCancel_Click(object? sender, RoutedEventArgs e) => Close(false);
+
+    private void Create()
+    {
+        var displayName = (DisplayNameInput.Text ?? "").Trim();
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            ShowError("Enter a display name.");
+            return;
+        }
+
+        try
+        {
+            CreatedInstance = NamedInstanceRegistry.Create(
+                displayName,
+                (GatewayUrlInput.Text ?? "").Trim(),
+                (GatewayTokenInput.Text ?? "").Trim());
+            LaunchAfter = LaunchAfterCheck.IsChecked == true;
+            Close(true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[CreateInstanceDialog] Create FAILED: {ex.Message}");
+            ShowError($"Could not create instance: {ex.Message}");
+        }
+    }
+
+    private void ShowError(string message)
+    {
+        ErrorText.Text = message;
+        ErrorText.IsVisible = true;
+    }
+}

--- a/src/CcDirector.Avalonia/InstanceProcess.cs
+++ b/src/CcDirector.Avalonia/InstanceProcess.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia;
+
+/// <summary>
+/// Spawns another named Director instance as a clean, independent process:
+/// <c>cc-director.exe --instance &lt;slug&gt;</c>.
+///
+/// The child must resolve the TRUE machine-wide shared root by itself, so we explicitly
+/// drop <c>CC_DIRECTOR_ROOT</c> from the child's environment - otherwise a named-instance
+/// parent (which has that override set to its own home) would leak it and the child would
+/// mistake its parent's home for the shared root.
+/// </summary>
+internal static class InstanceProcess
+{
+    public static void Launch(string slug)
+    {
+        var exe = Environment.ProcessPath
+            ?? throw new InvalidOperationException("Cannot determine the current executable path.");
+        FileLog.Write($"[InstanceProcess] Launch: slug={slug}, exe={exe}");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = exe,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("--instance");
+        psi.ArgumentList.Add(slug);
+        psi.Environment.Remove("CC_DIRECTOR_ROOT");
+
+        Process.Start(psi);
+    }
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -23,6 +23,7 @@ using CcDirector.Core.Claude;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.GatewayConnection;
 using CcDirector.Core.Home;
+using CcDirector.Core.Instances;
 using CcDirector.Core.Network;
 using CcDirector.Core.Onboarding;
 using CcDirector.Core.Sessions;
@@ -136,6 +137,9 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         FileLog.Write("[MainWindow] Avalonia MainWindow initialized");
+
+        // Show which named instance this window is, so multiple instances are distinguishable.
+        Title = "Director" + InstanceTitleSuffix();
 
         Loaded += MainWindow_Loaded;
         Activated += MainWindow_Activated;
@@ -1449,6 +1453,16 @@ public partial class MainWindow : Window
         {
             FileLog.Write($"[MainWindow] ToolsIndicator_PointerPressed FAILED: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Title-bar suffix identifying which instance this window is (e.g. " -- Company B").
+    /// Shown for every instance, default included - the default is not special.
+    /// </summary>
+    private static string InstanceTitleSuffix()
+    {
+        var name = InstanceContext.DisplayName ?? InstanceContext.Slug;
+        return string.IsNullOrWhiteSpace(name) ? "" : $" -- {name}";
     }
 
     private void SetBuildInfo()
@@ -3619,6 +3633,52 @@ public partial class MainWindow : Window
         file.Menu.Items.Add(Item("Settings...", () => BtnSettings_Click(this, new RoutedEventArgs()),
             new KeyGesture(Key.OemComma, KeyModifiers.Control)));
         file.Menu.Items.Add(new NativeMenuItemSeparator());
+
+        // ----- Named director instances -----
+        file.Menu.Items.Add(Item("Create named director instance...", async () =>
+        {
+            FileLog.Write("[MainWindow] Menu: Create named director instance");
+            var dlg = new CreateInstanceDialog();
+            var ok = await dlg.ShowDialog<bool?>(this);
+            if (ok == true && dlg.CreatedInstance is not null)
+            {
+                if (dlg.LaunchAfter)
+                    InstanceProcess.Launch(dlg.CreatedInstance.Name);
+                else
+                    ShowNotification($"Created director \"{dlg.CreatedInstance.DisplayName}\". " +
+                                     "Launch it from File → Switch director.");
+            }
+        }));
+        file.Menu.Items.Add(Item("Rename this director...", async () =>
+        {
+            FileLog.Write("[MainWindow] Menu: Rename this director");
+            var slug = InstanceContext.Slug;
+            var current = NamedInstanceRegistry.Get(slug)?.DisplayName
+                          ?? InstanceContext.DisplayName ?? slug;
+            var dlg = new RenameDirectorDialog(slug, current);
+            var ok = await dlg.ShowDialog<bool?>(this);
+            if (ok == true && dlg.NewDisplayName is not null)
+                ShowNotification($"Renamed to \"{dlg.NewDisplayName}\". Restart this director to update the title bar.");
+        }));
+        file.Menu.Items.Add(Item("Switch director...", async () =>
+        {
+            FileLog.Write("[MainWindow] Menu: Switch director");
+            var dlg = new SelectDirectorDialog("Switch to which director?");
+            var ok = await dlg.ShowDialog<bool?>(this);
+            if (ok != true) return;
+            if (dlg.WantsNew)
+            {
+                var create = new CreateInstanceDialog();
+                var created = await create.ShowDialog<bool?>(this);
+                if (created == true && create.CreatedInstance is not null && create.LaunchAfter)
+                    InstanceProcess.Launch(create.CreatedInstance.Name);
+                return;
+            }
+            if (dlg.LaunchSlug is not null)
+                InstanceProcess.Launch(dlg.LaunchSlug);
+        }));
+        file.Menu.Items.Add(new NativeMenuItemSeparator());
+
         file.Menu.Items.Add(Item("Save Workspace...", async () =>
         {
             var app = AppRef();

--- a/src/CcDirector.Avalonia/Program.cs
+++ b/src/CcDirector.Avalonia/Program.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using Avalonia;
 using CcDirector.ControlApi;
+using CcDirector.Core.Instances;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Update;
 using CcDirector.Core.Utilities;
@@ -12,9 +13,20 @@ internal static class Program
     [STAThread]
     public static int Main(string[] args)
     {
+        // Resolve which named instance this process runs as BEFORE FileLog/CcStorage,
+        // so logs and the whole data tree redirect to this instance's isolated home
+        // (every instance, default included). Skipped for the hidden --apply-update
+        // relauncher, which must run outside any instance context.
+        var isApplyUpdate = args.Length >= 1 && args[0] == "--apply-update";
+        if (!isApplyUpdate)
+            ResolveInstance(args);
+
         // Start logging first so the pre-startup update steps below (which run
         // before App initializes its own logging) are actually recorded.
         FileLog.Start();
+
+        FileLog.Write($"[Program] Instance: slug={InstanceContext.Slug}, isDefault={InstanceContext.IsDefault}, " +
+                      $"explicit={InstanceContext.WasExplicitlySelected}, home={InstanceContext.InstanceHome}, port={InstanceContext.Port}");
 
         // Catch anything that escapes a background thread so a crash is at least
         // recorded to a findable file rather than vanishing silently (issue #242).
@@ -145,6 +157,70 @@ internal static class Program
                 "Director - Startup error", MB_ICONERROR);
             return 1;
         }
+    }
+
+    /// <summary>
+    /// Resolve the named instance for this process from <c>--instance &lt;slug&gt;</c> and the
+    /// registry, then redirect the whole data tree to that instance's isolated home via the
+    /// <c>CC_DIRECTOR_ROOT</c> override. Runs before FileLog/CcStorage.
+    ///
+    /// EVERY instance - default included - gets its own isolated home. There is no migration
+    /// and no shared-root fallback: we never carry old flat data forward. Never throws; on any
+    /// failure it still isolates the default home rather than dropping to the shared root.
+    /// </summary>
+    private static void ResolveInstance(string[] args)
+    {
+        try
+        {
+            var slug = ParseInstanceArg(args);
+            var wasExplicit = slug is not null;
+            InstanceContext.Initialize(slug, wasExplicit);
+
+            // Guarantee the default entry exists (seeded from the hostname) so the picker and
+            // launcher always have at least one instance to show.
+            NamedInstanceRegistry.EnsureDefault(Environment.MachineName);
+
+            // Resolve this process's instance; an unknown slug falls back to the default entry.
+            var inst = NamedInstanceRegistry.Get(InstanceContext.Slug);
+            if (inst is null)
+            {
+                wasExplicit = false;
+                inst = NamedInstanceRegistry.Get(InstanceContext.DefaultSlug);
+            }
+            if (inst is not null)
+                InstanceContext.Initialize(inst.Name, wasExplicit, inst.DisplayName, inst.Port);
+
+            // Isolate this instance's home and redirect all storage into it - default too.
+            Directory.CreateDirectory(InstanceContext.InstanceHome);
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", InstanceContext.InstanceHome);
+        }
+        catch
+        {
+            // Instance resolution must never stop the app from starting - but still isolate the
+            // default home; never fall back to the shared root.
+            InstanceContext.Initialize(null, wasExplicit: false);
+            try
+            {
+                Directory.CreateDirectory(InstanceContext.InstanceHome);
+                Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", InstanceContext.InstanceHome);
+            }
+            catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>Extract the value of <c>--instance &lt;slug&gt;</c> or <c>--instance=&lt;slug&gt;</c>; null if absent.</summary>
+    private static string? ParseInstanceArg(string[] args)
+    {
+        const string flag = "--instance";
+        for (var i = 0; i < args.Length; i++)
+        {
+            var a = args[i];
+            if (a.StartsWith(flag + "=", StringComparison.OrdinalIgnoreCase))
+                return a.Substring(flag.Length + 1);
+            if (string.Equals(a, flag, StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+                return args[i + 1];
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/CcDirector.Avalonia/RenameDirectorDialog.axaml
+++ b/src/CcDirector.Avalonia/RenameDirectorDialog.axaml
@@ -1,0 +1,37 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="CcDirector.Avalonia.RenameDirectorDialog"
+        Title="Rename director"
+        Width="420" SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="#252526">
+
+    <StackPanel Margin="20" Spacing="4">
+
+        <TextBlock Text="Display name" Foreground="#CCCCCC" FontSize="14" Margin="0,0,0,8" />
+
+        <TextBox x:Name="NameInput"
+                 Background="#1E1E1E" Foreground="#CCCCCC" CaretBrush="#CCCCCC"
+                 BorderBrush="#3C3C3C" Padding="8,6" FontSize="14"
+                 KeyDown="NameInput_KeyDown" />
+
+        <TextBlock x:Name="UnchangedNote" Foreground="#888888" FontSize="12"
+                   TextWrapping="Wrap" Margin="0,10,0,0"
+                   Text="Only the label changes. The slug, folder, id, port and gateway all stay the same." />
+
+        <TextBlock x:Name="ErrorText" Foreground="#F14C4C" FontSize="12"
+                   TextWrapping="Wrap" IsVisible="False" Margin="0,6,0,0" />
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
+            <Button Content="Save" Width="80" Height="28"
+                    Click="BtnOk_Click"
+                    Background="#007ACC" Foreground="White"
+                    BorderThickness="0" Margin="0,0,8,0" Cursor="Hand" />
+            <Button Content="Cancel" Width="80" Height="28"
+                    Click="BtnCancel_Click"
+                    Background="#3C3C3C" Foreground="#CCCCCC"
+                    BorderThickness="0" Cursor="Hand" />
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/src/CcDirector.Avalonia/RenameDirectorDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/RenameDirectorDialog.axaml.cs
@@ -1,0 +1,67 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using CcDirector.Core.Instances;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia;
+
+public partial class RenameDirectorDialog : Window
+{
+    private readonly string _slug;
+
+    /// <summary>The new display name, once the dialog closes with true.</summary>
+    public string? NewDisplayName { get; private set; }
+
+    public RenameDirectorDialog(string slug, string currentDisplayName)
+    {
+        InitializeComponent();
+        _slug = slug;
+        NameInput.Text = currentDisplayName;
+        UnchangedNote.Text =
+            $"Only the label changes. The slug ({slug}), folder, id, port and gateway all stay the same.";
+        Loaded += (_, _) => Dispatcher.UIThread.Post(() =>
+        {
+            NameInput.Focus();
+            NameInput.SelectAll();
+        });
+    }
+
+    // Parameterless constructor for the XAML designer.
+    public RenameDirectorDialog() : this(InstanceContext.DefaultSlug, "") { }
+
+    private void NameInput_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter) { e.Handled = true; Accept(); }
+        else if (e.Key == Key.Escape) { e.Handled = true; Close(false); }
+    }
+
+    private void BtnOk_Click(object? sender, RoutedEventArgs e) => Accept();
+
+    private void BtnCancel_Click(object? sender, RoutedEventArgs e) => Close(false);
+
+    private void Accept()
+    {
+        var name = (NameInput.Text ?? "").Trim();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            ErrorText.Text = "Enter a display name.";
+            ErrorText.IsVisible = true;
+            return;
+        }
+
+        try
+        {
+            NamedInstanceRegistry.Rename(_slug, name);
+            NewDisplayName = name;
+            Close(true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RenameDirectorDialog] Rename FAILED: {ex.Message}");
+            ErrorText.Text = $"Could not rename: {ex.Message}";
+            ErrorText.IsVisible = true;
+        }
+    }
+}

--- a/src/CcDirector.Avalonia/SelectDirectorDialog.axaml
+++ b/src/CcDirector.Avalonia/SelectDirectorDialog.axaml
@@ -1,0 +1,59 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="CcDirector.Avalonia.SelectDirectorDialog"
+        Title="Select director"
+        Width="560" Height="440"
+        MinWidth="440" MinHeight="320"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True"
+        Background="#252526">
+
+    <Grid Margin="20" RowDefinitions="Auto,*,Auto">
+
+        <TextBlock Grid.Row="0" x:Name="HeaderText"
+                   Text="Which director?"
+                   Foreground="#CCCCCC" FontSize="16" FontWeight="SemiBold"
+                   Margin="0,0,0,12" />
+
+        <Border Grid.Row="1" BorderBrush="#3C3C3C" BorderThickness="1" CornerRadius="4">
+            <ListBox x:Name="InstanceList"
+                     Background="#1E1E1E"
+                     BorderThickness="0"
+                     DoubleTapped="InstanceList_DoubleTapped">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Grid ColumnDefinitions="*,Auto" Margin="4,6">
+                            <StackPanel Grid.Column="0" Spacing="2">
+                                <TextBlock Text="{Binding DisplayName}"
+                                           Foreground="#EAEAEA" FontSize="14" FontWeight="SemiBold" />
+                                <TextBlock Text="{Binding Meta}"
+                                           Foreground="#888888" FontSize="11"
+                                           FontFamily="Consolas,monospace" />
+                            </StackPanel>
+                            <Border Grid.Column="1" VerticalAlignment="Center"
+                                    CornerRadius="4" Padding="8,3" Background="#2A2D2E">
+                                <TextBlock Text="{Binding Status}"
+                                           Foreground="{Binding StatusBrush}" FontSize="11" />
+                            </Border>
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </Border>
+
+        <Grid Grid.Row="2" ColumnDefinitions="Auto,*,Auto,Auto" Margin="0,14,0,0">
+            <Button Grid.Column="0" Content="+ New named director…" Height="28"
+                    Click="BtnNew_Click"
+                    Background="#3C3C3C" Foreground="#CCCCCC"
+                    BorderThickness="0" Padding="12,0" Cursor="Hand" />
+            <Button Grid.Column="2" Content="Launch" Width="90" Height="28"
+                    Click="BtnLaunch_Click"
+                    Background="#007ACC" Foreground="White"
+                    BorderThickness="0" Margin="0,0,8,0" Cursor="Hand" />
+            <Button Grid.Column="3" Content="Cancel" Width="80" Height="28"
+                    Click="BtnCancel_Click"
+                    Background="#3C3C3C" Foreground="#CCCCCC"
+                    BorderThickness="0" Cursor="Hand" />
+        </Grid>
+    </Grid>
+</Window>

--- a/src/CcDirector.Avalonia/SelectDirectorDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/SelectDirectorDialog.axaml.cs
@@ -1,0 +1,144 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Net.Sockets;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CcDirector.Core.Instances;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia;
+
+public partial class SelectDirectorDialog : Window
+{
+    private static readonly IBrush RunningBrush = new SolidColorBrush(Color.Parse("#22C55E"));
+    private static readonly IBrush StoppedBrush = new SolidColorBrush(Color.Parse("#888888"));
+    private static readonly IBrush CheckingBrush = new SolidColorBrush(Color.Parse("#AAAAAA"));
+
+    private readonly ObservableCollection<InstanceRow> _rows = new();
+
+    /// <summary>The slug the user chose to launch, once the dialog closes with true.</summary>
+    public string? LaunchSlug { get; private set; }
+
+    /// <summary>True when the user asked to create a new instance instead of launching one.</summary>
+    public bool WantsNew { get; private set; }
+
+    public SelectDirectorDialog(string? header = null)
+    {
+        InitializeComponent();
+        if (!string.IsNullOrWhiteSpace(header))
+            HeaderText.Text = header;
+        InstanceList.ItemsSource = _rows;
+        Loaded += OnLoaded;
+    }
+
+    // Parameterless constructor for the XAML designer.
+    public SelectDirectorDialog() : this(null) { }
+
+    private void OnLoaded(object? sender, RoutedEventArgs e)
+    {
+        // Populate immediately for a responsive UI, then probe liveness in the background.
+        try
+        {
+            var instances = NamedInstanceRegistry.List();
+            foreach (var inst in instances)
+                _rows.Add(new InstanceRow(inst));
+            if (_rows.Count > 0)
+                InstanceList.SelectedIndex = 0;
+            _ = ProbeAllAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SelectDirectorDialog] Load FAILED: {ex.Message}");
+        }
+    }
+
+    private async Task ProbeAllAsync()
+    {
+        var tasks = _rows.Select(async row =>
+        {
+            var running = await IsPortOpenAsync(row.Port);
+            await Dispatcher.UIThread.InvokeAsync(() => row.SetStatus(running));
+        });
+        await Task.WhenAll(tasks);
+    }
+
+    private static async Task<bool> IsPortOpenAsync(int port)
+    {
+        try
+        {
+            using var client = new TcpClient();
+            var connect = client.ConnectAsync("127.0.0.1", port);
+            var done = await Task.WhenAny(connect, Task.Delay(300));
+            return done == connect && client.Connected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void InstanceList_DoubleTapped(object? sender, RoutedEventArgs e) => LaunchSelected();
+
+    private void BtnLaunch_Click(object? sender, RoutedEventArgs e) => LaunchSelected();
+
+    private void BtnNew_Click(object? sender, RoutedEventArgs e)
+    {
+        WantsNew = true;
+        Close(true);
+    }
+
+    private void BtnCancel_Click(object? sender, RoutedEventArgs e) => Close(false);
+
+    private void LaunchSelected()
+    {
+        if (InstanceList.SelectedItem is not InstanceRow row)
+            return;
+        LaunchSlug = row.Slug;
+        Close(true);
+    }
+
+    /// <summary>One selectable instance row; status updates in place as the liveness probe returns.</summary>
+    public sealed class InstanceRow : INotifyPropertyChanged
+    {
+        private string _status = "checking…";
+        private IBrush _statusBrush = CheckingBrush;
+
+        public InstanceRow(NamedInstance inst)
+        {
+            Slug = inst.Name;
+            Port = inst.Port;
+            DisplayName = inst.DisplayName;
+            var gateway = string.IsNullOrWhiteSpace(inst.GatewayUrl) ? "no gateway" : inst.GatewayUrl;
+            Meta = $"slug {inst.Name} · {gateway} · :{inst.Port}";
+        }
+
+        public string Slug { get; }
+        public int Port { get; }
+        public string DisplayName { get; }
+        public string Meta { get; }
+
+        public string Status
+        {
+            get => _status;
+            private set { _status = value; OnChanged(nameof(Status)); }
+        }
+
+        public IBrush StatusBrush
+        {
+            get => _statusBrush;
+            private set { _statusBrush = value; OnChanged(nameof(StatusBrush)); }
+        }
+
+        public void SetStatus(bool running)
+        {
+            Status = running ? "running" : "stopped";
+            StatusBrush = running ? RunningBrush : StoppedBrush;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnChanged(string name) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -357,6 +357,11 @@ public sealed class ControlApiHost : IAsyncDisposable
             // CLOSED on every client machine. LAN addressing mode used to bind IPAddress.Any here
             // (issue #457) for a Gateway->Director dial that no longer exists; it no longer changes
             // the bind interface.
+            //
+            // Named instances: PortAllocator is keyed by the per-slug DirectorId, so each instance
+            // (default or named) gets its own distinct fixed port with no collision. The actual
+            // bound port is recorded to the named-instance registry after Kestrel starts (below),
+            // so the picker shows/probes the right one even on the ephemeral-fallback path.
             int? allocated = PortAllocationOverride is not null
                 ? PortAllocationOverride(DirectorId)
                 : (PortAllocator.TryAllocate(DirectorId, out var p) ? p : (int?)null);
@@ -553,6 +558,12 @@ public sealed class ControlApiHost : IAsyncDisposable
         // (e.g. GET $CC_DIRECTOR_API/sessions/$CC_SESSION_ID to find themselves).
         _sessionManager.ControlApiBaseUrl = $"http://127.0.0.1:{Port}";
         _sessionManager.DirectorId = DirectorId;
+
+        // Named instances: record the ACTUAL bound port (fixed or ephemeral-fallback) back to the
+        // named-instance registry so the picker/switcher shows and probes the right port. Best-effort;
+        // never throws into startup.
+        CcDirector.Core.Instances.NamedInstanceRegistry.RecordBoundPort(
+            CcDirector.Core.Instances.InstanceContext.Slug, Port);
 
         // Issue #1357: let the (synchronous, non-blocking) Pi launch path name the signed-in user from
         // the provider's cached snapshot. Warm the cache once now so the first Pi session started right

--- a/src/CcDirector.ControlApi/DirectorIdStore.cs
+++ b/src/CcDirector.ControlApi/DirectorIdStore.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using CcDirector.Core.Instances;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
@@ -81,7 +82,14 @@ public static class DirectorIdStore
     public static string SlotFor(string slotKey) => Slot(slotKey);
 
     private static string DefaultSlotKey()
-        => Environment.ProcessPath ?? AppContext.BaseDirectory;
+    {
+        var exe = Environment.ProcessPath ?? AppContext.BaseDirectory;
+        // EVERY instance - default included - gets its own identity slot (and therefore its
+        // own mutex, DirectorId, port, and registration file) by folding its slug into the
+        // slot key. The default is not special-cased; it is just the instance whose slug is
+        // "default". No legacy exe-only key is kept - we start clean.
+        return $"{exe}|instance={InstanceContext.Slug}";
+    }
 
     private static string Slot(string slotKey)
     {

--- a/src/CcDirector.Core.Tests/Instances/NamedInstanceRegistryTests.cs
+++ b/src/CcDirector.Core.Tests/Instances/NamedInstanceRegistryTests.cs
@@ -1,0 +1,148 @@
+using System.Text.Json;
+using CcDirector.Core.Instances;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Instances;
+
+/// <summary>
+/// Tests for <see cref="NamedInstanceRegistry"/> - the cross-instance registry of named
+/// Director profiles. Each test runs against an isolated shared root (temp dir), captured
+/// by <see cref="InstanceContext.Initialize"/> after CC_DIRECTOR_ROOT is set. xUnit runs a
+/// class's methods sequentially; the collection serializes classes that mutate the
+/// process-wide CC_DIRECTOR_ROOT / InstanceContext.
+/// </summary>
+[Collection("CcStorageRoot")]
+public sealed class NamedInstanceRegistryTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+
+    public NamedInstanceRegistryTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-instances-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        // Capture the temp dir as the shared root; run as the default instance.
+        InstanceContext.Initialize(null, wasExplicit: false);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void EnsureDefault_seeds_default_with_hostname()
+    {
+        NamedInstanceRegistry.EnsureDefault("MY-BOX");
+
+        var def = NamedInstanceRegistry.Get("default");
+        Assert.NotNull(def);
+        Assert.True(def!.IsDefault);
+        Assert.Equal("default", def.Name);
+        Assert.Equal("MY-BOX", def.DisplayName);
+    }
+
+    [Fact]
+    public void List_always_includes_default_first()
+    {
+        NamedInstanceRegistry.Create("Company B", "https://gw-b.example", "tok");
+
+        var all = NamedInstanceRegistry.List();
+        Assert.True(all.Count >= 2);
+        Assert.True(all[0].IsDefault); // default sorts first
+    }
+
+    [Fact]
+    public void Create_assigns_slug_port_and_scaffolds_gateway_config()
+    {
+        var inst = NamedInstanceRegistry.Create("Company B", "https://gw-b.example", "secret-token");
+
+        Assert.Equal("company-b", inst.Name);
+        Assert.False(string.IsNullOrEmpty(inst.Id));
+        Assert.InRange(inst.Port, 7880, 7898);
+        Assert.Equal("Company B", inst.DisplayName);
+
+        // The instance's own config.json must carry the gateway block.
+        var configPath = Path.Combine(_root, "instances", "company-b", "config", "config.json");
+        Assert.True(File.Exists(configPath));
+        using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
+        var gw = doc.RootElement.GetProperty("gateway");
+        Assert.Equal("https://gw-b.example", gw.GetProperty("url").GetString());
+        Assert.Equal("secret-token", gw.GetProperty("token").GetString());
+    }
+
+    [Fact]
+    public void Create_duplicate_display_name_gets_distinct_slug_and_port()
+    {
+        var a = NamedInstanceRegistry.Create("Company B", "", "");
+        var b = NamedInstanceRegistry.Create("Company B", "", "");
+
+        Assert.Equal("company-b", a.Name);
+        Assert.Equal("company-b-2", b.Name);
+        Assert.NotEqual(a.Port, b.Port);
+    }
+
+    [Fact]
+    public void Create_never_takes_the_reserved_default_slug()
+    {
+        var inst = NamedInstanceRegistry.Create("Default", "", "");
+        Assert.NotEqual("default", inst.Name);
+        // The seeded default instance still exists and is unaffected.
+        Assert.NotNull(NamedInstanceRegistry.Get("default"));
+    }
+
+    [Fact]
+    public void Rename_changes_display_name_only()
+    {
+        var inst = NamedInstanceRegistry.Create("Company B", "https://gw-b.example", "tok");
+        var originalSlug = inst.Name;
+        var originalPort = inst.Port;
+        var originalId = inst.Id;
+
+        NamedInstanceRegistry.Rename(originalSlug, "Client B");
+
+        var after = NamedInstanceRegistry.Get(originalSlug);
+        Assert.NotNull(after);
+        Assert.Equal("Client B", after!.DisplayName);
+        Assert.Equal(originalSlug, after.Name);   // slug unchanged
+        Assert.Equal(originalPort, after.Port);   // port unchanged
+        Assert.Equal(originalId, after.Id);       // id unchanged
+    }
+
+    [Fact]
+    public void Get_returns_null_for_unknown_slug()
+    {
+        Assert.Null(NamedInstanceRegistry.Get("does-not-exist"));
+    }
+
+    [Fact]
+    public void Default_instance_home_is_isolated_not_the_shared_root()
+    {
+        // No migration / no shared-root fallback: even the default runs in instances\default.
+        InstanceContext.Initialize(null, wasExplicit: false);
+        Assert.True(InstanceContext.IsDefault);
+        Assert.Equal(Path.Combine(_root, "instances", "default"), InstanceContext.InstanceHome);
+        Assert.NotEqual(InstanceContext.SharedRoot, InstanceContext.InstanceHome);
+    }
+
+    [Fact]
+    public void Named_instance_home_is_under_its_slug()
+    {
+        InstanceContext.Initialize("company-b", wasExplicit: true);
+        Assert.Equal(Path.Combine(_root, "instances", "company-b"), InstanceContext.InstanceHome);
+    }
+
+    [Fact]
+    public void Malformed_registry_throws_rather_than_reset()
+    {
+        var path = NamedInstanceRegistry.FilePath;
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "{ not valid json ");
+
+        Assert.ThrowsAny<Exception>(() => NamedInstanceRegistry.List());
+        // The unparseable file must NOT have been reset.
+        Assert.Equal("{ not valid json ", File.ReadAllText(path));
+    }
+}

--- a/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
+++ b/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
@@ -70,6 +70,7 @@ public sealed class NoCrossMachineLoopbackGuardTests
         // --- Desktop app: local Director/Cockpit access + local-only labels ---
         ["src/CcDirector.Avalonia/App.axaml.cs"] = "Local Control API bootstrap / loopback references.",
         ["src/CcDirector.Avalonia/CockpitUrlResolver.cs"] = "Resolves the local Cockpit URL (same machine).",
+        ["src/CcDirector.Avalonia/SelectDirectorDialog.axaml.cs"] = "The named-instance picker probes each instance's liveness by opening a TCP connection to its Control API port on 127.0.0.1. All named instances are local processes on THIS machine (one exe, many profiles), so a running/stopped check is inherently a SAME-machine loopback probe - the same boundary as ControlApiHost's loopback bind.",
         ["src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs"] = "Epic #1069 A: BuildLoopbackEnrollUrl dials the co-located Gateway's /devices/enroll-signed-in at the literal 127.0.0.1 BY DESIGN - the Gateway's guardrail 1 requires the enroll caller to be a proven SAME-machine loopback connection (IPAddress.IsLoopback), so a machine-name or tailnet address would 403. Same-machine only; the enrolled key then registers/heartbeats over the pick's real address.",
         ["src/CcDirector.Avalonia/MainWindow.axaml.cs"] = "Local-only labelled endpoint strings (handover/about).",
         ["src/CcDirector.Avalonia/Controls/ConnectionsView.axaml.cs"] = "Local connection references.",

--- a/src/CcDirector.Core/Instances/InstanceContext.cs
+++ b/src/CcDirector.Core/Instances/InstanceContext.cs
@@ -1,0 +1,80 @@
+using CcDirector.Core.Storage;
+
+namespace CcDirector.Core.Instances;
+
+/// <summary>
+/// Process-wide identity of the named Director instance this process is running as.
+///
+/// A "named instance" is a settings profile: its own gateway, port, and data home,
+/// selected once at startup via <c>--instance &lt;slug&gt;</c>. EVERY instance - including
+/// the default (slug <see cref="DefaultSlug"/>) - runs in its own isolated home under
+/// <c>{SharedRoot}\instances\{slug}</c>. There is deliberately NO migration and NO
+/// shared-root fallback: the default is just an ordinary instance that happens to be
+/// created automatically. Nothing old is ever carried forward.
+///
+/// This holder is set ONCE at the very top of <c>Program.Main</c> (before FileLog and
+/// before any <see cref="Storage.CcStorage"/> use) so that the per-instance data-home
+/// redirection (via the <c>CC_DIRECTOR_ROOT</c> env override) and the per-instance
+/// identity slot (see <c>DirectorIdStore</c>) are in effect for the whole process.
+///
+/// Why a static holder: Avalonia constructs <c>App</c> itself, so there is no
+/// constructor seam to thread this through - the same rationale as GatewayAppOptions.
+/// </summary>
+public static class InstanceContext
+{
+    /// <summary>The reserved slug of the always-present default instance.</summary>
+    public const string DefaultSlug = "default";
+
+    /// <summary>
+    /// The machine-wide cc-director root, captured BEFORE any per-instance
+    /// <c>CC_DIRECTOR_ROOT</c> override is applied. Named-instance data lives under
+    /// <c>{SharedRoot}\instances\{slug}</c>; the cross-instance registry lives at the
+    /// shared root so every instance and the launcher can enumerate it.
+    /// </summary>
+    public static string SharedRoot { get; private set; } = CcStorage.Root();
+
+    /// <summary>This process's instance slug. Defaults to <see cref="DefaultSlug"/>.</summary>
+    public static string Slug { get; private set; } = DefaultSlug;
+
+    /// <summary>The instance's editable display name (label), when resolved from the registry.</summary>
+    public static string? DisplayName { get; private set; }
+
+    /// <summary>The instance's assigned Control API port, when resolved from the registry (null = default, use the allocator).</summary>
+    public static int? Port { get; private set; }
+
+    /// <summary>True when a <c>--instance</c> flag was explicitly passed on the command line.</summary>
+    public static bool WasExplicitlySelected { get; private set; }
+
+    /// <summary>True when this process is the default instance.</summary>
+    public static bool IsDefault => string.Equals(Slug, DefaultSlug, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// This instance's isolated data home: <c>{SharedRoot}\instances\{slug}</c> for EVERY
+    /// instance, default included. This is the value fed into the <c>CC_DIRECTOR_ROOT</c>
+    /// override so the whole data tree redirects here. Shared binaries/runtime
+    /// (<c>bin\</c>, <c>python\</c>, <c>app\</c>) stay at the shared root by design.
+    /// </summary>
+    public static string InstanceHome => Path.Combine(SharedRoot, "instances", Slug);
+
+    /// <summary>
+    /// Set the instance identity for this process. Call ONCE, first thing in Main,
+    /// before FileLog.Start and before any CcStorage use. Recaptures the shared root
+    /// from the environment as it stands right now (i.e. before the caller applies the
+    /// per-instance override), so the shared root is never polluted by our own redirect.
+    /// </summary>
+    public static void Initialize(string? slug, bool wasExplicit, string? displayName = null, int? port = null)
+    {
+        // Capture the shared machine root from CcStorage - the single owner of storage-root
+        // resolution (it honors CC_DIRECTOR_ROOT). Called BEFORE the caller applies the
+        // per-instance override, so this is the true machine root, not an instance home.
+        SharedRoot = CcStorage.Root();
+        Slug = Normalize(slug);
+        WasExplicitlySelected = wasExplicit;
+        DisplayName = displayName;
+        Port = port;
+    }
+
+    /// <summary>Normalize a raw slug: blank -&gt; default, else trimmed lower-case.</summary>
+    public static string Normalize(string? slug)
+        => string.IsNullOrWhiteSpace(slug) ? DefaultSlug : slug.Trim().ToLowerInvariant();
+}

--- a/src/CcDirector.Core/Instances/NamedInstance.cs
+++ b/src/CcDirector.Core/Instances/NamedInstance.cs
@@ -1,0 +1,41 @@
+using System.Text.Json.Serialization;
+
+namespace CcDirector.Core.Instances;
+
+/// <summary>
+/// One named Director instance = a settings profile. Persisted in the cross-instance
+/// registry (<see cref="NamedInstanceRegistry"/>) at the shared machine root.
+///
+/// Three independent name fields, deliberately NOT the same thing:
+///   - <see cref="Id"/>          immutable identity (uuid); the per-director "install id".
+///   - <see cref="Name"/>        the slug: the folder <c>instances\{slug}\</c> and the
+///                               <c>--instance {slug}</c> CLI handle. Fixed at creation.
+///                               The default instance's slug is ALWAYS <c>default</c>.
+///   - <see cref="DisplayName"/> the editable label shown in the menu/picker/Fleet Map.
+///                               Seeded from the hostname for the default instance.
+/// </summary>
+public sealed class NamedInstance
+{
+    /// <summary>Immutable identity (uuid). Never shown to the user.</summary>
+    public string Id { get; init; } = "";
+
+    /// <summary>The slug: folder name + CLI handle. Fixed at creation.</summary>
+    public string Name { get; init; } = "";
+
+    /// <summary>Editable label. This is the only name field the user renames.</summary>
+    public string DisplayName { get; set; } = "";
+
+    /// <summary>The gateway URL this instance binds to (stored for display in the picker).</summary>
+    public string GatewayUrl { get; init; } = "";
+
+    /// <summary>The Control API port for this instance. Assigned at creation; the running
+    /// instance records its actual bound port here so the picker shows the real port.</summary>
+    public int Port { get; set; }
+
+    /// <summary>ISO-8601 creation timestamp.</summary>
+    public string CreatedAt { get; init; } = "";
+
+    /// <summary>True when this is the reserved default instance.</summary>
+    [JsonIgnore]
+    public bool IsDefault => string.Equals(Name, InstanceContext.DefaultSlug, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/CcDirector.Core/Instances/NamedInstanceRegistry.cs
+++ b/src/CcDirector.Core/Instances/NamedInstanceRegistry.cs
@@ -1,0 +1,293 @@
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Instances;
+
+/// <summary>
+/// The cross-instance registry of named Director instances. One JSON file at the SHARED
+/// machine root - <c>{SharedRoot}\config\director\named-instances.json</c> - so that every
+/// instance process and the launcher can enumerate all instances without starting one.
+///
+/// This is deliberately at the shared root (via <see cref="InstanceContext.SharedRoot"/>),
+/// NOT under a per-instance data home, and NOT via <see cref="Storage.CcStorage"/> (whose
+/// base is redirected to the per-instance home once <c>CC_DIRECTOR_ROOT</c> is set).
+///
+/// Not to be confused with the pre-existing runtime registration directory
+/// <c>config\director\instances\{directorId}.json</c> (Director↔Gateway liveness), which is
+/// a different concept at a different path.
+/// </summary>
+public static class NamedInstanceRegistry
+{
+    private const int SchemaVersion = 1;
+
+    // Named instances are assigned from this range (mirrors PortAllocator's 7879-7898).
+    // 7879 is reserved as the nominal default; named instances start at 7880.
+    private const int PortRangeStart = 7880;
+    private const int PortRangeEnd = 7898;
+    private const int DefaultPort = 7879;
+
+    private static readonly object WriteLock = new();
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    /// <summary>The registry file path at the shared machine root.</summary>
+    public static string FilePath =>
+        Path.Combine(InstanceContext.SharedRoot, "config", "director", "named-instances.json");
+
+    /// <summary>
+    /// All instances, guaranteed to include the default (seeded from the hostname on first
+    /// read). Ordered default-first, then by creation time.
+    /// </summary>
+    public static IReadOnlyList<NamedInstance> List()
+    {
+        lock (WriteLock)
+        {
+            var instances = LoadRaw();
+            if (!instances.Any(i => i.IsDefault))
+            {
+                instances.Insert(0, BuildDefault());
+                SaveRaw(instances);
+            }
+            return instances
+                .OrderByDescending(i => i.IsDefault)
+                .ThenBy(i => i.CreatedAt, StringComparer.Ordinal)
+                .ToList();
+        }
+    }
+
+    /// <summary>The instance with the given slug, or null if unknown.</summary>
+    public static NamedInstance? Get(string slug)
+    {
+        var normalized = InstanceContext.Normalize(slug);
+        return List().FirstOrDefault(i =>
+            string.Equals(i.Name, normalized, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Ensure the default instance exists (seeded with the given hostname as its display
+    /// name). Safe to call before FileLog.Start. Idempotent.
+    /// </summary>
+    public static void EnsureDefault(string hostname)
+    {
+        lock (WriteLock)
+        {
+            var instances = LoadRaw();
+            if (instances.Any(i => i.IsDefault))
+                return;
+            instances.Insert(0, BuildDefault(hostname));
+            SaveRaw(instances);
+        }
+    }
+
+    /// <summary>
+    /// Create a new named instance: derive a unique slug from the display name, assign the
+    /// next free port, mint an id, persist to the registry, and scaffold the instance's data
+    /// home with a <c>config\config.json</c> carrying the gateway block. Returns the instance.
+    /// </summary>
+    public static NamedInstance Create(string displayName, string gatewayUrl, string gatewayToken)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+            throw new ArgumentException("Display name is required.", nameof(displayName));
+
+        FileLog.Write($"[NamedInstanceRegistry] Create: displayName=\"{displayName}\", gatewayUrl=\"{gatewayUrl}\"");
+        lock (WriteLock)
+        {
+            var instances = LoadRaw();
+            if (!instances.Any(i => i.IsDefault))
+                instances.Insert(0, BuildDefault());
+
+            var slug = UniqueSlug(Slugify(displayName), instances);
+            var port = NextFreePort(instances);
+            var instance = new NamedInstance
+            {
+                Id = Guid.NewGuid().ToString(),
+                Name = slug,
+                DisplayName = displayName.Trim(),
+                GatewayUrl = gatewayUrl?.Trim() ?? "",
+                Port = port,
+                CreatedAt = DateTime.UtcNow.ToString("o"),
+            };
+            instances.Add(instance);
+            SaveRaw(instances);
+
+            ScaffoldInstanceHome(instance, gatewayToken?.Trim() ?? "");
+            FileLog.Write($"[NamedInstanceRegistry] Created instance id={instance.Id}, slug={slug}, port={port}");
+            return instance;
+        }
+    }
+
+    /// <summary>
+    /// Rename an instance's DISPLAY NAME only. The slug, id, port, home and gateway are
+    /// untouched - nothing that identifies or addresses the instance moves.
+    /// </summary>
+    public static NamedInstance Rename(string slug, string newDisplayName)
+    {
+        if (string.IsNullOrWhiteSpace(newDisplayName))
+            throw new ArgumentException("Display name is required.", nameof(newDisplayName));
+
+        var normalized = InstanceContext.Normalize(slug);
+        FileLog.Write($"[NamedInstanceRegistry] Rename: slug={normalized}, newDisplayName=\"{newDisplayName}\"");
+        lock (WriteLock)
+        {
+            var instances = LoadRaw();
+            var target = instances.FirstOrDefault(i =>
+                string.Equals(i.Name, normalized, StringComparison.OrdinalIgnoreCase))
+                ?? throw new InvalidOperationException($"No instance with slug '{normalized}'.");
+            target.DisplayName = newDisplayName.Trim();
+            SaveRaw(instances);
+            FileLog.Write($"[NamedInstanceRegistry] Renamed slug={normalized} -> \"{target.DisplayName}\"");
+            return target;
+        }
+    }
+
+    /// <summary>Preview the slug that would be derived from a display name (no uniqueness suffix).</summary>
+    public static string PreviewSlug(string displayName) => Slugify(displayName ?? "");
+
+    /// <summary>
+    /// Record the actual Control API port a running instance bound to, so the picker shows the
+    /// real port and probes the right one. No-op if the slug is unknown or the port is already
+    /// current. Best-effort - never throws into the startup path.
+    /// </summary>
+    public static void RecordBoundPort(string slug, int port)
+    {
+        try
+        {
+            var normalized = InstanceContext.Normalize(slug);
+            lock (WriteLock)
+            {
+                var instances = LoadRaw();
+                var target = instances.FirstOrDefault(i =>
+                    string.Equals(i.Name, normalized, StringComparison.OrdinalIgnoreCase));
+                if (target is null || target.Port == port)
+                    return;
+                target.Port = port;
+                SaveRaw(instances);
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[NamedInstanceRegistry] RecordBoundPort FAILED (ignored): {ex.Message}");
+        }
+    }
+
+    // -- internals --
+
+    private static NamedInstance BuildDefault(string? hostname = null)
+        => new()
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = InstanceContext.DefaultSlug,
+            DisplayName = string.IsNullOrWhiteSpace(hostname) ? Environment.MachineName : hostname.Trim(),
+            GatewayUrl = "",
+            Port = DefaultPort,
+            CreatedAt = DateTime.UtcNow.ToString("o"),
+        };
+
+    private static List<NamedInstance> LoadRaw()
+    {
+        var path = FilePath;
+        if (!File.Exists(path))
+            return new List<NamedInstance>();
+
+        var text = File.ReadAllText(path);
+        if (string.IsNullOrWhiteSpace(text))
+            return new List<NamedInstance>();
+
+        // No-fallback rule: a malformed registry THROWS rather than being silently reset.
+        var doc = JsonSerializer.Deserialize<RegistryFile>(text, JsonOptions)
+            ?? throw new InvalidOperationException($"named-instances.json parsed to null: {path}");
+        return doc.Instances ?? new List<NamedInstance>();
+    }
+
+    private static void SaveRaw(List<NamedInstance> instances)
+    {
+        var path = FilePath;
+        var dir = Path.GetDirectoryName(path)
+            ?? throw new InvalidOperationException($"named-instances.json has no directory: {path}");
+        Directory.CreateDirectory(dir);
+
+        var doc = new RegistryFile { SchemaVersion = SchemaVersion, Instances = instances };
+        var json = JsonSerializer.Serialize(doc, JsonOptions);
+        var temp = Path.Combine(dir, $".named-instances.{Guid.NewGuid():N}.tmp");
+        File.WriteAllText(temp, json);
+        File.Move(temp, path, overwrite: true);
+    }
+
+    /// <summary>
+    /// Write the instance's own <c>config\config.json</c> with the gateway block, directly
+    /// (not via CcDirectorConfigService, whose target is the CURRENT process's home).
+    /// </summary>
+    private static void ScaffoldInstanceHome(NamedInstance instance, string gatewayToken)
+    {
+        var home = Path.Combine(InstanceContext.SharedRoot, "instances", instance.Name);
+        var configDir = Path.Combine(home, "config");
+        Directory.CreateDirectory(configDir);
+        var configPath = Path.Combine(configDir, "config.json");
+        if (File.Exists(configPath))
+            return; // never clobber an existing instance config
+
+        var config = new Dictionary<string, object?>
+        {
+            ["gateway"] = new Dictionary<string, object?>
+            {
+                ["url"] = instance.GatewayUrl,
+                ["token"] = gatewayToken,
+            },
+        };
+        var json = JsonSerializer.Serialize(config, JsonOptions);
+        var temp = Path.Combine(configDir, $".config.{Guid.NewGuid():N}.tmp");
+        File.WriteAllText(temp, json);
+        File.Move(temp, configPath, overwrite: true);
+    }
+
+    private static int NextFreePort(List<NamedInstance> instances)
+    {
+        var used = instances.Select(i => i.Port).ToHashSet();
+        for (var port = PortRangeStart; port <= PortRangeEnd; port++)
+            if (!used.Contains(port))
+                return port;
+        throw new InvalidOperationException(
+            $"No free instance port in {PortRangeStart}-{PortRangeEnd} (all {instances.Count} in use).");
+    }
+
+    private static string UniqueSlug(string baseSlug, List<NamedInstance> instances)
+    {
+        var existing = instances.Select(i => i.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        // Never let a user-created instance take the reserved default slug.
+        if (string.Equals(baseSlug, InstanceContext.DefaultSlug, StringComparison.OrdinalIgnoreCase))
+            baseSlug = baseSlug + "-1";
+        if (!existing.Contains(baseSlug))
+            return baseSlug;
+        for (var n = 2; ; n++)
+        {
+            var candidate = $"{baseSlug}-{n}";
+            if (!existing.Contains(candidate))
+                return candidate;
+        }
+    }
+
+    private static string Slugify(string displayName)
+    {
+        var sb = new StringBuilder();
+        foreach (var ch in displayName.Trim().ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(ch)) sb.Append(ch);
+            else if (ch is ' ' or '-' or '_' or '.') sb.Append('-');
+        }
+        var slug = sb.ToString();
+        while (slug.Contains("--")) slug = slug.Replace("--", "-");
+        slug = slug.Trim('-');
+        return string.IsNullOrEmpty(slug) ? "instance" : slug;
+    }
+
+    private sealed class RegistryFile
+    {
+        public int SchemaVersion { get; set; }
+        public List<NamedInstance>? Instances { get; set; }
+    }
+}


### PR DESCRIPTION
Run multiple named Directors from a single cc-director.exe, each an isolated settings profile with its own gateway, port, and data home. Selected at startup via `--instance <slug>`.

## Model — three independent name fields per instance
- **id** (uuid, immutable) — the real identity; folds into the DirectorId slot so each instance gets its own mutex, port, and registration.
- **name** (slug, fixed at create) — the folder `instances\<slug>\` and the CLI handle.
- **displayName** (editable) — the menu/picker/title label; seeded from the hostname for the default instance.

## No migration — clean slate
Every instance, the default included, runs in its own isolated home `instances\<slug>\` via the `CC_DIRECTOR_ROOT` redirect. Old flat data is never carried forward; on the next install everyone re-enters their gateway/settings once. Shared binaries/runtime (`bin\`, `python\`, `app\`) stay at the machine root by design.

## Backend (Core)
`InstanceContext`, `NamedInstance`, `NamedInstanceRegistry` (cross-instance registry at the shared root `config\director\named-instances.json`; auto-seeds the default from the hostname, allocates ports, scaffolds each instance's `config.json`). `Program` parses `--instance` and redirects storage before FileLog/CcStorage. `DirectorIdStore` folds the slug into the identity slot; `ControlApiHost` records each instance's actual bound port back to the registry.

## UI (Avalonia)
File menu — Create named director instance / Rename this director / Switch director. `CreateInstanceDialog`, `RenameDirectorDialog` (display name only), `SelectDirectorDialog` (picker with running/stopped probe). Startup shows the picker when more than one instance exists and none was requested; the title bar shows the instance name.

## Tests
`NamedInstanceRegistryTests` covers slug derivation, uniqueness, port assignment, gateway-config scaffolding, rename-changes-label-only, and the isolated-default-home invariant (10 tests).

Verified: full app builds on current main; two instances run concurrently with distinct DirectorIds, isolated homes, and separate ports; slot-5 default boot isolates into `instances\default\` with no stray shared-root data.