### PR TITLE
docs: dictation dictionary suggestions mockup v2 (all five screens)

### DIFF
--- a/docs/reviews/dictation-dictionary-suggestions-mockup-v2-2026-07-24.html
+++ b/docs/reviews/dictation-dictionary-suggestions-mockup-v2-2026-07-24.html
@@ -1,0 +1,792 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Dictation dictionary suggestions - mockups v2</title>
+</head>
+<body>
+<style>
+  /* ---- Review-document chrome (theme-aware) ---- */
+  :root {
+    --page-bg: #f4f6fa;
+    --page-surface: #ffffff;
+    --page-border: #d9deea;
+    --page-text: #1b2233;
+    --page-dim: #5c667e;
+    --page-accent: #2563c4;
+    --page-note-bg: #eef2fa;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --page-bg: #10141f;
+      --page-surface: #171d2c;
+      --page-border: #2a3247;
+      --page-text: #e4e8f2;
+      --page-dim: #939db4;
+      --page-accent: #6ea3f0;
+      --page-note-bg: #1b2336;
+    }
+  }
+  :root[data-theme="dark"] {
+    --page-bg: #10141f;
+    --page-surface: #171d2c;
+    --page-border: #2a3247;
+    --page-text: #e4e8f2;
+    --page-dim: #939db4;
+    --page-accent: #6ea3f0;
+    --page-note-bg: #1b2336;
+  }
+  :root[data-theme="light"] {
+    --page-bg: #f4f6fa;
+    --page-surface: #ffffff;
+    --page-border: #d9deea;
+    --page-text: #1b2233;
+    --page-dim: #5c667e;
+    --page-accent: #2563c4;
+    --page-note-bg: #eef2fa;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--page-bg); color: var(--page-text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 15px; line-height: 1.55;
+  }
+  .doc { max-width: 1120px; margin: 0 auto; padding: 36px 24px 80px; }
+  .doc-head { max-width: 720px; margin-bottom: 8px; }
+  .doc-head .eyebrow {
+    font-size: 12px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase;
+    color: var(--page-accent); margin: 0 0 10px;
+  }
+  .doc-head h1 { font-size: 30px; line-height: 1.2; margin: 0 0 12px; text-wrap: balance; }
+  .doc-head p { color: var(--page-dim); margin: 0 0 10px; }
+  .doc-head a { color: var(--page-accent); }
+  .toc {
+    display: flex; flex-wrap: wrap; gap: 8px; margin: 22px 0 46px; padding: 0; list-style: none;
+  }
+  .toc a {
+    display: inline-block; padding: 6px 13px; border: 1px solid var(--page-border);
+    border-radius: 999px; background: var(--page-surface); color: var(--page-text);
+    text-decoration: none; font-size: 13px;
+  }
+  .toc a:hover, .toc a:focus-visible { border-color: var(--page-accent); color: var(--page-accent); outline: none; }
+
+  .screen-block { margin: 0 0 64px; }
+  .screen-block h2 { font-size: 21px; margin: 0 0 4px; text-wrap: balance; }
+  .screen-block .screen-no {
+    font-size: 12px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase;
+    color: var(--page-dim); display: block; margin-bottom: 6px;
+  }
+  .screen-block > p.intent { color: var(--page-dim); max-width: 720px; margin: 0 0 18px; }
+
+  .frame-scroll { overflow-x: auto; border-radius: 14px; }
+  .browser {
+    min-width: 980px; border: 1px solid var(--page-border); border-radius: 14px;
+    overflow: hidden; background: #0b1020;
+    box-shadow: 0 12px 32px rgba(10, 16, 38, .18);
+  }
+  .browser-bar {
+    display: flex; align-items: center; gap: 10px; padding: 9px 14px;
+    background: #161c2e; border-bottom: 1px solid #28304a;
+  }
+  .browser-bar .lamp { width: 10px; height: 10px; border-radius: 50%; background: #3a4460; }
+  .browser-bar .url {
+    flex: 1; max-width: 460px; margin-left: 8px; background: #0a0f1e; color: #99a0b8;
+    border: 1px solid #28304a; border-radius: 7px; padding: 4px 12px; font-size: 12px;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+
+  .notes { margin: 18px 0 0; padding: 0; list-style: none; max-width: 860px; }
+  .notes li {
+    position: relative; padding: 10px 14px 10px 40px; margin-bottom: 8px;
+    background: var(--page-note-bg); border: 1px solid var(--page-border); border-radius: 10px;
+    font-size: 13.5px;
+  }
+  .notes li::before {
+    content: attr(data-n); position: absolute; left: 12px; top: 10px;
+    width: 19px; height: 19px; border-radius: 50%; background: var(--page-accent); color: #fff;
+    font-size: 11px; font-weight: 700; text-align: center; line-height: 19px;
+  }
+  .notes b { font-weight: 650; }
+
+  .open-q { max-width: 860px; }
+  .open-q h2 { font-size: 21px; margin: 0 0 14px; }
+  .open-q ol { margin: 0; padding-left: 22px; }
+  .open-q li { margin-bottom: 12px; }
+  .open-q li b { font-weight: 650; }
+  .open-q .lean { color: var(--page-dim); }
+
+  /* ---- Cockpit mock (deliberately single-theme: the real Cockpit is dark) ---- */
+  .ck {
+    --bg: #0b1020; --surface: #141a2e; --surface-2: #1b2238; --border: #28304a;
+    --text: #e6e9f2; --dim: #99a0b8; --accent: #3b82f6; --attention: #f14c4c;
+    --green-btn: #1f7a47; --green-line: #2a9c5b; --green-msg: #5fd08a; --code-bg: #0a0f1e;
+    display: grid; grid-template-columns: 220px 1fr; min-height: 620px;
+    background: var(--bg); color: var(--text); font-size: 14px; text-align: left;
+  }
+  .ck a { color: inherit; text-decoration: none; }
+  .ck .rail {
+    background: var(--surface); border-right: 1px solid var(--border);
+    padding: 16px 12px; display: flex; flex-direction: column;
+  }
+  .ck .brand { font-weight: 700; font-size: 16px; letter-spacing: .2px; padding: 4px 8px 16px; }
+  .ck .nav { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; flex: 1; }
+  .ck .nav-link {
+    display: flex; align-items: center; justify-content: space-between; gap: 8px;
+    padding: 9px 10px; border-radius: 8px; color: var(--dim); font-size: 14px;
+  }
+  .ck .nav-link-active { background: var(--surface-2); color: var(--text); box-shadow: inset 3px 0 0 var(--accent); }
+  .ck .badge {
+    background: var(--attention); color: #fff; font-size: 11px; font-weight: 700;
+    border-radius: 10px; padding: 1px 7px; min-width: 20px; text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+  .ck .rail-foot { padding: 12px 8px 4px; font-size: 11px; color: var(--dim); }
+  .ck .main { padding: 24px 28px; overflow: hidden; }
+  .ck .wrap { max-width: 900px; }
+  .ck h1 { font-size: 24px; font-weight: 600; margin: 0 0 4px; }
+  .ck .sub { color: var(--dim); font-size: 14px; margin: 0 0 16px; max-width: 640px; }
+
+  .ck .section {
+    background: var(--surface); border: 1px solid var(--border); border-radius: 14px;
+    padding: 16px 18px; margin: 14px 0;
+  }
+  .ck .section h2 { font-size: 15px; margin: 0 0 2px; }
+  .ck .hint { color: var(--dim); font-size: 12.5px; margin: 0 0 12px; }
+
+  .ck .suggest { border-color: rgba(241, 76, 76, .45); }
+  .ck .suggest-head { display: flex; align-items: center; gap: 9px; margin-bottom: 2px; }
+  .ck .dot {
+    width: 9px; height: 9px; border-radius: 50%; background: var(--attention);
+    box-shadow: 0 0 0 3px rgba(241, 76, 76, .16); flex: none;
+  }
+  .ck .srow {
+    display: grid; grid-template-columns: 22px 1fr auto auto; align-items: center;
+    gap: 12px; padding: 11px 0; border-top: 1px solid var(--border);
+  }
+  .ck .srow:first-of-type { border-top: none; }
+  .ck .term { font-weight: 600; font-size: 14px; }
+  .ck .heard { color: var(--dim); font-size: 12.5px; margin-top: 2px; }
+  .ck .heard b { color: #cdd5e4; font-weight: 600; }
+  .ck .freq { color: var(--dim); font-size: 12px; white-space: nowrap; font-variant-numeric: tabular-nums; }
+  .ck input[type="checkbox"] { width: 16px; height: 16px; accent-color: var(--accent); margin: 0; }
+  .ck .row-dismiss {
+    border: none; background: transparent; color: var(--dim); font-size: 12.5px;
+    cursor: pointer; padding: 4px 6px; border-radius: 6px;
+  }
+  .ck .row-dismiss:hover { color: var(--attention); background: var(--surface-2); }
+  .ck .actions {
+    display: flex; gap: 12px; align-items: center; margin-top: 14px;
+    padding-top: 14px; border-top: 1px solid var(--border);
+  }
+  .ck .btn {
+    border: 1px solid var(--border); background: var(--surface-2); color: var(--text);
+    padding: 8px 14px; border-radius: 8px; font-weight: 600; cursor: pointer; font-size: 13.5px;
+  }
+  .ck .btn-add { background: var(--green-btn); border-color: var(--green-line); color: #fff; }
+  .ck .btn-ghost { background: transparent; font-weight: 500; color: var(--dim); }
+  .ck .spacer { flex: 1; }
+  .ck .fineprint { color: var(--dim); font-size: 12px; }
+
+  .ck .chips { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+  .ck .chip {
+    display: inline-flex; align-items: center; gap: 7px; background: var(--surface-2);
+    border: 1px solid var(--border); border-radius: 999px; padding: 4px 6px 4px 12px; font-size: 13px;
+  }
+  .ck .chip-new { border-color: var(--green-line); }
+  .ck .chip .x { color: var(--dim); font-size: 14px; padding: 0 4px; }
+  .ck .addbox {
+    background: var(--code-bg); color: var(--dim); border: 1px dashed var(--border);
+    border-radius: 999px; padding: 5px 12px; font-size: 13px; min-width: 180px;
+  }
+  .ck .mrow { display: flex; align-items: flex-start; gap: 10px; padding: 10px 0; border-top: 1px solid var(--border); }
+  .ck .mrow:first-of-type { border-top: none; }
+  .ck .mterm { display: flex; align-items: center; gap: 7px; min-width: 170px; padding-top: 1px; }
+  .ck .mterm .name { font-weight: 600; font-size: 13.5px; }
+  .ck .mterm .arrow { color: var(--dim); }
+  .ck .mvariants { flex: 1; color: var(--dim); font-size: 13px; }
+  .ck .mvariants b { color: #cdd5e4; font-weight: 600; }
+
+  .ck .quiet-line { display: flex; align-items: center; gap: 10px; color: var(--dim); font-size: 13px; }
+  .ck .tick {
+    width: 18px; height: 18px; border-radius: 50%; background: rgba(95, 208, 138, .14);
+    color: var(--green-msg); font-size: 11px; font-weight: 700; text-align: center; line-height: 18px; flex: none;
+  }
+  .ck .textlink { color: var(--accent); font-size: 13px; }
+
+  .ck .drow {
+    display: grid; grid-template-columns: 1fr auto auto; align-items: center; gap: 12px;
+    padding: 10px 0; border-top: 1px solid var(--border);
+  }
+  .ck .drow:first-of-type { border-top: none; }
+  .ck .drow .when { color: var(--dim); font-size: 12px; white-space: nowrap; }
+  .ck .btn-restore { padding: 5px 12px; font-size: 12.5px; font-weight: 500; }
+
+  .ck .setrow { display: flex; align-items: flex-start; gap: 16px; padding: 14px 0; border-top: 1px solid var(--border); }
+  .ck .setrow:first-of-type { border-top: none; padding-top: 4px; }
+  .ck .setrow .grow { flex: 1; }
+  .ck .setname { font-weight: 600; font-size: 14px; margin-bottom: 3px; }
+  .ck .setdesc { color: var(--dim); font-size: 12.5px; max-width: 560px; }
+  .ck .setdesc b { color: #cdd5e4; font-weight: 600; }
+  .ck .toggle { width: 40px; height: 22px; border-radius: 999px; background: var(--accent); position: relative; flex: none; margin-top: 2px; }
+  .ck .toggle::after {
+    content: ""; position: absolute; top: 2px; right: 2px; width: 18px; height: 18px;
+    border-radius: 50%; background: #fff;
+  }
+  .ck .toggle-off { background: #3a4460; }
+  .ck .toggle-off::after { right: auto; left: 2px; }
+  .ck .danger-link { color: var(--attention); font-size: 12.5px; }
+
+  .callout {
+    background: rgba(232, 179, 57, .1); border: 1px dashed #b8912e; color: #e8ce8d;
+    border-radius: 8px; padding: 8px 12px; font-size: 12px; margin-top: 12px; line-height: 1.45;
+  }
+
+  /* ---- Email mock (deliberately single-theme: email renders on white) ---- */
+  .mail-shell { min-width: 0; background: var(--page-surface); border: 1px solid var(--page-border); border-radius: 14px; overflow: hidden; }
+  .mail-head { padding: 16px 22px; border-bottom: 1px solid var(--page-border); }
+  .mail-head .subj { font-weight: 650; font-size: 16px; margin: 0 0 6px; }
+  .mail-head .meta { color: var(--page-dim); font-size: 12.5px; }
+  .mail-body { background: #ffffff; color: #232a38; padding: 26px; font-size: 14px; }
+  .mail-inner { max-width: 560px; margin: 0 auto; }
+  .mail-inner h3 { font-size: 15px; margin: 0 0 4px; color: #101828; }
+  .mail-inner .mailhint { color: #66708a; font-size: 12.5px; margin: 0 0 14px; }
+  .mail-card { border: 1px solid #e3e7f0; border-radius: 10px; padding: 14px 16px; margin-bottom: 14px; }
+  .mail-card.flag { border-color: #f2b8b5; background: #fdf6f5; }
+  .mail-row { display: flex; justify-content: space-between; gap: 12px; padding: 7px 0; border-top: 1px solid #edf0f6; font-size: 13px; }
+  .mail-row:first-of-type { border-top: none; }
+  .mail-row .t { font-weight: 600; color: #101828; }
+  .mail-row .h { color: #66708a; font-size: 12px; margin-top: 1px; }
+  .mail-row .n { color: #66708a; font-size: 12px; white-space: nowrap; font-variant-numeric: tabular-nums; }
+  .mail-cta {
+    display: inline-block; background: #1f7a47; color: #fff; font-weight: 600; font-size: 13.5px;
+    padding: 9px 16px; border-radius: 8px; text-decoration: none;
+  }
+  .mail-foot { color: #8a93a8; font-size: 11.5px; margin-top: 16px; }
+  .mail-dim-sections { color: #aab1c2; font-size: 13px; padding: 10px 2px; }
+
+  @media (prefers-reduced-motion: reduce) { * { scroll-behavior: auto !important; } }
+</style>
+
+<div class="doc">
+  <header class="doc-head">
+    <p class="eyebrow">Design review - round 1</p>
+    <h1>Dictation dictionary suggestions: all five screens</h1>
+    <p>
+      The feature in one sentence: the gateway keeps your dictation transcripts for 30 days,
+      notices the words the speech model keeps getting wrong, and offers them as one-press
+      dictionary additions - on the Dictionary page, in the daily email, and over the API.
+    </p>
+    <p>
+      Every screen below is drawn in the real Cockpit design system (tokens, left rail, and the
+      existing Dictionary page sections lifted from the shipped app), so what you approve here is
+      what the built page will look like. Evidence counts are the real figures mined from two
+      months of dictation history. Covers devthrottle issues 2075 and 2074, on top of the storage
+      foundation in internal issue 509.
+    </p>
+  </header>
+
+  <ul class="toc">
+    <li><a href="#s1">1. Suggestions waiting</a></li>
+    <li><a href="#s2">2. Nothing to suggest</a></li>
+    <li><a href="#s3">3. Dismissed terms</a></li>
+    <li><a href="#s4">4. Privacy controls</a></li>
+    <li><a href="#s5">5. Daily email</a></li>
+    <li><a href="#qs">Open questions</a></li>
+  </ul>
+
+  <!-- ============ SCREEN 1 ============ -->
+  <section class="screen-block" id="s1">
+    <span class="screen-no">Screen 1 of 5</span>
+    <h2>Dictionary page with suggestions waiting</h2>
+    <p class="intent">
+      The main event. The red count on the Dictionary nav item says there is something to do;
+      the suggestions panel sits above the existing Vocabulary and Corrections sections and
+      turns the whole review into one press.
+    </p>
+
+    <div class="frame-scroll">
+      <div class="browser">
+        <div class="browser-bar">
+          <span class="lamp"></span><span class="lamp"></span><span class="lamp"></span>
+          <span class="url">gateway.devthrottle.com/c/dictionary</span>
+        </div>
+        <div class="ck">
+          <aside class="rail">
+            <div class="brand">DevThrottle</div>
+            <ul class="nav">
+              <li><a class="nav-link">Sessions</a></li>
+              <li><a class="nav-link">Fleet</a></li>
+              <li><a class="nav-link">Fleet Map</a></li>
+              <li><a class="nav-link">Directors</a></li>
+              <li><a class="nav-link">Schedule</a></li>
+              <li><a class="nav-link nav-link-active"><span>Dictionary</span><span class="badge">4</span></a></li>
+              <li><a class="nav-link">Learning</a></li>
+              <li><a class="nav-link">Account</a></li>
+              <li><a class="nav-link">Telemetry</a></li>
+              <li><a class="nav-link">Settings</a></li>
+              <li><a class="nav-link">About</a></li>
+            </ul>
+            <div class="rail-foot">Cockpit</div>
+          </aside>
+          <main class="main">
+            <div class="wrap">
+              <h1>Dictionary</h1>
+              <p class="sub">Terms that steer speech-to-text toward your vocabulary, plus corrections for spellings the model keeps getting wrong.</p>
+
+              <section class="section suggest">
+                <div class="suggest-head">
+                  <span class="dot"></span>
+                  <h2>4 suggestions from your recent dictations</h2>
+                </div>
+                <p class="hint">
+                  We compared what the model heard against your corrected text. These terms keep
+                  coming out wrong and are not in your dictionary yet. Nothing changes until you press Add.
+                </p>
+
+                <div class="srow">
+                  <input type="checkbox" checked>
+                  <div>
+                    <div class="term">mindzie</div>
+                    <div class="heard">heard as <b>Mindsee</b>, <b>Mindsy</b>, <b>Mindzee</b>, <b>Mindsea</b></div>
+                  </div>
+                  <div class="freq">wrong 53 of 97 times</div>
+                  <button class="row-dismiss">Dismiss</button>
+                </div>
+
+                <div class="srow">
+                  <input type="checkbox" checked>
+                  <div>
+                    <div class="term">ConPty</div>
+                    <div class="heard">heard as <b>Con-TY</b>, <b>ConTY</b></div>
+                  </div>
+                  <div class="freq">wrong 80 of 144 times</div>
+                  <button class="row-dismiss">Dismiss</button>
+                </div>
+
+                <div class="srow">
+                  <input type="checkbox" checked>
+                  <div>
+                    <div class="term">Frederiksen</div>
+                    <div class="heard">heard as <b>Fredriksson</b>, <b>Fredrickson</b>, <b>Fredrikson</b></div>
+                  </div>
+                  <div class="freq">wrong 98 of 364 times</div>
+                  <button class="row-dismiss">Dismiss</button>
+                </div>
+
+                <div class="srow">
+                  <input type="checkbox" checked>
+                  <div>
+                    <div class="term">Center Consulting</div>
+                    <div class="heard">heard as <b>Central Consulting</b></div>
+                  </div>
+                  <div class="freq">wrong 11 of 58 times</div>
+                  <button class="row-dismiss">Dismiss</button>
+                </div>
+
+                <div class="actions">
+                  <button class="btn btn-add">Add 4 selected to dictionary</button>
+                  <div class="spacer"></div>
+                  <span class="fineprint">Untick to skip a term this round. Dismiss to never see it again.</span>
+                </div>
+              </section>
+
+              <section class="section">
+                <h2>Vocabulary</h2>
+                <p class="hint">Terms biased into speech-to-text.</p>
+                <div class="chips">
+                  <span class="chip">Soren <span class="x">x</span></span>
+                  <span class="chip">DevThrottle <span class="x">x</span></span>
+                  <span class="chip">SignalR <span class="x">x</span></span>
+                  <span class="chip">Kestrel <span class="x">x</span></span>
+                  <span class="chip">Postgres <span class="x">x</span></span>
+                  <span class="chip">Supabase <span class="x">x</span></span>
+                  <span class="chip">Wingman <span class="x">x</span></span>
+                  <span class="addbox">+ add term</span>
+                </div>
+              </section>
+
+              <section class="section">
+                <h2>Common mistranscriptions</h2>
+                <p class="hint">Correct term &lt;- wrong spellings seen in practice. Fed to the cleanup pass.</p>
+                <div class="mrow">
+                  <div class="mterm"><span class="name">Supabase</span> <span class="arrow">&lt;-</span></div>
+                  <div class="mvariants"><b>Superbase</b>, <b>Super base</b></div>
+                </div>
+                <div class="mrow">
+                  <div class="mterm"><span class="name">cc-director</span> <span class="arrow">&lt;-</span></div>
+                  <div class="mvariants"><b>see see director</b>, <b>CC Directer</b></div>
+                </div>
+              </section>
+
+              <div class="callout">
+                Pressing Add writes each ticked term into BOTH sections at once: the term itself into
+                Vocabulary, and its observed wrong spellings into Common mistranscriptions. That is the
+                whole payoff - the user gets the full fix without understanding the two mechanisms.
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+    </div>
+
+    <ul class="notes">
+      <li data-n="1"><b>The red count</b> on the Dictionary nav item is the number of pending suggestions. It is the only attention signal in the whole design - no popups, no toasts. It clears when the queue is empty.</li>
+      <li data-n="2"><b>Evidence on every row.</b> "heard as Mindsee, Mindsy... wrong 53 of 97 times" is what makes the suggestion trustworthy. The user never has to wonder why a term is offered.</li>
+      <li data-n="3"><b>Untick and Dismiss are different acts.</b> Unticking skips a term this round but it may return with more evidence; Dismiss is permanent (until restored on screen 3). The v1 mockup conflated these - this is the main behavior change in v2.</li>
+      <li data-n="4"><b>Everything is pre-ticked</b> because the ranked list is already filtered to high-confidence terms. The happy path is exactly one press.</li>
+      <li data-n="5"><b>Add uses the green button</b> - the same green as the existing Save on this page, because it is the same kind of act (writes the dictionary). Red is reserved for attention, never for actions.</li>
+    </ul>
+  </section>
+
+  <!-- ============ SCREEN 2 ============ -->
+  <section class="screen-block" id="s2">
+    <span class="screen-no">Screen 2 of 5</span>
+    <h2>The zero state: nothing to suggest</h2>
+    <p class="intent">
+      What most users see most days. The panel must not look broken or nag - it shrinks to one
+      quiet reassuring line, the nav badge disappears, and the page is just the normal Dictionary.
+    </p>
+
+    <div class="frame-scroll">
+      <div class="browser">
+        <div class="browser-bar">
+          <span class="lamp"></span><span class="lamp"></span><span class="lamp"></span>
+          <span class="url">gateway.devthrottle.com/c/dictionary</span>
+        </div>
+        <div class="ck" style="min-height: 480px;">
+          <aside class="rail">
+            <div class="brand">DevThrottle</div>
+            <ul class="nav">
+              <li><a class="nav-link">Sessions</a></li>
+              <li><a class="nav-link">Fleet</a></li>
+              <li><a class="nav-link">Fleet Map</a></li>
+              <li><a class="nav-link">Directors</a></li>
+              <li><a class="nav-link">Schedule</a></li>
+              <li><a class="nav-link nav-link-active">Dictionary</a></li>
+              <li><a class="nav-link">Learning</a></li>
+              <li><a class="nav-link">Account</a></li>
+              <li><a class="nav-link">Telemetry</a></li>
+              <li><a class="nav-link">Settings</a></li>
+              <li><a class="nav-link">About</a></li>
+            </ul>
+            <div class="rail-foot">Cockpit</div>
+          </aside>
+          <main class="main">
+            <div class="wrap">
+              <h1>Dictionary</h1>
+              <p class="sub">Terms that steer speech-to-text toward your vocabulary, plus corrections for spellings the model keeps getting wrong.</p>
+
+              <section class="section">
+                <div class="quiet-line">
+                  <span class="tick">OK</span>
+                  <span>No suggestions right now. We keep comparing your dictations against your dictionary and will flag terms the model keeps getting wrong.</span>
+                  <div class="spacer"></div>
+                  <a class="textlink">Dismissed terms (2)</a>
+                </div>
+              </section>
+
+              <section class="section">
+                <h2>Vocabulary</h2>
+                <p class="hint">Terms biased into speech-to-text.</p>
+                <div class="chips">
+                  <span class="chip chip-new">mindzie <span class="x">x</span></span>
+                  <span class="chip chip-new">ConPty <span class="x">x</span></span>
+                  <span class="chip chip-new">Frederiksen <span class="x">x</span></span>
+                  <span class="chip chip-new">Center Consulting <span class="x">x</span></span>
+                  <span class="chip">Soren <span class="x">x</span></span>
+                  <span class="chip">DevThrottle <span class="x">x</span></span>
+                  <span class="chip">SignalR <span class="x">x</span></span>
+                  <span class="chip">Kestrel <span class="x">x</span></span>
+                  <span class="chip">Postgres <span class="x">x</span></span>
+                  <span class="chip">Supabase <span class="x">x</span></span>
+                  <span class="chip">Wingman <span class="x">x</span></span>
+                  <span class="addbox">+ add term</span>
+                </div>
+              </section>
+
+              <section class="section">
+                <h2>Common mistranscriptions</h2>
+                <p class="hint">Correct term &lt;- wrong spellings seen in practice. Fed to the cleanup pass.</p>
+                <div class="mrow">
+                  <div class="mterm"><span class="name">mindzie</span> <span class="arrow">&lt;-</span></div>
+                  <div class="mvariants"><b>Mindsee</b>, <b>Mindsy</b>, <b>Mindzee</b>, <b>Mindsea</b></div>
+                </div>
+                <div class="mrow">
+                  <div class="mterm"><span class="name">ConPty</span> <span class="arrow">&lt;-</span></div>
+                  <div class="mvariants"><b>Con-TY</b>, <b>ConTY</b></div>
+                </div>
+                <div class="mrow">
+                  <div class="mterm"><span class="name">Frederiksen</span> <span class="arrow">&lt;-</span></div>
+                  <div class="mvariants"><b>Fredriksson</b>, <b>Fredrickson</b>, <b>Fredrikson</b></div>
+                </div>
+              </section>
+            </div>
+          </main>
+        </div>
+      </div>
+    </div>
+
+    <ul class="notes">
+      <li data-n="1"><b>This frame shows the moment right after</b> pressing Add on screen 1: the four terms now sit in Vocabulary (green-edged chips mark the just-added ones, an edge that fades after this visit) and their wrong spellings landed in Common mistranscriptions.</li>
+      <li data-n="2"><b>The one-line state earns its place</b> - it tells the user the watcher exists (so they know suggestions will come without them hunting) but spends only one quiet row saying so. No badge anywhere.</li>
+      <li data-n="3"><b>The "Dismissed terms" link</b> lives here on the right, small. It is the doorway to screen 3 and doubles as the receipt that dismissals went somewhere recoverable.</li>
+    </ul>
+  </section>
+
+  <!-- ============ SCREEN 3 ============ -->
+  <section class="screen-block" id="s3">
+    <span class="screen-no">Screen 3 of 5</span>
+    <h2>Dismissed terms and the way back</h2>
+    <p class="intent">
+      "Never suggested again" needs a visible escape hatch, or a mis-click becomes permanent
+      silence about a word the user actually wanted. Clicking the link on screen 2 expands this
+      section in place - no separate page, no modal.
+    </p>
+
+    <div class="frame-scroll">
+      <div class="browser">
+        <div class="browser-bar">
+          <span class="lamp"></span><span class="lamp"></span><span class="lamp"></span>
+          <span class="url">gateway.devthrottle.com/c/dictionary</span>
+        </div>
+        <div class="ck" style="min-height: 400px;">
+          <aside class="rail">
+            <div class="brand">DevThrottle</div>
+            <ul class="nav">
+              <li><a class="nav-link">Sessions</a></li>
+              <li><a class="nav-link">Fleet</a></li>
+              <li><a class="nav-link">Fleet Map</a></li>
+              <li><a class="nav-link">Directors</a></li>
+              <li><a class="nav-link">Schedule</a></li>
+              <li><a class="nav-link nav-link-active">Dictionary</a></li>
+              <li><a class="nav-link">Learning</a></li>
+              <li><a class="nav-link">Account</a></li>
+              <li><a class="nav-link">Telemetry</a></li>
+              <li><a class="nav-link">Settings</a></li>
+              <li><a class="nav-link">About</a></li>
+            </ul>
+            <div class="rail-foot">Cockpit</div>
+          </aside>
+          <main class="main">
+            <div class="wrap">
+              <h1>Dictionary</h1>
+              <p class="sub">Terms that steer speech-to-text toward your vocabulary, plus corrections for spellings the model keeps getting wrong.</p>
+
+              <section class="section">
+                <h2>Dismissed suggestions</h2>
+                <p class="hint">Terms you told us to stop offering. Restore one and it becomes eligible again the next time the evidence supports it.</p>
+
+                <div class="drow">
+                  <div>
+                    <div class="term">Supabase</div>
+                    <div class="heard">was heard as <b>Superbase</b> - wrong 1 of 3 times</div>
+                  </div>
+                  <span class="when">dismissed 3 days ago</span>
+                  <button class="btn btn-restore">Restore</button>
+                </div>
+
+                <div class="drow">
+                  <div>
+                    <div class="term">Kubernetes</div>
+                    <div class="heard">was heard as <b>Cooper Netties</b> - wrong 2 of 2 times</div>
+                  </div>
+                  <span class="when">dismissed 2 weeks ago</span>
+                  <button class="btn btn-restore">Restore</button>
+                </div>
+              </section>
+
+              <div class="callout">
+                Dismissals are stored per tenant next to the suggestions themselves, so they survive
+                across devices and are honored by the API exactly as by this page.
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+    </div>
+
+    <ul class="notes">
+      <li data-n="1"><b>Evidence stays attached</b> even after dismissal ("was heard as Cooper Netties"), so the user restoring a term months later remembers why it was offered.</li>
+      <li data-n="2"><b>Restore does not re-suggest instantly.</b> It returns the term to the eligible pool; it reappears only when the mining pass next ranks it. The hint copy says exactly that, so Restore never looks broken when nothing happens immediately.</li>
+      <li data-n="3"><b>This section renders only when opened</b> from the "Dismissed terms" link - it is not a permanent third section fighting for attention on the page.</li>
+    </ul>
+  </section>
+
+  <!-- ============ SCREEN 4 ============ -->
+  <section class="screen-block" id="s4">
+    <span class="screen-no">Screen 4 of 5</span>
+    <h2>Settings: the privacy story as a screen</h2>
+    <p class="intent">
+      This screen IS the privacy policy. It answers, in plain words: what we store, for how long,
+      who can read it, what it powers, and how to make it stop - and turning it off deletes what
+      was stored, immediately.
+    </p>
+
+    <div class="frame-scroll">
+      <div class="browser">
+        <div class="browser-bar">
+          <span class="lamp"></span><span class="lamp"></span><span class="lamp"></span>
+          <span class="url">gateway.devthrottle.com/c/settings</span>
+        </div>
+        <div class="ck" style="min-height: 440px;">
+          <aside class="rail">
+            <div class="brand">DevThrottle</div>
+            <ul class="nav">
+              <li><a class="nav-link">Sessions</a></li>
+              <li><a class="nav-link">Fleet</a></li>
+              <li><a class="nav-link">Fleet Map</a></li>
+              <li><a class="nav-link">Directors</a></li>
+              <li><a class="nav-link">Schedule</a></li>
+              <li><a class="nav-link">Dictionary</a></li>
+              <li><a class="nav-link">Learning</a></li>
+              <li><a class="nav-link">Account</a></li>
+              <li><a class="nav-link">Telemetry</a></li>
+              <li><a class="nav-link nav-link-active">Settings</a></li>
+              <li><a class="nav-link">About</a></li>
+            </ul>
+            <div class="rail-foot">Cockpit</div>
+          </aside>
+          <main class="main">
+            <div class="wrap">
+              <h1>Settings</h1>
+              <p class="sub">Dictation</p>
+
+              <section class="section">
+                <h2>Dictionary suggestions</h2>
+                <p class="hint">How DevThrottle learns which words to suggest for your dictionary.</p>
+
+                <div class="setrow">
+                  <div class="grow">
+                    <div class="setname">Keep my transcripts to power suggestions</div>
+                    <div class="setdesc">
+                      Stores the raw and cleaned text of each dictation for <b>30 days</b> (newest
+                      10,000 kept). Only your account can read them. Used for one thing: spotting
+                      words the model keeps getting wrong so we can suggest dictionary fixes.
+                      Turning this off stops new storage and <b>deletes everything already stored</b>.
+                    </div>
+                  </div>
+                  <span class="toggle"></span>
+                </div>
+
+                <div class="setrow">
+                  <div class="grow">
+                    <div class="setname">Suggestions in my daily email</div>
+                    <div class="setdesc">
+                      When new suggestions are waiting, include them in the daily report email with a
+                      link to review. Never more than one mention per day; nothing is ever added
+                      automatically.
+                    </div>
+                  </div>
+                  <span class="toggle"></span>
+                </div>
+
+                <div class="setrow">
+                  <div class="grow">
+                    <div class="setname">Stored transcripts</div>
+                    <div class="setdesc">1,847 transcripts stored - oldest is 29 days. <a class="danger-link">Delete all stored transcripts now</a></div>
+                  </div>
+                </div>
+              </section>
+            </div>
+          </main>
+        </div>
+      </div>
+    </div>
+
+    <ul class="notes">
+      <li data-n="1"><b>Opt-out deletes, not just stops.</b> That is the deliberate design decision this screen exists to get approved: off means gone, so the promise is one sentence with no residue to explain.</li>
+      <li data-n="2"><b>Both toggles default on.</b> The feature only helps people who never open settings, so it must work for them - and the 30-day window plus tenant isolation is the guardrail that makes default-on defensible. Flip to default-off here if you disagree; it is a one-word change at this stage.</li>
+      <li data-n="3"><b>The stored count row is the receipt.</b> "1,847 transcripts - oldest is 29 days" quietly proves the retention promise is real, and the delete link gives an immediate out without touching the toggle.</li>
+      <li data-n="4"><b>Where this lives:</b> the Cockpit Settings page, in a Dictation group. The badge and suggestions panel never appear here - settings is for the rules, the Dictionary page is for the work.</li>
+    </ul>
+  </section>
+
+  <!-- ============ SCREEN 5 ============ -->
+  <section class="screen-block" id="s5">
+    <span class="screen-no">Screen 5 of 5</span>
+    <h2>The daily email block</h2>
+    <p class="intent">
+      The reach-out for users who are not in the Cockpit. One compact block inside the existing
+      daily report - top terms with their evidence, one button, nothing actionable from the email
+      itself except going to the page.
+    </p>
+
+    <div class="mail-shell">
+      <div class="mail-head">
+        <p class="subj">Your DevThrottle daily report - Thursday, July 24</p>
+        <p class="meta">email@devthrottle.com - to you - 7:00 AM</p>
+      </div>
+      <div class="mail-body">
+        <div class="mail-inner">
+          <div class="mail-dim-sections">[ ...sessions, usage, and cost sections of the existing daily report... ]</div>
+
+          <div class="mail-card flag">
+            <h3>Dictation: 4 words worth adding to your dictionary</h3>
+            <p class="mailhint">Your dictation keeps getting these wrong. Review takes one press - nothing is added until you approve it.</p>
+            <div class="mail-row">
+              <div><span class="t">mindzie</span><div class="h">heard as Mindsee, Mindsy, Mindzee</div></div>
+              <span class="n">wrong 53 of 97 times</span>
+            </div>
+            <div class="mail-row">
+              <div><span class="t">ConPty</span><div class="h">heard as Con-TY, ConTY</div></div>
+              <span class="n">wrong 80 of 144 times</span>
+            </div>
+            <div class="mail-row">
+              <div><span class="t">Frederiksen</span><div class="h">heard as Fredriksson, Fredrickson</div></div>
+              <span class="n">wrong 98 of 364 times</span>
+            </div>
+            <div class="mail-row">
+              <div><span class="t">+ 1 more</span><div class="h">Center Consulting</div></div>
+              <span class="n"></span>
+            </div>
+            <p style="margin: 14px 0 2px;"><a class="mail-cta">Review and add in Dictionary</a></p>
+          </div>
+
+          <div class="mail-dim-sections">[ ...rest of the report... ]</div>
+          <p class="mail-foot">You are getting suggestion notes because "Suggestions in my daily email" is on in Settings. Turn it off there any time.</p>
+        </div>
+      </div>
+    </div>
+
+    <ul class="notes">
+      <li data-n="1"><b>It rides the existing daily report</b> - no new email stream, no new sender, no separate unsubscribe to manage. If there are no suggestions, the block simply is not there.</li>
+      <li data-n="2"><b>Top three terms plus a count</b>, never the full list. The email is a doorbell, not a workbench: the one button leads to screen 1 where the real approve flow lives.</li>
+      <li data-n="3"><b>The footer names the exact setting</b> that controls this block, closing the loop with screen 4.</li>
+    </ul>
+  </section>
+
+  <!-- ============ OPEN QUESTIONS ============ -->
+  <section class="open-q" id="qs">
+    <h2>The four decisions this round should settle</h2>
+    <ol>
+      <li>
+        <b>How much evidence before we suggest?</b> The screens assume: at least 3 wrong
+        transcriptions of the same term, and wrong at least 25% of the times it was said.
+        Lower catches more, earlier, but risks noisy suggestions that erode trust in the panel.
+        <span class="lean">My lean: start strict; loosening later is invisible, tightening later looks like the feature got worse.</span>
+      </li>
+      <li>
+        <b>Does Add write corrections too?</b> Screen 1 says yes: one press writes the term into
+        Vocabulary AND its wrong spellings into Common mistranscriptions. The alternative -
+        vocabulary only - is safer but leaves half the fix on the table.
+        <span class="lean">My lean: write both; the wrong spellings shown as evidence are exactly the correction entries.</span>
+      </li>
+      <li>
+        <b>Default-on transcript storage?</b> Screen 4 assumes on-by-default with a delete-on-opt-out
+        switch. Default-off would make the whole feature invisible to the users it is meant to help,
+        but default-on must survive the privacy review.
+        <span class="lean">My lean: default on, 30-day window, off-means-delete - the settings copy above is written to make that defensible.</span>
+      </li>
+      <li>
+        <b>Email cadence.</b> Screen 5 rides the daily report only when suggestions exist. Should a
+        term that sits unreviewed for a week re-appear in the email, or is once per new batch enough?
+        <span class="lean">My lean: mention a given batch at most twice, then stay quiet until new evidence arrives - the badge keeps the durable signal.</span>
+      </li>
+    </ol>
+  </section>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Commits the v2 mockup set for the dictation dictionary suggestions feature (#2075, thefrederiksen/devthrottle_internal#924): all five screens - suggestions waiting, zero state, dismissed terms, the Settings privacy controls, and the daily email block - each with design notes and the four open decisions listed at the end.

v2 supersedes the v1 mockup (docs/reviews/dictation-dictionary-suggestions-mockup-2026-07-23.html). Main differences:

- Drawn in the real Cockpit design system: the actual tokens, left-rail navigation, and the existing /dictionary page sections (Vocabulary, Common mistranscriptions, the green Save), so the mock matches what the built page will look like. v1 had invented its own frame and palette.
- Untick and Dismiss are separate acts (untick skips a round; Dismiss is permanent with a visible Restore path).
- Add writes both halves of the fix: the term into Vocabulary and its observed wrong spellings into Common mistranscriptions.
- The Settings screen carries the privacy story: 30-day retention, per-tenant isolation, and off-means-delete opt-out.

Docs only; no code changes.