### PR TITLE
Name scheduled-run sessions after the schedule + fire time

### DIFF
--- a/src/CcDirector.Gateway.Tests/CronScheduleTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronScheduleTests.cs
@@ -183,4 +183,26 @@ public sealed class CronScheduleTests
 
         Assert.Null(CronSchedule.ComputeNextRunUtc(job, DateTime.UtcNow));
     }
+
+    [Fact]
+    public void LocalRunLabel_FormatsInJobTimeZone()
+    {
+        var job = ValidRecurring(); // America/Chicago, CDT (UTC-5) in July
+        var label = CronSchedule.LocalRunLabel(job, new DateTime(2026, 7, 24, 10, 0, 0, DateTimeKind.Utc));
+
+        Assert.Equal("2026-07-24 05:00", label);
+    }
+
+    [Fact]
+    public void LocalRunLabel_UnknownTimeZone_FallsBackToUtcSoItNeverThrows()
+    {
+        // A stored job whose zone id no longer resolves on this host must still yield a display label
+        // (the label is cosmetic and must never throw and break a fire); it reads in UTC.
+        var job = ValidRecurring();
+        job.TimeZoneId = "Mars Standard Time";
+
+        var label = CronSchedule.LocalRunLabel(job, new DateTime(2026, 7, 24, 10, 0, 0, DateTimeKind.Utc));
+
+        Assert.Equal("2026-07-24 10:00", label);
+    }
 }

--- a/src/CcDirector.Gateway.Tests/DirectorCronSessionStarterTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorCronSessionStarterTests.cs
@@ -1,0 +1,81 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Running;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="DirectorCronSessionStarter"/> - the cron seam that builds the
+/// <see cref="NewSessionRequest"/> for a due job and hands it to the shared
+/// <see cref="MachineSessionSpawner"/>. The behavior under test is the naming rule: a fired schedule
+/// spawns a session NAMED after the schedule plus when it ran (e.g. "Daily Error Triage -
+/// 2026-07-24 05:00"), stamped by the Gateway rather than the seeded agent (CLAUDE.md rule 7). A stub
+/// resolver + capturing create delegate stand in for the live registry/Director, and a fixed clock
+/// pins the timestamp, so the request the starter builds is asserted without a live Director.
+/// </summary>
+public sealed class DirectorCronSessionStarterTests
+{
+    private sealed class StubResolver : IDirectorTargetResolver
+    {
+        private readonly DirectorTargetResult _result;
+        public StubResolver(DirectorTargetResult result) => _result = result;
+        public Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct) =>
+            Task.FromResult(_result);
+    }
+
+    private sealed class FixedClock : IClock
+    {
+        public FixedClock(DateTime utcNow) => UtcNow = DateTime.SpecifyKind(utcNow, DateTimeKind.Utc);
+        public DateTime UtcNow { get; }
+    }
+
+    private static (DirectorCronSessionStarter starter, Func<NewSessionRequest?> seenReq) Build(DateTime utcNow)
+    {
+        NewSessionRequest? captured = null;
+        var resolver = new StubResolver(new DirectorTargetResult("d-1", null));
+        var spawner = new MachineSessionSpawner(resolver, (directorId, req, ct) =>
+        {
+            captured = req;
+            return Task.FromResult<(bool, SessionDto?, string?)>((true, new SessionDto { SessionId = "sid-1" }, null));
+        });
+        var starter = new DirectorCronSessionStarter(spawner, new FixedClock(utcNow));
+        return (starter, () => captured);
+    }
+
+    private static CronJobDto Job(string name, string timeZoneId) => new()
+    {
+        Id = "cj_1",
+        Name = name,
+        TimeZoneId = timeZoneId,
+        ScheduleKind = "recurring",
+        CronExpression = "0 5 * * *",
+        Target = new CronJobTarget { Machine = "MACHINE_A" },
+        Action = new CronJobAction { RepoPath = @"C:\repo", Seed = "/help" },
+    };
+
+    [Fact]
+    public async Task Start_NamesSessionAfterScheduleAndLocalFireTime()
+    {
+        // 05:00 UTC on a US-Eastern job is 01:00 local - the label uses the JOB's zone, not UTC.
+        var (starter, seenReq) = Build(new DateTime(2026, 7, 24, 5, 0, 0, DateTimeKind.Utc));
+
+        var (sessionId, _, error) = await starter.StartAsync(
+            Job("Daily Error Triage", "Eastern Standard Time"), CancellationToken.None);
+
+        Assert.Null(error);
+        Assert.Equal("sid-1", sessionId);
+        var req = seenReq();
+        Assert.NotNull(req);
+        Assert.Equal("Daily Error Triage - 2026-07-24 01:00", req!.Name);
+    }
+
+    [Fact]
+    public async Task Start_UtcJob_NamesSessionWithUtcWallClock()
+    {
+        var (starter, seenReq) = Build(new DateTime(2026, 7, 24, 5, 0, 0, DateTimeKind.Utc));
+
+        await starter.StartAsync(Job("Nightly Backup", "UTC"), CancellationToken.None);
+
+        Assert.Equal("Nightly Backup - 2026-07-24 05:00", seenReq()!.Name);
+    }
+}

--- a/src/CcDirector.Gateway/CronSchedule.cs
+++ b/src/CcDirector.Gateway/CronSchedule.cs
@@ -98,6 +98,25 @@ public static class CronSchedule
         return TimeZoneInfo.ConvertTimeToUtc(unspecified, zone);
     }
 
+    /// <summary>
+    /// Format a UTC instant as a short wall-clock label ("yyyy-MM-dd HH:mm") in the job's own time
+    /// zone, for naming the session a fire spawns after the schedule and when it ran (e.g.
+    /// "Daily Error Triage - 2026-07-24 05:00"). A job's time zone is validated at create time
+    /// (<see cref="Validate"/>), so it resolves here; a job whose stored id no longer resolves on this
+    /// host labels in UTC so a display string is always produced - the label is cosmetic and must
+    /// never throw and break a fire.
+    /// </summary>
+    public static string LocalRunLabel(CronJobDto job, DateTime utc)
+    {
+        if (job is null)
+            throw new ArgumentNullException(nameof(job));
+
+        var zone = TryFindTimeZone(job.TimeZoneId);
+        var utcKind = DateTime.SpecifyKind(utc, DateTimeKind.Utc);
+        var local = zone is null ? utcKind : TimeZoneInfo.ConvertTimeFromUtc(utcKind, zone);
+        return local.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
+    }
+
     private static bool IsRecurring(string? kind) =>
         string.Equals(kind?.Trim(), KindRecurring, StringComparison.OrdinalIgnoreCase);
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1032,9 +1032,10 @@ public sealed class GatewayHost : IAsyncDisposable
             // MTR-01 (Codex round 1): file the run-complete event into the current cron pass's OWN tenant ring,
             // the same per-tenant seam the deep-link resolver above reads. On self-host this is always Local.
             resolveTenant: () => _tenantPass.Current);
+        var cronClock = new Running.SystemClock();
         _cronEngine = new Running.CronEngine(
-            _cronJobs, _cronRuns, new Running.DirectorCronSessionStarter(_machineSessionSpawner),
-            cronWorkListRunner, cronNotifier, new Running.SystemClock(),
+            _cronJobs, _cronRuns, new Running.DirectorCronSessionStarter(_machineSessionSpawner, cronClock),
+            cronWorkListRunner, cronNotifier, cronClock,
             // MTR (audit MED): partition the overlap guard by the tenant of the CURRENT unit of work - the
             // run-now request scope on hosted, the single Local scope on self-host - the same seam the notifier
             // reads. A run-now for tenant A's cj_ id must never be refused by tenant B's in-flight same-id job.

--- a/src/CcDirector.Gateway/Running/DirectorCronSessionStarter.cs
+++ b/src/CcDirector.Gateway/Running/DirectorCronSessionStarter.cs
@@ -15,10 +15,12 @@ namespace CcDirector.Gateway.Running;
 public sealed class DirectorCronSessionStarter : ICronSessionStarter
 {
     private readonly MachineSessionSpawner _spawner;
+    private readonly IClock _clock;
 
-    public DirectorCronSessionStarter(MachineSessionSpawner spawner)
+    public DirectorCronSessionStarter(MachineSessionSpawner spawner, IClock clock)
     {
         _spawner = spawner ?? throw new ArgumentNullException(nameof(spawner));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
     }
 
     public async Task<(string? sessionId, string? directorId, string? error)> StartAsync(CronJobDto job, CancellationToken ct)
@@ -30,6 +32,13 @@ public sealed class DirectorCronSessionStarter : ICronSessionStarter
         {
             RepoPath = job.Action.RepoPath,
             Agent = "ClaudeCode",
+            // Name the spawned session after the SCHEDULE plus when it ran (e.g.
+            // "Daily Error Triage - 2026-07-24 05:00"), so a fired job reads as itself in the rail
+            // instead of the generic auto-name. The Gateway owns this naming (CLAUDE.md rule 7) - the
+            // scheduler knows the name and the fire time, so it stamps them rather than asking the
+            // seeded agent to rename itself. A job always has a name (required by CronSchedule.Validate),
+            // so this is never the bare-folder name the Director would reject.
+            Name = $"{job.Name} - {CronSchedule.LocalRunLabel(job, _clock.UtcNow)}",
             PrePrompt = job.Action.Seed,
             // Scheduled-run auto-dismiss (issue #1200): a seed run defaults to closing itself when it
             // finishes with nothing needing a human, so an hourly job stops piling leftover sessions into


### PR DESCRIPTION
## What

A fired cron job spawned a session with the generic auto-name, so the rail gave no hint of which schedule produced it. The scheduler already knows the schedule name and the fire time, so it now stamps the session name at fire time - e.g. **"Daily Error Triage - 2026-07-24 05:00"**.

## Why in the framework, not the task

Making each seeded skill rename its own session is fragile (races the UI, burns a turn, breaks if the skill errors early) and contradicts rule 7 ("the client is dumb, the Gateway owns the ruling"). The scheduler holds the name and the fire time - it stamps them.

## Change

- `DirectorCronSessionStarter` sets `NewSessionRequest.Name` from `job.Name` plus a local wall-clock label; takes an `IClock` for a deterministic fire time.
- `CronSchedule.LocalRunLabel` converts a UTC instant to the job's own time zone. A job's zone is validated at create time; an unresolvable stored id labels in UTC so the cosmetic label never throws and breaks a fire.
- No new field, no migration, no client change - `job.Name` already existed and `NewSessionRequest.Name` is honored verbatim by the Director.

## Tests

- Starter names the session correctly for a US-Eastern job (05:00 UTC -> 01:00 local) and a UTC job.
- `LocalRunLabel` formats in the job's zone and falls back to UTC for an unknown zone.

All 19 tests in the affected suites pass.